### PR TITLE
tech(modkit) Move core GTS types registration out of types_registry m…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.10"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15580ece6ea97cbf832d60ba19c021113469480852c6a2a6beb0db28f097bf1f"
+checksum = "16e4850548ff4a25a77ce3bda7241874e17fb702ea551f0cc62a2dbe052f1272"
 dependencies = [
  "anstyle",
  "unicode-width",
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -906,6 +906,7 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "uuid",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -1412,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1422,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1434,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1528,6 +1529,7 @@ dependencies = [
  "tenant-resolver-sdk",
  "thiserror 2.0.18",
  "tracing",
+ "types",
 ]
 
 [[package]]
@@ -2179,6 +2181,7 @@ dependencies = [
  "tenant-resolver-sdk",
  "thiserror 2.0.18",
  "tracing",
+ "types",
 ]
 
 [[package]]
@@ -2277,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -3032,15 +3035,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "types",
  "users_info",
  "uuid",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -3674,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "neli"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23bebbf3e157c402c4d5ee113233e5e0610cc27453b2f07eefce649c7365dcc"
+checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -6253,6 +6257,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "types",
  "utoipa",
 ]
 
@@ -6556,9 +6561,9 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
 dependencies = [
  "async-trait",
  "axum",
@@ -6585,9 +6590,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
+checksum = "27aac809edf60b741e2d7db6367214d078856b8a5bff0087e94ff330fb97b6fc"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -6597,9 +6602,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
 dependencies = [
  "bytes",
  "prost",
@@ -6608,9 +6613,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
+checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -6841,6 +6846,33 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "types"
+version = "0.1.5"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "cf-modkit",
+ "cf-modkit-security",
+ "cf-types-registry-sdk",
+ "inventory",
+ "tracing",
+ "types-sdk",
+]
+
+[[package]]
+name = "types-sdk"
+version = "0.1.5"
+dependencies = [
+ "async-trait",
+ "cf-modkit-odata",
+ "cf-modkit-security",
+ "thiserror 2.0.18",
+ "time",
+ "uuid",
+]
 
 [[package]]
 name = "uncased"
@@ -7733,18 +7765,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.34"
+version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ddd76bcebeed25db614f82bf31a9f4222d3fbba300e6fb6c00afa26cbd4d9d"
+checksum = "dafd85c832c1b68bbb4ec0c72c7f6f4fc5179627d2bc7c26b30e4c0cc11e76cc"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.34"
+version = "0.8.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8187381b52e32220d50b255276aa16a084ec0a9017a0ca2152a1f55c539758d"
+checksum = "7cb7e4e8436d9db52fbd6625dbf2f45243ab84994a72882ec8227b99e72b439a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ members = [
     "examples/oop-modules/calculator/calculator",
     "modules/system/types_registry/types_registry-sdk",
     "modules/system/types_registry/types_registry",
+    "modules/system/types-sdk",
+    "modules/system/types",
     "modules/simple_user_settings/simple_user_settings_sdk",
     "modules/simple_user_settings/simple_user_settings",
     "examples/plugin-modules/tenant_resolver/tenant_resolver-sdk",

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -36,6 +36,7 @@ modkit-db = { workspace = true, features = ["sqlite", "pg"] }
 api_gateway = { package = "cf-api-gateway", path = "../../modules/system/api_gateway" }
 grpc_hub = { package = "cf-grpc-hub", path = "../../modules/system/grpc_hub" }
 module_orchestrator = { package = "cf-module-orchestrator", path = "../../modules/system/module_orchestrator" }
+types = { path = "../../modules/system/types" }
 types_registry = { package = "cf-types-registry", path = "../../modules/system/types_registry/types_registry" }
 tenant-resolver-gw = { package = "cf-tenant-resolver-gw", path = "../../modules/system/tenant_resolver/tenant_resolver-gw" }
 

--- a/apps/hyperspot-server/src/registered_modules.rs
+++ b/apps/hyperspot-server/src/registered_modules.rs
@@ -10,6 +10,7 @@ use module_orchestrator as _;
 use nodes_registry as _;
 use simple_user_settings as _;
 use tenant_resolver_gw as _;
+use types as _;
 use types_registry as _;
 
 #[cfg(feature = "single-tenant")]

--- a/examples/plugin-modules/tenant_resolver/plugins/contoso_tr_plugin/Cargo.toml
+++ b/examples/plugin-modules/tenant_resolver/plugins/contoso_tr_plugin/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 tenant-resolver-example-sdk = { package = "tenant-resolver-sdk", path = "../../tenant_resolver-sdk" }
 types-registry-sdk = { workspace = true }
 modkit = { workspace = true }
+types = { path = "../../../../../modules/system/types" }
 modkit-security = { workspace = true }
 modkit-odata = { workspace = true }
 async-trait = { workspace = true }

--- a/examples/plugin-modules/tenant_resolver/plugins/fabrikam_tr_plugin/Cargo.toml
+++ b/examples/plugin-modules/tenant_resolver/plugins/fabrikam_tr_plugin/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 tenant-resolver-example-sdk = { package = "tenant-resolver-sdk", path = "../../tenant_resolver-sdk" }
 types-registry-sdk = { workspace = true }
 modkit = { workspace = true }
+types = { path = "../../../../../modules/system/types" }
 modkit-security = { workspace = true }
 modkit-odata = { workspace = true }
 async-trait = { workspace = true }

--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/Cargo.toml
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/Cargo.toml
@@ -20,6 +20,7 @@ types-registry-sdk = { workspace = true }
 
 # ModKit
 modkit = { workspace = true }
+types = { path = "../../../../modules/system/types" }
 modkit-security = { workspace = true }
 modkit-odata = { workspace = true, features = ["with-utoipa"] }
 modkit-macros = { workspace = true }

--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/module.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/module.rs
@@ -33,8 +33,8 @@ use crate::domain::service::Service;
 /// plugins in a build, add them to `registered_modules.rs` in the server
 /// binary or use Cargo feature flags.
 #[modkit::module(
-    name = "tenant_resolver_gateway",
-    deps = ["types_registry"],
+    name = "tenant_resolver_gw",
+    deps = ["types_registry", "types"],
     capabilities = [rest]
 )]
 pub struct TenantResolverGateway {

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -84,6 +84,7 @@ schemars = { workspace = true, features = ["derive"] }
 # GTS support
 gts = { workspace = true }
 gts-macros = { workspace = true }
+zip = { version = "2.3", default-features = false, features = ["deflate"] }
 
 # Performance / lock-free structures
 parking_lot = { workspace = true }
@@ -111,6 +112,9 @@ tonic = { workspace = true, optional = true }
 # Unix-specific dependencies for graceful process termination
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", default-features = false, features = ["signal"] }
+
+[build-dependencies]
+zip = { version = "2.3", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tower = { workspace = true }

--- a/libs/modkit/build.rs
+++ b/libs/modkit/build.rs
@@ -1,0 +1,72 @@
+use std::env;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::Path;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = env::var("OUT_DIR")?;
+    let dest_path = Path::new(&out_dir).join("core_gts_schemas.zip");
+
+    let schemas_dir = "schemas";
+
+    // Validate presence of schemas_dir and manifest.json up front
+    if !Path::new(schemas_dir).exists() {
+        return Err("schemas directory not found".into());
+    }
+    let manifest_path = Path::new(schemas_dir).join("manifest.json");
+    if !manifest_path.exists() {
+        return Err("manifest.json not found in schemas directory".into());
+    }
+
+    // Create ZIP archive containing all schema files
+    let file = File::create(&dest_path)?;
+    let mut zip = zip::ZipWriter::new(file);
+
+    // Add manifest.json
+    let buffer = std::fs::read(&manifest_path)?;
+
+    let options = zip::write::FileOptions::<()>::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .unix_permissions(0o755);
+    zip.start_file("manifest.json", options)?;
+    zip.write_all(&buffer)?;
+
+    // Add all .schema.json files
+    if Path::new(schemas_dir).exists() {
+        let mut entries: Vec<_> = std::fs::read_dir(schemas_dir)?.collect::<Result<_, _>>()?;
+        entries.sort_by_key(std::fs::DirEntry::path);
+        for entry in entries {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("json")
+                && path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|s| s.contains(".schema."))
+            {
+                let buffer = std::fs::read(&path)?;
+
+                let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
+                    continue;
+                };
+                let options = zip::write::FileOptions::<()>::default()
+                    .compression_method(zip::CompressionMethod::Deflated)
+                    .unix_permissions(0o755);
+                zip.start_file(file_name, options)?;
+                zip.write_all(&buffer)?;
+            }
+        }
+    }
+
+    zip.finish()?;
+
+    // Register individual files for rerun-if-changed to detect content changes
+    // (cargo only detects directory mtime changes, not file content changes)
+    println!("cargo:rerun-if-changed=Cargo.toml");
+
+    for entry in std::fs::read_dir(schemas_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        println!("cargo:rerun-if-changed={}", path.display());
+    }
+    Ok(())
+}

