### PR TITLE
docs: clarify module structure and plugin architecture

### DIFF
--- a/docs/MODKIT_PLUGINS.md
+++ b/docs/MODKIT_PLUGINS.md
@@ -19,6 +19,9 @@ This pattern enables:
 - **Runtime selection** — choose which plugin to use based on configuration, tenant, or other context
 - **Hot-pluggable extensions** — add new plugins without modifying the gateway
 
+> [!IMPORTANT]
+> **Plugin Isolation Rule:** Regular modules **cannot** depend on or consume plugin modules directly. All plugin functionality must be accessed through the Gateway Module's public API (`hub.get::<dyn GatewayClient>()`). This ensures plugin implementations remain swappable, isolated, and decoupled from consumers.
+
 ---
 
 ## Architecture Diagram


### PR DESCRIPTION
Update ARCHITECTURE_MANIFEST.md:
- Explain modules as packages with optional binary crates for OoP execution
- Improve module category descriptions (Regular, Gateway, Plugin)
- Add GTS instance ID mention for plugin identification
- Fix documentation reference link to MODKIT_PLUGINS.md