### PR TITLE
Feature/secure orm explicit scope columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ logs
 /hapig/
 
 .cargo/advisory-db
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,12 +2119,9 @@ dependencies = [
 name = "modkit-auth"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "arc-swap",
  "async-trait",
  "axum",
- "base64 0.22.1",
- "chrono",
  "http",
  "jsonwebtoken",
  "modkit-security",
@@ -5142,6 +5139,7 @@ dependencies = [
  "modkit",
  "modkit-auth",
  "modkit-db",
+ "modkit-db-macros",
  "modkit-errors",
  "modkit-errors-macro",
  "modkit-odata",

--- a/config/no-auth.yaml
+++ b/config/no-auth.yaml
@@ -1,0 +1,50 @@
+# Configuration for running HyperSpot with authentication disabled
+# This mode automatically injects SecurityCtx::root_ctx() for all requests
+# WARNING: Only use for single-user on-premise installations
+
+# Module configurations
+api_ingress:
+  bind_addr: "0.0.0.0:8080"
+  enable_docs: true
+  cors_enabled: true
+  
+  # DISABLE AUTHENTICATION - All requests get root tenant context
+  # This bypasses all tenant isolation and provides full system-level access
+  auth_disabled: true
+  
+  # When auth is disabled, these JWT settings are ignored
+  # jwks_uri: "https://auth.example.com/.well-known/jwks.json"
+  # issuer: "https://auth.example.com"
+  # audience: "hyperspot-api"
+  
+  # Routes without explicit role annotations will not require authentication
+  # (irrelevant when auth_disabled is true, but kept for reference)
+  require_auth_by_default: false
+  
+  defaults:
+    rate_limit:
+      rps: 100
+      burst: 200
+      in_flight: 128
+    body_limit_bytes: 16777216  # 16 MB
+
+  cors:
+    allowed_origins:
+      - "*"
+    allowed_methods:
+      - "GET"
+      - "POST"
+      - "PUT"
+      - "PATCH"
+      - "DELETE"
+      - "OPTIONS"
+    allowed_headers:
+      - "*"
+    allow_credentials: false
+    max_age_seconds: 600
+
+# Example module with database access - will use root context
+users_info:
+  # Module-specific configuration
+  log_level: "info"
+

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -90,7 +90,7 @@ modules:
       enable_docs: true
       cors_enabled: false
       # Authentication Configuration
-      auth_disabled: false
+      auth_disabled: true
       require_auth_by_default: true
       
       # JWKS Configuration (replace with your OIDC provider)

--- a/examples/modkit/users_info/Cargo.toml
+++ b/examples/modkit/users_info/Cargo.toml
@@ -59,6 +59,7 @@ thiserror = "2.0"
 modkit = { path = "../../../libs/modkit" }
 # NOTE: insecure-escape enabled for migrations and example infrastructure code
 modkit-db = { path = "../../../libs/modkit-db", default-features = false, features = ["pg", "sea-orm", "insecure-escape"] }
+modkit-db-macros = { path = "../../../libs/modkit-db-macros" }
 modkit-auth = { path = "../../../libs/modkit-auth" }
 modkit-security = { path = "../../../libs/modkit-security" }
 modkit-errors = { path = "../../../libs/modkit-errors" }

--- a/examples/modkit/users_info/src/api/rest/dto.rs
+++ b/examples/modkit/users_info/src/api/rest/dto.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use crate::contract::model::{User, UserPatch};
+use crate::contract::model::{NewUser, User, UserPatch};
 
 /// REST DTO for user representation with serde/utoipa
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -22,6 +22,7 @@ pub struct CreateUserReq {
     /// Optional ID for the user. If not provided, a UUID v7 will be generated
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Uuid>,
+    pub tenant_id: Uuid,
     pub email: String,
     pub display_name: String,
 }
@@ -47,9 +48,16 @@ impl From<User> for UserDto {
     }
 }
 
-// Note: NewUser conversion requires tenant_id from SecurityCtx,
-// so we can't implement a simple From trait here.
-// The handler will construct NewUser manually.
+impl From<CreateUserReq> for NewUser {
+    fn from(req: CreateUserReq) -> Self {
+        Self {
+            id: req.id,
+            tenant_id: req.tenant_id,
+            email: req.email,
+            display_name: req.display_name,
+        }
+    }
+}
 
 impl From<UpdateUserReq> for UserPatch {
     fn from(req: UpdateUserReq) -> Self {

--- a/examples/modkit/users_info/src/infra/storage/entity.rs
+++ b/examples/modkit/users_info/src/infra/storage/entity.rs
@@ -1,10 +1,20 @@
 use chrono::{DateTime, Utc};
-use modkit_db::secure::ScopableEntity;
+use modkit_db_macros::Scopable;
 use sea_orm::entity::prelude::*;
 use uuid::Uuid;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+/// User entity with multi-tenant isolation.
+///
+/// This entity demonstrates the use of the `#[derive(Scopable)]` macro
+/// for automatic implementation of secure ORM scoping.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
 #[sea_orm(table_name = "users")]
+#[secure(
+    tenant_col = "tenant_id",  // Multi-tenant entity - scope by tenant_id
+    resource_col = "id",        // Primary resource identifier
+    no_owner,                   // No owner-based filtering
+    no_type                     // No type-based filtering
+)]
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: Uuid,
@@ -19,16 +29,3 @@ pub struct Model {
 pub enum Relation {}
 
 impl ActiveModelBehavior for ActiveModel {}
-
-// Implement ScopableEntity for secure ORM support
-// This is a multi-tenant entity with tenant isolation
-impl ScopableEntity for Entity {
-    fn tenant_col() -> Option<Self::Column> {
-        // Multi-tenant entity - scope by tenant_id
-        Some(Column::TenantId)
-    }
-
-    fn id_col() -> Self::Column {
-        Column::Id
-    }
-}

--- a/examples/modkit/users_info/src/infra/storage/migrations/add_tenant_support_002.rs
+++ b/examples/modkit/users_info/src/infra/storage/migrations/add_tenant_support_002.rs
@@ -18,7 +18,7 @@ impl MigrationTrait for Migration {
         let uk_tenant_email = "uk_users_tenant_email";
         let idx_tenant = "idx_users_tenant";
 
-        let root_tenant = "00000000-0000-0000-0000-000000000001";
+        let root_tenant = modkit_security::constants::ROOT_TENANT_ID;
 
         // 1) Add tenant_id column if it doesn't exist
         if !manager
@@ -190,22 +190,14 @@ impl MigrationTrait for Migration {
         }
 
         // 4) Drop the tenant_id column
-        match backend {
-            DB::Postgres | DB::MySql => {
-                manager
-                    .alter_table(
-                        Table::alter()
-                            .table(users)
-                            .drop_column(tenant_id)
-                            .to_owned(),
-                    )
-                    .await?;
-            }
-            DB::Sqlite => {
-                // SQLite does not support DROP COLUMN in all builds.
-                // You could rebuild the table if absolutely necessary, but skipping is safe for down migration.
-            }
-        }
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(users)
+                    .drop_column(tenant_id)
+                    .to_owned(),
+            )
+            .await?;
 
         Ok(())
     }

--- a/examples/modkit/users_info/tests/repo_root_scope.rs
+++ b/examples/modkit/users_info/tests/repo_root_scope.rs
@@ -1,0 +1,142 @@
+//! Test that repository operations work with root scope (system-level access).
+
+mod support;
+
+use modkit_db::secure::SecureConn;
+use modkit_odata::ODataQuery;
+use support::{ctx_allow_tenants, ctx_root, inmem_db, seed_user};
+use users_info::{
+    domain::repo::UsersRepository, infra::storage::sea_orm_repo::SeaOrmUsersRepository,
+};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn root_scope_can_access_all_tenants() {
+    // Arrange: Create database with users in different tenants
+    let db = inmem_db().await;
+    let tenant1 = Uuid::new_v4();
+    let tenant2 = Uuid::new_v4();
+    let user1_id = Uuid::new_v4();
+    let user2_id = Uuid::new_v4();
+
+    seed_user(&db, user1_id, tenant1, "user1@example.com", "User 1").await;
+    seed_user(&db, user2_id, tenant2, "user2@example.com", "User 2").await;
+
+    let sec = SecureConn::new(db);
+    let repo = SeaOrmUsersRepository::new(sec);
+
+    // Create root context
+    let ctx = ctx_root();
+
+    // Act: List users with root context
+    let query = ODataQuery::default();
+    let result = repo.list_users_page(&ctx, &query).await;
+
+    // Assert: Should return users from all tenants
+    assert!(result.is_ok(), "Root scope query should succeed");
+    let page = result.unwrap();
+    assert_eq!(page.items.len(), 2, "Root scope should access all tenants");
+}
+
+#[tokio::test]
+async fn root_scope_can_find_users_in_any_tenant() {
+    // Arrange: Create database with users in different tenants
+    let db = inmem_db().await;
+    let tenant1 = Uuid::new_v4();
+    let tenant2 = Uuid::new_v4();
+    let user1_id = Uuid::new_v4();
+    let user2_id = Uuid::new_v4();
+
+    let user1 = seed_user(&db, user1_id, tenant1, "user1@example.com", "User 1").await;
+    let user2 = seed_user(&db, user2_id, tenant2, "user2@example.com", "User 2").await;
+
+    let sec = SecureConn::new(db);
+    let repo = SeaOrmUsersRepository::new(sec);
+
+    // Create root context
+    let ctx_root = ctx_root();
+
+    // Act & Assert: Root context can find users in tenant1
+    let result1 = repo.find_by_id(&ctx_root, user1.id).await.unwrap();
+    assert!(result1.is_some(), "Root scope should find user in tenant1");
+    assert_eq!(result1.unwrap().email, "user1@example.com");
+
+    // Act & Assert: Root context can find users in tenant2
+    let result2 = repo.find_by_id(&ctx_root, user2.id).await.unwrap();
+    assert!(result2.is_some(), "Root scope should find user in tenant2");
+    assert_eq!(result2.unwrap().email, "user2@example.com");
+}
+
+#[tokio::test]
+async fn root_scope_vs_tenant_scope() {
+    // Arrange: Create database with users in different tenants
+    let db = inmem_db().await;
+    let tenant1 = Uuid::new_v4();
+    let tenant2 = Uuid::new_v4();
+    let user1_id = Uuid::new_v4();
+    let user2_id = Uuid::new_v4();
+
+    seed_user(&db, user1_id, tenant1, "user1@example.com", "User 1").await;
+    seed_user(&db, user2_id, tenant2, "user2@example.com", "User 2").await;
+
+    let sec = SecureConn::new(db);
+    let repo = SeaOrmUsersRepository::new(sec);
+
+    // Create different contexts
+    let ctx_root = ctx_root();
+    let ctx_tenant1 = ctx_allow_tenants(&[tenant1]);
+
+    // Act: List with root context
+    let query = ODataQuery::default();
+    let root_result = repo.list_users_page(&ctx_root, &query).await.unwrap();
+
+    // Act: List with tenant-scoped context
+    let tenant_result = repo.list_users_page(&ctx_tenant1, &query).await.unwrap();
+
+    // Assert: Root context sees all users
+    assert_eq!(
+        root_result.items.len(),
+        2,
+        "Root scope should see all users"
+    );
+
+    // Assert: Tenant-scoped context sees only its tenant
+    assert_eq!(
+        tenant_result.items.len(),
+        1,
+        "Tenant scope should see only its tenant"
+    );
+    assert_eq!(tenant_result.items[0].tenant_id, tenant1);
+}
+
+#[tokio::test]
+async fn root_scope_is_not_empty_scope() {
+    // Arrange: Create database with a test user
+    let db = inmem_db().await;
+    let tenant_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    seed_user(&db, user_id, tenant_id, "test@example.com", "Test User").await;
+
+    let sec = SecureConn::new(db);
+    let repo = SeaOrmUsersRepository::new(sec);
+
+    // Create contexts
+    let ctx_root = ctx_root();
+
+    // Verify scope properties
+    assert!(ctx_root.scope().is_root(), "Should be root scope");
+    assert!(
+        !ctx_root.scope().is_empty(),
+        "Root scope should not be empty"
+    );
+    assert!(!ctx_root.is_denied(), "Root scope should not be denied");
+
+    // Act: List with root context
+    let query = ODataQuery::default();
+    let result = repo.list_users_page(&ctx_root, &query).await;
+
+    // Assert: Should succeed and return data
+    assert!(result.is_ok(), "Root scope query should succeed");
+    let page = result.unwrap();
+    assert_eq!(page.items.len(), 1, "Root scope should access data");
+}

--- a/examples/modkit/users_info/tests/support.rs
+++ b/examples/modkit/users_info/tests/support.rs
@@ -51,6 +51,13 @@ pub fn ctx_deny_all() -> SecurityCtx {
     SecurityCtx::new(AccessScope::default(), subject)
 }
 
+/// Create a root security context (system-level access).
+///
+/// This context bypasses all tenant filtering and allows access to all data.
+pub fn ctx_root() -> SecurityCtx {
+    SecurityCtx::root_ctx()
+}
+
 /// Create a fresh in-memory SQLite database with migrations applied.
 ///
 /// Each call creates a new isolated database for testing.

--- a/libs/modkit-auth/Cargo.toml
+++ b/libs/modkit-auth/Cargo.toml
@@ -12,8 +12,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
-anyhow = { workspace = true }
-chrono = { workspace = true }
 tokio = { workspace = true }
 time = { version = "0.3", features = ["serde", "formatting", "parsing"] }
 arc-swap = "1.7"
@@ -22,7 +20,6 @@ tracing = { workspace = true }
 # JWT and crypto
 jsonwebtoken = "9"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
-base64 = "0.22"
 
 # Axum integration
 axum = { workspace = true, optional = true }

--- a/libs/modkit-db-macros/src/lib.rs
+++ b/libs/modkit-db-macros/src/lib.rs
@@ -8,6 +8,8 @@
 //!
 //! Automatically implements `ScopableEntity` for a SeaORM entity based on attributes.
 //!
+//! **IMPORTANT**: All four scope dimensions must be explicitly specified. No implicit defaults.
+//!
 //! ### Example
 //!
 //! ```ignore
@@ -16,7 +18,12 @@
 //!
 //! #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
 //! #[sea_orm(table_name = "users")]
-//! #[secure(tenant_col = "tenant_id")]
+//! #[secure(
+//!     tenant_col = "tenant_id",
+//!     resource_col = "id",
+//!     no_owner,
+//!     no_type
+//! )]
 //! pub struct Model {
 //!     #[sea_orm(primary_key)]
 //!     pub id: Uuid,
@@ -27,10 +34,12 @@
 //!
 //! ### Attributes
 //!
-//! - `tenant_col = "column_name"` - Optional. The column containing tenant ID.
-//! - `resource_col = "column_name"` - Optional. The primary resource ID column (defaults to "id").
-//! - `owner_col = "column_name"` - Optional. The column containing owner ID.
-//! - `entity = "EntityName"` - Optional. Override the entity type name (defaults to "Entity").
+//! Each scope dimension requires exactly one declaration:
+//! - **Tenant**: `tenant_col = "column_name"` OR `no_tenant`
+//! - **Resource**: `resource_col = "column_name"` OR `no_resource`
+//! - **Owner**: `owner_col = "column_name"` OR `no_owner`
+//! - **Type**: `type_col = "column_name"` OR `no_type`
+//! - **Unrestricted**: `unrestricted` (forbids all other attributes)
 
 use proc_macro::TokenStream;
 use proc_macro_error::proc_macro_error;
@@ -44,18 +53,25 @@ mod scopable;
 ///
 /// # Attributes
 ///
-/// - `#[secure(tenant_col = "tenant_id")]` - Specify tenant column name
-/// - `#[secure(resource_col = "custom_id")]` - Override default resource ID column
-/// - `#[secure(owner_col = "owner_id")]` - Specify owner column name
-/// - `#[secure(entity = "CustomEntity")]` - Override entity type name
-/// - `#[secure(unrestricted)]` - Mark entity as unrestricted (global entity)
+/// **All four scope dimensions must be explicitly specified:**
+///
+/// - `tenant_col = "column_name"` OR `no_tenant` - Tenant isolation column
+/// - `resource_col = "column_name"` OR `no_resource` - Primary resource ID column
+/// - `owner_col = "column_name"` OR `no_owner` - Owner-based filtering column
+/// - `type_col = "column_name"` OR `no_type` - Type-based filtering column
+/// - `unrestricted` - Mark as global entity (forbids all other attributes)
 ///
 /// # Example
 ///
 /// ```ignore
 /// #[derive(DeriveEntityModel, Scopable)]
 /// #[sea_orm(table_name = "users")]
-/// #[secure(tenant_col = "tenant_id")]
+/// #[secure(
+///     tenant_col = "tenant_id",
+///     resource_col = "id",
+///     no_owner,
+///     no_type
+/// )]
 /// pub struct Model {
 ///     #[sea_orm(primary_key)]
 ///     pub id: Uuid,

--- a/libs/modkit-db-macros/src/scopable.rs
+++ b/libs/modkit-db-macros/src/scopable.rs
@@ -7,10 +7,23 @@ use syn::{spanned::Spanned, Data, DeriveInput};
 /// Configuration parsed from `#[secure(...)]` attributes
 #[derive(Default)]
 struct SecureConfig {
+    // Tenant dimension
     tenant_col: Option<(String, Span)>,
+    no_tenant: Option<Span>,
+
+    // Resource dimension
     resource_col: Option<(String, Span)>,
+    no_resource: Option<Span>,
+
+    // Owner dimension
     owner_col: Option<(String, Span)>,
-    entity: Option<(String, Span)>,
+    no_owner: Option<Span>,
+
+    // Type dimension
+    type_col: Option<(String, Span)>,
+    no_type: Option<Span>,
+
+    // Unrestricted flag
     unrestricted: Option<Span>,
 }
 
@@ -26,92 +39,218 @@ pub fn expand_derive_scopable(input: DeriveInput) -> TokenStream {
     // Parse #[secure(...)] attributes
     let config = parse_secure_attrs(&input);
 
-    // Determine entity type name (default: "Entity")
-    let entity_name = config
-        .entity
-        .as_ref()
-        .map(|(s, _)| s.as_str())
-        .unwrap_or("Entity");
-    let entity_ident = syn::Ident::new(entity_name, input.ident.span());
+    // Validate configuration
+    validate_config(&config, &input);
 
-    // Check for conflicting flags
-    if config.unrestricted.is_some() && config.tenant_col.is_some() {
-        emit_error!(
-            config.unrestricted.unwrap(),
-            "Cannot use both 'unrestricted' and 'tenant_col' attributes";
-            note = config.tenant_col.as_ref().unwrap().1 => "tenant_col defined here"
-        );
+    let entity_ident = syn::Ident::new("Entity", input.ident.span());
+
+    // If unrestricted, generate simple implementation with all None
+    if config.unrestricted.is_some() {
+        return quote! {
+            impl ::modkit_db::secure::ScopableEntity for #entity_ident {
+                const IS_UNRESTRICTED: bool = true;
+
+                fn tenant_col() -> ::core::option::Option<Self::Column> {
+                    ::core::option::Option::None
+                }
+
+                fn resource_col() -> ::core::option::Option<Self::Column> {
+                    ::core::option::Option::None
+                }
+
+                fn owner_col() -> ::core::option::Option<Self::Column> {
+                    ::core::option::Option::None
+                }
+
+                fn type_col() -> ::core::option::Option<Self::Column> {
+                    ::core::option::Option::None
+                }
+            }
+        };
     }
 
-    // Determine column names with defaults
-    let resource_col = config
-        .resource_col
-        .as_ref()
-        .map(|(s, _)| s.as_str())
-        .unwrap_or("id");
-
-    // Convert column names from snake_case to UpperCamelCase for enum variants
-    let resource_variant = snake_to_upper_camel(resource_col);
-    let tenant_variant = config
-        .tenant_col
-        .as_ref()
-        .map(|(s, _)| snake_to_upper_camel(s));
-    let owner_variant = config
-        .owner_col
-        .as_ref()
-        .map(|(s, _)| snake_to_upper_camel(s));
-
-    // Generate column identifiers
-    let resource_col_ident = syn::Ident::new(&resource_variant, input.ident.span());
-
     // Generate tenant_col implementation
-    let tenant_col_impl = if let Some(tenant_var) = tenant_variant {
-        let tenant_col_ident = syn::Ident::new(&tenant_var, input.ident.span());
-        quote! {
-            fn tenant_col() -> ::core::option::Option<Self::Column> {
-                ::core::option::Option::Some(Self::Column::#tenant_col_ident)
-            }
-        }
-    } else {
-        quote! {
-            fn tenant_col() -> ::core::option::Option<Self::Column> {
-                ::core::option::Option::None
-            }
-        }
-    };
+    let tenant_col_impl = generate_col_impl("tenant_col", &config.tenant_col, &input.ident.span());
+
+    // Generate resource_col implementation
+    let resource_col_impl =
+        generate_col_impl("resource_col", &config.resource_col, &input.ident.span());
 
     // Generate owner_col implementation
-    let owner_col_impl = if let Some(owner_var) = owner_variant {
-        let owner_col_ident = syn::Ident::new(&owner_var, input.ident.span());
-        quote! {
-            fn owner_col() -> ::core::option::Option<Self::Column> {
-                ::core::option::Option::Some(Self::Column::#owner_col_ident)
-            }
-        }
-    } else {
-        quote! {
-            // Use default implementation (returns None)
-        }
-    };
+    let owner_col_impl = generate_col_impl("owner_col", &config.owner_col, &input.ident.span());
 
-    // Generate IS_UNRESTRICTED constant
-    let is_unrestricted = config.unrestricted.is_some();
-    let is_unrestricted_impl = quote! {
-        const IS_UNRESTRICTED: bool = #is_unrestricted;
-    };
+    // Generate type_col implementation
+    let type_col_impl = generate_col_impl("type_col", &config.type_col, &input.ident.span());
 
     // Generate the implementation
     quote! {
         impl ::modkit_db::secure::ScopableEntity for #entity_ident {
-            #is_unrestricted_impl
-
-            fn id_col() -> Self::Column {
-                Self::Column::#resource_col_ident
-            }
+            const IS_UNRESTRICTED: bool = false;
 
             #tenant_col_impl
 
+            #resource_col_impl
+
             #owner_col_impl
+
+            #type_col_impl
+        }
+    }
+}
+
+/// Generate a column method implementation
+fn generate_col_impl(
+    method_name: &str,
+    col: &Option<(String, Span)>,
+    default_span: &Span,
+) -> TokenStream {
+    let method_ident = syn::Ident::new(method_name, *default_span);
+
+    if let Some((col_name, _)) = col {
+        let col_variant = snake_to_upper_camel(col_name);
+        let col_ident = syn::Ident::new(&col_variant, *default_span);
+        quote! {
+            fn #method_ident() -> ::core::option::Option<Self::Column> {
+                ::core::option::Option::Some(Self::Column::#col_ident)
+            }
+        }
+    } else {
+        quote! {
+            fn #method_ident() -> ::core::option::Option<Self::Column> {
+                ::core::option::Option::None
+            }
+        }
+    }
+}
+
+/// Validate the configuration for strict compile-time checks
+fn validate_config(config: &SecureConfig, input: &DeriveInput) {
+    let struct_span = input.span();
+
+    // If unrestricted is set, no other attributes should be present
+    if let Some(unrestricted_span) = config.unrestricted {
+        let mut has_error = false;
+
+        if let Some((_, span)) = &config.tenant_col {
+            emit_error!(
+                unrestricted_span,
+                "Cannot use 'unrestricted' with 'tenant_col'";
+                note = *span => "tenant_col defined here"
+            );
+            has_error = true;
+        }
+        if let Some(span) = &config.no_tenant {
+            emit_error!(
+                unrestricted_span,
+                "Cannot use 'unrestricted' with 'no_tenant'";
+                note = *span => "no_tenant defined here"
+            );
+            has_error = true;
+        }
+        if let Some((_, span)) = &config.resource_col {
+            emit_error!(
+                unrestricted_span,
+                "Cannot use 'unrestricted' with 'resource_col'";
+                note = *span => "resource_col defined here"
+            );
+            has_error = true;
+        }
+        if let Some(span) = &config.no_resource {
+            emit_error!(
+                unrestricted_span,
+                "Cannot use 'unrestricted' with 'no_resource'";
+                note = *span => "no_resource defined here"
+            );
+            has_error = true;
+        }
+        if let Some((_, span)) = &config.owner_col {
+            emit_error!(
+                unrestricted_span,
+                "Cannot use 'unrestricted' with 'owner_col'";
+                note = *span => "owner_col defined here"
+            );
+            has_error = true;
+        }
+        if let Some(span) = &config.no_owner {
+            emit_error!(
+                unrestricted_span,
+                "Cannot use 'unrestricted' with 'no_owner'";
+                note = *span => "no_owner defined here"
+            );
+            has_error = true;
+        }
+        if let Some((_, span)) = &config.type_col {
+            emit_error!(
+                unrestricted_span,
+                "Cannot use 'unrestricted' with 'type_col'";
+                note = *span => "type_col defined here"
+            );
+            has_error = true;
+        }
+        if let Some(span) = &config.no_type {
+            emit_error!(
+                unrestricted_span,
+                "Cannot use 'unrestricted' with 'no_type'";
+                note = *span => "no_type defined here"
+            );
+            has_error = true;
+        }
+
+        if has_error {
+            abort!(
+                unrestricted_span,
+                "When using 'unrestricted', no other column attributes are allowed"
+            );
+        }
+        return; // Valid unrestricted config
+    }
+
+    // Check each scope dimension has exactly one option
+    validate_dimension("tenant", &config.tenant_col, &config.no_tenant, struct_span);
+    validate_dimension(
+        "resource",
+        &config.resource_col,
+        &config.no_resource,
+        struct_span,
+    );
+    validate_dimension("owner", &config.owner_col, &config.no_owner, struct_span);
+    validate_dimension("type", &config.type_col, &config.no_type, struct_span);
+}
+
+/// Validate a single dimension has exactly one specification
+fn validate_dimension(
+    name: &str,
+    col: &Option<(String, Span)>,
+    no_col: &Option<Span>,
+    struct_span: Span,
+) {
+    match (col, no_col) {
+        (None, None) => {
+            // Missing explicit decision
+            let msg = format!(
+                "secure: missing explicit decision for {}:\n  \
+                 use `{}_col = \"column_name\"` or `no_{}`",
+                name, name, name
+            );
+            abort!(struct_span, msg);
+        }
+        (Some((_, col_span)), Some(no_span)) => {
+            // Both specified
+            let msg = format!("secure: conflicting attributes for {}", name);
+            let note_msg = format!("no_{} also defined here", name);
+            emit_error!(
+                *col_span,
+                msg;
+                note = *no_span => note_msg
+            );
+            let abort_msg = format!(
+                "secure: specify either `{}_col` or `no_{}`, not both",
+                name, name
+            );
+            abort!(struct_span, abort_msg);
+        }
+        _ => {
+            // Valid: exactly one is specified
         }
     }
 }
@@ -126,9 +265,10 @@ fn parse_secure_attrs(input: &DeriveInput) -> SecureConfig {
         }
 
         let result = attr.parse_nested_meta(|meta| {
-            // Check if this is a flag (unrestricted) or key-value pair
+            let span = meta.path.span();
+
+            // Check if this is a flag (no_* or unrestricted)
             if meta.path.is_ident("unrestricted") {
-                let span = meta.path.span();
                 if let Some(prev_span) = config.unrestricted {
                     abort!(
                         span,
@@ -140,13 +280,60 @@ fn parse_secure_attrs(input: &DeriveInput) -> SecureConfig {
                 return Ok(());
             }
 
+            if meta.path.is_ident("no_tenant") {
+                if let Some(prev_span) = config.no_tenant {
+                    abort!(
+                        span,
+                        "duplicate attribute 'no_tenant'";
+                        note = prev_span => "first defined here"
+                    );
+                }
+                config.no_tenant = Some(span);
+                return Ok(());
+            }
+
+            if meta.path.is_ident("no_resource") {
+                if let Some(prev_span) = config.no_resource {
+                    abort!(
+                        span,
+                        "duplicate attribute 'no_resource'";
+                        note = prev_span => "first defined here"
+                    );
+                }
+                config.no_resource = Some(span);
+                return Ok(());
+            }
+
+            if meta.path.is_ident("no_owner") {
+                if let Some(prev_span) = config.no_owner {
+                    abort!(
+                        span,
+                        "duplicate attribute 'no_owner'";
+                        note = prev_span => "first defined here"
+                    );
+                }
+                config.no_owner = Some(span);
+                return Ok(());
+            }
+
+            if meta.path.is_ident("no_type") {
+                if let Some(prev_span) = config.no_type {
+                    abort!(
+                        span,
+                        "duplicate attribute 'no_type'";
+                        note = prev_span => "first defined here"
+                    );
+                }
+                config.no_type = Some(span);
+                return Ok(());
+            }
+
             // Key-value pair
             let key = meta
                 .path
                 .get_ident()
                 .map(|i| i.to_string())
                 .unwrap_or_default();
-            let span = meta.path.span();
 
             if key.is_empty() {
                 abort!(span, "Expected attribute name");
@@ -191,20 +378,20 @@ fn parse_secure_attrs(input: &DeriveInput) -> SecureConfig {
                     }
                     config.owner_col = Some((value, span));
                 }
-                "entity" => {
-                    if let Some((_, prev_span)) = config.entity {
+                "type_col" => {
+                    if let Some((_, prev_span)) = config.type_col {
                         abort!(
                             span,
-                            "duplicate attribute 'entity'";
+                            "duplicate attribute 'type_col'";
                             note = prev_span => "first defined here"
                         );
                     }
-                    config.entity = Some((value, span));
+                    config.type_col = Some((value, span));
                 }
                 _ => {
                     abort!(
                         span,
-                        "Unknown attribute '{}'. Valid attributes: tenant_col, resource_col, owner_col, entity, unrestricted",
+                        "Unknown attribute '{}'. Valid attributes: tenant_col, no_tenant, resource_col, no_resource, owner_col, no_owner, type_col, no_type, unrestricted",
                         key
                     );
                 }

--- a/libs/modkit-db-macros/tests/compile.rs
+++ b/libs/modkit-db-macros/tests/compile.rs
@@ -1,13 +1,30 @@
 // Compile-fail tests for the Scopable derive macro.
 // IMPORTANT: These files must not import external crates like sea_orm or uuid.
 // We only validate macro input diagnostics here.
+//
+// Note: We don't test successful macro expansions here because they would require
+// importing the modkit-db crate. The macro is tested in actual usage in the main codebase.
 
 #[test]
 fn trybuild_tests() {
     let t = trybuild::TestCases::new();
 
+    // Error cases: Basic validation
     t.compile_fail("tests/ui/err_unknown_attr.rs");
     t.compile_fail("tests/ui/err_non_struct.rs");
     t.compile_fail("tests/ui/err_duplicate_tenant_col.rs");
+
+    // Error cases: Missing explicit decisions
+    t.compile_fail("tests/ui/err_missing_tenant_decision.rs");
+    t.compile_fail("tests/ui/err_missing_resource_decision.rs");
+    t.compile_fail("tests/ui/err_missing_owner_decision.rs");
+    t.compile_fail("tests/ui/err_missing_type_decision.rs");
+
+    // Error cases: Conflicting attributes
+    t.compile_fail("tests/ui/err_conflicting_tenant.rs");
+    t.compile_fail("tests/ui/err_conflicting_resource.rs");
+
+    // Error cases: Unrestricted with other flags
     t.compile_fail("tests/ui/err_unrestricted_with_tenant.rs");
+    t.compile_fail("tests/ui/err_unrestricted_with_resource.rs");
 }

--- a/libs/modkit-db-macros/tests/ui/err_conflicting_resource.rs
+++ b/libs/modkit-db-macros/tests/ui/err_conflicting_resource.rs
@@ -1,0 +1,16 @@
+// Both resource_col and no_resource specified should produce a compile error.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(
+    tenant_col = "tenant_id",
+    resource_col = "id",
+    no_resource,
+    no_owner,
+    no_type
+)]
+struct Model;
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/err_conflicting_resource.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_conflicting_resource.stderr
@@ -1,0 +1,14 @@
+error: secure: conflicting attributes for resource
+
+         = note: no_resource also defined here
+
+ --> tests/ui/err_conflicting_resource.rs:8:5
+  |
+8 |     resource_col = "id",
+  |     ^^^^^^^^^^^^
+
+error: secure: specify either `resource_col` or `no_resource`, not both
+ --> tests/ui/err_conflicting_resource.rs:6:1
+  |
+6 | #[secure(
+  | ^

--- a/libs/modkit-db-macros/tests/ui/err_conflicting_tenant.rs
+++ b/libs/modkit-db-macros/tests/ui/err_conflicting_tenant.rs
@@ -1,0 +1,16 @@
+// Both tenant_col and no_tenant specified should produce a compile error.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(
+    tenant_col = "tenant_id",
+    no_tenant,
+    resource_col = "id",
+    no_owner,
+    no_type
+)]
+struct Model;
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/err_conflicting_tenant.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_conflicting_tenant.stderr
@@ -1,0 +1,14 @@
+error: secure: conflicting attributes for tenant
+
+         = note: no_tenant also defined here
+
+ --> tests/ui/err_conflicting_tenant.rs:7:5
+  |
+7 |     tenant_col = "tenant_id",
+  |     ^^^^^^^^^^
+
+error: secure: specify either `tenant_col` or `no_tenant`, not both
+ --> tests/ui/err_conflicting_tenant.rs:6:1
+  |
+6 | #[secure(
+  | ^

--- a/libs/modkit-db-macros/tests/ui/err_missing_owner_decision.rs
+++ b/libs/modkit-db-macros/tests/ui/err_missing_owner_decision.rs
@@ -1,0 +1,14 @@
+// Missing explicit owner decision should produce a compile error.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(
+    tenant_col = "tenant_id",
+    resource_col = "id",
+    no_type
+)]
+struct Model;
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/err_missing_owner_decision.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_missing_owner_decision.stderr
@@ -1,0 +1,6 @@
+error: secure: missing explicit decision for owner:
+         use `owner_col = "column_name"` or `no_owner`
+ --> tests/ui/err_missing_owner_decision.rs:6:1
+  |
+6 | #[secure(
+  | ^

--- a/libs/modkit-db-macros/tests/ui/err_missing_resource_decision.rs
+++ b/libs/modkit-db-macros/tests/ui/err_missing_resource_decision.rs
@@ -1,0 +1,14 @@
+// Missing explicit resource decision should produce a compile error.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(
+    tenant_col = "tenant_id",
+    no_owner,
+    no_type
+)]
+struct Model;
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/err_missing_resource_decision.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_missing_resource_decision.stderr
@@ -1,0 +1,6 @@
+error: secure: missing explicit decision for resource:
+         use `resource_col = "column_name"` or `no_resource`
+ --> tests/ui/err_missing_resource_decision.rs:6:1
+  |
+6 | #[secure(
+  | ^

