### PR TITLE
Remove humantime_serde crate in favor of stdlib duration parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,22 +2141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "humantime-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
-dependencies = [
- "humantime",
- "serde",
-]
-
-[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,7 +2917,6 @@ dependencies = [
  "dashmap",
  "dirs",
  "figment",
- "humantime-serde",
  "modkit-db-macros",
  "modkit-odata",
  "modkit-security",
@@ -2944,6 +2927,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
+ "serde_with",
  "sqlx",
  "tempfile",
  "testcontainers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,7 +234,6 @@ chrono = { version = "0.4", default-features = false, features = ["serde"] }
 
 # DSN parsing
 dsn = "1.1.1"
-humantime-serde = "1.1"
 
 # URL parsing
 url = "2.5"

--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -52,7 +52,7 @@ database:
       # Connection pool settings shared by all modules using this server
       pool:
         max_conns: 5             # Maximum 5 concurrent connections
-        acquire_timeout: "30s"   # Timeout when acquiring connection from pool
+        acquire_timeout: 30   # Timeout when acquiring connection from pool
 
   # Global database options
   # auto_provision: true       # (default) Create directories automatically for SQLite files
@@ -250,7 +250,7 @@ tracing:
 #         application_name: "hyperspot"
 #       pool:
 #         max_conns: 20
-#         acquire_timeout: "30s"
+#         acquire_timeout: 30
 # modules:
 #   users_module:
 #     database:

--- a/config/quickstart-windows.yaml
+++ b/config/quickstart-windows.yaml
@@ -52,7 +52,7 @@ database:
       # Connection pool settings shared by all modules using this server
       pool:
         max_conns: 5             # Maximum 5 concurrent connections
-        acquire_timeout: "30s"   # Timeout when acquiring connection from pool
+        acquire_timeout: 30   # Timeout when acquiring connection from pool
   
   # Global database options
   # auto_provision: true       # (default) Create directories automatically for SQLite files
@@ -272,7 +272,7 @@ tracing:
 #         application_name: "hyperspot"
 #       pool:
 #         max_conns: 20
-#         acquire_timeout: "30s"
+#         acquire_timeout: 30
 # modules:
 #   users_module:
 #     database:

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -52,7 +52,7 @@ database:
       # Connection pool settings shared by all modules using this server
       pool:
         max_conns: 5             # Maximum 5 concurrent connections
-        acquire_timeout: "30s"   # Timeout when acquiring connection from pool
+        acquire_timeout: 30   # Timeout when acquiring connection from pool
   
   # Global database options
   # auto_provision: true       # (default) Create directories automatically for SQLite files
@@ -254,7 +254,7 @@ tracing:
 #         application_name: "hyperspot"
 #       pool:
 #         max_conns: 20
-#         acquire_timeout: "30s"
+#         acquire_timeout: 30
 # modules:
 #   users_module:
 #     database:

--- a/config/server.yaml
+++ b/config/server.yaml
@@ -13,28 +13,28 @@ database:
       dsn: "sqlite://sysinfo.db?wal=true&synchronous=NORMAL&busy_timeout=5000"
       pool:
         max_conns: 5
-        acquire_timeout: "30s"
+        acquire_timeout: 30
     
     # SQLite server for benchmarks module  
     sqlite_benchmarks:
       dsn: "sqlite://benchmarks.db?wal=true&synchronous=NORMAL&busy_timeout=5000"
       pool:
         max_conns: 8
-        acquire_timeout: "30s"
+        acquire_timeout: 30
     
     # SQLite server for chat module
     sqlite_chat:
       dsn: "sqlite://chat.db?wal=true&synchronous=NORMAL&busy_timeout=5000"
       pool:
         max_conns: 10
-        acquire_timeout: "30s"
+        acquire_timeout: 30
     
     # Example PostgreSQL server (uncomment to use)
     # postgres_main:
     #   dsn: "postgresql://hyperspot:${PG_PASSWORD}@localhost:5432/hyperspot"
     #   pool:
     #     max_conns: 10
-    #     acquire_timeout: "30s"
+    #     acquire_timeout: 30
 
 # Logging configuration
 logging:

--- a/libs/modkit-db/Cargo.toml
+++ b/libs/modkit-db/Cargo.toml
@@ -42,12 +42,12 @@ bigdecimal = { workspace = true }
 rust_decimal = { workspace = true }
 ryu = { workspace = true }
 url = { workspace = true }
-humantime-serde = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 dashmap = { workspace = true }
 figment = { workspace = true }
+serde_with = "3.16.1"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/libs/modkit-db/src/config.rs
+++ b/libs/modkit-db/src/config.rs
@@ -51,6 +51,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
+use serde_with::{serde_as, DurationSeconds};
 
 /// Global database configuration with server-based DBs.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -94,16 +95,17 @@ pub struct DbConnConfig {
     pub server: Option<String>,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct PoolCfg {
     pub max_conns: Option<u32>,
     pub min_conns: Option<u32>,
-    #[serde(with = "humantime_serde", default)]
+    #[serde_as(as = "Option<DurationSeconds<u64>>")]
     pub acquire_timeout: Option<Duration>,
-    #[serde(with = "humantime_serde", default)]
+    #[serde_as(as = "Option<DurationSeconds<u64>>")]
     pub idle_timeout: Option<Duration>,
-    #[serde(with = "humantime_serde", default)]
+    #[serde_as(as = "Option<DurationSeconds<u64>>")]
     pub max_lifetime: Option<Duration>,
     pub test_before_acquire: Option<bool>,
 }

--- a/libs/modkit-db/src/config.rs
+++ b/libs/modkit-db/src/config.rs
@@ -48,10 +48,10 @@
 //! See the test suite in `tests/precedence_tests.rs` for complete verification.
 
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DurationSeconds};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
-use serde_with::{serde_as, DurationSeconds};
 
 /// Global database configuration with server-based DBs.
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/libs/modkit-db/tests/concurrency_tests.rs
+++ b/libs/modkit-db/tests/concurrency_tests.rs
@@ -337,7 +337,7 @@ async fn test_concurrent_slow_initialization() {
                     "file": format!("slow_test_{}.db", std::process::id()),
                     "pool": {
                         "max_conns": 1,           // Force serialization
-                        "acquire_timeout": "5s"   // Longer timeout
+                        "acquire_timeout": 5   // Longer timeout
                     }
                 }
             }

