### PR TITLE
fix(ci): Linux test job to disable debug info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,19 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf
 
       # Unit tests (excluding integration tests)
+      - name: cargo clean
+        if: runner.os == 'Linux'
+        run: cargo clean
+      - name: disk space
+        if: runner.os == 'Linux'
+        run: df -h && df -i
       - name: cargo test (no ui)
+        env:
+          RUSTFLAGS: "-C debuginfo=0"
         run: cargo test --workspace --no-fail-fast --exclude modkit-macros --exclude modkit-db-macros
+      - name: disk space
+        if: always() && runner.os == 'Linux' 
+        run: df -h && df -i
       # Print sccache stats when active
       - name: sccache stats
         if: env.SCCACHE_OK == '1'


### PR DESCRIPTION
Problem: Tests with debug info consumed 17GB+ of disk storage and available space gets exhausted.

Solution: Run tests with flag disabling debug info - disk consumption ~5GB