--- a/libs/modkit-db-macros/tests/ui/err_missing_tenant_decision.rs
+++ b/libs/modkit-db-macros/tests/ui/err_missing_tenant_decision.rs
@@ -1,0 +1,14 @@
+// Missing explicit tenant decision should produce a compile error.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(
+    resource_col = "id",
+    no_owner,
+    no_type
+)]
+struct Model;
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/err_missing_tenant_decision.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_missing_tenant_decision.stderr
@@ -1,0 +1,6 @@
+error: secure: missing explicit decision for tenant:
+         use `tenant_col = "column_name"` or `no_tenant`
+ --> tests/ui/err_missing_tenant_decision.rs:6:1
+  |
+6 | #[secure(
+  | ^

--- a/libs/modkit-db-macros/tests/ui/err_missing_type_decision.rs
+++ b/libs/modkit-db-macros/tests/ui/err_missing_type_decision.rs
@@ -1,0 +1,14 @@
+// Missing explicit type decision should produce a compile error.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(
+    tenant_col = "tenant_id",
+    resource_col = "id",
+    no_owner
+)]
+struct Model;
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/err_missing_type_decision.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_missing_type_decision.stderr
@@ -1,0 +1,6 @@
+error: secure: missing explicit decision for type:
+         use `type_col = "column_name"` or `no_type`
+ --> tests/ui/err_missing_type_decision.rs:6:1
+  |
+6 | #[secure(
+  | ^

