### PR TITLE
replace gts-rust submodule with git dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       # Clippy lints across workspace and all targets; fail on warnings
       # Exclude gts crate (external submodule with its own lint rules)
       - name: cargo clippy
-        run: cargo clippy --workspace --all-targets --all-features --exclude gts -- -D warnings -D clippy::perf
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf
 
       # Unit tests (excluding integration tests)
       - name: cargo test (no ui)

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "guidelines/DNA"]
 	path = guidelines/DNA
 	url = https://github.com/hypernetix/DNA
-[submodule "modules/types-registry/gts-rust"]
-	path = modules/types-registry/gts-rust
-	url = https://github.com/globaltypesystem/gts-rust.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,6 +1825,7 @@ dependencies = [
 [[package]]
 name = "gts"
 version = "0.1.0"
+source = "git+https://github.com/globaltypesystem/gts-rust.git?branch=main#d1050a82d74e5afbb402d63e91365197897fdae8"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1832,7 +1833,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shellexpand",
- "thiserror 2.0.17",
+ "thiserror 1.0.69",
  "tracing",
  "uuid",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,8 +324,11 @@ temp-env = "0.3"
 # Additional utilities
 nanoid = "0.4"
 
-# GTS dependencies (for gts-rust submodule)
+# GTS dependencies
 jsonschema = "0.18"
 walkdir = "2.5"
 serde_yaml = "0.9"
 shellexpand = "3.1"
+
+# GTS library
+gts = { git = "https://github.com/globaltypesystem/gts-rust.git", branch = "main" }

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ fmt:
 # Run clippy linter (excludes gts-rust submodule which has its own lint settings)
 clippy:
 	$(call ensure_tool,cargo-clippy)
-	cargo clippy --workspace --all-targets --all-features --exclude gts -- -D warnings -D clippy::perf
+	cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf
 
 ## The Kani Rust Verifier for checking safety of the code
 kani:

--- a/modules/types-registry/types-registry-sdk/Cargo.toml
+++ b/modules/types-registry/types-registry-sdk/Cargo.toml
@@ -17,8 +17,8 @@ uuid = { workspace = true, features = ["v5"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
-# GTS types from gts-rust submodule
-gts = { path = "../gts-rust/gts" }
+# GTS types (from git dependency)
+gts = { workspace = true }
 
 # Security context for API methods
 modkit-security = { path = "../../../libs/modkit-security" }


### PR DESCRIPTION
- Remove gts-rust from .gitmodules
- Add gts as workspace git dependency in Cargo.toml
- Update types-registry-sdk to use workspace dependency