### PR TITLE
[WIP] docs(serverless_runtime): add PRD and ADRs for entrypoint + Starlark …

### DIFF
--- a/modules/serverless_runtime/docs/1_PRD.md
+++ b/modules/serverless_runtime/docs/1_PRD.md
@@ -1,0 +1,450 @@
+# PRD — Serverless Runtime (Business Requirements)
+
+## Purpose
+Provide a platform capability that enables tenants and their users to create, modify, register, and execute custom automation (functions and workflows) at runtime, without requiring a product rebuild or redeploy, while maintaining strong isolation, governance, and operational visibility.
+
+## Background / Problem Statement
+The platform requires a unified way to automate long-running and multi-step business processes across modules and external systems. Today, automation capability is limited by release cycles and lacks durable, tenant-isolated execution with governance, controls, and observability.
+
+This PRD defines the business requirements for a Serverless Runtime capability that supports:
+- tenant-specific automation assets (functions/workflows)
+- durable long-running execution
+- governance (limits, permissions, auditability)
+- operational excellence (visibility, debugging)
+
+## Goals (Business Outcomes)
+- Enable faster delivery of tenant-specific automation without platform redeploys.
+- Reduce operational risk for long-running processes by ensuring durability and resumability.
+- Improve supportability and incident resolution via rich observability and debugging.
+- Maintain compliance posture with auditability and strict tenant isolation.
+
+## Stakeholders / Users
+- **Platform service teams**: isolate and consolidate orchestration logic and reduce direct dependencies between platform components.
+- **Integration vendors**: provide custom functions/workflows for integrations in runtime.
+- **Tenant administrators**: manage automation assets, schedules, permissions, and governance.
+
+## Scope
+### In Scope
+- Runtime creation/modification/registration and execution of:
+  - **Functions** (single unit of custom logic)
+  - **Workflows** (multi-step orchestration)
+- Tenant- and user-scoped registries for functions/workflows.
+- Long-running asynchronous execution (including multi-day executions).
+- Governance controls via resource limits and policies.
+- Multiple trigger modes (schedule, API-triggered, event-triggered).
+- Secure execution context options (system account vs API client or user context).
+- Runtime interactions with platform capabilities (e.g., calling platform-provided runtime methods).
+- Durability features (snapshots / suspend-resume) for reliability and event waiting.
+- Operational tooling requirements: visibility, audit trail, and debugging capabilities.
+- Built-in support for distributed transaction patterns (saga and compensation).
+
+### Out of Scope
+- Visual workflow designer UI (future capability).
+- External workflow template marketplace.
+- Real-time event streaming infrastructure (assumed to exist as a separate platform capability).
+- Short-lived synchronous request/response patterns as a primary workload.
+
+## Business Requirements (Global)
+### P0 Requirements (Critical)
+
+### BR-001 (P0): Runtime authoring without platform rebuild
+The system MUST allow tenants and their users to create and modify functions and workflows at runtime, such that changes can be applied without rebuilding or redeploying the platform.
+
+### BR-002 (P0): Tenant and user registries
+The system MUST provide a registry of functions and workflows that is isolated per tenant and supports user-level ownership/management within a tenant.
+
+### BR-003 (P0): Long-running asynchronous execution
+The system MUST support long-running asynchronous functions and workflows, including executions lasting days (and longer where needed for business processes).
+
+### BR-004 (P0): Synchronous invocation for short executions
+The system MUST support synchronous request/response invocation as a first-class feature for short-running executions, where the caller receives the result (or error) in the same API response.
+This mode MUST be optional and MUST NOT replace long-running asynchronous execution as the primary workload.
+
+### BR-005 (P0): Resource governance
+The system MUST support defining and enforcing resource limits for function/workflow execution, including:
+- CPU limits
+- memory limits
+
+The P0 version may use runtime controlled resource isolation, not OS-level resource isolation.
+
+### BR-006 (P0): Execution identity context
+Functions/workflows MUST support being executed under:
+- a system account (platform/service context)
+- an API client context
+- a user context (end-user / tenant-user context)
+
+### BR-007 (P0): Trigger mechanisms
+The system MUST support starting functions/workflows via three trigger modes:
+- schedule-based triggers
+- API-triggered starts
+- event-driven triggers
+
+### BR-008 (P0): Runtime capabilities / integrations
+Workflows and functions MUST be able to invoke runtime-provided capabilities needed for business automation, such as:
+- making outbound HTTP requests
+- emitting or publishing business events
+- writing to audit logs
+- invoking platform-provided operations required for orchestration
+
+### BR-009 (P0): Durability via snapshots and suspend/resume
+Workflows MUST provide an integrated snapshot mechanism enabling:
+- suspend and resume behavior when waiting for events
+- survival across service restarts
+- continuation without losing progress
+
+### BR-010 (P0): Conditional logic and loops
+Workflow definitions MUST support conditional branching and loop constructs to model complex business logic.
+
+### BR-011 (P0): Function/Workflow definition validation
+The system MUST validate workflow/function definitions before registration and reject invalid definitions with actionable feedback.
+
+### BR-012 (P0): Graceful disconnection handling
+When an integration adapter or external dependency is disconnected, the system MUST:
+- reject new workflow/function starts that depend on the disconnected component
+- allow in-flight executions to complete or fail gracefully
+
+### BR-013 (P0): Per-function/workflow resource quotas
+The system MUST support defining resource limits at the individual workflow/function definition level, including:
+- maximum concurrent executions of that workflow/function
+- maximum memory allocation per execution
+- maximum CPU allocation per execution
+
+### BR-014 (P0): Long-running execution credential refresh
+For long-running asynchronous workflows, the system MUST support automatic refresh of initiator/caller authentication tokens or credentials, ensuring that:
+- workflows do not fail due to token expiration during extended execution
+- security context remains valid and auditable throughout the workflow lifetime
+
+### BR-015 (P0): Workflow and execution lifecycle management
+The system MUST support lifecycle management for workflows/functions and their executions, including the ability to:
+- start executions
+- cancel or terminate executions
+- retry failed executions
+- suspend and resume executions
+- apply compensation behavior on cancellation where applicable
+
+### BR-016 (P0): Execution visibility and querying
+The system MUST provide an interface for authorized users/operators to:
+- list available workflow/function definitions in their scope
+- list executions and their current status
+- inspect execution history and the current/pending step
+- filter/search by tenant, initiator, time range, status, and correlation identifier
+
+### BR-017 (P0): Access control and separation of duties
+The system MUST enforce authenticated and authorized access to all workflow/function management and execution operations and MUST fail closed on authorization failures.
+The system SHOULD support separation of duties so that permissions to author/modify workflows/functions can be distinct from permissions to execute or administer them.
+
+### BR-018 (P0): Data protection and privacy controls
+The system MUST protect workflow/function definitions, execution state, and audit records with appropriate data protection controls, including:
+- protection of data at rest and in transit
+- minimization of sensitive data exposure in logs and execution history
+- controls for handling sensitive inputs/outputs and restricting who can view them
+
+### BR-019 (P0): Workflow/function definition versioning
+The system MUST support versioning of workflow/function definitions so that:
+- new executions can use an updated version
+- in-flight executions continue with the version they started with
+- changes are traceable and can be rolled back where needed
+
+### BR-020 (P0): Retry and failure handling policies
+The system MUST support configurable retry and failure-handling policies for workflows/functions, including:
+- maximum retry attempts
+- backoff behavior
+- classification of non-retryable failures
+
+### BR-021 (P0): Tenant enablement and isolation provisioning
+The system MUST support enabling the workflow/function runtime for a tenant in a way that provisions required isolation and governance settings (including quotas) so the tenant can safely use the capability.
+
+### BR-022 (P0): Tenant and correlation identifiers in observability
+The system MUST ensure that tenant identifiers and correlation identifiers are consistently present across audit records, logs, and operational metrics for traceability and compliance.
+
+### BR-023 (P0): Schedule lifecycle and missed schedule handling
+The system MUST support schedule lifecycle management (create, update, pause/resume, and delete) and MUST support a configurable policy for handling missed schedules during downtime.
+
+### BR-024 (P0): Audit log integrity
+The system MUST ensure audit records are trustworthy for compliance purposes, including:
+- audit records are protected from unauthorized modification and deletion
+- audit records are available for compliance review within the configured retention period
+
+### BR-025 (P0): Security context availability to workflow/function steps
+The system MUST ensure that the execution security context is available throughout the lifetime of an execution and to every workflow/function step so that all actions performed by the runtime are attributable, authorized, and auditable.
+
+### BR-026 (P0): Secure handling of secrets and sensitive values
+The system MUST support secure handling of secrets and other sensitive values used by workflows/functions, ensuring that:
+- secrets are not inadvertently exposed via logs, execution history, or debugging views
+- access to secrets is restricted to authorized actors and permitted executions
+
+### BR-027 (P0): Workflow/function state consistency
+The system MUST ensure that workflow/function state remains consistent during concurrent operations and system failures, with no partial updates or corrupted states.
+
+### BR-028 (P0): Dead letter queue handling
+The system MUST provide dead letter handling for executions that repeatedly fail after all retry attempts, ensuring failed executions are preserved for analysis and manual recovery.
+
+### BR-029 (P0): Workflow/function maximum execution duration guardrail
+The system MUST enforce a maximum execution duration guardrail to prevent infinite or runaway executions.
+This guardrail MUST be configurable per tenant and workflow/function and MUST apply even if higher timeouts are requested.
+
+### BR-030 (P0): Workflow/function execution isolation during updates
+The system MUST ensure that updating a workflow/function definition does not affect executions currently running with the previous version.
+
+### BR-031 (P0): Workflow/function execution error boundaries
+The system MUST support error boundary mechanisms that contain failures within specific workflow sections and prevent cascading failures across the entire workflow.
+
+### BR-032 (P0): LLM-manageable workflow/function definitions
+Workflow/function definitions MUST be expressible in a form that allows an LLM to reliably:
+- create and update definitions
+- validate definitions and provide actionable feedback
+- explain the workflow/function behavior in human-readable form
+
+### BR-033 (P0): Typed workflow/function inputs and outputs
+The system MUST support starting workflows/functions with typed input parameters and receiving typed outputs, such that:
+- inputs/outputs can be validated before execution
+- inputs/outputs can be safely inspected in execution history (subject to privacy controls)
+
+### BR-034 (P0): Encryption controls
+The system MUST ensure workflow/function definitions, execution state, and execution history are encrypted at rest, and all network communication is encrypted in transit.
+
+### BR-035 (P0): Audit trail and change traceability
+The system MUST maintain a complete audit trail for:
+- workflow/function definition creation, modification, enable/disable, and deletion
+- execution lifecycle events (started, suspended, resumed, failed, compensated, canceled, completed)
+Audit records MUST identify the tenant, actor (system/API client/user), and correlation identifier.
+
+### P1 Requirements (Important)
+
+### BR-101 (P1): Debugging and auditability
+The platform MUST provide a way to debug workflow executions, including:
+- setting breakpoints
+- logging each action/function call with input parameters and return values
+- retaining sufficient execution history to troubleshoot failures
+
+### BR-102 (P1): Step-through execution
+The platform SHOULD provide step-through capabilities for workflow execution to support troubleshooting and controlled execution.
+
+### BR-103 (P1): Dry-run execution (no side effects)
+The system SHOULD support a dry-run mode for workflows/functions that validates execution readiness (definition validity, permissions, and configured limits) using user-provided input.
+Dry-run MUST NOT create a durable execution record and MUST NOT cause external side effects.
+
+### BR-104 (P1): Child workflows / modular composition
+The system SHOULD support invoking child workflows/functions from a parent workflow for modular composition and reuse.
+
+### BR-105 (P1): Parallel execution
+The system SHOULD support parallel execution of independent steps/functions within a workflow, with controllable concurrency caps (similar in spirit to browser parallel request limits) and configurable concurrency limits.
+
+### BR-106 (P1): Per-tenant resource quotas
+The system MUST support per-tenant resource quotas, including:
+- maximum total concurrent workflow/function executions per tenant
+- maximum execution history retention size per tenant
+
+### BR-107 (P1): Retention and deletion policies
+The system MUST support configurable retention policies for execution history and related audit records, including tenant-level defaults and deletion policies aligned to contractual and compliance needs.
+
+### BR-108 (P1): External signals and manual intervention
+The system SHOULD support controlled interaction with in-flight executions, including the ability for authorized actors to provide external signals/inputs (for event-driven continuation) and to perform manual intervention actions needed to resolve operational issues.
+
+### BR-109 (P1): Alerts and notifications
+The system SHOULD support notifying authorized users/operators about important workflow/function events, including failures, repeated retries, and abnormal execution duration, to reduce time-to-detection and time-to-recovery.
+
+### BR-110 (P1): Schedule-level input parameters and overrides
+The system SHOULD support defining schedule-level input parameters and overrides so that recurring executions can run with consistent defaults and can be adjusted without modifying the underlying workflow/function definition.
+
+### BR-111 (P1): Cost allocation and metering
+The system MUST provide metering of resource consumption per tenant and per workflow/function to support cost allocation and billing.
+
+### BR-112 (P1): Workflow/function execution timeouts
+The system MUST support configurable execution timeouts at both the workflow/function level and individual step level.
+Configured timeouts MUST NOT exceed the maximum execution duration guardrail defined in BR-033.
+
+### BR-113 (P1): Workflow/function execution throttling
+The system SHOULD support throttling of execution starts to protect downstream systems and prevent resource exhaustion under high load conditions.
+
+### BR-114 (P1): Workflow/function dependency management
+The system SHOULD support declaring and managing dependencies between workflows/functions to ensure proper deployment order and compatibility.
+
+### BR-115 (P1): Workflow/function execution tracing
+The system SHOULD provide distributed tracing capabilities that follow execution across multiple services and external system calls for end-to-end visibility.
+
+### BR-116 (P1): Workflow/function execution rate limits and volume caps
+The system MUST support configurable limits on execution frequency and total execution volume over time to prevent abuse and ensure fair resource allocation across tenants.
+
+### BR-117 (P1): Workflow/function execution environment customization
+The system SHOULD support customizing execution environment settings (such as time zones, locale, and regional compliance requirements) per tenant.
+
+### BR-118 (P1): Workflow/function execution result caching
+The system SHOULD support caching of execution results for idempotent operations to improve performance and reduce redundant processing.
+
+### BR-119 (P1): Workflow/function execution monitoring dashboards
+The system SHOULD provide pre-built monitoring dashboards for common operational metrics and health indicators.
+
+### BR-120 (P1): Workflow/function execution performance profiling
+The system SHOULD support performance profiling of executions to identify bottlenecks and optimization opportunities.
+
+### BR-121 (P1): Workflow/function execution blue-green deployment
+The system SHOULD support blue-green deployment strategies for workflow/function updates to minimize risk during changes.
+
+### BR-122 (P1): Workflow/function publishing governance
+The system SHOULD support governance controls for workflow/function changes (such as review/approval and controlled activation) to reduce operational risk and support compliance.
+
+### BR-123 (P1): Public/shared reusable workflows and functions
+The system SHOULD allow an authorized tenant administrator or vendor to mark a workflow/function definition as public (shared) so that other authorized administrators/vendors can discover and reuse that definition within the same tenant.
+
+### BR-124 (P1): Execution replay
+The system SHOULD support replaying an execution from a recorded history or saved state, to support debugging, incident analysis, and controlled recovery.
+
+### BR-125 (P1): Workflow visualization
+The system SHOULD make it easy for authorized users to visualize workflow structure (execution blocks and decisions/branches) and to understand which path is taken for a given execution.
+
+### BR-126 (P1): Default execution history retention period
+The system MUST provide a default retention period for execution history.
+The default retention period SHOULD be 7 days and MUST be configurable per tenant or per function type
+
+### BR-127 (P1): Debugging access model (tenant vs operator)
+The system MUST enforce a permission model for debugging capabilities, such that:
+- tenant users/administrators can debug and inspect only executions within their tenant scope
+- platform operators can debug across tenants only via explicit operator authorization and with tenant_id and correlation_id traceability
+- sensitive inputs/outputs and secrets are access-controlled and masked by default unless explicitly permitted
+
+### BR-128 (P1): Invocation lifecycle control APIs
+The system MUST provide lifecycle controls for individual executions, including:
+- querying execution status until completion
+- canceling an in-flight execution
+- replaying an execution for controlled recovery and incident analysis
+
+### BR-129 (P1): Standardized error taxonomy
+The system MUST expose a standardized error taxonomy for workflow/function execution failures, including at minimum:
+- upstream HTTP/integration failures
+- runtime/environment failures (timeouts, resource limits)
+- code execution and validation failures
+Errors MUST include a stable error identifier, a human-readable message, and a structured details object to support automation and support workflows.
+
+### BR-130 (P1): Debug call trace (inputs/outputs and durations)
+The system MUST provide a debug view for an execution that includes an ordered list of invoked calls (in order of execution), including:
+- input parameters
+- execution duration per call
+- the exact call response (result or error)
+This debug view MUST be available for completed executions (at least the call trace).
+
+The debug view MUST NOT expose secrets.
+Sensitive inputs/outputs and secrets MUST be masked by default unless explicitly permitted.
+
+### BR-131 (P1): Execution-level compute and memory metrics
+The system SHOULD provide execution-level compute and memory metrics that support troubleshooting, performance tuning, and cost allocation, including:
+- wall-clock duration
+- CPU time
+- memory usage and memory limits
+
+### BR-132 (P1): Result caching policy (TTL)
+The system SHOULD support a result caching policy for eligible workflows/functions where cached successful results may be reused for a configured time-to-live (TTL), to reduce redundant processing.
+
+### BR-133 (P1): Saga and compensation support
+The system MUST provide built-in support for saga-style orchestration, including compensation logic to reverse the effects of completed steps when a workflow cannot complete successfully.
+
+### BR-134 (P1): Idempotency mechanisms
+The platform MUST provide mechanisms to implement idempotency for workflow/function execution.
+The system SHOULD support common idempotency patterns, including idempotency keys, deduplication windows, and correlation identifiers to track and deduplicate requests.
+
+### BR-135 (P1): Tenant-segmented operational metrics
+The system MUST provide operational metrics for workflow/function execution, including volume, latency, error rates, and queue/backlog indicators, and support segmentation by tenant.
+
+### P2 Requirements (Nice-to-have)
+
+### BR-201 (P2): Archival for long-term compliance
+The system SHOULD support long-term archival of execution history and audit records for tenants with extended compliance and reporting requirements.
+
+### BR-202 (P2): Workflow/function definition import/export
+The system SHOULD support importing and exporting workflow/function definitions to enable backup, migration, and cross-environment management.
+
+### BR-203 (P2): Execution time travel
+The system SHOULD support execution time travel from historical states for debugging and compliance investigation purposes.
+
+### BR-204 (P2): Workflow/function execution A/B testing
+The system SHOULD support A/B testing of workflow/function versions to validate changes before full deployment.
+
+### BR-205 (P2): Workflow/function execution canary releases
+The system SHOULD support canary release patterns for gradual rollout of workflow/function updates.
+
+### BR-206 (P2): Execution environment isolation via stronger boundaries
+The system SHOULD provide stronger isolation boundaries for workflow/function execution to ensure:
+- one tenant's code execution cannot access or affect another tenant's execution environment
+- resource consumption by one execution does not negatively impact other executions (noisy neighbor prevention)
+- the isolation boundary is enforced at the operating system or equivalent level
+
+The P2 version may use process-level isolation with strict resource limits.
+
+### BR-207 (P2): Performance SLOs for execution and visibility
+Under normal load, the system SHOULD meet performance targets for:
+- workflow start latency p95 ≤ 100 ms from start request to first step scheduling
+- step dispatch latency p95 ≤ 50 ms from step scheduled to execution start
+- monitoring query latency p95 ≤ 200 ms for execution state/history queries
+- runtime overhead ≤ 10 ms per step (excluding business logic)
+
+### BR-208 (P2): Scalability targets
+The system SHOULD support scale targets including:
+- ≥ 10,000 concurrent executions per region under normal load
+- sustained workflow starts ≥ 1,000/sec per region under normal load
+- ≥ 100,000 workflow executions/day initially with a growth plan to ≥ 1,000,000/day
+- ≥ 1,000 tenants with a clear partitioning/isolation strategy
+- ≥ 10,000 registered workflow definitions across tenants (including per-tenant hot-plug)
+
+## Target Use Cases
+- **Resource provisioning**: multi-step provisioning with rollback on failure.
+- **Tenant onboarding**: staged setup, waiting on external approvals/events.
+- **Subscription lifecycle**: activation, renewal, suspension, cancellation flows.
+- **Billing cycles**: metering aggregation and invoice preparation workflows.
+- **Policy enforcement/remediation**: detect drift and execute corrective actions.
+- **Data migration**: long-running copy/checkpoint/resume processes.
+- **Disaster recovery orchestration**: controlled failover/failback sequences.
+
+## Acceptance Criteria (Business-Level)
+### Workflow Execution
+- Workflows can be started with inputs and produce a completion outcome (success or failure) with a correlation identifier.
+- In-progress workflows resume after a service restart without duplicating completed step side effects.
+- Transient failures result in automatic retries per defined policy until success or exhaustion.
+- Permanent failures in multi-step workflows invoke compensation for previously completed steps.
+- Workflows can remain active for 30+ days with state preserved and queryable, and can continue on external signals/events.
+
+### Tenant Isolation & Security Context
+- A tenant can only see and manage its own functions/workflows and executions.
+- Security context is preserved through long-running executions, ensuring actions are attributable to the correct tenant/user or system identity.
+- Unauthorized operations fail closed.
+
+### Hot-Plug / Runtime Updates
+- New or updated functions/workflows become available without interrupting existing in-flight executions.
+- Updates do not retroactively change the behavior of already-running executions (safe evolution).
+
+### Scheduling
+- Tenants can create, update, pause/resume, and cancel schedules for recurring workflows.
+- Missed schedules during downtime follow a defined policy (e.g., skip or catch-up) and are recorded.
+
+### Observability & Operations
+- Operators can view current execution state, history/timeline, and pending work.
+- Workflow lifecycle events are captured for audit and compliance.
+- Operational metrics exist for volume, latency, and error rates, and can be segmented by tenant.
+
+## Non-Functional Business Requirements (SLOs / Show-Stoppers)
+- **Availability**: runtime service availability MUST meet or exceed 99.95% monthly.
+- **Start responsiveness**: under normal load, new executions SHOULD begin promptly (target p95 start latency ≤ 100 ms).
+- **Step dispatch latency**: under normal load, scheduled steps SHOULD begin execution promptly (target p95 dispatch latency ≤ 50 ms).
+- **Monitoring query latency**: under normal load, execution visibility queries SHOULD respond promptly (target p95 ≤ 200 ms).
+- **Schedule accuracy**: under normal load and with no external dependencies or throttling limits, scheduled executions MUST start within 1 second of their scheduled time.
+- **Reliability**: excluding business-logic failures, the platform MUST achieve ≥ 99.9% completion success via retries/compensation.
+- **Business continuity**: recovery objectives MUST target RTO ≤ 30 seconds and RPO ≤ 1 minute for execution state.
+- **Scalability**: the platform SHOULD support at least 10,000 concurrent executions per region.
+- **Throughput**: the platform SHOULD support sustained workflow starts ≥ 1,000/sec per region under normal load.
+- **Definition scale**: the platform SHOULD support ≥ 10,000 registered workflow definitions across tenants.
+- **Compliance**: audit trails and tenant isolation MUST support SOC 2-aligned controls.
+
+## Assumptions
+- Platform identity and authorization are available and can be used to determine user/system context.
+- Event infrastructure exists to deliver event triggers and record lifecycle events.
+- Persistent storage exists to support durability of execution state.
+- Scheduling is logically part of the Serverless Runtime, but may be implemented as a cooperating internal service with its own persistence and scaling characteristics.
+
+## Risks to be mitigated
+- **Workflow logic complexity**: authoring and governance may be complex for tenants.
+- **Hot-plug reliability**: runtime updates must not destabilize ongoing operations.
+- **Security context propagation**: long-running state must preserve identity reliably.
+- **Scheduling scale**: large numbers of schedules may require careful scaling.
+- **Noisy neighbor**: multi-tenant runtime must enforce per-tenant limits to prevent impact.
+- **Sandbox escape / isolation boundary failure**: user-provided code could attempt to break isolation and access host resources or other tenants data (cache, logs, etc).
+- **Secret exfiltration**: workflows/functions could attempt to read or emit secrets via outputs, events, HTTP calls, or logs.
+- **Privilege escalation via execution identity**: misconfiguration of system/user/API-client execution contexts could grant unintended permissions.

