### PR TITLE
 refactor(plugin-modules):: correct OpenAPI schema and simplify plugi…

### DIFF
--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/api/rest/dto.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/api/rest/dto.rs
@@ -85,6 +85,33 @@ impl From<TenantFilterDto> for tenant_resolver_sdk::TenantFilter {
     }
 }
 
+// ============================================================================
+// Shared Helpers
+// ============================================================================
+
+/// Parses a comma-separated status string into a `Vec<TenantStatus>`.
+///
+/// Recognized values (case-insensitive): `ACTIVE`, `SOFT_DELETED`, `UNSPECIFIED`.
+/// Unknown values are ignored.
+fn parse_statuses_csv(statuses: Option<&str>) -> Vec<TenantStatus> {
+    statuses
+        .unwrap_or("")
+        .split(',')
+        .filter_map(|raw| {
+            let s = raw.trim();
+            if s.eq_ignore_ascii_case("ACTIVE") {
+                Some(TenantStatus::Active)
+            } else if s.eq_ignore_ascii_case("SOFT_DELETED") {
+                Some(TenantStatus::SoftDeleted)
+            } else if s.eq_ignore_ascii_case("UNSPECIFIED") {
+                Some(TenantStatus::Unspecified)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 /// Access control options.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -114,24 +141,8 @@ impl ListTenantsQuery {
     #[must_use]
     pub fn to_filter(&self) -> tenant_resolver_sdk::TenantFilter {
         tenant_resolver_sdk::TenantFilter {
-            statuses: self.parse_statuses(),
+            statuses: parse_statuses_csv(self.statuses.as_deref()),
         }
-    }
-
-    fn parse_statuses(&self) -> Vec<TenantStatus> {
-        self.statuses
-            .as_ref()
-            .map(|s| {
-                s.split(',')
-                    .filter_map(|status| match status.trim().to_uppercase().as_str() {
-                        "ACTIVE" => Some(TenantStatus::Active),
-                        "SOFT_DELETED" => Some(TenantStatus::SoftDeleted),
-                        "UNSPECIFIED" => Some(TenantStatus::Unspecified),
-                        _ => None,
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
     }
 }
 
@@ -149,7 +160,7 @@ impl GetParentsQuery {
     #[must_use]
     pub fn to_filter(&self) -> tenant_resolver_sdk::TenantFilter {
         tenant_resolver_sdk::TenantFilter {
-            statuses: self.parse_statuses(),
+            statuses: parse_statuses_csv(self.statuses.as_deref()),
         }
     }
 
@@ -159,22 +170,6 @@ impl GetParentsQuery {
         tenant_resolver_sdk::AccessOptions {
             ignore_parent_access_constraints: self.ignore_access.unwrap_or(false),
         }
-    }
-
-    fn parse_statuses(&self) -> Vec<TenantStatus> {
-        self.statuses
-            .as_ref()
-            .map(|s| {
-                s.split(',')
-                    .filter_map(|status| match status.trim().to_uppercase().as_str() {
-                        "ACTIVE" => Some(TenantStatus::Active),
-                        "SOFT_DELETED" => Some(TenantStatus::SoftDeleted),
-                        "UNSPECIFIED" => Some(TenantStatus::Unspecified),
-                        _ => None,
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
     }
 }
 
@@ -194,7 +189,7 @@ impl GetChildrenQuery {
     #[must_use]
     pub fn to_filter(&self) -> tenant_resolver_sdk::TenantFilter {
         tenant_resolver_sdk::TenantFilter {
-            statuses: self.parse_statuses(),
+            statuses: parse_statuses_csv(self.statuses.as_deref()),
         }
     }
 
@@ -204,22 +199,6 @@ impl GetChildrenQuery {
         tenant_resolver_sdk::AccessOptions {
             ignore_parent_access_constraints: self.ignore_access.unwrap_or(false),
         }
-    }
-
-    fn parse_statuses(&self) -> Vec<TenantStatus> {
-        self.statuses
-            .as_ref()
-            .map(|s| {
-                s.split(',')
-                    .filter_map(|status| match status.trim().to_uppercase().as_str() {
-                        "ACTIVE" => Some(TenantStatus::Active),
-                        "SOFT_DELETED" => Some(TenantStatus::SoftDeleted),
-                        "UNSPECIFIED" => Some(TenantStatus::Unspecified),
-                        _ => None,
-                    })
-                    .collect()
-            })
-            .unwrap_or_default()
     }
 }
 

--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/api/rest/routes.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/api/rest/routes.rs
@@ -28,10 +28,15 @@ pub fn register_routes(
         .register(router, openapi);
 
     // GET /tenant-resolver/v1/tenants
+    // NOTE: Response is `Page<serde_json::Value>` because `$select` projection may return
+    // a subset of TenantDto fields. When `$select` is omitted, the full TenantDto shape is returned.
     router = OperationBuilder::get("/tenant-resolver/v1/tenants")
         .operation_id("tenant_resolver_gateway.list_tenants")
         .summary("List tenants")
-        .description("Returns a paginated list of tenants with optional filtering by status.")
+        .description(
+            "Returns a paginated list of tenants with optional filtering by status. \
+             When `$select` is provided, the response items contain only the requested fields.",
+        )
         .tag("tenant_resolver_gateway")
         .public()
         .query_param(
@@ -47,10 +52,10 @@ pub fn register_routes(
         )
         .query_param("cursor", false, "Cursor for pagination")
         .handler(handlers::list_tenants)
-        .json_response_with_schema::<modkit_odata::Page<TenantDto>>(
+        .json_response_with_schema::<modkit_odata::Page<serde_json::Value>>(
             openapi,
             http::StatusCode::OK,
-            "Paginated list of tenants",
+            "Paginated list of tenants (shape depends on $select)",
         )
         .with_odata_select()
         .standard_errors(openapi)

--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/domain/error.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/domain/error.rs
@@ -28,9 +28,10 @@ impl From<tenant_resolver_sdk::TenantResolverError> for DomainError {
         use tenant_resolver_sdk::TenantResolverError;
         match e {
             TenantResolverError::NotFound(msg) => Self::TenantNotFound(msg),
-            TenantResolverError::PermissionDenied(msg) => Self::PermissionDenied(msg),
-            TenantResolverError::Unauthorized(msg) => {
-                Self::Internal(format!("unauthorized: {msg}"))
+            // Unauthorized maps to PermissionDenied since this is a gateway
+            // and authentication is handled at the ingress layer.
+            TenantResolverError::PermissionDenied(msg) | TenantResolverError::Unauthorized(msg) => {
+                Self::PermissionDenied(msg)
             }
             TenantResolverError::Internal(msg) => Self::Internal(msg),
         }


### PR DESCRIPTION
…n initialization

- Use OnceLock instead of ArcSwapOption for one-time service setup
- Decouple gateway from concrete tenant resolver plugins
- Fix OpenAPI response type to match $select projections
- Centralize CSV status parsing logic
- Simplify plugin instance selection logic
- Normalize auth-related domain error mapping

- one grpc flaky test is improved