--- a/libs/modkit/schemas/gts.x.core.modkit.plugin.v1~.schema.json
+++ b/libs/modkit/schemas/gts.x.core.modkit.plugin.v1~.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "gts://gts.x.core.modkit.plugin.v1~",
+  "description": "Base modkit plugin schema",
+  "type": "object",
+  "required": ["id", "vendor", "priority", "properties"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "x-gts-ref": "/$id",
+      "description": "Full GTS instance ID"
+    },
+    "vendor": {
+      "type": "string",
+      "description": "Vendor name for selection"
+    },
+    "priority": {
+      "type": "integer",
+      "description": "Lower = higher priority"
+    },
+    "properties": {
+      "type": "object",
+      "description": "Plugin-specific configuration"
+    }
+  },
+  "additionalProperties": false
+}

--- a/libs/modkit/schemas/manifest.json
+++ b/libs/modkit/schemas/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "core-modkit-schemas",
+  "version": "1.0.0",
+  "description": "Core ModKit GTS schemas",
+  "schemas": [
+    {
+      "file": "gts.x.core.modkit.plugin.v1~.schema.json",
+      "schema_id": "gts.x.core.modkit.plugin.v1~",
+      "priority": 1,
+      "description": "Base modkit plugin schema"
+    }
+  ]
+}