--- a/modules/serverless_runtime/docs/2_ADR_ENTRYPOINT.md
+++ b/modules/serverless_runtime/docs/2_ADR_ENTRYPOINT.md
@@ -1,0 +1,1267 @@
+# ADR — Serverless Runtime Entrypoints (Function & Workflow Definitions, Invocation API)
+
+## Status
+Proposed
+
+## Context
+The Serverless Runtime module needs a stable, tenant-safe way to:
+- register functions & workflows schema and code definitions at runtime
+- invoke those definitions via API
+- observe execution progress and outcomes
+
+This ADR defines:
+- GTS-based identifiers and JSON Schema conventions for functions & workflows definitions
+- definition “traits” (semantics, limits, runtime, error types)
+- invocation API (start, status, cancel, dry-run) with observability fields
+
+## Classifications
+
+### Function
+
+Functions are single-unit compute entrypoints designed for request/response execution:
+- Stateless with respect to the runtime (any durable state is stored externally).
+- Typically short-lived (bounded by platform timeout limits).
+- Commonly used as building blocks for APIs, event handlers, and single-step jobs.
+- Retries are common; authors SHOULD design for idempotency when side effects are possible.
+
+Event waiting is supported by the platform via execution suspension and later resumption.
+For functions this is an advanced capability and is primarily relevant for asynchronous execution.
+
+### Workflow
+
+Workflows are durable, multi-step orchestrations that coordinate one or more actions over time.
+A workflow is a definition that may contain multiple execution steps, suspension points, and runtime-managed continuation.
+- Persisted execution state (durable progress across restarts).
+- Supports long-running behavior (timers, waiting on external events, human-in-the-loop patterns).
+- Encodes orchestration logic (fan-out/fan-in, branching, retries, compensation) over multiple steps.
+- Individual steps are commonly implemented by calling functions or external integrations.
+
+For workflows, the underlying code interpreter/runtime is responsible for typical workflow execution processing, including:
+- step identification
+- step retry scheduling and retry status
+- compensation orchestration
+- checkpointing and suspend/resume
+- event subscription and event-driven continuation
+
+Event waiting for workflows is implemented via suspension plus event subscription, with runtime-level examples defined in the code runtime document (e.g. Starlark).
+
+In Hyperspot, functions and workflows use the same entrypoint definition schema and the same implementation language constructs (if/else, loops, variables, etc.).
+In practice, everything is defined and invoked as a function entrypoint, and the selected runtime MAY determine that a given entrypoint should be treated as a workflow by analyzing the code during validation. For example, the Starlark runtime can validate the program and detect runtime durability primitives (e.g., checkpoints/snapshots or awaiting events/timers); if present, the runtime can apply workflow execution semantics (durable suspend/resume and continuation) rather than treating it as a regular short-lived function.
+The practical difference is execution semantics:
+- Workflows are typically **async** and include internal snapshot/checkpoint behavior so the runtime can persist progress and support suspend/resume.
+- Functions are typically **sync**, short-lived, and stateless with respect to the runtime.
+
+## Synchronous vs Asynchronous
+
+Functions and workflows can be executed synchronously or asynchronously.
+
+- **sync**
+  - The client waits for completion and receives the result (or error) in the HTTP response.
+  - This is constrained by HTTP and gateway timeouts, so it is best for short executions.
+
+- **async**
+  - The client receives an `invocation_id` immediately and retrieves status/results later via the status endpoint.
+  - The client “polls” for completion:
+    - **Short poll**: `GET` returns immediately with the latest known status.
+    - **Long poll**: `GET` waits up to a timeout before returning (otherwise identical semantics); this reduces client round-trips while still using polling.
+
+## Functions & Workflows identifier conventions
+
+Both functions and workflows use the same schema and semantic definition following `https://github.com/GlobalTypeSystem/gts-spec` specification.
+
+According to GTS specification, function/workflow contract definitions are represented as GTS **types** (JSON Schema documents), identified by `$id` values that end with `~`.
+
+* Base function/workflow definition:
+  - `gts.x.core.faas.func.v1~` - defines the base function/workflow definition schema, including placeholders for `params`, `returns`, `errors`, and the schema for `traits` (semantics) such as timeouts and limits.
+
+* Specific function/workflow definitions:
+  - are derived GTS types (JSON Schemas) that reference the base type (typically via `allOf`) and then pin concrete `params`, `returns`, and initialized `traits` values.
+
+Functions/workflows identifier examples:
+  - `gts.x.core.faas.func.v1~vendor_x.app.namespace.func_name.v1~`
+  - `gts.x.core.faas.func.v1~vendor_y.pkg.domain.workflow_name.v1~`
+
+The invocation API uses GTS ID to refer to the specific function/workflow definition type identifier (the `$id` value without the `gts://` prefix).
+
+## Schemas
+This section defines base schema for functions/workflows definitions.
+
+### Base schema: Entrypoint Definition
+**Schema ID (type):** `gts.x.core.faas.func.v1~`
+
+Main schema elements are:
+- `id` - base function/workflow type identifier.
+- `params` - function input schema, to be refined by specific functions/workflows.
+- `returns` - function output schema, to be refined by specific functions/workflows.
+- `errors` - list of possible custom error type identifiers (GTS IDs).
+- `traits` - schema for `traits` (semantics) such as timeouts and limits, that must be pinned by specific functions/workflows (e.g., with property-level `const`)
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.func.v1~",
+  "title": "FaaS Function Definition",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Well-known type identifier of this function/workflow definition.",
+      "examples": ["gts.x.core.faas.func.v1~vendor.app.namespace.func_name.v1~"]
+    },
+
+    "title": { "type": "string" },
+    "description": { "type": "string" },
+
+    "params": {
+      "description": "Function input schema (DTS-style naming). May be a $ref to a GTS schema, inline JSON Schema, or void.",
+      "oneOf": [
+        {"$ref": "https://json-schema.org/draft/2020-12/schema"},
+        {"type": "object", "additionalProperties": true},
+        {"type": "null", "description": "Void params"}
+      ]
+    },
+
+    "returns": {
+      "description": "Function output schema (DTS-style naming). May be a $ref to a GTS schema, inline JSON Schema, or void.",
+      "oneOf": [
+        {"$ref": "https://json-schema.org/draft/2020-12/schema"},
+        {"type": "object", "additionalProperties": true},
+        {"type": "null", "description": "Void returns"}
+      ]
+    },
+
+    "errors": {
+      "type": "array",
+      "items": {"type": "string"},
+      "default": [],
+      "description": "List of possible customerror type identifiers (GTS IDs)."
+    },
+
+    "traits": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "entrypoint": {
+          "type": "boolean",
+          "default": true,
+          "description": "If true, the function is externally callable via the invocation API. If false, it is internal-only and can be referenced only from other workflows/functions."
+        },
+        "is_idempotent": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether repeated execution with the same effective input produces the same effect."
+        },
+
+        "invocation": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "supported": {
+              "type": "array",
+              "items": {"type": "string", "enum": ["sync", "async"]},
+              "minItems": 1,
+              "uniqueItems": true,
+              "default": ["async"],
+              "description": "Which invocation modes this entrypoint supports."
+            },
+            "default": {
+              "type": "string",
+              "enum": ["sync", "async"],
+              "default": "async",
+              "description": "Default invocation mode if the caller does not specify one."
+            }
+          },
+          "required": ["supported"]
+        },
+
+        "caching": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Client caching policy for successful results. Cache reuse is ALWAYS scoped by tenant, caller token/identity, all request headers, and the full `params` payload. This trait is a hint for the caller: the function owner is responsible for providing a reasonable hint, and the runtime cannot guarantee that a cached value equals what the function would return now. This trait only defines freshness TTL.",
+          "properties": {
+            "max_age_seconds": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "description": "How long a cached result is considered fresh (TTL). 0 means no caching (clients MUST NOT reuse cached results). TTL is a client-side reuse hint and does not guarantee correctness under non-determinism, data drift, or changing upstream dependencies."
+            }
+          },
+          "required": ["max_age_seconds"]
+        },
+        "runtime": {
+          "type": "string",
+          "description": "Mandatory runtime selector (e.g., Starlark, WASM, AWS Lambda, etc.)."
+        },
+
+        "default_timeout_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Default timeout for this function/workflow in seconds."
+        },
+        "default_memory_mb": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Default memory allocation for this function/workflow in MB."
+        },
+        "default_cpu": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Default CPU allocation for this function/workflow."
+        },
+
+        "localization_dictionary_id": {
+          "type": "string",
+          "description": "Optional localization dictionary reference (GTS ID)."
+        },
+
+        "tags": {
+          "type": "array",
+          "items": {"type": "string"},
+          "default": [],
+          "description": "Optional tags for this function/workflow categorization, searchability, etc."
+        }
+
+      },
+      "required": ["runtime"]
+    },
+
+    "implementation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "language": {"type": "string"},
+            "source": {
+              "type": "string",
+              "description": "Inline source code (optional)."
+            }
+          },
+          "required": ["language"]
+        }
+      },
+      "description": "Execution implementation. `code` MUST be provided.",
+      "minProperties": 1,
+      "required": ["code"]
+    }
+  },
+  "required": ["id", "params", "returns", "traits", "implementation"]
+}
+```
+
+### Base schema: Error
+**Schema ID (type):** `gts.x.core.faas.err.v1~`
+
+This is the base error envelope returned by the runtime (and referenced by entrypoints via `errors`). Derived error types specialize the `details` field.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.err.v1~",
+  "title": "FaaS Error",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Error code identifier (GTS ID).",
+      "examples": ["gts.x.core.faas.err.v1~x.core._.code.v1~"]
+    },
+    "message": {
+      "type": "string",
+      "description": "Human-readable error message."
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Error-class-specific structured payload."
+    }
+  },
+  "required": ["id", "message", "details"]
+}
+```
+
+### Derived error schema: Upstream HTTP error
+**Schema ID (type):** `gts.x.core.faas.err.v1~x.core._.http.v1~`
+
+Used for failures from upstream HTTP calls (e.g., `r_http_get_v1()`). This schema specializes `details`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.err.v1~x.core._.http.v1~",
+  "title": "FaaS Upstream HTTP Error",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.err.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.err.v1~x.core._.http.v1~"},
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "status_code": {"type": "integer", "minimum": 100, "maximum": 599},
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {"type": "string"},
+              {"type": "array", "items": {"type": "string"}}
+            ]
+          }
+        },
+        "body": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Parsed JSON body when available; otherwise an empty object."
+        }
+      },
+      "required": ["status_code", "headers", "body"]
+    }
+  },
+  "required": ["id", "message", "details"]
+}
+```
+
+### Derived error schema: Upstream HTTP transport error (timeout / no connection)
+**Schema ID (type):** `gts.x.core.faas.err.v1~x.core._.http_transport.v1~`
+
+Used for upstream HTTP call failures where **no HTTP response** is available (e.g., timeout, connection failure). This schema specializes `details`.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.err.v1~x.core._.http_transport.v1~",
+  "title": "FaaS Upstream HTTP Transport Error",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.err.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.err.v1~x.core._.http_transport.v1~"},
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {"type": "string"}
+      },
+      "required": ["url"]
+    }
+  },
+  "required": ["id", "message", "details"]
+}
+```
+
+### Derived error schema: Upstream HTTP transport timeout
+**Schema ID (type):** `gts.x.core.faas.err.v1~x.core._.http_transport.v1~x.core._.timeout.v1~`
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.err.v1~x.core._.http_transport.v1~x.core._.timeout.v1~",
+  "title": "FaaS Upstream HTTP Transport Timeout",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.err.v1~x.core._.http_transport.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.err.v1~x.core._.http_transport.v1~x.core._.timeout.v1~"}
+  },
+  "required": ["id", "message", "details"]
+}
+```
+
+### Derived error schema: Upstream HTTP transport no connection
+**Schema ID (type):** `gts.x.core.faas.err.v1~x.core._.http_transport.v1~x.core._.no_connection.v1~`
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.err.v1~x.core._.http_transport.v1~x.core._.no_connection.v1~",
+  "title": "FaaS Upstream HTTP Transport No Connection",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.err.v1~x.core._.http_transport.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.err.v1~x.core._.http_transport.v1~x.core._.no_connection.v1~"}
+  },
+  "required": ["id", "message", "details"]
+}
+```
+
+### Derived error schema: Runtime resource/timeout error
+**Schema ID (type):** `gts.x.core.faas.err.v1~x.core._.runtime.v1~`
+
+Used when the runtime aborts execution due to resource limits or platform constraints.
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.err.v1~x.core._.runtime.v1~",
+  "title": "FaaS Runtime Error",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.err.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.err.v1~x.core._.runtime.v1~"},
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limit": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "timeout_seconds": {"type": "integer", "minimum": 1},
+            "memory_limit_mb": {"type": "integer", "minimum": 1},
+            "cpu_limit": {"type": "number", "minimum": 0}
+          }
+        },
+        "observed": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "duration_ms": {"type": "integer", "minimum": 0},
+            "cpu_time_ms": {"type": "integer", "minimum": 0},
+            "max_memory_used_mb": {"type": "integer", "minimum": 0}
+          }
+        }
+      },
+      "required": []
+    }
+  },
+  "required": ["id", "message", "details"]
+}
+```
+
+### Derived error schema: Runtime timeout
+**Schema ID (type):** `gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.timeout.v1~`
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.timeout.v1~",
+  "title": "FaaS Runtime Timeout",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.err.v1~x.core._.runtime.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.timeout.v1~"}
+  },
+  "required": ["id", "message", "details"]
+}
+```
+
+### Derived error schema: Runtime memory limit
+**Schema ID (type):** `gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.memory_limit.v1~`
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.memory_limit.v1~",
+  "title": "FaaS Runtime Memory Limit",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.err.v1~x.core._.runtime.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.memory_limit.v1~"}
+  },
+  "required": ["id", "message", "details"]
+}
+```
+
+### Derived error schema: Runtime CPU limit
+**Schema ID (type):** `gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.cpu_limit.v1~`
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.cpu_limit.v1~",
+  "title": "FaaS Runtime CPU Limit",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.err.v1~x.core._.runtime.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.cpu_limit.v1~"}
+  },
+  "required": ["id", "message", "details"]
+}
+```
+
+### Derived error schema: Runtime canceled
+**Schema ID (type):** `gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.canceled.v1~`
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.canceled.v1~",
+  "title": "FaaS Runtime Canceled",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.err.v1~x.core._.runtime.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.canceled.v1~"}
+  },
+  "required": ["id", "message", "details"]
+}
+```
+
+### Derived error schema: Code execution/validation error
+**Schema ID (type):** `gts.x.core.faas.err.v1~x.core._.code.v1~`
+
+Used for code-level failures produced by the selected runtime (e.g., Starlark validation/compile/runtime errors).
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.err.v1~x.core._.code.v1~",
+  "title": "FaaS Code Error",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.err.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.err.v1~x.core._.code.v1~"},
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "runtime": {"type": "string", "description": "Language/runtime identifier (e.g., starlark)."},
+        "phase": {"type": "string", "enum": ["validate", "compile", "execute"]},
+        "error_kind": {"type": "string", "description": "Runtime-specific diagnostic kind/code (not an exception)."},
+        "location": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "line": {"type": "integer", "minimum": 1},
+            "code": {"type": "string"}
+          },
+          "required": ["line", "code"]
+        },
+        "stack": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "frames": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "function": {"type": "string"},
+                  "file": {"type": "string"},
+                  "line": {"type": "integer", "minimum": 1}
+                },
+                "required": ["function", "file", "line"]
+              }
+            }
+          },
+          "required": ["frames"]
+        }
+      },
+      "required": ["runtime", "phase"]
+    }
+  },
+  "required": ["id", "message", "details"]
+}
+```
+
+## Examples
+### Function definition type example #1
+
+This is a tax calculation function example written in Starlark that:
+- Supports both sync and async invocation (default is async)
+- Idempotent
+- Includes default resource/time limits
+- Enables client caching for 60 seconds (within tenant + token/identity + headers + params)
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.func.v1~vendor.app.billing.calculate_tax.v1~",
+  "title": "Calculate Tax",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.func.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.func.v1~vendor.app.billing.calculate_tax.v1~"},
+    "params": {
+      "const": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "invoice_total": {"type": "number"},
+          "region": {"type": "string"}
+        },
+        "required": ["invoice_total", "region"]
+      }
+    },
+    "returns": {
+      "const": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "tax": {"type": "number"}
+        },
+        "required": ["tax"]
+      }
+    },
+    "errors": {"const": ["gts.x.core.faas.err.v1~x.core._.code.v1~", "gts.x.core.faas.err.v1~vendor.app.billing.tax_error.v1~"]},
+    "traits": {
+      "type": "object",
+      "properties": {
+        "runtime": {"const": "starlark"},
+        "is_idempotent": {"const": true},
+        "invocation": {
+          "type": "object",
+          "properties": {
+            "supported": {"const": ["sync", "async"]},
+            "default": {"const": "async"}
+          }
+        },
+        "default_timeout_seconds": {"const": 10},
+        "default_memory_mb": {"const": 128},
+        "caching": {
+          "type": "object",
+          "properties": {
+            "max_age_seconds": {"const": 60}
+          },
+          "required": ["max_age_seconds"]
+        }
+      }
+    },
+    "implementation": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "object",
+          "properties": {
+            "language": {"const": "starlark"},
+            "source": {"const": "def main(ctx, input):\n  return {\"tax\": 0}\n"}
+          },
+          "required": ["language"]
+        }
+      },
+      "required": ["code"]
+    }
+  },
+  "required": ["id", "params", "returns", "traits", "implementation"]
+}
+```
+
+### Function definition type example #2
+
+This is an example of a customer lookup function written in Starlark that:
+- Supports both sync and async invocation (default is sync)
+- Idempotent
+- No client caching by default (`max_age_seconds = 0`)
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.func.v1~vendor.app.crm.lookup_customer.v1~",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.func.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.func.v1~vendor.app.crm.lookup_customer.v1~"},
+    "params": {
+      "const": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "customer_id": {"type": "string"}
+        },
+        "required": ["customer_id"]
+      }
+    },
+    "returns": {
+      "const": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "customer": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": ["customer"]
+      }
+    },
+    "traits": {
+      "type": "object",
+      "properties": {
+        "runtime": {"const": "starlark"},
+        "is_idempotent": {"const": true},
+        "invocation": {
+          "type": "object",
+          "properties": {
+            "supported": {"const": ["sync", "async"]},
+            "default": {"const": "sync"}
+          }
+        },
+        "default_timeout_seconds": {"const": 5},
+        "caching": {
+          "type": "object",
+          "properties": {
+            "max_age_seconds": {"const": 0}
+          },
+          "required": ["max_age_seconds"]
+        }
+      }
+    },
+    "implementation": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "object",
+          "properties": {
+            "language": {"const": "starlark"},
+            "source": {"const": "def main(ctx, input):\\n  url = \"https://example.crm/api/customer/\" + input[\"customer_id\"]\\n  resp = r_http_get_v1(url)\\n  return {\"customer\": resp}\\n"}
+          },
+          "required": ["language"]
+        }
+      },
+      "required": ["code"]
+    }
+  },
+  "required": ["id", "params", "returns", "traits", "implementation"]
+}
+```
+
+## Invocation API (Entrypoint)
+### Principles
+- Executed invocations produce an **invocation record** with a stable `invocation_id`.
+- Invocations SHOULD support:
+  - `Idempotency-Key` (to prevent duplicate starts)
+  - `X-Request-Id` / correlation id
+  - `traceparent` (W3C trace context)
+- Invocation status is obtained via a dedicated endpoint.
+
+Throttling and rate limiting:
+- The runtime SHOULD enforce throttling to protect itself and downstream dependencies (e.g., per-tenant rate limits, per-entrypoint concurrency caps).
+- When throttled, the runtime SHOULD return `429 Too Many Requests` and SHOULD include `Retry-After`.
+
+Dry run vs execute:
+- `dry_run: true` performs validation (including authorization) without creating a durable invocation record.
+- This aligns with AWS Lambda `InvocationType=DryRun`.
+
+### 1) Invoke an entrypoint (sync or async)
+`POST /api/serverless-runtime/v1/invocations`
+
+Request body:
+```json
+{
+  "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.namespace.func_name.v1~",
+  "params": {},
+  "mode": "async",
+  "dry_run": false
+}
+```
+
+Response:
+- `200 OK` (when `mode` is `sync` and `dry_run` is false) — **InvocationRecord (completed)**
+```json
+{
+  "invocation_id": "<opaque-id>",
+  "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.namespace.func_name.v1~",
+  "status": "gts.x.core.faas.status.v1~x.core._.succeeded.v1",
+  "timestamps": {
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "started_at": "2026-01-01T00:00:00.010Z",
+    "finished_at": "2026-01-01T00:00:00.120Z"
+  },
+  "result": {
+    "tax": 0
+  },
+  "error": null,
+  "observability": {
+    "correlation_id": "<id>",
+    "trace_id": "<trace>",
+    "metrics": {
+      "duration_ms": 110,
+      "billed_duration_ms": 200,
+      "cpu_time_ms": 70,
+      "memory_limit_mb": 128,
+      "max_memory_used_mb": 64
+    }
+  }
+}
+```
+
+- `200 OK` (when `mode` is `sync` and `dry_run` is false) — **InvocationRecord (failed)**
+```json
+{
+  "invocation_id": "<opaque-id>",
+  "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.crm.lookup_customer.v1~",
+  "status": "gts.x.core.faas.status.v1~x.core._.failed.v1",
+  "timestamps": {
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "started_at": "2026-01-01T00:00:00.010Z",
+    "finished_at": "2026-01-01T00:00:00.120Z"
+  },
+  "result": null,
+  "error": {
+    "id": "gts.x.core.faas.err.v1~x.core._.http.v1~",
+    "message": "Upstream CRM returned non-success status",
+    "details": {
+      "status_code": 503,
+      "headers": {"content-type": "application/json"},
+      "body": {"error": "service_unavailable"}
+    }
+  },
+  "observability": {
+    "correlation_id": "<id>",
+    "trace_id": "<trace>",
+    "metrics": {
+      "duration_ms": 110,
+      "billed_duration_ms": 200,
+      "cpu_time_ms": 70,
+      "memory_limit_mb": 128,
+      "max_memory_used_mb": 64
+    }
+  }
+}
+```
+
+- `202 Accepted` (when `mode` is `async` and `dry_run` is false) — **InvocationRecord (pending)**
+```json
+{
+  "invocation_id": "<opaque-id>",
+  "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.namespace.func_name.v1~",
+  "status": "gts.x.core.faas.status.v1~x.core._.queued.v1",
+  "timestamps": {
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "started_at": null,
+    "finished_at": null
+  },
+  "result": null,
+  "error": null,
+  "observability": {
+    "correlation_id": "<id>",
+    "trace_id": "<trace>",
+    "metrics": {
+      "duration_ms": null,
+      "billed_duration_ms": null,
+      "cpu_time_ms": null,
+      "memory_limit_mb": 128,
+      "max_memory_used_mb": null
+    }
+  }
+}
+```
+
+- `200 OK` (when `dry_run` is true)
+```json
+{
+  "dry_run": true,
+  "result": {},
+  "error": null,
+  "observability": {
+    "correlation_id": "<id>",
+    "trace_id": "<trace>",
+    "metrics": {
+      "duration_ms": null,
+      "billed_duration_ms": null,
+      "cpu_time_ms": null,
+      "memory_limit_mb": null,
+      "max_memory_used_mb": null
+    }
+  }
+}
+```
+
+### 2) Get invocation status
+`GET /api/serverless-runtime/v1/invocations/{invocation_id}`
+
+Response:
+- `200 OK` — **InvocationRecord (pending)**
+```json
+{
+  "invocation_id": "<opaque-id>",
+  "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.namespace.func_name.v1~",
+  "status": "gts.x.core.faas.status.v1~x.core._.queued.v1",
+  "timestamps": {
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "started_at": null,
+    "finished_at": null
+  },
+  "result": null,
+  "error": null,
+  "observability": {
+    "correlation_id": "<id>",
+    "trace_id": "<trace>",
+    "metrics": {
+      "duration_ms": null,
+      "billed_duration_ms": null,
+      "cpu_time_ms": null,
+      "memory_limit_mb": 128,
+      "max_memory_used_mb": null
+    }
+  }
+}
+```
+
+- `200 OK` — **InvocationRecord (failed: code error)**
+```json
+{
+  "invocation_id": "<opaque-id>",
+  "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.billing.calculate_tax.v1~",
+  "status": "gts.x.core.faas.status.v1~x.core._.failed.v1",
+  "timestamps": {
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "started_at": "2026-01-01T00:00:00.010Z",
+    "finished_at": "2026-01-01T00:00:00.020Z"
+  },
+  "result": null,
+  "error": {
+    "id": "gts.x.core.faas.err.v1~x.core._.code.v1~",
+    "message": "Starlark execution error: division by zero",
+    "details": {
+      "runtime": "starlark",
+      "phase": "execute",
+      "error_kind": "division_by_zero",
+      "location": {"line": 12, "code": "x = 1 / 0"},
+      "stack": {
+        "frames": [
+          {"function": "main", "file": "inline", "line": 1},
+          {"function": "calculate", "file": "inline", "line": 12}
+        ]
+      }
+    }
+  },
+  "observability": {
+    "correlation_id": "<id>",
+    "trace_id": "<trace>",
+    "metrics": {
+      "duration_ms": 10,
+      "billed_duration_ms": 100,
+      "cpu_time_ms": 8,
+      "memory_limit_mb": 128,
+      "max_memory_used_mb": 24
+    }
+  }
+}
+```
+
+- `200 OK` — **InvocationRecord (failed: runtime timeout)**
+```json
+{
+  "invocation_id": "<opaque-id>",
+  "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.namespace.func_name.v1~",
+  "status": "gts.x.core.faas.status.v1~x.core._.failed.v1",
+  "timestamps": {
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "started_at": "2026-01-01T00:00:00.010Z",
+    "finished_at": "2026-01-01T00:00:05.010Z"
+  },
+  "result": null,
+  "error": {
+    "id": "gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.timeout.v1~",
+    "message": "Execution timed out",
+    "details": {
+      "limit": {"timeout_seconds": 5},
+      "observed": {"duration_ms": 5000, "cpu_time_ms": 4900, "max_memory_used_mb": 90}
+    }
+  },
+  "observability": {
+    "correlation_id": "<id>",
+    "trace_id": "<trace>",
+    "metrics": {
+      "duration_ms": 5000,
+      "billed_duration_ms": 5000,
+      "cpu_time_ms": 4900,
+      "memory_limit_mb": 128,
+      "max_memory_used_mb": 90
+    }
+  }
+}
+```
+
+- `200 OK` — **InvocationRecord (failed: upstream no connection)**
+```json
+{
+  "invocation_id": "<opaque-id>",
+  "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.crm.lookup_customer.v1~",
+  "status": "gts.x.core.faas.status.v1~x.core._.failed.v1",
+  "timestamps": {
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "started_at": "2026-01-01T00:00:00.010Z",
+    "finished_at": "2026-01-01T00:00:00.520Z"
+  },
+  "result": null,
+  "error": {
+    "id": "gts.x.core.faas.err.v1~x.core._.http_transport.v1~x.core._.no_connection.v1~",
+    "message": "Upstream HTTP request failed",
+    "details": {
+      "url": "https://example.crm/api/customers/123"
+    }
+  },
+  "observability": {
+    "correlation_id": "<id>",
+    "trace_id": "<trace>",
+    "metrics": {
+      "duration_ms": 510,
+      "billed_duration_ms": 600,
+      "cpu_time_ms": 30,
+      "memory_limit_mb": 128,
+      "max_memory_used_mb": 40
+    }
+  }
+}
+```
+
+- `200 OK` — **InvocationRecord (completed)**
+```json
+{
+  "invocation_id": "<opaque-id>",
+  "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.namespace.func_name.v1~",
+  "status": "gts.x.core.faas.status.v1~x.core._.succeeded.v1",
+  "timestamps": {
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "started_at": "2026-01-01T00:00:01.000Z",
+    "finished_at": "2026-01-01T00:00:02.000Z"
+  },
+  "result": {},
+  "error": null,
+  "observability": {
+    "correlation_id": "<id>",
+    "trace_id": "<trace>",
+    "metrics": {
+      "duration_ms": 1000,
+      "billed_duration_ms": 1000,
+      "cpu_time_ms": 620,
+      "memory_limit_mb": 128,
+      "max_memory_used_mb": 80
+    }
+  }
+}
+```
+
+Status values:
+- `gts.x.core.faas.status.v1~x.core._.queued.v1`
+- `gts.x.core.faas.status.v1~x.core._.running.v1`
+- `gts.x.core.faas.status.v1~x.core._.suspended.v1`
+- `gts.x.core.faas.status.v1~x.core._.succeeded.v1`
+- `gts.x.core.faas.status.v1~x.core._.failed.v1`
+- `gts.x.core.faas.status.v1~x.core._.canceled.v1`
+
+`gts.x.core.faas.status.v1~x.core._.suspended.v1` indicates execution is waiting on a timer or an external event subscription and will be resumed by the runtime.
+
+### 3) Cancel function/workflow execution
+`POST /api/serverless-runtime/v1/invocations/{invocation_id}:cancel`
+
+Response:
+- `202 Accepted`
+
+### 4) Timeline / step history (observability)
+`GET /api/serverless-runtime/v1/invocations/{invocation_id}/timeline`
+
+Query params:
+- `limit` (optional)
+- `cursor` (optional)
+
+Response (example):
+```json
+{
+  "invocation_id": "<opaque-id>",
+  "items": [
+    {"at": "2026-01-01T00:00:00Z", "type": "STARTED"},
+    {"at": "2026-01-01T00:00:01Z", "type": "STEP_STARTED", "step_id": "step-1"},
+    {"at": "2026-01-01T00:00:02Z", "type": "STEP_SUCCEEDED", "step_id": "step-1"}
+  ],
+  "page_info": {
+    "next_cursor": "<opaque-cursor>",
+    "prev_cursor": null,
+    "limit": 25
+  }
+}
+```
+
+### 5) Debug invocation (invocation record + debug info)
+`GET /api/serverless-runtime/v1/invocations/{invocation_id}/debug`
+
+Response (example):
+```json
+{
+  "invocation_id": "<opaque-id>",
+  "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.namespace.func_name.v1~",
+  "status": "gts.x.core.faas.status.v1~x.core._.running.v1",
+  "timestamps": {
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "started_at": "2026-01-01T00:00:00.010Z",
+    "finished_at": null
+  },
+  "result": null,
+  "error": null,
+  "observability": {
+    "correlation_id": "<id>",
+    "trace_id": "<trace>",
+    "metrics": {
+      "duration_ms": null,
+      "billed_duration_ms": null,
+      "cpu_time_ms": null,
+      "memory_limit_mb": 128,
+      "max_memory_used_mb": null
+    }
+  },
+  "debug": {
+    "location": {
+      "line": 12,
+      "code": "resp = r_http_get_v1(url)"
+    },
+    "stack": {
+      "frames": [
+        {"function": "main", "file": "inline", "line": 1},
+        {"function": "calculate", "file": "inline", "line": 12}
+      ]
+    }
+  }
+}
+```
+
+Call trace retrieval (paginated via `debug.page`):
+`GET /api/serverless-runtime/v1/invocations/{invocation_id}/debug/calls`
+
+Query params:
+- `limit` (optional)
+- `cursor` (optional)
+
+Response (example):
+```json
+{
+  "invocation_id": "<opaque-id>",
+  "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.namespace.func_name.v1~",
+  "status": "gts.x.core.faas.status.v1~x.core._.running.v1",
+  "timestamps": {
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "started_at": "2026-01-01T00:00:00.010Z",
+    "finished_at": null
+  },
+  "result": null,
+  "error": null,
+  "observability": {
+    "correlation_id": "<id>",
+    "trace_id": "<trace>",
+    "metrics": {
+      "duration_ms": null,
+      "billed_duration_ms": null,
+      "cpu_time_ms": null,
+      "memory_limit_mb": 128,
+      "max_memory_used_mb": null
+    }
+  },
+  "debug": {
+    "location": {
+      "line": 12,
+      "code": "resp = r_http_get_v1(url)"
+    },
+    "stack": {
+      "frames": [
+        {"function": "main", "file": "inline", "line": 1},
+        {"function": "calculate", "file": "inline", "line": 12}
+      ]
+    },
+    "page": {
+      "items": [
+        {
+          "call_invocation_id": "<opaque-id>",
+          "entrypoint_id": "gts.x.core.faas.func.v1~vendor.app.crm.lookup_customer.v1~",
+          "params": {"customer_id": "c_123"},
+          "duration_ms": 42,
+          "response": {
+            "result": {"customer": {"id": "c_123", "name": "Jane"}},
+            "error": null
+          }
+        }
+      ],
+      "page_info": {
+        "next_cursor": "<opaque-cursor>",
+        "prev_cursor": null,
+        "limit": 25
+      }
+    }
+  }
+}
+```
+
+## TODO:
+
+## Comparison with similar solutions
+
+This section compares the proposed Serverless Runtime entrypoint model and invocation APIs with similar capabilities in:
+- AWS (Lambda + Step Functions)
+- Google Cloud (Cloud Functions + Workflows)
+- Azure (Azure Functions + Durable Functions)
+
+Notes:
+- Public clouds generally split “function” and “workflow/orchestration” into different products.
+- Hyperspot deliberately exposes a unified entrypoint definition schema and a single invocation surface, with consistent response shapes.
+
+### Category: Definition model and versioning
+
+| Capability | Hyperspot Serverless Runtime | AWS | Google Cloud | Azure |
+|---|---|---|---|---|
+| Definition type model | Unified entrypoint definition schema (function/workflow) via GTS-identified JSON Schemas | Split: Lambda functions vs Step Functions state machines | Split: Cloud Functions vs Workflows | Split: Functions vs Durable orchestrations |
+| Type system / schema IDs | GTS identifiers for base + derived definition types | No first-class type IDs; resource ARNs + service-specific specs | No first-class type IDs; resource names + service-specific specs | No first-class type IDs; resource IDs + service-specific specs |
+| Versioning concept | Definitions are versioned types; invocations point to an explicit definition ID | Lambda versions/aliases; Step Functions revisions via updates | Function revisions; workflow updates | Function versions; durable orchestration code deployments |
+
+### Category: Invocation semantics and lifecycle
+
+| Capability | Hyperspot Serverless Runtime | AWS | Google Cloud | Azure |
+|---|---|---|---|---|
+| Sync invocation | Supported (`mode: sync`) | Lambda: `RequestResponse` | HTTP-triggered functions are synchronous by default | HTTP-triggered functions are synchronous by default |
+| Async invocation | Supported (`mode: async` + poll status) | Lambda: `Event`; Step Functions: start execution then poll/described execution | Workflows: start execution then poll; Functions: async via events/pubsub | Durable: start orchestration then query status |
+| Dry-run | Supported (`dry_run: true`) without durable record | Lambda: `DryRun` (permission check) | Generally via validation/testing tools rather than a single universal API | Generally via validation/testing tools rather than a single universal API |
+| Durable invocation record shape | Unified `InvocationRecord` for start + status + debug | Different response shapes per service | Different response shapes per service | Different response shapes per service |
+| Cancel | Supported (`:cancel`) | Step Functions: stop execution; Lambda: no “cancel running invocation” | Workflows: cancel execution; Functions: stop depends on trigger/runtime | Durable: terminate instance |
+| Suspend/resume (event waiting) | Supported (`status: suspended`) for timers and event-driven continuation | Step Functions: wait states + event-driven patterns; Lambda: event-driven via triggers | Workflows support waiting; functions are event-triggered or use separate services | Durable: timers + external events |
+| Idempotency | Supported via idempotency key on start | Step Functions supports idempotency via execution name constraints; Lambda typically handled externally | Typically handled externally per trigger/service | Typically handled externally per trigger/service |
+
+### Category: Observability and timeline
+
+| Capability | Hyperspot Serverless Runtime | AWS | Google Cloud | Azure |
+|---|---|---|---|---|
+| Timeline / step history | Dedicated timeline endpoint (`/timeline`) | Step Functions execution history | Workflows execution history | Durable Functions history/events |
+| Correlation and tracing | `observability.correlation_id` + `trace_id` fields | CloudWatch + X-Ray trace IDs (service-dependent) | Cloud Logging + Trace IDs | Application Insights correlation/tracing |
+| Compute/memory metrics | Returned in `observability.metrics` (duration, billed duration, CPU time, memory limit/usage) | Lambda reports duration/billed duration/max memory used; CPU time not universally exposed | Execution metrics available via monitoring; CPU time not always directly exposed | Metrics via App Insights/monitoring; CPU time not always directly exposed |
+
+### Category: Debugging and call trace
+
+| Capability | Hyperspot Serverless Runtime | AWS | Google Cloud | Azure |
+|---|---|---|---|---|
+| Debug endpoint | `GET /debug` returns `InvocationRecord` + `debug` section (`location`, `stack`) | No single universal debug endpoint; relies on logs, traces, and per-service UIs | No single universal debug endpoint; relies on logs/traces/UIs | No single universal debug endpoint; relies on logs/App Insights/Durable history |
+| Call trace (ordered) | `GET /debug/calls` returns the same shape as `GET /debug`, with `debug.page` containing a paginated ordered call list including params, duration, and exact response | Achievable via X-Ray subsegments/instrumentation; not a standard structured API output | Achievable via tracing/instrumentation; not a standard structured API output | Achievable via Durable history/instrumentation; not a standard structured API output |
+| Completed-execution debug | Supported (`GET /debug` with `location`/`stack` null; `GET /debug/calls` for full trace via `debug.page`) | Historical logs/traces; UI varies by service | Historical logs/traces; UI varies by service | Historical logs/traces; durable history |
+
+### Category: Error taxonomy
+
+| Capability | Hyperspot Serverless Runtime | AWS | Google Cloud | Azure |
+|---|---|---|---|---|
+| Standard error envelope | Base error type `gts.x.core.faas.err.v1~` with `id`, `message`, `details` | Service-specific error payloads (varies) | Service-specific error payloads (varies) | Service-specific error payloads (varies) |
+| Structured error classes | Derived errors: upstream HTTP, runtime limits/timeouts, code errors | Often string-based error+cause (Step Functions) and runtime-specific error types/statuses | Runtime-specific error types/statuses | Runtime-specific error types/statuses |
+
+### Category: Caching and client behavior
+
+| Capability | Hyperspot Serverless Runtime | AWS | Google Cloud | Azure |
+|---|---|---|---|---|
+| Result caching (TTL) | `traits.caching.max_age_seconds` defines client caching TTL for successful results | No first-class “function result cache TTL”; caching typically external (API gateway/CDN/app cache) | No first-class “function result cache TTL”; caching typically external | No first-class “function result cache TTL”; caching typically external |
+
+### Open-source landscape (context)
+
+Open-source systems that overlap with parts of this ADR:
+- Temporal: strong durable workflow orchestration, rich history and retries; different model (SDK-first, not GTS-schema-first) and not a unified “function+workflow definition schema”.
+- Apache Airflow: batch/workflow scheduling with strong DAG semantics; less aligned with request/response serverless invocation and per-invocation records.
+- Knative / OpenFaaS: function execution and autoscaling; workflows/orchestration typically handled by separate systems.