--- a/libs/modkit-db/tests/config_tests.rs
+++ b/libs/modkit-db/tests/config_tests.rs
@@ -116,26 +116,6 @@ fn test_poolcfg_defaults() {
 }
 
 #[test]
-fn test_poolcfg_with_humantime() {
-    // Test that humantime_serde works correctly
-    let json = r#"{
-        "max_conns": 15,
-        "acquire_timeout": "45s"
-    }"#;
-
-    let pool: PoolCfg = serde_json::from_str(json).expect("Failed to deserialize PoolCfg");
-    assert_eq!(pool.max_conns, Some(15));
-    assert_eq!(pool.acquire_timeout, Some(Duration::from_secs(45)));
-
-    // Test serialization back
-    let serialized = serde_json::to_string(&pool).expect("Failed to serialize PoolCfg");
-    let deserialized: PoolCfg =
-        serde_json::from_str(&serialized).expect("Failed to deserialize again");
-    assert_eq!(deserialized.max_conns, Some(15));
-    assert_eq!(deserialized.acquire_timeout, Some(Duration::from_secs(45)));
-}
-
-#[test]
 fn test_deny_unknown_fields() {
     // Test that serde(deny_unknown_fields) works for DbConnConfig
     let json_with_unknown = r#"{

--- a/libs/modkit-db/tests/pooling_tests.rs
+++ b/libs/modkit-db/tests/pooling_tests.rs
@@ -20,7 +20,7 @@ async fn test_pool_cfg_options_applied() {
                     "pool": {
                         "max_conns": 20,
                         "min_conns": 2,
-                        "acquire_timeout": "45",
+                        "acquire_timeout": 45,
                         "idle_timeout": "300",
                         "max_lifetime": "1800",
                         "test_before_acquire": true

--- a/libs/modkit-db/tests/pooling_tests.rs
+++ b/libs/modkit-db/tests/pooling_tests.rs
@@ -20,9 +20,9 @@ async fn test_pool_cfg_options_applied() {
                     "pool": {
                         "max_conns": 20,
                         "min_conns": 2,
-                        "acquire_timeout": "45s",
-                        "idle_timeout": "300s",
-                        "max_lifetime": "1800s",
+                        "acquire_timeout": "45",
+                        "idle_timeout": "300",
+                        "max_lifetime": "1800",
                         "test_before_acquire": true
                     }
                 }
@@ -82,7 +82,7 @@ async fn test_module_pool_overrides_server_pool() {
                     "dsn": "sqlite::memory:",
                     "pool": {
                         "max_conns": 25,          // Should override server value (10)
-                        "acquire_timeout": "60s"  // Should override server value (30s)
+                        "acquire_timeout": 60.    // Should override server value (30s)
                         // Other values should be inherited from server
                     }
                 }
@@ -98,7 +98,7 @@ async fn test_module_pool_overrides_server_pool() {
     match result {
         Ok(_handle) => {
             // Connection succeeded - module pool config took precedence
-            // The pool should have max_conns=25 and acquire_timeout=60s from module config
+            // The pool should have max_conns=25 and acquire_timeout=60 from module config
         }
         Err(err) => {
             panic!("Expected successful connection with overridden pool settings, got: {err:?}");
@@ -246,7 +246,7 @@ async fn test_partial_pool_configuration() {
                     "dsn": "sqlite::memory:",
                     "pool": {
                         "max_conns": 8,
-                        "acquire_timeout": "20s"
+                        "acquire_timeout": 20
                         // Other fields should use defaults
                     }
                 }
@@ -267,30 +267,6 @@ async fn test_partial_pool_configuration() {
             panic!("Expected successful connection with partial pool config, got: {err:?}");
         }
     }
-}
-
-/// Test humantime parsing for duration fields.
-#[test]
-fn test_humantime_parsing() {
-    // Test various humantime formats
-    let test_cases = vec![
-        r#"{"acquire_timeout": "30s"}"#,
-        r#"{"acquire_timeout": "5m"}"#,
-        r#"{"acquire_timeout": "1h"}"#,
-        r#"{"acquire_timeout": "500ms"}"#,
-        r#"{"idle_timeout": "10min"}"#,
-        r#"{"max_lifetime": "2hours"}"#,
-    ];
-
-    for case in test_cases {
-        let result: Result<PoolCfg, _> = serde_json::from_str(case);
-        assert!(result.is_ok(), "Failed to parse: {case}");
-    }
-
-    // Test invalid humantime format
-    let invalid_case = r#"{"acquire_timeout": "invalid_duration"}"#;
-    let result: Result<PoolCfg, _> = serde_json::from_str(invalid_case);
-    assert!(result.is_err());
 }
 
 /// Test `PoolCfg` serialization and deserialization roundtrip.

--- a/libs/modkit/src/bootstrap/config/mod.rs
+++ b/libs/modkit/src/bootstrap/config/mod.rs
@@ -2404,7 +2404,7 @@ logging:
                 "server": "test_server",
                 "pool": {
                     "max_conns": 30,
-                    "acquire_timeout": "10s"
+                    "acquire_timeout": 10
                 }
             }),
         );


### PR DESCRIPTION
Closes #45 

Removes `humantime-serde` since it is unmaintained and we can achieve almost the same functionality using the standard library. The only difference is now durations have to be integers in the yaml, which represent seconds, instead of allowing strings such as `5s`. The existing configs have been aligned with the new approach, so they can be viewed to see the difference.