### PR TITLE
fix: prevent unsafe PID conversion in process termination

### DIFF
--- a/libs/modkit/src/backends/local.rs
+++ b/libs/modkit/src/backends/local.rs
@@ -36,8 +36,15 @@ fn send_terminate_signal(child: &Child) -> bool {
     use nix::unistd::Pid;
 
     if let Some(pid) = child.id() {
-        let pid_i32 = i32::try_from(pid).unwrap_or(0);
-        kill(Pid::from_raw(pid_i32), Signal::SIGTERM).is_ok()
+        if let Ok(pid_i32) = i32::try_from(pid) {
+            kill(Pid::from_raw(pid_i32), Signal::SIGTERM).is_ok()
+        } else {
+            tracing::warn!(
+                pid = pid,
+                "Failed to convert PID to i32, cannot send SIGTERM (PID exceeds i32::MAX)"
+            );
+            false
+        }
     } else {
         false
     }


### PR DESCRIPTION
Fixed a critical bug in send_terminate_signal() where u32 to i32 conversion could silently fail and default to PID 0. On Unix systems, sending signals to PID 0 targets all processes in the process group, which could terminate unintended processes.

Changes:
- Replace unwrap_or(0) with proper match statement
- Add warning log when PID exceeds i32::MAX
- Return false when conversion fails instead of using dangerous default

This prevents potential security/safety issues where wrong processes could be terminated during shutdown.