--- a/modules/serverless_runtime/docs/3_ADR_STARLARK_RUNTIME.md
+++ b/modules/serverless_runtime/docs/3_ADR_STARLARK_RUNTIME.md
@@ -1,0 +1,516 @@
+# ADR — Starlark Runtime (Function & Workflow Execution)
+
+## Status
+Proposed
+
+## Context
+Hyperspot Serverless Runtime supports functions and workflows defined as GTS-identified JSON Schemas and invoked via a unified invocation API.
+
+This ADR defines the design of the Starlark runtime implementation used to execute those definitions:
+- the Starlark program structure (entrypoint contract)
+- strong typing rules and runtime validation
+- runtime-provided helper methods (`r_*`) and their versioning
+- asynchronous execution model (promise + await)
+- workflow orchestration hooks (steps, retries, compensation, snapshots, event waiting)
+- example definitions and Starlark programs for functions and workflows
+
+This ADR is intentionally aligned with `2_ADR_ENTRYPOINT.md` (Entrypoint schema + Invocation API).
+
+## Why Starlark?
+
+Starlark is a good fit for Hyperspot Serverless Runtime because it provides a constrained, embeddable, deterministic scripting language with strong tooling hooks.
+
+### Fit for functions and workflows
+- Starlark can express both short-lived function handlers and long-lived workflow orchestration logic using the same `main(ctx, input)` contract.
+- Workflows rely on runtime-provided primitives (`r_snapshot_v1`, `r_wait_event_v1`, `r_run_step_v1`) rather than language-level threads, exceptions, or background I/O.
+  This keeps orchestration behavior explicit and makes suspend/resume semantics a runtime feature instead of a language hack.
+
+### Rust-first embedding model
+- The runtime is implemented in Rust and can interpret Starlark directly via an embedded interpreter.
+- Runtime helpers (`r_*`) are the primary integration surface: the Rust host controls all I/O, persistence, event waiting, step tracking, and compensation.
+- This model minimizes the host surface area compared to embedding Python/JS while still giving an ergonomic authoring experience.
+
+### Static validation via parse/AST and policy checks
+Starlark allows a practical pre-execution validation pipeline:
+- parse source into an AST and fail fast on syntax errors
+- restrict the available built-ins and prohibit disallowed constructs
+- validate that the program exports `main(ctx, input)`
+- validate calls to runtime helpers (`r_*`) for arity and argument types where possible
+- optionally enforce additional policy (e.g., forbid dynamic `load()`, forbid unbounded loops, or require explicit timeouts on I/O helpers)
+
+The runtime MAY also perform system-aware validation when registering a function/workflow, for example:
+- validate that outbound URLs are recognized/allowed by policy and have corresponding credentials configured (e.g., via an outbound API gateway)
+- validate that referenced event type IDs are registered in the system
+- validate error types are registered in the system
+- validate function/workflow contract against entrypoint schema
+
+### Determinism and replayability
+- Starlark is designed to be deterministic given the same inputs and host-provided functions.
+- The runtime can ensure all nondeterminism flows through `r_*` helpers, which are versioned and can be recorded/replayed.
+- This is critical for durable workflows that may be resumed from snapshots and must behave consistently.
+
+### Resource controls and safe execution
+- Because execution happens inside our Rust host, the runtime can enforce limits (wall-clock, instruction count/step budget, memory, and CPU quotas) at the interpreter boundary.
+- Restricting the language and the host surface makes it easier to sandbox than general-purpose runtimes.
+
+### Debuggability (breakpoints, stack traces, tracing)
+- Starlark evaluation naturally exposes execution state (call stack, frames, current location) to the host.
+- The runtime can implement:
+  - setting breakpoints by source location
+  - pausing/resuming execution and inspecting locals
+  - structured tracing of `r_*` calls, including step boundaries and awaited events
+  - deterministic stack traces aligned with source
+
+### Familiarity (humans and LLMs)
+- Starlark syntax is intentionally Python-like, making it familiar to Python users.
+- Its Python-like surface also makes it a strong target for LLM-assisted authoring, review, and transformation.
+
+### Stewardship
+Starlark is used by Bazel and the language specification is maintained in the `bazelbuild` ecosystem with strong ongoing involvement from the Bazel community and Google.
+
+For Rust-based embedding, `starlark-rust` is a widely used Rust implementation of Starlark (commonly referenced as `facebook/starlark-rust` / Meta) published as standard crates.
+
+### Alternatives (quick comparison)
+- WebAssembly (Wasm)
+  - Pros: strong sandboxing, mature tooling, good performance
+  - Cons: heavier authoring model, less ergonomic for orchestration scripting, debugging and host-call surface can be more complex, deterministic replay requires additional conventions
+- JavaScript (embedded engine)
+  - Pros: familiar language, large ecosystem
+  - Cons: larger runtime/attack surface, more complexity around determinism, resource control, and sandboxing; host embedding is heavier
+- Python
+  - Pros: very popular, high productivity
+  - Cons: embedding/sandboxing is hard, resource controls are complex, too many dynamic escape hatches for a multi-tenant runtime
+- Lua
+  - Pros: embeddable, small
+  - Cons: less aligned with structured typing via `struct(...)` conventions and our desired validation ergonomics; ecosystem familiarity varies
+- Custom DSL
+  - Pros: maximum control and validation
+  - Cons: high implementation cost, poor ergonomics, and tends to grow into a full language over time
+
+## Goals
+- Provide a deterministic and safe execution model for runtime created/updated code.
+- Make functions and workflows compatible with a single language/runtime surface.
+- Enforce schema-based typing and prevent invalid input/output at runtime.
+- Support long-running execution patterns: waiting on events, suspend/resume, and snapshots.
+- Provide a versioned runtime API so code remains forward-compatible.
+
+## Non-goals
+- Defining the full sandboxing / isolation strategy.
+- Defining the persistence format for snapshots.
+- Defining the complete event transport implementation.
+
+## Starlark program structure
+
+### Entrypoint
+All Starlark functions and workflows MUST expose a `main(ctx, input)` function.
+
+- `ctx` is a runtime-provided context object.
+- `input` is the validated input object matching the entrypoint `params` schema.
+
+`main()` MUST return a value matching the entrypoint `returns` schema or terminate execution via `r_exit(...)`.
+
+## Strong type system
+
+### Source of truth
+The source of truth for function/workflow types is the GTS-identified JSON Schema:
+- `params` (input)
+- `returns` (output)
+- `errors` (error envelope types)
+
+### Validation rules
+- On function registration, the runtime MUST validate `params` against the entrypoint schema before executing Starlark.
+- Similarly, the runtime MUST validate the returned value against the `returns` schema.
+- For workflows, the runtime MUST validate snapshot state and resumption input before continuing.
+
+### Starlark typing model
+Starlark is dynamically typed, but the runtime enforces a strong type system by:
+- validating boundary values (input/output)
+- validating `r_*` method arguments (e.g., `url` must be string)
+- validating `r_wait_event(...)` against an event schema ID and payload schema
+
+For maximum ergonomics and stricter typing, the runtime SHOULD materialize validated inputs as a Starlark `struct(...)` with fields matching the JSON Schema properties (instead of a generic dict). This enables `input.customer_id` style access.
+
+All objects returned to the caller MUST be compatible with the JSON Schema types declared in `returns`.
+In practice, this means Starlark programs MUST treat returned objects as strongly typed structs:
+- no missing required fields
+- no additional fields when `additionalProperties` is false
+- field types must match schema
+
+## Runtime helper methods (versioned)
+All runtime helper methods (`r_*`) MUST be versioned to preserve compatibility across functions and workflows.
+
+### Common conventions
+- All helper names are prefixed with `r_`.
+- Methods that perform I/O MUST be async and return a promise.
+- Methods that influence control flow (`r_exit`, `r_snapshot`) MUST be deterministic.
+
+To preserve determinism and replayability, Starlark programs MUST NOT use nondeterministic sources such as embedded `datetime.now()` or `random.random()`.
+If time or randomness is required, it MUST be obtained via runtime helpers provided by the Rust host.
+
+### Promise and await
+The runtime provides a minimal async model:
+
+- `Promise<T>` is an opaque runtime object.
+- `r_await(promise)` waits for the promise to resolve and returns `T`.
+
+The runtime MAY also support `r_await_all([p1, p2, ...])` to resolve multiple promises concurrently.
+
+If `r_await(...)` is called on a promise that cannot complete without external input (event or timer), the runtime MUST suspend the invocation and resume it when the promise becomes ready.
+
+### HTTP helpers
+
+#### Response shape
+`r_http_*_v1()` resolves to an `HttpResult` value which never raises exceptions and can represent either a successful HTTP response or an error.
+
+`HttpResult` SHOULD be represented as a Starlark `struct(...)` so callers can use attribute access (`result.ok`, `result.response`, `result.error`).
+
+Successful response:
+- `ok` (boolean, `true`)
+- `response` (a Starlark `struct(...)`)
+  - `status_code` (integer)
+  - `headers` (dict)
+  - `body` (dict)
+
+Error response:
+- `ok` (boolean, `false`)
+- `error` (a Starlark `struct(...)`) compatible with the runtime error envelope defined in `2_ADR_ENTRYPOINT.md`.
+  - for non-2xx upstream responses: `gts.x.core.faas.err.v1~x.core._.http.v1~`
+  - for upstream transport failures: `gts.x.core.faas.err.v1~x.core._.http_transport.v1~x.core._.timeout.v1~` and `gts.x.core.faas.err.v1~x.core._.http_transport.v1~x.core._.no_connection.v1~`
+  - for runtime failures: `gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.timeout.v1~`, `gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.memory_limit.v1~`, `gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.cpu_limit.v1~`, and `gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.canceled.v1~`
+
+If the upstream response body is not JSON, the runtime SHOULD return an empty object for `response.body`.
+
+#### r_http_get_v1(...)
+Signature:
+- `r_http_get_v1(url, headers=None, timeout_ms=None, retry=None, exit_on_http_error=True) -> Promise<HttpResult>`
+
+Notes:
+- `url` is required.
+- `headers` is an optional dict.
+- `timeout_ms` is optional.
+- `retry` is optional runtime-defined retry policy (e.g., {"max_attempts": 3, "backoff_ms": 200}).
+- `exit_on_http_error=true` means the runtime calls `r_exit(...)` on non-2xx upstream responses or on upstream transport failures.
+- `exit_on_http_error=false` means the promise resolves to an `HttpResult` and the Starlark code is responsible for handling `ok=false` and/or non-2xx status codes.
+
+NOTE: The runtime MUST NOT perform outbound HTTP requests directly. Instead, it MUST delegate outbound calls to the outbound API gateway so that security context, credential management, and internal-to-external token/authorization exchange are applied consistently and all egress traffic is centrally enforced and observed.
+
+#### r_http_post_v1(...)
+Signature:
+- `r_http_post_v1(url, body, headers=None, timeout_ms=None, retry=None, exit_on_http_error=True) -> Promise<HttpResult>`
+
+### Sleep
+- `r_sleep(milliseconds) -> Promise<None>`
+
+### Time and randomness (deterministic)
+- `r_now_v1() -> string`
+- `r_rand_v1(label=None) -> string`
+
+`r_now_v1()` returns a runtime-provided timestamp string. For workflows, the runtime MUST ensure the returned value is replay-safe (e.g., captured/recorded at a deterministic boundary and reused on resume).
+
+`r_rand_v1(...)` returns a runtime-provided pseudo-random value. For workflows, the runtime MUST ensure the returned value is replay-safe (e.g., derived from invocation identity + an optional label, and/or recorded for deterministic replay).
+
+### Exit
+- `r_exit(error) -> None`
+
+`error` MUST be an object compatible with the runtime error envelope.
+
+For workflows, calling `r_exit(...)` terminates execution and triggers compensation for previously completed steps:
+- the runtime MUST execute all registered compensation actions for steps that completed successfully prior to the `r_exit(...)` call
+- compensations MUST be executed in reverse step completion order
+- the runtime MUST NOT invoke compensation for steps that did not complete successfully
+
+### Event waiting
+
+#### r_wait_event_v1(...)
+Signature:
+- `r_wait_event_v1(event_type_id, event_filter_query=None, timeout_ms=None, exit_on_error=True) -> Promise<EventWaitResult>`
+
+- `event_type_id` MUST be a GTS type ID string ending with `~` (e.g., `gts.x.core.events.event.v1~vendor.app.some.event.v1~`).
+- `event_filter_query` MUST be a valid event filter query string supported by the event broker.
+- `timeout_ms` MUST be a non-negative integer.
+- The event payload MUST be validated against the event type schema.
+
+`EventWaitResult` SHOULD be represented as a Starlark `struct(...)` so callers can use attribute access.
+
+- `struct(ok = True, value = <Event>)` when the event is received
+- `struct(ok = False, error = <FaaS Error envelope>)` when the wait fails
+
+When an error occurs while waiting (including a timeout):
+- if `exit_on_error=true`, the runtime MUST call `r_exit(...)` with an error envelope
+- if `exit_on_error=false`, the promise MUST resolve with `struct(ok = False, error = ...)`
+
+When `timeout_ms` is provided and the timeout occurs, the error envelope id MUST be `gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.timeout.v1~`.
+
+Waiting on an event is implemented by:
+- the runtime suspending the invocation
+- registering an event subscription
+- resuming execution when the event arrives or timeout occurs
+
+### Snapshotting
+
+#### r_snapshot_v1(...)
+Signature:
+- `r_snapshot_v1(label=None) -> None`
+
+Calling `r_snapshot_v1()` requests the runtime to capture a durable snapshot of execution state.
+The snapshot includes:
+- call stack / instruction pointer
+- relevant variable bindings
+- workflow runtime metadata needed for resume
+
+The runtime may automatically take snapshots at safe points, but `r_snapshot_v1()` allows user code to request one explicitly.
+
+## Workflow orchestration hooks
+For workflows, the runtime is responsible for orchestrating typical workflow processing:
+- identifying steps
+- tracking step status and retries
+- scheduling retries
+- registering compensation actions
+- checkpointing and suspend/resume via snapshots
+- event subscription and event-driven continuation
+
+To support this, the runtime provides workflow helpers.
+
+### Workflow helpers
+
+#### r_step_v1(name, fn, compensate_fn=None)
+Registers a step function, optional compensation function, and returns a callable wrapper.
+
+If `compensate_fn` is provided, it MUST accept the step output as its second argument:
+- `fn(ctx, step_input) -> <step output>`
+- `compensate_fn(ctx, step_input, step_output) -> None`
+
+The runtime automatically passes:
+- `step_input` to the step function when executing the step and as the first argument to the compensation function
+- `step_output` to the compensation function when invoking compensation
+
+This enables the main action to provide context to the compensation action by returning it as part of the step output (e.g., a created object ID).
+
+#### r_run_step_v1(step_name, fn, input, exit_on_error=True)
+Executes a step with runtime tracking, retry policy, and status updates.
+
+`exit_on_error=true` means the runtime calls `r_exit(...)` if the step fails.
+`exit_on_error=false` means the function returns a result object and the Starlark code is responsible for handling `ok=false`.
+
+The `r_run_step_v1(...)` function returns a result object:
+- `struct(ok = True, value = <step output>)` on success
+- `struct(ok = False, error = <FaaS Error envelope>)` on failure
+
+The exact internal representation is runtime-defined; the Starlark surface remains stable.
+
+Compensation invocation:
+- When a workflow terminates unsuccessfully via `r_exit(...)` (or a runtime abort that maps to a workflow failure), the runtime MUST execute registered compensation actions for all previously completed steps.
+- Compensations MUST be executed in reverse step completion order.
+- Compensation failures MUST NOT cause additional compensations to be skipped; they MUST be recorded and surfaced via workflow status and logs.
+
+## Examples
+
+### Function example #1: two upstream calls and composite output
+
+#### Function definition (GTS schema)
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "gts://gts.x.core.faas.func.v1~vendor.app.example.compose_customer_profile.v1~",
+  "allOf": [
+    {"$ref": "gts://gts.x.core.faas.func.v1~"}
+  ],
+  "type": "object",
+  "properties": {
+    "id": {"const": "gts.x.core.faas.func.v1~vendor.app.example.compose_customer_profile.v1~"},
+    "params": {
+      "const": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "customer_id": {"type": "string"}
+        },
+        "required": ["customer_id"]
+      }
+    },
+    "returns": {
+      "const": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "customer": {"type": "object", "additionalProperties": true},
+          "orders": {"type": "array", "items": {"type": "object", "additionalProperties": true}}
+        },
+        "required": ["customer", "orders"]
+      }
+    },
+    "traits": {
+      "type": "object",
+      "properties": {
+        "runtime": {"const": "starlark"},
+        "invocation": {
+          "type": "object",
+          "properties": {"supported": {"const": ["sync", "async"]}, "default": {"const": "sync"}},
+          "required": ["supported"]
+        },
+        "caching": {
+          "type": "object",
+          "properties": {"max_age_seconds": {"const": 0}},
+          "required": ["max_age_seconds"]
+        }
+      },
+      "required": ["runtime"]
+    },
+    "implementation": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "object",
+          "properties": {
+            "language": {"const": "starlark"},
+            "source": {"const": ""}
+          },
+          "required": ["language"]
+        }
+      },
+      "required": ["code"]
+    }
+  },
+  "required": ["id", "params", "returns", "traits", "implementation"]
+}
+```
+
+#### Starlark code
+```python
+# main() is the required entrypoint.
+
+def main(ctx, input):
+    customer_id = input.customer_id
+
+    p_customer = r_http_get_v1(
+        "https://example.crm/api/customers/" + customer_id,
+        timeout_ms = 2000,
+        retry = {"max_attempts": 3, "backoff_ms": 200},
+        exit_on_http_error = True,
+    )
+
+    p_orders = r_http_get_v1(
+        "https://example.orders/api/orders?customer_id=" + customer_id,
+        timeout_ms = 2000,
+        retry = {"max_attempts": 3, "backoff_ms": 200},
+        exit_on_http_error = True,
+    )
+
+    customer_result = r_await(p_customer)
+    orders_result = r_await(p_orders)
+
+    customer_resp = customer_result.response
+    orders_resp = orders_result.response
+
+    orders_body = orders_resp.body
+    orders_items = orders_body["items"] if "items" in orders_body else []
+
+    return {
+        "customer": customer_resp.body,
+        "orders": orders_items,
+    }
+```
+
+### Function example #2: handle upstream HTTP error/timeout
+
+This example demonstrates disabling automatic exit and returning a structured result.
+
+```python
+
+def main(ctx, input):
+    customer_id = input.customer_id
+
+    p_customer = r_http_get_v1(
+        "https://example.crm/api/customers/" + customer_id,
+        timeout_ms = 500,
+        retry = {"max_attempts": 1, "backoff_ms": 0},
+        exit_on_http_error = False,
+    )
+
+    customer_result = r_await(p_customer)
+
+    if not customer_result.ok:
+        return {
+            "customer": {"id": customer_id, "status": "unavailable"},
+            "orders": [],
+        }
+
+    customer_resp = customer_result.response
+
+    if customer_resp.status_code >= 400:
+        return {
+            "customer": {"id": customer_id, "status": "unavailable"},
+            "orders": [],
+        }
+
+    return {
+        "customer": customer_resp.body,
+        "orders": [],
+    }
+```
+
+### Example #3: workflow with steps, event waiting, snapshots, and compensation
+
+#### Workflow definition (high-level)
+Workflows use the same entrypoint schema model, but are executed with durable semantics.
+
+#### Starlark workflow code
+```python
+
+def step_reserve_inventory(ctx, input):
+    p = r_http_post_v1(
+        "https://example.inventory/api/reservations",
+        body = {"sku": input.sku, "qty": input.qty},
+        timeout_ms = 2000,
+        retry = {"max_attempts": 3, "backoff_ms": 200},
+        exit_on_http_error = True,
+    )
+    resp = r_await(p).response
+    reservation_id = resp.body.get("reservation_id")
+    return struct(reservation_id = reservation_id)
+
+
+def compensate_release_inventory(ctx, step_input, step_output):
+    reservation = step_output
+    p = r_http_post_v1(
+        "https://example.inventory/api/reservations:release",
+        body = {"reservation_id": reservation.reservation_id},
+        timeout_ms = 2000,
+        retry = {"max_attempts": 3, "backoff_ms": 200},
+        exit_on_http_error = False,
+    )
+    release_result = r_await(p)
+    if not release_result.ok:
+        return None
+    return None
+
+
+def main(ctx, input):
+    reserve = r_step_v1("reserve_inventory", step_reserve_inventory, compensate_release_inventory)
+
+    reservation_result = r_run_step_v1("reserve_inventory", reserve, input) # exists on error
+    reservation = reservation_result.value
+
+    r_snapshot_v1("after_reserve") # make a snapshot before waiting for approval
+
+    approval_result = r_await(
+        r_wait_event_v1(
+            "gts.x.core.events.event.v1~vendor.app.orders.approved.v1~",
+            event_filter_query = "payload.reservation_id = " + reservation.reservation_id,
+            timeout_ms = 86400000,
+            exit_on_error = False, # handle error explicitly below
+        )
+    )
+    if not approval_result.ok:
+        if approval_result.error.id == "gts.x.core.faas.err.v1~x.core._.runtime.v1~x.core._.timeout.v1~":
+            approval_event = None
+        else:
+            r_exit(approval_result.error) # this triggers compensation actions for all completed steps
+    else:
+        approval_event = approval_result.value
+
+    return {
+        "reservation": reservation,
+        "approval": approval_event,
+    }
+```


### PR DESCRIPTION
…runtime

Add initial Serverless Runtime documentation set:

- PRD: clarify scheduling as logically part of runtime, potentially implemented as cooperating internal service
- Entrypoint ADR: define workflow semantics, expand error taxonomy using derived GTS error IDs, and paginate /timeline with items + page_info
- Starlark ADR: specify struct-like return values, status-based error handling (no exceptions), deterministic execution (no datetime/random builtins) with r_* helpers, and step/compensation + event-wait semantics