### PR TITLE
refactor(system modules) - implement as_system_module() function for system modules are not required now

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,6 @@ impl Module for MyModule {
         tracing::info!("My module initialized");
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 impl RestfulModule for MyModule {

--- a/docs/MODKIT_UNIFIED_SYSTEM.md
+++ b/docs/MODKIT_UNIFIED_SYSTEM.md
@@ -1491,7 +1491,6 @@ impl Module for MyModule {
         expose_my_module_client(ctx, &api)?;
         Ok(())
     }
-    fn as_any(&self) -> &dyn std::any::Any { self }
 }
 ```
 
@@ -1511,7 +1510,6 @@ let api = ctx.client_hub.get::<dyn my_module::contract::client::MyModuleApi>() ?
 #[async_trait::async_trait]
 pub trait Module: Send + Sync + 'static {
     async fn init(&self, ctx: &crate::context::ModuleCtx) -> anyhow::Result<()>;
-    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 #[async_trait::async_trait]

--- a/examples/modkit/type_safe_api_builder.rs
+++ b/examples/modkit/type_safe_api_builder.rs
@@ -52,9 +52,6 @@ impl OpenApiRegistry for ExampleRegistry {
         root_name.to_string()
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 // Example handlers

--- a/examples/modkit/users_info/users_info/src/module.rs
+++ b/examples/modkit/users_info/users_info/src/module.rs
@@ -112,10 +112,6 @@ impl Module for UsersInfo {
         info!("UsersInfo local client registered into ClientHub");
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 #[async_trait]

--- a/examples/oop-modules/calculator/calculator/src/module.rs
+++ b/examples/oop-modules/calculator/calculator/src/module.rs
@@ -45,10 +45,6 @@ impl modkit::Module for CalculatorModule {
         tracing::info!("calculator module initialized");
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 /// Export gRPC services to grpc_hub

--- a/examples/oop-modules/calculator_gateway/calculator_gateway/src/module.rs
+++ b/examples/oop-modules/calculator_gateway/calculator_gateway/src/module.rs
@@ -47,10 +47,6 @@ impl modkit::Module for CalculatorGateway {
         tracing::info!("calculator_gateway module initialized");
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 impl RestfulModule for CalculatorGateway {

--- a/guidelines/NEW_MODULE.md
+++ b/guidelines/NEW_MODULE.md
@@ -922,14 +922,9 @@ This is where all components are assembled and registered with ModKit.
    **Checklist:** Ensure `capabilities` and `deps` are set correctly for your module.
 
 2. **`src/module.rs` - `impl Module for YourModule`:**
-   **Rule:** The Module trait requires implementing `as_any()` method:
 
    ```rust
    impl Module for YourModule {
-       fn as_any(&self) -> &dyn std::any::Any {
-           self
-       }
-
        async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
            // ... init logic
        }
@@ -1040,10 +1035,6 @@ impl Module for UsersInfo {
         ctx.client_hub().register::<dyn UsersInfoApi>(api);
         info!("UsersInfo API registered in ClientHub via local adapter");
         Ok(())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 
@@ -2178,10 +2169,6 @@ impl modkit::Module for MyModule {
         // Register local implementation in ClientHub
         ctx.client_hub().register::<dyn MyModuleApi>(self.api.clone());
         Ok(())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 

--- a/libs/modkit-macros/src/lib.rs
+++ b/libs/modkit-macros/src/lib.rs
@@ -655,7 +655,8 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }
             },
             Capability::System => quote! {
-                b.register_system_with_meta(#name_lit);
+                b.register_system_with_meta(#name_lit,
+                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::SystemModule>);
             },
             Capability::GrpcHub => quote! {
                 b.register_grpc_hub_with_meta(#name_lit,

--- a/libs/modkit-macros/tests/ui/fail/lifecycle_entry_not_found.rs
+++ b/libs/modkit-macros/tests/ui/fail/lifecycle_entry_not_found.rs
@@ -13,7 +13,6 @@ impl X {
 #[async_trait::async_trait]
 impl modkit::Module for X {
     async fn init(&self, _ctx: &modkit::ModuleCtx) -> anyhow::Result<()> { Ok(()) }
-    fn as_any(&self) -> &dyn core::any::Any { self }
 }
 
 fn main() {}

--- a/libs/modkit-macros/tests/ui/pass/stateful_ok.rs
+++ b/libs/modkit-macros/tests/ui/pass/stateful_ok.rs
@@ -18,9 +18,6 @@ impl modkit::Module for Demo {
     async fn init(&self, _ctx: &modkit::ModuleCtx) -> anyhow::Result<()> {
         Ok(())
     }
-    fn as_any(&self) -> &dyn core::any::Any {
-        self
-    }
 }
 
 fn main() {}

--- a/libs/modkit-macros/tests/ui/pass/stateful_ready_ok.rs
+++ b/libs/modkit-macros/tests/ui/pass/stateful_ready_ok.rs
@@ -20,7 +20,6 @@ impl DemoReady {
 #[async_trait::async_trait]
 impl modkit::Module for DemoReady {
     async fn init(&self, _ctx: &modkit::ModuleCtx) -> anyhow::Result<()> { Ok(()) }
-    fn as_any(&self) -> &dyn core::any::Any { self }
 }
 
 fn main() {}

--- a/libs/modkit/src/contracts.rs
+++ b/libs/modkit/src/contracts.rs
@@ -36,15 +36,6 @@ pub trait SystemModule: Send + Sync {
 #[async_trait]
 pub trait Module: Send + Sync + 'static {
     async fn init(&self, ctx: &crate::context::ModuleCtx) -> anyhow::Result<()>;
-
-    fn as_any(&self) -> &dyn std::any::Any;
-
-    /// Return self as a `SystemModule` if this module has the "system" capability.
-    ///
-    /// Default implementation returns None. System modules override this to return Some(self).
-    fn as_system_module(&self) -> Option<&dyn SystemModule> {
-        None
-    }
 }
 
 #[async_trait]

--- a/libs/modkit/tests/macro_tests.rs
+++ b/libs/modkit/tests/macro_tests.rs
@@ -64,9 +64,6 @@ impl Module for BasicModule {
     async fn init(&self, _ctx: &modkit::context::ModuleCtx) -> Result<()> {
         Ok(())
     }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 #[derive(Default)]
@@ -77,9 +74,6 @@ struct FullFeaturedModule;
 impl Module for FullFeaturedModule {
     async fn init(&self, _ctx: &modkit::context::ModuleCtx) -> Result<()> {
         Ok(())
-    }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 #[async_trait]
@@ -117,9 +111,6 @@ impl Module for DependentModule {
     async fn init(&self, _ctx: &modkit::context::ModuleCtx) -> Result<()> {
         Ok(())
     }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 #[derive(Default)]
@@ -139,9 +130,6 @@ impl Module for CustomCtorModule {
     async fn init(&self, _ctx: &modkit::context::ModuleCtx) -> Result<()> {
         Ok(())
     }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 #[derive(Default)]
@@ -151,9 +139,6 @@ struct DbOnlyModule;
 impl Module for DbOnlyModule {
     async fn init(&self, _ctx: &modkit::context::ModuleCtx) -> Result<()> {
         Ok(())
-    }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 #[async_trait]
@@ -170,9 +155,6 @@ struct RestOnlyModule;
 impl Module for RestOnlyModule {
     async fn init(&self, _ctx: &modkit::context::ModuleCtx) -> Result<()> {
         Ok(())
-    }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 impl RestfulModule for RestOnlyModule {
@@ -196,9 +178,6 @@ struct TestRestHostModule {
 impl Module for TestRestHostModule {
     async fn init(&self, _ctx: &modkit::context::ModuleCtx) -> Result<()> {
         Ok(())
-    }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 
@@ -231,9 +210,6 @@ struct StatefulOnlyModule;
 impl Module for StatefulOnlyModule {
     async fn init(&self, _ctx: &modkit::context::ModuleCtx) -> Result<()> {
         Ok(())
-    }
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 #[async_trait]

--- a/libs/modkit/tests/runner_tests.rs
+++ b/libs/modkit/tests/runner_tests.rs
@@ -149,10 +149,6 @@ impl Module for TestModule {
         }
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 #[async_trait::async_trait]

--- a/modules/api_ingress/src/lib.rs
+++ b/modules/api_ingress/src/lib.rs
@@ -39,7 +39,7 @@ use router_cache::RouterCache;
 /// typed operation specs to emit a single `OpenAPI` document.
 #[modkit::module(
 	name = "api_ingress",
-	capabilities = [rest_host, rest, stateful, system],
+	capabilities = [rest_host, rest, stateful],
     deps = ["grpc_hub"],
 	lifecycle(entry = "serve", stop_timeout = "30s", await_ready)
 )]
@@ -426,10 +426,6 @@ impl modkit::Module for ApiIngress {
             self.config.load()
         );
         Ok(())
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 }
 

--- a/modules/api_ingress/tests/auth_middleware.rs
+++ b/modules/api_ingress/tests/auth_middleware.rs
@@ -100,10 +100,6 @@ impl Module for TestAuthModule {
     async fn init(&self, _ctx: &ModuleCtx) -> Result<()> {
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 enum TestResource {

--- a/modules/api_ingress/tests/body_limit_tests.rs
+++ b/modules/api_ingress/tests/body_limit_tests.rs
@@ -73,10 +73,6 @@ impl Module for BodyLimitTestModule {
     async fn init(&self, _ctx: &modkit::ModuleCtx) -> Result<()> {
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 impl RestfulModule for BodyLimitTestModule {

--- a/modules/api_ingress/tests/cors_tests.rs
+++ b/modules/api_ingress/tests/cors_tests.rs
@@ -90,10 +90,6 @@ impl Module for CorsTestModule {
     async fn init(&self, _ctx: &modkit::ModuleCtx) -> Result<()> {
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 impl RestfulModule for CorsTestModule {

--- a/modules/api_ingress/tests/integration_router.rs
+++ b/modules/api_ingress/tests/integration_router.rs
@@ -65,10 +65,6 @@ impl Module for TestUsersModule {
     async fn init(&self, _ctx: &modkit::ModuleCtx) -> Result<()> {
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 impl RestfulModule for TestUsersModule {

--- a/modules/api_ingress/tests/rate_limit_tests.rs
+++ b/modules/api_ingress/tests/rate_limit_tests.rs
@@ -65,10 +65,6 @@ impl Module for RateLimitedModule {
     async fn init(&self, _ctx: &modkit::ModuleCtx) -> Result<()> {
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 impl RestfulModule for RateLimitedModule {

--- a/modules/file_parser/src/module.rs
+++ b/modules/file_parser/src/module.rs
@@ -77,10 +77,6 @@ impl Module for FileParserModule {
         info!("FileParserService initialized successfully");
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 impl RestfulModule for FileParserModule {

--- a/modules/grpc_hub/src/lib.rs
+++ b/modules/grpc_hub/src/lib.rs
@@ -547,14 +547,6 @@ impl Module for GrpcHub {
 
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn as_system_module(&self) -> Option<&dyn SystemModule> {
-        Some(self)
-    }
 }
 
 #[cfg(test)]

--- a/modules/module_orchestrator/module_orchestrator/src/lib.rs
+++ b/modules/module_orchestrator/module_orchestrator/src/lib.rs
@@ -92,14 +92,6 @@ impl modkit::Module for ModuleOrchestrator {
 
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn as_system_module(&self) -> Option<&dyn SystemModule> {
-        Some(self)
-    }
 }
 
 /// Export gRPC services to `grpc_hub`

--- a/modules/nodes_registry/src/module.rs
+++ b/modules/nodes_registry/src/module.rs
@@ -54,10 +54,6 @@ impl Module for NodesRegistry {
         tracing::info!("Nodes registry module initialized");
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 
 impl RestfulModule for NodesRegistry {

--- a/modules/types-registry/openspec/changes/add-types-registry-module/design.md
+++ b/modules/types-registry/openspec/changes/add-types-registry-module/design.md
@@ -134,10 +134,6 @@ impl Module for TypesRegistryModule {
         tracing::info!("Types registry module initialized");
         Ok(())
     }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
 }
 ```
 


### PR DESCRIPTION
- Redundant as_any() and as_system_module() are removed
- implement as_system_module() function for system modules are not required now