--- a/libs/modkit/src/gts/schemas.rs
+++ b/libs/modkit/src/gts/schemas.rs
@@ -1,29 +1,51 @@
-use crate::gts::BaseModkitPluginV1;
+use std::io::Read;
 use tracing::info;
+use zip;
 
-/// Returns the core GTS schemas provided by the modkit framework.
+/// Get core GTS schemas provided by the modkit framework.
 ///
-/// These are base types that other modules' plugin systems depend on
-///
-/// This function is called by `types_registry` during initialization to register
-/// these core types before any dependent modules can register their derived schemas.
-///
-/// NOTE: This is temporary logic until <https://github.com/hypernetix/hyperspot/issues/156> is resolved
+/// These schemas are loaded from an embedded ZIP archive containing JSON schema files.
+/// The schemas are fundamental types that other modules build upon.
+/// Examples: `BaseModkitPluginV1` for plugin systems.
 ///
 /// # Errors
 ///
-/// Returns an error if the schema JSON cannot be parsed.
+/// Returns an error if the embedded ZIP archive cannot be read or if any schema
+/// file cannot be parsed as valid JSON.
 pub fn get_core_gts_schemas() -> anyhow::Result<Vec<serde_json::Value>> {
-    info!("Generating core GTS schemas");
+    info!("Loading core GTS schemas from embedded archive");
 
     let mut schemas = Vec::new();
 
-    // BaseModkitPluginV1 schema (gts.x.core.modkit.plugin.v1~)
-    // This is the base type for all plugin schemas in the modkit framework.
-    let schema_str = BaseModkitPluginV1::<()>::gts_schema_with_refs_as_string();
-    let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
-    schemas.push(schema_json);
+    // Load embedded ZIP archive created by build script
+    let zip_data = include_bytes!(concat!(env!("OUT_DIR"), "/core_gts_schemas.zip"));
+    let cursor = std::io::Cursor::new(zip_data);
+    let mut archive = zip::ZipArchive::new(cursor)?;
 
-    info!("Core GTS schemas generated: gts.x.core.modkit.plugin.v1~");
+    // Extract and parse each schema file
+    for i in 0..archive.len() {
+        let mut file = archive.by_index(i)?;
+        let file_name = file.name().to_owned();
+
+        // Skip manifest.json, only process .schema.json files
+        if file_name.ends_with(".schema.json") {
+            let mut contents = String::new();
+            file.read_to_string(&mut contents)?;
+
+            let schema_json: serde_json::Value = serde_json::from_str(&contents)
+                .map_err(|e| anyhow::anyhow!("Failed to parse schema {file_name}: {e}"))?;
+
+            schemas.push(schema_json);
+            info!("Loaded core GTS schema: {}", file_name);
+        }
+    }
+
+    if schemas.is_empty() {
+        return Err(anyhow::anyhow!(
+            "no core GTS schemas found in embedded archive"
+        ));
+    }
+
+    info!("Core GTS schemas loaded: {} schemas", schemas.len());
     Ok(schemas)
 }

