### PR TITLE
CI: coverage and codecov integration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  range: "85...100" # Set the color range in Codecov's UI
+  status:
+    patch:
+      default:
+        # Sets the required coverage for lines changed in the PR
+        target: 85%
+        # Allows for a small drop from the target to still pass (e.g. 0.1% drop allowed)
+        threshold: 0%
+    project:
+      default:
+        # 'auto' means the PR must maintain or increase the overall project coverage
+        # You can replace 'auto' with a fixed percentage, e.g., '75%'
+        target: auto
+        # Allows the overall project coverage to drop by up to 1% and still pass
+        threshold: 1%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,6 @@ jobs:
         run: cargo deny check
 
   coverage:
-    if: false
     name: Code Coverage (cargo-llvm-cov)
     runs-on: ubuntu-latest
     steps:
@@ -212,8 +211,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain (with llvm-tools)
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2025-12-13
           components: llvm-tools-preview
 
       - name: Cache Cargo/target
@@ -256,9 +256,13 @@ jobs:
 
       # Generate lcov.info for upload. Customize flags/features as needed.
       - name: Coverage (lcov)
+        env:
+          RUSTFLAGS: "-C debuginfo=0 --cfg coverage_nightly"
+          CARGO_LLVM_COV_TARGET_DIR: llvm-cov-target
+          CARGO_LLVM_COV_BUILD_DIR: llvm-cov-build
         run: |
           cargo llvm-cov clean --workspace
-          cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
+          cargo +nightly llvm-cov --workspace --lcov --output-path lcov.info
 
       # Upload to Codecov; do not fail CI if Codecov is down/misconfigured.
       - name: Upload to Codecov

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ unsafe_code = "forbid"
 unused_mut = "warn"
 noop_method_call = "warn"
 unused_import_braces = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
 
 [workspace.lints.clippy]
 # See clippy rules details https://rust-lang.github.io/rust-clippy/master/index.html

