### PR TITLE
feat(modkit)!: require_auth to accept strongly typed resource and actions

### DIFF
--- a/docs/MODKIT_UNIFIED_SYSTEM.md
+++ b/docs/MODKIT_UNIFIED_SYSTEM.md
@@ -754,8 +754,8 @@ OperationBuilder::<Missing, Missing, S>::post("/my-module/v1/path")
 **Authentication**
 
 ```rust
-// Require authentication with resource:action permission:
-.require_auth("users", "read")
+// Require authentication with resource:action permission (module-defined Resource/Action enums):
+.require_auth(&Resource::Users, &Action::Read)
 
 // Or mark as public (no auth required):
 .public()

--- a/guidelines/NEW_MODULE.md
+++ b/guidelines/NEW_MODULE.md
@@ -482,7 +482,7 @@ The `modkit::api::prelude` module provides:
 // src/api/rest/routes.rs
 router = OperationBuilder::get("/users-info/v1/users/{id}")
     .operation_id("users_info.get_user")
-    .require_auth("users", "read")
+    .require_auth(&Resource::Users, &Action::Read)
     .handler(handlers::get_user)
     .json_response_with_schema::<UserDto>(openapi, StatusCode::OK, "User found")
     .error_400(openapi)   // Bad Request
@@ -1243,7 +1243,7 @@ external API clients.
 
 5. **`src/api/rest/routes.rs`:**
    **Rule:** Register ALL endpoints in a single `register_routes` function.
-   **Rule:** Use `OperationBuilder` for every route with `.require_auth("resource", "action")` for protected endpoints.
+   **Rule:** Use `OperationBuilder` for every route with `.require_auth(&Resource::X, [Action::Y])` for protected endpoints.
    **Rule:** Use `.error_400(openapi)`, `.error_404(openapi)` etc. instead of raw `.problem_response()`.
    **Rule:** After all routes are registered, attach the service ONCE with `router.layer(Extension(service.clone()))`.
 
@@ -1264,7 +1264,7 @@ external API clients.
            .operation_id("users_info.list_users")
            .summary("List users with cursor pagination")
            .tag("users")
-           .require_auth("users", "read")
+           .require_auth(&Resource::Users, &Action::Read)
            .query_param_typed("limit", false, "Max users to return", "integer")
            .query_param("cursor", false, "Cursor for pagination")
            .handler(handlers::list_users)
@@ -1282,7 +1282,7 @@ external API clients.
            .operation_id("users_info.get_user")
            .summary("Get user by ID")
            .tag("users")
-           .require_auth("users", "read")
+           .require_auth(&Resource::Users, &Action::Read)
            .path_param("id", "User UUID")
            .handler(handlers::get_user)
            .json_response_with_schema::<dto::UserDto>(openapi, http::StatusCode::OK, "User found")
@@ -1297,7 +1297,7 @@ external API clients.
            .operation_id("users_info.create_user")
            .summary("Create a new user")
            .tag("users")
-           .require_auth("users", "create")
+           .require_auth(&Resource::Users, &Action::Create)
            .json_request::<dto::CreateUserReq>(openapi, "User creation data")
            .handler(handlers::create_user)
            .json_response_with_schema::<dto::UserDto>(openapi, http::StatusCode::CREATED, "Created")
@@ -1313,7 +1313,7 @@ external API clients.
            .operation_id("users_info.delete_user")
            .summary("Delete user")
            .tag("users")
-           .require_auth("users", "delete")
+           .require_auth(&Resource::Users, &Action::Delete)
            .path_param("id", "User UUID")
            .handler(handlers::delete_user)
            .json_response(http::StatusCode::NO_CONTENT, "User deleted")

--- a/libs/modkit/tests/integration_test.rs
+++ b/libs/modkit/tests/integration_test.rs
@@ -6,9 +6,42 @@
 //! the builder works as expected when used correctly.
 
 use axum::{response::IntoResponse, Json, Router};
-use modkit::api::{Missing, OpenApiRegistry, OperationBuilder, OperationSpec, ParamLocation};
+use modkit::api::{
+    operation_builder::{AuthReqAction, AuthReqResource},
+    Missing, OpenApiRegistry, OperationBuilder, OperationSpec, ParamLocation,
+};
 use serde_json::Value;
 use std::sync::Mutex;
+
+enum TestResource {
+    Users,
+}
+
+impl AsRef<str> for TestResource {
+    fn as_ref(&self) -> &'static str {
+        match self {
+            TestResource::Users => "users",
+        }
+    }
+}
+
+impl AuthReqResource for TestResource {}
+
+enum Action {
+    Read,
+    Write,
+}
+
+impl AsRef<str> for Action {
+    fn as_ref(&self) -> &'static str {
+        match self {
+            Action::Read => "read",
+            Action::Write => "write",
+        }
+    }
+}
+
+impl AuthReqAction for Action {}
 
 // Test registry that captures operations
 #[derive(Default)]
@@ -83,7 +116,7 @@ async fn test_complete_api_builder_flow() {
     router = OperationBuilder::<Missing, Missing, ()>::post("/users-info/v1/users")
         .operation_id("users.create")
         .summary("Create a new user")
-        .require_auth("users", "write")
+        .require_auth(&TestResource::Users, &Action::Write)
         .description("Creates a new user in the system")
         .tag("users")
         .json_response(http::StatusCode::CREATED, "User created successfully")
@@ -99,7 +132,7 @@ async fn test_complete_api_builder_flow() {
     let _router = OperationBuilder::<Missing, Missing, ()>::get("/users-info/v1/users/{id}")
         .operation_id("users.get")
         .summary("Get user by ID")
-        .require_auth("users", "read")
+        .require_auth(&TestResource::Users, &Action::Read)
         .description("Retrieves a specific user by their unique identifier")
         .tag("users")
         .path_param("id", "User unique identifier")
@@ -189,7 +222,7 @@ fn test_response_types() {
     let router = Router::new();
 
     let _router = OperationBuilder::<Missing, Missing, ()>::get("/tests/v1/text")
-        .require_auth("users", "read")
+        .require_auth(&TestResource::Users, &Action::Read)
         .text_response(http::StatusCode::OK, "Plain text response", "text/plain")
         .html_response(http::StatusCode::OK, "HTML response")
         .json_response(http::StatusCode::INTERNAL_SERVER_ERROR, "Error response")

--- a/modules/file_parser/src/api/rest/routes.rs
+++ b/modules/file_parser/src/api/rest/routes.rs
@@ -1,8 +1,39 @@
 use crate::api::rest::handlers;
 use crate::domain::service::FileParserService;
 use axum::{Extension, Router};
-use modkit::api::{OpenApiRegistry, OperationBuilder};
+use modkit::api::{
+    operation_builder::{AuthReqAction, AuthReqResource},
+    OpenApiRegistry, OperationBuilder,
+};
 use std::sync::Arc;
+
+enum Resource {
+    FileParser,
+}
+
+enum Action {
+    Read,
+}
+
+impl AsRef<str> for Resource {
+    fn as_ref(&self) -> &'static str {
+        match self {
+            Resource::FileParser => "file_parser",
+        }
+    }
+}
+
+impl AuthReqResource for Resource {}
+
+impl AsRef<str> for Action {
+    fn as_ref(&self) -> &'static str {
+        match self {
+            Action::Read => "read",
+        }
+    }
+}
+
+impl AuthReqAction for Action {}
 
 #[allow(clippy::needless_pass_by_value)] // Arc is intentionally passed by value for Extension layer
 pub fn register_routes(
@@ -15,7 +46,7 @@ pub fn register_routes(
         .operation_id("file_parser.get_parser_info")
         .summary("Get information about available file parsers")
         .tag("File Parser")
-        .require_auth("file_parser", "read")
+        .require_auth(&Resource::FileParser, &Action::Read)
         .handler(handlers::get_parser_info)
         .json_response_with_schema::<crate::api::rest::dto::FileParserInfoDto>(
             openapi,
@@ -30,7 +61,7 @@ pub fn register_routes(
         .operation_id("file_parser.parse_local")
         .summary("Parse a file from a local path")
         .tag("File Parser")
-        .require_auth("file_parser", "read")
+        .require_auth(&Resource::FileParser, &Action::Read)
         .query_param_typed(
             "render_markdown",
             false,
@@ -54,7 +85,7 @@ pub fn register_routes(
         .operation_id("file_parser.upload")
         .summary("Upload and parse a file")
         .tag("File Parser")
-        .require_auth("file_parser", "read")
+        .require_auth(&Resource::FileParser, &Action::Read)
         .query_param_typed(
             "render_markdown",
             false,
@@ -83,7 +114,7 @@ pub fn register_routes(
         .operation_id("file_parser.parse_url")
         .summary("Parse a file from a URL")
         .tag("File Parser")
-        .require_auth("file_parser", "read")
+        .require_auth(&Resource::FileParser, &Action::Read)
         .query_param_typed(
             "render_markdown",
             false,
@@ -107,7 +138,7 @@ pub fn register_routes(
         .operation_id("file_parser.parse_local_markdown")
         .summary("Parse a local file and stream Markdown")
         .tag("File Parser")
-        .require_auth("file_parser", "read")
+        .require_auth(&Resource::FileParser, &Action::Read)
         .json_request::<crate::api::rest::dto::ParseLocalFileRequest>(openapi, "Local file path")
         .allow_content_types(&["application/json"])
         .handler(handlers::parse_local_markdown)
@@ -120,7 +151,7 @@ pub fn register_routes(
         .operation_id("file_parser.upload_markdown")
         .summary("Upload and parse a file, streaming Markdown")
         .tag("File Parser")
-        .require_auth("file_parser", "read")
+        .require_auth(&Resource::FileParser, &Action::Read)
         .multipart_file_request("file", Some("File to parse and stream as Markdown"))
         .handler(handlers::upload_and_parse_markdown)
         .text_response(http::StatusCode::OK, "Markdown stream", "text/markdown")
@@ -133,7 +164,7 @@ pub fn register_routes(
         .operation_id("file_parser.parse_url_markdown")
         .summary("Parse a file from a URL and stream Markdown")
         .tag("File Parser")
-        .require_auth("file_parser", "read")
+        .require_auth(&Resource::FileParser, &Action::Read)
         .json_request::<crate::api::rest::dto::ParseUrlRequest>(openapi, "URL to file")
         .allow_content_types(&["application/json"])
         .handler(handlers::parse_url_markdown)


### PR DESCRIPTION
## Motivation

Closes #112 

- **Reduce auth bugs from string literals**: `require_auth("users", "read")` is easy to mistype and hard to refactor safely.
- **Tighten the auth requirements API contract**

## Summary of changes

- **Breaking API change (ModKit)**
  - `OperationBuilder::require_auth` now accepts:
    -  strongly typed resource
    - strongly typed action
  - Introduced `AuthReqResource` / `AuthReqAction` traits (string conversion via `as_str()`).
 
- **Docs/examples/tests updated**
  - Updated `docs/MODKIT_UNIFIED_SYSTEM.md` and `guidelines/NEW_MODULE.md` to the new `require_auth(&Resource::X, &Action::Y)` style.
  - Updated example module routes (`examples/modkit/users_info`) and real module routes (`modules/file_parser`).
  