### PR TITLE
refactor(auth): finalize unified authentication

### DIFF
--- a/libs/modkit-auth/src/lib.rs
+++ b/libs/modkit-auth/src/lib.rs
@@ -30,7 +30,8 @@ pub mod axum_ext;
 // Core exports
 pub use claims::Claims;
 pub use errors::AuthError;
-pub use types::SecRequirement;
+pub use traits::TokenValidator;
+pub use types::{AuthRequirement, RoutePolicy, SecRequirement};
 
 // Plugin system exports
 pub use auth_mode::{AuthModeConfig, PluginRegistry};

--- a/libs/modkit-auth/src/traits.rs
+++ b/libs/modkit-auth/src/traits.rs
@@ -2,6 +2,13 @@ use crate::{claims::Claims, errors::AuthError, types::SecRequirement};
 use async_trait::async_trait;
 use modkit_security::AccessScope;
 
+/// Validates and parses JWT tokens
+#[async_trait]
+pub trait TokenValidator: Send + Sync {
+    /// Validate a JWT token and return normalized claims
+    async fn validate_and_parse(&self, token: &str) -> Result<Claims, AuthError>;
+}
+
 /// Builds an AccessScope from JWT claims
 pub trait ScopeBuilder: Send + Sync {
     /// Convert tenant claims into an AccessScope

--- a/libs/modkit-auth/src/types.rs
+++ b/libs/modkit-auth/src/types.rs
@@ -1,12 +1,35 @@
 /// Security requirement - defines required resource and action
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SecRequirement {
-    pub resource: &'static str,
-    pub action: &'static str,
+    pub resource: String,
+    pub action: String,
 }
 
 impl SecRequirement {
-    pub fn new(resource: &'static str, action: &'static str) -> Self {
-        Self { resource, action }
+    pub fn new(resource: impl Into<String>, action: impl Into<String>) -> Self {
+        Self {
+            resource: resource.into(),
+            action: action.into(),
+        }
     }
+}
+
+/// Route-level authentication requirement
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthRequirement {
+    /// No authentication required; route is public from auth perspective.
+    None,
+    /// Authentication required; `None` means no extra RBAC requirement,
+    /// `Some(SecRequirement)` means enforce this resource:action requirement.
+    Required(Option<SecRequirement>),
+    /// Optional authentication: if a valid token is present, use it;
+    /// otherwise proceed anonymously.
+    Optional,
+}
+
+/// Route policy that determines authentication requirements for routes
+#[async_trait::async_trait]
+pub trait RoutePolicy: Send + Sync {
+    /// Resolve the authentication requirement for a given method and path
+    async fn resolve(&self, method: &http::Method, path: &str) -> AuthRequirement;
 }

--- a/libs/modkit-odata/src/tests.rs
+++ b/libs/modkit-odata/src/tests.rs
@@ -241,30 +241,6 @@ mod tests {
     }
 
     #[test]
-    fn test_odata_query_legacy_compatibility() {
-        use crate::ast::*;
-
-        let expr = Expr::Compare(
-            Box::new(Expr::Identifier("name".to_string())),
-            CompareOperator::Eq,
-            Box::new(Expr::Value(Value::String("test".to_string()))),
-        );
-
-        // Test new API
-        let query = ODataQuery::default().with_filter(expr.clone());
-        assert!(query.has_filter());
-        assert!(query.filter().is_some());
-
-        let empty = ODataQuery::default();
-        assert!(!empty.has_filter());
-        assert!(empty.filter().is_none());
-
-        // Test conversion
-        let from_option = ODataQuery::from(Some(expr));
-        assert!(from_option.has_filter());
-    }
-
-    #[test]
     fn test_orderby_from_signed_tokens() {
         // Test basic parsing
         let result = ODataOrderBy::from_signed_tokens("+name,-created_at").unwrap();

--- a/libs/modkit-security/src/constants.rs
+++ b/libs/modkit-security/src/constants.rs
@@ -1,8 +1,12 @@
 use uuid::uuid;
 use uuid::Uuid;
 
-/// Root (bootstrap) tenant and subject.
-/// These are used only for system-level operations or bootstrap contexts.
+/// Root (bootstrap) tenant and subject
+/// These are used only for system-level operations or bootstrap contexts
 pub const ROOT_TENANT_ID: Uuid = uuid!("00000000-df51-5b42-9538-d2b56b7ee953");
 pub const ROOT_SUBJECT_ID: Uuid = uuid!("11111111-6a88-4768-9dfc-6bcd5187d9ed");
+
+/// Anonymous subject ID
+pub const ANONYMOUS_SUBJECT_ID: Uuid = uuid!("22222222-0830-5695-92eb-d648d8b346a6");
+
 pub const GTS_DEFAULT_TYPE_ID: Uuid = uuid!("22222222-0000-0000-0000-000000000001");

--- a/libs/modkit-security/src/security_ctx.rs
+++ b/libs/modkit-security/src/security_ctx.rs
@@ -1,4 +1,4 @@
-use crate::{AccessScope, Subject};
+use crate::{constants, AccessScope, Subject};
 use uuid::Uuid;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -38,6 +38,12 @@ impl SecurityCtx {
             scope: AccessScope::default(),
             subject: Subject::new(subject_id),
         }
+    }
+
+    /// Anonymous/unauthenticated context with no access to any resources.
+    /// Use this for public routes where no authentication is required.
+    pub fn anonymous() -> Self {
+        Self::deny_all(constants::ANONYMOUS_SUBJECT_ID)
     }
 
     /// Root subject operating within the root tenant (system context).

--- a/libs/modkit/macros/tests/ui/fail/lifecycle_runner_not_async.stderr
+++ b/libs/modkit/macros/tests/ui/fail/lifecycle_runner_not_async.stderr
@@ -10,4 +10,4 @@ warning: unused import: `tokio_util::sync::CancellationToken`
 2 | use tokio_util::sync::CancellationToken;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/libs/modkit/macros/tests/ui/fail/lifecycle_wrong_third_param.stderr
+++ b/libs/modkit/macros/tests/ui/fail/lifecycle_wrong_third_param.stderr
@@ -10,4 +10,4 @@ warning: unused import: `tokio_util::sync::CancellationToken`
 2 | use tokio_util::sync::CancellationToken;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/modules/api_ingress/src/lib.rs
+++ b/modules/api_ingress/src/lib.rs
@@ -130,8 +130,8 @@ impl ApiIngress {
         Ok(())
     }
 
-    /// Build auth state from operation specs
-    fn build_auth_state_from_specs(&self) -> Result<auth::AuthState> {
+    /// Build auth state and route policy from operation specs
+    fn build_auth_state_from_specs(&self) -> Result<(auth::AuthState, auth::IngressRoutePolicy)> {
         let mut req_map = std::collections::HashMap::new();
         let mut public_routes = std::collections::HashSet::new();
 
@@ -164,23 +164,25 @@ impl ApiIngress {
 
         let config = self.get_cached_config();
         let requirements_count = req_map.len();
-        let auth_state = auth::build_auth_state(&config, req_map, public_routes)?;
+        let public_routes_count = public_routes.len();
+
+        let (auth_state, route_policy) = auth::build_auth_state(&config, req_map, public_routes)?;
 
         tracing::info!(
             auth_disabled = config.auth_disabled,
             require_auth_by_default = config.require_auth_by_default,
             requirements_count = requirements_count,
-            public_routes_count = auth_state.public_routes.len(),
-            "Auth state built from operation specs"
+            public_routes_count = public_routes_count,
+            "Auth state and route policy built from operation specs"
         );
 
-        Ok(auth_state)
+        Ok((auth_state, route_policy))
     }
 
     /// Apply all middleware layers to a router (request ID, tracing, timeout, body limit, CORS, rate limiting, error mapping, auth)
     fn apply_middleware_stack(&self, mut router: Router) -> Result<Router> {
-        // Build auth state once
-        let auth_state = self.build_auth_state_from_specs()?;
+        // Build auth state and route policy once
+        let (auth_state, route_policy) = self.build_auth_state_from_specs()?;
 
         // Correct middleware order (outermost to innermost):
         // RequestId(Propagate -> Set) -> Trace -> push_req_id_to_extensions -> Timeout -> BodyLimit -> CORS -> RateLimit -> ErrorMapping -> Auth -> Router
@@ -291,12 +293,45 @@ impl ApiIngress {
         router = router.layer(from_fn(modkit::api::error_layer::error_mapping_middleware));
 
         // 10. Auth middleware - MUST be after CORS; preflight short-circuits before this.
-        router = router.layer(from_fn(
-            move |req: axum::extract::Request, next: axum::middleware::Next| {
-                let state = auth_state.clone();
-                auth::auth_middleware(state, req, next)
-            },
-        ));
+        let config = self.get_cached_config();
+        if config.auth_disabled {
+            tracing::warn!(
+                "API Ingress auth is DISABLED: all requests will run with root SecurityCtx. \
+                 This mode is for development only and MUST NOT be used in production."
+            );
+            router = router.layer(from_fn(
+                |mut req: axum::extract::Request, next: axum::middleware::Next| async move {
+                    let sec = modkit_security::SecurityCtx::root_ctx();
+                    req.extensions_mut().insert(sec);
+                    next.run(req).await
+                },
+            ));
+        } else {
+            let validator = auth_state.validator.clone();
+            let scope_builder = auth_state.scope_builder.clone();
+            let authorizer = auth_state.authorizer.clone();
+            let policy = Arc::new(route_policy) as Arc<dyn modkit_auth::RoutePolicy>;
+
+            router = router.layer(from_fn(
+                move |req: axum::extract::Request, next: axum::middleware::Next| {
+                    let validator = validator.clone();
+                    let scope_builder = scope_builder.clone();
+                    let authorizer = authorizer.clone();
+                    let policy = policy.clone();
+                    async move {
+                        modkit_auth::axum_ext::auth_with_policy(
+                            axum::extract::State(validator),
+                            axum::extract::State(scope_builder),
+                            axum::extract::State(authorizer),
+                            axum::extract::State(policy),
+                            req,
+                            next,
+                        )
+                        .await
+                    }
+                },
+            ));
+        }
 
         Ok(router)
     }


### PR DESCRIPTION
**Summary:**
Completed the full unification and cleanup of the ModKit authentication subsystem across `modkit-auth`, `modkit-security`, and `api_ingress`. Removed all duplicated logic, stabilized route-policy–based access control, and added comprehensive unit and integration tests.

**Key changes:**

* Finalized the `auth_with_policy` middleware as the single entry point for authentication and authorization.
* Migrated all Axum layers to idiomatic Axum 0.8 style — middleware now returns `Response` directly via `IntoResponse`.
* Simplified `auth_required` / `auth_optional` wrappers using static route policies.
* Introduced `AuthRequirement::{None, Required, Optional}` for explicit per-route behavior.
* Added `SecurityCtx::anonymous()` for unauthenticated contexts; kept `root_ctx()` only for internal system or `auth_disabled` mode.
* Removed all `Box::leak` usage and `&'static str` lifetimes from security requirements.
* Refactored `IngressRoutePolicy` to use `matchit` for safe path-pattern matching, supporting templated paths.
* Consolidated `AuthState` initialization and eliminated redundant `api_ingress` auth middleware.
* Added extensive unit and integration tests covering:

  * all `AuthRequirement` branches (`None`, `Required`, `Optional`),
  * JWT validation and RBAC enforcement,
  * preflight bypass and `auth_disabled` behavior,
  * `IngressRoutePolicy` matching and default-auth logic.

**Outcome:**
Authentication and authorization in ModKit are now fully centralized, leak-free, Axum 0.8-compliant, and covered by deterministic tests. The codebase is cleaner, safer, and production-ready.