--- a/examples/modkit/users_info/users_info/src/api/rest/dto.rs
+++ b/examples/modkit/users_info/users_info/src/api/rest/dto.rs
@@ -105,6 +105,7 @@ impl From<&crate::domain::events::UserDomainEvent> for UserEvent {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::domain::events::UserDomainEvent;

--- a/examples/modkit/users_info/users_info/src/api/rest/routes.rs
+++ b/examples/modkit/users_info/users_info/src/api/rest/routes.rs
@@ -139,6 +139,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod sse_tests {
     use super::*;
     use crate::api::rest::sse_adapter::SseUserEventPublisher;

--- a/examples/modkit/users_info/users_info/src/lib.rs
+++ b/examples/modkit/users_info/users_info/src/lib.rs
@@ -11,7 +11,7 @@
 //! - `UsersInfoError` - error types
 //!
 //! Other modules should use `hub.get::<dyn UsersInfoApi>()?` to obtain the client.
-
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 // === PUBLIC API (from SDK) ===
 pub use user_info_sdk::{
     NewUser, UpdateUserRequest, User, UserPatch, UsersInfoApi, UsersInfoError,

--- a/examples/oop-modules/calculator/calculator/Cargo.toml
+++ b/examples/oop-modules/calculator/calculator/Cargo.toml
@@ -38,3 +38,6 @@ inventory = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/examples/oop-modules/calculator/calculator/src/domain/service.rs
+++ b/examples/oop-modules/calculator/calculator/src/domain/service.rs
@@ -26,6 +26,7 @@ impl Service {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/examples/oop-modules/calculator/calculator/src/lib.rs
+++ b/examples/oop-modules/calculator/calculator/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! External consumers should use `calculator-sdk` crate which provides
 //! the gRPC client and `wire_client()` for ClientHub integration.
-
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 // === MODULE DEFINITION ===
 mod module;
 pub use module::CalculatorModule;

--- a/examples/oop-modules/calculator/calculator/src/module.rs
+++ b/examples/oop-modules/calculator/calculator/src/module.rs
@@ -74,6 +74,7 @@ impl GrpcServiceModule for CalculatorModule {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-auth/src/auth_mode.rs
+++ b/libs/modkit-auth/src/auth_mode.rs
@@ -58,6 +58,7 @@ impl PluginRegistry {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::{claims::Claims, claims_error::ClaimsError};

--- a/libs/modkit-auth/src/authorizer.rs
+++ b/libs/modkit-auth/src/authorizer.rs
@@ -49,6 +49,7 @@ impl PrimaryAuthorizer for RoleAuthorizer {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use uuid::Uuid;

--- a/libs/modkit-auth/src/claims.rs
+++ b/libs/modkit-auth/src/claims.rs
@@ -72,6 +72,7 @@ impl Claims {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-auth/src/config.rs
+++ b/libs/modkit-auth/src/config.rs
@@ -189,6 +189,7 @@ pub fn build_auth_dispatcher(config: &AuthConfig) -> Result<AuthDispatcher, Conf
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-auth/src/dispatcher.rs
+++ b/libs/modkit-auth/src/dispatcher.rs
@@ -359,6 +359,7 @@ impl TokenValidator for AuthDispatcher {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::auth_mode::AuthModeConfig;

--- a/libs/modkit-auth/src/lib.rs
+++ b/libs/modkit-auth/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![warn(warnings)]
 
 // Core modules

--- a/libs/modkit-auth/src/metrics.rs
+++ b/libs/modkit-auth/src/metrics.rs
@@ -127,6 +127,7 @@ impl AuthMetrics for LoggingMetrics {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-auth/src/plugin_traits.rs
+++ b/libs/modkit-auth/src/plugin_traits.rs
@@ -59,6 +59,7 @@ pub trait IntrospectionProvider: Send + Sync {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-auth/src/plugins/keycloak.rs
+++ b/libs/modkit-auth/src/plugins/keycloak.rs
@@ -192,6 +192,7 @@ impl ClaimsPlugin for KeycloakClaimsPlugin {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/libs/modkit-auth/src/plugins/oidc.rs
+++ b/libs/modkit-auth/src/plugins/oidc.rs
@@ -148,6 +148,7 @@ impl ClaimsPlugin for GenericOidcPlugin {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/libs/modkit-auth/src/providers/jwks.rs
+++ b/libs/modkit-auth/src/providers/jwks.rs
@@ -369,6 +369,7 @@ pub async fn run_jwks_refresh_task(provider: Arc<JwksKeyProvider>) {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-auth/src/validation.rs
+++ b/libs/modkit-auth/src/validation.rs
@@ -177,6 +177,7 @@ pub fn extract_audiences(value: &serde_json::Value) -> Vec<String> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/libs/modkit-bootstrap/src/config/mod.rs
+++ b/libs/modkit-bootstrap/src/config/mod.rs
@@ -1077,6 +1077,7 @@ pub fn module_home(app: &AppConfig, module_name: &str) -> PathBuf {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::{env, fs};

--- a/libs/modkit-bootstrap/src/host/paths/home_dir.rs
+++ b/libs/modkit-bootstrap/src/host/paths/home_dir.rs
@@ -162,6 +162,7 @@ pub fn resolve_home_dir(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/libs/modkit-bootstrap/src/lib.rs
+++ b/libs/modkit-bootstrap/src/lib.rs
@@ -13,6 +13,7 @@
 //! ## Backends
 //!
 //! Backend types for spawning OoP modules have been moved to `modkit::backends`.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 pub mod config;
 pub mod host;

--- a/libs/modkit-bootstrap/src/oop.rs
+++ b/libs/modkit-bootstrap/src/oop.rs
@@ -599,5 +599,6 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[path = "oop_tests.rs"]
 mod tests;

--- a/libs/modkit-db-macros/src/lib.rs
+++ b/libs/modkit-db-macros/src/lib.rs
@@ -40,6 +40,7 @@
 //! - **Owner**: `owner_col = "column_name"` OR `no_owner`
 //! - **Type**: `type_col = "column_name"` OR `no_type`
 //! - **Unrestricted**: `unrestricted` (forbids all other attributes)
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 use proc_macro::TokenStream;
 use proc_macro_error2::proc_macro_error;

--- a/libs/modkit-db-macros/src/scopable.rs
+++ b/libs/modkit-db-macros/src/scopable.rs
@@ -429,6 +429,7 @@ fn snake_to_upper_camel(s: &str) -> String {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-db-macros/tests/ui.rs
+++ b/libs/modkit-db-macros/tests/ui.rs
@@ -8,6 +8,7 @@
 // importing the modkit-db crate. The macro is tested in actual usage in the main codebase.
 
 #[test]
+#[cfg(not(coverage_nightly))]
 fn ui() {
     let t = trybuild::TestCases::new();
 

--- a/libs/modkit-db/src/advisory_locks.rs
+++ b/libs/modkit-db/src/advisory_locks.rs
@@ -536,6 +536,7 @@ pub enum DbLockError {
 // --------------------------- Tests -------------------------------------------
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use anyhow::Result;

--- a/libs/modkit-db/src/lib.rs
+++ b/libs/modkit-db/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(
     not(any(feature = "pg", feature = "mysql", feature = "sqlite")),
     allow(
@@ -660,6 +661,7 @@ impl DbHandle {
 // ===================== tests =====================
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use tokio::time::Duration;

--- a/libs/modkit-db/src/odata/filter.rs
+++ b/libs/modkit-db/src/odata/filter.rs
@@ -465,6 +465,7 @@ fn validate_value_type<F: FilterField>(field: F, value: &odata_ast::Value) -> Fi
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-db/src/odata/pager.rs
+++ b/libs/modkit-db/src/odata/pager.rs
@@ -302,6 +302,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-db/src/odata/sea_orm_filter.rs
+++ b/libs/modkit-db/src/odata/sea_orm_filter.rs
@@ -667,6 +667,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-db/src/odata/tests.rs
+++ b/libs/modkit-db/src/odata/tests.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use crate::odata::*;
     use modkit_odata::{ast::*, CursorV1, ODataOrderBy, OrderKey, SortDir};

--- a/libs/modkit-db/src/secure/cond.rs
+++ b/libs/modkit-db/src/secure/cond.rs
@@ -67,6 +67,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-db/src/secure/db_ops.rs
+++ b/libs/modkit-db/src/secure/db_ops.rs
@@ -277,6 +277,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-db/src/secure/provider.rs
+++ b/libs/modkit-db/src/secure/provider.rs
@@ -67,6 +67,7 @@ impl TenantFilterProvider for SimpleTenantFilter {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-db/src/secure/select.rs
+++ b/libs/modkit-db/src/secure/select.rs
@@ -262,6 +262,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-db/src/secure/tests.rs
+++ b/libs/modkit-db/src/secure/tests.rs
@@ -7,6 +7,7 @@
 //! See USAGE_EXAMPLE.md for complete usage examples with real SeaORM entities.
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[allow(clippy::disallowed_methods)]
 mod integration_tests {
     use crate::secure::AccessScope;

--- a/libs/modkit-db/src/sqlite/dsn.rs
+++ b/libs/modkit-db/src/sqlite/dsn.rs
@@ -77,6 +77,7 @@ pub(crate) fn is_memory_dsn(dsn: &str) -> bool {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-db/src/sqlite/path.rs
+++ b/libs/modkit-db/src/sqlite/path.rs
@@ -97,6 +97,7 @@ fn extract_file_path_from_dsn(dsn: &str) -> Option<std::path::PathBuf> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/libs/modkit-db/src/sqlite/pragmas.rs
+++ b/libs/modkit-db/src/sqlite/pragmas.rs
@@ -155,6 +155,7 @@ impl Pragmas {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-errors-macro/src/lib.rs
+++ b/libs/modkit-errors-macro/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 //! Proc-macro for generating strongly-typed error catalogs from JSON.
 //!
 //! This macro reads a JSON file at compile time, validates error definitions,

--- a/libs/modkit-errors-macro/tests/gts_validation.rs
+++ b/libs/modkit-errors-macro/tests/gts_validation.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 //! Compile-time tests for GTS validation in declare_errors! macro
 //!
@@ -34,6 +35,7 @@ const _VALID_UNDERSCORES: &str = r#"[{
 // For now, we'll create JSON test fixtures that the macro can validate
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     #[test]
     fn test_gts_validation_documented() {

--- a/libs/modkit-errors/src/catalog.rs
+++ b/libs/modkit-errors/src/catalog.rs
@@ -25,6 +25,7 @@ impl ErrDef {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-errors/src/lib.rs
+++ b/libs/modkit-errors/src/lib.rs
@@ -4,6 +4,7 @@
 //! on HTTP frameworks. It includes:
 //! - RFC 9457 Problem Details (`Problem`)
 //! - Error catalog support (`ErrDef`)
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 pub mod catalog;
 pub mod problem;

--- a/libs/modkit-errors/src/problem.rs
+++ b/libs/modkit-errors/src/problem.rs
@@ -160,6 +160,7 @@ impl axum::response::IntoResponse for Problem {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-macros/src/lib.rs
+++ b/libs/modkit-macros/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 use heck::ToSnakeCase;
 use proc_macro::TokenStream;
 use proc_macro2::Span;

--- a/libs/modkit-macros/tests/ui.rs
+++ b/libs/modkit-macros/tests/ui.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 #[test]
+#[cfg(not(coverage_nightly))]
 fn ui() {
     let t = trybuild::TestCases::new();
     // Passing cases

--- a/libs/modkit-node-info/src/hardware_uuid.rs
+++ b/libs/modkit-node-info/src/hardware_uuid.rs
@@ -82,6 +82,7 @@ pub fn get_hardware_uuid() -> Uuid {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-node-info/src/lib.rs
+++ b/libs/modkit-node-info/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 //! Node Information Library
 //!
 //! This library provides system information collection for the current node

--- a/libs/modkit-odata/src/lib.rs
+++ b/libs/modkit-odata/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 pub mod errors;
 pub mod limits;
 pub mod page;

--- a/libs/modkit-odata/src/limits.rs
+++ b/libs/modkit-odata/src/limits.rs
@@ -98,6 +98,7 @@ impl ODataLimits {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-odata/src/pagination.rs
+++ b/libs/modkit-odata/src/pagination.rs
@@ -85,6 +85,7 @@ pub fn short_filter_hash(expr: Option<&ast::Expr>) -> Option<String> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::ast::{CompareOperator, Expr, Value};

--- a/libs/modkit-odata/src/problem_mapping.rs
+++ b/libs/modkit-odata/src/problem_mapping.rs
@@ -61,6 +61,7 @@ impl From<Error> for Problem {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-odata/src/tests.rs
+++ b/libs/modkit-odata/src/tests.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[allow(clippy::module_inception)]
 mod tests {
     use crate::{base64_url, CursorV1, Error, ODataOrderBy, ODataQuery, OrderKey, SortDir};

--- a/libs/modkit-security/src/lib.rs
+++ b/libs/modkit-security/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 pub mod bin_codec;
 pub mod constants;
 pub mod prelude;

--- a/libs/modkit-transport-grpc/src/client.rs
+++ b/libs/modkit-transport-grpc/src/client.rs
@@ -300,6 +300,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit-transport-grpc/src/lib.rs
+++ b/libs/modkit-transport-grpc/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 pub mod client;
 pub mod rpc_retry;
 

--- a/libs/modkit-transport-grpc/src/rpc_retry.rs
+++ b/libs/modkit-transport-grpc/src/rpc_retry.rs
@@ -228,6 +228,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/api/error_layer.rs
+++ b/libs/modkit/src/api/error_layer.rs
@@ -174,6 +174,7 @@ impl IntoProblem for anyhow::Error {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/api/mod.rs
+++ b/libs/modkit/src/api/mod.rs
@@ -14,6 +14,7 @@ pub mod response;
 pub mod trace_layer;
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod odata_policy_tests;
 
 pub use error::ApiError;

--- a/libs/modkit/src/api/odata.rs
+++ b/libs/modkit/src/api/odata.rs
@@ -237,5 +237,6 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 #[path = "odata_tests.rs"]
 mod odata_tests;

--- a/libs/modkit/src/api/odata/error.rs
+++ b/libs/modkit/src/api/odata/error.rs
@@ -121,6 +121,7 @@ pub fn odata_error_to_problem(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/api/odata_policy_tests.rs
+++ b/libs/modkit/src/api/odata_policy_tests.rs
@@ -1,6 +1,7 @@
 //! Tests for cursor+orderby policy enforcement
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::super::odata::*;
     use axum::http::{request::Parts, Uri};

--- a/libs/modkit/src/api/odata_tests.rs
+++ b/libs/modkit/src/api/odata_tests.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use crate::api::odata::*;
     use axum::extract::FromRequestParts;

--- a/libs/modkit/src/api/openapi_registry.rs
+++ b/libs/modkit/src/api/openapi_registry.rs
@@ -380,6 +380,7 @@ impl OpenApiRegistry for OpenApiRegistryImpl {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::api::operation_builder::{OperationSpec, ParamLocation, ParamSpec, ResponseSpec};

--- a/libs/modkit/src/api/operation_builder.rs
+++ b/libs/modkit/src/api/operation_builder.rs
@@ -1231,6 +1231,7 @@ where
 // Tests
 // -------------------------------------------------------------------------------------------------
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use axum::Json;

--- a/libs/modkit/src/api/problem.rs
+++ b/libs/modkit/src/api/problem.rs
@@ -29,6 +29,7 @@ pub fn internal_error(detail: impl Into<String>) -> Problem {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use axum::response::IntoResponse;

--- a/libs/modkit/src/api/trace_layer.rs
+++ b/libs/modkit/src/api/trace_layer.rs
@@ -57,6 +57,7 @@ impl WithRequestContext for Problem {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/backends/mod.rs
+++ b/libs/modkit/src/backends/mod.rs
@@ -123,6 +123,7 @@ impl OopBackend for LocalProcessBackend {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/libs/modkit/src/client_hub.rs
+++ b/libs/modkit/src/client_hub.rs
@@ -121,6 +121,7 @@ impl ClientHub {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/config.rs
+++ b/libs/modkit/src/config.rs
@@ -116,6 +116,7 @@ pub fn module_config_required<T: DeserializeOwned>(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use serde::Deserialize;

--- a/libs/modkit/src/context.rs
+++ b/libs/modkit/src/context.rs
@@ -210,6 +210,7 @@ impl ModuleCtx {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use serde::Deserialize;

--- a/libs/modkit/src/directory.rs
+++ b/libs/modkit/src/directory.rs
@@ -100,6 +100,7 @@ impl DirectoryApi for LocalDirectoryApi {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/http/client.rs
+++ b/libs/modkit/src/http/client.rs
@@ -105,6 +105,7 @@ impl Default for TracedClient {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use httpmock::prelude::*;

--- a/libs/modkit/src/http/otel.rs
+++ b/libs/modkit/src/http/otel.rs
@@ -131,6 +131,7 @@ mod imp {
 pub use imp::{inject_current_span, set_parent_from_headers};
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use tracing::info_span;

--- a/libs/modkit/src/http/sse.rs
+++ b/libs/modkit/src/http/sse.rs
@@ -141,6 +141,7 @@ impl<T: Clone + Send + 'static> SseBroadcaster<T> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use futures::StreamExt;

--- a/libs/modkit/src/lib.rs
+++ b/libs/modkit/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 //! # ModKit - Declarative Module System
 //!
 //! A unified crate for building modular applications with declarative module definitions.
@@ -140,4 +141,5 @@ pub use runtime::{
 };
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests;

--- a/libs/modkit/src/lifecycle.rs
+++ b/libs/modkit/src/lifecycle.rs
@@ -611,6 +611,7 @@ impl<T: Runnable> Drop for WithLifecycle<T> {
 // ----- Tests -----------------------------------------------------------------
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering as AOrd};

--- a/libs/modkit/src/registry.rs
+++ b/libs/modkit/src/registry.rs
@@ -558,6 +558,7 @@ pub enum RegistryError {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::sync::Arc;

--- a/libs/modkit/src/result.rs
+++ b/libs/modkit/src/result.rs
@@ -23,6 +23,7 @@ use crate::api::problem::Problem;
 pub type ApiResult<T = ()> = Result<T, Problem>;
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -561,6 +561,7 @@ impl HostRuntime {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::context::ModuleCtx;

--- a/libs/modkit/src/runtime/module_manager.rs
+++ b/libs/modkit/src/runtime/module_manager.rs
@@ -390,6 +390,7 @@ impl Default for ModuleManager {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::thread::sleep;

--- a/libs/modkit/src/runtime/tests.rs
+++ b/libs/modkit/src/runtime/tests.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, coverage(off))]
 //! Tests for runtime lifecycle ready/timeout/cancel scenarios
 
 use crate::lifecycle::{Lifecycle, Status, StopReason};

--- a/libs/modkit/src/telemetry/init.rs
+++ b/libs/modkit/src/telemetry/init.rs
@@ -366,6 +366,7 @@ pub fn otel_connectivity_probe(_cfg: &serde_json::Value) -> anyhow::Result<()> {
 // ===== tests ==================================================================
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::telemetry::config::{Exporter, Sampler, TracingConfig};

--- a/libs/modkit/src/tests.rs
+++ b/libs/modkit/src/tests.rs
@@ -1,4 +1,5 @@
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod module_tests {
     use crate::registry::ModuleRegistry;
 

--- a/libs/modkit/tests/typed_builder_compilefail.rs
+++ b/libs/modkit/tests/typed_builder_compilefail.rs
@@ -6,6 +6,7 @@
 //! invalid API operations from compiling.
 
 #[test]
+#[cfg(not(coverage_nightly))]
 #[ignore = "TODO: Need to turn it on after fix issue with CR/LF"]
 fn compile_fail_tests() {
     // On MinGW (windows-gnu), native deps like `ring` may fail to build in trybuild sandboxes.

--- a/modules/api_ingress/src/auth.rs
+++ b/modules/api_ingress/src/auth.rs
@@ -286,6 +286,7 @@ impl TokenValidator for NoopValidator {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use axum::http::Method;

--- a/modules/api_ingress/src/lib.rs
+++ b/modules/api_ingress/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 use async_trait::async_trait;
 use std::sync::Arc;
 
@@ -416,6 +417,7 @@ impl modkit::Module for ApiIngress {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 
@@ -584,6 +586,7 @@ impl OpenApiRegistry for ApiIngress {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod problem_openapi_tests {
     use super::*;
     use axum::Json;
@@ -645,6 +648,7 @@ mod problem_openapi_tests {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod sse_openapi_tests {
     use super::*;
     use axum::Json;

--- a/modules/api_ingress/src/middleware/mime_validation.rs
+++ b/modules/api_ingress/src/middleware/mime_validation.rs
@@ -128,6 +128,7 @@ pub async fn mime_validation_middleware(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/modules/api_ingress/src/router_cache.rs
+++ b/modules/api_ingress/src/router_cache.rs
@@ -175,6 +175,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/modules/file_parser/src/domain/markdown.rs
+++ b/modules/file_parser/src/domain/markdown.rs
@@ -363,6 +363,7 @@ impl MarkdownRenderer {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::domain::ir::{

--- a/modules/file_parser/src/lib.rs
+++ b/modules/file_parser/src/lib.rs
@@ -1,5 +1,6 @@
 // === MODULE DEFINITION ===
 // ModKit needs access to the module struct for instantiation
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 pub mod module;
 pub use module::FileParserModule;
 

--- a/modules/grpc_hub/src/lib.rs
+++ b/modules/grpc_hub/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 //! gRPC Hub Module
 //!
 //! This module builds and hosts the single tonic::Server instance for the process.
@@ -547,6 +548,7 @@ impl Module for GrpcHub {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use http::{Request, Response};

--- a/modules/module_orchestrator/module_orchestrator-contracts/Cargo.toml
+++ b/modules/module_orchestrator/module_orchestrator-contracts/Cargo.toml
@@ -10,6 +10,9 @@ description = "Domain contracts and client interfaces for module orchestrator"
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+
 
 
 

--- a/modules/module_orchestrator/module_orchestrator-contracts/src/api.rs
+++ b/modules/module_orchestrator/module_orchestrator-contracts/src/api.rs
@@ -86,6 +86,7 @@ pub trait DirectoryApi: Send + Sync {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/modules/module_orchestrator/module_orchestrator-contracts/src/lib.rs
+++ b/modules/module_orchestrator/module_orchestrator-contracts/src/lib.rs
@@ -3,6 +3,7 @@
 //! Domain contracts and client interfaces for module orchestration.
 //! This crate provides the `DirectoryApi` trait and related types that
 //! define the contract for service discovery and instance management.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 mod api;
 

--- a/modules/module_orchestrator/module_orchestrator-grpc/Cargo.toml
+++ b/modules/module_orchestrator/module_orchestrator-grpc/Cargo.toml
@@ -23,3 +23,6 @@ tonic-prost-build = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true }
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+

--- a/modules/module_orchestrator/module_orchestrator-grpc/src/client.rs
+++ b/modules/module_orchestrator/module_orchestrator-grpc/src/client.rs
@@ -199,6 +199,7 @@ impl DirectoryApi for DirectoryGrpcClient {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/modules/module_orchestrator/module_orchestrator-grpc/src/lib.rs
+++ b/modules/module_orchestrator/module_orchestrator-grpc/src/lib.rs
@@ -2,10 +2,9 @@
 //!
 //! This crate provides gRPC transport for the module orchestrator.
 //! It includes generated protobuf types and client/server implementations.
-
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
-
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 mod client;
 
 // Generated protobuf types for DirectoryService

--- a/modules/module_orchestrator/module_orchestrator/src/lib.rs
+++ b/modules/module_orchestrator/module_orchestrator/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! System module for service discovery.
 //! This module provides DirectoryService for gRPC service registration and discovery.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/modules/nodes_registry/src/domain/node_storage.rs
+++ b/modules/nodes_registry/src/domain/node_storage.rs
@@ -259,6 +259,7 @@ impl Default for NodeStorage {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::contract::SysCap;

--- a/modules/nodes_registry/src/lib.rs
+++ b/modules/nodes_registry/src/lib.rs
@@ -13,6 +13,7 @@
 //! - Get node information by ID
 //! - Access node sysinfo via /nodes/{id}/sysinfo
 //! - Access node syscap via /nodes/{id}/syscap
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 // === PUBLIC CONTRACT ===
 pub mod contract;


### PR DESCRIPTION
## Summary
This PR enables automated code coverage reporting in the CI pipeline using `cargo-llvm-cov` and integrates with Codecov. It switches the coverage job to use a nightly Rust toolchain to leverage the `coverage(off)` attribute, ensuring that test code itself is excluded from coverage statistics.

See issue #65 

Coverage report (62% overall line coverage): https://app.codecov.io/github/hypernetix/hyperspot/commit/973b934d68728bd1221a392d82c88c5c2f4230ac

## Motivation
Accurate code coverage tracking is essential for LLM-enhanced development. By excluding test code from the reports, we get a true reflection of how well our application logic is tested. The nightly toolchain is currently required to use the unstable `coverage` attribute for this exclusion.

## Changes

### CI & Infrastructure
- **Workflow (`.github/workflows/ci.yml`)**:
  - Enabled the `coverage` job.
  - Switched the Rust toolchain to `nightly-2025-12-13` for the coverage job.
  - Updated `cargo llvm-cov` command to use the nightly toolchain and pass the `coverage_nightly` configuration flag via `RUSTFLAGS`.
- **Codecov (`.codecov.yml`)**: Added configuration to define coverage targets (85-100%) and thresholds.

### Codebase
- **Configuration Flag**: We use a custom `cfg(coverage_nightly)` flag passed via `RUSTFLAGS` in CI.
- **Test Exclusion**: Applied `#[cfg_attr(coverage_nightly, coverage(off))]` to `#[cfg(test)]` modules and test functions across multiple crates (examples, libs, etc.). This ensures that unit tests and integration tests are not counted towards the coverage percentage.
- **Lints**: Updated `Cargo.toml` to allow the `cfg(coverage_nightly)` configuration to avoid unexpected cfg warnings.
