### PR TITLE
feat: Odata dylints

### DIFF
--- a/dylint_lints/Cargo.lock
+++ b/dylint_lints/Cargo.lock
@@ -428,6 +428,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "de0802_use_odata_ext"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "dylint_testing",
+ "lint_utils",
+]
+
+[[package]]
 name = "de0901_gts_string_pattern"
 version = "0.1.0"
 dependencies = [

--- a/dylint_lints/Cargo.toml
+++ b/dylint_lints/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "de02_api_layer/de0203_dtos_must_have_serde_derives",
     "de02_api_layer/de0204_dtos_must_have_toschema_derive",
     "de08_rest_api_conventions/de0801_api_endpoint_version",
+    "de08_rest_api_conventions/de0802_use_odata_ext",
     "de09_gts_layer/de0901_gts_string_pattern",
     "de09_gts_layer/de0902_no_schema_for_on_gts_structs",
 ]

--- a/dylint_lints/README.md
+++ b/dylint_lints/README.md
@@ -41,6 +41,7 @@ make dylint-test         # Test UI cases (compile & verify violations)
 
 **REST Conventions (DE08xx)**
 - ✅ DE0801: API Endpoint Must Have Version
+- ✅ DE0802: Use OData Extension Methods
 
 **GTS (DE09xx)**
 - TODO

--- a/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/Cargo.toml
+++ b/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "de0802_use_odata_ext"
+version = "0.1.0"
+authors = ["Hypernetix"]
+description = "DE0802: Use OperationBuilderODataExt methods instead of .query_param() for OData parameters"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[[example]]
+name = "valid_odata"
+path = "ui/valid_odata.rs"
+
+[[example]]
+name = "invalid_odata"
+path = "ui/invalid_odata.rs"
+
+[dependencies]
+clippy_utils.workspace = true
+dylint_linting.workspace = true
+lint_utils.workspace = true
+
+[dev-dependencies]
+dylint_testing.workspace = true
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/rust-toolchain
+++ b/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-09-18"
+components = ["llvm-tools-preview", "rustc-dev"]

