### PR TITLE
Add Tenant Resolver Gateway module for multi-tenant access control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,11 +151,13 @@ dependencies = [
  "dashmap",
  "futures-core",
  "governor",
+ "hs-tenant-resolver-sdk",
  "http",
  "inventory",
  "matchit 0.9.0",
  "modkit",
  "modkit-auth",
+ "modkit-odata",
  "modkit-security",
  "nanoid",
  "parking_lot",
@@ -2062,6 +2064,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "hs-single-tenant-tr-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "hs-tenant-resolver-sdk",
+ "inventory",
+ "modkit",
+ "modkit-odata",
+ "modkit-security",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "types-registry-sdk",
+ "uuid",
+]
+
+[[package]]
+name = "hs-static-tr-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "hs-tenant-resolver-sdk",
+ "inventory",
+ "modkit",
+ "modkit-odata",
+ "modkit-security",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "types-registry-sdk",
+ "uuid",
+]
+
+[[package]]
+name = "hs-tenant-resolver-gw"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "hs-tenant-resolver-sdk",
+ "inventory",
+ "modkit",
+ "modkit-odata",
+ "modkit-security",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "types-registry-sdk",
+ "uuid",
+]
+
+[[package]]
+name = "hs-tenant-resolver-sdk"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "gts",
+ "gts-macros",
+ "modkit",
+ "modkit-odata",
+ "modkit-security",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "uuid",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2267,6 +2344,9 @@ dependencies = [
  "figment",
  "file_parser",
  "grpc_hub",
+ "hs-single-tenant-tr-plugin",
+ "hs-static-tr-plugin",
+ "hs-tenant-resolver-gw",
  "mimalloc",
  "modkit",
  "modkit-db",
@@ -6457,6 +6537,7 @@ dependencies = [
  "async-trait",
  "axum",
  "futures-util",
+ "hs-tenant-resolver-sdk",
  "http",
  "httpmock",
  "inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,11 @@ members = [
     "examples/plugin-modules/tenant_resolver/tenant_resolver-sdk",
     "examples/plugin-modules/tenant_resolver/tenant_resolver-gw",
     "examples/plugin-modules/tenant_resolver/plugins/contoso_tr_plugin",
-    "examples/plugin-modules/tenant_resolver/plugins/fabrikam_tr_plugin"
+    "examples/plugin-modules/tenant_resolver/plugins/fabrikam_tr_plugin",
+    "modules/system/tenant_resolver/tenant_resolver-sdk",
+    "modules/system/tenant_resolver/tenant_resolver-gw",
+    "modules/system/tenant_resolver/plugins/static_tr_plugin",
+    "modules/system/tenant_resolver/plugins/single_tenant_tr_plugin",
 ]
 resolver = "2"
 

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -13,6 +13,8 @@ default = []
 users-info-example = ["dep:users_info"]
 oop-example = ["dep:calculator_gateway", "dep:calculator"]
 tenant-resolver-example = ["dep:tenant_resolver_gw", "dep:contoso_tr_plugin", "dep:fabrikam_tr_plugin"]
+single-tenant = ["dep:hs-single-tenant-tr-plugin"]
+static-tenants = ["dep:hs-static-tr-plugin"]
 otel = ["modkit/otel"]
 
 [[bin]]
@@ -30,6 +32,11 @@ api_gateway = { path = "../../modules/system/api_gateway" }
 grpc_hub = { path = "../../modules/system/grpc_hub" }
 module_orchestrator = { path = "../../modules/system/module_orchestrator/module_orchestrator" }
 types-registry = { path = "../../modules/system/types-registry/types-registry" }
+hs-tenant-resolver-gw = { path = "../../modules/system/tenant_resolver/tenant_resolver-gw" }
+
+# Optional tenant resolver plugins
+hs-single-tenant-tr-plugin = { path = "../../modules/system/tenant_resolver/plugins/single_tenant_tr_plugin", optional = true }
+hs-static-tr-plugin = { path = "../../modules/system/tenant_resolver/plugins/static_tr_plugin", optional = true }
 
 # user modules
 file_parser = { path = "../../modules/file_parser" }

--- a/apps/hyperspot-server/src/registered_modules.rs
+++ b/apps/hyperspot-server/src/registered_modules.rs
@@ -6,9 +6,18 @@
 use api_gateway as _;
 use file_parser as _;
 use grpc_hub as _;
+use hs_tenant_resolver_gw as _;
 use module_orchestrator as _;
 use nodes_registry as _;
 use types_registry as _;
+
+#[cfg(feature = "single-tenant")]
+use hs_single_tenant_tr_plugin as _;
+
+#[cfg(feature = "static-tenants")]
+use hs_static_tr_plugin as _;
+
+// === Example Features ===
 
 #[cfg(feature = "users-info-example")]
 use users_info as _;

--- a/config/static-tenants.yaml
+++ b/config/static-tenants.yaml
@@ -1,0 +1,61 @@
+# Test configuration for static_tr_plugin integration testing
+#
+# This config uses auth_disabled mode with the hardcoded tenant ID from
+# modkit-security/constants.rs (DEFAULT_TENANT_ID).
+#
+# Run with:
+#   cargo run --bin hyperspot-server -- --config config/test-static-tr.yaml run
+
+server:
+  home_dir: "~/.hyperspot"
+
+database:
+  servers:
+    sqlite_test:
+      params:
+        WAL: "true"
+      pool:
+        max_conns: 5
+
+modules:
+  api_gateway:
+    config:
+      bind_addr: "127.0.0.1:8087"
+      enable_docs: true
+      auth_disabled: true  # Uses DEFAULT_TENANT_ID from modkit-security
+
+  types_registry:
+    config: {}
+
+  static_tr_plugin:
+    config:
+      vendor: "hyperspot"
+      priority: 100
+      tenants:
+        # Default tenant (used when auth_disabled)
+        # Matches DEFAULT_TENANT_ID from modkit-security/constants.rs
+        - id: "00000000-df51-5b42-9538-d2b56b7ee953"
+          name: "Dev Tenant"
+          status: active
+          type: development
+        # Another tenant that Dev Tenant can access
+        - id: "22222222-2222-2222-2222-222222222222"
+          name: "Partner Tenant"
+          status: active
+          type: partner
+      access_rules:
+        # Dev tenant can access Partner tenant
+        - source: "00000000-df51-5b42-9538-d2b56b7ee953"
+          target: "22222222-2222-2222-2222-222222222222"
+
+  tenant_resolver:
+    config:
+      vendor: "hyperspot"
+
+  users_info:
+    database:
+      server: "sqlite_test"
+      file: "users_info_test.db"
+    config:
+      default_page_size: 10
+      max_page_size: 100

--- a/examples/modkit/users_info/users_info/Cargo.toml
+++ b/examples/modkit/users_info/users_info/Cargo.toml
@@ -18,6 +18,9 @@ integration = []   # gate integration tests
 # SDK - public API, models, and errors
 user_info-sdk = { path = "../user_info-sdk", features = ["odata"] }
 
+# Tenant resolver for multi-tenant access
+hs-tenant-resolver-sdk = { path = "../../../../modules/system/tenant_resolver/tenant_resolver-sdk" }
+
 # Core dependencies
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/examples/modkit/users_info/users_info/src/domain/service/tests_security_scoping.rs
+++ b/examples/modkit/users_info/users_info/src/domain/service/tests_security_scoping.rs
@@ -3,9 +3,7 @@
 use uuid::Uuid;
 
 use crate::domain::service::ServiceConfig;
-use crate::test_support::{
-    build_services, ctx_allow_tenants, ctx_deny_all, ctx_root, inmem_db, seed_user,
-};
+use crate::test_support::{build_services, ctx_allow_tenants, ctx_deny_all, inmem_db, seed_user};
 use modkit_db::secure::SecureConn;
 use user_info_sdk::NewUser;
 
@@ -47,26 +45,6 @@ async fn deny_all_sees_nothing() {
         .await
         .unwrap();
     assert!(page.items.is_empty());
-}
-
-#[tokio::test]
-async fn root_sees_all_tenants() {
-    let db = inmem_db().await;
-    let tenant1 = Uuid::new_v4();
-    let tenant2 = Uuid::new_v4();
-
-    seed_user(&db, Uuid::new_v4(), tenant1, "u1@example.com", "U1").await;
-    seed_user(&db, Uuid::new_v4(), tenant2, "u2@example.com", "U2").await;
-
-    let services = build_services(SecureConn::new(db), ServiceConfig::default());
-    let ctx = ctx_root();
-
-    let page = services
-        .users
-        .list_users_page(&ctx, &modkit_odata::ODataQuery::default())
-        .await
-        .unwrap();
-    assert_eq!(page.items.len(), 2);
 }
 
 #[tokio::test]

--- a/examples/modkit/users_info/users_info/src/infra/storage/addresses_sea_repo.rs
+++ b/examples/modkit/users_info/users_info/src/infra/storage/addresses_sea_repo.rs
@@ -96,7 +96,7 @@ impl AddressesRepository for OrmAddressesRepository {
         scope: &AccessScope,
         address: Address,
     ) -> Result<Address, DomainError> {
-        if !scope.has_tenants() && !scope.is_root() {
+        if !scope.has_tenants() {
             return Err(DomainError::validation(
                 "scope",
                 "Security scope must contain tenant for insert operation",

--- a/examples/modkit/users_info/users_info/src/infra/storage/cities_sea_repo.rs
+++ b/examples/modkit/users_info/users_info/src/infra/storage/cities_sea_repo.rs
@@ -77,7 +77,7 @@ impl CitiesRepository for OrmCitiesRepository {
         scope: &AccessScope,
         city: City,
     ) -> Result<City, DomainError> {
-        if !scope.has_tenants() && !scope.is_root() {
+        if !scope.has_tenants() {
             return Err(DomainError::validation(
                 "scope",
                 "Security scope must contain tenant for insert operation",

--- a/examples/modkit/users_info/users_info/src/infra/storage/migrations/m20260111_000002_add_tenant_support.rs
+++ b/examples/modkit/users_info/users_info/src/infra/storage/migrations/m20260111_000002_add_tenant_support.rs
@@ -9,7 +9,7 @@ impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let backend = manager.get_database_backend();
         let conn = manager.get_connection();
-        let root_tenant = modkit_security::constants::ROOT_TENANT_ID;
+        let root_tenant = modkit_security::constants::DEFAULT_TENANT_ID;
 
         if backend == sea_orm::DatabaseBackend::MySql {
             let tenant_added = if manager.has_column("users", "tenant_id").await? {

--- a/examples/modkit/users_info/users_info/src/infra/storage/users_sea_repo.rs
+++ b/examples/modkit/users_info/users_info/src/infra/storage/users_sea_repo.rs
@@ -75,7 +75,7 @@ impl UsersRepository for OrmUsersRepository {
         scope: &AccessScope,
         user: User,
     ) -> Result<User, DomainError> {
-        if !scope.has_tenants() && !scope.is_root() {
+        if !scope.has_tenants() {
             return Err(DomainError::validation(
                 "scope",
                 "Security scope must contain tenant for insert operation",

--- a/examples/plugin-modules/tenant_resolver/plugins/contoso_tr_plugin/src/module.rs
+++ b/examples/plugin-modules/tenant_resolver/plugins/contoso_tr_plugin/src/module.rs
@@ -7,7 +7,6 @@ use modkit::client_hub::ClientScope;
 use modkit::context::ModuleCtx;
 use modkit::gts::BaseModkitPluginV1;
 use modkit::Module;
-use modkit_security::SecurityContext;
 use tenant_resolver_sdk::{TenantResolverPluginClient, TenantResolverPluginSpecV1};
 use tracing::info;
 use types_registry_sdk::TypesRegistryApi;
@@ -63,9 +62,7 @@ impl Module for ContosoTrPlugin {
         };
         let instance_json = serde_json::to_value(&instance)?;
 
-        let _ = registry
-            .register(&SecurityContext::root(), vec![instance_json])
-            .await?;
+        let _ = registry.register(vec![instance_json]).await?;
 
         // Create and store the service
         let service = Arc::new(Service);

--- a/examples/plugin-modules/tenant_resolver/plugins/fabrikam_tr_plugin/src/module.rs
+++ b/examples/plugin-modules/tenant_resolver/plugins/fabrikam_tr_plugin/src/module.rs
@@ -7,7 +7,6 @@ use modkit::client_hub::ClientScope;
 use modkit::context::ModuleCtx;
 use modkit::gts::BaseModkitPluginV1;
 use modkit::Module;
-use modkit_security::SecurityContext;
 use tenant_resolver_sdk::{TenantResolverPluginClient, TenantResolverPluginSpecV1};
 use tracing::info;
 use types_registry_sdk::TypesRegistryApi;
@@ -64,9 +63,7 @@ impl Module for FabrikamTrPlugin {
         };
         let instance_json = serde_json::to_value(&instance)?;
 
-        let _ = registry
-            .register(&SecurityContext::root(), vec![instance_json])
-            .await?;
+        let _ = registry.register(vec![instance_json]).await?;
 
         // Create service with tenant tree from config
         let domain_service = Arc::new(

--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/domain/service.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/domain/service.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use modkit::client_hub::{ClientHub, ClientScope};
 use modkit::gts::BaseModkitPluginV1;
 use modkit_odata::{ODataQuery, Page};
-use modkit_security::{SecurityContext, SecurityCtx};
+use modkit_security::SecurityCtx;
 use tenant_resolver_sdk::{
     AccessOptions, GetParentsResponse, Tenant, TenantFilter, TenantResolverPluginClient,
     TenantResolverPluginSpecV1,
@@ -16,6 +16,9 @@ use tenant_resolver_sdk::{
 use tokio::sync::OnceCell;
 use tracing::info;
 use types_registry_sdk::{GtsEntity, ListQuery, TypesRegistryApi};
+
+// Note: This example gateway still uses SecurityCtx in its public API methods
+// because it uses an older SDK with hierarchical tenant model.
 
 use crate::domain::error::DomainError;
 
@@ -78,7 +81,6 @@ impl Service {
 
         let instances = registry
             .list(
-                &SecurityContext::root(),
                 ListQuery::new()
                     .with_pattern(format!("{plugin_type_id}*"))
                     .with_is_type(false),

--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/module.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/module.rs
@@ -5,7 +5,6 @@ use modkit::api::OpenApiRegistry;
 use modkit::context::ModuleCtx;
 use modkit::contracts::RestfulModule;
 use modkit::Module;
-use modkit_security::SecurityContext;
 use tenant_resolver_sdk::{TenantResolverClient, TenantResolverPluginSpecV1};
 use tracing::info;
 use types_registry_sdk::TypesRegistryApi;
@@ -67,9 +66,7 @@ impl Module for TenantResolverGateway {
         let schema_str = TenantResolverPluginSpecV1::gts_schema_with_refs_as_string();
         let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
 
-        let _ = registry
-            .register(&SecurityContext::root(), vec![schema_json])
-            .await?;
+        let _ = registry.register(vec![schema_json]).await?;
         info!(
             "Registered {} schema in types-registry",
             TenantResolverPluginSpecV1::gts_schema_id().clone()

--- a/libs/modkit-auth/src/axum_ext.rs
+++ b/libs/modkit-auth/src/axum_ext.rs
@@ -152,8 +152,7 @@ where
 
             match auth_requirement {
                 AuthRequirement::None => {
-                    // 3. For public routes (AuthRequirement::None): inserts anonymous SecurityCtx
-                    request.extensions_mut().insert(SecurityCtx::anonymous());
+                    // 3. For public routes (AuthRequirement::None): inserts anonymous SecurityContext
                     request
                         .extensions_mut()
                         .insert(SecurityContext::anonymous());
@@ -181,6 +180,7 @@ where
 
                     // Build SecurityCtx from validated claims (legacy)
                     let scope = state.scope_builder.tenants_to_scope(&claims);
+                    #[allow(deprecated)]
                     let sec =
                         SecurityCtx::new(scope, modkit_security::Subject::new(claims.subject));
 
@@ -202,6 +202,7 @@ where
                             Ok(claims) => {
                                 // Build SecurityCtx from validated claims (legacy)
                                 let scope = state.scope_builder.tenants_to_scope(&claims);
+                                #[allow(deprecated)]
                                 let sec = SecurityCtx::new(
                                     scope,
                                     modkit_security::Subject::new(claims.subject),
@@ -219,14 +220,12 @@ where
                             }
                             Err(err) => {
                                 tracing::debug!("Optional auth: invalid token: {err}");
-                                request.extensions_mut().insert(SecurityCtx::anonymous());
                                 request
                                     .extensions_mut()
                                     .insert(SecurityContext::anonymous());
                             }
                         }
                     } else {
-                        request.extensions_mut().insert(SecurityCtx::anonymous());
                         request
                             .extensions_mut()
                             .insert(SecurityContext::anonymous());

--- a/libs/modkit-auth/tests/auth_integration.rs
+++ b/libs/modkit-auth/tests/auth_integration.rs
@@ -19,7 +19,7 @@ use modkit_auth::{
     types::{AuthRequirement, RoutePolicy, SecRequirement},
     Claims,
 };
-use modkit_security::{AccessScope, SecurityCtx};
+use modkit_security::{AccessScope, SecurityContext};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -123,10 +123,11 @@ fn fake_claims(sub_id: Uuid) -> Claims {
     }
 }
 
-/// Handler that returns `SecurityCtx` information
-async fn test_handler(ctx: axum::Extension<SecurityCtx>) -> impl IntoResponse {
+/// Handler that returns `SecurityContext` information for anonymous routes
+async fn test_handler(ctx: axum::Extension<SecurityContext>) -> impl IntoResponse {
     let ctx = ctx.0;
-    if ctx.is_denied() {
+    // Check if it's an anonymous context by checking for default subject_id
+    if ctx.subject_id() == Uuid::default() {
         format!("anonymous:{}", ctx.subject_id())
     } else {
         format!("user:{}", ctx.subject_id())

--- a/libs/modkit-db/src/secure/provider.rs
+++ b/libs/modkit-db/src/secure/provider.rs
@@ -46,11 +46,6 @@ impl TenantFilterProvider for SimpleTenantFilter {
         E: ScopableEntity + EntityTrait,
         E::Column: ColumnTrait + Copy,
     {
-        // Root scope: skip tenant filtering entirely
-        if scope.is_root() {
-            return None;
-        }
-
         // No tenant IDs in scope → no tenant filter
         if scope.tenant_ids().is_empty() {
             return None;

--- a/libs/modkit-sdk/examples/secured_client.rs
+++ b/libs/modkit-sdk/examples/secured_client.rs
@@ -45,10 +45,11 @@ fn main() {
     println!("Tenant ID: {}", secured.ctx().tenant_id());
     println!("Subject ID: {}", secured.ctx().subject_id());
 
-    let root_ctx = SecurityContext::root();
-    let secured_root = client.security_ctx(&root_ctx);
+    // Context for internal operations (still scoped to a tenant)
+    let internal_ctx = SecurityContext::builder().tenant_id(tenant_id).build();
+    let secured_internal = client.security_ctx(&internal_ctx);
 
-    println!("\nRoot context:");
-    println!("Tenant ID: {}", secured_root.ctx().tenant_id());
-    println!("Subject ID: {}", secured_root.ctx().subject_id());
+    println!("\nInternal context:");
+    println!("Tenant ID: {}", secured_internal.ctx().tenant_id());
+    println!("Subject ID: {}", secured_internal.ctx().subject_id());
 }

--- a/libs/modkit-sdk/src/secured.rs
+++ b/libs/modkit-sdk/src/secured.rs
@@ -10,7 +10,7 @@
 //! use modkit_security::SecurityContext;
 //!
 //! let client = MyClient::new();
-//! let ctx = SecurityContext::root();
+//! let ctx = SecurityContext::builder().tenant_id(TEST_TENANT_ID).build();
 //!
 //! // Bind the security context to the client
 //! let secured = client.security_ctx(&ctx);
@@ -157,7 +157,10 @@ impl<T> WithSecurityContext for T {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use uuid::Uuid;
+    use uuid::{uuid, Uuid};
+
+    /// Test tenant ID for unit tests.
+    const TEST_TENANT_ID: Uuid = uuid!("00000000-0000-0000-0000-000000000001");
 
     struct MockClient {
         name: String,
@@ -178,7 +181,7 @@ mod tests {
     #[test]
     fn test_secured_new() {
         let client = MockClient::new("test-client");
-        let ctx = SecurityContext::root();
+        let ctx = SecurityContext::builder().tenant_id(TEST_TENANT_ID).build();
 
         let secured = Secured::new(&client, &ctx);
 
@@ -204,7 +207,7 @@ mod tests {
     #[test]
     fn test_with_security_context_trait() {
         let client = MockClient::new("test-client");
-        let ctx = SecurityContext::root();
+        let ctx = SecurityContext::builder().tenant_id(TEST_TENANT_ID).build();
 
         let secured = client.security_ctx(&ctx);
 
@@ -215,7 +218,7 @@ mod tests {
     #[test]
     fn test_secured_clone() {
         let client = MockClient::new("test-client");
-        let ctx = SecurityContext::root();
+        let ctx = SecurityContext::builder().tenant_id(TEST_TENANT_ID).build();
 
         let secured1 = client.security_ctx(&ctx);
         let secured2 = secured1;
@@ -227,7 +230,7 @@ mod tests {
     #[test]
     fn test_secured_copy() {
         let client = MockClient::new("test-client");
-        let ctx = SecurityContext::root();
+        let ctx = SecurityContext::builder().tenant_id(TEST_TENANT_ID).build();
 
         let secured1 = client.security_ctx(&ctx);
         let secured2 = secured1;
@@ -269,7 +272,7 @@ mod tests {
     #[test]
     fn test_secured_zero_allocation() {
         let client = MockClient::new("test-client");
-        let ctx = SecurityContext::root();
+        let ctx = SecurityContext::builder().tenant_id(TEST_TENANT_ID).build();
 
         let secured = client.security_ctx(&ctx);
 
@@ -283,7 +286,7 @@ mod tests {
     fn test_multiple_clients_with_same_context() {
         let client1 = MockClient::new("client-1");
         let client2 = MockClient::new("client-2");
-        let ctx = SecurityContext::root();
+        let ctx = SecurityContext::builder().tenant_id(TEST_TENANT_ID).build();
 
         let secured1 = client1.security_ctx(&ctx);
         let secured2 = client2.security_ctx(&ctx);
@@ -296,7 +299,7 @@ mod tests {
     #[test]
     fn test_secured_preserves_lifetimes() {
         let client = MockClient::new("test-client");
-        let ctx = SecurityContext::root();
+        let ctx = SecurityContext::builder().tenant_id(TEST_TENANT_ID).build();
 
         let secured = client.security_ctx(&ctx);
 
@@ -327,7 +330,7 @@ mod tests {
         }
 
         let client = MockClient::new("test-client");
-        let ctx = SecurityContext::root();
+        let ctx = SecurityContext::builder().tenant_id(TEST_TENANT_ID).build();
 
         let secured = client.security_ctx(&ctx);
         let query_builder = secured.query::<TestSchema>();

--- a/libs/modkit-security/src/constants.rs
+++ b/libs/modkit-security/src/constants.rs
@@ -1,12 +1,24 @@
 use uuid::uuid;
 use uuid::Uuid;
 
-/// Root (bootstrap) tenant and subject
-/// These are used only for system-level operations or bootstrap contexts
-pub const ROOT_TENANT_ID: Uuid = uuid!("00000000-df51-5b42-9538-d2b56b7ee953");
-pub const ROOT_SUBJECT_ID: Uuid = uuid!("11111111-6a88-4768-9dfc-6bcd5187d9ed");
+/// Default tenant ID for single-tenant or auth-disabled deployments.
+///
+/// Used when:
+/// - Auth is disabled (on-premises single-user mode)
+/// - Default/fallback tenant ID is needed (e.g., migrations, examples)
+///
+/// In multi-tenant production deployments, tenant IDs come from
+/// the authentication layer or tenant resolver.
+pub const DEFAULT_TENANT_ID: Uuid = uuid!("00000000-df51-5b42-9538-d2b56b7ee953");
 
-/// Anonymous subject ID
-pub const ANONYMOUS_SUBJECT_ID: Uuid = uuid!("22222222-0830-5695-92eb-d648d8b346a6");
+/// Default subject ID for single-tenant or auth-disabled deployments.
+///
+/// Used when:
+/// - Auth is disabled (on-premises single-user mode)
+/// - Default/fallback subject ID is needed
+///
+/// In production deployments, subject IDs come from the authentication layer.
+pub const DEFAULT_SUBJECT_ID: Uuid = uuid!("11111111-6a88-4768-9dfc-6bcd5187d9ed");
 
+/// Default GTS type ID placeholder.
 pub const GTS_DEFAULT_TYPE_ID: Uuid = uuid!("22222222-0000-0000-0000-000000000001");

--- a/libs/modkit-security/src/lib.rs
+++ b/libs/modkit-security/src/lib.rs
@@ -10,7 +10,6 @@ pub mod security_ctx;
 pub mod subject;
 
 pub use access_scope::AccessScope;
-pub use constants::{ROOT_SUBJECT_ID, ROOT_TENANT_ID};
 pub use context::SecurityContext;
 pub use permission::Permission;
 pub use policy_engine::{DummyPolicyEngine, PolicyEngine, PolicyEngineRef};

--- a/libs/modkit-security/src/security_ctx.rs
+++ b/libs/modkit-security/src/security_ctx.rs
@@ -1,4 +1,4 @@
-use crate::{constants, AccessScope, Subject};
+use crate::{AccessScope, Subject};
 use uuid::Uuid;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -52,23 +52,6 @@ impl SecurityCtx {
             scope: AccessScope::default(),
             subject: Subject::new(subject_id),
         }
-    }
-
-    /// Anonymous/unauthenticated context with no access to any resources.
-    /// Use this for public routes where no authentication is required.
-    #[must_use]
-    #[deprecated]
-    pub fn anonymous() -> Self {
-        #[allow(deprecated)]
-        Self::deny_all(constants::ANONYMOUS_SUBJECT_ID)
-    }
-
-    /// Root subject operating within the root tenant (system context).
-    #[must_use]
-    #[deprecated]
-    pub fn root_ctx() -> Self {
-        #[allow(deprecated)]
-        Self::new(AccessScope::root_tenant(), Subject::root())
     }
 
     #[inline]

--- a/libs/modkit-security/src/subject.rs
+++ b/libs/modkit-security/src/subject.rs
@@ -1,5 +1,6 @@
 use uuid::Uuid;
 
+/// Represents the actor (user or service) making a request.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Subject {
     pub(crate) id: Uuid,
@@ -11,21 +12,10 @@ impl Subject {
     pub fn new(id: Uuid) -> Self {
         Self { id }
     }
+
     #[inline]
     #[must_use]
     pub fn id(&self) -> Uuid {
         self.id
-    }
-
-    /// Returns the special root/system subject.
-    #[must_use]
-    pub fn root() -> Self {
-        Self::new(crate::constants::ROOT_SUBJECT_ID)
-    }
-
-    /// Returns true if this subject represents the root/system identity.
-    #[must_use]
-    pub fn is_root(&self) -> bool {
-        self.id == crate::constants::ROOT_SUBJECT_ID
     }
 }

--- a/libs/modkit-security/tests/root_constants.rs
+++ b/libs/modkit-security/tests/root_constants.rs
@@ -1,35 +1,36 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use modkit_security::{AccessScope, SecurityCtx, Subject, ROOT_SUBJECT_ID};
+use modkit_security::constants::{DEFAULT_SUBJECT_ID, DEFAULT_TENANT_ID};
+use modkit_security::{AccessScope, SecurityCtx, Subject};
 
 #[test]
-fn root_constants_and_helpers() {
-    // Root context now uses explicit is_root flag
+fn default_subject_and_context() {
+    // Create subject with default ID
+    let subj = Subject::new(DEFAULT_SUBJECT_ID);
+    assert_eq!(subj.id(), DEFAULT_SUBJECT_ID);
+
+    // Context operates within the default tenant
     #[allow(deprecated)]
-    let ctx = SecurityCtx::root_ctx();
-    assert_eq!(ctx.subject_id(), ROOT_SUBJECT_ID);
-    assert!(
-        ctx.scope().is_root(),
-        "Root context should have is_root=true"
-    );
-    assert!(
-        ctx.scope().tenant_ids().is_empty(),
-        "Root scope should have empty tenant_ids (no longer contains ROOT_TENANT_ID)"
-    );
-    assert!(
-        !ctx.scope().is_empty(),
-        "Root scope should not be considered empty"
-    );
-    assert!(ctx.subject().is_root());
+    let ctx = SecurityCtx::for_tenant(DEFAULT_TENANT_ID, DEFAULT_SUBJECT_ID);
 
-    // Root scope no longer contains ROOT_TENANT_ID by default
-    let scope = AccessScope::root_tenant();
-    assert!(scope.is_root());
-    assert!(
-        !scope.includes_root_tenant(),
-        "Root scope no longer uses ROOT_TENANT_ID"
-    );
+    assert_eq!(ctx.subject_id(), DEFAULT_SUBJECT_ID);
+    assert!(!ctx.scope().is_empty(), "Context should have tenant scope");
+    assert_eq!(ctx.scope().tenant_ids(), &[DEFAULT_TENANT_ID]);
+}
 
-    let subj = Subject::root();
-    assert!(subj.is_root());
+#[test]
+fn empty_scope_is_deny_all() {
+    // Empty scope means deny all access
+    let scope = AccessScope::default();
+    assert!(scope.is_empty());
+    assert!(scope.tenant_ids().is_empty());
+    assert!(scope.resource_ids().is_empty());
+}
+
+#[test]
+fn tenant_scope_is_not_empty() {
+    let scope = AccessScope::tenant(DEFAULT_TENANT_ID);
+
+    assert!(!scope.is_empty());
+    assert_eq!(scope.tenant_ids(), &[DEFAULT_TENANT_ID]);
 }

--- a/modules/system/api_gateway/Cargo.toml
+++ b/modules/system/api_gateway/Cargo.toml
@@ -38,6 +38,7 @@ matchit = { workspace = true }
 governor = { workspace = true }
 
 chrono = { workspace = true }
+uuid = { workspace = true }
 
 utoipa = { workspace = true }
 http = { workspace = true }
@@ -46,6 +47,8 @@ rust-embed = { workspace = true }
 [dev-dependencies]
 futures-core = { workspace = true }
 uuid = { workspace = true }
+modkit-odata = { path = "../../../libs/modkit-odata" }
+hs-tenant-resolver-sdk = { path = "../tenant_resolver/tenant_resolver-sdk" }
 
 [features]
 grpc = []

--- a/modules/system/api_gateway/tests/auth_disabled_root_context.rs
+++ b/modules/system/api_gateway/tests/auth_disabled_root_context.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-//! Test that `auth_disabled` mode properly injects root context
+//! Test that `auth_disabled` mode properly injects default tenant context
 
 use axum::{
     body::Body,
@@ -13,34 +13,44 @@ use axum::{
 };
 use modkit_security::SecurityCtx;
 use tower::ServiceExt;
+use uuid::{uuid, Uuid};
+
+/// Test tenant ID for auth-disabled mode tests
+const TEST_DEFAULT_TENANT_ID: Uuid = uuid!("00000000-0000-0000-0000-000000000001");
+/// Test subject ID for auth-disabled mode (matches `api_gateway` constant)
+const TEST_DEFAULT_SUBJECT_ID: Uuid = uuid!("11111111-0000-0000-0000-000000000001");
 
 /// Test handler that extracts `SecurityCtx` and returns its properties as JSON
 async fn test_handler(Extension(ctx): Extension<SecurityCtx>) -> impl IntoResponse {
-    let is_root = ctx.scope().is_root();
     let is_empty = ctx.scope().is_empty();
-    let tenant_count = ctx.scope().tenant_ids().len();
+    let tenant_ids = ctx.scope().tenant_ids().to_vec();
+    let tenant_count = tenant_ids.len();
 
     axum::Json(serde_json::json!({
-        "is_root": is_root,
         "is_empty": is_empty,
         "tenant_count": tenant_count,
-        "is_denied": ctx.is_denied()
+        "tenant_ids": tenant_ids,
+        "is_denied": ctx.is_denied(),
+        "subject_id": ctx.subject_id()
     }))
 }
 
-/// Middleware that simulates `auth_disabled` mode by injecting root context
-async fn inject_root_context(mut req: Request, next: Next) -> Response {
+/// Middleware that simulates `auth_disabled` mode by injecting default tenant context
+async fn inject_default_tenant_context(mut req: Request, next: Next) -> Response {
+    // This simulates what api_gateway does in auth_disabled mode:
+    // Uses SecurityCtx::for_tenant() with the default tenant and subject
     #[allow(deprecated)]
-    req.extensions_mut().insert(SecurityCtx::root_ctx());
+    let ctx = SecurityCtx::for_tenant(TEST_DEFAULT_TENANT_ID, TEST_DEFAULT_SUBJECT_ID);
+    req.extensions_mut().insert(ctx);
     next.run(req).await
 }
 
 #[tokio::test]
-async fn test_auth_disabled_injects_root_context() {
+async fn test_auth_disabled_injects_default_tenant_context() {
     // Build a router with the auth-disabled middleware
     let app = Router::new()
         .route("/test", get(test_handler))
-        .layer(middleware::from_fn(inject_root_context));
+        .layer(middleware::from_fn(inject_default_tenant_context));
 
     // Make a request
     let response = app
@@ -62,42 +72,58 @@ async fn test_auth_disabled_injects_root_context() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    // Verify root context properties
-    assert_eq!(json["is_root"], true, "SecurityCtx should have root scope");
-    assert_eq!(json["is_empty"], false, "Root scope should not be empty");
+    // Verify default tenant context properties
     assert_eq!(
-        json["tenant_count"], 0,
-        "Root scope has no explicit tenant IDs"
+        json["is_empty"], false,
+        "Default tenant scope should not be empty"
+    );
+    assert_eq!(
+        json["tenant_count"], 1,
+        "Should have exactly one tenant (the default)"
     );
     assert_eq!(
         json["is_denied"], false,
-        "Root context should not be denied"
+        "Default tenant context should not be denied"
+    );
+    assert_eq!(
+        json["subject_id"],
+        TEST_DEFAULT_SUBJECT_ID.to_string(),
+        "Subject should be TEST_DEFAULT_SUBJECT_ID"
     );
 }
 
 #[tokio::test]
-async fn test_auth_disabled_allows_access_to_all_tenants() {
-    // Handler that verifies root access bypasses tenant filtering
-    async fn check_root_access(Extension(ctx): Extension<SecurityCtx>) -> impl IntoResponse {
-        // In disabled mode, we should have root access
+async fn test_auth_disabled_scoped_to_default_tenant() {
+    // Handler that verifies the context is scoped to the default tenant
+    async fn check_tenant_access(Extension(ctx): Extension<SecurityCtx>) -> impl IntoResponse {
+        // In disabled mode, we should have access scoped to the default tenant
         assert!(
-            ctx.scope().is_root(),
-            "Should have root scope in disabled mode"
+            !ctx.scope().is_empty(),
+            "Should have non-empty scope in disabled mode"
         );
-        assert!(!ctx.is_denied(), "Root context should not be denied");
-
-        // Root scope bypasses tenant filtering - it's marked as root, not as having all tenant IDs
         assert!(
-            ctx.scope().tenant_ids().is_empty(),
-            "Root scope uses flag, not tenant list"
+            !ctx.is_denied(),
+            "Default tenant context should not be denied"
         );
 
-        axum::Json(serde_json::json!({"access": "granted", "mode": "root"}))
+        // Should have exactly the default tenant
+        let tenant_ids = ctx.scope().tenant_ids();
+        assert_eq!(tenant_ids.len(), 1, "Should have exactly one tenant");
+        assert_eq!(
+            tenant_ids[0], TEST_DEFAULT_TENANT_ID,
+            "Should be the default tenant"
+        );
+
+        axum::Json(serde_json::json!({
+            "access": "granted",
+            "mode": "default_tenant",
+            "tenant_id": tenant_ids[0]
+        }))
     }
 
     let app = Router::new()
-        .route("/check", get(check_root_access))
-        .layer(middleware::from_fn(inject_root_context));
+        .route("/check", get(check_tenant_access))
+        .layer(middleware::from_fn(inject_default_tenant_context));
 
     let response = app
         .oneshot(
@@ -118,26 +144,65 @@ async fn test_auth_disabled_allows_access_to_all_tenants() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(json["access"], "granted");
-    assert_eq!(json["mode"], "root");
+    assert_eq!(json["mode"], "default_tenant");
+    assert_eq!(json["tenant_id"], TEST_DEFAULT_TENANT_ID.to_string());
 }
 
 #[tokio::test]
-async fn test_auth_disabled_vs_normal_scope() {
-    // Handler that distinguishes between root and normal scopes
-    async fn scope_info(Extension(ctx): Extension<SecurityCtx>) -> impl IntoResponse {
+async fn test_auth_disabled_uses_default_subject() {
+    // Handler that verifies the default subject ID is used
+    async fn check_subject(Extension(ctx): Extension<SecurityCtx>) -> impl IntoResponse {
         axum::Json(serde_json::json!({
-            "is_root": ctx.scope().is_root(),
-            "is_empty": ctx.scope().is_empty(),
-            "has_tenants": ctx.scope().has_tenants(),
+            "subject_id": ctx.subject_id(),
+            "is_default_subject": ctx.subject_id() == TEST_DEFAULT_SUBJECT_ID,
         }))
     }
 
-    // Test 1: Root context (auth disabled)
-    let app_root = Router::new()
-        .route("/info", get(scope_info))
-        .layer(middleware::from_fn(inject_root_context));
+    let app = Router::new()
+        .route("/subject", get(check_subject))
+        .layer(middleware::from_fn(inject_default_tenant_context));
 
-    let response = app_root
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/subject")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(
+        json["is_default_subject"], true,
+        "Auth-disabled mode should use TEST_DEFAULT_SUBJECT_ID"
+    );
+}
+
+#[tokio::test]
+async fn test_default_tenant_vs_normal_scope() {
+    // Handler that reports scope info
+    async fn scope_info(Extension(ctx): Extension<SecurityCtx>) -> impl IntoResponse {
+        axum::Json(serde_json::json!({
+            "is_empty": ctx.scope().is_empty(),
+            "has_tenants": ctx.scope().has_tenants(),
+            "tenant_count": ctx.scope().tenant_ids().len(),
+        }))
+    }
+
+    // Test: Default tenant context (auth disabled)
+    let app = Router::new()
+        .route("/info", get(scope_info))
+        .layer(middleware::from_fn(inject_default_tenant_context));
+
+    let response = app
         .oneshot(
             Request::builder()
                 .method(Method::GET)
@@ -153,7 +218,8 @@ async fn test_auth_disabled_vs_normal_scope() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-    assert_eq!(json["is_root"], true);
+    // Default tenant context has explicit tenant, not a bypass
     assert_eq!(json["is_empty"], false);
-    assert_eq!(json["has_tenants"], false); // Root doesn't use tenant list
+    assert_eq!(json["has_tenants"], true);
+    assert_eq!(json["tenant_count"], 1);
 }

--- a/modules/system/api_gateway/tests/auth_middleware.rs
+++ b/modules/system/api_gateway/tests/auth_middleware.rs
@@ -15,6 +15,10 @@ use axum::{
     http::{Request, StatusCode},
     Json, Router,
 };
+use hs_tenant_resolver_sdk::{
+    AccessOptions, TenantFilter, TenantId, TenantInfo, TenantResolverError,
+    TenantResolverGatewayClient, TenantStatus,
+};
 use modkit::{
     api::{
         operation_builder::{AuthReqAction, AuthReqResource, LicenseFeature},
@@ -26,6 +30,8 @@ use modkit::{
     ClientHub, Module,
 };
 use modkit_auth::axum_ext::Authz;
+
+use modkit_security::SecurityContext;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
@@ -33,6 +39,43 @@ use tower::ServiceExt;
 use uuid::Uuid;
 // for oneshot
 use utoipa::ToSchema;
+
+/// Mock tenant resolver for tests
+struct MockTenantResolver;
+
+#[async_trait]
+impl TenantResolverGatewayClient for MockTenantResolver {
+    async fn get_tenant(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+    ) -> std::result::Result<TenantInfo, TenantResolverError> {
+        Ok(TenantInfo {
+            id,
+            name: format!("Tenant {id}"),
+            status: TenantStatus::Active,
+            tenant_type: None,
+        })
+    }
+
+    async fn can_access(
+        &self,
+        _ctx: &SecurityContext,
+        _target: TenantId,
+        _options: Option<&AccessOptions>,
+    ) -> std::result::Result<bool, TenantResolverError> {
+        Ok(true)
+    }
+
+    async fn get_accessible_tenants(
+        &self,
+        _ctx: &SecurityContext,
+        _filter: Option<&TenantFilter>,
+        _options: Option<&AccessOptions>,
+    ) -> std::result::Result<Vec<TenantInfo>, TenantResolverError> {
+        Ok(vec![])
+    }
+}
 
 /// Test configuration provider
 struct TestConfigProvider {
@@ -45,13 +88,18 @@ impl ConfigProvider for TestConfigProvider {
     }
 }
 
-/// Create test context for `api_gateway` module
+/// Create test context for `api_gateway` module with mock tenant resolver
 fn create_api_gateway_ctx(config: serde_json::Value) -> ModuleCtx {
+    let hub = Arc::new(ClientHub::new());
+
+    // Register mock tenant resolver for auth_disabled mode
+    hub.register::<dyn TenantResolverGatewayClient>(Arc::new(MockTenantResolver));
+
     ModuleCtx::new(
         "api_gateway",
         Uuid::new_v4(),
         Arc::new(TestConfigProvider { config }),
-        Arc::new(ClientHub::new()),
+        hub,
         tokio_util::sync::CancellationToken::new(),
         None,
     )

--- a/modules/system/api_gateway/tests/body_limit_tests.rs
+++ b/modules/system/api_gateway/tests/body_limit_tests.rs
@@ -5,16 +5,58 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use axum::{extract::Json, routing::post, Router};
+use hs_tenant_resolver_sdk::{
+    AccessOptions, TenantFilter, TenantId, TenantInfo, TenantResolverError,
+    TenantResolverGatewayClient, TenantStatus,
+};
 use modkit::{
     api::OperationBuilder,
     config::ConfigProvider,
     contracts::{OpenApiRegistry, RestHostModule},
     Module, ModuleCtx, RestfulModule,
 };
+
+use modkit_security::SecurityContext;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
+
+struct MockTenantResolver;
+
+#[async_trait]
+impl TenantResolverGatewayClient for MockTenantResolver {
+    async fn get_tenant(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+    ) -> std::result::Result<TenantInfo, TenantResolverError> {
+        Ok(TenantInfo {
+            id,
+            name: format!("Tenant {id}"),
+            status: TenantStatus::Active,
+            tenant_type: None,
+        })
+    }
+
+    async fn can_access(
+        &self,
+        _ctx: &SecurityContext,
+        _target: TenantId,
+        _options: Option<&AccessOptions>,
+    ) -> std::result::Result<bool, TenantResolverError> {
+        Ok(true)
+    }
+
+    async fn get_accessible_tenants(
+        &self,
+        _ctx: &SecurityContext,
+        _filter: Option<&TenantFilter>,
+        _options: Option<&AccessOptions>,
+    ) -> std::result::Result<Vec<TenantInfo>, TenantResolverError> {
+        Ok(vec![])
+    }
+}
 
 struct TestConfigProvider {
     config: serde_json::Value,
@@ -51,11 +93,14 @@ fn create_test_module_ctx_with_body_limit(limit_bytes: usize) -> ModuleCtx {
         }
     }));
 
+    let hub = Arc::new(modkit::ClientHub::new());
+    hub.register::<dyn TenantResolverGatewayClient>(Arc::new(MockTenantResolver));
+
     ModuleCtx::new(
         "api_gateway",
         Uuid::new_v4(),
         Arc::new(TestConfigProvider { config }),
-        Arc::new(modkit::ClientHub::new()),
+        hub,
         tokio_util::sync::CancellationToken::new(),
         None,
     )
@@ -160,11 +205,14 @@ async fn test_default_body_limit() {
         "auth_disabled": true
     }));
 
+    let hub = Arc::new(modkit::ClientHub::new());
+    hub.register::<dyn TenantResolverGatewayClient>(Arc::new(MockTenantResolver));
+
     let ctx = ModuleCtx::new(
         "api_gateway",
         Uuid::new_v4(),
         Arc::new(TestConfigProvider { config }),
-        Arc::new(modkit::ClientHub::new()),
+        hub,
         tokio_util::sync::CancellationToken::new(),
         None,
     );

--- a/modules/system/api_gateway/tests/license_middleware.rs
+++ b/modules/system/api_gateway/tests/license_middleware.rs
@@ -8,6 +8,10 @@ use axum::{
     response::IntoResponse,
     Router,
 };
+use hs_tenant_resolver_sdk::{
+    AccessOptions, TenantFilter, TenantId, TenantInfo, TenantResolverError,
+    TenantResolverGatewayClient, TenantStatus,
+};
 use modkit::{
     api::operation_builder::{AuthReqAction, AuthReqResource, LicenseFeature},
     api::OperationBuilder,
@@ -16,10 +20,48 @@ use modkit::{
     contracts::{OpenApiRegistry, RestHostModule, RestfulModule},
     ClientHub, Module,
 };
+
+use modkit_security::SecurityContext;
 use serde_json::json;
 use std::sync::Arc;
 use tower::ServiceExt;
 use uuid::Uuid;
+
+struct MockTenantResolver;
+
+#[async_trait]
+impl TenantResolverGatewayClient for MockTenantResolver {
+    async fn get_tenant(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+    ) -> std::result::Result<TenantInfo, TenantResolverError> {
+        Ok(TenantInfo {
+            id,
+            name: format!("Tenant {id}"),
+            status: TenantStatus::Active,
+            tenant_type: None,
+        })
+    }
+
+    async fn can_access(
+        &self,
+        _ctx: &SecurityContext,
+        _target: TenantId,
+        _options: Option<&AccessOptions>,
+    ) -> std::result::Result<bool, TenantResolverError> {
+        Ok(true)
+    }
+
+    async fn get_accessible_tenants(
+        &self,
+        _ctx: &SecurityContext,
+        _filter: Option<&TenantFilter>,
+        _options: Option<&AccessOptions>,
+    ) -> std::result::Result<Vec<TenantInfo>, TenantResolverError> {
+        Ok(vec![])
+    }
+}
 
 struct TestConfigProvider {
     config: serde_json::Value,
@@ -32,11 +74,14 @@ impl ConfigProvider for TestConfigProvider {
 }
 
 fn create_api_gateway_ctx(config: serde_json::Value) -> ModuleCtx {
+    let hub = Arc::new(ClientHub::new());
+    hub.register::<dyn TenantResolverGatewayClient>(Arc::new(MockTenantResolver));
+
     ModuleCtx::new(
         "api_gateway",
         Uuid::new_v4(),
         Arc::new(TestConfigProvider { config }),
-        Arc::new(ClientHub::new()),
+        hub,
         tokio_util::sync::CancellationToken::new(),
         None,
     )

--- a/modules/system/api_gateway/tests/middleware_order.rs
+++ b/modules/system/api_gateway/tests/middleware_order.rs
@@ -7,6 +7,7 @@
 //! -> timeout -> body limit -> CORS -> MIME validation -> rate limit -> error mapping -> auth -> router
 //!
 use anyhow::Result;
+use async_trait::async_trait;
 use axum::{
     body::Body,
     extract::{Extension, Json},
@@ -14,16 +15,58 @@ use axum::{
     response::IntoResponse,
     Router,
 };
+use hs_tenant_resolver_sdk::{
+    AccessOptions, TenantFilter, TenantId, TenantInfo, TenantResolverError,
+    TenantResolverGatewayClient, TenantStatus,
+};
 use modkit::{
     api::OperationBuilder, config::ConfigProvider, context::ModuleCtx, contracts::RestHostModule,
     Module,
 };
+
+use modkit_security::SecurityContext;
 use serde_json::json;
 use std::sync::Arc;
 use tower::ServiceExt;
 use uuid::Uuid;
 
 use api_gateway::middleware::request_id::XRequestId;
+
+struct MockTenantResolver;
+
+#[async_trait]
+impl TenantResolverGatewayClient for MockTenantResolver {
+    async fn get_tenant(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+    ) -> std::result::Result<TenantInfo, TenantResolverError> {
+        Ok(TenantInfo {
+            id,
+            name: format!("Tenant {id}"),
+            status: TenantStatus::Active,
+            tenant_type: None,
+        })
+    }
+
+    async fn can_access(
+        &self,
+        _ctx: &SecurityContext,
+        _target: TenantId,
+        _options: Option<&AccessOptions>,
+    ) -> std::result::Result<bool, TenantResolverError> {
+        Ok(true)
+    }
+
+    async fn get_accessible_tenants(
+        &self,
+        _ctx: &SecurityContext,
+        _filter: Option<&TenantFilter>,
+        _options: Option<&AccessOptions>,
+    ) -> std::result::Result<Vec<TenantInfo>, TenantResolverError> {
+        Ok(vec![])
+    }
+}
 
 struct TestConfigProvider {
     config: serde_json::Value,
@@ -36,11 +79,14 @@ impl ConfigProvider for TestConfigProvider {
 }
 
 fn create_api_gateway_ctx(config: serde_json::Value) -> ModuleCtx {
+    let hub = Arc::new(modkit::ClientHub::new());
+    hub.register::<dyn TenantResolverGatewayClient>(Arc::new(MockTenantResolver));
+
     ModuleCtx::new(
         "api_gateway",
         Uuid::new_v4(),
         Arc::new(TestConfigProvider { config }),
-        Arc::new(modkit::ClientHub::new()),
+        hub,
         tokio_util::sync::CancellationToken::new(),
         None,
     )

--- a/modules/system/tenant_resolver/README.md
+++ b/modules/system/tenant_resolver/README.md
@@ -1,0 +1,304 @@
+# Tenant Resolver
+
+Tenant information and access resolution for HyperSpot's security layer.
+
+## Overview
+
+The **tenant_resolver** module answers two fundamental questions:
+
+1. **What is this tenant?** — Retrieve tenant metadata (name, status)
+2. **Can I access this tenant's data?** — Resolve access relationships from the current security context
+
+The module is **topology-agnostic** — it makes no assumptions about tenant hierarchy structure. Whether the integrating system uses flat tenants, tree hierarchies, DAGs (directed acyclic graph) with multiple parents, or arbitrary graphs, the API remains the same.
+
+## Architecture
+
+```
+modules/system/tenant_resolver/
+├── tenant_resolver-sdk/         # Public API traits and models
+├── tenant_resolver-gw/          # Gateway module (routes to plugins)
+└── plugins/
+    ├── static_tr_plugin/        # Config-based multi-tenant plugin
+    └── single_tenant_tr_plugin/ # Zero-config single-tenant plugin
+```
+
+| Layer | Responsibility |
+|-------|----------------|
+| **SDK** | Public API, plugin API, models |
+| **Gateway** | Plugin discovery via GTS, request routing |
+| **Plugins** | Actual tenant data and access rule implementations |
+
+## Public API
+
+The gateway registers [`TenantResolverGatewayClient`](tenant_resolver-sdk/src/api.rs) in ClientHub:
+
+- `get_tenant(ctx, id)` — Retrieve tenant by ID
+- `can_access(ctx, target, options)` — Check if current tenant can access target
+- `get_accessible_tenants(ctx, filter, options)` — List accessible tenants
+
+Source tenant is always taken from `ctx.tenant_id()`.
+
+> [!IMPORTANT]
+> All API methods require a valid tenant in the security context. Calls with an
+> empty/anonymous context (nil tenant ID) will return `Unauthorized` error.
+
+### Access Rules
+
+- **Non-transitive**: A→B and B→C does NOT imply A→C
+- **Non-symmetric**: A→B does NOT imply B→A
+
+> [!NOTE]
+> Self-access behavior is plugin-determined. The built-in plugins allow full self-access,
+> but custom plugins can implement restrictions (e.g., a tenant cannot delete itself,
+> or a suspended tenant may have restricted functionality).
+
+### TenantFilter
+
+`TenantFilter` is used only in `get_accessible_tenants` to filter the returned list:
+
+```rust
+// No filter (all tenants)
+let tenants = resolver.get_accessible_tenants(&ctx, None, None).await?;
+
+// Only active tenants
+let filter = TenantFilter {
+    status: vec![TenantStatus::Active],
+    ..Default::default()
+};
+let tenants = resolver.get_accessible_tenants(&ctx, Some(&filter), None).await?;
+
+// Specific tenant IDs that are active
+let filter = TenantFilter {
+    id: vec![tenant_a, tenant_b],
+    status: vec![TenantStatus::Active],
+};
+let tenants = resolver.get_accessible_tenants(&ctx, Some(&filter), None).await?;
+```
+
+Empty vectors mean "no constraint" (include all). This avoids `Option<Vec<T>>` ambiguity.
+
+### AccessOptions
+
+`AccessOptions` specifies permission requirements for access checks:
+
+```rust
+// Basic access check (no specific permission required)
+let can = resolver.can_access(&ctx, target_id, None).await?;
+
+// Check for specific permission
+let options = AccessOptions {
+    permission: vec!["read".to_string()],
+};
+let can = resolver.can_access(&ctx, target_id, Some(&options)).await?;
+
+// Multiple permissions (all required - AND semantics)
+let options = AccessOptions {
+    permission: vec!["read".to_string(), "write".to_string()],
+};
+```
+
+### Models
+
+See [`models.rs`](tenant_resolver-sdk/src/models.rs): `TenantId`, `TenantInfo`, `TenantStatus`, `TenantFilter`, `AccessOptions`
+
+`TenantInfo` fields:
+- `id` — Unique tenant identifier
+- `name` — Human-readable tenant name
+- `status` — Lifecycle status (`active`, `suspended`, `deleted`)
+- `type` — Optional classification string (e.g., `"enterprise"`, `"trial"`)
+
+### Errors
+
+See [`error.rs`](tenant_resolver-sdk/src/error.rs): `NotFound`, `AccessDenied`, `Unauthorized`, `NoPluginAvailable`, `Internal`
+
+## Plugin API
+
+Plugins implement [`TenantResolverPluginClient`](tenant_resolver-sdk/src/plugin_api.rs) and register via GTS. The gateway handles self-access before delegating to plugins.
+
+HyperSpot includes two plugins out of the box:
+- [`static_tr_plugin`](plugins/static_tr_plugin/) — Config-based plugin for testing multi-tenant deployments
+- [`single_tenant_tr_plugin`](plugins/single_tenant_tr_plugin/) — Zero-config plugin for single-tenant deployments
+
+## Integration with External Systems
+
+The plugin architecture enables HyperSpot to integrate with existing multi-tenant systems where tenant data and access rules are managed externally.
+
+**Example: Integration with [Zanzibar](https://research.google/pubs/zanzibar-googles-consistent-global-authorization-system/)-style authorization**
+
+Systems like [SpiceDB](https://authzed.com/spicedb), [OpenFGA](https://openfga.dev/), or [Ory Keto](https://www.ory.sh/keto/) provide relationship-based access control. A plugin can bridge HyperSpot to these systems:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                      HyperSpot                          │
+│                                                         │
+│  ┌─────────────────┐      ┌─────────────────────────┐   │
+│  │ tenant_resolver │      │  zanzibar_tr_plugin     │   │
+│  │    gateway      │─────▶│  (adapter)              │   │
+│  └─────────────────┘      └────────┬────────────────┘   │
+│                                    │                    │
+└────────────────────────────────────┼────────────────────┘
+                                     │
+                   ┌─────────────────┴─────────────────┐
+                   ▼                                   ▼
+          ┌──────────────┐                    ┌──────────────┐
+          │  Tenant DB   │                    │   Zanzibar   │
+          │  (external)  │                    │  (external)  │
+          └──────────────┘                    └──────────────┘
+```
+
+In this scenario:
+- **Tenant DB** — External database storing tenant metadata (name, status)
+- **Zanzibar** — External authorization service storing access relationships
+- **Plugin** — Adapter that bridges HyperSpot to both external systems
+
+| Method | Data Source |
+|--------|-------------|
+| `get_tenant` | Tenant DB |
+| `can_access` | Zanzibar `Check` API |
+| `get_accessible_tenants` | Zanzibar `LookupResources` + Tenant DB |
+
+**Example Zanzibar schema:**
+
+```
+definition tenant {
+    relation accessor: tenant    // direct access grant
+    relation parent: tenant      // optional hierarchy
+
+    permission access = accessor + parent + parent->access
+}
+
+// Example relationships:
+// tenant:acme#accessor@tenant:partner    → partner can access acme
+// tenant:acme#parent@tenant:corp         → corp (and its accessors) can access acme
+```
+
+This pattern allows HyperSpot to operate as a component within a larger system without owning the tenant or authorization data.
+
+Similar plugins can integrate with other authorization systems (LDAP, custom APIs, etc.) — the gateway remains agnostic to the backend.
+
+## Configuration
+
+### Gateway
+
+See [`config.rs`](tenant_resolver-gw/src/config.rs)
+
+```yaml
+modules:
+  tenant_resolver:
+    vendor: "hyperspot"  # Selects plugin by matching vendor
+```
+
+### Static Plugin
+
+See [`config.rs`](plugins/static_tr_plugin/src/config.rs)
+
+```yaml
+modules:
+  static_tr_plugin:
+    vendor: "hyperspot"
+    priority: 100           # Lower = higher priority
+    tenants:
+      - id: "550e8400-e29b-41d4-a716-446655440001"
+        name: "Tenant A"
+        status: active
+        type: enterprise  # optional
+    access_rules:
+      - source: "550e8400-e29b-41d4-a716-446655440001"
+        target: "550e8400-e29b-41d4-a716-446655440002"
+```
+
+## Usage
+
+```rust
+let resolver = hub.get::<dyn TenantResolverGatewayClient>()?;
+
+// Get tenant info (returns any status)
+let tenant = resolver.get_tenant(&ctx, tenant_id).await?;
+
+// Check basic access
+let can_access = resolver.can_access(&ctx, target_id, None).await?;
+
+// Get all accessible tenants
+let accessible = resolver.get_accessible_tenants(&ctx, None, None).await?;
+
+// Get only active accessible tenants
+let filter = TenantFilter {
+    status: vec![TenantStatus::Active],
+    ..Default::default()
+};
+let active_tenants = resolver.get_accessible_tenants(&ctx, Some(&filter), None).await?;
+```
+
+## Technical Decisions
+
+### Gateway + Plugin Pattern
+
+Multiple backends are planned (config-based, DB-driven, external API). The gateway handles cross-cutting concerns consistently while plugins can be developed independently.
+
+### Source Tenant from security_context
+
+Using `security_context.tenant_id()` as the source tenant reduces API surface, prevents misuse, and aligns with existing patterns.
+
+### Self-Access Enforcement
+
+Self-access is plugin-determined, not gateway-enforced. This allows plugins to implement
+nuanced access policies (e.g., restricting certain operations on the tenant itself, or
+limiting functionality for suspended tenants). The built-in plugins (`static_tr_plugin`,
+`single_tenant_tr_plugin`) allow full self-access.
+
+## API Rationale
+
+### Why `get_tenant` Has No Filter
+
+The `get_tenant` method returns tenant info regardless of status. Rationale:
+
+1. **Information preservation**: Consumers can decide how to handle different statuses (active, suspended, deleted) based on their business logic
+2. **Better error messages**: Consumers can show "Tenant is suspended" vs "Tenant not found"
+3. **Flexibility**: Some consumers may need to access deleted tenants for audit purposes
+
+### Why `can_access` Has No Filter
+
+Access rules (including status-based restrictions) are **plugin-determined**. Rationale:
+
+1. **Plugin autonomy**: A plugin may allow read-only access to suspended tenants
+2. **Consumer flexibility**: If consumers need status-specific logic, they can call `get_tenant` separately
+3. **Cleaner semantics**: `can_access` answers "can I access?" — not "can I access if active?"
+
+### Why Filter Only in `get_accessible_tenants`
+
+Filtering makes sense for list operations:
+
+1. **Performance**: Filter at source, not after fetching potentially large lists
+2. **Common pattern**: "Give me all active tenants I can access" is a frequent use case
+3. **No information loss**: Single-item operations (`get_tenant`, `can_access`) benefit from returning full info
+
+### Why `AccessOptions` Uses AND Semantics
+
+Multiple permissions in `AccessOptions` require **all** to be satisfied:
+
+```rust
+// Must have BOTH read AND write permission
+let options = AccessOptions {
+    permission: vec!["read".to_string(), "write".to_string()],
+};
+```
+
+Rationale:
+- AND is the safer, more restrictive default
+- OR can be achieved client-side with multiple calls
+- Most permission systems use AND for "must have these capabilities"
+
+## Implementation Phases
+
+### Phase 1: Core (Current)
+
+- `get_tenant`, `can_access`, `get_accessible_tenants` APIs
+- `TenantFilter` for id/status-based filtering
+- `AccessOptions` for permission-based access checks
+- Static plugin with config-driven access rules
+- Single-tenant plugin for simple deployments
+- ClientHub registration for in-process consumption
+
+### Phase 2: gRPC (Planned)
+
+- gRPC API for out-of-process consumers

--- a/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/Cargo.toml
+++ b/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "hs-single-tenant-tr-plugin"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Zero-config tenant resolver plugin for single-tenant deployments"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+hs-tenant-resolver-sdk = { path = "../../tenant_resolver-sdk" }
+types-registry-sdk = { path = "../../../types-registry/types-registry-sdk" }
+
+# ModKit dependencies
+modkit = { path = "../../../../../libs/modkit" }
+modkit-security = { path = "../../../../../libs/modkit-security" }
+modkit-odata = { path = "../../../../../libs/modkit-odata" }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Data structures
+uuid = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# Required by modkit::module macro
+inventory = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/README.md
+++ b/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/README.md
@@ -1,0 +1,12 @@
+# Single Tenant Resolver Plugin
+
+Zero-config plugin for single-tenant deployments.
+
+See [../../README.md](../../README.md) for full documentation.
+
+## Quick Reference
+
+- No configuration required
+- Returns tenant from security context as the only tenant (name: "Default")
+- No cross-tenant access allowed (single-tenant mode)
+- Implements `TenantResolverPluginClient`

--- a/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/domain/client.rs
+++ b/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/domain/client.rs
@@ -1,0 +1,173 @@
+//! Client implementation for the single-tenant resolver plugin.
+//!
+//! Implements `TenantResolverPluginClient` using single-tenant semantics.
+
+use async_trait::async_trait;
+use hs_tenant_resolver_sdk::{
+    AccessOptions, TenantFilter, TenantId, TenantInfo, TenantResolverError,
+    TenantResolverPluginClient, TenantStatus,
+};
+use modkit_security::SecurityContext;
+
+use super::service::Service;
+
+// Tenant name for single-tenant mode.
+const TENANT_NAME: &str = "Default";
+
+#[async_trait]
+impl TenantResolverPluginClient for Service {
+    async fn get_tenant(
+        &self,
+        ctx: &SecurityContext,
+        id: TenantId,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        // Only return tenant info if ID matches security context
+        if id == ctx.tenant_id() {
+            Ok(TenantInfo {
+                id,
+                name: TENANT_NAME.to_owned(),
+                status: TenantStatus::Active,
+                tenant_type: None,
+            })
+        } else {
+            Err(TenantResolverError::TenantNotFound { tenant_id: id })
+        }
+    }
+
+    async fn can_access(
+        &self,
+        ctx: &SecurityContext,
+        target: TenantId,
+        _options: Option<&AccessOptions>,
+    ) -> Result<bool, TenantResolverError> {
+        // In single-tenant mode, only self-access is valid
+        if target == ctx.tenant_id() {
+            return Ok(true);
+        }
+        // Other tenants don't exist
+        Err(TenantResolverError::TenantNotFound { tenant_id: target })
+    }
+
+    async fn get_accessible_tenants(
+        &self,
+        ctx: &SecurityContext,
+        filter: Option<&TenantFilter>,
+        _options: Option<&AccessOptions>,
+    ) -> Result<Vec<TenantInfo>, TenantResolverError> {
+        // Build self-tenant info
+        let self_info = TenantInfo {
+            id: ctx.tenant_id(),
+            name: TENANT_NAME.to_owned(),
+            status: TenantStatus::Active,
+            tenant_type: None,
+        };
+
+        // Apply filter
+        if let Some(f) = filter {
+            if !f.id.is_empty() && !f.id.contains(&self_info.id) {
+                return Ok(vec![]);
+            }
+            if !f.status.is_empty() && !f.status.contains(&self_info.status) {
+                return Ok(vec![]);
+            }
+        }
+
+        Ok(vec![self_info])
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use hs_tenant_resolver_sdk::TenantStatus;
+    use uuid::Uuid;
+
+    fn ctx_for_tenant(tenant_id: Uuid) -> SecurityContext {
+        SecurityContext::builder().tenant_id(tenant_id).build()
+    }
+
+    const TENANT_A: &str = "11111111-1111-1111-1111-111111111111";
+    const TENANT_B: &str = "22222222-2222-2222-2222-222222222222";
+
+    #[tokio::test]
+    async fn get_tenant_returns_info_for_matching_id() {
+        let service = Service;
+        let tenant_id = Uuid::parse_str(TENANT_A).unwrap();
+        let ctx = ctx_for_tenant(tenant_id);
+
+        let result = service.get_tenant(&ctx, tenant_id).await;
+
+        assert!(result.is_ok());
+        let info = result.unwrap();
+        assert_eq!(info.id, tenant_id);
+        assert_eq!(info.name, TENANT_NAME);
+        assert_eq!(info.status, TenantStatus::Active);
+        assert!(info.tenant_type.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_tenant_returns_error_for_different_id() {
+        let service = Service;
+        let ctx_tenant = Uuid::parse_str(TENANT_A).unwrap();
+        let query_tenant = Uuid::parse_str(TENANT_B).unwrap();
+        let ctx = ctx_for_tenant(ctx_tenant);
+
+        let result = service.get_tenant(&ctx, query_tenant).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TenantResolverError::TenantNotFound { tenant_id } => {
+                assert_eq!(tenant_id, query_tenant);
+            }
+            other => panic!("Expected TenantNotFound, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn can_access_returns_error_for_different_tenant() {
+        let service = Service;
+        let ctx_tenant = Uuid::parse_str(TENANT_A).unwrap();
+        let target_tenant = Uuid::parse_str(TENANT_B).unwrap();
+        let ctx = ctx_for_tenant(ctx_tenant);
+
+        let result = service.can_access(&ctx, target_tenant, None).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TenantResolverError::TenantNotFound { tenant_id } => {
+                assert_eq!(tenant_id, target_tenant);
+            }
+            other => panic!("Expected TenantNotFound, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn can_access_returns_true_for_self() {
+        // Plugin handles self-access: returns true
+        let service = Service;
+        let tenant_id = Uuid::parse_str(TENANT_A).unwrap();
+        let ctx = ctx_for_tenant(tenant_id);
+
+        let result = service.can_access(&ctx, tenant_id, None).await;
+
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn get_accessible_tenants_returns_self() {
+        let service = Service;
+        let tenant_id = Uuid::parse_str(TENANT_A).unwrap();
+        let ctx = ctx_for_tenant(tenant_id);
+
+        let result = service.get_accessible_tenants(&ctx, None, None).await;
+
+        assert!(result.is_ok());
+        let items = result.unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, tenant_id);
+        assert_eq!(items[0].name, TENANT_NAME);
+        assert_eq!(items[0].status, TenantStatus::Active);
+    }
+}

--- a/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/domain/mod.rs
+++ b/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/domain/mod.rs
@@ -1,0 +1,6 @@
+//! Domain layer for the single-tenant resolver plugin.
+
+mod client;
+pub mod service;
+
+pub use service::Service;

--- a/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/domain/service.rs
+++ b/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/domain/service.rs
@@ -1,0 +1,7 @@
+//! Domain service for the single-tenant resolver plugin.
+
+/// Single-tenant resolver service.
+///
+/// Zero-configuration service for single-tenant deployments.
+/// No state is needed - all tenant info is derived from the security context.
+pub struct Service;

--- a/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/lib.rs
+++ b/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/lib.rs
@@ -1,0 +1,23 @@
+//! Single-Tenant Resolver Plugin
+//!
+//! Zero-configuration plugin for single-tenant deployments.
+//! Always returns the tenant from the security context as the only accessible tenant.
+//!
+//! ## Behavior
+//!
+//! - `get_tenant`: Returns tenant info (name: "Default") only if ID matches security context
+//! - `can_access`: Always returns `false` (cross-tenant access not allowed; self-access handled by gateway)
+//! - `get_accessible_tenants`: Returns empty list (gateway adds self-tenant automatically)
+//!
+//! ## Configuration
+//!
+//! No configuration required. The plugin registers itself automatically with:
+//! - Vendor: `hyperspot`
+//! - Priority: `1000` (lower than static plugin, so static wins when both are enabled)
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+pub mod domain;
+pub mod module;
+
+pub use module::SingleTenantTrPlugin;

--- a/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/module.rs
+++ b/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/module.rs
@@ -1,0 +1,78 @@
+//! Single-tenant resolver plugin module.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use hs_tenant_resolver_sdk::{TenantResolverPluginClient, TenantResolverPluginSpecV1};
+use modkit::client_hub::ClientScope;
+use modkit::context::ModuleCtx;
+use modkit::gts::BaseModkitPluginV1;
+use modkit::Module;
+use tracing::info;
+use types_registry_sdk::TypesRegistryApi;
+
+use crate::domain::Service;
+
+/// Hardcoded vendor name for GTS instance registration.
+const VENDOR: &str = "hyperspot";
+
+/// Hardcoded priority (higher value = lower priority).
+/// Set to 1000 so `static_tr_plugin` (priority 100) wins when both are enabled.
+const PRIORITY: i16 = 1000;
+
+/// Single-tenant resolver plugin module.
+///
+/// Zero-configuration plugin for single-tenant deployments.
+/// Returns the tenant from security context as the only accessible tenant.
+#[modkit::module(
+    name = "single_tenant_tr_plugin",
+    deps = ["types_registry"]
+)]
+pub struct SingleTenantTrPlugin;
+
+impl Default for SingleTenantTrPlugin {
+    fn default() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Module for SingleTenantTrPlugin {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        info!("Initializing single_tenant_tr_plugin");
+
+        // Generate plugin instance ID
+        let instance_id = TenantResolverPluginSpecV1::gts_make_instance_id(
+            "hyperspot.builtin.single_tenant_resolver.plugin.v1",
+        );
+
+        // Register plugin instance in types-registry
+        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+        let instance = BaseModkitPluginV1::<TenantResolverPluginSpecV1> {
+            id: instance_id.clone(),
+            vendor: VENDOR.to_owned(),
+            priority: PRIORITY,
+            properties: TenantResolverPluginSpecV1,
+        };
+        let instance_json = serde_json::to_value(&instance)?;
+
+        let _ = registry.register(vec![instance_json]).await?;
+
+        // Create service and register scoped client in ClientHub
+        let service = Arc::new(Service);
+        let api: Arc<dyn TenantResolverPluginClient> = service;
+        ctx.client_hub()
+            .register_scoped::<dyn TenantResolverPluginClient>(
+                ClientScope::gts_id(&instance_id),
+                api,
+            );
+
+        info!(
+            instance_id = %instance_id,
+            vendor = VENDOR,
+            priority = PRIORITY,
+            "Single-tenant plugin initialized"
+        );
+        Ok(())
+    }
+}

--- a/modules/system/tenant_resolver/plugins/static_tr_plugin/Cargo.toml
+++ b/modules/system/tenant_resolver/plugins/static_tr_plugin/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "hs-static-tr-plugin"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Tenant resolver plugin with static config-based tenant data and access rules"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+hs-tenant-resolver-sdk = { path = "../../tenant_resolver-sdk" }
+types-registry-sdk = { path = "../../../types-registry/types-registry-sdk" }
+
+# ModKit dependencies
+modkit = { path = "../../../../../libs/modkit" }
+modkit-security = { path = "../../../../../libs/modkit-security" }
+modkit-odata = { path = "../../../../../libs/modkit-odata" }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Data structures
+uuid = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# Required by modkit::module macro
+inventory = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/modules/system/tenant_resolver/plugins/static_tr_plugin/README.md
+++ b/modules/system/tenant_resolver/plugins/static_tr_plugin/README.md
@@ -1,0 +1,11 @@
+# Static Tenant Resolver Plugin
+
+Config-based plugin for testing multi-tenant deployments.
+
+See [../../README.md](../../README.md) for full documentation.
+
+## Quick Reference
+
+- Tenants and access rules defined in YAML config
+- In-memory storage (no database required)
+- Implements `TenantResolverPluginClient`

--- a/modules/system/tenant_resolver/plugins/static_tr_plugin/src/config.rs
+++ b/modules/system/tenant_resolver/plugins/static_tr_plugin/src/config.rs
@@ -1,0 +1,65 @@
+//! Configuration for the static tenant resolver plugin.
+
+use hs_tenant_resolver_sdk::TenantStatus;
+use serde::Deserialize;
+use uuid::Uuid;
+
+/// Plugin configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct StaticTrPluginConfig {
+    /// Vendor name for GTS instance registration.
+    pub vendor: String,
+
+    /// Plugin priority (lower = higher priority).
+    pub priority: i16,
+
+    /// Static tenant definitions.
+    pub tenants: Vec<TenantConfig>,
+
+    /// Static access rules.
+    pub access_rules: Vec<AccessRuleConfig>,
+}
+
+impl Default for StaticTrPluginConfig {
+    fn default() -> Self {
+        Self {
+            vendor: "hyperspot".to_owned(),
+            priority: 100,
+            tenants: Vec::new(),
+            access_rules: Vec::new(),
+        }
+    }
+}
+
+/// Configuration for a single tenant.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TenantConfig {
+    /// Tenant ID.
+    pub id: Uuid,
+
+    /// Tenant name.
+    pub name: String,
+
+    /// Tenant status (defaults to Active).
+    #[serde(default)]
+    pub status: TenantStatus,
+
+    /// Tenant type classification.
+    #[serde(rename = "type", default)]
+    pub tenant_type: Option<String>,
+}
+
+/// Configuration for an access rule.
+///
+/// Defines that `source` tenant can access `target` tenant's data.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AccessRuleConfig {
+    /// Source tenant ID (the one requesting access).
+    pub source: Uuid,
+
+    /// Target tenant ID (the one being accessed).
+    pub target: Uuid,
+}

--- a/modules/system/tenant_resolver/plugins/static_tr_plugin/src/domain/client.rs
+++ b/modules/system/tenant_resolver/plugins/static_tr_plugin/src/domain/client.rs
@@ -1,0 +1,514 @@
+//! Client implementation for the static tenant resolver plugin.
+//!
+//! Implements `TenantResolverPluginClient` using the domain service.
+
+use async_trait::async_trait;
+use hs_tenant_resolver_sdk::{
+    AccessOptions, TenantFilter, TenantId, TenantInfo, TenantResolverError,
+    TenantResolverPluginClient,
+};
+use modkit_security::SecurityContext;
+
+use super::service::Service;
+
+#[async_trait]
+impl TenantResolverPluginClient for Service {
+    async fn get_tenant(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        self.tenants
+            .get(&id)
+            .cloned()
+            .ok_or(TenantResolverError::TenantNotFound { tenant_id: id })
+    }
+
+    async fn can_access(
+        &self,
+        ctx: &SecurityContext,
+        target: TenantId,
+        _options: Option<&AccessOptions>,
+    ) -> Result<bool, TenantResolverError> {
+        let source = ctx.tenant_id();
+
+        // First, check if target tenant exists
+        if !self.tenants.contains_key(&target) {
+            return Err(TenantResolverError::TenantNotFound { tenant_id: target });
+        }
+
+        // Self-access is always allowed
+        if source == target {
+            return Ok(true);
+        }
+
+        // Check if access rule exists
+        Ok(self.access_rules.contains(&(source, target)))
+    }
+
+    async fn get_accessible_tenants(
+        &self,
+        ctx: &SecurityContext,
+        filter: Option<&TenantFilter>,
+        _options: Option<&AccessOptions>,
+    ) -> Result<Vec<TenantInfo>, TenantResolverError> {
+        let source = ctx.tenant_id();
+
+        let mut items: Vec<TenantInfo> = Vec::new();
+
+        // Add self-tenant first if it exists and matches filter
+        if let Some(self_info) = self.tenants.get(&source) {
+            if Self::matches_filter(self_info, filter) {
+                items.push(self_info.clone());
+            }
+        }
+
+        // Get all targets accessible by this source
+        let accessible_ids = self.accessible_by.get(&source);
+
+        // Add accessible tenants (if any) that match the filter
+        if let Some(ids) = accessible_ids {
+            for id in ids {
+                // Skip self (already added)
+                if *id == source {
+                    continue;
+                }
+                if let Some(info) = self.tenants.get(id) {
+                    if Self::matches_filter(info, filter) {
+                        items.push(info.clone());
+                    }
+                }
+            }
+        }
+
+        Ok(items)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::config::{AccessRuleConfig, StaticTrPluginConfig, TenantConfig};
+    use hs_tenant_resolver_sdk::TenantStatus;
+    use uuid::Uuid;
+
+    // Helper to create a test tenant config
+    fn tenant(id: &str, name: &str, status: TenantStatus) -> TenantConfig {
+        TenantConfig {
+            id: Uuid::parse_str(id).unwrap(),
+            name: name.to_owned(),
+            status,
+            tenant_type: None,
+        }
+    }
+
+    // Helper to create an access rule config
+    fn access_rule(source: &str, target: &str) -> AccessRuleConfig {
+        AccessRuleConfig {
+            source: Uuid::parse_str(source).unwrap(),
+            target: Uuid::parse_str(target).unwrap(),
+        }
+    }
+
+    // Helper to create a security context for a tenant
+    fn ctx_for_tenant(tenant_id: &str) -> SecurityContext {
+        SecurityContext::builder()
+            .tenant_id(Uuid::parse_str(tenant_id).unwrap())
+            .build()
+    }
+
+    // Filter for active tenants only
+    fn active_filter() -> TenantFilter {
+        TenantFilter {
+            status: vec![TenantStatus::Active],
+            ..Default::default()
+        }
+    }
+
+    // Test UUIDs
+    const TENANT_A: &str = "11111111-1111-1111-1111-111111111111";
+    const TENANT_B: &str = "22222222-2222-2222-2222-222222222222";
+    const TENANT_C: &str = "33333333-3333-3333-3333-333333333333";
+    const NONEXISTENT: &str = "99999999-9999-9999-9999-999999999999";
+
+    // ==================== get_tenant tests ====================
+
+    #[tokio::test]
+    async fn get_tenant_existing() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![tenant(TENANT_A, "Tenant A", TenantStatus::Active)],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+
+        let result = service
+            .get_tenant(&ctx, Uuid::parse_str(TENANT_A).unwrap())
+            .await;
+
+        assert!(result.is_ok());
+        let info = result.unwrap();
+        assert_eq!(info.name, "Tenant A");
+        assert_eq!(info.status, TenantStatus::Active);
+    }
+
+    #[tokio::test]
+    async fn get_tenant_nonexistent() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![tenant(TENANT_A, "Tenant A", TenantStatus::Active)],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+        let nonexistent_id = Uuid::parse_str(NONEXISTENT).unwrap();
+
+        let result = service.get_tenant(&ctx, nonexistent_id).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TenantResolverError::TenantNotFound { tenant_id } => {
+                assert_eq!(tenant_id, nonexistent_id);
+            }
+            other => panic!("Expected TenantNotFound, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_tenant_empty_service() {
+        let cfg = StaticTrPluginConfig::default();
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+        let tenant_a_id = Uuid::parse_str(TENANT_A).unwrap();
+
+        let result = service.get_tenant(&ctx, tenant_a_id).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TenantResolverError::TenantNotFound { tenant_id } => {
+                assert_eq!(tenant_id, tenant_a_id);
+            }
+            other => panic!("Expected TenantNotFound, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_tenant_returns_any_status() {
+        // get_tenant now returns tenant regardless of status
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![tenant(TENANT_A, "Tenant A", TenantStatus::Suspended)],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+        let tenant_a_id = Uuid::parse_str(TENANT_A).unwrap();
+
+        // Returns tenant even if suspended
+        let result = service.get_tenant(&ctx, tenant_a_id).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().status, TenantStatus::Suspended);
+    }
+
+    // ==================== can_access tests ====================
+
+    #[tokio::test]
+    async fn can_access_allowed() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![
+                tenant(TENANT_A, "A", TenantStatus::Active),
+                tenant(TENANT_B, "B", TenantStatus::Active),
+            ],
+            access_rules: vec![access_rule(TENANT_A, TENANT_B)],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+
+        let result = service
+            .can_access(&ctx, Uuid::parse_str(TENANT_B).unwrap(), None)
+            .await;
+
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn can_access_denied_no_rule() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![
+                tenant(TENANT_A, "A", TenantStatus::Active),
+                tenant(TENANT_B, "B", TenantStatus::Active),
+            ],
+            access_rules: vec![], // No rules
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+
+        let result = service
+            .can_access(&ctx, Uuid::parse_str(TENANT_B).unwrap(), None)
+            .await;
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn can_access_error_for_nonexistent_target() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![tenant(TENANT_A, "A", TenantStatus::Active)],
+            access_rules: vec![],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+        let nonexistent_id = Uuid::parse_str(NONEXISTENT).unwrap();
+
+        let result = service.can_access(&ctx, nonexistent_id, None).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            TenantResolverError::TenantNotFound { tenant_id } => {
+                assert_eq!(tenant_id, nonexistent_id);
+            }
+            other => panic!("Expected TenantNotFound, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn can_access_not_symmetric() {
+        // A can access B does NOT mean B can access A
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![
+                tenant(TENANT_A, "A", TenantStatus::Active),
+                tenant(TENANT_B, "B", TenantStatus::Active),
+            ],
+            access_rules: vec![access_rule(TENANT_A, TENANT_B)], // Only A -> B
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+
+        // A can access B
+        let ctx_a = ctx_for_tenant(TENANT_A);
+        let result = service
+            .can_access(&ctx_a, Uuid::parse_str(TENANT_B).unwrap(), None)
+            .await;
+        assert!(result.unwrap());
+
+        // B cannot access A (no reverse rule)
+        let ctx_b = ctx_for_tenant(TENANT_B);
+        let result = service
+            .can_access(&ctx_b, Uuid::parse_str(TENANT_A).unwrap(), None)
+            .await;
+        assert!(!result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn can_access_not_transitive() {
+        // A -> B and B -> C does NOT mean A -> C
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![
+                tenant(TENANT_A, "A", TenantStatus::Active),
+                tenant(TENANT_B, "B", TenantStatus::Active),
+                tenant(TENANT_C, "C", TenantStatus::Active),
+            ],
+            access_rules: vec![
+                access_rule(TENANT_A, TENANT_B), // A -> B
+                access_rule(TENANT_B, TENANT_C), // B -> C
+            ],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+
+        // A can access B
+        let result = service
+            .can_access(&ctx, Uuid::parse_str(TENANT_B).unwrap(), None)
+            .await;
+        assert!(result.unwrap());
+
+        // A cannot access C (no direct rule)
+        let result = service
+            .can_access(&ctx, Uuid::parse_str(TENANT_C).unwrap(), None)
+            .await;
+        assert!(!result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn can_access_self_allowed() {
+        // Plugin handles self-access: always allowed
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![tenant(TENANT_A, "A", TenantStatus::Active)],
+            access_rules: vec![], // No explicit self-access rule needed
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+
+        // Plugin returns true for self-access
+        let result = service
+            .can_access(&ctx, Uuid::parse_str(TENANT_A).unwrap(), None)
+            .await;
+        assert!(result.unwrap());
+    }
+
+    #[tokio::test]
+    async fn can_access_allows_any_status() {
+        // can_access no longer filters by status - that's plugin policy
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![
+                tenant(TENANT_A, "A", TenantStatus::Active),
+                tenant(TENANT_B, "B", TenantStatus::Suspended),
+            ],
+            access_rules: vec![access_rule(TENANT_A, TENANT_B)],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+        let tenant_b_id = Uuid::parse_str(TENANT_B).unwrap();
+
+        // Returns true even if target is suspended (access rule exists)
+        let result = service.can_access(&ctx, tenant_b_id, None).await;
+        assert!(result.unwrap());
+    }
+
+    // ==================== get_accessible_tenants tests ====================
+
+    #[tokio::test]
+    async fn get_accessible_tenants_with_rules() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![
+                tenant(TENANT_A, "A", TenantStatus::Active),
+                tenant(TENANT_B, "B", TenantStatus::Active),
+                tenant(TENANT_C, "C", TenantStatus::Active),
+            ],
+            access_rules: vec![
+                access_rule(TENANT_A, TENANT_B),
+                access_rule(TENANT_A, TENANT_C),
+            ],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+
+        let result = service.get_accessible_tenants(&ctx, None, None).await;
+
+        assert!(result.is_ok());
+        let items = result.unwrap();
+        // Self-tenant A + accessible B and C
+        assert_eq!(items.len(), 3);
+
+        // Self-tenant should be first
+        assert_eq!(items[0].id, Uuid::parse_str(TENANT_A).unwrap());
+
+        let ids: Vec<_> = items.iter().map(|t| t.id).collect();
+        assert!(ids.contains(&Uuid::parse_str(TENANT_B).unwrap()));
+        assert!(ids.contains(&Uuid::parse_str(TENANT_C).unwrap()));
+    }
+
+    #[tokio::test]
+    async fn get_accessible_tenants_no_rules() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![
+                tenant(TENANT_A, "A", TenantStatus::Active),
+                tenant(TENANT_B, "B", TenantStatus::Active),
+            ],
+            access_rules: vec![],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+
+        let result = service.get_accessible_tenants(&ctx, None, None).await;
+
+        assert!(result.is_ok());
+        let items = result.unwrap();
+        // Only self-tenant (no cross-tenant rules)
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, Uuid::parse_str(TENANT_A).unwrap());
+    }
+
+    #[tokio::test]
+    async fn get_accessible_tenants_missing_tenant_info() {
+        // Access rule references a tenant that doesn't exist in tenants list
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![tenant(TENANT_A, "A", TenantStatus::Active)],
+            access_rules: vec![access_rule(TENANT_A, TENANT_B)], // B not in tenants
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+
+        let result = service.get_accessible_tenants(&ctx, None, None).await;
+
+        assert!(result.is_ok());
+        let items = result.unwrap();
+        // B is in access_rules but not in tenants, so it's skipped
+        // Only self-tenant A is returned
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, Uuid::parse_str(TENANT_A).unwrap());
+    }
+
+    #[tokio::test]
+    async fn get_accessible_tenants_filtered_by_status() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![
+                tenant(TENANT_A, "A", TenantStatus::Active),
+                tenant(TENANT_B, "B", TenantStatus::Active),
+                tenant(TENANT_C, "C", TenantStatus::Suspended),
+            ],
+            access_rules: vec![
+                access_rule(TENANT_A, TENANT_B),
+                access_rule(TENANT_A, TENANT_C),
+            ],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+
+        // Without filter - returns self (A) plus B and C
+        let result = service.get_accessible_tenants(&ctx, None, None).await;
+        assert_eq!(result.unwrap().len(), 3);
+
+        // With active filter - returns self (A) and B (C is suspended)
+        let filter = active_filter();
+        let result = service
+            .get_accessible_tenants(&ctx, Some(&filter), None)
+            .await;
+        let items = result.unwrap();
+        assert_eq!(items.len(), 2);
+        // Self-tenant should be first
+        assert_eq!(items[0].id, Uuid::parse_str(TENANT_A).unwrap());
+        assert_eq!(items[1].id, Uuid::parse_str(TENANT_B).unwrap());
+    }
+
+    #[tokio::test]
+    async fn get_accessible_tenants_filtered_by_id() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![
+                tenant(TENANT_A, "A", TenantStatus::Active),
+                tenant(TENANT_B, "B", TenantStatus::Active),
+                tenant(TENANT_C, "C", TenantStatus::Active),
+            ],
+            access_rules: vec![
+                access_rule(TENANT_A, TENANT_B),
+                access_rule(TENANT_A, TENANT_C),
+            ],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+        let ctx = ctx_for_tenant(TENANT_A);
+
+        // Filter by specific ID
+        let filter = TenantFilter {
+            id: vec![Uuid::parse_str(TENANT_B).unwrap()],
+            ..Default::default()
+        };
+        let result = service
+            .get_accessible_tenants(&ctx, Some(&filter), None)
+            .await;
+        let items = result.unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, Uuid::parse_str(TENANT_B).unwrap());
+    }
+}

--- a/modules/system/tenant_resolver/plugins/static_tr_plugin/src/domain/mod.rs
+++ b/modules/system/tenant_resolver/plugins/static_tr_plugin/src/domain/mod.rs
@@ -1,0 +1,6 @@
+//! Domain layer for the static tenant resolver plugin.
+
+mod client;
+pub mod service;
+
+pub use service::Service;

--- a/modules/system/tenant_resolver/plugins/static_tr_plugin/src/domain/service.rs
+++ b/modules/system/tenant_resolver/plugins/static_tr_plugin/src/domain/service.rs
@@ -1,0 +1,212 @@
+//! Domain service for the static tenant resolver plugin.
+
+use std::collections::{HashMap, HashSet};
+
+use hs_tenant_resolver_sdk::{TenantFilter, TenantId, TenantInfo};
+
+use crate::config::StaticTrPluginConfig;
+
+/// Static tenant resolver service.
+///
+/// Stores tenant data and access rules in memory, loaded from configuration.
+pub struct Service {
+    /// Tenant info by ID.
+    pub(super) tenants: HashMap<TenantId, TenantInfo>,
+
+    /// Access rules: set of (source, target) pairs.
+    pub(super) access_rules: HashSet<(TenantId, TenantId)>,
+
+    /// Reverse index: target -> list of sources that can access it.
+    /// Used for efficient `get_accessible_tenants`.
+    pub(super) accessible_by: HashMap<TenantId, Vec<TenantId>>,
+}
+
+impl Service {
+    /// Creates a new service from configuration.
+    #[must_use]
+    pub fn from_config(cfg: &StaticTrPluginConfig) -> Self {
+        let tenants: HashMap<TenantId, TenantInfo> = cfg
+            .tenants
+            .iter()
+            .map(|t| {
+                (
+                    t.id,
+                    TenantInfo {
+                        id: t.id,
+                        name: t.name.clone(),
+                        status: t.status,
+                        tenant_type: t.tenant_type.clone(),
+                    },
+                )
+            })
+            .collect();
+
+        let access_rules: HashSet<(TenantId, TenantId)> = cfg
+            .access_rules
+            .iter()
+            .map(|r| (r.source, r.target))
+            .collect();
+
+        // Build reverse index: for each source, which targets can it access?
+        let mut accessible_by: HashMap<TenantId, Vec<TenantId>> = HashMap::new();
+        for (source, target) in &access_rules {
+            accessible_by.entry(*source).or_default().push(*target);
+        }
+
+        Self {
+            tenants,
+            access_rules,
+            accessible_by,
+        }
+    }
+
+    /// Check if a tenant matches the filter criteria.
+    pub(super) fn matches_filter(tenant: &TenantInfo, filter: Option<&TenantFilter>) -> bool {
+        let Some(filter) = filter else {
+            return true;
+        };
+
+        // Check ID filter
+        if !filter.id.is_empty() && !filter.id.contains(&tenant.id) {
+            return false;
+        }
+
+        // Check status filter
+        if !filter.status.is_empty() && !filter.status.contains(&tenant.status) {
+            return false;
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::config::{AccessRuleConfig, TenantConfig};
+    use hs_tenant_resolver_sdk::TenantStatus;
+    use uuid::Uuid;
+
+    // Helper to create a test tenant config
+    fn tenant(id: &str, name: &str, status: TenantStatus) -> TenantConfig {
+        TenantConfig {
+            id: Uuid::parse_str(id).unwrap(),
+            name: name.to_owned(),
+            status,
+            tenant_type: None,
+        }
+    }
+
+    // Helper to create an access rule config
+    fn access_rule(source: &str, target: &str) -> AccessRuleConfig {
+        AccessRuleConfig {
+            source: Uuid::parse_str(source).unwrap(),
+            target: Uuid::parse_str(target).unwrap(),
+        }
+    }
+
+    // Test UUIDs
+    const TENANT_A: &str = "11111111-1111-1111-1111-111111111111";
+    const TENANT_B: &str = "22222222-2222-2222-2222-222222222222";
+    const TENANT_C: &str = "33333333-3333-3333-3333-333333333333";
+
+    // ==================== from_config tests ====================
+
+    #[test]
+    fn from_config_empty() {
+        let cfg = StaticTrPluginConfig::default();
+        let service = Service::from_config(&cfg);
+
+        assert!(service.tenants.is_empty());
+        assert!(service.access_rules.is_empty());
+        assert!(service.accessible_by.is_empty());
+    }
+
+    #[test]
+    fn from_config_with_tenants_only() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![
+                tenant(TENANT_A, "Tenant A", TenantStatus::Active),
+                tenant(TENANT_B, "Tenant B", TenantStatus::Suspended),
+            ],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+
+        assert_eq!(service.tenants.len(), 2);
+        assert!(service.access_rules.is_empty());
+        assert!(service.accessible_by.is_empty());
+
+        let a = service
+            .tenants
+            .get(&Uuid::parse_str(TENANT_A).unwrap())
+            .unwrap();
+        assert_eq!(a.name, "Tenant A");
+        assert_eq!(a.status, TenantStatus::Active);
+
+        let b = service
+            .tenants
+            .get(&Uuid::parse_str(TENANT_B).unwrap())
+            .unwrap();
+        assert_eq!(b.name, "Tenant B");
+        assert_eq!(b.status, TenantStatus::Suspended);
+    }
+
+    #[test]
+    fn from_config_with_access_rules() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![
+                tenant(TENANT_A, "A", TenantStatus::Active),
+                tenant(TENANT_B, "B", TenantStatus::Active),
+                tenant(TENANT_C, "C", TenantStatus::Active),
+            ],
+            access_rules: vec![
+                access_rule(TENANT_A, TENANT_B), // A can access B
+                access_rule(TENANT_A, TENANT_C), // A can access C
+                access_rule(TENANT_B, TENANT_C), // B can access C
+            ],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+
+        assert_eq!(service.access_rules.len(), 3);
+
+        // Check reverse index
+        let a_id = Uuid::parse_str(TENANT_A).unwrap();
+        let b_id = Uuid::parse_str(TENANT_B).unwrap();
+        let c_id = Uuid::parse_str(TENANT_C).unwrap();
+
+        let a_accessible = service.accessible_by.get(&a_id).unwrap();
+        assert_eq!(a_accessible.len(), 2);
+        assert!(a_accessible.contains(&b_id));
+        assert!(a_accessible.contains(&c_id));
+
+        let b_accessible = service.accessible_by.get(&b_id).unwrap();
+        assert_eq!(b_accessible.len(), 1);
+        assert!(b_accessible.contains(&c_id));
+
+        // C has no access rules
+        assert!(!service.accessible_by.contains_key(&c_id));
+    }
+
+    #[test]
+    fn from_config_with_tenant_type() {
+        let cfg = StaticTrPluginConfig {
+            tenants: vec![TenantConfig {
+                id: Uuid::parse_str(TENANT_A).unwrap(),
+                name: "Enterprise".to_owned(),
+                status: TenantStatus::Active,
+                tenant_type: Some("enterprise".to_owned()),
+            }],
+            ..Default::default()
+        };
+        let service = Service::from_config(&cfg);
+
+        let a = service
+            .tenants
+            .get(&Uuid::parse_str(TENANT_A).unwrap())
+            .unwrap();
+        assert_eq!(a.tenant_type, Some("enterprise".to_owned()));
+    }
+}

--- a/modules/system/tenant_resolver/plugins/static_tr_plugin/src/lib.rs
+++ b/modules/system/tenant_resolver/plugins/static_tr_plugin/src/lib.rs
@@ -1,0 +1,28 @@
+//! Static Tenant Resolver Plugin
+//!
+//! This plugin provides tenant data and access rules from configuration.
+//! Useful for testing, development, and simple deployments.
+//!
+//! ## Configuration
+//!
+//! ```yaml
+//! modules:
+//!   static_tr_plugin:
+//!     vendor: "hyperspot"
+//!     priority: 100
+//!     tenants:
+//!       - id: "550e8400-e29b-41d4-a716-446655440001"
+//!         name: "Tenant A"
+//!         status: active
+//!     access_rules:
+//!       - source: "550e8400-e29b-41d4-a716-446655440001"
+//!         target: "550e8400-e29b-41d4-a716-446655440002"
+//! ```
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+pub mod config;
+pub mod domain;
+pub mod module;
+
+pub use module::StaticTrPlugin;

--- a/modules/system/tenant_resolver/plugins/static_tr_plugin/src/module.rs
+++ b/modules/system/tenant_resolver/plugins/static_tr_plugin/src/module.rs
@@ -1,0 +1,90 @@
+//! Static tenant resolver plugin module.
+
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use hs_tenant_resolver_sdk::{TenantResolverPluginClient, TenantResolverPluginSpecV1};
+use modkit::client_hub::ClientScope;
+use modkit::context::ModuleCtx;
+use modkit::gts::BaseModkitPluginV1;
+use modkit::Module;
+use tracing::info;
+use types_registry_sdk::TypesRegistryApi;
+
+use crate::config::StaticTrPluginConfig;
+use crate::domain::Service;
+
+/// Static tenant resolver plugin module.
+///
+/// Provides tenant data and access rules from configuration.
+///
+/// **Plugin registration pattern:**
+/// - Gateway registers the plugin schema (GTS type definition)
+/// - This plugin registers its instance (implementation metadata)
+/// - This plugin registers its scoped client (implementation in `ClientHub`)
+#[modkit::module(
+    name = "static_tr_plugin",
+    deps = ["types_registry"]
+)]
+pub struct StaticTrPlugin {
+    service: OnceLock<Arc<Service>>,
+}
+
+impl Default for StaticTrPlugin {
+    fn default() -> Self {
+        Self {
+            service: OnceLock::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Module for StaticTrPlugin {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        info!("Initializing static_tr_plugin");
+
+        // Load configuration
+        let cfg: StaticTrPluginConfig = ctx.config()?;
+        info!(
+            vendor = %cfg.vendor,
+            priority = cfg.priority,
+            tenant_count = cfg.tenants.len(),
+            access_rule_count = cfg.access_rules.len(),
+            "Loaded plugin configuration"
+        );
+
+        // Generate plugin instance ID
+        let instance_id = TenantResolverPluginSpecV1::gts_make_instance_id(
+            "hyperspot.builtin.static_tenant_resolver.plugin.v1",
+        );
+
+        // Register plugin instance in types-registry
+        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+        let instance = BaseModkitPluginV1::<TenantResolverPluginSpecV1> {
+            id: instance_id.clone(),
+            vendor: cfg.vendor.clone(),
+            priority: cfg.priority,
+            properties: TenantResolverPluginSpecV1,
+        };
+        let instance_json = serde_json::to_value(&instance)?;
+
+        let _ = registry.register(vec![instance_json]).await?;
+
+        // Create service from config
+        let service = Arc::new(Service::from_config(&cfg));
+        self.service
+            .set(service.clone())
+            .map_err(|_| anyhow::anyhow!("Service already initialized"))?;
+
+        // Register scoped client in ClientHub
+        let api: Arc<dyn TenantResolverPluginClient> = service;
+        ctx.client_hub()
+            .register_scoped::<dyn TenantResolverPluginClient>(
+                ClientScope::gts_id(&instance_id),
+                api,
+            );
+
+        info!(instance_id = %instance_id, "Static plugin initialized");
+        Ok(())
+    }
+}

--- a/modules/system/tenant_resolver/tenant_resolver-gw/Cargo.toml
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "hs-tenant-resolver-gw"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Tenant resolver gateway module - discovers and routes to plugins"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+hs-tenant-resolver-sdk = { path = "../tenant_resolver-sdk" }
+types-registry-sdk = { path = "../../types-registry/types-registry-sdk" }
+
+# ModKit dependencies
+modkit = { path = "../../../../libs/modkit" }
+modkit-security = { path = "../../../../libs/modkit-security" }
+modkit-odata = { path = "../../../../libs/modkit-odata" }
+
+# Async runtime
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
+
+# Data types
+uuid = { workspace = true }
+
+# Error handling and serialization
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Required by modkit::module macro
+inventory = { workspace = true }
+
+# Logging
+tracing = { workspace = true }

--- a/modules/system/tenant_resolver/tenant_resolver-gw/README.md
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/README.md
@@ -1,0 +1,12 @@
+# Tenant Resolver Gateway
+
+Gateway module that routes requests to the selected plugin.
+
+See [../README.md](../README.md) for full documentation.
+
+## Quick Reference
+
+- Discovers plugins via GTS (types-registry)
+- Selects plugin by vendor + priority
+- Enforces self-access (source == target always allowed)
+- Registers `TenantResolverGatewayClient` in ClientHub

--- a/modules/system/tenant_resolver/tenant_resolver-gw/src/config.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/src/config.rs
@@ -1,0 +1,22 @@
+//! Configuration for the tenant resolver gateway.
+
+use serde::Deserialize;
+
+/// Gateway configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TenantResolverGwConfig {
+    /// Vendor selector used to pick a plugin implementation.
+    ///
+    /// The gateway queries types-registry for plugin instances matching
+    /// this vendor and selects the one with lowest priority.
+    pub vendor: String,
+}
+
+impl Default for TenantResolverGwConfig {
+    fn default() -> Self {
+        Self {
+            vendor: "hyperspot".to_owned(),
+        }
+    }
+}

--- a/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/error.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/error.rs
@@ -1,0 +1,86 @@
+//! Domain errors for the tenant resolver gateway.
+
+use hs_tenant_resolver_sdk::TenantResolverError;
+use uuid::Uuid;
+
+/// Internal domain errors.
+#[derive(thiserror::Error, Debug)]
+pub enum DomainError {
+    #[error("types registry is not available: {0}")]
+    TypesRegistryUnavailable(String),
+
+    #[error("no plugin instances found for vendor '{vendor}'")]
+    PluginNotFound { vendor: String },
+
+    #[error("invalid plugin instance content for '{gts_id}': {reason}")]
+    InvalidPluginInstance { gts_id: String, reason: String },
+
+    #[error("plugin client not registered in ClientHub for '{gts_id}'")]
+    PluginClientNotFound { gts_id: String },
+
+    #[error("tenant not found: {tenant_id}")]
+    TenantNotFound { tenant_id: Uuid },
+
+    #[error("access denied to tenant: {target_tenant}")]
+    AccessDenied { target_tenant: Uuid },
+
+    #[error("unauthorized")]
+    Unauthorized,
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl From<types_registry_sdk::TypesRegistryError> for DomainError {
+    fn from(e: types_registry_sdk::TypesRegistryError) -> Self {
+        Self::Internal(e.to_string())
+    }
+}
+
+impl From<modkit::client_hub::ClientHubError> for DomainError {
+    fn from(e: modkit::client_hub::ClientHubError) -> Self {
+        Self::Internal(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for DomainError {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Internal(e.to_string())
+    }
+}
+
+impl From<TenantResolverError> for DomainError {
+    fn from(e: TenantResolverError) -> Self {
+        match e {
+            TenantResolverError::TenantNotFound { tenant_id } => Self::TenantNotFound { tenant_id },
+            TenantResolverError::AccessDenied { target_tenant } => {
+                Self::AccessDenied { target_tenant }
+            }
+            TenantResolverError::Unauthorized => Self::Unauthorized,
+            TenantResolverError::NoPluginAvailable => Self::PluginNotFound {
+                vendor: "unknown".to_owned(),
+            },
+            TenantResolverError::Internal(msg) => Self::Internal(msg),
+        }
+    }
+}
+
+impl From<DomainError> for TenantResolverError {
+    fn from(e: DomainError) -> Self {
+        match e {
+            DomainError::PluginNotFound { .. } => Self::NoPluginAvailable,
+            DomainError::InvalidPluginInstance { gts_id, reason } => {
+                Self::Internal(format!("invalid plugin instance '{gts_id}': {reason}"))
+            }
+            DomainError::PluginClientNotFound { gts_id } => {
+                Self::Internal(format!("plugin client not registered for '{gts_id}'"))
+            }
+            DomainError::TenantNotFound { tenant_id } => Self::TenantNotFound { tenant_id },
+            DomainError::AccessDenied { target_tenant } => Self::AccessDenied { target_tenant },
+            DomainError::Unauthorized => Self::Unauthorized,
+            DomainError::TypesRegistryUnavailable(reason) | DomainError::Internal(reason) => {
+                Self::Internal(reason)
+            }
+        }
+    }
+}

--- a/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/local_client.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/local_client.rs
@@ -1,0 +1,73 @@
+//! Local (in-process) client for the tenant resolver gateway.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use hs_tenant_resolver_sdk::{
+    AccessOptions, TenantFilter, TenantId, TenantInfo, TenantResolverError,
+    TenantResolverGatewayClient,
+};
+use modkit_security::SecurityContext;
+
+use super::{DomainError, Service};
+
+/// Local client wrapping the gateway service.
+///
+/// Registered in `ClientHub` by the gateway module during `init()`.
+pub struct TenantResolverGwLocalClient {
+    svc: Arc<Service>,
+}
+
+impl TenantResolverGwLocalClient {
+    #[must_use]
+    pub fn new(svc: Arc<Service>) -> Self {
+        Self { svc }
+    }
+}
+
+#[async_trait]
+impl TenantResolverGatewayClient for TenantResolverGwLocalClient {
+    async fn get_tenant(
+        &self,
+        ctx: &SecurityContext,
+        id: TenantId,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        self.svc
+            .get_tenant(ctx, id)
+            .await
+            .map_err(|e: DomainError| {
+                tracing::error!(error = ?e, "tenant_resolver gateway call failed");
+                e.into()
+            })
+    }
+
+    async fn can_access(
+        &self,
+        ctx: &SecurityContext,
+        target: TenantId,
+        options: Option<&AccessOptions>,
+    ) -> Result<bool, TenantResolverError> {
+        self.svc
+            .can_access(ctx, target, options)
+            .await
+            .map_err(|e: DomainError| {
+                tracing::error!(error = ?e, "tenant_resolver gateway call failed");
+                e.into()
+            })
+    }
+
+    async fn get_accessible_tenants(
+        &self,
+        ctx: &SecurityContext,
+        filter: Option<&TenantFilter>,
+        options: Option<&AccessOptions>,
+    ) -> Result<Vec<TenantInfo>, TenantResolverError> {
+        self.svc
+            .get_accessible_tenants(ctx, filter, options)
+            .await
+            .map_err(|e: DomainError| {
+                tracing::error!(error = ?e, "tenant_resolver gateway call failed");
+                e.into()
+            })
+    }
+}

--- a/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/mod.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/mod.rs
@@ -1,0 +1,9 @@
+//! Domain layer for the tenant resolver gateway.
+
+pub mod error;
+pub mod local_client;
+pub mod service;
+
+pub use error::DomainError;
+pub use local_client::TenantResolverGwLocalClient;
+pub use service::Service;

--- a/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/service.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/service.rs
@@ -1,0 +1,297 @@
+//! Domain service for the tenant resolver gateway.
+//!
+//! Plugin discovery is lazy: resolved on first API call after
+//! types-registry is ready.
+
+use std::sync::Arc;
+
+use hs_tenant_resolver_sdk::{
+    AccessOptions, TenantFilter, TenantId, TenantInfo, TenantResolverPluginClient,
+    TenantResolverPluginSpecV1,
+};
+use modkit::client_hub::{ClientHub, ClientScope};
+use modkit::gts::BaseModkitPluginV1;
+use modkit_security::SecurityContext;
+use tokio::sync::OnceCell;
+use tracing::info;
+use types_registry_sdk::{GtsEntity, ListQuery, TypesRegistryApi};
+use uuid::Uuid;
+
+use super::error::DomainError;
+
+/// Cached result of plugin resolution.
+struct ResolvedPlugin {
+    gts_id: String,
+    scope: ClientScope,
+}
+
+/// Tenant resolver gateway service.
+///
+/// Discovers plugins via types-registry and delegates API calls.
+pub struct Service {
+    hub: Arc<ClientHub>,
+    vendor: String,
+    /// Lazily resolved plugin (cached after first call).
+    resolved: OnceCell<ResolvedPlugin>,
+}
+
+impl Service {
+    /// Creates a new service with lazy plugin resolution.
+    #[must_use]
+    pub fn new(hub: Arc<ClientHub>, vendor: String) -> Self {
+        Self {
+            hub,
+            vendor,
+            resolved: OnceCell::new(),
+        }
+    }
+
+    /// Lazily resolves and returns the plugin client.
+    async fn get_plugin(&self) -> Result<Arc<dyn TenantResolverPluginClient>, DomainError> {
+        let resolved = self
+            .resolved
+            .get_or_try_init(|| self.resolve_plugin())
+            .await?;
+
+        self.hub
+            .get_scoped::<dyn TenantResolverPluginClient>(&resolved.scope)
+            .map_err(|_| DomainError::PluginClientNotFound {
+                gts_id: resolved.gts_id.clone(),
+            })
+    }
+
+    /// Resolves the plugin instance from types-registry.
+    #[tracing::instrument(skip_all, fields(vendor = %self.vendor))]
+    async fn resolve_plugin(&self) -> Result<ResolvedPlugin, DomainError> {
+        info!("Resolving tenant resolver plugin");
+
+        let registry = self
+            .hub
+            .get::<dyn TypesRegistryApi>()
+            .map_err(|e| DomainError::TypesRegistryUnavailable(e.to_string()))?;
+
+        let plugin_type_id = TenantResolverPluginSpecV1::gts_schema_id().clone();
+
+        let instances = registry
+            .list(
+                ListQuery::new()
+                    .with_pattern(format!("{plugin_type_id}*"))
+                    .with_is_type(false),
+            )
+            .await?;
+
+        let gts_id = choose_plugin_instance(&self.vendor, &instances)?;
+        info!(plugin_gts_id = %gts_id, "Selected tenant resolver plugin instance");
+
+        let scope = ClientScope::gts_id(&gts_id);
+        Ok(ResolvedPlugin { gts_id, scope })
+    }
+
+    /// Get tenant information by ID.
+    ///
+    /// Returns tenant info regardless of status - the consumer can decide
+    /// how to handle different statuses.
+    ///
+    /// # Errors
+    ///
+    /// - `Unauthorized` if security context has no tenant
+    /// - `TenantNotFound` if tenant doesn't exist
+    /// - Plugin resolution errors
+    #[tracing::instrument(skip_all, fields(tenant.id = %id))]
+    pub async fn get_tenant(
+        &self,
+        ctx: &SecurityContext,
+        id: TenantId,
+    ) -> Result<TenantInfo, DomainError> {
+        require_tenant_context(ctx)?;
+        let plugin = self.get_plugin().await?;
+        plugin.get_tenant(ctx, id).await.map_err(DomainError::from)
+    }
+
+    /// Check if current tenant can access target tenant.
+    ///
+    /// Access rules (including self-access, status-based, and permission-based)
+    /// are plugin-determined.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` if access is allowed
+    /// - `Ok(false)` if target exists but access is denied
+    ///
+    /// # Errors
+    ///
+    /// - `Unauthorized` if security context has no tenant
+    /// - `TenantNotFound` if target tenant doesn't exist
+    pub async fn can_access(
+        &self,
+        ctx: &SecurityContext,
+        target: TenantId,
+        options: Option<&AccessOptions>,
+    ) -> Result<bool, DomainError> {
+        require_tenant_context(ctx)?;
+        let plugin = self.get_plugin().await?;
+        plugin
+            .can_access(ctx, target, options)
+            .await
+            .map_err(DomainError::from)
+    }
+
+    /// Get all tenants accessible by the current tenant.
+    ///
+    /// # Errors
+    ///
+    /// - `Unauthorized` if security context has no tenant
+    /// - Plugin resolution errors
+    pub async fn get_accessible_tenants(
+        &self,
+        ctx: &SecurityContext,
+        filter: Option<&TenantFilter>,
+        options: Option<&AccessOptions>,
+    ) -> Result<Vec<TenantInfo>, DomainError> {
+        require_tenant_context(ctx)?;
+        let plugin = self.get_plugin().await?;
+        plugin
+            .get_accessible_tenants(ctx, filter, options)
+            .await
+            .map_err(DomainError::from)
+    }
+}
+
+/// Validates that the security context has a tenant ID.
+///
+/// Returns `Unauthorized` if the context has no tenant (nil UUID).
+fn require_tenant_context(ctx: &SecurityContext) -> Result<(), DomainError> {
+    if ctx.tenant_id() == Uuid::nil() {
+        return Err(DomainError::Unauthorized);
+    }
+    Ok(())
+}
+
+/// Selects the best plugin instance for the given vendor.
+///
+/// If multiple instances match, the one with lowest priority wins.
+#[tracing::instrument(skip_all, fields(vendor, instance_count = instances.len()))]
+fn choose_plugin_instance(vendor: &str, instances: &[GtsEntity]) -> Result<String, DomainError> {
+    let mut best: Option<(String, i16)> = None;
+
+    for ent in instances {
+        let content: BaseModkitPluginV1<TenantResolverPluginSpecV1> =
+            serde_json::from_value(ent.content.clone()).map_err(|e| {
+                tracing::error!(
+                    gts_id = %ent.gts_id,
+                    error = %e,
+                    "Failed to deserialize plugin instance content"
+                );
+                DomainError::InvalidPluginInstance {
+                    gts_id: ent.gts_id.clone(),
+                    reason: e.to_string(),
+                }
+            })?;
+
+        if content.id != ent.gts_id {
+            return Err(DomainError::InvalidPluginInstance {
+                gts_id: ent.gts_id.clone(),
+                reason: format!(
+                    "content.id mismatch: expected {:?}, got {:?}",
+                    ent.gts_id, content.id
+                ),
+            });
+        }
+
+        if content.vendor != vendor {
+            continue;
+        }
+
+        match &best {
+            None => best = Some((ent.gts_id.clone(), content.priority)),
+            Some((_, cur_priority)) => {
+                if content.priority < *cur_priority {
+                    best = Some((ent.gts_id.clone(), content.priority));
+                }
+            }
+        }
+    }
+
+    best.map(|(gts_id, _)| gts_id)
+        .ok_or_else(|| DomainError::PluginNotFound {
+            vendor: vendor.to_owned(),
+        })
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    fn anonymous_ctx() -> SecurityContext {
+        SecurityContext::anonymous()
+    }
+
+    #[test]
+    fn require_tenant_context_rejects_anonymous() {
+        let ctx = anonymous_ctx();
+        let result = require_tenant_context(&ctx);
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), DomainError::Unauthorized));
+    }
+
+    #[test]
+    fn require_tenant_context_accepts_valid_tenant() {
+        let ctx = SecurityContext::builder().tenant_id(Uuid::new_v4()).build();
+        let result = require_tenant_context(&ctx);
+
+        assert!(result.is_ok());
+    }
+
+    // Integration tests for Service methods require a mock plugin setup.
+    // These tests verify the early-return behavior for anonymous context.
+
+    mod service_anonymous_context {
+        use super::*;
+        use modkit::client_hub::ClientHub;
+        use std::sync::Arc;
+
+        fn create_service() -> Service {
+            // Create a minimal Service. Plugin resolution will never be reached
+            // because anonymous context check fails first.
+            let hub = Arc::new(ClientHub::new());
+            Service::new(hub, "test-vendor".to_owned())
+        }
+
+        #[tokio::test]
+        async fn get_tenant_rejects_anonymous_context() {
+            let service = create_service();
+            let ctx = anonymous_ctx();
+            let tenant_id = Uuid::new_v4();
+
+            let result = service.get_tenant(&ctx, tenant_id).await;
+
+            assert!(result.is_err());
+            assert!(matches!(result.unwrap_err(), DomainError::Unauthorized));
+        }
+
+        #[tokio::test]
+        async fn can_access_rejects_anonymous_context() {
+            let service = create_service();
+            let ctx = anonymous_ctx();
+            let target_id = Uuid::new_v4();
+
+            let result = service.can_access(&ctx, target_id, None).await;
+
+            assert!(result.is_err());
+            assert!(matches!(result.unwrap_err(), DomainError::Unauthorized));
+        }
+
+        #[tokio::test]
+        async fn get_accessible_tenants_rejects_anonymous_context() {
+            let service = create_service();
+            let ctx = anonymous_ctx();
+
+            let result = service.get_accessible_tenants(&ctx, None, None).await;
+
+            assert!(result.is_err());
+            assert!(matches!(result.unwrap_err(), DomainError::Unauthorized));
+        }
+    }
+}

--- a/modules/system/tenant_resolver/tenant_resolver-gw/src/lib.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/src/lib.rs
@@ -1,0 +1,11 @@
+//! Tenant Resolver Gateway Module
+//!
+//! This module discovers tenant resolver plugins via types-registry
+//! and routes API calls to the selected plugin based on vendor configuration.
+//!
+//! The gateway provides the `TenantResolverGatewayClient` trait registered
+//! in `ClientHub` for consumption by other modules.
+
+pub mod config;
+pub mod domain;
+pub mod module;

--- a/modules/system/tenant_resolver/tenant_resolver-gw/src/module.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/src/module.rs
@@ -1,0 +1,75 @@
+//! Tenant resolver gateway module.
+
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use hs_tenant_resolver_sdk::{TenantResolverGatewayClient, TenantResolverPluginSpecV1};
+use modkit::context::ModuleCtx;
+use modkit::Module;
+use tracing::info;
+use types_registry_sdk::TypesRegistryApi;
+
+use crate::config::TenantResolverGwConfig;
+use crate::domain::{Service, TenantResolverGwLocalClient};
+
+/// Tenant Resolver Gateway module.
+///
+/// This module:
+/// 1. Registers the plugin schema in types-registry
+/// 2. Discovers plugin instances via types-registry
+/// 3. Routes requests to the selected plugin based on vendor configuration
+///
+/// Plugin discovery is lazy: happens on first API call after types-registry
+/// is ready.
+#[modkit::module(
+    name = "tenant_resolver",
+    deps = ["types_registry"],
+    capabilities = []
+)]
+pub(crate) struct TenantResolverGateway {
+    service: OnceLock<Arc<Service>>,
+}
+
+impl Default for TenantResolverGateway {
+    fn default() -> Self {
+        Self {
+            service: OnceLock::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Module for TenantResolverGateway {
+    #[tracing::instrument(skip_all, fields(vendor))]
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        let cfg: TenantResolverGwConfig = ctx.config()?;
+        tracing::Span::current().record("vendor", cfg.vendor.as_str());
+        info!(vendor = %cfg.vendor, "Initializing tenant_resolver gateway");
+
+        // Register plugin schema in types-registry
+        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+        let schema_str = TenantResolverPluginSpecV1::gts_schema_with_refs_as_string();
+        let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
+        let _ = registry.register(vec![schema_json]).await?;
+        info!(
+            schema_id = %TenantResolverPluginSpecV1::gts_schema_id(),
+            "Registered plugin schema in types-registry"
+        );
+
+        // Create service
+        let hub = ctx.client_hub();
+        let svc = Arc::new(Service::new(hub, cfg.vendor));
+
+        // Register gateway client in ClientHub
+        let api: Arc<dyn TenantResolverGatewayClient> =
+            Arc::new(TenantResolverGwLocalClient::new(svc.clone()));
+        ctx.client_hub()
+            .register::<dyn TenantResolverGatewayClient>(api);
+
+        self.service
+            .set(svc)
+            .map_err(|_| anyhow::anyhow!("Service already initialized"))?;
+
+        Ok(())
+    }
+}

--- a/modules/system/tenant_resolver/tenant_resolver-sdk/Cargo.toml
+++ b/modules/system/tenant_resolver/tenant_resolver-sdk/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "hs-tenant-resolver-sdk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "SDK for tenant_resolver module: API traits, models, and error definitions"
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = { workspace = true }
+
+# GTS types
+gts = { workspace = true }
+gts-macros = { workspace = true }
+
+# ModKit dependencies
+modkit = { path = "../../../../libs/modkit" }
+modkit-security = { path = "../../../../libs/modkit-security" }
+modkit-odata = { path = "../../../../libs/modkit-odata" }

--- a/modules/system/tenant_resolver/tenant_resolver-sdk/README.md
+++ b/modules/system/tenant_resolver/tenant_resolver-sdk/README.md
@@ -1,0 +1,12 @@
+# Tenant Resolver SDK
+
+Public API traits and models for tenant resolution.
+
+See [../README.md](../README.md) for full documentation.
+
+## Quick Reference
+
+- `TenantResolverGatewayClient` - Public API for consumers
+- `TenantResolverPluginClient` - API for plugin implementations
+- `TenantInfo`, `TenantStatus` - Domain models
+- `TenantResolverError` - Error types

--- a/modules/system/tenant_resolver/tenant_resolver-sdk/src/api.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-sdk/src/api.rs
@@ -1,0 +1,103 @@
+//! Public API trait for the tenant resolver gateway.
+//!
+//! This trait defines the interface that consumers use to interact with
+//! the tenant resolver. The gateway implements this trait and delegates
+//! to the appropriate plugin.
+
+use async_trait::async_trait;
+use modkit_security::SecurityContext;
+
+use crate::error::TenantResolverError;
+use crate::models::{AccessOptions, TenantFilter, TenantId, TenantInfo};
+
+/// Public API trait for the tenant resolver gateway.
+///
+/// This trait is registered in `ClientHub` by the gateway module and
+/// can be consumed by other modules:
+///
+/// ```ignore
+/// let resolver = hub.get::<dyn TenantResolverGatewayClient>()?;
+///
+/// // Get tenant info
+/// let tenant = resolver.get_tenant(&ctx, tenant_id).await?;
+///
+/// // Check basic access
+/// let can = resolver.can_access(&ctx, target_id, None).await?;
+///
+/// // Get accessible tenants with filter
+/// let filter = TenantFilter { status: vec![TenantStatus::Active], ..Default::default() };
+/// let tenants = resolver.get_accessible_tenants(&ctx, Some(&filter), None).await?;
+/// ```
+///
+/// The source tenant for access checks is always taken from `ctx.tenant_id()`.
+#[async_trait]
+pub trait TenantResolverGatewayClient: Send + Sync {
+    /// Get tenant information by ID.
+    ///
+    /// Returns tenant info regardless of status - the consumer can decide
+    /// how to handle different statuses (active, suspended, deleted).
+    ///
+    /// # Errors
+    ///
+    /// - `TenantNotFound` if the tenant does not exist
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Security context (`tenant_id` used for access control)
+    /// * `id` - The tenant ID to retrieve
+    async fn get_tenant(
+        &self,
+        ctx: &SecurityContext,
+        id: TenantId,
+    ) -> Result<TenantInfo, TenantResolverError>;
+
+    /// Check if the current tenant can access the target tenant's data.
+    ///
+    /// The source tenant is taken from `ctx.tenant_id()`.
+    /// Access rules (including status-based restrictions) are plugin-determined.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` if access is allowed
+    /// - `Ok(false)` if target exists but access is denied
+    ///
+    /// # Errors
+    ///
+    /// - `TenantNotFound` if the target tenant doesn't exist
+    ///
+    /// # Access Rules
+    ///
+    /// - Self-access: A tenant can always access its own data
+    /// - Non-transitive: A→B and B→C does NOT imply A→C
+    /// - Non-symmetric: A→B does NOT imply B→A
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Security context (`tenant_id` is the source tenant)
+    /// * `target` - The target tenant ID to check access for
+    /// * `options` - Optional access options (e.g., required permissions)
+    async fn can_access(
+        &self,
+        ctx: &SecurityContext,
+        target: TenantId,
+        options: Option<&AccessOptions>,
+    ) -> Result<bool, TenantResolverError>;
+
+    /// Get all tenants that the current tenant can access.
+    ///
+    /// The source tenant is taken from `ctx.tenant_id()`.
+    /// The result includes the source tenant itself (self-access),
+    /// provided it matches the filter criteria.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Security context (`tenant_id` is the source tenant)
+    /// * `filter` - Optional filter criteria (e.g., id, status)
+    /// * `options` - Optional access options (e.g., required permissions)
+    async fn get_accessible_tenants(
+        &self,
+        ctx: &SecurityContext,
+        filter: Option<&TenantFilter>,
+        options: Option<&AccessOptions>,
+    ) -> Result<Vec<TenantInfo>, TenantResolverError>;
+}

--- a/modules/system/tenant_resolver/tenant_resolver-sdk/src/error.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-sdk/src/error.rs
@@ -1,0 +1,36 @@
+//! Error types for the tenant resolver module.
+
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Errors that can occur when using the tenant resolver API.
+#[derive(Debug, Error)]
+pub enum TenantResolverError {
+    /// The requested target tenant was not found.
+    #[error("tenant not found: {tenant_id}")]
+    TenantNotFound {
+        /// The tenant ID that was not found.
+        tenant_id: Uuid,
+    },
+
+    /// Access to target tenant is denied.
+    ///
+    /// The source tenant is available from the security context.
+    #[error("access denied to tenant: {target_tenant}")]
+    AccessDenied {
+        /// The target tenant being accessed.
+        target_tenant: Uuid,
+    },
+
+    /// The request is not authorized.
+    #[error("unauthorized")]
+    Unauthorized,
+
+    /// No plugin is available to handle the request.
+    #[error("no plugin available")]
+    NoPluginAvailable,
+
+    /// An internal error occurred.
+    #[error("internal error: {0}")]
+    Internal(String),
+}

--- a/modules/system/tenant_resolver/tenant_resolver-sdk/src/gts.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-sdk/src/gts.rs
@@ -1,0 +1,47 @@
+//! GTS schema definitions for tenant resolver plugins.
+//!
+//! This module defines the GTS type for tenant resolver plugin instances.
+//! Plugins register instances of this type with the types-registry to be
+//! discovered by the gateway.
+
+use gts_macros::struct_to_gts_schema;
+use modkit::gts::BaseModkitPluginV1;
+
+/// GTS type definition for tenant resolver plugin instances.
+///
+/// Each plugin registers an instance of this type with its vendor-specific
+/// instance ID. The gateway discovers plugins by querying types-registry
+/// for instances matching this schema.
+///
+/// # Instance ID Format
+///
+/// ```text
+/// gts.x.core.modkit.plugin.v1~<vendor>.<package>.tenant_resolver.plugin.v1~
+/// ```
+///
+/// # Example
+///
+/// ```ignore
+/// // Plugin generates its instance ID
+/// let instance_id = TenantResolverPluginSpecV1::gts_make_instance_id(
+///     "hyperspot.builtin.static_tenant_resolver.plugin.v1"
+/// );
+///
+/// // Plugin creates instance data
+/// let instance = BaseModkitPluginV1::<TenantResolverPluginSpecV1> {
+///     id: instance_id.clone(),
+///     priority: 100,
+///     properties: TenantResolverPluginSpecV1,
+/// };
+///
+/// // Register with types-registry
+/// registry.register(&ctx, vec![serde_json::to_value(&instance)?]).await?;
+/// ```
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = BaseModkitPluginV1,
+    schema_id = "gts.x.core.modkit.plugin.v1~x.core.tenant_resolver.plugin.v1~",
+    description = "Tenant Resolver plugin specification",
+    properties = ""
+)]
+pub struct TenantResolverPluginSpecV1;

--- a/modules/system/tenant_resolver/tenant_resolver-sdk/src/lib.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-sdk/src/lib.rs
@@ -1,0 +1,42 @@
+//! Tenant Resolver SDK
+//!
+//! This crate provides the public API for the `tenant_resolver` module:
+//!
+//! - [`TenantResolverGatewayClient`] - Public API trait for consumers
+//! - [`TenantResolverPluginClient`] - Plugin API trait for implementations
+//! - [`TenantInfo`], [`TenantStatus`] - Domain models
+//! - [`TenantResolverError`] - Error types
+//! - [`TenantResolverPluginSpecV1`] - GTS schema for plugin discovery
+//!
+//! ## Usage
+//!
+//! Consumers obtain the client from `ClientHub`:
+//!
+//! ```ignore
+//! use tenant_resolver_sdk::TenantResolverGatewayClient;
+//!
+//! // Get the client from ClientHub
+//! let resolver = hub.get::<dyn TenantResolverGatewayClient>()?;
+//!
+//! // Get tenant info
+//! let tenant = resolver.get_tenant(&ctx, tenant_id).await?;
+//!
+//! // Check access
+//! let can_access = resolver.can_access(&ctx, target_tenant_id).await?;
+//!
+//! // Get all accessible tenants
+//! let accessible = resolver.get_accessible_tenants(&ctx, query).await?;
+//! ```
+
+pub mod api;
+pub mod error;
+pub mod gts;
+pub mod models;
+pub mod plugin_api;
+
+// Re-export main types at crate root
+pub use api::TenantResolverGatewayClient;
+pub use error::TenantResolverError;
+pub use gts::TenantResolverPluginSpecV1;
+pub use models::{AccessOptions, TenantFilter, TenantId, TenantInfo, TenantStatus};
+pub use plugin_api::TenantResolverPluginClient;

--- a/modules/system/tenant_resolver/tenant_resolver-sdk/src/models.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-sdk/src/models.rs
@@ -1,0 +1,116 @@
+//! Domain models for the tenant resolver module.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Unique identifier for a tenant.
+pub type TenantId = Uuid;
+
+/// Information about a tenant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TenantInfo {
+    /// Unique tenant identifier.
+    pub id: TenantId,
+    /// Human-readable tenant name.
+    pub name: String,
+    /// Current status of the tenant.
+    pub status: TenantStatus,
+    /// Tenant type classification.
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
+    pub tenant_type: Option<String>,
+}
+
+/// Tenant lifecycle status.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TenantStatus {
+    /// Tenant is active and operational.
+    #[default]
+    Active,
+    /// Tenant is temporarily suspended.
+    Suspended,
+    /// Tenant has been deleted (soft delete).
+    Deleted,
+}
+
+/// Filter for tenant listing queries.
+///
+/// Used by `get_accessible_tenants` to filter results.
+/// Empty vectors mean "no constraint" (include all).
+///
+/// # Example
+///
+/// ```
+/// use hs_tenant_resolver_sdk::{TenantFilter, TenantStatus};
+/// use uuid::Uuid;
+///
+/// // No filter (all tenants)
+/// let filter = TenantFilter::default();
+///
+/// // Only active tenants
+/// let filter = TenantFilter {
+///     status: vec![TenantStatus::Active],
+///     ..Default::default()
+/// };
+///
+/// // Specific tenant IDs with active status
+/// let tenant_a = Uuid::new_v4();
+/// let tenant_b = Uuid::new_v4();
+/// let filter = TenantFilter {
+///     id: vec![tenant_a, tenant_b],
+///     status: vec![TenantStatus::Active],
+/// };
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TenantFilter {
+    /// Filter by tenant IDs. Empty means all IDs are included.
+    pub id: Vec<TenantId>,
+    /// Filter by tenant status. Empty means all statuses are included.
+    pub status: Vec<TenantStatus>,
+}
+
+impl TenantFilter {
+    /// Returns `true` if no filter criteria are set.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.id.is_empty() && self.status.is_empty()
+    }
+}
+
+/// Options for access checking.
+///
+/// Used by `can_access` and `get_accessible_tenants` to specify
+/// permission requirements. Empty vectors mean "no constraint".
+///
+/// # Example
+///
+/// ```
+/// use hs_tenant_resolver_sdk::AccessOptions;
+///
+/// // Basic access check (no specific permission required)
+/// let options = AccessOptions::default();
+///
+/// // Check for specific permission
+/// let options = AccessOptions {
+///     permission: vec!["read".to_string()],
+/// };
+///
+/// // Check for multiple permissions (all required - AND semantics)
+/// let options = AccessOptions {
+///     permission: vec!["read".to_string(), "write".to_string()],
+/// };
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AccessOptions {
+    /// Required permissions (all must be satisfied - AND semantics).
+    /// Empty means no specific permission required.
+    pub permission: Vec<String>,
+}
+
+impl AccessOptions {
+    /// Returns `true` if no access options are set.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.permission.is_empty()
+    }
+}

--- a/modules/system/tenant_resolver/tenant_resolver-sdk/src/plugin_api.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-sdk/src/plugin_api.rs
@@ -1,0 +1,90 @@
+//! Plugin API trait for tenant resolver implementations.
+//!
+//! Plugins implement this trait to provide tenant data and access rules.
+//! The gateway discovers plugins via GTS types-registry and delegates
+//! API calls to the selected plugin.
+
+use async_trait::async_trait;
+use modkit_security::SecurityContext;
+
+use crate::error::TenantResolverError;
+use crate::models::{AccessOptions, TenantFilter, TenantId, TenantInfo};
+
+/// Plugin API trait for tenant resolver implementations.
+///
+/// Each plugin registers this trait with a scoped `ClientHub` entry
+/// using its GTS instance ID as the scope.
+///
+/// The gateway calls these methods after applying cross-cutting concerns
+/// (e.g., self-access check).
+#[async_trait]
+pub trait TenantResolverPluginClient: Send + Sync {
+    /// Get tenant information by ID.
+    ///
+    /// Returns tenant info regardless of status - status filtering is only
+    /// applied in `get_accessible_tenants`.
+    ///
+    /// # Errors
+    ///
+    /// - `TenantNotFound` if the tenant doesn't exist in the plugin's data source
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Security context
+    /// * `id` - The tenant ID to retrieve
+    async fn get_tenant(
+        &self,
+        ctx: &SecurityContext,
+        id: TenantId,
+    ) -> Result<TenantInfo, TenantResolverError>;
+
+    /// Check if source tenant can access target tenant's data.
+    ///
+    /// The source tenant is taken from `ctx.tenant_id()`.
+    /// Access rules (including status-based and permission-based) are
+    /// plugin-determined.
+    ///
+    /// Note: Gateway already handles self-access (source == target).
+    /// Plugin should check its access rules for cross-tenant access.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` if access is allowed
+    /// - `Ok(false)` if target exists but access is denied
+    ///
+    /// # Errors
+    ///
+    /// - `TenantNotFound` if the target tenant doesn't exist
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Security context (source tenant from `ctx.tenant_id()`)
+    /// * `target` - The target tenant ID to check
+    /// * `options` - Optional access options (e.g., required permissions)
+    async fn can_access(
+        &self,
+        ctx: &SecurityContext,
+        target: TenantId,
+        options: Option<&AccessOptions>,
+    ) -> Result<bool, TenantResolverError>;
+
+    /// Get all tenants accessible by the source tenant.
+    ///
+    /// The source tenant is taken from `ctx.tenant_id()`.
+    ///
+    /// Note: Gateway ensures the source tenant is included in the result.
+    /// Plugin should return tenants accessible via its access rules,
+    /// filtered by the provided criteria.
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Security context (source tenant from `ctx.tenant_id()`)
+    /// * `filter` - Optional filter criteria (e.g., id, status)
+    /// * `options` - Optional access options (e.g., required permissions)
+    async fn get_accessible_tenants(
+        &self,
+        ctx: &SecurityContext,
+        filter: Option<&TenantFilter>,
+        options: Option<&AccessOptions>,
+    ) -> Result<Vec<TenantInfo>, TenantResolverError>;
+}

--- a/modules/system/types-registry/types-registry-sdk/src/api.rs
+++ b/modules/system/types-registry/types-registry-sdk/src/api.rs
@@ -1,10 +1,9 @@
 //! `TypesRegistryApi` trait definition.
 //!
 //! This trait defines the public API for the `types-registry` module.
-//! All methods require a `SecurityContext` for authorization and access control.
+//! GTS schemas and instances are global resources, so no security context is required.
 
 use async_trait::async_trait;
-use modkit_security::SecurityContext;
 
 use crate::error::TypesRegistryError;
 use crate::models::{GtsEntity, ListQuery, RegisterResult};
@@ -14,10 +13,11 @@ use crate::models::{GtsEntity, ListQuery, RegisterResult};
 /// This trait can be consumed by other modules via `ClientHub`:
 /// ```ignore
 /// let client = hub.get::<dyn TypesRegistryApi>()?;
-/// let entity = client.get(&ctx, "gts.acme.core.events.user_created.v1~").await?;
+/// let entity = client.get("gts.acme.core.events.user_created.v1~").await?;
 /// ```
 ///
-/// All methods require a `SecurityCtx` for proper authorization and access control.
+/// GTS schemas and instances are global resources (not tenant-scoped),
+/// so no security context is required for these operations.
 #[async_trait]
 pub trait TypesRegistryApi: Send + Sync {
     /// Register GTS entities (types or instances) in batch.
@@ -27,7 +27,6 @@ pub trait TypesRegistryApi: Send + Sync {
     ///
     /// # Arguments
     ///
-    /// * `ctx` - Security context for authorization
     /// * `entities` - JSON values representing GTS entities to register
     ///
     /// # Returns
@@ -41,7 +40,7 @@ pub trait TypesRegistryApi: Send + Sync {
     /// # Example
     ///
     /// ```ignore
-    /// let results = registry.register(&ctx, entities).await?;
+    /// let results = registry.register(entities).await?;
     /// let summary = RegisterSummary::from_results(&results);
     /// println!("Registered {}/{} entities", summary.succeeded, summary.total());
     ///
@@ -61,7 +60,6 @@ pub trait TypesRegistryApi: Send + Sync {
     /// Per-item errors are returned in the `RegisterResult::Err` variant.
     async fn register(
         &self,
-        ctx: &SecurityContext,
         entities: Vec<serde_json::Value>,
     ) -> Result<Vec<RegisterResult>, TypesRegistryError>;
 
@@ -69,23 +67,17 @@ pub trait TypesRegistryApi: Send + Sync {
     ///
     /// # Arguments
     ///
-    /// * `ctx` - Security context for authorization
     /// * `query` - Query parameters for filtering results
     ///
     /// # Returns
     ///
     /// A vector of `GtsEntity` objects matching the query.
-    async fn list(
-        &self,
-        ctx: &SecurityContext,
-        query: ListQuery,
-    ) -> Result<Vec<GtsEntity>, TypesRegistryError>;
+    async fn list(&self, query: ListQuery) -> Result<Vec<GtsEntity>, TypesRegistryError>;
 
     /// Retrieve a single GTS entity by its identifier.
     ///
     /// # Arguments
     ///
-    /// * `ctx` - Security context for authorization
     /// * `gts_id` - The GTS identifier string
     ///
     /// # Returns
@@ -96,9 +88,5 @@ pub trait TypesRegistryApi: Send + Sync {
     ///
     /// * `NotFound` - If no entity with the given GTS ID exists
     /// * `InvalidGtsId` - If the GTS ID format is invalid
-    async fn get(
-        &self,
-        ctx: &SecurityContext,
-        gts_id: &str,
-    ) -> Result<GtsEntity, TypesRegistryError>;
+    async fn get(&self, gts_id: &str) -> Result<GtsEntity, TypesRegistryError>;
 }

--- a/modules/system/types-registry/types-registry/src/module.rs
+++ b/modules/system/types-registry/types-registry/src/module.rs
@@ -7,7 +7,6 @@ use modkit::api::OpenApiRegistry;
 use modkit::contracts::SystemModule;
 use modkit::gts::get_core_gts_schemas; // NOTE: This is temporary logic until <https://github.com/hypernetix/hyperspot/issues/156> resolved
 use modkit::{Module, ModuleCtx, RestfulModule};
-use modkit_security::SecurityContext;
 use tracing::{debug, info};
 use types_registry_sdk::TypesRegistryApi;
 
@@ -80,7 +79,7 @@ impl Module for TypesRegistryModule {
         // Register core GTS types that other modules depend on.
         // This must happen before any module registers derived schemas/instances.
         let core_schemas = get_core_gts_schemas()?;
-        api.register(&SecurityContext::root(), core_schemas).await?;
+        api.register(core_schemas).await?;
         info!("Core GTS types registered");
 
         ctx.client_hub().register::<dyn TypesRegistryApi>(api);


### PR DESCRIPTION
Add tenant resolver module for multi-tenant access control:
- SDK with TenantResolverGatewayClient and TenantResolverPluginClient APIs
- Gateway module with GTS-based plugin discovery and routing
- Static plugin for config-driven tenant access rules
- Single-tenant plugin for simple deployments
- Integrate with api_gateway and users_info example
- Simplify TypesRegistryApi by removing SecurityCtx from signatures
- Rename ROOT_TENANT_ID to DEFAULT_TENANT_ID for better following topology-agnostic approach

closes #109