--- a/libs/modkit-db-macros/tests/ui/err_unknown_attr.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_unknown_attr.stderr
@@ -1,4 +1,4 @@
-error: Unknown attribute 'does_not_exist'. Valid attributes: tenant_col, resource_col, owner_col, entity, unrestricted
+error: Unknown attribute 'does_not_exist'. Valid attributes: tenant_col, no_tenant, resource_col, no_resource, owner_col, no_owner, type_col, no_type, unrestricted
  --> tests/ui/err_unknown_attr.rs:6:10
   |
 6 | #[secure(does_not_exist = "oops")]

--- a/libs/modkit-db-macros/tests/ui/err_unrestricted_with_no_tenant.rs
+++ b/libs/modkit-db-macros/tests/ui/err_unrestricted_with_no_tenant.rs
@@ -1,0 +1,10 @@
+// Using unrestricted with no_tenant should produce a compile error.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(unrestricted, no_tenant)]
+struct Model;
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/err_unrestricted_with_no_tenant.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_unrestricted_with_no_tenant.stderr
@@ -1,0 +1,18 @@
+error: Cannot use 'unrestricted' with 'no_tenant'
+ --> tests/ui/err_unrestricted_with_no_tenant.rs:6:9
+  |
+6 | #[secure(unrestricted, no_tenant)]
+  |         ^^^^^^^^^^^^
+  |
+note: no_tenant defined here
+ --> tests/ui/err_unrestricted_with_no_tenant.rs:6:24
+  |
+6 | #[secure(unrestricted, no_tenant)]
+  |                        ^^^^^^^^^
+
+error: When using 'unrestricted', no other column attributes are allowed
+ --> tests/ui/err_unrestricted_with_no_tenant.rs:6:9
+  |
+6 | #[secure(unrestricted, no_tenant)]
+  |         ^^^^^^^^^^^^
+

