### PR TITLE
fix: update GTS library (gts-rust) to 0.7.5 and fix the e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "gts"
 version = "0.1.0"
-source = "git+https://github.com/globaltypesystem/gts-rust.git?tag=v0.7.4#df8d29f11988aa46aeb03f8fc5c06a3df1df540b"
+source = "git+https://github.com/globaltypesystem/gts-rust.git?tag=v0.7.5#89c34b9a32bfb3a6c92fd3bb8205699b82d58106"
 dependencies = [
  "anyhow",
  "jsonschema",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "gts-macros"
 version = "0.1.0"
-source = "git+https://github.com/globaltypesystem/gts-rust.git?tag=v0.7.4#df8d29f11988aa46aeb03f8fc5c06a3df1df540b"
+source = "git+https://github.com/globaltypesystem/gts-rust.git?tag=v0.7.5#89c34b9a32bfb3a6c92fd3bb8205699b82d58106"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -337,5 +337,5 @@ serde_yaml = "0.9"
 shellexpand = "3.1"
 
 # GTS library
-gts = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.4" }
-gts-macros = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.4" }
+gts = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.5" }
+gts-macros = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.5" }

--- a/dylint_lints/Cargo.toml
+++ b/dylint_lints/Cargo.toml
@@ -36,8 +36,8 @@ dylint_linting = "5.0.0"
 dylint_testing = "5.0.0"
 lint_utils = { path = "lint_utils" }
 # NOTE: Keep gts version in sync with /Cargo.toml workspace dependencies
-gts = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.4" }
-gts-macros = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.4" }
+gts = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.5" }
+gts-macros = { git = "https://github.com/globaltypesystem/gts-rust.git", tag = "v0.7.5" }
 
 [workspace.lints.clippy]
 all = "warn"

--- a/modules/types-registry/types-registry/tests/ready_mode_tests.rs
+++ b/modules/types-registry/types-registry/tests/ready_mode_tests.rs
@@ -566,7 +566,7 @@ async fn test_concurrent_registrations() {
         let svc = service.clone();
         let handle = tokio::spawn(async move {
             let entity = json!({
-                "$id": format!("gts.acme.core.events.concurrent_{i}.v1~"),
+                "$id": format!("gts://gts.acme.core.events.concurrent_{i}.v1~"),
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "type": "object"
             });

--- a/modules/types-registry/types-registry/tests/registration_tests.rs
+++ b/modules/types-registry/types-registry/tests/registration_tests.rs
@@ -258,7 +258,7 @@ async fn test_large_batch_registration() {
     let entities: Vec<_> = (0..100)
         .map(|i| {
             json!({
-                "$id": format!("gts.acme.core.events.batch_{i}.v1~"),
+                "$id": format!("gts://gts.acme.core.events.batch_{i}.v1~"),
                 "$schema": "http://json-schema.org/draft-07/schema#",
                 "type": "object"
             })

--- a/testing/e2e/modules/types_registry/test_types_registry_error_handling.py
+++ b/testing/e2e/modules/types_registry/test_types_registry_error_handling.py
@@ -13,6 +13,10 @@ def unique_type_id(name: str) -> str:
     return f"gts.e2etest.err.models.{name}{_counter}.v1~"
 
 
+def make_schema_id(gts_id: str) -> str:
+    return "gts://" + gts_id
+
+
 @pytest.mark.asyncio
 async def test_error_response_format_rfc9457(base_url, auth_headers):
     """
@@ -183,7 +187,7 @@ async def test_large_batch_registration(base_url, auth_headers):
         entities = []
         for i in range(50):
             entities.append({
-                "$id": f"gts.e2etest.large.models.type{i}x{batch_id}.v1~",
+                "$id": make_schema_id(f"gts.e2etest.large.models.type{i}x{batch_id}.v1~"),
                 "type": "object",
                 "properties": {
                     "field": {"type": "string"}
@@ -226,7 +230,7 @@ async def test_duplicate_entity_registration_different_content_fails(base_url, a
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "description": "First registration"
@@ -286,7 +290,7 @@ async def test_very_long_gts_id(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "type": "object"
                 }
             ]
@@ -320,7 +324,7 @@ async def test_unicode_in_content(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -366,7 +370,7 @@ async def test_null_values_in_entity(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "type": "object",
                     "properties": {
                         "optional_field": {"type": ["string", "null"]}
@@ -404,7 +408,7 @@ async def test_deeply_nested_schema(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {

--- a/testing/e2e/modules/types_registry/test_types_registry_get.py
+++ b/testing/e2e/modules/types_registry/test_types_registry_get.py
@@ -17,6 +17,10 @@ def unique_id(name: str) -> str:
     return f"gts.e2etest.pkg.ns.{name}{_counter}.v1~"
 
 
+def make_schema_id(gts_id: str) -> str:
+    return "gts://" + gts_id
+
+
 @pytest.mark.asyncio
 async def test_get_entity_by_id(base_url, auth_headers):
     """
@@ -30,7 +34,7 @@ async def test_get_entity_by_id(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -122,7 +126,7 @@ async def test_get_entity_returns_full_content(base_url, auth_headers):
         gts_id = unique_id("fullcontent")
 
         original_content = {
-            "$id": gts_id,
+            "$id": make_schema_id(gts_id),
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
             "properties": {
@@ -188,7 +192,7 @@ async def test_get_instance_entity(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": type_id,
+                    "$id": make_schema_id(type_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -253,7 +257,7 @@ async def test_get_entity_with_special_characters_in_id(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "description": "Entity with underscores in ID"
@@ -303,7 +307,7 @@ async def test_get_entity_uuid_format(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object"
                 }
@@ -359,7 +363,7 @@ async def test_get_entity_vendor_package_namespace(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "description": "Entity for segment test"
@@ -410,7 +414,7 @@ async def test_get_entity_deterministic_uuid(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object"
                 }
@@ -467,7 +471,7 @@ async def test_get_entity_returns_segments(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -538,7 +542,7 @@ async def test_get_instance_with_multiple_segments(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": type_id,
+                    "$id": make_schema_id(type_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -618,7 +622,7 @@ async def test_get_instance_with_different_vendor_segments(base_url, auth_header
         payload = {
             "entities": [
                 {
-                    "$id": type_id,
+                    "$id": make_schema_id(type_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {

--- a/testing/e2e/modules/types_registry/test_types_registry_register.py
+++ b/testing/e2e/modules/types_registry/test_types_registry_register.py
@@ -13,6 +13,10 @@ def unique_type_id(name: str) -> str:
     return f"gts.e2etest.reg.models.{name}{_counter}.v1~"
 
 
+def make_schema_id(gts_id: str) -> str:
+    return "gts://" + gts_id
+
+
 @pytest.mark.asyncio
 async def test_register_single_type_entity(base_url, auth_headers):
     """
@@ -26,7 +30,7 @@ async def test_register_single_type_entity(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -94,7 +98,7 @@ async def test_register_batch_entities(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": product_id,
+                    "$id": make_schema_id(product_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -104,7 +108,7 @@ async def test_register_batch_entities(base_url, auth_headers):
                     "required": ["productId", "price"]
                 },
                 {
-                    "$id": order_id,
+                    "$id": make_schema_id(order_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -114,7 +118,7 @@ async def test_register_batch_entities(base_url, auth_headers):
                     "required": ["orderId", "total"]
                 },
                 {
-                    "$id": customer_id,
+                    "$id": make_schema_id(customer_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -174,7 +178,7 @@ async def test_register_type_with_instance(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": type_id,
+                    "$id": make_schema_id(type_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -281,7 +285,7 @@ async def test_register_mixed_valid_and_invalid(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": valid1_id,
+                    "$id": make_schema_id(valid1_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object"
                 },
@@ -289,7 +293,7 @@ async def test_register_mixed_valid_and_invalid(base_url, auth_headers):
                     "type": "object"
                 },
                 {
-                    "$id": valid2_id,
+                    "$id": make_schema_id(valid2_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object"
                 }
@@ -374,7 +378,7 @@ async def test_register_entity_with_description(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": gts_id,
+                    "$id": make_schema_id(gts_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -448,7 +452,7 @@ async def test_register_idempotent_identical_content(base_url, auth_headers):
     gts_id = unique_type_id("idempotent")
 
     entity = {
-        "$id": gts_id,
+        "$id": make_schema_id(gts_id),
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
@@ -511,7 +515,7 @@ async def test_register_conflict_different_content(base_url, auth_headers):
     gts_id = unique_type_id("conflict")
 
     entity1 = {
-        "$id": gts_id,
+        "$id": make_schema_id(gts_id),
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {
@@ -521,7 +525,7 @@ async def test_register_conflict_different_content(base_url, auth_headers):
     }
 
     entity2 = {
-        "$id": gts_id,
+        "$id": make_schema_id(gts_id),
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "properties": {

--- a/testing/e2e/modules/types_registry/test_types_registry_validation.py
+++ b/testing/e2e/modules/types_registry/test_types_registry_validation.py
@@ -16,6 +16,10 @@ def unique_type_id(name: str) -> str:
     return f"gts.e2etest.validation.models.{name}{_counter}.v1~"
 
 
+def make_schema_id(gts_id: str) -> str:
+    return "gts://" + gts_id
+
+
 def unique_instance_id(type_id: str, name: str) -> str:
     """Generate a unique instance GTS ID based on a type ID."""
     global _counter
@@ -37,7 +41,7 @@ async def test_validation_invalid_instance_against_schema(base_url, auth_headers
         payload = {
             "entities": [
                 {
-                    "$id": type_id,
+                    "$id": make_schema_id(type_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -92,7 +96,7 @@ async def test_validation_wrong_type_for_field(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": type_id,
+                    "$id": make_schema_id(type_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -147,7 +151,7 @@ async def test_validation_valid_instance_succeeds(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": type_id,
+                    "$id": make_schema_id(type_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -207,7 +211,7 @@ async def test_validation_instance_before_type_fails(base_url, auth_headers):
                     "widgetId": "w-001"
                 },
                 {
-                    "$id": type_id,
+                    "$id": make_schema_id(type_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -292,7 +296,7 @@ async def test_validation_complex_nested_schema(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": type_id,
+                    "$id": make_schema_id(type_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {
@@ -357,7 +361,7 @@ async def test_validation_multiple_instances_same_type(base_url, auth_headers):
         payload = {
             "entities": [
                 {
-                    "$id": type_id,
+                    "$id": make_schema_id(type_id),
                     "$schema": "http://json-schema.org/draft-07/schema#",
                     "type": "object",
                     "properties": {

--- a/testing/requirements.txt
+++ b/testing/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-asyncio
+httpx


### PR DESCRIPTION
The 0.7.5 version prohibits using of 'gts.' prefix in JSON Schema $id values, it must start with "gts://gts."