--- a/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/src/lib.rs
+++ b/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/src/lib.rs
@@ -1,0 +1,164 @@
+#![feature(rustc_private)]
+#![warn(unused_extern_crates)]
+
+extern crate rustc_ast;
+extern crate rustc_hir;
+
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Checks that OData query parameters (`$filter`, `$orderby`, `$select`, `$top`, `$skip`)
+    /// are registered using `OperationBuilderODataExt` methods instead of manual `.query_param()` calls.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Using `.query_param("$filter", ...)` bypasses the type-safe OData system:
+    /// - No compile-time validation of filterable/orderable fields
+    /// - No automatic OpenAPI schema generation for allowed fields
+    /// - Inconsistent API documentation
+    /// - Harder to maintain as DTO fields change
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// // Bad - manual OData parameter registration
+    /// OperationBuilder::get("/users-info/v1/users")
+    ///     .query_param("$filter", false, "OData filter")
+    ///     .query_param("$orderby", false, "OData ordering")
+    ///     .query_param("$select", false, "OData field selection")
+    /// ```
+    ///
+    /// Use instead:
+    ///
+    /// ```rust,ignore
+    /// // Good - type-safe OData registration
+    /// OperationBuilder::get("/users-info/v1/users")
+    ///     .with_odata_filter::<dto::UserDtoFilterField>()
+    ///     .with_odata_orderby::<dto::UserDtoFilterField>()
+    ///     .with_odata_select()
+    /// ```
+    pub DE0802_USE_ODATA_EXT,
+    Deny,
+    "use OperationBuilderODataExt methods instead of .query_param() for OData parameters (DE0802)"
+}
+
+/// OData query parameter names that should use the type-safe extension methods
+const ODATA_PARAMS: &[&str] = &["$filter", "$orderby", "$select", "$top", "$skip", "$count"];
+
+/// Mapping from OData parameter to the recommended method
+fn get_recommended_method(param: &str) -> &'static str {
+    match param {
+        "$filter" => ".with_odata_filter::<FilterFieldEnum>()",
+        "$orderby" => ".with_odata_orderby::<FilterFieldEnum>()",
+        "$select" => ".with_odata_select()",
+        "$top" | "$skip" | "$count" => ".query_param_typed() with proper OData extractor",
+        _ => "the appropriate OperationBuilderODataExt method",
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for De0802UseOdataExt {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        // Look for method calls like .query_param(...) or .query_param_typed(...)
+        if let ExprKind::MethodCall(method_segment, receiver, args, _span) = &expr.kind {
+            let method_name = method_segment.ident.name.as_str();
+
+            // Check if this is a query_param or query_param_typed call
+            if method_name != "query_param" && method_name != "query_param_typed" {
+                return;
+            }
+
+            // Check if the receiver chain contains OperationBuilder
+            if !is_operation_builder_chain(receiver) {
+                return;
+            }
+
+            // Check the first argument (parameter name)
+            if let Some(first_arg) = args.first() {
+                check_odata_param(cx, first_arg, method_name);
+            }
+        }
+    }
+}
+
+/// Check if an expression is part of an OperationBuilder method chain
+fn is_operation_builder_chain(expr: &Expr<'_>) -> bool {
+    match &expr.kind {
+        // Direct call like OperationBuilder::get(...)
+        ExprKind::Call(func, _) => {
+            if let ExprKind::Path(qpath) = &func.kind {
+                return path_contains_operation_builder(qpath);
+            }
+            false
+        }
+        // Method chain like builder.something().query_param(...)
+        ExprKind::MethodCall(_, receiver, _, _) => is_operation_builder_chain(receiver),
+        // Path expression
+        ExprKind::Path(qpath) => path_contains_operation_builder(qpath),
+        _ => false,
+    }
+}
+
+/// Check if a QPath contains "OperationBuilder"
+fn path_contains_operation_builder(qpath: &rustc_hir::QPath<'_>) -> bool {
+    match qpath {
+        rustc_hir::QPath::Resolved(_, path) => path
+            .segments
+            .iter()
+            .any(|seg| seg.ident.name.as_str() == "OperationBuilder"),
+        rustc_hir::QPath::TypeRelative(ty, segment) => {
+            segment.ident.name.as_str() == "OperationBuilder"
+                || type_contains_operation_builder(ty)
+        }
+        _ => false,
+    }
+}
+
+/// Recursively check if a type contains "OperationBuilder"
+fn type_contains_operation_builder(ty: &rustc_hir::Ty<'_>) -> bool {
+    match &ty.kind {
+        rustc_hir::TyKind::Path(qpath) => path_contains_operation_builder(qpath),
+        _ => false,
+    }
+}
+
+/// Check if the first argument is an OData parameter and emit lint if so
+fn check_odata_param<'tcx>(cx: &LateContext<'tcx>, arg: &'tcx Expr<'tcx>, method_name: &str) {
+    if let ExprKind::Lit(lit) = &arg.kind
+        && let rustc_ast::ast::LitKind::Str(sym, _) = lit.node
+    {
+        let param_name = sym.as_str();
+
+        // Check if this is an OData parameter
+        if ODATA_PARAMS.contains(&param_name) {
+            let recommended = get_recommended_method(param_name);
+
+            cx.span_lint(DE0802_USE_ODATA_EXT, arg.span, |diag| {
+                diag.primary_message(format!(
+                    "use OperationBuilderODataExt instead of .{}() for OData parameter `{}` (DE0802)",
+                    method_name, param_name
+                ));
+                diag.help(format!("use {} instead", recommended));
+                diag.note(
+                    "type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation",
+                );
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn ui_examples() {
+        dylint_testing::ui_test_examples(env!("CARGO_PKG_NAME"));
+    }
+
+    #[test]
+    fn test_comment_annotations_match_stderr() {
+        let ui_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
+        lint_utils::test_comment_annotations_match_stderr(&ui_dir, "DE0802", "use OData ext");
+    }
+}

--- a/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/ui/invalid_odata.rs
+++ b/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/ui/invalid_odata.rs
@@ -1,0 +1,74 @@
+#![allow(dead_code)]
+
+pub struct OperationBuilder;
+
+impl OperationBuilder {
+    pub fn get(_path: &str) -> Self {
+        Self
+    }
+    pub fn post(_path: &str) -> Self {
+        Self
+    }
+    pub fn query_param(self, _name: &str, _required: bool, _desc: &str) -> Self {
+        self
+    }
+    pub fn query_param_typed(self, _name: &str, _required: bool, _desc: &str, _type: &str) -> Self {
+        self
+    }
+    pub fn handler<F>(self, _handler: F) -> Self {
+        self
+    }
+    pub fn register(self) -> Self {
+        self
+    }
+}
+
+fn dummy_handler() {}
+
+pub fn define_endpoints() {
+    // Using query_param for $filter - should use with_odata_filter
+    // Should trigger DE0802 - use OData ext
+    OperationBuilder::get("/users-info/v1/users")
+        .query_param("$filter", false, "OData filter expression");
+
+    // Using query_param for $orderby - should use with_odata_orderby
+    // Should trigger DE0802 - use OData ext
+    OperationBuilder::get("/users-info/v1/users")
+        .query_param("$orderby", false, "OData ordering");
+
+    // Using query_param for $select - should use with_odata_select
+    // Should trigger DE0802 - use OData ext
+    OperationBuilder::get("/users-info/v1/users")
+        .query_param("$select", false, "OData field selection");
+
+    // Using query_param_typed for $filter
+    // Should trigger DE0802 - use OData ext
+    OperationBuilder::post("/users-info/v1/users")
+        .query_param_typed("$filter", false, "OData filter", "string");
+
+    // Using query_param for $top
+    // Should trigger DE0802 - use OData ext
+    OperationBuilder::get("/users-info/v1/users")
+        .query_param("$top", false, "Maximum number of results");
+
+    // Using query_param for $skip
+    // Should trigger DE0802 - use OData ext
+    OperationBuilder::get("/users-info/v1/users")
+        .query_param("$skip", false, "Number of results to skip");
+
+    // Using query_param for $count
+    // Should trigger DE0802 - use OData ext
+    OperationBuilder::get("/users-info/v1/users")
+        .query_param("$count", false, "Include total count");
+
+    // Multiple OData params in chain
+    // Should trigger DE0802 - use OData ext
+    OperationBuilder::get("/users-info/v1/users")
+        .query_param("$filter", false, "Filter")
+        // Should trigger DE0802 - use OData ext
+        .query_param("$orderby", false, "Order")
+        .handler(dummy_handler)
+        .register();
+}
+
+fn main() {}

--- a/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/ui/invalid_odata.stderr
+++ b/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/ui/invalid_odata.stderr
@@ -1,0 +1,83 @@
+error: use OperationBuilderODataExt instead of .query_param() for OData parameter `$filter` (DE0802)
+  --> $DIR/invalid_odata.rs:32:22
+   |
+LL |         .query_param("$filter", false, "OData filter expression");
+   |                      ^^^^^^^^^
+   |
+   = help: use .with_odata_filter::<FilterFieldEnum>() instead
+   = note: type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation
+   = note: `#[deny(de0802_use_odata_ext)]` on by default
+
+error: use OperationBuilderODataExt instead of .query_param() for OData parameter `$orderby` (DE0802)
+  --> $DIR/invalid_odata.rs:37:22
+   |
+LL |         .query_param("$orderby", false, "OData ordering");
+   |                      ^^^^^^^^^^
+   |
+   = help: use .with_odata_orderby::<FilterFieldEnum>() instead
+   = note: type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation
+
+error: use OperationBuilderODataExt instead of .query_param() for OData parameter `$select` (DE0802)
+  --> $DIR/invalid_odata.rs:42:22
+   |
+LL |         .query_param("$select", false, "OData field selection");
+   |                      ^^^^^^^^^
+   |
+   = help: use .with_odata_select() instead
+   = note: type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation
+
+error: use OperationBuilderODataExt instead of .query_param_typed() for OData parameter `$filter` (DE0802)
+  --> $DIR/invalid_odata.rs:47:28
+   |
+LL |         .query_param_typed("$filter", false, "OData filter", "string");
+   |                            ^^^^^^^^^
+   |
+   = help: use .with_odata_filter::<FilterFieldEnum>() instead
+   = note: type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation
+
+error: use OperationBuilderODataExt instead of .query_param() for OData parameter `$top` (DE0802)
+  --> $DIR/invalid_odata.rs:52:22
+   |
+LL |         .query_param("$top", false, "Maximum number of results");
+   |                      ^^^^^^
+   |
+   = help: use .query_param_typed() with proper OData extractor instead
+   = note: type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation
+
+error: use OperationBuilderODataExt instead of .query_param() for OData parameter `$skip` (DE0802)
+  --> $DIR/invalid_odata.rs:57:22
+   |
+LL |         .query_param("$skip", false, "Number of results to skip");
+   |                      ^^^^^^^
+   |
+   = help: use .query_param_typed() with proper OData extractor instead
+   = note: type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation
+
+error: use OperationBuilderODataExt instead of .query_param() for OData parameter `$count` (DE0802)
+  --> $DIR/invalid_odata.rs:62:22
+   |
+LL |         .query_param("$count", false, "Include total count");
+   |                      ^^^^^^^^
+   |
+   = help: use .query_param_typed() with proper OData extractor instead
+   = note: type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation
+
+error: use OperationBuilderODataExt instead of .query_param() for OData parameter `$filter` (DE0802)
+  --> $DIR/invalid_odata.rs:67:22
+   |
+LL |         .query_param("$filter", false, "Filter")
+   |                      ^^^^^^^^^
+   |
+   = help: use .with_odata_filter::<FilterFieldEnum>() instead
+   = note: type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation
+
+error: use OperationBuilderODataExt instead of .query_param() for OData parameter `$orderby` (DE0802)
+  --> $DIR/invalid_odata.rs:69:22
+   |
+LL |         .query_param("$orderby", false, "Order")
+   |                      ^^^^^^^^^^
+   |
+   = help: use .with_odata_orderby::<FilterFieldEnum>() instead
+   = note: type-safe OData methods provide compile-time validation and automatic OpenAPI schema generation
+
+error: aborting due to 9 previous errors

--- a/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/ui/valid_odata.rs
+++ b/dylint_lints/de08_rest_api_conventions/de0802_use_odata_ext/ui/valid_odata.rs
@@ -1,0 +1,72 @@
+#![allow(dead_code)]
+
+pub struct OperationBuilder;
+
+impl OperationBuilder {
+    pub fn get(_path: &str) -> Self {
+        Self
+    }
+    pub fn post(_path: &str) -> Self {
+        Self
+    }
+    pub fn query_param(self, _name: &str, _required: bool, _desc: &str) -> Self {
+        self
+    }
+    pub fn query_param_typed(self, _name: &str, _required: bool, _desc: &str, _type: &str) -> Self {
+        self
+    }
+    pub fn with_odata_filter<T>(self) -> Self {
+        self
+    }
+    pub fn with_odata_orderby<T>(self) -> Self {
+        self
+    }
+    pub fn with_odata_select(self) -> Self {
+        self
+    }
+    pub fn handler<F>(self, _handler: F) -> Self {
+        self
+    }
+    pub fn register(self) -> Self {
+        self
+    }
+}
+
+struct UserDtoFilterField;
+
+fn dummy_handler() {}
+
+pub fn define_endpoints() {
+    // Should not trigger DE0802 - use OData ext (using proper OData extension methods)
+    OperationBuilder::get("/users-info/v1/users")
+        .with_odata_filter::<UserDtoFilterField>()
+        .with_odata_orderby::<UserDtoFilterField>()
+        .with_odata_select()
+        .handler(dummy_handler)
+        .register();
+
+    // Should not trigger DE0802 - use OData ext (non-OData query params are fine)
+    OperationBuilder::get("/users-info/v1/users")
+        .query_param("limit", false, "Maximum number of results")
+        .query_param("cursor", false, "Pagination cursor")
+        .query_param("search", false, "Search term")
+        .handler(dummy_handler)
+        .register();
+
+    // Should not trigger DE0802 - use OData ext (typed non-OData params are fine)
+    OperationBuilder::post("/users-info/v1/users")
+        .query_param_typed("limit", false, "Max results", "integer")
+        .query_param_typed("offset", false, "Offset", "integer")
+        .handler(dummy_handler)
+        .register();
+
+    // Should not trigger DE0802 - use OData ext (mixed valid usage)
+    OperationBuilder::get("/users-info/v1/users")
+        .with_odata_filter::<UserDtoFilterField>()
+        .with_odata_select()
+        .query_param("include_deleted", false, "Include soft-deleted records")
+        .handler(dummy_handler)
+        .register();
+}
+
+fn main() {}


### PR DESCRIPTION
Add DE0802 dylint: enforce OperationBuilderODataExt for OData parameters
    
- Detect .query_param()/.query_param_typed() calls on OperationBuilder with OData params
- Suggest using .with_odata_filter(), .with_odata_orderby(), .with_odata_select() instead
- Covers $filter, $orderby, $select, $top, $skip, $count parameters
- Include UI tests with valid/invalid examples
- Update dylint_lints README with new lint entry
- Update MODKIT_PLUGINS, MODKIT_UNIFIED_SYSTEM, NEW_MODULE
    
This enforces type-safe OData registration and prevents bypassing the
type-safe OData system that provides compile-time validation and automatic
OpenAPI schema generation.
    
Fix: https://github.com/hypernetix/hyperspot/issues/178
    
Signed-off-by: Artifizer <artifizer@gmail.com>