--- a/libs/modkit-db-macros/tests/ui/err_unrestricted_with_owner.rs
+++ b/libs/modkit-db-macros/tests/ui/err_unrestricted_with_owner.rs
@@ -1,0 +1,10 @@
+// Using unrestricted with owner_col should produce a compile error.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(unrestricted, owner_col = "owner_id")]
+struct Model;
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/err_unrestricted_with_owner.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_unrestricted_with_owner.stderr
@@ -1,0 +1,18 @@
+error: Cannot use 'unrestricted' with 'owner_col'
+ --> tests/ui/err_unrestricted_with_owner.rs:6:9
+  |
+6 | #[secure(unrestricted, owner_col = "owner_id")]
+  |         ^^^^^^^^^^^^
+  |
+note: owner_col defined here
+ --> tests/ui/err_unrestricted_with_owner.rs:6:24
+  |
+6 | #[secure(unrestricted, owner_col = "owner_id")]
+  |                        ^^^^^^^^^
+
+error: When using 'unrestricted', no other column attributes are allowed
+ --> tests/ui/err_unrestricted_with_owner.rs:6:9
+  |
+6 | #[secure(unrestricted, owner_col = "owner_id")]
+  |         ^^^^^^^^^^^^
+

--- a/libs/modkit-db-macros/tests/ui/err_unrestricted_with_resource.rs
+++ b/libs/modkit-db-macros/tests/ui/err_unrestricted_with_resource.rs
@@ -1,0 +1,10 @@
+// Using unrestricted with resource_col should produce a compile error.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(unrestricted, resource_col = "id")]
+struct Model;
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/err_unrestricted_with_resource.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_unrestricted_with_resource.stderr
@@ -1,0 +1,14 @@
+error: Cannot use 'unrestricted' with 'resource_col'
+
+         = note: resource_col defined here
+
+ --> tests/ui/err_unrestricted_with_resource.rs:6:10
+  |
+6 | #[secure(unrestricted, resource_col = "id")]
+  |          ^^^^^^^^^^^^
+
+error: When using 'unrestricted', no other column attributes are allowed
+ --> tests/ui/err_unrestricted_with_resource.rs:6:10
+  |
+6 | #[secure(unrestricted, resource_col = "id")]
+  |          ^^^^^^^^^^^^

