### PR TITLE
Remove SecurityCtx from Calculator example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,26 +421,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
 ]
 
 [[package]]
@@ -836,6 +825,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,6 +928,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1350,6 +1354,18 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -1938,6 +1954,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,6 +2030,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3158,7 +3197,7 @@ name = "modkit-security"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bincode",
+ "postcard",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -4001,6 +4040,19 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "postscript"
@@ -6449,12 +6501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "uom"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6645,12 +6691,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,7 @@ nvml-wrapper = "0.11"
 
 # Text processing
 base64 = "0.22"
-bincode = { version = "2.0", features = ["serde"] }
+postcard = { version = "1.1.3", features = ["alloc"] }
 strsim = "0.11"
 
 # OData support

--- a/deny.toml
+++ b/deny.toml
@@ -36,7 +36,6 @@ yanked = "warn"
 ignore = [
   # "RUSTSEC-0000-0000",
   "RUSTSEC-2023-0071", # we cannot replace rsa 0.9 as it's used by sqlx-mysql AND jsonwebtoken
-  "RUSTSEC-2025-0141"  # temporary allow using of bincode 2.0.1
 ]
 
 # Note:

--- a/examples/oop-modules/calculator/calculator-sdk/src/api.rs
+++ b/examples/oop-modules/calculator/calculator-sdk/src/api.rs
@@ -3,16 +3,16 @@
 //! Contract trait and types for the calculator service.
 
 use async_trait::async_trait;
-use modkit_security::SecurityCtx;
+use modkit_security::SecurityContext;
 
 /// Calculator API trait
 ///
 /// A simple service that performs addition operations.
