### PR TITLE
refactor(modkit): rename capability traits to use *Capability suffix

### DIFF
--- a/docs/MODKIT_UNIFIED_SYSTEM.md
+++ b/docs/MODKIT_UNIFIED_SYSTEM.md
@@ -158,13 +158,13 @@ pub struct MyModule {
 
 ### Capabilities
 
-* `db` → implement `DbModule` (migrations / schema setup).
-* `rest` → implement `RestfulModule` (register routes synchronously).
+* `db` → implement `DatabaseCapability` (migrations / schema setup).
+* `rest` → implement `RestApiCapability` (register routes synchronously).
 * `rest_host` → own the Axum server/OpenAPI (e.g., `api_gateway`).
 * `stateful` → background job:
 
     * With `lifecycle(...)`, the macro generates `Runnable` and registers `WithLifecycle<Self>`.
-    * Without it, implement `StatefulModule` yourself.
+    * Without it, implement `RunnableCapability` yourself.
 
 ### Client helpers (when `client` is set)
 
@@ -1239,7 +1239,7 @@ impl Module for UsersModule {
     }
 }
 
-impl RestfulModule for UsersModule {
+impl RestApiCapability for UsersModule {
     fn register_rest(&self, _ctx: &ModuleCtx, router: Router, openapi: &dyn OpenApiRegistry) -> anyhow::Result<Router> {
         let router = register_crud_routes(router, openapi, self.service.clone())?;
         let router = register_sse_route(router, openapi, self.sse_broadcaster.clone());

--- a/examples/modkit/users_info/users_info/src/module.rs
+++ b/examples/modkit/users_info/users_info/src/module.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use modkit::api::OpenApiRegistry;
-use modkit::{DbModule, Module, ModuleCtx, RestfulModule, SseBroadcaster, TracedClient};
+use modkit::{
+    DatabaseCapability, Module, ModuleCtx, RestApiCapability, SseBroadcaster, TracedClient,
+};
 use sea_orm_migration::MigratorTrait;
 use tracing::{debug, info};
 use url::Url;
@@ -140,7 +142,7 @@ impl Module for UsersInfo {
 }
 
 #[async_trait]
-impl DbModule for UsersInfo {
+impl DatabaseCapability for UsersInfo {
     async fn migrate(&self, db: &modkit_db::DbHandle) -> anyhow::Result<()> {
         info!("Running users_info database migrations");
         let conn = db.sea();
@@ -150,7 +152,7 @@ impl DbModule for UsersInfo {
     }
 }
 
-impl RestfulModule for UsersInfo {
+impl RestApiCapability for UsersInfo {
     fn register_rest(
         &self,
         _ctx: &ModuleCtx,

--- a/examples/modkit/users_info/users_info/tests/sdk_blackbox.rs
+++ b/examples/modkit/users_info/users_info/tests/sdk_blackbox.rs
@@ -7,7 +7,7 @@ use hs_tenant_resolver_sdk::{
     TenantFilter, TenantResolverError, TenantResolverGatewayClient, TenantStatus,
 };
 use modkit::config::ConfigProvider;
-use modkit::{ClientHub, DbModule, Module, ModuleCtx};
+use modkit::{ClientHub, DatabaseCapability, Module, ModuleCtx};
 use modkit_db::{ConnectOpts, DbHandle};
 use modkit_security::SecurityContext;
 use serde_json::json;

--- a/examples/oop-modules/calculator/calculator/src/module.rs
+++ b/examples/oop-modules/calculator/calculator/src/module.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use modkit::context::ModuleCtx;
-use modkit::contracts::{GrpcServiceModule, RegisterGrpcServiceFn};
+use modkit::contracts::{GrpcServiceCapability, RegisterGrpcServiceFn};
 
 use calculator_sdk::{CalculatorServiceServer, SERVICE_NAME};
 
@@ -49,7 +49,7 @@ impl modkit::Module for CalculatorModule {
 
 /// Export gRPC services to grpc_hub
 #[async_trait]
-impl GrpcServiceModule for CalculatorModule {
+impl GrpcServiceCapability for CalculatorModule {
     async fn get_grpc_services(&self, ctx: &ModuleCtx) -> Result<Vec<RegisterGrpcServiceFn>> {
         // Get Service from ClientHub
         let service = ctx

--- a/examples/oop-modules/calculator_gateway/calculator_gateway/src/module.rs
+++ b/examples/oop-modules/calculator_gateway/calculator_gateway/src/module.rs
@@ -11,7 +11,7 @@ use axum::Router;
 
 use modkit::api::OpenApiRegistry;
 use modkit::context::ModuleCtx;
-use modkit::contracts::RestfulModule;
+use modkit::contracts::RestApiCapability;
 
 use crate::api::rest::routes;
 use crate::domain::Service;
@@ -49,7 +49,7 @@ impl modkit::Module for CalculatorGateway {
     }
 }
 
-impl RestfulModule for CalculatorGateway {
+impl RestApiCapability for CalculatorGateway {
     fn register_rest(
         &self,
         ctx: &ModuleCtx,

--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/module.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/module.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, OnceLock};
 use async_trait::async_trait;
 use modkit::api::OpenApiRegistry;
 use modkit::context::ModuleCtx;
-use modkit::contracts::RestfulModule;
+use modkit::contracts::RestApiCapability;
 use modkit::Module;
 use tenant_resolver_sdk::{TenantResolverClient, TenantResolverPluginSpecV1};
 use tracing::info;
@@ -87,7 +87,7 @@ impl Module for TenantResolverGateway {
     }
 }
 
-impl RestfulModule for TenantResolverGateway {
+impl RestApiCapability for TenantResolverGateway {
     fn register_rest(
         &self,
         _ctx: &ModuleCtx,

--- a/guidelines/NEW_MODULE.md
+++ b/guidelines/NEW_MODULE.md
@@ -937,9 +937,9 @@ This is where all components are assembled and registered with ModKit.
        ```
     7. Config structs SHOULD use `#[serde(deny_unknown_fields)]` and provide safe defaults.
 
-3. **`src/module.rs` - `impl DbModule` and `impl RestfulModule`:**
-   **Rule:** `DbModule::migrate` MUST be implemented to run your SeaORM migrations.
-   **Rule:** `RestfulModule::register_rest` MUST fail if the service is not yet initialized, then call your single
+3. **`src/module.rs` - `impl DatabaseCapability` and `impl RestApiCapability`:**
+   **Rule:** `DatabaseCapability::migrate` MUST be implemented to run your SeaORM migrations.
+   **Rule:** `RestApiCapability::register_rest` MUST fail if the service is not yet initialized, then call your single
    `register_routes` function.
 
 ```rust
@@ -947,7 +947,7 @@ This is where all components are assembled and registered with ModKit.
 use std::sync::Arc;
 use async_trait::async_trait;
 use modkit::api::OpenApiRegistry;
-use modkit::{DbModule, Module, ModuleCtx, RestfulModule, SseBroadcaster};
+use modkit::{DatabaseCapability, Module, ModuleCtx, RestApiCapability, SseBroadcaster};
 use sea_orm_migration::MigratorTrait;
 use tracing::info;
 
@@ -1030,7 +1030,7 @@ impl Module for UsersInfo {
 }
 
 #[async_trait]
-impl DbModule for UsersInfo {
+impl DatabaseCapability for UsersInfo {
     async fn migrate(&self, db: &modkit_db::DbHandle) -> anyhow::Result<()> {
         info!("Running users_info database migrations");
         let conn = db.sea();
@@ -1039,7 +1039,7 @@ impl DbModule for UsersInfo {
     }
 }
 
-impl RestfulModule for UsersInfo {
+impl RestApiCapability for UsersInfo {
     fn register_rest(
         &self,
         _ctx: &ModuleCtx,
@@ -1367,7 +1367,7 @@ schema:
 
 ### Step 8: Infra/Storage Layer (Optional)
 
-If no database required: skip `DbModule`, remove `db` from capabilities.
+If no database required: skip `DatabaseCapability`, remove `db` from capabilities.
 
 This layer implements the domain's repository traits with **Secure ORM** for tenant isolation.
 

--- a/libs/modkit-macros/src/lib.rs
+++ b/libs/modkit-macros/src/lib.rs
@@ -455,39 +455,39 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
             Capability::Db => quote! {
                 const _: () = {
                     #[allow(dead_code)]
-                    fn __modkit_require_DbModule_impl()
+                    fn __modkit_require_DatabaseCapability_impl()
                     where
-                        #struct_ident #ty_generics: ::modkit::contracts::DbModule,
+                        #struct_ident #ty_generics: ::modkit::contracts::DatabaseCapability,
                     {}
                 };
             },
             Capability::Rest => quote! {
                 const _: () = {
                     #[allow(dead_code)]
-                    fn __modkit_require_RestfulModule_impl()
+                    fn __modkit_require_RestApiCapability_impl()
                     where
-                        #struct_ident #ty_generics: ::modkit::contracts::RestfulModule,
+                        #struct_ident #ty_generics: ::modkit::contracts::RestApiCapability,
                     {}
                 };
             },
             Capability::RestHost => quote! {
                 const _: () = {
                     #[allow(dead_code)]
-                    fn __modkit_require_RestHostModule_impl()
+                    fn __modkit_require_ApiGatewayCapability_impl()
                     where
-                        #struct_ident #ty_generics: ::modkit::contracts::RestHostModule,
+                        #struct_ident #ty_generics: ::modkit::contracts::ApiGatewayCapability,
                     {}
                 };
             },
             Capability::Stateful => {
                 if lifecycle_cfg_opt.is_none() {
-                    // Only require direct StatefulModule impl when lifecycle(...) is NOT used.
+                    // Only require direct RunnableCapability impl when lifecycle(...) is NOT used.
                     quote! {
                         const _: () = {
                             #[allow(dead_code)]
-                            fn __modkit_require_StatefulModule_impl()
+                            fn __modkit_require_RunnableCapability_impl()
                             where
-                                #struct_ident #ty_generics: ::modkit::contracts::StatefulModule,
+                                #struct_ident #ty_generics: ::modkit::contracts::RunnableCapability,
                             {}
                         };
                     }
@@ -502,18 +502,18 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
             Capability::GrpcHub => quote! {
                 const _: () = {
                     #[allow(dead_code)]
-                    fn __modkit_require_GrpcHubModule_impl()
+                    fn __modkit_require_GrpcHubCapability_impl()
                     where
-                        #struct_ident #ty_generics: ::modkit::contracts::GrpcHubModule,
+                        #struct_ident #ty_generics: ::modkit::contracts::GrpcHubCapability,
                     {}
                 };
             },
             Capability::Grpc => quote! {
                 const _: () = {
                     #[allow(dead_code)]
-                    fn __modkit_require_GrpcServiceModule_impl()
+                    fn __modkit_require_GrpcServiceCapability_impl()
                     where
-                        #struct_ident #ty_generics: ::modkit::contracts::GrpcServiceModule,
+                        #struct_ident #ty_generics: ::modkit::contracts::GrpcServiceCapability,
                     {}
                 };
             },
@@ -599,15 +599,15 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
         match cap {
             Capability::Db => quote! {
                 b.register_db_with_meta(#name_lit,
-                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::DbModule>);
+                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::DatabaseCapability>);
             },
             Capability::Rest => quote! {
                 b.register_rest_with_meta(#name_lit,
-                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::RestfulModule>);
+                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::RestApiCapability>);
             },
             Capability::RestHost => quote! {
                 b.register_rest_host_with_meta(#name_lit,
-                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::RestHostModule>);
+                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::ApiGatewayCapability>);
             },
             Capability::Stateful => {
                 if let Some(lc) = &lifecycle_cfg_opt {
@@ -628,7 +628,7 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                             b.register_stateful_with_meta(
                                 #name_lit,
-                                ::std::sync::Arc::new(wl) as ::std::sync::Arc<dyn ::modkit::contracts::StatefulModule>
+                                ::std::sync::Arc::new(wl) as ::std::sync::Arc<dyn ::modkit::contracts::RunnableCapability>
                             );
                         }
                     } else {
@@ -642,29 +642,29 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
 
                             b.register_stateful_with_meta(
                                 #name_lit,
-                                ::std::sync::Arc::new(wl) as ::std::sync::Arc<dyn ::modkit::contracts::StatefulModule>
+                                ::std::sync::Arc::new(wl) as ::std::sync::Arc<dyn ::modkit::contracts::RunnableCapability>
                             );
                         }
                     }
                 } else {
-                    // Alternative path: the type itself must implement StatefulModule
+                    // Alternative path: the type itself must implement RunnableCapability
                     quote! {
                         b.register_stateful_with_meta(#name_lit,
-                            module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::StatefulModule>);
+                            module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::RunnableCapability>);
                     }
                 }
             },
             Capability::System => quote! {
                 b.register_system_with_meta(#name_lit,
-                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::SystemModule>);
+                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::SystemCapability>);
             },
             Capability::GrpcHub => quote! {
                 b.register_grpc_hub_with_meta(#name_lit,
-                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::GrpcHubModule>);
+                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::GrpcHubCapability>);
             },
             Capability::Grpc => quote! {
                 b.register_grpc_service_with_meta(#name_lit,
-                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::GrpcServiceModule>);
+                    module.clone() as ::std::sync::Arc<dyn ::modkit::contracts::GrpcServiceCapability>);
             },
         }
     });

--- a/libs/modkit/src/contracts.rs
+++ b/libs/modkit/src/contracts.rs
@@ -4,12 +4,12 @@ use tokio_util::sync::CancellationToken;
 
 pub use crate::api::openapi_registry::OpenApiRegistry;
 
-/// System module: receives runtime internals before init.
+/// System capability: receives runtime internals before init.
 ///
-/// This trait is internal to modkit and only used by system modules
-/// (those with the "system" capability). Normal user modules don't implement this.
+/// This trait is internal to modkit and only used by modules with the "system" capability.
+/// Normal user modules don't implement this.
 #[async_trait]
-pub trait SystemModule: Send + Sync {
+pub trait SystemCapability: Send + Sync {
     /// Optional pre-init hook for system modules.
     ///
     /// This runs BEFORE `init()` has completed for ALL modules, and only for system modules.
@@ -39,13 +39,13 @@ pub trait Module: Send + Sync + 'static {
 }
 
 #[async_trait]
-pub trait DbModule: Send + Sync {
+pub trait DatabaseCapability: Send + Sync {
     /// Runs AFTER init, BEFORE REST/start.
     async fn migrate(&self, db: &modkit_db::DbHandle) -> anyhow::Result<()>;
 }
 
-/// Pure wiring; must be sync. Runs AFTER DB migrations.
-pub trait RestfulModule: Send + Sync {
+/// REST API capability: Pure wiring; must be sync. Runs AFTER DB migrations.
+pub trait RestApiCapability: Send + Sync {
     /// Register REST routes for this module.
     ///
     /// # Errors
@@ -58,10 +58,10 @@ pub trait RestfulModule: Send + Sync {
     ) -> anyhow::Result<Router>;
 }
 
-/// REST host module: handles gateway hosting with prepare/finalize phases.
+/// API Gateway capability: handles gateway hosting with prepare/finalize phases.
 /// Must be sync. Runs during REST phase, but doesn't start the server.
 #[allow(dead_code)]
-pub trait RestHostModule: Send + Sync + 'static {
+pub trait ApiGatewayCapability: Send + Sync + 'static {
     /// Prepare a base Router (e.g., global middlewares, /healthz) and optionally touch `OpenAPI` meta.
     /// Do NOT start the server here.
     ///
@@ -89,7 +89,7 @@ pub trait RestHostModule: Send + Sync + 'static {
 }
 
 #[async_trait]
-pub trait StatefulModule: Send + Sync {
+pub trait RunnableCapability: Send + Sync {
     async fn start(&self, cancel: CancellationToken) -> anyhow::Result<()>;
     async fn stop(&self, cancel: CancellationToken) -> anyhow::Result<()>;
 }
@@ -109,12 +109,12 @@ pub struct RegisterGrpcServiceFn {
     pub service_name: &'static str,
 }
 
-/// Trait for modules that export gRPC services.
+/// gRPC Service capability: modules that export gRPC services.
 ///
 /// The runtime will call this during the gRPC registration phase to collect
 /// all services that should be exposed on the shared gRPC server.
 #[async_trait]
-pub trait GrpcServiceModule: Send + Sync {
+pub trait GrpcServiceCapability: Send + Sync {
     /// Returns all gRPC services this module wants to expose.
     ///
     /// Each installer adds one service to the `tonic::Server` builder.
@@ -124,11 +124,11 @@ pub trait GrpcServiceModule: Send + Sync {
     ) -> anyhow::Result<Vec<RegisterGrpcServiceFn>>;
 }
 
-/// Trait for the gRPC hub module that hosts the gRPC server.
+/// gRPC Hub capability: hosts the gRPC server.
 ///
 /// This trait is implemented by the single module responsible for hosting
 /// the `tonic::Server` instance. Only one module per process should implement this.
-pub trait GrpcHubModule: Send + Sync {
+pub trait GrpcHubCapability: Send + Sync {
     /// Returns the bound endpoint after the server starts listening.
     ///
     /// Examples:

--- a/libs/modkit/src/lib.rs
+++ b/libs/modkit/src/lib.rs
@@ -71,7 +71,7 @@ pub use inventory;
 
 // Module system exports
 pub use crate::contracts::*;
-pub use crate::contracts::{GrpcServiceModule, RegisterGrpcServiceFn};
+pub use crate::contracts::{GrpcServiceCapability, RegisterGrpcServiceFn};
 
 // Configuration module
 pub mod config;

--- a/libs/modkit/src/lifecycle.rs
+++ b/libs/modkit/src/lifecycle.rs
@@ -573,7 +573,7 @@ impl<T: Runnable + Default> Default for WithLifecycle<T> {
 }
 
 #[async_trait]
-impl<T: Runnable> crate::contracts::StatefulModule for WithLifecycle<T> {
+impl<T: Runnable> crate::contracts::RunnableCapability for WithLifecycle<T> {
     #[tracing::instrument(skip(self, external_cancel), level = "debug")]
     async fn start(&self, external_cancel: CancellationToken) -> TaskResult<()> {
         let inner = self.inner.clone();
@@ -827,7 +827,7 @@ mod tests {
 
     #[tokio::test]
     async fn stateful_wrapper_start_stop_roundtrip() {
-        use crate::contracts::StatefulModule;
+        use crate::contracts::RunnableCapability;
 
         let wrapper = WithLifecycle::new(TestRunnable::new());
         assert_eq!(wrapper.status(), Status::Stopped);
@@ -841,7 +841,7 @@ mod tests {
 
     #[tokio::test]
     async fn with_lifecycle_double_start_fails() {
-        use crate::contracts::StatefulModule;
+        use crate::contracts::RunnableCapability;
 
         let wrapper = WithLifecycle::new(TestRunnable::new());
         let cancel = CancellationToken::new();
@@ -853,7 +853,7 @@ mod tests {
 
     #[tokio::test]
     async fn with_lifecycle_concurrent_stop_calls() {
-        use crate::contracts::StatefulModule;
+        use crate::contracts::RunnableCapability;
         let wrapper = Arc::new(WithLifecycle::new(TestRunnable::new()));
         wrapper.start(CancellationToken::new()).await.unwrap();
         let a = wrapper.clone();

--- a/libs/modkit/tests/lifecycle_macro_tests.rs
+++ b/libs/modkit/tests/lifecycle_macro_tests.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::Result;
-use modkit::{lifecycle as lifecycle_attr, lifecycle::*, StatefulModule};
+use modkit::{lifecycle as lifecycle_attr, lifecycle::*, RunnableCapability};
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 

--- a/libs/modkit/tests/lifecycle_state.rs
+++ b/libs/modkit/tests/lifecycle_state.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use modkit::contracts::StatefulModule;
+use modkit::contracts::RunnableCapability;
 use modkit::lifecycle::*;
 use std::sync::Arc;
 use std::time::Duration;

--- a/libs/modkit/tests/macro_tests.rs
+++ b/libs/modkit/tests/macro_tests.rs
@@ -9,7 +9,10 @@ use uuid::Uuid;
 
 use modkit::{
     config::ConfigProvider,
-    contracts::{DbModule, Module, OpenApiRegistry, RestHostModule, RestfulModule, StatefulModule},
+    contracts::{
+        ApiGatewayCapability, DatabaseCapability, Module, OpenApiRegistry, RestApiCapability,
+        RunnableCapability,
+    },
     module, ModuleCtx,
 };
 use std::sync::Arc;
@@ -77,12 +80,12 @@ impl Module for FullFeaturedModule {
     }
 }
 #[async_trait]
-impl DbModule for FullFeaturedModule {
+impl DatabaseCapability for FullFeaturedModule {
     async fn migrate(&self, _db: &modkit_db::DbHandle) -> Result<()> {
         Ok(())
     }
 }
-impl RestfulModule for FullFeaturedModule {
+impl RestApiCapability for FullFeaturedModule {
     fn register_rest(
         &self,
         _ctx: &modkit::context::ModuleCtx,
@@ -93,7 +96,7 @@ impl RestfulModule for FullFeaturedModule {
     }
 }
 #[async_trait]
-impl StatefulModule for FullFeaturedModule {
+impl RunnableCapability for FullFeaturedModule {
     async fn start(&self, _t: CancellationToken) -> Result<()> {
         Ok(())
     }
@@ -142,7 +145,7 @@ impl Module for DbOnlyModule {
     }
 }
 #[async_trait]
-impl DbModule for DbOnlyModule {
+impl DatabaseCapability for DbOnlyModule {
     async fn migrate(&self, _db: &modkit_db::DbHandle) -> Result<()> {
         Ok(())
     }
@@ -157,7 +160,7 @@ impl Module for RestOnlyModule {
         Ok(())
     }
 }
-impl RestfulModule for RestOnlyModule {
+impl RestApiCapability for RestOnlyModule {
     fn register_rest(
         &self,
         _ctx: &modkit::context::ModuleCtx,
@@ -170,18 +173,18 @@ impl RestfulModule for RestOnlyModule {
 
 #[derive(Default)]
 #[module(name = "rest_host", capabilities = [rest_host])]
-struct TestRestHostModule {
+struct TestApiGatewayModule {
     registry: TestOpenApiRegistry,
 }
 
 #[async_trait]
-impl Module for TestRestHostModule {
+impl Module for TestApiGatewayModule {
     async fn init(&self, _ctx: &modkit::context::ModuleCtx) -> Result<()> {
         Ok(())
     }
 }
 
-impl RestHostModule for TestRestHostModule {
+impl ApiGatewayCapability for TestApiGatewayModule {
     fn rest_prepare(
         &self,
         _ctx: &modkit::context::ModuleCtx,
@@ -213,7 +216,7 @@ impl Module for StatefulOnlyModule {
     }
 }
 #[async_trait]
-impl StatefulModule for StatefulOnlyModule {
+impl RunnableCapability for StatefulOnlyModule {
     async fn start(&self, _t: CancellationToken) -> Result<()> {
         Ok(())
     }
@@ -261,9 +264,9 @@ async fn test_full_capabilities() {
 #[test]
 fn test_capability_trait_markers() {
     fn assert_module<T: Module>(_: &T) {}
-    fn assert_db<T: DbModule>(_: &T) {}
-    fn assert_rest<T: RestfulModule>(_: &T) {}
-    fn assert_stateful<T: StatefulModule>(_: &T) {}
+    fn assert_db<T: DatabaseCapability>(_: &T) {}
+    fn assert_rest<T: RestApiCapability>(_: &T) {}
+    fn assert_stateful<T: RunnableCapability>(_: &T) {}
 
     assert_module(&BasicModule);
     assert_module(&DependentModule);

--- a/modules/file_parser/src/module.rs
+++ b/modules/file_parser/src/module.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use modkit::api::OpenApiRegistry;
-use modkit::{Module, ModuleCtx, RestfulModule};
+use modkit::{Module, ModuleCtx, RestApiCapability};
 use tracing::{debug, info};
 
 use crate::config::FileParserConfig;
@@ -79,7 +79,7 @@ impl Module for FileParserModule {
     }
 }
 
-impl RestfulModule for FileParserModule {
+impl RestApiCapability for FileParserModule {
     fn register_rest(
         &self,
         _ctx: &ModuleCtx,

--- a/modules/system/api_gateway/src/module.rs
+++ b/modules/system/api_gateway/src/module.rs
@@ -471,7 +471,7 @@ impl modkit::Module for ApiGateway {
 }
 
 // REST host role: prepare/finalize the router, but do not start the server here.
-impl modkit::contracts::RestHostModule for ApiGateway {
+impl modkit::contracts::ApiGatewayCapability for ApiGateway {
     fn rest_prepare(
         &self,
         _ctx: &modkit::context::ModuleCtx,
@@ -541,7 +541,7 @@ impl modkit::contracts::RestHostModule for ApiGateway {
     }
 }
 
-impl modkit::contracts::RestfulModule for ApiGateway {
+impl modkit::contracts::RestApiCapability for ApiGateway {
     fn register_rest(
         &self,
         _ctx: &modkit::context::ModuleCtx,

--- a/modules/system/api_gateway/tests/auth_middleware.rs
+++ b/modules/system/api_gateway/tests/auth_middleware.rs
@@ -26,7 +26,7 @@ use modkit::{
     },
     config::ConfigProvider,
     context::ModuleCtx,
-    contracts::{OpenApiRegistry, RestHostModule, RestfulModule},
+    contracts::{ApiGatewayCapability, OpenApiRegistry, RestApiCapability},
     ClientHub, Module,
 };
 use modkit_auth::axum_ext::Authz;
@@ -188,7 +188,7 @@ impl AsRef<str> for License {
 
 impl LicenseFeature for License {}
 
-impl RestfulModule for TestAuthModule {
+impl RestApiCapability for TestAuthModule {
     fn register_rest(
         &self,
         _ctx: &ModuleCtx,

--- a/modules/system/api_gateway/tests/body_limit_tests.rs
+++ b/modules/system/api_gateway/tests/body_limit_tests.rs
@@ -12,8 +12,8 @@ use hs_tenant_resolver_sdk::{
 use modkit::{
     api::OperationBuilder,
     config::ConfigProvider,
-    contracts::{OpenApiRegistry, RestHostModule},
-    Module, ModuleCtx, RestfulModule,
+    contracts::{ApiGatewayCapability, OpenApiRegistry},
+    Module, ModuleCtx, RestApiCapability,
 };
 
 use modkit_security::SecurityContext;
@@ -120,7 +120,7 @@ impl Module for BodyLimitTestModule {
     }
 }
 
-impl RestfulModule for BodyLimitTestModule {
+impl RestApiCapability for BodyLimitTestModule {
     fn register_rest(
         &self,
         _ctx: &modkit::ModuleCtx,

--- a/modules/system/api_gateway/tests/cors_tests.rs
+++ b/modules/system/api_gateway/tests/cors_tests.rs
@@ -12,8 +12,8 @@ use hs_tenant_resolver_sdk::{
 use modkit::{
     api::OperationBuilder,
     config::ConfigProvider,
-    contracts::{OpenApiRegistry, RestHostModule},
-    Module, ModuleCtx, RestfulModule,
+    contracts::{ApiGatewayCapability, OpenApiRegistry},
+    Module, ModuleCtx, RestApiCapability,
 };
 
 use modkit_security::SecurityContext;
@@ -140,7 +140,7 @@ impl Module for CorsTestModule {
     }
 }
 
-impl RestfulModule for CorsTestModule {
+impl RestApiCapability for CorsTestModule {
     fn register_rest(
         &self,
         _ctx: &modkit::ModuleCtx,

--- a/modules/system/api_gateway/tests/integration_router.rs
+++ b/modules/system/api_gateway/tests/integration_router.rs
@@ -13,7 +13,7 @@ use axum::{
     Router,
 };
 use modkit::{
-    config::ConfigProvider, contracts::OpenApiRegistry, Module, ModuleCtx, RestfulModule,
+    config::ConfigProvider, contracts::OpenApiRegistry, Module, ModuleCtx, RestApiCapability,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -67,7 +67,7 @@ impl Module for TestUsersModule {
     }
 }
 
-impl RestfulModule for TestUsersModule {
+impl RestApiCapability for TestUsersModule {
     fn register_rest(
         &self,
         _ctx: &modkit::ModuleCtx,

--- a/modules/system/api_gateway/tests/license_middleware.rs
+++ b/modules/system/api_gateway/tests/license_middleware.rs
@@ -17,7 +17,7 @@ use modkit::{
     api::OperationBuilder,
     config::ConfigProvider,
     context::ModuleCtx,
-    contracts::{OpenApiRegistry, RestHostModule, RestfulModule},
+    contracts::{ApiGatewayCapability, OpenApiRegistry, RestApiCapability},
     ClientHub, Module,
 };
 
@@ -159,7 +159,7 @@ impl AsRef<str> for BaseFeature {
 
 impl LicenseFeature for BaseFeature {}
 
-impl RestfulModule for TestLicenseModule {
+impl RestApiCapability for TestLicenseModule {
     fn register_rest(
         &self,
         _ctx: &ModuleCtx,

--- a/modules/system/api_gateway/tests/middleware_order.rs
+++ b/modules/system/api_gateway/tests/middleware_order.rs
@@ -20,8 +20,8 @@ use hs_tenant_resolver_sdk::{
     TenantResolverGatewayClient, TenantStatus,
 };
 use modkit::{
-    api::OperationBuilder, config::ConfigProvider, context::ModuleCtx, contracts::RestHostModule,
-    Module,
+    api::OperationBuilder, config::ConfigProvider, context::ModuleCtx,
+    contracts::ApiGatewayCapability, Module,
 };
 
 use modkit_security::SecurityContext;

--- a/modules/system/api_gateway/tests/rate_limit_tests.rs
+++ b/modules/system/api_gateway/tests/rate_limit_tests.rs
@@ -12,8 +12,8 @@ use hs_tenant_resolver_sdk::{
 use modkit::{
     api::OperationBuilder,
     config::ConfigProvider,
-    contracts::{OpenApiRegistry, RestHostModule},
-    Module, ModuleCtx, RestfulModule,
+    contracts::{ApiGatewayCapability, OpenApiRegistry},
+    Module, ModuleCtx, RestApiCapability,
 };
 use modkit_security::SecurityContext;
 use serde::{Deserialize, Serialize};
@@ -111,7 +111,7 @@ impl Module for RateLimitedModule {
     }
 }
 
-impl RestfulModule for RateLimitedModule {
+impl RestApiCapability for RateLimitedModule {
     fn register_rest(
         &self,
         _ctx: &modkit::ModuleCtx,

--- a/modules/system/grpc_hub/src/module.rs
+++ b/modules/system/grpc_hub/src/module.rs
@@ -6,7 +6,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use modkit::{
     context::ModuleCtx,
-    contracts::{Module, SystemModule},
+    contracts::{Module, SystemCapability},
     lifecycle::ReadySignal,
     runtime::{GrpcInstallerData, GrpcInstallerStore, ModuleInstallers},
     DirectoryApi,
@@ -507,7 +507,7 @@ impl GrpcHub {
 }
 
 #[async_trait]
-impl SystemModule for GrpcHub {
+impl SystemCapability for GrpcHub {
     fn pre_init(&self, sys: &modkit::runtime::SystemContext) -> anyhow::Result<()> {
         self.installer_store
             .set(Arc::clone(&sys.grpc_installers))
@@ -522,7 +522,7 @@ impl SystemModule for GrpcHub {
     }
 }
 
-impl modkit::contracts::GrpcHubModule for GrpcHub {
+impl modkit::contracts::GrpcHubCapability for GrpcHub {
     fn bound_endpoint(&self) -> Option<String> {
         self.get_bound_endpoint()
     }

--- a/modules/system/module_orchestrator/module_orchestrator/src/module.rs
+++ b/modules/system/module_orchestrator/module_orchestrator/src/module.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, OnceLock};
 use tokio::sync::RwLock;
 
 use modkit::context::ModuleCtx;
-use modkit::contracts::{GrpcServiceModule, RegisterGrpcServiceFn, SystemModule};
+use modkit::contracts::{GrpcServiceCapability, RegisterGrpcServiceFn, SystemCapability};
 use modkit::directory::LocalDirectoryApi;
 use modkit::runtime::ModuleManager;
 use modkit::DirectoryApi;
@@ -47,7 +47,7 @@ impl Default for ModuleOrchestrator {
 }
 
 #[async_trait]
-impl SystemModule for ModuleOrchestrator {
+impl SystemCapability for ModuleOrchestrator {
     fn pre_init(&self, sys: &modkit::runtime::SystemContext) -> anyhow::Result<()> {
         self.module_manager
             .set(Arc::clone(&sys.module_manager))
@@ -87,7 +87,7 @@ impl modkit::Module for ModuleOrchestrator {
 
 /// Export gRPC services to `grpc_hub`
 #[async_trait]
-impl GrpcServiceModule for ModuleOrchestrator {
+impl GrpcServiceCapability for ModuleOrchestrator {
     async fn get_grpc_services(&self, _ctx: &ModuleCtx) -> Result<Vec<RegisterGrpcServiceFn>> {
         let api = self
             .directory_api

--- a/modules/system/nodes_registry/src/module.rs
+++ b/modules/system/nodes_registry/src/module.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 use modkit::context::ModuleCtx;
-use modkit::contracts::{OpenApiRegistry, RestfulModule};
+use modkit::contracts::{OpenApiRegistry, RestApiCapability};
 use modkit::Module;
 
 use crate::contract::client::NodesRegistryApi;
@@ -56,7 +56,7 @@ impl Module for NodesRegistry {
     }
 }
 
-impl RestfulModule for NodesRegistry {
+impl RestApiCapability for NodesRegistry {
     fn register_rest(
         &self,
         _ctx: &ModuleCtx,

--- a/modules/system/types-registry/types-registry/src/module.rs
+++ b/modules/system/types-registry/types-registry/src/module.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use modkit::api::OpenApiRegistry;
-use modkit::contracts::SystemModule;
+use modkit::contracts::SystemCapability;
 use modkit::gts::get_core_gts_schemas; // NOTE: This is temporary logic until <https://github.com/hypernetix/hyperspot/issues/156> resolved
-use modkit::{Module, ModuleCtx, RestfulModule};
+use modkit::{Module, ModuleCtx, RestApiCapability};
 use tracing::{debug, info};
 use types_registry_sdk::TypesRegistryApi;
 
@@ -90,7 +90,7 @@ impl Module for TypesRegistryModule {
 }
 
 #[async_trait]
-impl SystemModule for TypesRegistryModule {
+impl SystemCapability for TypesRegistryModule {
     /// Post-init hook: switches the registry to ready mode.
     ///
     /// This runs AFTER `init()` has completed for ALL modules.
@@ -133,7 +133,7 @@ impl SystemModule for TypesRegistryModule {
     }
 }
 
-impl RestfulModule for TypesRegistryModule {
+impl RestApiCapability for TypesRegistryModule {
     fn register_rest(
         &self,
         _ctx: &ModuleCtx,


### PR DESCRIPTION
Refactor module capability trait naming to improve clarity and distinguish optional capabilities from the core (#213  and #212) 