--- a/modules/system/types-sdk/Cargo.toml
+++ b/modules/system/types-sdk/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "types-sdk"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "SDK for types module: API trait, domain models and error definitions"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Core dependencies for API trait
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+
+# Domain model dependencies
+uuid = { workspace = true }
+time = { workspace = true }
+
+# Security context for API methods
+modkit-security = { workspace = true }
+
+# Optional: OData filtering/pagination support
+modkit-odata = { workspace = true }

--- a/modules/system/types-sdk/src/api.rs
+++ b/modules/system/types-sdk/src/api.rs
@@ -1,0 +1,31 @@
+//! `TypesClient` trait definition.
+//!
+//! This trait defines the public API for the `types` module.
+
+use async_trait::async_trait;
+
+use crate::error::TypesError;
+
+/// Public API trait for the `types` module.
+///
+/// This trait can be consumed by other modules via `ClientHub`:
+/// ```ignore
+/// let client = hub.get::<dyn TypesClient>()?;
+/// let ready = client.is_ready().await?;
+/// ```
+///
+/// The types module is responsible for registering core GTS types
+/// that other modules depend on (e.g., `BaseModkitPluginV1`).
+#[async_trait]
+pub trait TypesClient: Send + Sync {
+    /// Check if core types have been registered.
+    ///
+    /// # Returns
+    ///
+    /// `true` if core types are registered and ready.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the check fails.
+    async fn is_ready(&self) -> Result<bool, TypesError>;
+}