-/// All methods require a SecurityCtx for authorization.
+/// All methods require a SecurityContext for authorization.
 #[async_trait]
 pub trait CalculatorClient: Send + Sync {
     /// Add two numbers and return the sum.
-    async fn add(&self, ctx: &SecurityCtx, a: i64, b: i64) -> Result<i64, CalculatorError>;
+    async fn add(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, CalculatorError>;
 }
 
 /// Error type for Calculator operations

--- a/examples/oop-modules/calculator/calculator-sdk/src/client.rs
+++ b/examples/oop-modules/calculator/calculator-sdk/src/client.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tonic::transport::Channel;
 
-use modkit_security::SecurityCtx;
+use modkit_security::SecurityContext;
 use modkit_transport_grpc::attach_secctx;
 use modkit_transport_grpc::client::{connect_with_retry, GrpcClientConfig};
 
@@ -32,14 +32,14 @@ impl CalculatorGrpcClient {
 
 #[async_trait]
 impl CalculatorClient for CalculatorGrpcClient {
-    async fn add(&self, ctx: &SecurityCtx, a: i64, b: i64) -> Result<i64, CalculatorError> {
+    async fn add(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, CalculatorError> {
         let mut client = self.inner.clone();
 
-        // Build request with SecurityCtx in metadata
+        // Build request with SecurityContext in metadata
         let proto_req = AddRequest { a, b };
         let mut request = tonic::Request::new(proto_req);
 
-        // Attach SecurityCtx to metadata
+        // Attach SecurityContext to metadata
         attach_secctx(request.metadata_mut(), ctx)
             .map_err(|e| CalculatorError::Internal(e.to_string()))?;
 

--- a/examples/oop-modules/calculator_gateway/calculator_gateway-sdk/src/api.rs
+++ b/examples/oop-modules/calculator_gateway/calculator_gateway-sdk/src/api.rs
@@ -1,19 +1,24 @@
 //! API trait and error types for CalculatorGateway
 
 use async_trait::async_trait;
-use modkit_security::SecurityCtx;
+use modkit_security::SecurityContext;
 
 /// Calculator Gateway API trait
 ///
 /// A simple service that performs addition operations.
-/// All methods require a SecurityCtx for authorization.
+/// All methods require a SecurityContext for authorization.
 ///
 /// This trait is implemented by `CalculatorGatewayLocalClient` which
 /// delegates to the module's internal Service.
 #[async_trait]
 pub trait CalculatorGatewayClient: Send + Sync {
     /// Add two numbers and return the sum.
-    async fn add(&self, ctx: &SecurityCtx, a: i64, b: i64) -> Result<i64, CalculatorGatewayError>;
+    async fn add(
+        &self,
+        ctx: &SecurityContext,
+        a: i64,
+        b: i64,
+    ) -> Result<i64, CalculatorGatewayError>;
 }
 
 /// Error type for CalculatorGateway operations

--- a/examples/oop-modules/calculator_gateway/calculator_gateway-sdk/src/client.rs
+++ b/examples/oop-modules/calculator_gateway/calculator_gateway-sdk/src/client.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use modkit_security::SecurityCtx;
+use modkit_security::SecurityContext;
 
 use calculator_gateway::{Service, ServiceError};
 
@@ -25,7 +25,12 @@ impl CalculatorGatewayLocalClient {
 
 #[async_trait]
 impl CalculatorGatewayClient for CalculatorGatewayLocalClient {
-    async fn add(&self, ctx: &SecurityCtx, a: i64, b: i64) -> Result<i64, CalculatorGatewayError> {
+    async fn add(
+        &self,
+        ctx: &SecurityContext,
+        a: i64,
+        b: i64,
+    ) -> Result<i64, CalculatorGatewayError> {
         self.service.add(ctx, a, b).await.map_err(convert_error)
     }
 }

--- a/examples/oop-modules/calculator_gateway/calculator_gateway/src/api/rest/handlers.rs
+++ b/examples/oop-modules/calculator_gateway/calculator_gateway/src/api/rest/handlers.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use axum::{Extension, Json};
 
 use modkit::api::problem::{internal_error, Problem};
-use modkit_security::SecurityCtx;
+use modkit_security::SecurityContext;
 
 use crate::domain::Service;
 
@@ -16,7 +16,7 @@ use super::dto::{AddRequest, AddResponse};
 /// Accepts a JSON body with operands and returns their sum.
 /// Delegates to Service directly.
 pub async fn handle_add(
-    Extension(ctx): Extension<SecurityCtx>,
+    Extension(ctx): Extension<SecurityContext>,
     Extension(service): Extension<Arc<Service>>,
     Json(req): Json<AddRequest>,
 ) -> Result<Json<AddResponse>, Problem> {

--- a/examples/oop-modules/calculator_gateway/calculator_gateway/src/domain/service.rs
+++ b/examples/oop-modules/calculator_gateway/calculator_gateway/src/domain/service.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use calculator_sdk::CalculatorClient;
 use modkit::client_hub::ClientHub;
-use modkit_security::SecurityCtx;
+use modkit_security::SecurityContext;
 use tracing::{debug, instrument};
 
 /// Error type for Service operations.
@@ -40,7 +40,7 @@ impl Service {
 
     /// Add two numbers by delegating to calculator service.
     #[instrument(skip(self, ctx), fields(a, b))]
-    pub async fn add(&self, ctx: &SecurityCtx, a: i64, b: i64) -> Result<i64, ServiceError> {
+    pub async fn add(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, ServiceError> {
         debug!("Resolving calculator client from ClientHub");
 
         let calculator = self.client_hub.get::<dyn CalculatorClient>().map_err(|e| {

--- a/libs/modkit-security/Cargo.toml
+++ b/libs/modkit-security/Cargo.toml
@@ -11,6 +11,6 @@ workspace = true
 uuid = { workspace = true, features = ["v4"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-bincode = { workspace = true }
+postcard = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }

--- a/libs/modkit-security/tests/bin_codec.rs
+++ b/libs/modkit-security/tests/bin_codec.rs
@@ -1,46 +1,69 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-use modkit_security::{
-    decode_bin, encode_bin, AccessScope, SecurityCtx, Subject, SECCTX_BIN_VERSION,
-};
+use modkit_security::{decode_bin, encode_bin, Permission, SecurityContext, SECCTX_BIN_VERSION};
 use uuid::Uuid;
 
 #[test]
 #[allow(clippy::unreadable_literal)] // UUID hex patterns are intentionally repeating
 fn round_trips_security_ctx_binary_payload() {
-    let tenant_ids = vec![
-        Uuid::from_u128(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa),
-        Uuid::from_u128(0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb),
-    ];
-    let resource_ids = vec![
+    let tenant_id = Uuid::from_u128(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);
+    let resource_ids = [
         Uuid::from_u128(0x11111111111111111111111111111111),
         Uuid::from_u128(0x22222222222222222222222222222222),
     ];
     let subject_id = Uuid::from_u128(0xdeadbeefdeadbeefdeadbeefdeadbeef);
 
-    let scope = AccessScope::both(tenant_ids.clone(), resource_ids.clone());
-    let subject = Subject::new(subject_id);
-    #[allow(deprecated)]
-    let ctx = SecurityCtx::new(scope, subject.clone());
+    let ctx = SecurityContext::builder()
+        .tenant_id(tenant_id)
+        .subject_id(subject_id)
+        .add_permission(
+            Permission::builder()
+                .resource_pattern("book")
+                .resource_id(resource_ids[0])
+                .action("read")
+                .build()
+                .unwrap(),
+        )
+        .add_permission(
+            Permission::builder()
+                .resource_pattern("book")
+                .resource_id(resource_ids[1])
+                .action("read")
+                .build()
+                .unwrap(),
+        )
+        .build();
 
     let encoded = encode_bin(&ctx).expect("security context encodes");
     let decoded = decode_bin(&encoded).expect("security context decodes");
 
-    assert_eq!(decoded.scope(), ctx.scope());
-    assert_eq!(decoded.scope().tenant_ids(), tenant_ids.as_slice());
-    assert_eq!(decoded.scope().resource_ids(), resource_ids.as_slice());
-    assert_eq!(decoded.subject(), ctx.subject());
-    assert_eq!(decoded.subject_id(), subject.id());
+    // Validate core fields round-trip
+    assert_eq!(decoded.tenant_id(), ctx.tenant_id());
+    assert_eq!(decoded.subject_id(), ctx.subject_id());
+
+    let decoded_perms = decoded.permissions();
+    let orig_perms = ctx.permissions();
+    assert_eq!(decoded_perms.len(), orig_perms.len());
+
+    for (i, p) in decoded_perms.iter().enumerate() {
+        assert_eq!(p.resource_pattern(), orig_perms[i].resource_pattern());
+        assert_eq!(p.resource_id(), orig_perms[i].resource_id());
+        assert_eq!(p.action(), orig_perms[i].action());
+        assert_eq!(p.tenant_id(), orig_perms[i].tenant_id());
+    }
 }
 
 #[test]
 #[allow(clippy::unreadable_literal)] // UUID hex patterns are intentionally repeating
 fn decode_rejects_unknown_version() {
-    let tenant_ids = vec![Uuid::from_u128(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)];
+    let tenant_id = Uuid::from_u128(0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa);
     let subject_id = Uuid::from_u128(0x33333333333333333333333333333333);
 
-    #[allow(deprecated)]
-    let ctx = SecurityCtx::for_tenants(tenant_ids, subject_id);
+    let ctx = SecurityContext::builder()
+        .tenant_id(tenant_id)
+        .subject_id(subject_id)
+        .build();
+
     let mut encoded = encode_bin(&ctx).expect("encodes context");
     encoded[0] = SECCTX_BIN_VERSION.wrapping_add(1);
 

--- a/libs/modkit-transport-grpc/src/lib.rs
+++ b/libs/modkit-transport-grpc/src/lib.rs
@@ -10,26 +10,26 @@ pub use windows_named_pipe::{create_named_pipe_incoming, NamedPipeConnection, Na
 
 pub const SECCTX_METADATA_KEY: &str = "x-secctx-bin";
 
-use modkit_security::{decode_bin, encode_bin, SecurityCtx};
+use modkit_security::{decode_bin, encode_bin, SecurityContext};
 use tonic::metadata::{MetadataMap, MetadataValue};
 use tonic::Status;
 
-/// Encode `SecurityCtx` into gRPC metadata.
+/// Encode `SecurityContext` into gRPC metadata.
 ///
 /// # Errors
 /// Returns `Status::internal` if encoding fails.
-pub fn attach_secctx(meta: &mut MetadataMap, ctx: &SecurityCtx) -> Result<(), Status> {
+pub fn attach_secctx(meta: &mut MetadataMap, ctx: &SecurityContext) -> Result<(), Status> {
     let encoded = encode_bin(ctx).map_err(|e| Status::internal(format!("secctx encode: {e}")))?;
 
     meta.insert_bin(SECCTX_METADATA_KEY, MetadataValue::from_bytes(&encoded));
     Ok(())
 }
 
-/// Decode `SecurityCtx` from gRPC metadata.
+/// Decode `SecurityContext` from gRPC metadata.
 ///
 /// # Errors
 /// Returns `Status::unauthenticated` if the metadata is missing or decoding fails.
-pub fn extract_secctx(meta: &MetadataMap) -> Result<SecurityCtx, Status> {
+pub fn extract_secctx(meta: &MetadataMap) -> Result<SecurityContext, Status> {
     let raw = meta
         .get_bin(SECCTX_METADATA_KEY)
         .ok_or_else(|| Status::unauthenticated("missing secctx metadata"))?;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched binary serialization from bincode to postcard and updated dependencies.
  * Renamed the security context type consistently across public APIs and SDKs; introduced Permission and SecurityContext exports.

* **Bug Fixes**
  * Removed an advisory ignore entry so the specified vulnerability is now subject to the configured advisory policy (now reported as a warning).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->