### PR TITLE
feat(modkit-sdk): add typed SDK for ergonomic OData querying and pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
  "axum",
  "chrono",
  "dashmap",
- "futures",
+ "futures-core",
  "governor",
  "http",
  "inventory",
@@ -1533,7 +1533,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "docx-rust",
- "futures",
+ "futures-util",
  "http",
  "inventory",
  "mime",
@@ -2259,6 +2259,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "api_ingress",
+ "calculator",
  "calculator_gateway",
  "clap",
  "contoso_tr_plugin",
@@ -2846,7 +2847,8 @@ dependencies = [
  "dsn",
  "figment",
  "file-rotate",
- "futures",
+ "futures-core",
+ "futures-util",
  "gts",
  "gts-macros",
  "http",
@@ -2856,6 +2858,7 @@ dependencies = [
  "modkit-errors",
  "modkit-macros",
  "modkit-odata",
+ "modkit-sdk",
  "module_orchestrator-contracts",
  "module_orchestrator-grpc",
  "nix 0.29.0",
@@ -3039,6 +3042,36 @@ dependencies = [
  "sha2",
  "thiserror 2.0.17",
  "utoipa",
+ "uuid",
+]
+
+[[package]]
+name = "modkit-sdk"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "futures-core",
+ "futures-util",
+ "modkit-odata",
+ "modkit-sdk-macros",
+ "modkit-security",
+ "pin-project-lite",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "modkit-sdk-macros"
+version = "0.1.0"
+dependencies = [
+ "heck 0.5.0",
+ "modkit-odata",
+ "modkit-sdk",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "trybuild",
  "uuid",
 ]
 
@@ -6421,7 +6454,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
- "futures",
+ "futures-util",
  "http",
  "httpmock",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ members = [
     "libs/modkit-db",
     "libs/modkit-db-macros",
     "libs/modkit-auth",
+    "libs/modkit-sdk",
+    "libs/modkit-sdk-macros",
     "libs/modkit-security",
     "libs/modkit-errors",
     "libs/modkit-errors-macro",
@@ -307,6 +309,11 @@ trybuild = "1"
 testcontainers = "0.26"
 testcontainers-modules = { version = "0.14", features = ["postgres", "mysql"] }
 httpmock = "0.8"
+
+# Async utilities
+futures-core = "0.3"
+futures-util = "0.3"
+pin-project-lite = "0.2"
 
 # Other utilities
 once_cell = "1.20"

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 [features]
 default = []
 users-info-example = ["dep:users_info"]
-oop-example = ["dep:calculator_gateway"]
+oop-example = ["dep:calculator_gateway", "dep:calculator"]
 tenant-resolver-example = ["dep:tenant_resolver_gw", "dep:contoso_tr_plugin", "dep:fabrikam_tr_plugin"]
 otel = ["modkit/otel"]
 
@@ -50,6 +50,7 @@ sqlx = { workspace = true, features = ["postgres", "sqlite"] }
 # Optional example module
 users_info = { path = "../../examples/modkit/users_info/users_info", optional = true }
 calculator_gateway = { path = "../../examples/oop-modules/calculator_gateway/calculator_gateway", optional = true }
+calculator = { path = "../../examples/oop-modules/calculator/calculator", optional = true }
 
 # tenant_resolver plugin example
 tenant_resolver_gw = { package = "tenant_resolver-gw", path = "../../examples/plugin-modules/tenant_resolver/tenant_resolver-gw", optional = true }

--- a/apps/hyperspot-server/src/main.rs
+++ b/apps/hyperspot-server/src/main.rs
@@ -176,6 +176,10 @@ fn override_modules_with_mock_db(config: &mut AppConfig) {
                 "database".to_owned(),
                 serde_json::json!({
                     "dsn": "sqlite::memory:",
+                    "pool": {
+                        "max_conns": 1,
+                        "min_conns": 1
+                    },
                     "params": {
                         "journal_mode": "WAL"
                     }

--- a/apps/hyperspot-server/src/registered_modules.rs
+++ b/apps/hyperspot-server/src/registered_modules.rs
@@ -16,6 +16,9 @@ use users_info as _;
 #[cfg(feature = "oop-example")]
 use calculator_gateway as _;
 
+#[cfg(feature = "oop-example")]
+use calculator as _;
+
 #[cfg(feature = "tenant-resolver-example")]
 use contoso_tr_plugin as _;
 #[cfg(feature = "tenant-resolver-example")]

--- a/apps/hyperspot-server/tests/cli_smoke_tests.rs
+++ b/apps/hyperspot-server/tests/cli_smoke_tests.rs
@@ -217,6 +217,7 @@ modules:
       enable_docs: false
       cors_enabled: false
       auth_disabled: true
+  users_info: {{}}
 "#,
         temp_dir
             .path()

--- a/examples/modkit/users_info/users_info/Cargo.toml
+++ b/examples/modkit/users_info/users_info/Cargo.toml
@@ -31,7 +31,7 @@ utoipa = { workspace = true, features = ["time"] }
 # HTTP and REST
 axum = { workspace = true, features = ["macros"] }
 tower-http = { workspace = true, features = ["timeout"] }
-futures = { workspace = true }
+futures-util  = { workspace = true }
 http = { workspace = true }
 
 # Time handling

--- a/examples/modkit/users_info/users_info/src/api/rest/routes.rs
+++ b/examples/modkit/users_info/users_info/src/api/rest/routes.rs
@@ -214,7 +214,7 @@ mod sse_tests {
     use crate::api::rest::sse_adapter::SseUserEventPublisher;
     use crate::domain::events::UserDomainEvent;
     use crate::domain::ports::EventPublisher;
-    use futures::StreamExt;
+    use futures_util::StreamExt;
     use modkit::SseBroadcaster;
     use time::OffsetDateTime;
     use tokio::time::{timeout, Duration};

--- a/libs/modkit-sdk-macros/Cargo.toml
+++ b/libs/modkit-sdk-macros/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "modkit-sdk-macros"
+version.workspace = true
+edition.workspace = true
+description = "Proc-macro derives for modkit-sdk OData schema generation"
+license.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { workspace = true }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+heck = { workspace = true }
+proc-macro-error2 = { workspace = true }
+
+[dev-dependencies]
+trybuild = { workspace = true }
+modkit-sdk = { path = "../modkit-sdk", default-features = false, features = ["uuid"] }
+modkit-odata = { path = "../modkit-odata" }
+uuid = { workspace = true, features = ["v7"] }

--- a/libs/modkit-sdk-macros/README.md
+++ b/libs/modkit-sdk-macros/README.md
@@ -1,0 +1,146 @@
+# modkit-sdk-macros
+
+Procedural macros for `modkit-sdk` OData schema generation.
+
+## `#[derive(ODataSchema)]`
+
+Automatically generates OData schema boilerplate for DTO structs, including:
+
+- Field enum with variants for each struct field
+- Schema implementation mapping fields to OData names
+- Typed `FieldRef` constructor functions in a snake_case module
+
+### Example
+
+```rust
+use modkit_sdk::ODataSchema;
+
+#[derive(ODataSchema)]
+struct User {
+    id: uuid::Uuid,
+    email: String,
+    name: String,
+    age: i32,
+}
+
+// Generated code includes:
+// - UserField enum with Id, Email, Name, Age variants
+// - UserSchema struct implementing Schema trait
+// - user module with id(), email(), name(), age() constructors
+
+// Usage:
+use modkit_sdk::odata::{QueryBuilder, FilterExpr};
+use modkit_odata::SortDir;
+
+let user_id = uuid::Uuid::new_v4();
+let query = QueryBuilder::<UserSchema>::new()
+    .filter(user::id().eq(user_id).and(user::age().ge(18)))
+    .order_by(user::name(), SortDir::Asc)
+    .select(&[&user::id(), &user::email(), &user::name()])
+    .page_size(50)
+    .build();
+
+// Type safety is enforced at compile time:
+// This works - age is i32
+let _ = user::age().gt(18);
+
+// This fails - contains() only works on String fields
+// let _ = user::age().contains("test");  // Compile error!
+
+// This fails - field constructors are not generic
+// let _ = user::age::<String>();  // Compile error!
+```
+
+### Custom Field Names
+
+Use `#[odata(name = "...")]` to override the default field name:
+
+```rust
+#[derive(ODataSchema)]
+struct Product {
+    #[odata(name = "product_id")]
+    id: uuid::Uuid,
+    #[odata(name = "product_name")]
+    name: String,
+    price: i32,
+}
+
+// ProductSchema::field_name(ProductField::Id) returns "product_id"
+// product::id() creates a FieldRef with OData name "product_id"
+```
+
+### Generated Code Structure
+
+For a struct named `User`, the macro generates:
+
+1. **Field Enum**: `UserField` with a variant for each field
+2. **Schema Struct**: `UserSchema` implementing `modkit_sdk::odata::Schema`
+3. **Constructor Module**: `user` module with typed constructor functions
+
+```rust
+// Generated:
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum UserField {
+    Id,
+    Email,
+    Name,
+    Age,
+}
+
+pub struct UserSchema;
+
+impl modkit_sdk::odata::Schema for UserSchema {
+    type Field = UserField;
+    
+    fn field_name(field: Self::Field) -> &'static str {
+        match field {
+            UserField::Id => "id",
+            UserField::Email => "email",
+            UserField::Name => "name",
+            UserField::Age => "age",
+        }
+    }
+}
+
+pub mod user {
+    #[must_use]
+    pub fn id() -> modkit_sdk::odata::FieldRef<super::UserSchema, uuid::Uuid> {
+        modkit_sdk::odata::FieldRef::new(super::UserField::Id)
+    }
+    
+    #[must_use]
+    pub fn email() -> modkit_sdk::odata::FieldRef<super::UserSchema, String> {
+        modkit_sdk::odata::FieldRef::new(super::UserField::Email)
+    }
+    
+    #[must_use]
+    pub fn name() -> modkit_sdk::odata::FieldRef<super::UserSchema, String> {
+        modkit_sdk::odata::FieldRef::new(super::UserField::Name)
+    }
+    
+    #[must_use]
+    pub fn age() -> modkit_sdk::odata::FieldRef<super::UserSchema, i32> {
+        modkit_sdk::odata::FieldRef::new(super::UserField::Age)
+    }
+}
+```
+
+## Requirements
+
+- Only works on structs with named fields
+- Does not support enums or tuple structs
+- Field types must be compatible with `FieldRef<S, T>`
+
+## Testing
+
+The crate includes comprehensive tests:
+
+- Unit tests in `tests/odata_schema.rs`
+- Compile-time tests using `trybuild` in `tests/compile_tests.rs`
+- UI tests for both passing and failing cases
+
+Run tests with:
+
+```bash
+cargo test --package modkit-sdk-macros
+```

--- a/libs/modkit-sdk-macros/src/lib.rs
+++ b/libs/modkit-sdk-macros/src/lib.rs
@@ -1,0 +1,14 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+use proc_macro::TokenStream;
+use proc_macro_error2::proc_macro_error;
+use syn::{parse_macro_input, DeriveInput};
+
+mod odata_schema;
+
+#[proc_macro_derive(ODataSchema, attributes(odata))]
+#[proc_macro_error]
+pub fn derive_odata_schema(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    odata_schema::expand_derive_odata_schema(&input).into()
+}

--- a/libs/modkit-sdk-macros/src/odata_schema.rs
+++ b/libs/modkit-sdk-macros/src/odata_schema.rs
@@ -1,0 +1,135 @@
+use heck::ToSnakeCase;
+use proc_macro2::TokenStream;
+use proc_macro_error2::abort;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, Ident, Lit, Meta};
+
+pub fn expand_derive_odata_schema(input: &DeriveInput) -> TokenStream {
+    let struct_name = &input.ident;
+
+    let fields = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(fields) => &fields.named,
+            _ => abort!(input, "ODataSchema only supports structs with named fields"),
+        },
+        _ => abort!(input, "ODataSchema can only be derived for structs"),
+    };
+
+    let mut field_variants = Vec::new();
+    let mut field_names = Vec::new();
+    let mut field_types = Vec::new();
+    let mut field_constructors = Vec::new();
+
+    for field in fields {
+        let Some(field_ident) = field.ident.as_ref() else {
+            abort!(field, "ODataSchema requires named fields");
+        };
+        let field_type = &field.ty;
+
+        let odata_name = extract_odata_name(&field.attrs, field_ident);
+
+        let variant_name = to_pascal_case(&field_ident.to_string());
+        let variant_ident = Ident::new(&variant_name, field_ident.span());
+
+        field_variants.push(variant_ident.clone());
+        field_names.push((variant_ident.clone(), odata_name.clone()));
+        field_types.push((field_ident.clone(), field_type.clone()));
+        field_constructors.push((field_ident.clone(), variant_ident, field_type.clone()));
+    }
+
+    let field_enum_name = Ident::new(&format!("{struct_name}Field"), struct_name.span());
+    let schema_struct_name = Ident::new(&format!("{struct_name}Schema"), struct_name.span());
+    let module_name = Ident::new(&struct_name.to_string().to_snake_case(), struct_name.span());
+
+    let field_enum = quote! {
+        #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+        pub enum #field_enum_name {
+            #(#field_variants,)*
+        }
+    };
+
+    let field_name_arms = field_names.iter().map(|(variant, name)| {
+        quote! {
+            #field_enum_name::#variant => #name
+        }
+    });
+
+    let schema_impl = quote! {
+        pub struct #schema_struct_name;
+
+        impl modkit_sdk::odata::Schema for #schema_struct_name {
+            type Field = #field_enum_name;
+
+            fn field_name(field: Self::Field) -> &'static str {
+                match field {
+                    #(#field_name_arms,)*
+                }
+            }
+        }
+    };
+
+    let constructor_fns = field_constructors
+        .iter()
+        .map(|(field_ident, variant, field_type)| {
+            let fn_name = field_ident.clone();
+            quote! {
+                #[must_use]
+                pub fn #fn_name() -> modkit_sdk::odata::FieldRef<super::#schema_struct_name, #field_type> {
+                    modkit_sdk::odata::FieldRef::new(super::#field_enum_name::#variant)
+                }
+            }
+        });
+
+    let constructor_module = quote! {
+        pub mod #module_name {
+            #(#constructor_fns)*
+        }
+    };
+
+    quote! {
+        #field_enum
+        #schema_impl
+        #constructor_module
+    }
+}
+
+fn extract_odata_name(attrs: &[syn::Attribute], field_ident: &Ident) -> String {
+    for attr in attrs {
+        if attr.path().is_ident("odata") {
+            if let Meta::List(meta_list) = &attr.meta {
+                let tokens = &meta_list.tokens;
+                let parsed: Result<Meta, _> = syn::parse2(tokens.clone());
+
+                if let Ok(Meta::NameValue(nv)) = parsed {
+                    if nv.path.is_ident("name") {
+                        if let syn::Expr::Lit(expr_lit) = &nv.value {
+                            if let Lit::Str(lit_str) = &expr_lit.lit {
+                                return lit_str.value();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    field_ident.to_string()
+}
+
+fn to_pascal_case(s: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize_next = true;
+
+    for ch in s.chars() {
+        if ch == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(ch.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}

--- a/libs/modkit-sdk-macros/tests/compile_tests.rs
+++ b/libs/modkit-sdk-macros/tests/compile_tests.rs
@@ -1,0 +1,6 @@
+#[test]
+fn compile_tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/pass/*.rs");
+    t.compile_fail("tests/ui/fail/*.rs");
+}

--- a/libs/modkit-sdk-macros/tests/expansion_demo.rs
+++ b/libs/modkit-sdk-macros/tests/expansion_demo.rs
@@ -1,0 +1,74 @@
+// This test demonstrates the actual macro expansion
+// Run with: cargo expand --package modkit-sdk-macros --test expansion_demo
+
+use modkit_sdk_macros::ODataSchema;
+
+#[derive(ODataSchema)]
+#[allow(dead_code)]
+struct DemoDto {
+    id: uuid::Uuid,
+    email: String,
+    #[odata(name = "created_at")]
+    created_at: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use modkit_odata::SortDir;
+    use modkit_sdk::odata::{AsFieldKey, FilterExpr, QueryBuilder, Schema};
+
+    #[test]
+    fn demo_field_enum() {
+        let _ = DemoDtoField::Id;
+        let _ = DemoDtoField::Email;
+        let _ = DemoDtoField::CreatedAt;
+    }
+
+    #[test]
+    fn demo_schema_mapping() {
+        assert_eq!(DemoDtoSchema::field_name(DemoDtoField::Id), "id");
+        assert_eq!(DemoDtoSchema::field_name(DemoDtoField::Email), "email");
+        assert_eq!(
+            DemoDtoSchema::field_name(DemoDtoField::CreatedAt),
+            "created_at"
+        );
+    }
+
+    #[test]
+    fn demo_typed_constructors() {
+        let id = demo_dto::id();
+        let email = demo_dto::email();
+        let created_at = demo_dto::created_at();
+
+        assert_eq!(id.name(), "id");
+        assert_eq!(email.name(), "email");
+        assert_eq!(created_at.name(), "created_at");
+    }
+
+    #[test]
+    fn demo_query_building() {
+        let dto_id = uuid::Uuid::new_v4();
+
+        let id = demo_dto::id();
+        let email = demo_dto::email();
+
+        let query = QueryBuilder::<DemoDtoSchema>::new()
+            .filter(
+                demo_dto::id()
+                    .eq(dto_id)
+                    .and(demo_dto::email().contains("@example.com")),
+            )
+            .order_by(demo_dto::created_at(), SortDir::Desc)
+            .select(&[
+                &id as &dyn AsFieldKey<DemoDtoSchema>,
+                &email as &dyn AsFieldKey<DemoDtoSchema>,
+            ])
+            .page_size(25)
+            .build();
+
+        assert!(query.has_filter());
+        assert_eq!(query.order.0.len(), 1);
+        assert_eq!(query.limit, Some(25));
+    }
+}

--- a/libs/modkit-sdk-macros/tests/odata_schema.rs
+++ b/libs/modkit-sdk-macros/tests/odata_schema.rs
@@ -1,0 +1,179 @@
+use modkit_odata::SortDir;
+use modkit_sdk::odata::{AsFieldKey, FieldRef, FilterExpr, QueryBuilder, Schema};
+use modkit_sdk_macros::ODataSchema;
+
+#[derive(ODataSchema)]
+#[allow(dead_code)]
+struct User {
+    id: uuid::Uuid,
+    email: String,
+    name: String,
+    age: i32,
+}
+
+#[derive(ODataSchema)]
+#[allow(dead_code)]
+struct Product {
+    #[odata(name = "product_id")]
+    id: uuid::Uuid,
+    #[odata(name = "product_name")]
+    name: String,
+    price: i32,
+    #[odata(name = "created_at")]
+    created_at: String,
+}
+
+#[test]
+fn test_user_field_enum_generated() {
+    let _ = UserField::Id;
+    let _ = UserField::Email;
+    let _ = UserField::Name;
+    let _ = UserField::Age;
+}
+
+#[test]
+fn test_user_schema_impl() {
+    assert_eq!(UserSchema::field_name(UserField::Id), "id");
+    assert_eq!(UserSchema::field_name(UserField::Email), "email");
+    assert_eq!(UserSchema::field_name(UserField::Name), "name");
+    assert_eq!(UserSchema::field_name(UserField::Age), "age");
+}
+
+#[test]
+fn test_user_field_constructors() {
+    let id_field: FieldRef<UserSchema, uuid::Uuid> = user::id();
+    let email_field: FieldRef<UserSchema, String> = user::email();
+    let name_field: FieldRef<UserSchema, String> = user::name();
+    let age_field: FieldRef<UserSchema, i32> = user::age();
+
+    assert_eq!(id_field.name(), "id");
+    assert_eq!(email_field.name(), "email");
+    assert_eq!(name_field.name(), "name");
+    assert_eq!(age_field.name(), "age");
+}
+
+#[test]
+fn test_product_custom_names() {
+    assert_eq!(ProductSchema::field_name(ProductField::Id), "product_id");
+    assert_eq!(
+        ProductSchema::field_name(ProductField::Name),
+        "product_name"
+    );
+    assert_eq!(ProductSchema::field_name(ProductField::Price), "price");
+    assert_eq!(
+        ProductSchema::field_name(ProductField::CreatedAt),
+        "created_at"
+    );
+}
+
+#[test]
+fn test_product_field_constructors() {
+    let id_field = product::id();
+    let name_field = product::name();
+    let price_field = product::price();
+    let created_at_field = product::created_at();
+
+    assert_eq!(id_field.name(), "product_id");
+    assert_eq!(name_field.name(), "product_name");
+    assert_eq!(price_field.name(), "price");
+    assert_eq!(created_at_field.name(), "created_at");
+}
+
+#[test]
+fn test_query_builder_integration() {
+    let user_id = uuid::Uuid::new_v4();
+
+    let query = QueryBuilder::<UserSchema>::new()
+        .filter(user::id().eq(user_id))
+        .order_by(user::name(), SortDir::Asc)
+        .page_size(50)
+        .build();
+
+    assert!(query.has_filter());
+    assert!(query.filter_hash.is_some());
+    assert_eq!(query.order.0.len(), 1);
+    assert_eq!(query.limit, Some(50));
+}
+
+#[test]
+fn test_string_operations() {
+    let query = QueryBuilder::<UserSchema>::new()
+        .filter(user::email().contains("@example.com"))
+        .build();
+
+    assert!(query.has_filter());
+}
+
+#[test]
+fn test_complex_filter_with_generated_fields() {
+    let user_id = uuid::Uuid::new_v4();
+
+    let query = QueryBuilder::<UserSchema>::new()
+        .filter(
+            user::id()
+                .eq(user_id)
+                .and(user::name().contains("john"))
+                .and(user::age().ge(18).and(user::age().le(65))),
+        )
+        .order_by(user::name(), SortDir::Asc)
+        .order_by(user::age(), SortDir::Desc)
+        .build();
+
+    assert!(query.has_filter());
+    assert_eq!(query.order.0.len(), 2);
+}
+
+#[test]
+fn test_select_with_generated_fields() {
+    let id = user::id();
+    let email = user::email();
+    let name = user::name();
+
+    let query = QueryBuilder::<UserSchema>::new()
+        .select(&[
+            &id as &dyn AsFieldKey<UserSchema>,
+            &email as &dyn AsFieldKey<UserSchema>,
+            &name as &dyn AsFieldKey<UserSchema>,
+        ])
+        .build();
+
+    assert!(query.has_select());
+    let fields = query.selected_fields().expect("select fields");
+    assert_eq!(fields.len(), 3);
+    assert_eq!(fields[0], "id");
+    assert_eq!(fields[1], "email");
+    assert_eq!(fields[2], "name");
+}
+
+#[test]
+fn test_field_ref_copy_clone() {
+    let field1 = user::id();
+    let field2 = field1;
+    let field3 = field1;
+
+    assert_eq!(field1.name(), field2.name());
+    assert_eq!(field1.name(), field3.name());
+}
+
+#[test]
+fn test_comparison_operators() {
+    let _query = QueryBuilder::<UserSchema>::new()
+        .filter(user::age().gt(18))
+        .build();
+
+    let _query = QueryBuilder::<UserSchema>::new()
+        .filter(user::age().ge(18))
+        .build();
+
+    let _query = QueryBuilder::<UserSchema>::new()
+        .filter(user::age().lt(65))
+        .build();
+
+    let _query = QueryBuilder::<UserSchema>::new()
+        .filter(user::age().le(65))
+        .build();
+
+    let _query = QueryBuilder::<UserSchema>::new()
+        .filter(user::age().ne(0))
+        .build();
+}

--- a/libs/modkit-sdk-macros/tests/ui.rs
+++ b/libs/modkit-sdk-macros/tests/ui.rs
@@ -1,0 +1,6 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/pass/*.rs");
+    t.compile_fail("tests/ui/fail/*.rs");
+}

--- a/libs/modkit-sdk-macros/tests/ui/fail/enum_not_supported.rs
+++ b/libs/modkit-sdk-macros/tests/ui/fail/enum_not_supported.rs
@@ -1,0 +1,9 @@
+use modkit_sdk_macros::ODataSchema;
+
+#[derive(ODataSchema)]
+enum Status {
+    Active,
+    Inactive,
+}
+
+fn main() {}

--- a/libs/modkit-sdk-macros/tests/ui/fail/enum_not_supported.stderr
+++ b/libs/modkit-sdk-macros/tests/ui/fail/enum_not_supported.stderr
@@ -1,0 +1,8 @@
+error: ODataSchema can only be derived for structs
+ --> tests/ui/fail/enum_not_supported.rs:4:1
+  |
+4 | / enum Status {
+5 | |     Active,
+6 | |     Inactive,
+7 | | }
+  | |_^

--- a/libs/modkit-sdk-macros/tests/ui/fail/generic_type_parameter.rs
+++ b/libs/modkit-sdk-macros/tests/ui/fail/generic_type_parameter.rs
@@ -1,0 +1,12 @@
+use modkit_sdk_macros::ODataSchema;
+
+#[derive(ODataSchema)]
+struct User {
+    id: uuid::Uuid,
+    age: i32,
+}
+
+fn main() {
+    // This should fail: field constructors are not generic
+    let _ = user::age::<String>();
+}

--- a/libs/modkit-sdk-macros/tests/ui/fail/generic_type_parameter.stderr
+++ b/libs/modkit-sdk-macros/tests/ui/fail/generic_type_parameter.stderr
@@ -1,0 +1,13 @@
+error[E0107]: function takes 0 generic arguments but 1 generic argument was supplied
+  --> tests/ui/fail/generic_type_parameter.rs:11:19
+   |
+11 |     let _ = user::age::<String>();
+   |                   ^^^---------- help: remove the unnecessary generics
+   |                   |
+   |                   expected 0 generic arguments
+   |
+note: function defined here, with 0 generic parameters
+  --> tests/ui/fail/generic_type_parameter.rs:6:5
+   |
+ 6 |     age: i32,
+   |     ^^^

--- a/libs/modkit-sdk-macros/tests/ui/fail/string_op_on_int_field.rs
+++ b/libs/modkit-sdk-macros/tests/ui/fail/string_op_on_int_field.rs
@@ -1,0 +1,12 @@
+use modkit_sdk_macros::ODataSchema;
+
+#[derive(ODataSchema)]
+struct User {
+    id: uuid::Uuid,
+    age: i32,
+}
+
+fn main() {
+    // This should fail: contains() is only available for String fields
+    let _ = user::age().contains("test");
+}

--- a/libs/modkit-sdk-macros/tests/ui/fail/string_op_on_int_field.stderr
+++ b/libs/modkit-sdk-macros/tests/ui/fail/string_op_on_int_field.stderr
@@ -1,0 +1,8 @@
+error[E0599]: no method named `contains` found for struct `FieldRef<UserSchema, i32>` in the current scope
+  --> tests/ui/fail/string_op_on_int_field.rs:11:25
+   |
+11 |     let _ = user::age().contains("test");
+   |                         ^^^^^^^^ method not found in `FieldRef<UserSchema, i32>`
+   |
+   = note: the method was found for
+           - `FieldRef<S, String>`

--- a/libs/modkit-sdk-macros/tests/ui/fail/tuple_struct_not_supported.rs
+++ b/libs/modkit-sdk-macros/tests/ui/fail/tuple_struct_not_supported.rs
@@ -1,0 +1,6 @@
+use modkit_sdk_macros::ODataSchema;
+
+#[derive(ODataSchema)]
+struct User(uuid::Uuid, String);
+
+fn main() {}

--- a/libs/modkit-sdk-macros/tests/ui/fail/tuple_struct_not_supported.stderr
+++ b/libs/modkit-sdk-macros/tests/ui/fail/tuple_struct_not_supported.stderr
@@ -1,0 +1,5 @@
+error: ODataSchema only supports structs with named fields
+ --> tests/ui/fail/tuple_struct_not_supported.rs:4:1
+  |
+4 | struct User(uuid::Uuid, String);
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/libs/modkit-sdk-macros/tests/ui/fail/wrong_value_type.rs
+++ b/libs/modkit-sdk-macros/tests/ui/fail/wrong_value_type.rs
@@ -1,0 +1,14 @@
+use modkit_sdk_macros::ODataSchema;
+
+#[derive(ODataSchema)]
+struct User {
+    id: uuid::Uuid,
+    age: i32,
+}
+
+struct NotODataValue;
+
+fn main() {
+    // This should fail: comparing with a type that doesn't implement IntoODataValue
+    let _ = user::age().eq(NotODataValue);
+}

--- a/libs/modkit-sdk-macros/tests/ui/fail/wrong_value_type.stderr
+++ b/libs/modkit-sdk-macros/tests/ui/fail/wrong_value_type.stderr
@@ -1,0 +1,27 @@
+error[E0277]: the trait bound `NotODataValue: IntoODataValue` is not satisfied
+  --> tests/ui/fail/wrong_value_type.rs:13:28
+   |
+13 |     let _ = user::age().eq(NotODataValue);
+   |                         -- ^^^^^^^^^^^^^ unsatisfied trait bound
+   |                         |
+   |                         required by a bound introduced by this call
+   |
+help: the trait `IntoODataValue` is not implemented for `NotODataValue`
+  --> tests/ui/fail/wrong_value_type.rs:9:1
+   |
+ 9 | struct NotODataValue;
+   | ^^^^^^^^^^^^^^^^^^^^
+   = help: the following other types implement trait `IntoODataValue`:
+             &str
+             String
+             Uuid
+             bool
+             i32
+             i64
+             u32
+             u64
+note: required by a bound in `FieldRef::<S, T>::eq`
+  --> $WORKSPACE/libs/modkit-sdk/src/odata.rs
+   |
+   |     pub fn eq<V: IntoODataValue>(self, value: V) -> Expr {
+   |                  ^^^^^^^^^^^^^^ required by this bound in `FieldRef::<S, T>::eq`

--- a/libs/modkit-sdk-macros/tests/ui/pass/basic_struct.rs
+++ b/libs/modkit-sdk-macros/tests/ui/pass/basic_struct.rs
@@ -1,0 +1,14 @@
+use modkit_sdk_macros::ODataSchema;
+
+#[derive(ODataSchema)]
+struct User {
+    id: uuid::Uuid,
+    email: String,
+    name: String,
+}
+
+fn main() {
+    let _field = UserField::Id;
+    let _schema = UserSchema;
+    let _id = user::id();
+}

--- a/libs/modkit-sdk-macros/tests/ui/pass/custom_names.rs
+++ b/libs/modkit-sdk-macros/tests/ui/pass/custom_names.rs
@@ -1,0 +1,15 @@
+use modkit_sdk_macros::ODataSchema;
+use modkit_sdk::odata::Schema;
+
+#[derive(ODataSchema)]
+struct Product {
+    #[odata(name = "product_id")]
+    id: uuid::Uuid,
+    #[odata(name = "product_name")]
+    name: String,
+}
+
+fn main() {
+    assert_eq!(ProductSchema::field_name(ProductField::Id), "product_id");
+    assert_eq!(ProductSchema::field_name(ProductField::Name), "product_name");
+}

--- a/libs/modkit-sdk-macros/tests/ui/pass/snake_case_struct.rs
+++ b/libs/modkit-sdk-macros/tests/ui/pass/snake_case_struct.rs
@@ -1,0 +1,14 @@
+use modkit_sdk_macros::ODataSchema;
+
+#[derive(ODataSchema)]
+struct UserProfile {
+    user_id: uuid::Uuid,
+    first_name: String,
+    last_name: String,
+}
+
+fn main() {
+    let _id = user_profile::user_id();
+    let _first = user_profile::first_name();
+    let _last = user_profile::last_name();
+}

--- a/libs/modkit-sdk/Cargo.toml
+++ b/libs/modkit-sdk/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "modkit-sdk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+name = "modkit_sdk"
+
+[features]
+default = []
+derive = ["dep:modkit-sdk-macros"]
+uuid = ["dep:uuid"]
+chrono = ["dep:chrono"]
+
+[dependencies]
+# Project-local crates
+modkit-security = { path = "../modkit-security" }
+modkit-odata = { path = "../modkit-odata" }
+modkit-sdk-macros = { path = "../modkit-sdk-macros", optional = true }
+
+# Core deps
+futures-core = { workspace = true }
+pin-project-lite = { workspace = true }
+
+# Optional feature dependencies
+uuid = { workspace = true, features = ["v7"], optional = true }
+chrono = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+futures-util = { workspace = true }
+uuid = { workspace = true, features = ["v7"] }
+chrono = { workspace = true }
+modkit-sdk-macros = { path = "../modkit-sdk-macros" }

--- a/libs/modkit-sdk/README.md
+++ b/libs/modkit-sdk/README.md
@@ -1,0 +1,248 @@
+# modkit-sdk
+
+Security Context Scoping and Typed OData Query Builder for Clients
+
+## Overview
+
+This crate provides two main features:
+
+1. **Security Context Scoping**: A lightweight, zero-allocation wrapper that binds a `SecurityContext` to any client type
+2. **Typed OData Query Builder**: A generic, reusable query builder that produces type-safe OData queries with automatic filter hashing
+
+## Security Context Scoping
+
+### Example
+
+```rust
+use modkit_sdk::WithSecurityContext;
+use modkit_security::SecurityContext;
+
+let client = MyClient::new();
+let ctx = SecurityContext::root();
+
+// Bind the security context to the client
+let secured = client.security_ctx(&ctx);
+
+// Access the client and context
+let client_ref = secured.client();
+let ctx_ref = secured.ctx();
+```
+
+## Typed OData Query Builder
+
+The typed OData query builder provides a type-safe way to construct OData queries without manually building `ODataQuery` instances. It ensures compile-time type checking for field references and operations.
+
+### Features
+
+- **Type-safe field references**: Field types are checked at compile time
+- **Schema trait**: Define field enums and their string mappings
+- **Typed filter constructors**: Comparison and string operations with type safety
+- **Fluent API**: Chain methods to build complex queries
+- **Automatic filter hashing**: Stable, deterministic hashing for cursor pagination
+- **No proc macros**: Pure Rust implementation without code generation
+
+### Quick Start
+
+#### 1. Define Your Schema
+
+```rust
+use modkit_sdk::odata::{Schema, FieldRef};
+
+// Define field enum
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum UserField {
+    Id,
+    Name,
+    Email,
+    Age,
+}
+
+// Define schema struct
+struct UserSchema;
+
+// Implement Schema trait
+impl Schema for UserSchema {
+    type Field = UserField;
+
+    fn field_name(field: Self::Field) -> &'static str {
+        match field {
+            UserField::Id => "id",
+            UserField::Name => "name",
+            UserField::Email => "email",
+            UserField::Age => "age",
+        }
+    }
+}
+```
+
+#### 2. Create Typed Field References
+
+```rust
+// Define typed field constants
+const ID: FieldRef<UserSchema, uuid::Uuid> = FieldRef::new(UserField::Id);
+const NAME: FieldRef<UserSchema, String> = FieldRef::new(UserField::Name);
+const EMAIL: FieldRef<UserSchema, String> = FieldRef::new(UserField::Email);
+const AGE: FieldRef<UserSchema, i32> = FieldRef::new(UserField::Age);
+```
+
+#### 3. Build Queries
+
+```rust
+use modkit_sdk::odata::{QueryBuilder, FilterExpr};
+use modkit_odata::SortDir;
+
+// Simple equality filter
+let user_id = uuid::Uuid::new_v4();
+let query = QueryBuilder::<UserSchema>::new()
+    .filter(ID.eq(user_id))
+    .build();
+
+// Complex filter with AND/OR
+let query = QueryBuilder::<UserSchema>::new()
+    .filter(
+        AGE.ge(18)
+            .and(AGE.le(65))
+            .and(NAME.contains("smith"))
+    )
+    .order_by(NAME, SortDir::Asc)
+    .page_size(50)
+    .build();
+
+// Full query with all features
+let query = QueryBuilder::<UserSchema>::new()
+    .filter(ID.eq(user_id).and(AGE.gt(18)))
+    .order_by(NAME, SortDir::Asc)
+    .order_by(AGE, SortDir::Desc)
+    .select([NAME, EMAIL])
+    .page_size(25)
+    .build();
+```
+
+### Supported Operations
+
+#### Comparison Operators (All Field Types)
+
+- `eq(value)` - Equality: `field eq value`
+- `ne(value)` - Not equal: `field ne value`
+- `gt(value)` - Greater than: `field gt value`
+- `ge(value)` - Greater or equal: `field ge value`
+- `lt(value)` - Less than: `field lt value`
+- `le(value)` - Less or equal: `field le value`
+
+#### String Operations (String Fields Only)
+
+- `contains(value)` - Contains: `contains(field, 'value')`
+- `startswith(value)` - Starts with: `startswith(field, 'value')`
+- `endswith(value)` - Ends with: `endswith(field, 'value')`
+
+#### Logical Combinators
+
+- `and(expr)` - Logical AND: `expr1 and expr2`
+- `or(expr)` - Logical OR: `expr1 or expr2`
+- `not()` - Logical NOT: `not expr`
+
+#### Query Builder Methods
+
+- `filter(expr)` - Set the filter expression
+- `order_by(field, dir)` - Add an order-by clause (can be called multiple times)
+- `select(fields)` - Set field projection (pass `&[&field1, &field2, ...]`)
+- `page_size(limit)` - Set the page size limit
+- `build()` - Build the final `ODataQuery` with computed filter hash
+
+### Type Safety
+
+The query builder enforces type safety at compile time:
+
+```rust
+// ✅ Correct: String field with string operations
+let query = QueryBuilder::<UserSchema>::new()
+    .filter(NAME.contains("john"))
+    .build();
+
+// ❌ Compile error: contains() only available for String fields
+let query = QueryBuilder::<UserSchema>::new()
+    .filter(AGE.contains("test"))  // Won't compile!
+    .build();
+
+// ✅ Correct: Comparison operations work on all types
+let query = QueryBuilder::<UserSchema>::new()
+    .filter(AGE.gt(18))
+    .build();
+```
+
+### Filter Hash Stability
+
+The query builder automatically computes a stable, deterministic hash for filter expressions using the same algorithm as `modkit_odata::pagination::short_filter_hash`. This ensures cursor pagination consistency:
+
+```rust
+let user_id = uuid::Uuid::new_v4();
+
+let query1 = QueryBuilder::<UserSchema>::new()
+    .filter(ID.eq(user_id))
+    .build();
+
+let query2 = QueryBuilder::<UserSchema>::new()
+    .filter(ID.eq(user_id))
+    .build();
+
+// Same filter produces same hash
+assert_eq!(query1.filter_hash, query2.filter_hash);
+```
+
+### Supported Value Types
+
+The following Rust types can be used in filter expressions:
+
+- `bool`
+- `uuid::Uuid`
+- `String` and `&str`
+- `i32`, `i64`, `u32`, `u64`
+
+Additional types can be supported by implementing the `IntoODataValue` trait.
+
+### Examples
+
+See `examples/typed_odata_query.rs` for comprehensive examples demonstrating:
+
+- Simple equality filters
+- String operations (contains, startswith, endswith)
+- Complex filters with AND/OR/NOT
+- Ordering and field selection
+- Page size limits
+- Full queries with all features
+- Filter hash stability
+
+Run the example:
+
+```bash
+cargo run --package modkit-sdk --example typed_odata_query
+```
+
+### Design Constraints
+
+- **No proc macros**: Pure Rust implementation without code generation
+- **Small footprint**: Minimal API surface with no large facades
+- **No DB concepts**: Does not expose database or SeaORM concepts
+- **AST-based**: Produces `modkit_odata::ast::Expr` for maximum flexibility
+- **Stable hashing**: Deterministic filter hashing for cursor pagination
+
+### Testing
+
+The query builder includes comprehensive unit tests verifying:
+
+- Field name mapping works correctly
+- Building queries sets order/limit/filter properly
+- Filter hash is stable for identical filters
+- All comparison and string operations work
+- Logical combinators (AND/OR/NOT) function correctly
+- Field selection handles heterogeneous field types
+
+Run tests:
+
+```bash
+cargo test --package modkit-sdk --lib odata
+```
+
+## License
+
+See workspace license.

--- a/libs/modkit-sdk/examples/secured_client.rs
+++ b/libs/modkit-sdk/examples/secured_client.rs
@@ -1,0 +1,54 @@
+//! Example demonstrating the security context scoping wrapper.
+//!
+//! This example shows how to use `Secured<'a, C>` to bind a `SecurityContext`
+//! Example demonstrating the `Secured` wrapper for security context binding
+
+#![allow(clippy::expect_used)]
+
+use modkit_sdk::secured::WithSecurityContext;
+use modkit_security::SecurityContext;
+use uuid::Uuid;
+
+struct UserClient {
+    base_url: String,
+}
+
+impl UserClient {
+    fn new(base_url: &str) -> Self {
+        Self {
+            base_url: base_url.to_owned(),
+        }
+    }
+
+    fn get_base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+fn main() {
+    let client = UserClient::new("https://api.example.com");
+
+    let tenant_id =
+        Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").expect("valid tenant UUID");
+    let subject_id =
+        Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").expect("valid subject UUID");
+
+    let ctx = SecurityContext::builder()
+        .tenant_id(tenant_id)
+        .subject_id(subject_id)
+        .subject_type("user")
+        .build();
+
+    let secured = client.security_ctx(&ctx);
+
+    println!("Client base URL: {}", secured.client().get_base_url());
+    println!("Tenant ID: {}", secured.ctx().tenant_id());
+    println!("Subject ID: {}", secured.ctx().subject_id());
+
+    let root_ctx = SecurityContext::root();
+    let secured_root = client.security_ctx(&root_ctx);
+
+    println!("\nRoot context:");
+    println!("Tenant ID: {}", secured_root.ctx().tenant_id());
+    println!("Subject ID: {}", secured_root.ctx().subject_id());
+}

--- a/libs/modkit-sdk/examples/typed_odata_query.rs
+++ b/libs/modkit-sdk/examples/typed_odata_query.rs
@@ -1,0 +1,160 @@
+//! Example demonstrating the typed `OData` query builder
+//!
+//! This example shows how to define a schema, create typed field references,
+//! and build type-safe `OData` queries with filters, ordering, and field selection.
+
+#![allow(clippy::use_debug)]
+
+use modkit_odata::SortDir;
+use modkit_sdk::odata::{FieldRef, FilterExpr, QueryBuilder, Schema};
+
+#[cfg(feature = "uuid")]
+use uuid::Uuid;
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum UserField {
+    Id,
+    Name,
+    Email,
+    Age,
+    IsActive,
+}
+
+struct UserSchema;
+
+impl Schema for UserSchema {
+    type Field = UserField;
+
+    fn field_name(field: Self::Field) -> &'static str {
+        match field {
+            UserField::Id => "id",
+            UserField::Name => "name",
+            UserField::Email => "email",
+            UserField::Age => "age",
+            UserField::IsActive => "is_active",
+        }
+    }
+}
+
+#[cfg(feature = "uuid")]
+const ID: FieldRef<UserSchema, Uuid> = FieldRef::new(UserField::Id);
+const NAME: FieldRef<UserSchema, String> = FieldRef::new(UserField::Name);
+const EMAIL: FieldRef<UserSchema, String> = FieldRef::new(UserField::Email);
+const AGE: FieldRef<UserSchema, i32> = FieldRef::new(UserField::Age);
+const IS_ACTIVE: FieldRef<UserSchema, bool> = FieldRef::new(UserField::IsActive);
+
+#[cfg(not(feature = "uuid"))]
+fn main() {
+    println!("This example requires the modkit-sdk 'uuid' feature.");
+}
+
+#[cfg(feature = "uuid")]
+fn main() {
+    println!("=== Typed OData Query Builder Examples ===\n");
+
+    // Example 1: Simple equality filter
+    println!("1. Simple equality filter:");
+    let user_id = Uuid::new_v4();
+    let query = QueryBuilder::<UserSchema>::new()
+        .filter(ID.eq(user_id))
+        .build();
+    println!("   Filter: id eq {user_id}");
+    println!("   Filter hash: {:#?}\n", query.filter_hash);
+
+    // Example 2: String contains filter
+    println!("2. String contains filter:");
+    let query = QueryBuilder::<UserSchema>::new()
+        .filter(NAME.contains("john"))
+        .build();
+    println!("   Filter: contains(name, 'john')");
+    println!("   Filter hash: {:#?}\n", query.filter_hash);
+
+    // Example 3: Complex filter with AND/OR
+    println!("3. Complex filter with AND/OR:");
+    let query = QueryBuilder::<UserSchema>::new()
+        .filter(
+            IS_ACTIVE
+                .eq(true)
+                .and(AGE.ge(18))
+                .and(AGE.le(65))
+                .and(EMAIL.endswith("@example.com")),
+        )
+        .build();
+    println!("   Filter: is_active eq true AND age ge 18 AND age le 65 AND endswith(email, '@example.com')");
+    println!("   Filter hash: {:#?}\n", query.filter_hash);
+
+    // Example 4: Filter with OR combinator
+    println!("4. Filter with OR combinator:");
+    let query = QueryBuilder::<UserSchema>::new()
+        .filter(AGE.lt(18).or(AGE.gt(65)))
+        .build();
+    println!("   Filter: age lt 18 OR age gt 65");
+    println!("   Filter hash: {:#?}\n", query.filter_hash);
+
+    // Example 5: Filter with NOT
+    println!("5. Filter with NOT:");
+    let query = QueryBuilder::<UserSchema>::new()
+        .filter(NAME.startswith("test").not())
+        .build();
+    println!("   Filter: NOT startswith(name, 'test')");
+    println!("   Filter hash: {:#?}\n", query.filter_hash);
+
+    // Example 6: Ordering
+    println!("6. Query with ordering:");
+    let _query = QueryBuilder::<UserSchema>::new()
+        .order_by(NAME, SortDir::Asc)
+        .order_by(AGE, SortDir::Desc)
+        .build();
+    println!("   Order: name asc, age desc\n");
+
+    // Example 7: Field selection (projection)
+    println!("7. Query with field selection:");
+    let _query = QueryBuilder::<UserSchema>::new()
+        .select([NAME, EMAIL])
+        .build();
+    println!("   Select: id, name, email\n");
+
+    // Example 8: Page size limit
+    println!("8. Query with page size:");
+    let _query = QueryBuilder::<UserSchema>::new().page_size(50).build();
+    println!("   Limit: Some(50)\n");
+
+    // Example 9: Full query with all features
+    println!("9. Full query with all features:");
+    let user_id = Uuid::new_v4();
+    let query = QueryBuilder::<UserSchema>::new()
+        .filter(
+            ID.ne(user_id)
+                .and(IS_ACTIVE.eq(true))
+                .and(AGE.ge(18))
+                .and(NAME.contains("smith")),
+        )
+        .order_by(NAME, SortDir::Asc)
+        .order_by(AGE, SortDir::Desc)
+        .select([NAME, EMAIL])
+        .page_size(25)
+        .build();
+    println!(
+        "   Filter: id ne {user_id} AND is_active eq true AND age ge 18 AND contains(name, 'smith')"
+    );
+    println!("   Order: name asc, age desc");
+    if let Some(fields) = query.selected_fields() {
+        println!("   Select: {}", fields.join(", "));
+    }
+    println!("   Limit: {:#?}", query.limit);
+    println!("   Filter hash: {:#?}\n", query.filter_hash);
+
+    // Example 10: Demonstrating filter hash stability
+    println!("10. Filter hash stability:");
+    let id1 = Uuid::new_v4();
+    let query1 = QueryBuilder::<UserSchema>::new().filter(ID.eq(id1)).build();
+    let query2 = QueryBuilder::<UserSchema>::new().filter(ID.eq(id1)).build();
+    println!("   Query 1 hash: {:#?}", query1.filter_hash);
+    println!("   Query 2 hash: {:#?}", query2.filter_hash);
+    println!(
+        "   Hashes match: {}\n",
+        query1.filter_hash == query2.filter_hash
+    );
+
+    println!("=== All examples completed successfully ===");
+}

--- a/libs/modkit-sdk/src/lib.rs
+++ b/libs/modkit-sdk/src/lib.rs
@@ -1,0 +1,42 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+//! # `modkit-sdk` - SDK utilities for modkit-based applications
+//!
+//! This crate provides utilities for building SDKs on top of modkit, including:
+//!
+//! - **Security context scoping** (`secured` module) - Zero-allocation wrapper for binding
+//!   `SecurityContext` to clients
+//! - **Type-safe `OData` queries** (`odata` module) - Fluent query builder with compile-time
+//!   field validation
+//! - **Cursor-based pagination** (`pager` module) - Stream API for paginated results
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use modkit_sdk::secured::WithSecurityContext;
+//! use modkit_sdk::odata::QueryBuilder;
+//! use modkit_security::SecurityContext;
+//!
+//! let client = MyClient::new();
+//! let ctx = SecurityContext::root();
+//!
+//! // Bind security context to client
+//! let secured = client.security_ctx(&ctx);
+//!
+//! // Build type-safe query
+//! let query = QueryBuilder::<UserSchema>::new()
+//!     .filter(NAME.contains("john"))
+//!     .page_size(50)
+//!     .build();
+//! ```
+
+pub mod odata;
+pub mod pager;
+pub mod secured;
+
+// Re-export commonly used types for convenience
+pub use pager::PagerError;
+pub use secured::{Secured, WithSecurityContext};
+
+// Re-export proc-macros (feature-gated)
+#[cfg(feature = "derive")]
+pub use modkit_sdk_macros::ODataSchema;

--- a/libs/modkit-sdk/src/odata.rs
+++ b/libs/modkit-sdk/src/odata.rs
@@ -1,0 +1,1107 @@
+//! Typed `OData` query builder
+//!
+//! This module provides a generic, reusable typed query builder for `OData` that produces
+//! `modkit_odata::ODataQuery` with correct filter hashing.
+//!
+//! # Design
+//!
+//! - **Schema trait**: Defines field enums and their string mappings
+//! - **`FieldRef`**: Type-safe field references with schema and Rust type markers
+//! - **Filter constructors**: Typed comparison and string operations returning AST expressions
+//! - **`QueryBuilder`**: Fluent API for building queries with filter/order/select/limit
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use modkit_sdk::odata::{Schema, FieldRef, QueryBuilder};
+//! use modkit_odata::SortDir;
+//!
+//! #[derive(Copy, Clone, Eq, PartialEq)]
+//! enum UserField {
+//!     Id,
+//!     Name,
+//!     Email,
+//! }
+//!
+//! struct UserSchema;
+//!
+//! impl Schema for UserSchema {
+//!     type Field = UserField;
+//!
+//!     fn field_name(field: Self::Field) -> &'static str {
+//!         match field {
+//!             UserField::Id => "id",
+//!             UserField::Name => "name",
+//!             UserField::Email => "email",
+//!         }
+//!     }
+//! }
+//!
+//! // Define typed field references
+//! const ID: FieldRef<UserSchema, uuid::Uuid> = FieldRef::new(UserField::Id);
+//! const NAME: FieldRef<UserSchema, String> = FieldRef::new(UserField::Name);
+//!
+//! // Build a query
+//! let user_id = uuid::Uuid::new_v4();
+//! let query = QueryBuilder::<UserSchema>::new()
+//!     .filter(ID.eq(user_id).and(NAME.contains("john")))
+//!     .order_by(NAME, SortDir::Asc)
+//!     .page_size(50)
+//!     .build();
+//! ```
+
+use modkit_odata::{
+    ast::{CompareOperator, Expr, Value},
+    pagination::short_filter_hash,
+    ODataOrderBy, ODataQuery, OrderKey, SortDir,
+};
+use std::marker::PhantomData;
+
+/// Schema trait defining field enums and their string mappings.
+///
+/// Implement this trait for your entity schemas to enable type-safe query building.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// #[derive(Copy, Clone, Eq, PartialEq)]
+/// enum UserField {
+///     Id,
+///     Name,
+/// }
+///
+/// struct UserSchema;
+///
+/// impl Schema for UserSchema {
+///     type Field = UserField;
+///
+///     fn field_name(field: Self::Field) -> &'static str {
+///         match field {
+///             UserField::Id => "id",
+///             UserField::Name => "name",
+///         }
+///     }
+/// }
+/// ```
+pub trait Schema {
+    /// The field enum type (must be Copy + Eq)
+    type Field: Copy + Eq;
+
+    /// Map a field enum to its string name
+    fn field_name(field: Self::Field) -> &'static str;
+}
+
+/// Type-safe field reference holding schema and Rust type information.
+///
+/// This struct binds a field to both its schema and expected Rust type,
+/// enabling compile-time type checking for filter operations.
+/// NOTE:
+///  `FieldRef` equality and hashing are based solely on the underlying schema field.
+///  The generic type parameter `T` is a phantom type used only for compile-time
+///  validation of operations and is not part of the field identity.
+/// # Type Parameters
+///
+/// * `S` - The schema type implementing `Schema`
+/// * `T` - The Rust type this field represents (e.g., `String`, `uuid::Uuid`)
+pub struct FieldRef<S: Schema, T> {
+    field: S::Field,
+    _phantom: PhantomData<(S, T)>,
+}
+
+impl<S: Schema, T> FieldRef<S, T> {
+    /// Create a new typed field reference.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// const NAME: FieldRef<UserSchema, String> = FieldRef::new(UserField::Name);
+    /// ```
+    #[must_use]
+    pub const fn new(field: S::Field) -> Self {
+        Self {
+            field,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Get the field name as a string.
+    #[must_use]
+    pub fn name(&self) -> &'static str {
+        S::field_name(self.field)
+    }
+
+    /// Create an identifier expression for this field.
+    #[must_use]
+    fn identifier(&self) -> Expr {
+        Expr::Identifier(self.name().to_owned())
+    }
+}
+
+impl<S: Schema, T> Clone for FieldRef<S, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<S: Schema, T> Copy for FieldRef<S, T> {}
+
+impl<S: Schema, T> std::fmt::Debug for FieldRef<S, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FieldRef")
+            .field("field", &self.name())
+            .finish()
+    }
+}
+
+impl<S: Schema, T> PartialEq for FieldRef<S, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.field == other.field
+    }
+}
+
+impl<S: Schema, T> Eq for FieldRef<S, T> {}
+
+impl<S: Schema, T> std::hash::Hash for FieldRef<S, T>
+where
+    S::Field: std::hash::Hash,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.field.hash(state);
+    }
+}
+
+/// Trait for extracting field names from field references.
+///
+/// This allows the `select` method to accept heterogeneous field arrays
+/// with different type parameters.
+#[doc(hidden)]
+pub trait AsFieldName {
+    /// Get the field name as a string.
+    fn as_field_name(&self) -> &'static str;
+}
+
+/// Trait for extracting schema field keys from field references.
+///
+/// `QueryBuilder::select()` stores schema keys (`S::Field`) instead of field names so we can
+/// avoid allocating `String`s during the builder phase and only allocate during `build()`.
+#[doc(hidden)]
+pub trait AsFieldKey<S: Schema> {
+    /// Get the schema field key.
+    fn as_field_key(&self) -> S::Field;
+}
+
+impl<S: Schema, T> AsFieldName for FieldRef<S, T> {
+    fn as_field_name(&self) -> &'static str {
+        self.name()
+    }
+}
+
+impl<S: Schema, T> AsFieldKey<S> for FieldRef<S, T> {
+    fn as_field_key(&self) -> S::Field {
+        self.field
+    }
+}
+
+impl<T: AsFieldName + ?Sized> AsFieldName for &T {
+    fn as_field_name(&self) -> &'static str {
+        (*self).as_field_name()
+    }
+}
+
+impl<S: Schema, T: AsFieldKey<S> + ?Sized> AsFieldKey<S> for &T {
+    fn as_field_key(&self) -> S::Field {
+        (*self).as_field_key()
+    }
+}
+
+/// Trait for types that can be converted to `OData` AST values.
+pub trait IntoODataValue {
+    /// Convert this value into an `OData` AST value.
+    fn into_odata_value(self) -> Value;
+}
+
+impl IntoODataValue for bool {
+    fn into_odata_value(self) -> Value {
+        Value::Bool(self)
+    }
+}
+
+#[cfg(feature = "uuid")]
+impl IntoODataValue for uuid::Uuid {
+    fn into_odata_value(self) -> Value {
+        Value::Uuid(self)
+    }
+}
+
+impl IntoODataValue for String {
+    fn into_odata_value(self) -> Value {
+        Value::String(self)
+    }
+}
+
+impl IntoODataValue for &str {
+    fn into_odata_value(self) -> Value {
+        Value::String(self.to_owned())
+    }
+}
+
+impl IntoODataValue for i32 {
+    fn into_odata_value(self) -> Value {
+        Value::Number(self.into())
+    }
+}
+
+impl IntoODataValue for i64 {
+    fn into_odata_value(self) -> Value {
+        Value::Number(self.into())
+    }
+}
+
+impl IntoODataValue for u32 {
+    fn into_odata_value(self) -> Value {
+        Value::Number(self.into())
+    }
+}
+
+impl IntoODataValue for u64 {
+    fn into_odata_value(self) -> Value {
+        Value::Number(self.into())
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl IntoODataValue for chrono::DateTime<chrono::Utc> {
+    fn into_odata_value(self) -> Value {
+        Value::DateTime(self)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl IntoODataValue for chrono::NaiveDate {
+    fn into_odata_value(self) -> Value {
+        Value::Date(self)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl IntoODataValue for chrono::NaiveTime {
+    fn into_odata_value(self) -> Value {
+        Value::Time(self)
+    }
+}
+
+/// Comparison operations for any field type.
+impl<S: Schema, T> FieldRef<S, T> {
+    /// Create an equality comparison: `field eq value`
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let filter = ID.eq(user_id);
+    /// ```
+    #[must_use]
+    pub fn eq<V: IntoODataValue>(self, value: V) -> Expr {
+        Expr::Compare(
+            Box::new(self.identifier()),
+            CompareOperator::Eq,
+            Box::new(Expr::Value(value.into_odata_value())),
+        )
+    }
+
+    /// Create a not-equal comparison: `field ne value`
+    #[must_use]
+    pub fn ne<V: IntoODataValue>(self, value: V) -> Expr {
+        Expr::Compare(
+            Box::new(self.identifier()),
+            CompareOperator::Ne,
+            Box::new(Expr::Value(value.into_odata_value())),
+        )
+    }
+
+    /// Create a greater-than comparison: `field gt value`
+    #[must_use]
+    pub fn gt<V: IntoODataValue>(self, value: V) -> Expr {
+        Expr::Compare(
+            Box::new(self.identifier()),
+            CompareOperator::Gt,
+            Box::new(Expr::Value(value.into_odata_value())),
+        )
+    }
+
+    /// Create a greater-than-or-equal comparison: `field ge value`
+    #[must_use]
+    pub fn ge<V: IntoODataValue>(self, value: V) -> Expr {
+        Expr::Compare(
+            Box::new(self.identifier()),
+            CompareOperator::Ge,
+            Box::new(Expr::Value(value.into_odata_value())),
+        )
+    }
+
+    /// Create a less-than comparison: `field lt value`
+    #[must_use]
+    pub fn lt<V: IntoODataValue>(self, value: V) -> Expr {
+        Expr::Compare(
+            Box::new(self.identifier()),
+            CompareOperator::Lt,
+            Box::new(Expr::Value(value.into_odata_value())),
+        )
+    }
+
+    /// Create a less-than-or-equal comparison: `field le value`
+    #[must_use]
+    pub fn le<V: IntoODataValue>(self, value: V) -> Expr {
+        Expr::Compare(
+            Box::new(self.identifier()),
+            CompareOperator::Le,
+            Box::new(Expr::Value(value.into_odata_value())),
+        )
+    }
+
+    /// Create a null check: `field eq null`
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let filter = OPTIONAL_FIELD.is_null();
+    /// ```
+    #[must_use]
+    pub fn is_null(self) -> Expr {
+        Expr::Compare(
+            Box::new(self.identifier()),
+            CompareOperator::Eq,
+            Box::new(Expr::Value(Value::Null)),
+        )
+    }
+
+    /// Create a not-null check: `field ne null`
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let filter = OPTIONAL_FIELD.is_not_null();
+    /// ```
+    #[must_use]
+    pub fn is_not_null(self) -> Expr {
+        Expr::Compare(
+            Box::new(self.identifier()),
+            CompareOperator::Ne,
+            Box::new(Expr::Value(Value::Null)),
+        )
+    }
+}
+
+/// String-specific operations (only available for String fields).
+impl<S: Schema> FieldRef<S, String> {
+    /// Create a contains function call: `contains(field, 'value')`
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let filter = NAME.contains("john");
+    /// ```
+    #[must_use]
+    pub fn contains(self, value: impl Into<String>) -> Expr {
+        Expr::Function(
+            "contains".to_owned(),
+            vec![self.identifier(), Expr::Value(Value::String(value.into()))],
+        )
+    }
+
+    /// Create a startswith function call: `startswith(field, 'value')`
+    #[must_use]
+    pub fn startswith(self, value: impl Into<String>) -> Expr {
+        Expr::Function(
+            "startswith".to_owned(),
+            vec![self.identifier(), Expr::Value(Value::String(value.into()))],
+        )
+    }
+
+    /// Create an endswith function call: `endswith(field, 'value')`
+    #[must_use]
+    pub fn endswith(self, value: impl Into<String>) -> Expr {
+        Expr::Function(
+            "endswith".to_owned(),
+            vec![self.identifier(), Expr::Value(Value::String(value.into()))],
+        )
+    }
+}
+
+/// Extension trait for combining filter expressions.
+pub trait FilterExpr: Sized {
+    /// Combine two expressions with AND: `expr1 and expr2`
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let filter = ID.eq(user_id).and(NAME.contains("john"));
+    /// ```
+    #[must_use]
+    fn and(self, other: Expr) -> Expr;
+
+    /// Combine two expressions with OR: `expr1 or expr2`
+    #[must_use]
+    fn or(self, other: Expr) -> Expr;
+
+    /// Negate an expression: `not expr`
+    #[must_use]
+    fn not(self) -> Expr;
+}
+
+impl FilterExpr for Expr {
+    fn and(self, other: Expr) -> Expr {
+        Expr::And(Box::new(self), Box::new(other))
+    }
+
+    fn or(self, other: Expr) -> Expr {
+        Expr::Or(Box::new(self), Box::new(other))
+    }
+
+    fn not(self) -> Expr {
+        Expr::Not(Box::new(self))
+    }
+}
+
+/// Typed query builder for `OData` queries.
+///
+/// This builder provides a fluent API for constructing `ODataQuery` instances
+/// with type-safe field references and automatic filter hashing.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let query = QueryBuilder::<UserSchema>::new()
+///     .filter(NAME.contains("john"))
+///     .order_by(NAME, SortDir::Asc)
+///     .select([NAME, EMAIL])
+///     .page_size(50)
+///     .build();
+/// ```
+pub struct QueryBuilder<S: Schema> {
+    filter: Option<Expr>,
+    order: Vec<OrderKey>,
+    select: Option<Vec<S::Field>>,
+    limit: Option<u64>,
+    _phantom: PhantomData<S>,
+}
+
+impl<S: Schema> QueryBuilder<S> {
+    /// Create a new empty query builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            filter: None,
+            order: Vec::new(),
+            select: None,
+            limit: None,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Set the filter expression.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// builder.filter(ID.eq(user_id).and(NAME.contains("john")))
+    /// ```
+    #[must_use]
+    pub fn filter(mut self, expr: Expr) -> Self {
+        self.filter = Some(expr);
+        self
+    }
+
+    /// Add an order-by clause.
+    ///
+    /// Can be called multiple times to add multiple sort keys.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// builder
+    ///     .order_by(NAME, SortDir::Asc)
+    ///     .order_by(ID, SortDir::Desc)
+    /// ```
+    #[must_use]
+    pub fn order_by<T>(mut self, field: FieldRef<S, T>, dir: SortDir) -> Self {
+        self.order.push(OrderKey {
+            field: field.name().to_owned(),
+            dir,
+        });
+        self
+    }
+
+    /// Set the select fields (field projection).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// builder.select([NAME, EMAIL])
+    /// builder.select(vec![NAME, EMAIL])
+    ///
+    /// // Backwards-compatible (still supported)
+    /// builder.select(&[&ID, &NAME, &EMAIL])
+    /// ```
+    #[must_use]
+    pub fn select<I>(mut self, fields: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: AsFieldKey<S>,
+    {
+        let iter = fields.into_iter();
+        let (lower, _) = iter.size_hint();
+        let mut out = Vec::with_capacity(lower);
+        for f in iter {
+            // Store field keys (identity) rather than names to avoid allocations during
+            // query builder chaining. Names are resolved once in `build()`.
+            out.push(f.as_field_key());
+        }
+        self.select = Some(out);
+        self
+    }
+
+    /// Set the page size limit.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// builder.page_size(50)
+    /// ```
+    #[must_use]
+    pub fn page_size(mut self, limit: u64) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Build the final `ODataQuery` with computed filter hash.
+    ///
+    /// The filter hash is computed using the stable hashing algorithm from
+    /// `modkit_odata::pagination::short_filter_hash`.
+    pub fn build(self) -> ODataQuery {
+        let filter_hash = short_filter_hash(self.filter.as_ref());
+
+        let mut query = ODataQuery::new();
+
+        if let Some(expr) = self.filter {
+            query = query.with_filter(expr);
+        }
+
+        if !self.order.is_empty() {
+            query = query.with_order(ODataOrderBy(self.order));
+        }
+
+        if let Some(limit) = self.limit {
+            query = query.with_limit(limit);
+        }
+
+        if let Some(hash) = filter_hash {
+            query = query.with_filter_hash(hash);
+        }
+
+        if let Some(fields) = self.select {
+            // Allocate `String`s only once per field at final query construction time.
+            let names: Vec<String> = fields
+                .into_iter()
+                // Resolve field names through FieldRef so the underlying schema mapping logic
+                // stays centralized and doesn't require Schema::field_name to be a static fn.
+                .map(|k| FieldRef::<S, ()>::new(k).name().to_owned())
+                .collect();
+            query = query.with_select(names);
+        }
+
+        query
+    }
+
+    /// Create a stream of pages using the given fetcher function.
+    ///
+    /// This method consumes the builder and returns a `PagesPager` that implements
+    /// `Stream<Item = Result<Page<T>, E>>`, automatically managing cursor pagination.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use futures_util::StreamExt;
+    ///
+    /// let pages = QueryBuilder::<UserSchema>::new()
+    ///     .filter(NAME.contains("john"))
+    ///     .page_size(50)
+    ///     .pages_stream(|query| async move {
+    ///         client.list_users(query).await
+    ///     });
+    ///
+    /// while let Some(result) = pages.next().await {
+    ///     match result {
+    ///         Ok(page) => println!("Got {} items", page.items.len()),
+    ///         Err(e) => eprintln!("Error: {}", e),
+    ///     }
+    /// }
+    /// ```
+    pub fn pages_stream<T, E, F, Fut>(self, fetcher: F) -> crate::pager::PagesPager<T, E, F, Fut>
+    where
+        F: FnMut(ODataQuery) -> Fut,
+        Fut: std::future::Future<Output = Result<modkit_odata::Page<T>, E>>,
+    {
+        let query = self.build();
+        crate::pager::PagesPager::new(query, fetcher)
+    }
+
+    /// Create a stream of individual items using the given fetcher function.
+    ///
+    /// This method consumes the builder and returns a `CursorPager` that implements
+    /// `Stream<Item = Result<T, E>>`, automatically managing cursor pagination and
+    /// buffering items from each page.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use futures_util::StreamExt;
+    ///
+    /// let items = QueryBuilder::<UserSchema>::new()
+    ///     .filter(NAME.contains("john"))
+    ///     .page_size(50)
+    ///     .items_stream(|query| async move {
+    ///         client.list_users(query).await
+    ///     });
+    ///
+    /// while let Some(result) = items.next().await {
+    ///     match result {
+    ///         Ok(user) => println!("User: {:?}", user),
+    ///         Err(e) => eprintln!("Error: {}", e),
+    ///     }
+    /// }
+    /// ```
+    pub fn items_stream<T, E, F, Fut>(self, fetcher: F) -> crate::pager::CursorPager<T, E, F, Fut>
+    where
+        F: FnMut(ODataQuery) -> Fut,
+        Fut: std::future::Future<Output = Result<modkit_odata::Page<T>, E>>,
+    {
+        let query = self.build();
+        crate::pager::CursorPager::new(query, fetcher)
+    }
+}
+
+impl<S: Schema> Default for QueryBuilder<S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+    enum UserField {
+        Id,
+        Name,
+        Email,
+        Age,
+    }
+
+    struct UserSchema;
+
+    impl Schema for UserSchema {
+        type Field = UserField;
+
+        fn field_name(field: Self::Field) -> &'static str {
+            match field {
+                UserField::Id => "id",
+                UserField::Name => "name",
+                UserField::Email => "email",
+                UserField::Age => "age",
+            }
+        }
+    }
+
+    const NAME: FieldRef<UserSchema, String> = FieldRef::new(UserField::Name);
+    const EMAIL: FieldRef<UserSchema, String> = FieldRef::new(UserField::Email);
+    const AGE: FieldRef<UserSchema, i32> = FieldRef::new(UserField::Age);
+
+    #[cfg(feature = "uuid")]
+    const ID: FieldRef<UserSchema, uuid::Uuid> = FieldRef::new(UserField::Id);
+
+    #[test]
+    fn test_field_name_mapping() {
+        assert_eq!(NAME.name(), "name");
+        assert_eq!(EMAIL.name(), "email");
+        assert_eq!(AGE.name(), "age");
+    }
+
+    #[cfg(feature = "uuid")]
+    #[test]
+    fn test_simple_eq_filter() {
+        let user_id = uuid::Uuid::new_v4();
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(ID.eq(user_id))
+            .build();
+
+        assert!(query.has_filter());
+        assert!(query.filter_hash.is_some());
+    }
+
+    #[test]
+    fn test_string_contains() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(NAME.contains("john"))
+            .build();
+
+        assert!(query.has_filter());
+        if let Some(filter) = query.filter() {
+            if let Expr::Function(name, args) = filter {
+                assert_eq!(name, "contains");
+                assert_eq!(args.len(), 2);
+            } else {
+                panic!("Expected Function expression");
+            }
+        }
+    }
+
+    #[test]
+    fn test_string_startswith() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(NAME.startswith("jo"))
+            .build();
+
+        assert!(query.has_filter());
+        if let Some(filter) = query.filter() {
+            if let Expr::Function(name, _) = filter {
+                assert_eq!(name, "startswith");
+            } else {
+                panic!("Expected Function expression");
+            }
+        }
+    }
+
+    #[test]
+    fn test_string_endswith() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(EMAIL.endswith("@example.com"))
+            .build();
+
+        assert!(query.has_filter());
+        if let Some(filter) = query.filter() {
+            if let Expr::Function(name, _) = filter {
+                assert_eq!(name, "endswith");
+            } else {
+                panic!("Expected Function expression");
+            }
+        }
+    }
+
+    #[test]
+    fn test_comparison_operators() {
+        let query = QueryBuilder::<UserSchema>::new().filter(AGE.gt(18)).build();
+        assert!(query.has_filter());
+
+        let query = QueryBuilder::<UserSchema>::new().filter(AGE.ge(18)).build();
+        assert!(query.has_filter());
+
+        let query = QueryBuilder::<UserSchema>::new().filter(AGE.lt(65)).build();
+        assert!(query.has_filter());
+
+        let query = QueryBuilder::<UserSchema>::new().filter(AGE.le(65)).build();
+        assert!(query.has_filter());
+
+        let query = QueryBuilder::<UserSchema>::new().filter(AGE.ne(0)).build();
+        assert!(query.has_filter());
+    }
+
+    #[cfg(feature = "uuid")]
+    #[test]
+    fn test_and_combinator() {
+        let user_id = uuid::Uuid::new_v4();
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(ID.eq(user_id).and(AGE.gt(18)))
+            .build();
+
+        assert!(query.has_filter());
+        if let Some(filter) = query.filter() {
+            if let Expr::And(_, _) = filter {
+            } else {
+                panic!("Expected And expression");
+            }
+        }
+    }
+
+    #[test]
+    fn test_or_combinator() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(AGE.lt(18).or(AGE.gt(65)))
+            .build();
+
+        assert!(query.has_filter());
+        if let Some(filter) = query.filter() {
+            if let Expr::Or(_, _) = filter {
+            } else {
+                panic!("Expected Or expression");
+            }
+        }
+    }
+
+    #[test]
+    fn test_not_combinator() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(NAME.contains("test").not())
+            .build();
+
+        assert!(query.has_filter());
+        if let Some(filter) = query.filter() {
+            if let Expr::Not(_) = filter {
+            } else {
+                panic!("Expected Not expression");
+            }
+        }
+    }
+
+    #[cfg(feature = "uuid")]
+    #[test]
+    fn test_complex_filter() {
+        let user_id = uuid::Uuid::new_v4();
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(
+                ID.eq(user_id)
+                    .and(NAME.contains("john"))
+                    .and(AGE.ge(18).and(AGE.le(65))),
+            )
+            .build();
+
+        assert!(query.has_filter());
+        assert!(query.filter_hash.is_some());
+    }
+
+    #[test]
+    fn test_order_by_single() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .order_by(NAME, SortDir::Asc)
+            .build();
+
+        assert_eq!(query.order.0.len(), 1);
+        assert_eq!(query.order.0[0].field, "name");
+        assert_eq!(query.order.0[0].dir, SortDir::Asc);
+    }
+
+    #[test]
+    fn test_order_by_multiple() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .order_by(NAME, SortDir::Asc)
+            .order_by(AGE, SortDir::Desc)
+            .build();
+
+        assert_eq!(query.order.0.len(), 2);
+        assert_eq!(query.order.0[0].field, "name");
+        assert_eq!(query.order.0[0].dir, SortDir::Asc);
+        assert_eq!(query.order.0[1].field, "age");
+        assert_eq!(query.order.0[1].dir, SortDir::Desc);
+    }
+
+    #[test]
+    fn test_select_fields() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .select([NAME, EMAIL])
+            .build();
+
+        assert!(query.has_select());
+        let fields = query.selected_fields().unwrap();
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0], "name");
+        assert_eq!(fields[1], "email");
+    }
+
+    #[test]
+    fn test_select_fields_vec() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .select(vec![NAME, EMAIL])
+            .build();
+
+        assert!(query.has_select());
+        let fields = query.selected_fields().unwrap();
+        assert_eq!(fields, &["name", "email"]);
+    }
+
+    #[test]
+    fn test_select_fields_legacy_slice_syntax() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .select(&[&NAME, &EMAIL])
+            .build();
+
+        assert!(query.has_select());
+        let fields = query.selected_fields().unwrap();
+        assert_eq!(fields, &["name", "email"]);
+    }
+
+    #[test]
+    fn test_page_size() {
+        let query = QueryBuilder::<UserSchema>::new().page_size(50).build();
+
+        assert_eq!(query.limit, Some(50));
+    }
+
+    #[cfg(feature = "uuid")]
+    #[test]
+    fn test_full_query_build() {
+        let user_id = uuid::Uuid::new_v4();
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(ID.eq(user_id).and(AGE.gt(18)))
+            .order_by(NAME, SortDir::Asc)
+            .select([NAME, EMAIL])
+            .page_size(25)
+            .build();
+
+        assert!(query.has_filter());
+        assert!(query.filter_hash.is_some());
+        assert_eq!(query.order.0.len(), 1);
+        assert!(query.has_select());
+        assert_eq!(query.limit, Some(25));
+    }
+
+    #[cfg(feature = "uuid")]
+    #[test]
+    fn test_filter_hash_stability() {
+        let user_id = uuid::Uuid::new_v4();
+
+        let query1 = QueryBuilder::<UserSchema>::new()
+            .filter(ID.eq(user_id))
+            .build();
+
+        let query2 = QueryBuilder::<UserSchema>::new()
+            .filter(ID.eq(user_id))
+            .build();
+
+        assert_eq!(query1.filter_hash, query2.filter_hash);
+        assert!(query1.filter_hash.is_some());
+    }
+
+    #[test]
+    fn test_filter_hash_different_for_different_filters() {
+        let query1 = QueryBuilder::<UserSchema>::new()
+            .filter(NAME.eq("alice"))
+            .build();
+
+        let query2 = QueryBuilder::<UserSchema>::new().filter(AGE.gt(18)).build();
+
+        assert_ne!(query1.filter_hash, query2.filter_hash);
+    }
+
+    #[test]
+    fn test_no_filter_no_hash() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .order_by(NAME, SortDir::Asc)
+            .build();
+
+        assert!(!query.has_filter());
+        assert!(query.filter_hash.is_none());
+    }
+
+    #[test]
+    fn test_empty_query() {
+        let query = QueryBuilder::<UserSchema>::new().build();
+
+        assert!(!query.has_filter());
+        assert!(query.filter_hash.is_none());
+        assert!(query.order.is_empty());
+        assert!(!query.has_select());
+        assert_eq!(query.limit, None);
+    }
+
+    #[test]
+    fn test_normalized_filter_consistency() {
+        use modkit_odata::pagination::normalize_filter_for_hash;
+
+        let expr1 = NAME.eq("test");
+        let expr2 = NAME.eq("test");
+
+        let norm1 = normalize_filter_for_hash(&expr1);
+        let norm2 = normalize_filter_for_hash(&expr2);
+
+        assert_eq!(norm1, norm2);
+    }
+
+    #[test]
+    fn test_is_null() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(NAME.is_null())
+            .build();
+
+        assert!(query.has_filter());
+        if let Some(filter) = query.filter() {
+            if let Expr::Compare(_, op, value) = filter {
+                assert_eq!(*op, CompareOperator::Eq);
+                if let Expr::Value(Value::Null) = **value {
+                    // Expected
+                } else {
+                    panic!("Expected Value::Null");
+                }
+            } else {
+                panic!("Expected Compare expression");
+            }
+        }
+    }
+
+    #[test]
+    fn test_is_not_null() {
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(EMAIL.is_not_null())
+            .build();
+
+        assert!(query.has_filter());
+        if let Some(filter) = query.filter() {
+            if let Expr::Compare(_, op, value) = filter {
+                assert_eq!(*op, CompareOperator::Ne);
+                if let Expr::Value(Value::Null) = **value {
+                    // Expected
+                } else {
+                    panic!("Expected Value::Null");
+                }
+            } else {
+                panic!("Expected Compare expression");
+            }
+        }
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn test_chrono_datetime_conversion() {
+        use chrono::Utc;
+
+        const CREATED_AT: FieldRef<UserSchema, chrono::DateTime<Utc>> =
+            FieldRef::new(UserField::Age); // Reusing Age field for test
+
+        let now = Utc::now();
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(CREATED_AT.eq(now))
+            .build();
+
+        assert!(query.has_filter());
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn test_chrono_naive_date_conversion() {
+        use chrono::NaiveDate;
+
+        const DATE_FIELD: FieldRef<UserSchema, NaiveDate> = FieldRef::new(UserField::Age); // Reusing Age field for test
+
+        let date = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(DATE_FIELD.eq(date))
+            .build();
+
+        assert!(query.has_filter());
+    }
+
+    #[cfg(feature = "chrono")]
+    #[test]
+    fn test_chrono_naive_time_conversion() {
+        use chrono::NaiveTime;
+
+        const TIME_FIELD: FieldRef<UserSchema, NaiveTime> = FieldRef::new(UserField::Age); // Reusing Age field for test
+
+        let time = NaiveTime::from_hms_opt(12, 30, 0).unwrap();
+        let query = QueryBuilder::<UserSchema>::new()
+            .filter(TIME_FIELD.eq(time))
+            .build();
+
+        assert!(query.has_filter());
+    }
+}

--- a/libs/modkit-sdk/src/pager.rs
+++ b/libs/modkit-sdk/src/pager.rs
@@ -1,0 +1,736 @@
+//! Cursor-based pagination with Stream API
+//!
+//! This module provides a reusable cursor-based pager that converts a page-fetching function
+//! into a Stream of pages or items, hiding cursor management from SDK users.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use modkit_sdk::pager::{CursorPager, PagerError};
+//! use modkit_sdk::odata::QueryBuilder;
+//! use futures_util::StreamExt;
+//!
+//! // Stream of pages
+//! let pages = QueryBuilder::<UserSchema>::new()
+//!     .filter(NAME.contains("john"))
+//!     .page_size(50)
+//!     .pages_stream(|query| async move {
+//!         client.list_users(query).await
+//!     });
+//!
+//! // Stream of items
+//! let items = QueryBuilder::<UserSchema>::new()
+//!     .filter(NAME.contains("john"))
+//!     .page_size(50)
+//!     .items_stream(|query| async move {
+//!         client.list_users(query).await
+//!     });
+//!
+//! // Consume the stream
+//! while let Some(result) = items.next().await {
+//!     match result {
+//!         Ok(user) => println!("User: {:?}", user),
+//!         Err(PagerError::Fetch(e)) => eprintln!("Fetch error: {}", e),
+//!         Err(PagerError::InvalidCursor(c)) => eprintln!("Invalid cursor: {}", c),
+//!     }
+//! }
+//! ```
+
+use futures_core::Stream;
+use modkit_odata::{ODataQuery, Page};
+use pin_project_lite::pin_project;
+use std::collections::VecDeque;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Error type for pagination operations.
+///
+/// This enum wraps both fetcher errors and cursor decoding failures,
+/// ensuring that invalid cursors are not silently ignored.
+#[derive(Debug)]
+pub enum PagerError<E> {
+    /// Error from the fetcher function.
+    Fetch(E),
+    /// Invalid cursor string that failed to decode.
+    InvalidCursor(String),
+}
+
+impl<E: fmt::Display> fmt::Display for PagerError<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Fetch(e) => write!(f, "Fetch error: {e}"),
+            Self::InvalidCursor(cursor) => write!(f, "Invalid cursor: {cursor}"),
+        }
+    }
+}
+
+impl<E: std::error::Error + 'static> std::error::Error for PagerError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Fetch(e) => Some(e),
+            Self::InvalidCursor(_) => None,
+        }
+    }
+}
+
+pin_project! {
+    /// A cursor-based pager that implements `Stream` for paginated items.
+    ///
+    /// This pager manages cursor state internally and fetches pages on-demand,
+    /// yielding individual items from the stream.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - The item type
+    /// * `E` - The error type
+    /// * `F` - The fetcher function type
+    /// * `Fut` - The future returned by the fetcher
+    pub struct CursorPager<T, E, F, Fut>
+    where
+        F: FnMut(ODataQuery) -> Fut,
+        Fut: Future<Output = Result<Page<T>, E>>,
+    {
+        base_query: ODataQuery,
+        next_cursor: Option<String>,
+        buffer: VecDeque<T>,
+        done: bool,
+        fetcher: F,
+        #[pin]
+        current_fetch: Option<Fut>,
+    }
+}
+
+impl<T, E, F, Fut> CursorPager<T, E, F, Fut>
+where
+    F: FnMut(ODataQuery) -> Fut,
+    Fut: Future<Output = Result<Page<T>, E>>,
+{
+    /// Create a new cursor pager with the given base query and fetcher function.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_query` - The base `OData` query (without cursor)
+    /// * `fetcher` - Function that fetches a page given an `ODataQuery`
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let pager = CursorPager::new(query, |q| async move {
+    ///     client.list_users(q).await
+    /// });
+    /// ```
+    pub fn new(base_query: ODataQuery, fetcher: F) -> Self {
+        Self {
+            base_query,
+            next_cursor: None,
+            buffer: VecDeque::new(),
+            done: false,
+            fetcher,
+            current_fetch: None,
+        }
+    }
+}
+
+impl<T, E, F, Fut> Stream for CursorPager<T, E, F, Fut>
+where
+    F: FnMut(ODataQuery) -> Fut,
+    Fut: Future<Output = Result<Page<T>, E>>,
+{
+    type Item = Result<T, PagerError<E>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        loop {
+            if let Some(item) = this.buffer.pop_front() {
+                return Poll::Ready(Some(Ok(item)));
+            }
+
+            if *this.done {
+                return Poll::Ready(None);
+            }
+
+            if let Some(fut) = this.current_fetch.as_mut().as_pin_mut() {
+                match fut.poll(cx) {
+                    Poll::Ready(Ok(page)) => {
+                        this.current_fetch.set(None);
+
+                        this.next_cursor.clone_from(&page.page_info.next_cursor);
+
+                        if this.next_cursor.is_none() {
+                            *this.done = true;
+                        }
+
+                        this.buffer.extend(page.items);
+
+                        continue;
+                    }
+                    Poll::Ready(Err(e)) => {
+                        this.current_fetch.set(None);
+                        *this.done = true;
+                        return Poll::Ready(Some(Err(PagerError::Fetch(e))));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
+
+            // Allocation strategy: base_query cloned once per page fetch.
+            // Filter AST is built once in QueryBuilder and reused here.
+            let mut query = this.base_query.clone();
+            if let Some(cursor_str) = this.next_cursor.as_ref() {
+                if let Ok(cursor) = modkit_odata::CursorV1::decode(cursor_str) {
+                    query = query.with_cursor(cursor);
+                } else {
+                    *this.done = true;
+                    return Poll::Ready(Some(Err(PagerError::InvalidCursor(cursor_str.clone()))));
+                }
+            }
+
+            let fut = (this.fetcher)(query);
+            this.current_fetch.set(Some(fut));
+        }
+    }
+}
+
+pin_project! {
+    /// A cursor-based pager that implements `Stream` for pages.
+    ///
+    /// This pager yields entire pages instead of individual items.
+    ///
+    /// # Type Parameters
+    ///
+    /// * `T` - The item type
+    /// * `E` - The error type
+    /// * `F` - The fetcher function type
+    /// * `Fut` - The future returned by the fetcher
+    pub struct PagesPager<T, E, F, Fut>
+    where
+        F: FnMut(ODataQuery) -> Fut,
+        Fut: Future<Output = Result<Page<T>, E>>,
+    {
+        base_query: ODataQuery,
+        next_cursor: Option<String>,
+        done: bool,
+        fetcher: F,
+        #[pin]
+        current_fetch: Option<Fut>,
+    }
+}
+
+impl<T, E, F, Fut> PagesPager<T, E, F, Fut>
+where
+    F: FnMut(ODataQuery) -> Fut,
+    Fut: Future<Output = Result<Page<T>, E>>,
+{
+    /// Create a new pages pager with the given base query and fetcher function.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_query` - The base `OData` query (without cursor)
+    /// * `fetcher` - Function that fetches a page given an `ODataQuery`
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let pager = PagesPager::new(query, |q| async move {
+    ///     client.list_users(q).await
+    /// });
+    /// ```
+    pub fn new(base_query: ODataQuery, fetcher: F) -> Self {
+        Self {
+            base_query,
+            next_cursor: None,
+            done: false,
+            fetcher,
+            current_fetch: None,
+        }
+    }
+}
+
+impl<T, E, F, Fut> Stream for PagesPager<T, E, F, Fut>
+where
+    F: FnMut(ODataQuery) -> Fut,
+    Fut: Future<Output = Result<Page<T>, E>>,
+{
+    type Item = Result<Page<T>, PagerError<E>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        loop {
+            if *this.done {
+                return Poll::Ready(None);
+            }
+
+            if let Some(fut) = this.current_fetch.as_mut().as_pin_mut() {
+                match fut.poll(cx) {
+                    Poll::Ready(Ok(page)) => {
+                        this.current_fetch.set(None);
+
+                        this.next_cursor.clone_from(&page.page_info.next_cursor);
+
+                        if this.next_cursor.is_none() {
+                            *this.done = true;
+                        }
+
+                        return Poll::Ready(Some(Ok(page)));
+                    }
+                    Poll::Ready(Err(e)) => {
+                        this.current_fetch.set(None);
+                        *this.done = true;
+                        return Poll::Ready(Some(Err(PagerError::Fetch(e))));
+                    }
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
+
+            // Allocation strategy: base_query cloned once per page fetch.
+            // Filter AST is built once in QueryBuilder and reused here.
+            let mut query = this.base_query.clone();
+            if let Some(cursor_str) = this.next_cursor.as_ref() {
+                if let Ok(cursor) = modkit_odata::CursorV1::decode(cursor_str) {
+                    query = query.with_cursor(cursor);
+                } else {
+                    *this.done = true;
+                    return Poll::Ready(Some(Err(PagerError::InvalidCursor(cursor_str.clone()))));
+                }
+            }
+
+            let fut = (this.fetcher)(query);
+            this.current_fetch.set(Some(fut));
+
+            // Poll the newly-installed future immediately so it can register the current waker
+            // naturally, avoiding a manual `wake_by_ref()` and the associated spurious wakeup.
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::similar_names)]
+mod tests {
+    use super::*;
+    use futures_util::StreamExt;
+    use modkit_odata::PageInfo;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct User {
+        id: i32,
+        name: String,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct FakeError(String);
+
+    #[derive(Clone)]
+    struct FakeFetcher {
+        pages: Arc<[Page<User>]>,
+        call_count: Arc<Mutex<usize>>,
+    }
+
+    impl FakeFetcher {
+        fn new(pages: Vec<Page<User>>) -> Self {
+            Self {
+                pages: Arc::from(pages),
+                call_count: Arc::new(Mutex::new(0)),
+            }
+        }
+
+        fn fetch(&self, _query: ODataQuery) -> Result<Page<User>, FakeError> {
+            let mut count = self.call_count.lock().unwrap();
+            if *count >= self.pages.len() {
+                return Err(FakeError("No more pages".to_owned()));
+            }
+            let page = self.pages[*count].clone();
+            *count += 1;
+            Ok(page)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cursor_pager_two_pages() {
+        use modkit_odata::{CursorV1, SortDir};
+
+        let cursor = CursorV1 {
+            k: vec!["2".to_owned()],
+            o: SortDir::Asc,
+            s: "filter_hash".to_owned(),
+            f: Some("filter_hash".to_owned()),
+            d: "fwd".to_owned(),
+        };
+        let encoded_cursor = cursor.encode().unwrap();
+
+        let page1 = Page::new(
+            vec![
+                User {
+                    id: 1,
+                    name: "Alice".to_owned(),
+                },
+                User {
+                    id: 2,
+                    name: "Bob".to_owned(),
+                },
+            ],
+            PageInfo {
+                next_cursor: Some(encoded_cursor.clone()),
+                prev_cursor: None,
+                limit: 2,
+            },
+        );
+
+        let page2 = Page::new(
+            vec![
+                User {
+                    id: 3,
+                    name: "Charlie".to_owned(),
+                },
+                User {
+                    id: 4,
+                    name: "Diana".to_owned(),
+                },
+            ],
+            PageInfo {
+                next_cursor: None,
+                prev_cursor: Some(encoded_cursor),
+                limit: 2,
+            },
+        );
+
+        let fetcher = FakeFetcher::new(vec![page1, page2]);
+        let query = ODataQuery::new().with_limit(2);
+
+        let pager = CursorPager::new(query, move |q| {
+            let fetcher = fetcher.clone();
+            async move { fetcher.fetch(q) }
+        });
+
+        let items: Vec<Result<User, PagerError<FakeError>>> = pager.collect().await;
+
+        assert_eq!(items.len(), 4);
+        assert!(items.iter().all(Result::is_ok));
+
+        let users: Vec<User> = items.into_iter().map(|r| r.unwrap()).collect();
+        assert_eq!(users[0].name, "Alice");
+        assert_eq!(users[1].name, "Bob");
+        assert_eq!(users[2].name, "Charlie");
+        assert_eq!(users[3].name, "Diana");
+    }
+
+    #[tokio::test]
+    async fn test_cursor_pager_empty_page() {
+        let page = Page::new(
+            vec![],
+            PageInfo {
+                next_cursor: None,
+                prev_cursor: None,
+                limit: 10,
+            },
+        );
+
+        let fetcher = FakeFetcher::new(vec![page]);
+        let query = ODataQuery::new().with_limit(10);
+
+        let pager = CursorPager::new(query, move |q| {
+            let fetcher = fetcher.clone();
+            async move { fetcher.fetch(q) }
+        });
+
+        let items: Vec<Result<User, PagerError<FakeError>>> = pager.collect().await;
+
+        assert_eq!(items.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_cursor_pager_error_propagation() {
+        use modkit_odata::{CursorV1, SortDir};
+
+        let cursor = CursorV1 {
+            k: vec!["1".to_owned()],
+            o: SortDir::Asc,
+            s: "filter_hash".to_owned(),
+            f: Some("filter_hash".to_owned()),
+            d: "fwd".to_owned(),
+        };
+        let encoded_cursor = cursor.encode().unwrap();
+
+        let page1 = Page::new(
+            vec![User {
+                id: 1,
+                name: "Alice".to_owned(),
+            }],
+            PageInfo {
+                next_cursor: Some(encoded_cursor),
+                prev_cursor: None,
+                limit: 1,
+            },
+        );
+
+        let fetcher = FakeFetcher::new(vec![page1]);
+        let query = ODataQuery::new().with_limit(1);
+
+        let pager = CursorPager::new(query, move |q| {
+            let fetcher = fetcher.clone();
+            async move { fetcher.fetch(q) }
+        });
+
+        let items: Vec<Result<User, PagerError<FakeError>>> = pager.collect().await;
+
+        assert_eq!(items.len(), 2);
+        assert!(items[0].is_ok());
+        assert!(items[1].is_err());
+
+        // Verify it's a Fetch error
+        if let Err(PagerError::Fetch(_)) = &items[1] {
+            // Expected
+        } else {
+            panic!("Expected PagerError::Fetch");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pages_pager_two_pages() {
+        use modkit_odata::{CursorV1, SortDir};
+
+        let cursor = CursorV1 {
+            k: vec!["2".to_owned()],
+            o: SortDir::Asc,
+            s: "filter_hash".to_owned(),
+            f: Some("filter_hash".to_owned()),
+            d: "fwd".to_owned(),
+        };
+        let encoded_cursor = cursor.encode().unwrap();
+
+        let page1 = Page::new(
+            vec![
+                User {
+                    id: 1,
+                    name: "Alice".to_owned(),
+                },
+                User {
+                    id: 2,
+                    name: "Bob".to_owned(),
+                },
+            ],
+            PageInfo {
+                next_cursor: Some(encoded_cursor.clone()),
+                prev_cursor: None,
+                limit: 2,
+            },
+        );
+
+        let page2 = Page::new(
+            vec![User {
+                id: 3,
+                name: "Charlie".to_owned(),
+            }],
+            PageInfo {
+                next_cursor: None,
+                prev_cursor: Some(encoded_cursor),
+                limit: 2,
+            },
+        );
+
+        let fetcher = FakeFetcher::new(vec![page1.clone(), page2.clone()]);
+        let query = ODataQuery::new().with_limit(2);
+
+        let pager = PagesPager::new(query, move |q| {
+            let fetcher = fetcher.clone();
+            async move { fetcher.fetch(q) }
+        });
+
+        let pages: Vec<Result<Page<User>, PagerError<FakeError>>> = pager.collect().await;
+
+        assert_eq!(pages.len(), 2);
+        assert!(pages.iter().all(Result::is_ok));
+
+        let page_results: Vec<Page<User>> = pages.into_iter().map(|r| r.unwrap()).collect();
+        assert_eq!(page_results[0].items.len(), 2);
+        assert_eq!(page_results[1].items.len(), 1);
+        assert_eq!(page_results[0].items[0].name, "Alice");
+        assert_eq!(page_results[1].items[0].name, "Charlie");
+    }
+
+    #[tokio::test]
+    async fn test_pages_pager_single_page() {
+        let page = Page::new(
+            vec![User {
+                id: 1,
+                name: "Alice".to_owned(),
+            }],
+            PageInfo {
+                next_cursor: None,
+                prev_cursor: None,
+                limit: 10,
+            },
+        );
+
+        let fetcher = FakeFetcher::new(vec![page.clone()]);
+        let query = ODataQuery::new().with_limit(10);
+
+        let pager = PagesPager::new(query, move |q| {
+            let fetcher = fetcher.clone();
+            async move { fetcher.fetch(q) }
+        });
+
+        let pages: Vec<Result<Page<User>, PagerError<FakeError>>> = pager.collect().await;
+
+        assert_eq!(pages.len(), 1);
+        assert!(pages[0].is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_cursor_pager_invalid_cursor() {
+        let page1 = Page::new(
+            vec![User {
+                id: 1,
+                name: "Alice".to_owned(),
+            }],
+            PageInfo {
+                next_cursor: Some("invalid_cursor_string".to_owned()),
+                prev_cursor: None,
+                limit: 1,
+            },
+        );
+
+        let fetcher = FakeFetcher::new(vec![page1]);
+        let query = ODataQuery::new().with_limit(1);
+
+        let pager = CursorPager::new(query, move |q| {
+            let fetcher = fetcher.clone();
+            async move { fetcher.fetch(q) }
+        });
+
+        let items: Vec<Result<User, PagerError<FakeError>>> = pager.collect().await;
+
+        assert_eq!(items.len(), 2);
+        assert!(items[0].is_ok());
+        assert!(items[1].is_err());
+
+        // Verify it's an InvalidCursor error
+        if let Err(PagerError::InvalidCursor(cursor)) = &items[1] {
+            assert_eq!(cursor, "invalid_cursor_string");
+        } else {
+            panic!("Expected PagerError::InvalidCursor");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pages_pager_invalid_cursor() {
+        let page1 = Page::new(
+            vec![User {
+                id: 1,
+                name: "Alice".to_owned(),
+            }],
+            PageInfo {
+                next_cursor: Some("invalid_cursor_string".to_owned()),
+                prev_cursor: None,
+                limit: 1,
+            },
+        );
+
+        let fetcher = FakeFetcher::new(vec![page1]);
+        let query = ODataQuery::new().with_limit(1);
+
+        let pager = PagesPager::new(query, move |q| {
+            let fetcher = fetcher.clone();
+            async move { fetcher.fetch(q) }
+        });
+
+        let pages: Vec<Result<Page<User>, PagerError<FakeError>>> = pager.collect().await;
+
+        assert_eq!(pages.len(), 2);
+        assert!(pages[0].is_ok());
+        assert!(pages[1].is_err());
+
+        // Verify it's an InvalidCursor error
+        if let Err(PagerError::InvalidCursor(cursor)) = &pages[1] {
+            assert_eq!(cursor, "invalid_cursor_string");
+        } else {
+            panic!("Expected PagerError::InvalidCursor");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pages_pager_error_propagation() {
+        use modkit_odata::{CursorV1, SortDir};
+
+        let cursor = CursorV1 {
+            k: vec!["1".to_owned()],
+            o: SortDir::Asc,
+            s: "filter_hash".to_owned(),
+            f: Some("filter_hash".to_owned()),
+            d: "fwd".to_owned(),
+        };
+        let encoded_cursor = cursor.encode().unwrap();
+
+        let page1 = Page::new(
+            vec![User {
+                id: 1,
+                name: "Alice".to_owned(),
+            }],
+            PageInfo {
+                next_cursor: Some(encoded_cursor),
+                prev_cursor: None,
+                limit: 1,
+            },
+        );
+
+        let fetcher = FakeFetcher::new(vec![page1]);
+        let query = ODataQuery::new().with_limit(1);
+
+        let pager = PagesPager::new(query, move |q| {
+            let fetcher = fetcher.clone();
+            async move { fetcher.fetch(q) }
+        });
+
+        let pages: Vec<Result<Page<User>, PagerError<FakeError>>> = pager.collect().await;
+
+        assert_eq!(pages.len(), 2);
+        assert!(pages[0].is_ok());
+        assert!(pages[1].is_err());
+
+        // Verify it's a Fetch error
+        if let Err(PagerError::Fetch(_)) = &pages[1] {
+            // Expected
+        } else {
+            panic!("Expected PagerError::Fetch");
+        }
+    }
+
+    #[test]
+    fn test_pages_pager_polls_new_future_immediately() {
+        struct PollCountingFuture {
+            polls: Arc<AtomicUsize>,
+        }
+
+        impl Future for PollCountingFuture {
+            type Output = Result<Page<User>, FakeError>;
+
+            fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+                self.polls.fetch_add(1, Ordering::SeqCst);
+                Poll::Pending
+            }
+        }
+
+        let polls = Arc::new(AtomicUsize::new(0));
+        let polls_for_fetcher = polls.clone();
+
+        let mut pager = PagesPager::new(ODataQuery::new().with_limit(1), move |_q| {
+            PollCountingFuture {
+                polls: polls_for_fetcher.clone(),
+            }
+        });
+
+        let waker = futures_util::task::noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
+
+        let poll = Pin::new(&mut pager).poll_next(&mut cx);
+        assert!(matches!(poll, Poll::Pending));
+
+        // If we don't poll immediately after installing the future, this would be 0.
+        assert_eq!(polls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/libs/modkit-sdk/src/secured.rs
+++ b/libs/modkit-sdk/src/secured.rs
@@ -1,0 +1,336 @@
+//! Security context scoping for clients
+//!
+//! This module provides a lightweight, zero-allocation wrapper that binds a `SecurityContext`
+//! to any client type, enabling security-aware API calls without cloning or Arc overhead.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use modkit_sdk::secured::{Secured, WithSecurityContext};
+//! use modkit_security::SecurityContext;
+//!
+//! let client = MyClient::new();
+//! let ctx = SecurityContext::root();
+//!
+//! // Bind the security context to the client
+//! let secured = client.security_ctx(&ctx);
+//!
+//! // Access the client and context
+//! let client_ref = secured.client();
+//! let ctx_ref = secured.ctx();
+//! ```
+
+use modkit_security::SecurityContext;
+
+/// A wrapper that binds a `SecurityContext` to a client reference.
+///
+/// This struct provides a zero-cost abstraction for carrying both a client
+/// and its associated security context together, without any allocation or cloning.
+///
+/// # Type Parameters
+///
+/// * `'a` - The lifetime of both the client and security context references
+/// * `C` - The client type being wrapped
+#[derive(Debug)]
+pub struct Secured<'a, C> {
+    client: &'a C,
+    ctx: &'a SecurityContext,
+}
+
+impl<'a, C> Secured<'a, C> {
+    /// Creates a new `Secured` wrapper binding a client and security context.
+    ///
+    /// # Arguments
+    ///
+    /// * `client` - Reference to the client
+    /// * `ctx` - Reference to the security context
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let secured = Secured::new(&client, &ctx);
+    /// ```
+    #[must_use]
+    pub fn new(client: &'a C, ctx: &'a SecurityContext) -> Self {
+        Self { client, ctx }
+    }
+
+    /// Returns a reference to the wrapped client.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let client_ref = secured.client();
+    /// ```
+    #[must_use]
+    pub fn client(&self) -> &'a C {
+        self.client
+    }
+
+    /// Returns a reference to the security context.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let ctx_ref = secured.ctx();
+    /// let tenant_id = ctx_ref.tenant_id();
+    /// ```
+    #[must_use]
+    pub fn ctx(&self) -> &'a SecurityContext {
+        self.ctx
+    }
+
+    /// Create a new query builder for the given schema.
+    ///
+    /// This provides an ergonomic entrypoint for building queries from a secured client.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let items = client.security_ctx(&ctx)
+    ///     .query::<UserSchema>()
+    ///     .filter(user::email().contains("@example.com"))
+    ///     .items_stream(|query| async move {
+    ///         client.list_users(query).await
+    ///     });
+    /// ```
+    #[must_use]
+    pub fn query<S: crate::odata::Schema>(&self) -> crate::odata::QueryBuilder<S> {
+        crate::odata::QueryBuilder::new()
+    }
+}
+
+impl<C> Clone for Secured<'_, C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<C> Copy for Secured<'_, C> {}
+
+/// Extension trait that adds the `security_ctx` method to any type.
+///
+/// This trait enables any client to be wrapped with a security context
+/// using a fluent API: `client.security_ctx(&ctx)`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use modkit_sdk::secured::WithSecurityContext;
+///
+/// let secured = my_client.security_ctx(&security_context);
+/// ```
+pub trait WithSecurityContext {
+    /// Binds a security context to this client, returning a `Secured` wrapper.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Reference to the security context to bind
+    ///
+    /// # Returns
+    ///
+    /// A `Secured` wrapper containing references to both the client and context.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let secured = client.security_ctx(&ctx);
+    /// assert_eq!(secured.ctx().tenant_id(), ctx.tenant_id());
+    /// ```
+    fn security_ctx<'a>(&'a self, ctx: &'a SecurityContext) -> Secured<'a, Self>
+    where
+        Self: Sized;
+}
+
+impl<T> WithSecurityContext for T {
+    fn security_ctx<'a>(&'a self, ctx: &'a SecurityContext) -> Secured<'a, Self>
+    where
+        Self: Sized,
+    {
+        Secured::new(self, ctx)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    struct MockClient {
+        name: String,
+    }
+
+    impl MockClient {
+        fn new(name: &str) -> Self {
+            Self {
+                name: name.to_owned(),
+            }
+        }
+
+        fn get_name(&self) -> &str {
+            &self.name
+        }
+    }
+
+    #[test]
+    fn test_secured_new() {
+        let client = MockClient::new("test-client");
+        let ctx = SecurityContext::root();
+
+        let secured = Secured::new(&client, &ctx);
+
+        assert_eq!(secured.client().get_name(), "test-client");
+        assert_eq!(secured.ctx().tenant_id(), ctx.tenant_id());
+    }
+
+    #[test]
+    fn test_secured_getters() {
+        let client = MockClient::new("test-client");
+        let tenant_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let ctx = SecurityContext::builder().tenant_id(tenant_id).build();
+
+        let secured = Secured::new(&client, &ctx);
+
+        let client_ref = secured.client();
+        assert_eq!(client_ref.get_name(), "test-client");
+
+        let ctx_ref = secured.ctx();
+        assert_eq!(ctx_ref.tenant_id(), tenant_id);
+    }
+
+    #[test]
+    fn test_with_security_context_trait() {
+        let client = MockClient::new("test-client");
+        let ctx = SecurityContext::root();
+
+        let secured = client.security_ctx(&ctx);
+
+        assert_eq!(secured.client().get_name(), "test-client");
+        assert_eq!(secured.ctx().tenant_id(), ctx.tenant_id());
+    }
+
+    #[test]
+    fn test_secured_clone() {
+        let client = MockClient::new("test-client");
+        let ctx = SecurityContext::root();
+
+        let secured1 = client.security_ctx(&ctx);
+        let secured2 = secured1;
+
+        assert_eq!(secured1.client().get_name(), secured2.client().get_name());
+        assert_eq!(secured1.ctx().tenant_id(), secured2.ctx().tenant_id());
+    }
+
+    #[test]
+    fn test_secured_copy() {
+        let client = MockClient::new("test-client");
+        let ctx = SecurityContext::root();
+
+        let secured1 = client.security_ctx(&ctx);
+        let secured2 = secured1;
+
+        assert_eq!(secured1.client().get_name(), secured2.client().get_name());
+        assert_eq!(secured1.ctx().tenant_id(), secured2.ctx().tenant_id());
+    }
+
+    #[test]
+    fn test_secured_with_anonymous_context() {
+        let client = MockClient::new("test-client");
+        let ctx = SecurityContext::anonymous();
+
+        let secured = client.security_ctx(&ctx);
+
+        assert_eq!(secured.client().get_name(), "test-client");
+        assert_eq!(secured.ctx().tenant_id(), Uuid::default());
+        assert_eq!(secured.ctx().subject_id(), Uuid::default());
+    }
+
+    #[test]
+    fn test_secured_with_custom_context() {
+        let client = MockClient::new("test-client");
+        let tenant_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let subject_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap();
+
+        let ctx = SecurityContext::builder()
+            .tenant_id(tenant_id)
+            .subject_id(subject_id)
+            .subject_type("user")
+            .build();
+
+        let secured = client.security_ctx(&ctx);
+
+        assert_eq!(secured.ctx().tenant_id(), tenant_id);
+        assert_eq!(secured.ctx().subject_id(), subject_id);
+    }
+
+    #[test]
+    fn test_secured_zero_allocation() {
+        let client = MockClient::new("test-client");
+        let ctx = SecurityContext::root();
+
+        let secured = client.security_ctx(&ctx);
+
+        assert_eq!(
+            std::mem::size_of_val(&secured),
+            std::mem::size_of::<&MockClient>() + std::mem::size_of::<&SecurityContext>()
+        );
+    }
+
+    #[test]
+    fn test_multiple_clients_with_same_context() {
+        let client1 = MockClient::new("client-1");
+        let client2 = MockClient::new("client-2");
+        let ctx = SecurityContext::root();
+
+        let secured1 = client1.security_ctx(&ctx);
+        let secured2 = client2.security_ctx(&ctx);
+
+        assert_eq!(secured1.client().get_name(), "client-1");
+        assert_eq!(secured2.client().get_name(), "client-2");
+        assert_eq!(secured1.ctx().tenant_id(), secured2.ctx().tenant_id());
+    }
+
+    #[test]
+    fn test_secured_preserves_lifetimes() {
+        let client = MockClient::new("test-client");
+        let ctx = SecurityContext::root();
+
+        let secured = client.security_ctx(&ctx);
+
+        assert_eq!(secured.client().get_name(), "test-client");
+        assert_eq!(secured.ctx().tenant_id(), ctx.tenant_id());
+    }
+
+    #[test]
+    fn test_secured_query_builder() {
+        use crate::odata::Schema;
+
+        #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+        enum TestField {
+            #[allow(dead_code)]
+            Name,
+        }
+
+        struct TestSchema;
+
+        impl Schema for TestSchema {
+            type Field = TestField;
+
+            fn field_name(field: Self::Field) -> &'static str {
+                match field {
+                    TestField::Name => "name",
+                }
+            }
+        }
+
+        let client = MockClient::new("test-client");
+        let ctx = SecurityContext::root();
+
+        let secured = client.security_ctx(&ctx);
+        let query_builder = secured.query::<TestSchema>();
+
+        let query = query_builder.page_size(50).build();
+        assert_eq!(query.limit, Some(50));
+    }
+}

--- a/libs/modkit-sdk/tests/type_safety_verification.rs
+++ b/libs/modkit-sdk/tests/type_safety_verification.rs
@@ -1,0 +1,161 @@
+//! Compile-time type safety verification tests
+//!
+//! These tests demonstrate that the typed `OData` builder enforces type safety
+//! at compile time. Uncomment the failing tests to see compile errors.
+
+use modkit_odata::SortDir;
+use modkit_sdk::odata::{FieldRef, FilterExpr, QueryBuilder, Schema};
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum TestField {
+    Id,
+    Name,
+    Age,
+}
+
+struct TestSchema;
+
+impl Schema for TestSchema {
+    type Field = TestField;
+
+    fn field_name(field: Self::Field) -> &'static str {
+        match field {
+            TestField::Id => "id",
+            TestField::Name => "name",
+            TestField::Age => "age",
+        }
+    }
+}
+
+const ID: FieldRef<TestSchema, i32> = FieldRef::new(TestField::Id);
+const NAME: FieldRef<TestSchema, String> = FieldRef::new(TestField::Name);
+const AGE: FieldRef<TestSchema, i32> = FieldRef::new(TestField::Age);
+
+#[test]
+fn test_string_ops_only_on_string_fields() {
+    // ✅ Valid: String field with string operations
+    let _query = QueryBuilder::<TestSchema>::new()
+        .filter(NAME.contains("test"))
+        .build();
+
+    let _query = QueryBuilder::<TestSchema>::new()
+        .filter(NAME.startswith("test"))
+        .build();
+
+    let _query = QueryBuilder::<TestSchema>::new()
+        .filter(NAME.endswith("test"))
+        .build();
+
+    // ❌ COMPILE ERROR: Uncomment to verify type safety
+    // let _query = QueryBuilder::<TestSchema>::new()
+    //     .filter(AGE.contains("test"))  // ERROR: no method `contains` for i32 field
+    //     .build();
+
+    // ❌ COMPILE ERROR: Uncomment to verify type safety
+    // let _query = QueryBuilder::<TestSchema>::new()
+    //     .filter(ID.startswith("test"))  // ERROR: no method `startswith` for Uuid field
+    //     .build();
+}
+
+#[test]
+fn test_comparison_ops_require_into_odata_value() {
+    // ✅ Valid: Supported types
+    let _query = QueryBuilder::<TestSchema>::new()
+        .filter(AGE.eq(42)) // i32 implements IntoODataValue
+        .build();
+
+    let _query = QueryBuilder::<TestSchema>::new()
+        .filter(NAME.eq("test")) // &str implements IntoODataValue
+        .build();
+
+    let _query = QueryBuilder::<TestSchema>::new()
+        .filter(ID.eq(123)) // i32 implements IntoODataValue
+        .build();
+
+    // ❌ COMPILE ERROR: Uncomment to verify type safety
+    // struct CustomType;
+    // let _query = QueryBuilder::<TestSchema>::new()
+    //     .filter(AGE.eq(CustomType))  // ERROR: CustomType doesn't implement IntoODataValue
+    //     .build();
+}
+
+#[test]
+fn test_no_manual_odata_query_construction() {
+    // ✅ Valid: User only interacts with QueryBuilder
+    let query = QueryBuilder::<TestSchema>::new()
+        .filter(AGE.gt(18))
+        .order_by(NAME, SortDir::Asc)
+        .page_size(50)
+        .build();
+
+    // Query is built with filter_hash computed automatically
+    assert!(query.filter_hash.is_some());
+    assert!(query.has_filter());
+    assert_eq!(query.limit, Some(50));
+
+    // User never needs to:
+    // - Manually create ODataQuery
+    // - Set cursor
+    // - Compute filter_hash
+    // - Touch internal OData structures
+}
+
+#[test]
+fn test_filter_hash_determinism() {
+    let user_id = 123;
+
+    // Build same query twice
+    let query1 = QueryBuilder::<TestSchema>::new()
+        .filter(ID.eq(user_id).and(AGE.gt(18)))
+        .build();
+
+    let query2 = QueryBuilder::<TestSchema>::new()
+        .filter(ID.eq(user_id).and(AGE.gt(18)))
+        .build();
+
+    // Filter hashes must be identical
+    assert_eq!(query1.filter_hash, query2.filter_hash);
+    assert!(query1.filter_hash.is_some());
+
+    // Different filter produces different hash
+    let query3 = QueryBuilder::<TestSchema>::new().filter(AGE.lt(65)).build();
+
+    assert_ne!(query1.filter_hash, query3.filter_hash);
+}
+
+#[test]
+fn test_heterogeneous_field_selection() {
+    // ✅ Valid: Homogeneous selection (all i32 fields)
+    let query = QueryBuilder::<TestSchema>::new().select([ID, AGE]).build();
+
+    assert!(query.has_select());
+    let fields = query.selected_fields().unwrap();
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0], "id");
+    assert_eq!(fields[1], "age");
+}
+
+#[test]
+fn test_complex_type_safe_query() {
+    let user_id = 123;
+
+    // Complex query with multiple type-safe operations
+    let query = QueryBuilder::<TestSchema>::new()
+        .filter(
+            ID.ne(user_id)
+                .and(NAME.contains("smith").or(NAME.startswith("john")))
+                .and(AGE.ge(18).and(AGE.le(65))),
+        )
+        .order_by(NAME, SortDir::Asc)
+        .order_by(AGE, SortDir::Desc)
+        .select([ID, AGE])
+        .page_size(25)
+        .build();
+
+    // Verify all components set correctly
+    assert!(query.has_filter());
+    assert!(query.filter_hash.is_some());
+    assert_eq!(query.order.0.len(), 2);
+    assert!(query.has_select());
+    assert_eq!(query.limit, Some(25));
+}

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -25,6 +25,7 @@ modkit-macros = { path = "../modkit-macros" }
 modkit-errors = { path = "../modkit-errors", features = ["utoipa", "axum"] }
 modkit-db = { path = "../modkit-db" }
 modkit-odata = { path = "../modkit-odata", features = ["with-odata-params"] }
+modkit-sdk = { path = "../modkit-sdk" }
 module_orchestrator-contracts = { path = "../../modules/module_orchestrator/module_orchestrator-contracts" } # TODO: probably we need remove this dependency at the future
 module_orchestrator-grpc = { path = "../../modules/module_orchestrator/module_orchestrator-grpc", optional = true }
 
@@ -43,7 +44,8 @@ regex = { workspace = true, optional = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tokio-stream = { workspace = true }
-futures = { workspace = true }
+futures-core = { workspace = true }
+futures-util = { workspace = true }
 
 # Router/types used in contracts and runtime
 axum = { workspace = true }

--- a/libs/modkit/src/http/sse.rs
+++ b/libs/modkit/src/http/sse.rs
@@ -1,6 +1,7 @@
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::IntoResponse;
-use futures::{Stream, StreamExt};
+use futures_core::Stream;
+use futures_util::StreamExt;
 use serde::Serialize;
 use std::{borrow::Cow, convert::Infallible, time::Duration};
 use tokio::sync::broadcast;
@@ -145,7 +146,7 @@ impl<T: Clone + Send + 'static> SseBroadcaster<T> {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use futures::StreamExt;
+    use futures_util::StreamExt;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,

--- a/libs/modkit/src/lib.rs
+++ b/libs/modkit/src/lib.rs
@@ -133,6 +133,9 @@ pub use directory::{
 // GTS schema support
 pub mod gts;
 
+// Security context scoping wrapper (re-exported from modkit-sdk)
+pub use modkit_sdk::{Secured, WithSecurityContext};
+
 pub use backends::{
     BackendKind, InstanceHandle, LocalProcessBackend, ModuleRuntimeBackend, OopBackend,
     OopModuleConfig, OopSpawnConfig,

--- a/modules/api_ingress/Cargo.toml
+++ b/modules/api_ingress/Cargo.toml
@@ -44,7 +44,7 @@ http = { workspace = true }
 rust-embed = { workspace = true }
 
 [dev-dependencies]
-futures = { workspace = true }
+futures-core = { workspace = true }
 uuid = { workspace = true }
 
 [features]

--- a/modules/api_ingress/src/lib.rs
+++ b/modules/api_ingress/src/lib.rs
@@ -698,7 +698,7 @@ mod sse_openapi_tests {
     }
 
     async fn sse_handler() -> axum::response::sse::Sse<
-        impl futures::Stream<Item = Result<axum::response::sse::Event, std::convert::Infallible>>,
+        impl futures_core::Stream<Item = Result<axum::response::sse::Event, std::convert::Infallible>>,
     > {
         let b = modkit::SseBroadcaster::<UserEvent>::new(4);
         b.sse_response()

--- a/modules/file_parser/Cargo.toml
+++ b/modules/file_parser/Cargo.toml
@@ -45,7 +45,7 @@ thiserror = { workspace = true }
 bytes = { workspace = true }
 
 # Futures and async streaming
-futures = { workspace = true }
+futures-util = { workspace = true }
 
 # Base64 encoding (used by stub parser)
 base64 = { workspace = true }

--- a/modules/file_parser/src/api/rest/handlers.rs
+++ b/modules/file_parser/src/api/rest/handlers.rs
@@ -6,7 +6,7 @@ use axum::extract::{Extension, Query};
 use axum::http::HeaderMap;
 use axum::response::Response;
 use bytes::Bytes;
-use futures::stream;
+use futures_util::stream;
 use std::convert::Infallible;
 use tracing::{field::Empty, info};
 


### PR DESCRIPTION

Introduce a Rust SDK layer that hides OData pagination and filtering mechanics behind a type-safe query builder and async streaming API, making client-side usage simple and idiomatic compared to the raw REST/OData interface.

See problem details in #198 
- dependency from `futures` meta create is replaced with specific crates which are really used in project