--- a/libs/modkit-db-macros/tests/ui/err_unrestricted_with_tenant.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_unrestricted_with_tenant.stderr
@@ -1,7 +1,13 @@
-error: Cannot use both 'unrestricted' and 'tenant_col' attributes
+error: Cannot use 'unrestricted' with 'tenant_col'
 
          = note: tenant_col defined here
 
+ --> tests/ui/err_unrestricted_with_tenant.rs:6:10
+  |
+6 | #[secure(unrestricted, tenant_col = "tenant_id")]
+  |          ^^^^^^^^^^^^
+
+error: When using 'unrestricted', no other column attributes are allowed
  --> tests/ui/err_unrestricted_with_tenant.rs:6:10
   |
 6 | #[secure(unrestricted, tenant_col = "tenant_id")]

--- a/libs/modkit-db-macros/tests/ui/err_unrestricted_with_type.rs
+++ b/libs/modkit-db-macros/tests/ui/err_unrestricted_with_type.rs
@@ -1,0 +1,10 @@
+// Using unrestricted with type_col should produce a compile error.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(unrestricted, type_col = "type_id")]
+struct Model;
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/err_unrestricted_with_type.stderr
+++ b/libs/modkit-db-macros/tests/ui/err_unrestricted_with_type.stderr
@@ -1,0 +1,18 @@
+error: Cannot use 'unrestricted' with 'type_col'
+ --> tests/ui/err_unrestricted_with_type.rs:6:9
+  |
+6 | #[secure(unrestricted, type_col = "type_id")]
+  |         ^^^^^^^^^^^^
+  |
+note: type_col defined here
+ --> tests/ui/err_unrestricted_with_type.rs:6:24
+  |
+6 | #[secure(unrestricted, type_col = "type_id")]
+  |                        ^^^^^^^^
+
+error: When using 'unrestricted', no other column attributes are allowed
+ --> tests/ui/err_unrestricted_with_type.rs:6:9
+  |
+6 | #[secure(unrestricted, type_col = "type_id")]
+  |         ^^^^^^^^^^^^
+