--- a/modules/system/types-sdk/src/error.rs
+++ b/modules/system/types-sdk/src/error.rs
@@ -1,0 +1,83 @@
+//! Public error types for the `types` module.
+//!
+//! These errors are safe to expose to other modules and consumers.
+
+use thiserror::Error;
+
+/// Errors that can be returned by the `TypesClient`.
+#[derive(Error, Debug, Clone)]
+pub enum TypesError {
+    /// Core types are not yet registered.
+    #[error("Core types not ready")]
+    NotReady,
+
+    /// Failed to register core types.
+    #[error("Registration failed: {0}")]
+    RegistrationFailed(String),
+
+    /// An internal error occurred.
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+impl TypesError {
+    /// Creates a `NotReady` error.
+    #[must_use]
+    pub const fn not_ready() -> Self {
+        Self::NotReady
+    }
+
+    /// Creates a `RegistrationFailed` error.
+    #[must_use]
+    pub fn registration_failed(message: impl Into<String>) -> Self {
+        Self::RegistrationFailed(message.into())
+    }
+
+    /// Creates an `Internal` error.
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal(message.into())
+    }
+
+    /// Returns `true` if this is a not ready error.
+    #[must_use]
+    pub const fn is_not_ready(&self) -> bool {
+        matches!(self, Self::NotReady)
+    }
+
+    /// Returns `true` if this is a registration failed error.
+    #[must_use]
+    pub const fn is_registration_failed(&self) -> bool {
+        matches!(self, Self::RegistrationFailed(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_constructors() {
+        let err = TypesError::not_ready();
+        assert!(err.is_not_ready());
+
+        let err = TypesError::registration_failed("schema invalid");
+        assert!(err.is_registration_failed());
+        assert!(err.to_string().contains("schema invalid"));
+
+        let err = TypesError::internal("unexpected");
+        assert!(matches!(err, TypesError::Internal(_)));
+    }
+
+    #[test]
+    fn test_error_display() {
+        let err = TypesError::NotReady;
+        assert_eq!(err.to_string(), "Core types not ready");
+
+        let err = TypesError::RegistrationFailed("failed to parse".to_owned());
+        assert_eq!(err.to_string(), "Registration failed: failed to parse");
+
+        let err = TypesError::Internal("database error".to_owned());
+        assert_eq!(err.to_string(), "Internal error: database error");
+    }
+}

--- a/modules/system/types-sdk/src/lib.rs
+++ b/modules/system/types-sdk/src/lib.rs
@@ -1,0 +1,33 @@
+//! Types SDK
+//!
+//! This crate provides the public API for the `types` module:
+//! - `TypesClient` trait for inter-module communication
+//! - `TypesError` for error handling
+//!
+//! ## Purpose
+//!
+//! The `types` module is responsible for registering core GTS types that are used
+//! throughout the framework (e.g., `BaseModkitPluginV1` for plugin systems).
+//!
+//! ## Usage
+//!
+//! Consumers obtain the client from `ClientHub`:
+//! ```ignore
+//! use types_sdk::TypesClient;
+//!
+//! // Get the client from ClientHub
+//! let client = hub.get::<dyn TypesClient>()?;
+//!
+//! // Check if core types are registered
+//! let ready = client.is_ready().await?;
+//! ```
+
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+
+pub mod api;
+pub mod error;
+
+// Re-export main types at crate root for convenience
+pub use api::TypesClient;
+pub use error::TypesError;

--- a/modules/system/types/Cargo.toml
+++ b/modules/system/types/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "types"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Core types registration system module - implementation crate"
+
+[lints]
+workspace = true
+
+[lib]
+name = "types"
+path = "src/lib.rs"
+
+[dependencies]
+# Core dependencies
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+inventory = { workspace = true }
+arc-swap = { workspace = true }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-security = { workspace = true }
+
+# Types SDK (public API, errors, models)
+types-sdk = { path = "../types-sdk" }
+
+# Types registry for registering core types
+types-registry-sdk = { workspace = true }

--- a/modules/system/types/src/domain/local_client.rs
+++ b/modules/system/types/src/domain/local_client.rs
@@ -1,0 +1,34 @@
+//! Local client implementation for the types module.
+
+use async_trait::async_trait;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use types_sdk::{TypesClient, TypesError};
+
+/// Local client implementation of [`TypesClient`].
+///
+/// This client is used for in-process communication when the types module
+/// is running in the same process as the caller.
+pub struct TypesLocalClient {
+    ready: Arc<AtomicBool>,
+}
+
+impl TypesLocalClient {
+    /// Creates a new local client.
+    #[must_use]
+    pub fn new(ready: Arc<AtomicBool>) -> Self {
+        Self { ready }
+    }
+
+    /// Marks the types module as ready.
+    pub fn set_ready(&self) {
+        self.ready.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl TypesClient for TypesLocalClient {
+    async fn is_ready(&self) -> Result<bool, TypesError> {
+        Ok(self.ready.load(Ordering::SeqCst))
+    }
+}

--- a/modules/system/types/src/domain/mod.rs
+++ b/modules/system/types/src/domain/mod.rs
@@ -1,0 +1,5 @@
+//! Domain layer for the types module.
+
+pub mod local_client;
+
+pub use local_client::TypesLocalClient;

--- a/modules/system/types/src/lib.rs
+++ b/modules/system/types/src/lib.rs
@@ -1,0 +1,31 @@
+//! Core Types Registration Module
+//!
+//! This system module is responsible for registering core GTS types that are used
+//! throughout the framework, particularly for plugin systems.
+//!
+//! ## Purpose
+//!
+//! Previously, core types like `BaseModkitPluginV1` were registered directly
+//! by the `types_registry` module, creating a circular dependency issue.
+//! This module resolves that by:
+//!
+//! - Acting as the owner of core framework types
+//! - Registering these types during its initialization
+//! - Depended on by `types_registry` (not the other way around)
+//!
+//! ## Dependency Chain
+//!
+//! ```text
+//! `types_registry` → `types` → `plugin_modules`
+//! ```
+//!
+//! This ensures core types are available when plugin modules initialize.
+//!
+//! ## SDK
+//!
+//! Public API traits, error types, and models are exported from `types-sdk`.
+
+mod domain;
+pub mod module;
+
+pub use module::Types;

--- a/modules/system/types/src/module.rs
+++ b/modules/system/types/src/module.rs
@@ -1,0 +1,91 @@
+//! Core types registration module implementation.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use async_trait::async_trait;
+use modkit::contracts::SystemCapability;
+use modkit::gts::get_core_gts_schemas;
+use modkit::{Module, ModuleCtx};
+use tracing::{debug, info};
+use types_registry_sdk::TypesRegistryClient;
+use types_sdk::TypesClient;
+
+use crate::domain::TypesLocalClient;
+
+/// Core types registration module.
+///
+/// This system module is responsible for registering core GTS types that are used
+/// throughout the framework (e.g., `BaseModkitPluginV1` for plugin systems).
+///
+/// ## Initialization Order
+///
+/// This module must initialize after `types_registry` but before any modules that
+/// use plugin systems or other core GTS types.
+///
+/// Dependency chain: `types_registry` → `types` → plugin modules
+///
+/// ## Core Types Registered
+///
+/// - `BaseModkitPluginV1` - Base schema for all plugin instances
+/// - Any future core framework types
+#[modkit::module(
+    name = "types",
+    deps = ["types_registry"],
+    capabilities = [system]
+)]
+pub struct Types {
+    ready: Arc<AtomicBool>,
+}
+
+impl Default for Types {
+    fn default() -> Self {
+        Self {
+            ready: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl Clone for Types {
+    fn clone(&self) -> Self {
+        Self {
+            ready: Arc::clone(&self.ready),
+        }
+    }
+}
+
+#[async_trait]
+impl Module for Types {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        info!("Initializing types module");
+
+        // Get the types registry client
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
+
+        // Register core GTS types that other modules depend on
+        // This must happen before any module registers derived schemas/instances
+        debug!("Registering core GTS schemas");
+        let core_schemas = get_core_gts_schemas()?;
+
+        registry
+            .register(core_schemas)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to register core GTS schemas: {e}"))?;
+
+        info!("Core GTS schemas registered successfully");
+
+        // Create and register the local client
+        let client = TypesLocalClient::new(Arc::clone(&self.ready));
+        client.set_ready();
+
+        let api: Arc<dyn TypesClient> = Arc::new(client);
+        ctx.client_hub().register::<dyn TypesClient>(api);
+
+        info!("Types module initialized");
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SystemCapability for Types {}


### PR DESCRIPTION
…odule

closes #156 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a central "types" module and SDK exposing a readiness API and an in-process client so other modules can detect when core types are available.

* **Infrastructure**
  * Core schemas are packaged into an embedded archive and loaded at startup.
  * Initialization now registers core schemas via the new types module to avoid circular startup dependencies.

* **Chores**
  * Manifests updated to include new packages, schema metadata, and build steps to produce the embedded schema archive.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->