--- a/libs/modkit-db-macros/tests/ui/ok_all_cols_specified.rs
+++ b/libs/modkit-db-macros/tests/ui/ok_all_cols_specified.rs
@@ -1,0 +1,21 @@
+// All columns explicitly specified - macro should expand without errors.
+// Note: This test only validates macro expansion, not the full trait implementation.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(
+    tenant_col = "tenant_id",
+    resource_col = "id",
+    owner_col = "owner_id",
+    type_col = "type_id"
+)]
+struct Model {
+    tenant_id: String,
+    id: String,
+    owner_id: String,
+    type_id: String,
+}
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/ok_unrestricted.rs
+++ b/libs/modkit-db-macros/tests/ui/ok_unrestricted.rs
@@ -1,0 +1,13 @@
+// Unrestricted flag with no other attributes - macro should expand without errors.
+// Note: This test only validates macro expansion, not the full trait implementation.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(unrestricted)]
+struct Model {
+    id: String,
+}
+
+fn main() {}
+

--- a/libs/modkit-db-macros/tests/ui/ok_with_no_flags.rs
+++ b/libs/modkit-db-macros/tests/ui/ok_with_no_flags.rs
@@ -1,0 +1,19 @@
+// Using no_* flags explicitly - macro should expand without errors.
+// Note: This test only validates macro expansion, not the full trait implementation.
+
+use modkit_db_macros::Scopable;
+
+#[derive(Scopable)]
+#[secure(
+    tenant_col = "tenant_id",
+    resource_col = "id",
+    no_owner,
+    no_type
+)]
+struct Model {
+    tenant_id: String,
+    id: String,
+}
+
+fn main() {}
+

--- a/libs/modkit-db/src/odata/core.rs
+++ b/libs/modkit-db/src/odata/core.rs
@@ -748,21 +748,17 @@ where
     ) -> ODataBuildResult<Self> {
         let mut select = self;
 
-        // Apply filter first
         if let Some(ast) = query.filter.as_deref() {
             let cond = expr_to_condition::<E>(ast, fld_map)?;
             select = select.filter(cond);
         }
 
-        // Ensure tiebreaker is present in order
         let effective_order = ensure_tiebreaker(query.order.clone(), tiebreaker.0, tiebreaker.1);
 
-        // Apply cursor if present
         if let Some(cursor) = &query.cursor {
             select = select.apply_cursor_forward(cursor, &effective_order, fld_map)?;
         }
 
-        // Apply ordering
         select = select.apply_odata_order(&effective_order, fld_map)?;
 
         Ok(select)

--- a/libs/modkit-db/src/secure/cond.rs
+++ b/libs/modkit-db/src/secure/cond.rs
@@ -7,11 +7,14 @@ use crate::secure::{AccessScope, ScopableEntity};
 /// Builds a SeaORM `Condition` based on the implicit security policy.
 ///
 /// # Policy Rules
-/// 1. **Empty scope** (no tenants, no resources) → deny all (`false`)
-/// 2. **Tenants only** → filter by `tenant_col IN tenant_ids` (via provider)
+/// 1. **Empty scope** (no tenants, no resources, not root) → deny all (`false`)
+/// 2. **Root scope** → bypass tenant filtering entirely
+///    - If no resource filters either → return `Condition::all()` (no filters)
+///    - If resource filters present → apply only resource filters
+/// 3. **Tenants only** → filter by `tenant_col IN tenant_ids` (via provider)
 ///    - If entity has no tenant_col but tenant_ids provided → deny all
-/// 3. **Resources only** → filter by `id_col IN resource_ids`
-/// 4. **Both present** → AND them: `(tenant_col IN ...) AND (id_col IN ...)`
+/// 4. **Resources only** → filter by `resource_col IN resource_ids`
+/// 5. **Both present** → AND them: `(tenant_col IN ...) AND (resource_col IN ...)`
 ///
 /// # Provider Pattern
 ///
@@ -21,6 +24,7 @@ use crate::secure::{AccessScope, ScopableEntity};
 ///
 /// This ensures that:
 /// - No query can bypass tenant isolation when tenants are specified
+/// - Root scope explicitly bypasses all tenant filtering for system-level access
 /// - Explicit resource IDs provide fine-grained access
 /// - Empty scopes are explicitly denied rather than returning all data
 pub fn build_scope_condition<E>(scope: &AccessScope) -> Result<Condition, ScopeError>
@@ -37,27 +41,26 @@ where
 
     let mut parts: Vec<Condition> = Vec::new();
 
-    // Build tenant filter using provider pattern
     if let Some(tenant_cond) = SimpleTenantFilter::tenant_condition::<E>(scope) {
         parts.push(tenant_cond);
     }
 
-    // Build resource ID filter
     if !scope.resource_ids().is_empty() {
-        let id_col = E::id_col();
-        let id_filter =
-            Condition::all().add(Expr::col(id_col).is_in(scope.resource_ids().to_vec()));
-        parts.push(id_filter);
+        if let Some(resource_col) = E::resource_col() {
+            let id_filter =
+                Condition::all().add(Expr::col(resource_col).is_in(scope.resource_ids().to_vec()));
+            parts.push(id_filter);
+        } else {
+            // Entity has no resource_col but scope requires resource filtering → deny all
+            return Ok(deny_all());
+        }
     }
 
-    // Combine parts
     let cond = match parts.as_slice() {
-        // Only one constraint
         [only] => only.clone(),
-        // Both constraints → AND them
         [a, b] => Condition::all().add(a.clone()).add(b.clone()),
-        // Neither (shouldn't happen due to earlier checks)
-        [] => deny_all(),
+        [] if scope.is_root() => Condition::all(), // root with no filters at all
+        [] => deny_all(),                          // non-root, no filters → deny all
         _ => unreachable!(),
     };
 

--- a/libs/modkit-db/src/secure/docs.rs
+++ b/libs/modkit-db/src/secure/docs.rs
@@ -41,8 +41,14 @@
 //!     fn tenant_col() -> Option<Self::Column> {
 //!         Some(user::Column::TenantId)  // Multi-tenant entity
 //!     }
-//!     fn id_col() -> Self::Column {
-//!         user::Column::Id
+//!     fn resource_col() -> Option<Self::Column> {
+//!         Some(user::Column::Id)
+//!     }
+//!     fn owner_col() -> Option<Self::Column> {
+//!         None
+//!     }
+//!     fn type_col() -> Option<Self::Column> {
+//!         None
 //!     }
 //! }
 //!
@@ -51,8 +57,14 @@
 //!     fn tenant_col() -> Option<Self::Column> {
 //!         None  // Global entity
 //!     }
-//!     fn id_col() -> Self::Column {
-//!         system_config::Column::Id
+//!     fn resource_col() -> Option<Self::Column> {
+//!         Some(system_config::Column::Id)
+//!     }
+//!     fn owner_col() -> Option<Self::Column> {
+//!         None
+//!     }
+//!     fn type_col() -> Option<Self::Column> {
+//!         None
 //!     }
 //! }
 //! ```
@@ -87,8 +99,8 @@
 //! | Empty (no tenant, no resource) | `WHERE 1=0` (deny all) |
 //! | Tenants only | `WHERE tenant_id IN (...)` |
 //! | Tenants only + entity has no tenant_col | `WHERE 1=0` (deny all) |
-//! | Resources only | `WHERE id IN (...)` |
-//! | Both tenants and resources | `WHERE tenant_id IN (...) AND id IN (...)` |
+//! | Resources only | `WHERE resource_col IN (...)` |
+//! | Both tenants and resources | `WHERE tenant_col IN (...) AND resource_col IN (...)` |
 //!
 //! ## Usage Examples
 //!

--- a/libs/modkit-db/src/secure/mod.rs
+++ b/libs/modkit-db/src/secure/mod.rs
@@ -36,7 +36,12 @@
 //! // 1. Derive Scopable for your entity (or implement manually)
 //! #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
 //! #[sea_orm(table_name = "users")]
-//! #[secure(tenant_col = "tenant_id")]
+//! #[secure(
+//!     tenant_col = "tenant_id",
+//!     resource_col = "id",
+//!     no_owner,
+//!     no_type
+//! )]
 //! pub struct Model {
 //!     #[sea_orm(primary_key)]
 //!     pub id: Uuid,
@@ -66,8 +71,14 @@
 //!     fn tenant_col() -> Option<Self::Column> {
 //!         Some(Column::TenantId)
 //!     }
-//!     fn id_col() -> Self::Column {
-//!         Column::Id
+//!     fn resource_col() -> Option<Self::Column> {
+//!         Some(Column::Id)
+//!     }
+//!     fn owner_col() -> Option<Self::Column> {
+//!         None
+//!     }
+//!     fn type_col() -> Option<Self::Column> {
+//!         None
 //!     }
 //! }
 //! ```

--- a/libs/modkit-db/src/secure/provider.rs
+++ b/libs/modkit-db/src/secure/provider.rs
@@ -46,6 +46,11 @@ impl TenantFilterProvider for SimpleTenantFilter {
         E: ScopableEntity + EntityTrait,
         E::Column: ColumnTrait + Copy,
     {
+        // Root scope: skip tenant filtering entirely
+        if scope.is_root() {
+            return None;
+        }
+
         // No tenant IDs in scope → no tenant filter
         if scope.tenant_ids().is_empty() {
             return None;
@@ -68,8 +73,6 @@ mod tests {
     // Note: Full integration tests with SeaORM entities should be written in actual
     // application code where real entities are defined. These are basic unit tests
     // for the provider trait pattern.
-    //
-    // See USAGE_EXAMPLE.md for complete usage examples with real SeaORM entities.
 
     #[test]
     fn test_provider_trait_compiles() {

--- a/libs/modkit-db/src/secure/select.rs
+++ b/libs/modkit-db/src/secure/select.rs
@@ -132,12 +132,17 @@ where
     ///     .one(conn)
     ///     .await?;
     /// ```
+    ///
+    /// # Panics
+    /// Panics if the entity does not have a resource_col defined.
     pub fn and_id(self, id: uuid::Uuid) -> Self
     where
         E: ScopableEntity,
         E::Column: ColumnTrait + Copy,
     {
-        let cond = sea_orm::Condition::all().add(Expr::col(E::id_col()).eq(id));
+        let resource_col =
+            E::resource_col().expect("Entity must have a resource_col to use and_id()");
+        let cond = sea_orm::Condition::all().add(Expr::col(resource_col).eq(id));
         self.filter(cond)
     }
 

--- a/libs/modkit-db/src/secure/tests.rs
+++ b/libs/modkit-db/src/secure/tests.rs
@@ -16,15 +16,52 @@ mod integration_tests {
     fn test_access_scope_is_empty() {
         let scope = AccessScope::default();
         assert!(scope.is_empty());
+        assert!(!scope.is_root());
 
         let scope = AccessScope::tenants_only(vec![Uuid::new_v4()]);
         assert!(!scope.is_empty());
+        assert!(!scope.is_root());
 
         let scope = AccessScope::resources_only(vec![Uuid::new_v4()]);
         assert!(!scope.is_empty());
+        assert!(!scope.is_root());
 
         let scope = AccessScope::both(vec![Uuid::new_v4()], vec![Uuid::new_v4()]);
         assert!(!scope.is_empty());
+        assert!(!scope.is_root());
+    }
+
+    #[test]
+    fn test_root_scope_behavior() {
+        let root_scope = AccessScope::root_tenant();
+
+        // Root scope should never be considered empty
+        assert!(!root_scope.is_empty());
+
+        // Root scope should be marked as root
+        assert!(root_scope.is_root());
+
+        // Root scope should have no tenant or resource IDs by default
+        assert!(root_scope.tenant_ids().is_empty());
+        assert!(root_scope.resource_ids().is_empty());
+    }
+
+    #[test]
+    fn test_root_vs_empty_scope() {
+        let empty_scope = AccessScope::default();
+        let root_scope = AccessScope::root_tenant();
+
+        // Empty scope is empty, root scope is not
+        assert!(empty_scope.is_empty());
+        assert!(!root_scope.is_empty());
+
+        // Only root scope is marked as root
+        assert!(!empty_scope.is_root());
+        assert!(root_scope.is_root());
+
+        // Both have no tenant/resource IDs, but different semantics
+        assert!(empty_scope.tenant_ids().is_empty());
+        assert!(root_scope.tenant_ids().is_empty());
     }
 
     #[test]
@@ -43,6 +80,38 @@ mod integration_tests {
         let scope = AccessScope::both(vec![tid], vec![rid]);
         assert_eq!(scope.tenant_ids(), &[tid]);
         assert_eq!(scope.resource_ids(), &[rid]);
+    }
+
+    #[test]
+    fn test_security_ctx_root_ctx() {
+        use crate::secure::SecurityCtx;
+
+        let root_ctx = SecurityCtx::root_ctx();
+
+        // Root context should have root scope
+        assert!(root_ctx.scope().is_root());
+        assert!(!root_ctx.scope().is_empty());
+
+        // Root context should not be denied
+        assert!(!root_ctx.is_denied());
+    }
+
+    #[test]
+    fn test_security_ctx_deny_all_vs_root() {
+        use crate::secure::SecurityCtx;
+
+        let deny_all_ctx = SecurityCtx::deny_all(Uuid::new_v4());
+        let root_ctx = SecurityCtx::root_ctx();
+
+        // Deny-all context should be denied
+        assert!(deny_all_ctx.is_denied());
+        assert!(deny_all_ctx.scope().is_empty());
+        assert!(!deny_all_ctx.scope().is_root());
+
+        // Root context should not be denied
+        assert!(!root_ctx.is_denied());
+        assert!(!root_ctx.scope().is_empty());
+        assert!(root_ctx.scope().is_root());
     }
 
     // Note: Full entity integration tests should be written in application code

--- a/libs/modkit-security/src/scope.rs
+++ b/libs/modkit-security/src/scope.rs
@@ -1,8 +1,10 @@
 use uuid::Uuid;
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct AccessScope {
+    /// True if this is a root scope (system-level access with no tenant filtering)
+    pub(crate) is_root: bool,
     pub(crate) tenant_ids: Vec<Uuid>,
     pub(crate) resource_ids: Vec<Uuid>,
     // future: include_descendants (unused in v1)
@@ -19,7 +21,18 @@ impl AccessScope {
         &self.resource_ids
     }
 
+    /// Returns true if this is a root scope (system-level access).
+    #[inline]
+    pub fn is_root(&self) -> bool {
+        self.is_root
+    }
+
+    /// Returns true if this scope is empty (no tenants, no resources, not root).
+    /// A root scope is never considered empty.
     pub fn is_empty(&self) -> bool {
+        if self.is_root {
+            return false;
+        }
         self.tenant_ids.is_empty() && self.resource_ids.is_empty()
     }
     pub fn has_tenants(&self) -> bool {
@@ -31,12 +44,14 @@ impl AccessScope {
 
     pub fn tenants_only(tenant_ids: Vec<Uuid>) -> Self {
         Self {
+            is_root: false,
             tenant_ids,
             resource_ids: vec![],
         }
     }
     pub fn resources_only(resource_ids: Vec<Uuid>) -> Self {
         Self {
+            is_root: false,
             tenant_ids: vec![],
             resource_ids,
         }
@@ -53,14 +68,21 @@ impl AccessScope {
     /// This is less common but useful for very specific access scenarios.
     pub fn both(tenant_ids: Vec<Uuid>, resource_ids: Vec<Uuid>) -> Self {
         Self {
+            is_root: false,
             tenant_ids,
             resource_ids,
         }
     }
 
-    /// Scope limited to the root tenant (system-level access).
+    /// Root scope for system-level access.
+    /// This bypasses all tenant filtering and allows access to all tenants.
+    /// Resource filters can still be applied if resource_ids are set.
     pub fn root_tenant() -> Self {
-        Self::tenant(crate::constants::ROOT_TENANT_ID)
+        Self {
+            is_root: true,
+            tenant_ids: Vec::new(),
+            resource_ids: Vec::new(),
+        }
     }
 
     /// True if this scope explicitly includes the root tenant.

--- a/libs/modkit-security/tests/root_constants.rs
+++ b/libs/modkit-security/tests/root_constants.rs
@@ -2,15 +2,41 @@ use modkit_security::{AccessScope, SecurityCtx, Subject, ROOT_SUBJECT_ID, ROOT_T
 
 #[test]
 fn root_constants_and_helpers() {
+    // Root context now uses explicit is_root flag
     let ctx = SecurityCtx::root_ctx();
     assert_eq!(ctx.subject_id(), ROOT_SUBJECT_ID);
-    assert!(ctx.scope().tenant_ids().contains(&ROOT_TENANT_ID));
+    assert!(
+        ctx.scope().is_root(),
+        "Root context should have is_root=true"
+    );
+    assert!(
+        ctx.scope().tenant_ids().is_empty(),
+        "Root scope should have empty tenant_ids (no longer contains ROOT_TENANT_ID)"
+    );
+    assert!(
+        !ctx.scope().is_empty(),
+        "Root scope should not be considered empty"
+    );
     assert!(ctx.subject().is_root());
-    assert!(ctx.scope().includes_root_tenant());
 
+    // Root scope no longer contains ROOT_TENANT_ID by default
     let scope = AccessScope::root_tenant();
-    assert!(scope.includes_root_tenant());
+    assert!(scope.is_root());
+    assert!(
+        !scope.includes_root_tenant(),
+        "Root scope no longer uses ROOT_TENANT_ID"
+    );
 
     let subj = Subject::root();
     assert!(subj.is_root());
+
+    // The constants still exist for backward compatibility or explicit usage
+    assert_eq!(
+        ROOT_TENANT_ID.as_u128(),
+        0x00000000_df51_5b42_9538_d2b56b7ee953
+    );
+    assert_eq!(
+        ROOT_SUBJECT_ID.as_u128(),
+        0x11111111_6a88_4768_9dfc_6bcd5187d9ed
+    );
 }

--- a/modules/api_ingress/src/config.rs
+++ b/modules/api_ingress/src/config.rs
@@ -26,7 +26,10 @@ pub struct ApiIngressConfig {
     pub defaults: Defaults,
 
     /// Disable authentication and authorization completely.
-    /// When true, middleware injects SecurityCtx::root_ctx() (full access).
+    /// When true, middleware automatically injects SecurityCtx::root_ctx() for all requests,
+    /// providing full system-level access with no tenant filtering (scope.is_root() == true).
+    /// This bypasses all tenant isolation and should only be used for single-user on-premise installations.
+    /// Default: false (authentication required).
     #[serde(default)]
     pub auth_disabled: bool,
 

--- a/modules/api_ingress/src/cors.rs
+++ b/modules/api_ingress/src/cors.rs
@@ -8,7 +8,6 @@ pub fn build_cors_layer(cfg: &ApiIngressConfig) -> Option<CorsLayer> {
 
     let mut layer = CorsLayer::new();
 
-    // Allowed origins
     if cors_cfg.allowed_origins.iter().any(|o| o == "*") {
         layer = layer.allow_origin(tower_http::cors::Any);
     } else {
@@ -22,7 +21,6 @@ pub fn build_cors_layer(cfg: &ApiIngressConfig) -> Option<CorsLayer> {
         }
     }
 
-    // Methods
     if cors_cfg.allowed_methods.iter().any(|m| m == "*") {
         layer = layer.allow_methods(tower_http::cors::Any);
     } else {
@@ -36,7 +34,6 @@ pub fn build_cors_layer(cfg: &ApiIngressConfig) -> Option<CorsLayer> {
         }
     }
 
-    // Headers
     if cors_cfg.allowed_headers.iter().any(|h| h == "*") {
         layer = layer.allow_headers(tower_http::cors::Any);
     } else {
@@ -50,12 +47,10 @@ pub fn build_cors_layer(cfg: &ApiIngressConfig) -> Option<CorsLayer> {
         }
     }
 
-    // Credentials
     if cors_cfg.allow_credentials {
         layer = layer.allow_credentials(true);
     }
 
-    // Max Age
     if cors_cfg.max_age_seconds > 0 {
         layer = layer.max_age(std::time::Duration::from_secs(cors_cfg.max_age_seconds));
     }

--- a/modules/api_ingress/tests/auth_disabled_root_context.rs
+++ b/modules/api_ingress/tests/auth_disabled_root_context.rs
@@ -1,0 +1,156 @@
+//! Test that auth_disabled mode properly injects root context
+
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{Method, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::get,
+    Extension, Router,
+};
+use modkit_security::SecurityCtx;
+use tower::ServiceExt;
+
+/// Test handler that extracts SecurityCtx and returns its properties as JSON
+async fn test_handler(Extension(ctx): Extension<SecurityCtx>) -> impl IntoResponse {
+    let is_root = ctx.scope().is_root();
+    let is_empty = ctx.scope().is_empty();
+    let tenant_count = ctx.scope().tenant_ids().len();
+
+    axum::Json(serde_json::json!({
+        "is_root": is_root,
+        "is_empty": is_empty,
+        "tenant_count": tenant_count,
+        "is_denied": ctx.is_denied()
+    }))
+}
+
+/// Middleware that simulates auth_disabled mode by injecting root context
+async fn inject_root_context(mut req: Request, next: Next) -> Response {
+    req.extensions_mut().insert(SecurityCtx::root_ctx());
+    next.run(req).await
+}
+
+#[tokio::test]
+async fn test_auth_disabled_injects_root_context() {
+    // Build a router with the auth-disabled middleware
+    let app = Router::new()
+        .route("/test", get(test_handler))
+        .layer(middleware::from_fn(inject_root_context));
+
+    // Make a request
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Verify response
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // Verify root context properties
+    assert_eq!(json["is_root"], true, "SecurityCtx should have root scope");
+    assert_eq!(json["is_empty"], false, "Root scope should not be empty");
+    assert_eq!(
+        json["tenant_count"], 0,
+        "Root scope has no explicit tenant IDs"
+    );
+    assert_eq!(
+        json["is_denied"], false,
+        "Root context should not be denied"
+    );
+}
+
+#[tokio::test]
+async fn test_auth_disabled_allows_access_to_all_tenants() {
+    // Handler that verifies root access bypasses tenant filtering
+    async fn check_root_access(Extension(ctx): Extension<SecurityCtx>) -> impl IntoResponse {
+        // In disabled mode, we should have root access
+        assert!(
+            ctx.scope().is_root(),
+            "Should have root scope in disabled mode"
+        );
+        assert!(!ctx.is_denied(), "Root context should not be denied");
+
+        // Root scope bypasses tenant filtering - it's marked as root, not as having all tenant IDs
+        assert!(
+            ctx.scope().tenant_ids().is_empty(),
+            "Root scope uses flag, not tenant list"
+        );
+
+        axum::Json(serde_json::json!({"access": "granted", "mode": "root"}))
+    }
+
+    let app = Router::new()
+        .route("/check", get(check_root_access))
+        .layer(middleware::from_fn(inject_root_context));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/check")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["access"], "granted");
+    assert_eq!(json["mode"], "root");
+}
+
+#[tokio::test]
+async fn test_auth_disabled_vs_normal_scope() {
+    // Handler that distinguishes between root and normal scopes
+    async fn scope_info(Extension(ctx): Extension<SecurityCtx>) -> impl IntoResponse {
+        axum::Json(serde_json::json!({
+            "is_root": ctx.scope().is_root(),
+            "is_empty": ctx.scope().is_empty(),
+            "has_tenants": ctx.scope().has_tenants(),
+        }))
+    }
+
+    // Test 1: Root context (auth disabled)
+    let app_root = Router::new()
+        .route("/info", get(scope_info))
+        .layer(middleware::from_fn(inject_root_context));
+
+    let response = app_root
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/info")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["is_root"], true);
+    assert_eq!(json["is_empty"], false);
+    assert_eq!(json["has_tenants"], false); // Root doesn't use tenant list
+}


### PR DESCRIPTION
feat(security, db, ingress): enforce explicit Scopable contract, root tenant scope, and on-prem auth mode

- **modkit-db / macros**
  - Updated `#[derive(Scopable)]` to require explicit declaration for all scope-related columns:
    - Each entity must specify either `<name>_col = "..."` or `no_<name>` for:
      `tenant_col`, `resource_col`, `owner_col`, and `type_col`.
    - Removed all implicit defaults (e.g. `resource_col = "id"`).
    - Added strict validation at macro level:
      - Exactly one alternative must be present per field.
      - `unrestricted` cannot be combined with any of the above.
      - Missing declarations now produce compile-time errors.
  - Generated trait implementation now returns `Option<Self::Column>` for all four fields.

- **modkit-security**
  - Added explicit `is_root` flag to `AccessScope` to distinguish
    root context from an empty/unauthorized one.
  - Implemented `AccessScope::root_tenant()` and `AccessScope::is_root()`.
  - Updated `is_empty()` to never treat root scopes as empty.
  - Adjusted `SecurityCtx::root_ctx()` to use the new `root_tenant()` constructor.

- **modkit-db / secure**
  - Updated `build_scope_condition()` to handle root scopes:
    - Empty scope → `WHERE false` (deny all).
    - Root scope without filters → `Condition::all()` (allow all).
    - Root scope with filters → apply only non-tenant filters.
  - secure_insert is fixed
  - Modified `SimpleTenantFilter`:
    - Skips tenant filtering entirely for root scopes.
    - Keeps existing deny-all semantics for tenant-scoped entities missing a tenant column.

- **api_ingress**
  - Added explicit `AuthMode` enum: `Required | Optional | Disabled`.
  - Implemented `with_auth_layers()` helper to attach correct Axum middleware:
    - `Required` → `auth_required`
    - `Optional` → `auth_optional`
    - `Disabled` → injects `SecurityCtx::root_ctx()` for all requests
      (default mode for single-user on-prem deployments without IdP)

**Result:**
Security and ORM layers now enforce strict compile-time Scopable contracts
and fully support single-tenant (root) mode for on-prem deployments.
Empty/unauthorized scopes still deny all by default, preserving isolation guarantees.