### PR TITLE
refactor(naming):

### DIFF
--- a/apps/hyperspot-server/src/main.rs
+++ b/apps/hyperspot-server/src/main.rs
@@ -253,7 +253,6 @@ async fn run_server(config: AppConfig, args: Cli) -> Result<()> {
 
     // Run the ModKit runtime with the root cancellation token.
     // Shutdown is driven by the signal handler spawned above, not by ShutdownOptions::Signals.
-    // Note: DirectoryApi is registered by the ModuleOrchestrator system module, not here.
     // OoP modules are spawned after the start phase (once grpc_hub has bound its port).
     let run_options = RunOptions {
         modules_cfg: Arc::new(config),

--- a/docs/MODKIT_PLUGINS.md
+++ b/docs/MODKIT_PLUGINS.md
@@ -167,7 +167,7 @@ This separation ensures:
 
 ```rust
 // In gateway module init()
-let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
 
 // Register schema using GTS-provided method for proper $id and $ref handling
 let schema_str = MyModulePluginSpecV1::gts_schema_with_refs_as_string();
@@ -179,7 +179,7 @@ registry.register(vec![schema_json]).await?;
 
 ```rust
 // In plugin module init()
-let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
 
 // Register instance only (schema is already registered by gateway)
 let instance = BaseModkitPluginV1::<MyModulePluginSpecV1> {
@@ -313,7 +313,7 @@ use async_trait::async_trait;
 use modkit::{Module, ModuleCtx};
 use modkit_security::SecurityCtx;
 use my_sdk::{MyModuleGatewayClient, MyModulePluginSpecV1};
-use types_registry_sdk::TypesRegistryApi;
+use types_registry_sdk::TypesRegistryClient;
 
 #[modkit::module(
     name = "my_gateway",
@@ -332,7 +332,7 @@ impl Module for MyGateway {
         // === SCHEMA REGISTRATION ===
         // Gateway is responsible for registering the plugin SCHEMA.
         // Plugins only register their INSTANCES.
-        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
         let schema_str = MyModulePluginSpecV1::gts_schema_with_refs_as_string();
         let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
         let _ = registry
@@ -393,7 +393,7 @@ The domain service handles plugin resolution:
 use modkit::client_hub::{ClientHub, ClientScope};
 use my_sdk::{MyModulePluginClient, MyModulePluginSpec};
 use tokio::sync::OnceCell;
-use types_registry_sdk::TypesRegistryApi;
+use types_registry_sdk::TypesRegistryClient;
 
 pub struct Service {
     hub: Arc<ClientHub>,
@@ -414,7 +414,7 @@ impl Service {
     }
 
     async fn resolve_plugin(&self) -> Result<ClientScope, DomainError> {
-        let registry = self.hub.get::<dyn TypesRegistryApi>()?;
+        let registry = self.hub.get::<dyn TypesRegistryClient>()?;
 
         // Query for plugin instances
         let plugin_type_id = MyModulePluginSpecV1::gts_schema_id().clone();
@@ -456,7 +456,7 @@ use modkit::gts::BaseModkitPluginV1;
 use modkit::{Module, ModuleCtx};
 use modkit_security::SecurityCtx;
 use my_sdk::{MyModulePluginClient, MyModulePluginSpecV1};
-use types_registry_sdk::TypesRegistryApi;
+use types_registry_sdk::TypesRegistryClient;
 
 #[modkit::module(
     name = "vendor_a_plugin",
@@ -476,7 +476,7 @@ impl Module for VendorAPlugin {
 
         // 2. Register plugin INSTANCE in types-registry
         //    Note: The plugin SCHEMA is registered by the gateway module
-        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
         let instance = BaseModkitPluginV1::<MyModulePluginSpecV1> {
             id: instance_id.clone(),
             vendor: cfg.vendor,
@@ -757,7 +757,7 @@ async fn test_gateway_plugin_resolution() {
 
     // Register mock types-registry
     let mock_registry = Arc::new(MockTypesRegistry::new());
-    hub.register::<dyn TypesRegistryApi>(mock_registry);
+    hub.register::<dyn TypesRegistryClient>(mock_registry);
 
     // Register mock plugin
     let instance_id = "gts.x.core.modkit.plugin.v1~vendor.pkg.my_module.plugin.v1~fabrikam.test._.plugin.v1";

--- a/docs/MODKIT_UNIFIED_SYSTEM.md
+++ b/docs/MODKIT_UNIFIED_SYSTEM.md
@@ -332,75 +332,6 @@ Shutdown is driven by a single root `CancellationToken` per process:
 ## Module Orchestrator & Directory API
 
 The **Module Orchestrator** provides service discovery and instance management for both in-process and OoP modules.
-
-### DirectoryApi Trait
-
-```rust
-#[async_trait]
-pub trait DirectoryApi: Send + Sync {
-    /// Resolve a gRPC service by its logical name to an endpoint
-    async fn resolve_grpc_service(&self, service_name: &str) -> Result<ServiceEndpoint>;
-
-    /// List all service instances for a given module
-    async fn list_instances(&self, module: &str) -> Result<Vec<ServiceInstanceInfo>>;
-
-    /// Register a new module instance with the directory
-    async fn register_instance(&self, info: RegisterInstanceInfo) -> Result<()>;
-
-    /// Deregister a module instance (for graceful shutdown)
-    async fn deregister_instance(&self, module: &str, instance_id: &str) -> Result<()>;
-
-    /// Send a heartbeat for a module instance to indicate it's still alive
-    async fn send_heartbeat(&self, module: &str, instance_id: &str) -> Result<()>;
-}
-```
-
-### Service Endpoint Types
-
-```rust
-/// Represents an endpoint where a service can be reached
-pub struct ServiceEndpoint {
-    pub uri: String,
-}
-
-impl ServiceEndpoint {
-    pub fn tcp(host: &str, port: u16) -> Self;  // "http://host:port"
-    pub fn uds(path: impl AsRef<Path>) -> Self; // "unix:///path/to/socket"
-}
-
-/// Information about a service instance
-pub struct ServiceInstanceInfo {
-    pub module: String,
-    pub instance_id: String,
-    pub endpoint: ServiceEndpoint,
-    pub version: Option<String>,
-}
-
-/// Information for registering a new module instance
-pub struct RegisterInstanceInfo {
-    pub module: String,
-    pub instance_id: String,
-    pub grpc_services: Vec<(String, ServiceEndpoint)>,
-    pub version: Option<String>,
-}
-```
-
-### Using DirectoryApi
-
-**From an OoP module** — the DirectoryApi client is injected into the ClientHub:
-
-```rust
-async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-    // DirectoryApi is available via ClientHub in OoP modules
-    let directory = ctx.client_hub.get::<dyn DirectoryApi>()?;
-
-    // Resolve another service's endpoint
-    let endpoint = directory.resolve_grpc_service("my.package.MyService").await?;
-
-    Ok(())
-}
-```
-
 **From the master host** — the Module Orchestrator registers itself as the DirectoryApi implementation.
 
 ---
@@ -619,7 +550,7 @@ impl MyModuleApi for MyModuleGrpcClient {
 use std::sync::Arc;
 use anyhow::Result;
 use modkit::client_hub::ClientHub;
-use module_orchestrator_sdk::DirectoryApi;
+use module_orchestrator_sdk::DirectoryClient;
 use crate::{MyModuleApi, MyModuleGrpcClient, SERVICE_NAME};
 
 /// Wire the gRPC client into ClientHub
@@ -1539,13 +1470,13 @@ remote clients:
 
 ### In-Process vs Remote Clients
 
-| Aspect       | In-Process           | Remote (OoP)                  |
-|--------------|----------------------|-------------------------------|
-| Transport    | Direct call          | gRPC                          |
-| Latency      | Nanoseconds          | Milliseconds                  |
-| Isolation    | Shared process       | Separate process              |
-| Contract     | Trait in `contract/` | Trait in `*-contracts/` crate |
-| Registration | `expose_*_client()`  | DirectoryApi + gRPC client    |
+| Aspect       | In-Process              | Remote (OoP)               |
+|--------------|-------------------------|----------------------------|
+| Transport    | Direct call             | gRPC                       |
+| Latency      | Nanoseconds             | Milliseconds               |
+| Isolation    | Shared process          | Separate process           |
+| Contract     | Trait in `*-sdk/` crate | Trait in `*-sdk/` crate    |
+| Registration | `expose_*_client()`     | DirectoryApi + gRPC client |
 
 **Publish in `init`**
 

--- a/examples/modkit/users_info/users_info/src/infra/audit/http_audit_client.rs
+++ b/examples/modkit/users_info/users_info/src/infra/audit/http_audit_client.rs
@@ -10,8 +10,8 @@ use modkit::TracedClient;
 
 /// Single HTTP adapter implementing the `AuditPort`.
 /// Holds two base URLs:
-///  - `audit_base` (e.g., <http://audit.local>)
-///  - `notify_base` (e.g., <http://notifications.local>)
+///  - `audit_base` (e.g., <https://audit.local>)
+///  - `notify_base` (e.g., <https://notifications.local>)
 pub struct HttpAuditClient {
     client: TracedClient,
     audit_base: Url,

--- a/examples/oop-modules/calculator/calculator-sdk/src/wiring.rs
+++ b/examples/oop-modules/calculator/calculator-sdk/src/wiring.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use modkit::client_hub::ClientHub;
-use module_orchestrator_sdk::DirectoryApi;
+use module_orchestrator_sdk::DirectoryClient;
 
 use crate::api::CalculatorClient;
 use crate::client::CalculatorGrpcClient;
@@ -15,7 +15,7 @@ use crate::SERVICE_NAME;
 /// Wire the Calculator gRPC client into the ClientHub.
 ///
 /// This function:
-/// 1. Resolves the CalculatorService endpoint from the DirectoryApi
+/// 1. Resolves the CalculatorService endpoint from the DirectoryClient
 /// 2. Creates a gRPC client
 /// 3. Registers it in the ClientHub as `dyn CalculatorClient`
 ///
@@ -26,7 +26,7 @@ use crate::SERVICE_NAME;
 /// wire_client(&hub, &directory_api).await?;
 /// let client = hub.get::<dyn CalculatorClient>()?;
 /// ```
-pub async fn wire_client(hub: &ClientHub, resolver: &dyn DirectoryApi) -> Result<()> {
+pub async fn wire_client(hub: &ClientHub, resolver: &dyn DirectoryClient) -> Result<()> {
     let endpoint = resolver.resolve_grpc_service(SERVICE_NAME).await?;
     let client = CalculatorGrpcClient::connect(&endpoint.uri).await?;
     hub.register::<dyn CalculatorClient>(Arc::new(client));

--- a/examples/plugin-modules/tenant_resolver/plugins/contoso_tr_plugin/src/module.rs
+++ b/examples/plugin-modules/tenant_resolver/plugins/contoso_tr_plugin/src/module.rs
@@ -9,7 +9,7 @@ use modkit::gts::BaseModkitPluginV1;
 use modkit::Module;
 use tenant_resolver_sdk::{TenantResolverPluginClient, TenantResolverPluginSpecV1};
 use tracing::info;
-use types_registry_sdk::TypesRegistryApi;
+use types_registry_sdk::TypesRegistryClient;
 
 use crate::config::ContosoPluginConfig;
 use crate::domain::Service;
@@ -53,7 +53,7 @@ impl Module for ContosoTrPlugin {
         // === INSTANCE REGISTRATION ===
         // Register the plugin INSTANCE in types-registry.
         // Note: The plugin SCHEMA is registered by the gateway module.
-        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
         let instance = BaseModkitPluginV1::<TenantResolverPluginSpecV1> {
             id: instance_id.clone(),
             vendor: cfg.vendor,

--- a/examples/plugin-modules/tenant_resolver/plugins/fabrikam_tr_plugin/src/module.rs
+++ b/examples/plugin-modules/tenant_resolver/plugins/fabrikam_tr_plugin/src/module.rs
@@ -9,7 +9,7 @@ use modkit::gts::BaseModkitPluginV1;
 use modkit::Module;
 use tenant_resolver_sdk::{TenantResolverPluginClient, TenantResolverPluginSpecV1};
 use tracing::info;
-use types_registry_sdk::TypesRegistryApi;
+use types_registry_sdk::TypesRegistryClient;
 
 use crate::config::FabrikamPluginConfig;
 use crate::domain::Service;
@@ -53,7 +53,7 @@ impl Module for FabrikamTrPlugin {
         // === INSTANCE REGISTRATION ===
         // Register the plugin INSTANCE in types-registry.
         // Note: The plugin SCHEMA is registered by the gateway module.
-        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
         let vendor_clone = cfg.vendor.clone();
         let instance = BaseModkitPluginV1::<TenantResolverPluginSpecV1> {
             id: instance_id.clone(),

--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/domain/service.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/domain/service.rs
@@ -15,7 +15,7 @@ use tenant_resolver_sdk::{
 };
 use tokio::sync::OnceCell;
 use tracing::info;
-use types_registry_sdk::{GtsEntity, ListQuery, TypesRegistryApi};
+use types_registry_sdk::{GtsEntity, ListQuery, TypesRegistryClient};
 
 // Note: This example gateway still uses SecurityContext in its public API methods
 // because it uses an older SDK with hierarchical tenant model.
@@ -74,7 +74,7 @@ impl Service {
 
         let registry = self
             .hub
-            .get::<dyn TypesRegistryApi>()
+            .get::<dyn TypesRegistryClient>()
             .map_err(|e| DomainError::TypesRegistryUnavailable(e.to_string()))?;
 
         let plugin_type_id = TenantResolverPluginSpecV1::gts_schema_id().clone();

--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/module.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/module.rs
@@ -7,7 +7,7 @@ use modkit::contracts::RestApiCapability;
 use modkit::Module;
 use tenant_resolver_sdk::{TenantResolverClient, TenantResolverPluginSpecV1};
 use tracing::info;
-use types_registry_sdk::TypesRegistryApi;
+use types_registry_sdk::TypesRegistryClient;
 
 use crate::config::TenantResolverConfig;
 use crate::domain::service::Service;
@@ -62,7 +62,7 @@ impl Module for TenantResolverGateway {
         // Gateway is responsible for registering the plugin SCHEMA in types-registry.
         // Plugins only register their INSTANCES.
         // Use GTS-provided method for proper $id and $ref handling.
-        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
         let schema_str = TenantResolverPluginSpecV1::gts_schema_with_refs_as_string();
         let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
 

--- a/guidelines/NEW_MODULE.md
+++ b/guidelines/NEW_MODULE.md
@@ -1933,7 +1933,7 @@ OoP modules use the **contracts pattern** with three crates:
 
 ```
 modules/<name>/
-├── <name>-contracts/        # Shared API trait + types (NO transport)
+├── <name>-sdk/        # Shared API trait + types (NO transport)
 │   ├── Cargo.toml
 │   └── src/lib.rs
 ├── <name>-grpc/             # Proto stubs + gRPC CLIENT only
@@ -1950,12 +1950,12 @@ modules/<name>/
         └── main.rs          # OoP binary entry point
 ```
 
-#### 1. Contracts Crate (`<name>-contracts`)
+#### 1. SDK Crate (`<name>-sdk`)
 
 Define the API trait and types in a separate crate (no transport dependencies):
 
 ```rust
-// <name>-contracts/src/lib.rs
+// <name>-sdk/src/lib.rs
 use async_trait::async_trait;
 use modkit_security::SecurityCtx;
 
@@ -1985,9 +1985,9 @@ pub enum MyModuleError {
 ```
 
 ```toml
-# <name>-contracts/Cargo.toml
+# <name>-sdk/Cargo.toml
 [package]
-name = "<name>-contracts"
+name = "<name>-sdk"
 version.workspace = true
 edition.workspace = true
 
@@ -2028,7 +2028,7 @@ use modkit_transport_grpc::client::{connect_with_retry, GrpcClientConfig};
 use modkit_transport_grpc::inject_secctx;
 use tonic::transport::Channel;
 
-use mymodule_contracts::{MyModuleApi, MyModuleError};
+use mymodule_sdk::{MyModuleApi, MyModuleError};
 
 pub struct MyModuleGrpcClient {
     inner: crate::mymodule::my_module_service_client::MyModuleServiceClient<Channel>,
@@ -2104,10 +2104,10 @@ use modkit_transport_grpc::extract_secctx;
 
 // Re-export contracts and grpc for consumers
 // Re-export contracts (SDK) and grpc for consumers
-pub use mymodule_contracts as sdk;
+pub use mymodule_sdk as sdk;
 pub use mymodule_grpc as grpc;
 
-use mymodule_contracts::{MyModuleApi, MyModuleError};
+use mymodule_sdk::{MyModuleApi, MyModuleError};
 use mymodule_grpc::{MyModuleService, MyModuleServiceServer, SERVICE_NAME};
 
 /// Module struct

--- a/libs/modkit-macros/src/lib.rs
+++ b/libs/modkit-macros/src/lib.rs
@@ -672,7 +672,7 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
     // ClientHub DX helpers (optional)
     // Note: The `client` parameter now only triggers compile-time trait checks.
     // For client registration/access, use `hub.register::<dyn Trait>(client)` and
-    // `hub.get::<dyn Trait>()` directly, or provide helpers in your *-contracts crate.
+    // `hub.get::<dyn Trait>()` directly, or provide helpers in your *-sdk crate.
     let client_code = if let Some(client_trait_path) = &client_trait_opt {
         quote! {
             // Compile-time trait checks: object-safe + Send + Sync + 'static

--- a/libs/modkit/src/client_hub.rs
+++ b/libs/modkit/src/client_hub.rs
@@ -138,7 +138,7 @@ impl ClientHub {
 
 impl ClientHub {
     /// Register a client under the interface type `T`.
-    /// `T` can be a trait object like `dyn my_module::contract::MyApi`.
+    /// `T` can be a trait object like `dyn my_module::api::MyClient`.
     pub fn register<T>(&self, client: Arc<T>)
     where
         T: ?Sized + Send + Sync + 'static,

--- a/libs/modkit/src/directory.rs
+++ b/libs/modkit/src/directory.rs
@@ -1,7 +1,4 @@
 //! Directory API - contract for service discovery and instance resolution
-//!
-//! This module re-exports the `DirectoryApi` trait and related types from
-//! `module_orchestrator_sdk` and provides the `LocalDirectoryApi` implementation.
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -12,18 +9,18 @@ use crate::runtime::{Endpoint, ModuleInstance, ModuleManager};
 
 // Re-export all types from contracts - this is the single source of truth
 pub use module_orchestrator_sdk::{
-    DirectoryApi, RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
+    DirectoryClient, RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
 };
 
-/// Local implementation of `DirectoryApi` that delegates to `ModuleManager`
+/// Local implementation of `DirectoryClient` that delegates to `ModuleManager`
 ///
 /// This is the in-process implementation used by modules running in the same
 /// process as the module orchestrator.
-pub struct LocalDirectoryApi {
+pub struct LocalDirectoryClient {
     mgr: Arc<ModuleManager>,
 }
 
-impl LocalDirectoryApi {
+impl LocalDirectoryClient {
     #[must_use]
     pub fn new(mgr: Arc<ModuleManager>) -> Self {
         Self { mgr }
@@ -31,7 +28,7 @@ impl LocalDirectoryApi {
 }
 
 #[async_trait]
-impl DirectoryApi for LocalDirectoryApi {
+impl DirectoryClient for LocalDirectoryClient {
     async fn resolve_grpc_service(&self, service_name: &str) -> Result<ServiceEndpoint> {
         if let Some((_module, _inst, ep)) = self.mgr.pick_service_round_robin(service_name) {
             return Ok(ServiceEndpoint::new(ep.uri));
@@ -105,7 +102,7 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_grpc_service_not_found() {
         let dir = Arc::new(ModuleManager::new());
-        let api = LocalDirectoryApi::new(dir);
+        let api = LocalDirectoryClient::new(dir);
 
         let result = api.resolve_grpc_service("nonexistent.Service").await;
         assert!(result.is_err());
@@ -114,7 +111,7 @@ mod tests {
     #[tokio::test]
     async fn test_register_instance_via_api() {
         let dir = Arc::new(ModuleManager::new());
-        let api = LocalDirectoryApi::new(dir.clone());
+        let api = LocalDirectoryClient::new(dir.clone());
 
         let instance_id = Uuid::new_v4();
         // Register an instance through the API
@@ -141,7 +138,7 @@ mod tests {
     #[tokio::test]
     async fn test_deregister_instance_via_api() {
         let dir = Arc::new(ModuleManager::new());
-        let api = LocalDirectoryApi::new(dir.clone());
+        let api = LocalDirectoryClient::new(dir.clone());
 
         let instance_id = Uuid::new_v4();
         // Register an instance first
@@ -165,7 +162,7 @@ mod tests {
         use crate::runtime::InstanceState;
 
         let dir = Arc::new(ModuleManager::new());
-        let api = LocalDirectoryApi::new(dir.clone());
+        let api = LocalDirectoryClient::new(dir.clone());
 
         let instance_id = Uuid::new_v4();
         // Register an instance first

--- a/libs/modkit/src/lib.rs
+++ b/libs/modkit/src/lib.rs
@@ -127,7 +127,8 @@ pub use result::ApiResult;
 // Directory API for service discovery
 pub mod directory;
 pub use directory::{
-    DirectoryApi, LocalDirectoryApi, RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
+    DirectoryClient, LocalDirectoryClient, RegisterInstanceInfo, ServiceEndpoint,
+    ServiceInstanceInfo,
 };
 
 // GTS schema support

--- a/libs/modkit/src/runtime/runner.rs
+++ b/libs/modkit/src/runtime/runner.rs
@@ -40,8 +40,8 @@ impl ClientRegistration {
     ///
     /// # Example
     /// ```ignore
-    /// let api: Arc<dyn DirectoryApi> = Arc::new(client);
-    /// ClientRegistration::new::<dyn DirectoryApi>(api)
+    /// let api: Arc<dyn DirectoryClient> = Arc::new(client);
+    /// ClientRegistration::new::<dyn DirectoryClient>(api)
     /// ```
     pub fn new<T>(client: Arc<T>) -> Self
     where

--- a/modules/system/module_orchestrator/module_orchestrator-grpc/src/client.rs
+++ b/modules/system/module_orchestrator/module_orchestrator-grpc/src/client.rs
@@ -1,4 +1,4 @@
-//! gRPC client implementation of DirectoryApi
+//! gRPC client implementation of Directory API
 //!
 //! This client allows remote modules to discover and resolve services via gRPC.
 
@@ -8,7 +8,7 @@ use tonic::transport::Channel;
 
 use modkit_transport_grpc::client::{connect_with_retry, GrpcClientConfig};
 use module_orchestrator_sdk::{
-    DirectoryApi, RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
+    DirectoryClient, RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo,
 };
 
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
     ListInstancesRequest, RegisterInstanceRequest, ResolveGrpcServiceRequest,
 };
 
-/// gRPC client implementation of DirectoryApi
+/// gRPC client for Directory API
 ///
 /// This client connects to a remote DirectoryService via gRPC and provides
 /// typed access to service discovery functionality. It includes:
@@ -89,7 +89,7 @@ impl DirectoryGrpcClient {
 }
 
 #[async_trait]
-impl DirectoryApi for DirectoryGrpcClient {
+impl DirectoryClient for DirectoryGrpcClient {
     async fn resolve_grpc_service(&self, service_name: &str) -> Result<ServiceEndpoint> {
         let mut client = self.inner.clone();
         let request = tonic::Request::new(ResolveGrpcServiceRequest {

--- a/modules/system/module_orchestrator/module_orchestrator-sdk/src/api.rs
+++ b/modules/system/module_orchestrator/module_orchestrator-sdk/src/api.rs
@@ -68,7 +68,7 @@ pub struct RegisterInstanceInfo {
 /// - A local implementation that delegates to `ModuleManager`
 /// - A gRPC client for out-of-process modules
 #[async_trait]
-pub trait DirectoryApi: Send + Sync {
+pub trait DirectoryClient: Send + Sync {
     /// Resolve a gRPC service by its logical name to an endpoint
     async fn resolve_grpc_service(&self, service_name: &str) -> Result<ServiceEndpoint>;
 

--- a/modules/system/module_orchestrator/module_orchestrator-sdk/src/lib.rs
+++ b/modules/system/module_orchestrator/module_orchestrator-sdk/src/lib.rs
@@ -1,10 +1,10 @@
 //! Module Orchestrator Contracts
 //!
 //! Domain contracts and client interfaces for module orchestration.
-//! This crate provides the `DirectoryApi` trait and related types that
+//! This crate provides the `DirectoryClient` trait and related types that
 //! define the contract for service discovery and instance management.
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 mod api;
 
-pub use api::{DirectoryApi, RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo};
+pub use api::{DirectoryClient, RegisterInstanceInfo, ServiceEndpoint, ServiceInstanceInfo};

--- a/modules/system/module_orchestrator/module_orchestrator/src/module.rs
+++ b/modules/system/module_orchestrator/module_orchestrator/src/module.rs
@@ -7,9 +7,9 @@ use tokio::sync::RwLock;
 
 use modkit::context::ModuleCtx;
 use modkit::contracts::{GrpcServiceCapability, RegisterGrpcServiceFn, SystemCapability};
-use modkit::directory::LocalDirectoryApi;
+use modkit::directory::LocalDirectoryClient;
 use modkit::runtime::ModuleManager;
-use modkit::DirectoryApi;
+use modkit::DirectoryClient;
 
 use module_orchestrator_grpc::DIRECTORY_SERVICE_NAME;
 
@@ -22,17 +22,17 @@ pub struct ModuleOrchestratorConfig;
 /// Module Orchestrator - system module for service discovery
 ///
 /// This module:
-/// - Provides `DirectoryApi` to the `ClientHub` for in-process modules
+/// - Provides `DirectoryClient` to the `ClientHub` for in-process modules
 /// - Exposes `DirectoryService` gRPC service via `grpc_hub`
 /// - Tracks module instances and provides service resolution
 #[modkit::module(
     name = "module_orchestrator",
     capabilities = [grpc, system],
-    client = module_orchestrator_sdk::DirectoryApi
+    client = module_orchestrator_sdk::DirectoryClient
 )]
 pub struct ModuleOrchestrator {
     config: RwLock<ModuleOrchestratorConfig>,
-    directory_api: OnceLock<Arc<dyn DirectoryApi>>,
+    directory_api: OnceLock<Arc<dyn DirectoryClient>>,
     module_manager: OnceLock<Arc<ModuleManager>>,
 }
 
@@ -63,21 +63,21 @@ impl modkit::Module for ModuleOrchestrator {
         let cfg = ctx.config::<ModuleOrchestratorConfig>().unwrap_or_default();
         *self.config.write().await = cfg;
 
-        // Use the injected ModuleManager to create the LocalDirectoryApi
+        // Use the injected ModuleManager to create the DirectoryClient
         let manager =
             self.module_manager.get().cloned().ok_or_else(|| {
                 anyhow::anyhow!("ModuleManager not wired into ModuleOrchestrator")
             })?;
 
-        let api_impl: Arc<dyn DirectoryApi> = Arc::new(LocalDirectoryApi::new(manager));
+        let api_impl: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(manager));
 
         // Register in ClientHub directly
         ctx.client_hub()
-            .register::<dyn DirectoryApi>(api_impl.clone());
+            .register::<dyn DirectoryClient>(api_impl.clone());
 
         self.directory_api
             .set(api_impl)
-            .map_err(|_| anyhow::anyhow!("DirectoryApi already set (init called twice?)"))?;
+            .map_err(|_| anyhow::anyhow!("DirectoryClient already set (init called twice?)"))?;
 
         tracing::info!("ModuleOrchestrator initialized");
 
@@ -93,7 +93,7 @@ impl GrpcServiceCapability for ModuleOrchestrator {
             .directory_api
             .get()
             .cloned()
-            .ok_or_else(|| anyhow::anyhow!("DirectoryApi not initialized"))?;
+            .ok_or_else(|| anyhow::anyhow!("DirectoryClient not initialized"))?;
 
         // Build DirectoryService
         let directory_svc = server::make_directory_service(api);

--- a/modules/system/module_orchestrator/module_orchestrator/src/server.rs
+++ b/modules/system/module_orchestrator/module_orchestrator/src/server.rs
@@ -1,6 +1,6 @@
 //! gRPC server implementation for `DirectoryService`
 //!
-//! This module provides the gRPC service implementation that wraps `DirectoryApi`.
+//! This module provides the gRPC service implementation for Directory Service.
 
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
@@ -10,16 +10,16 @@ use module_orchestrator_grpc::{
     InstanceInfo, ListInstancesRequest, ListInstancesResponse, RegisterInstanceRequest,
     ResolveGrpcServiceRequest, ResolveGrpcServiceResponse,
 };
-use module_orchestrator_sdk::{DirectoryApi, RegisterInstanceInfo, ServiceEndpoint};
+use module_orchestrator_sdk::{DirectoryClient, RegisterInstanceInfo, ServiceEndpoint};
 
-/// gRPC service implementation that wraps `DirectoryApi`
+/// gRPC service implementation of Directory Service
 #[derive(Clone)]
 pub struct DirectoryServiceImpl {
-    api: Arc<dyn DirectoryApi>,
+    api: Arc<dyn DirectoryClient>,
 }
 
 impl DirectoryServiceImpl {
-    pub fn new(api: Arc<dyn DirectoryApi>) -> Self {
+    pub fn new(api: Arc<dyn DirectoryClient>) -> Self {
         Self { api }
     }
 }
@@ -130,7 +130,7 @@ impl DirectoryService for DirectoryServiceImpl {
 
 /// Create a `DirectoryService` server with the given API implementation
 pub fn make_directory_service(
-    api: Arc<dyn DirectoryApi>,
+    api: Arc<dyn DirectoryClient>,
 ) -> DirectoryServiceServer<DirectoryServiceImpl> {
     DirectoryServiceServer::new(DirectoryServiceImpl::new(api))
 }

--- a/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/module.rs
+++ b/modules/system/tenant_resolver/plugins/single_tenant_tr_plugin/src/module.rs
@@ -9,7 +9,7 @@ use modkit::context::ModuleCtx;
 use modkit::gts::BaseModkitPluginV1;
 use modkit::Module;
 use tracing::info;
-use types_registry_sdk::TypesRegistryApi;
+use types_registry_sdk::TypesRegistryClient;
 
 use crate::domain::Service;
 
@@ -47,7 +47,7 @@ impl Module for SingleTenantTrPlugin {
         );
 
         // Register plugin instance in types-registry
-        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
         let instance = BaseModkitPluginV1::<TenantResolverPluginSpecV1> {
             id: instance_id.clone(),
             vendor: VENDOR.to_owned(),

--- a/modules/system/tenant_resolver/plugins/static_tr_plugin/src/module.rs
+++ b/modules/system/tenant_resolver/plugins/static_tr_plugin/src/module.rs
@@ -9,7 +9,7 @@ use modkit::context::ModuleCtx;
 use modkit::gts::BaseModkitPluginV1;
 use modkit::Module;
 use tracing::info;
-use types_registry_sdk::TypesRegistryApi;
+use types_registry_sdk::TypesRegistryClient;
 
 use crate::config::StaticTrPluginConfig;
 use crate::domain::Service;
@@ -59,7 +59,7 @@ impl Module for StaticTrPlugin {
         );
 
         // Register plugin instance in types-registry
-        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
         let instance = BaseModkitPluginV1::<TenantResolverPluginSpecV1> {
             id: instance_id.clone(),
             vendor: cfg.vendor.clone(),

--- a/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/service.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/service.rs
@@ -14,7 +14,7 @@ use modkit::gts::BaseModkitPluginV1;
 use modkit_security::SecurityContext;
 use tokio::sync::OnceCell;
 use tracing::info;
-use types_registry_sdk::{GtsEntity, ListQuery, TypesRegistryApi};
+use types_registry_sdk::{GtsEntity, ListQuery, TypesRegistryClient};
 use uuid::Uuid;
 
 use super::error::DomainError;
@@ -67,7 +67,7 @@ impl Service {
 
         let registry = self
             .hub
-            .get::<dyn TypesRegistryApi>()
+            .get::<dyn TypesRegistryClient>()
             .map_err(|e| DomainError::TypesRegistryUnavailable(e.to_string()))?;
 
         let plugin_type_id = TenantResolverPluginSpecV1::gts_schema_id().clone();

--- a/modules/system/tenant_resolver/tenant_resolver-gw/src/module.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/src/module.rs
@@ -7,7 +7,7 @@ use hs_tenant_resolver_sdk::{TenantResolverGatewayClient, TenantResolverPluginSp
 use modkit::context::ModuleCtx;
 use modkit::Module;
 use tracing::info;
-use types_registry_sdk::TypesRegistryApi;
+use types_registry_sdk::TypesRegistryClient;
 
 use crate::config::TenantResolverGwConfig;
 use crate::domain::{Service, TenantResolverGwLocalClient};
@@ -47,7 +47,7 @@ impl Module for TenantResolverGateway {
         info!(vendor = %cfg.vendor, "Initializing tenant_resolver gateway");
 
         // Register plugin schema in types-registry
-        let registry = ctx.client_hub().get::<dyn TypesRegistryApi>()?;
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
         let schema_str = TenantResolverPluginSpecV1::gts_schema_with_refs_as_string();
         let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
         let _ = registry.register(vec![schema_json]).await?;

--- a/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-module/design.md
+++ b/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-module/design.md
@@ -8,7 +8,7 @@
 
 Phase 1.1 focuses on establishing the foundational contracts, in-memory storage, and REST API, deferring database persistence (Phase 1.2) to later phases.
 
-The Types Registry module implements the `TypesRegistryApi` trait from `types-registry-sdk` and provides:
+The Types Registry module implements the `TypesRegistryClient` trait from `types-registry-sdk` and provides:
 - Two-phase registration (configuration → production)
 - In-memory storage using gts-rust `GtsOps`
 - REST API endpoints
@@ -18,7 +18,7 @@ The Types Registry module implements the `TypesRegistryApi` trait from `types-re
 
 ## Goals
 
-- Implement `TypesRegistryApi` trait
+- Implement `TypesRegistryClient` trait
 - Provide two-phase storage with validation
 - Expose REST API endpoints
 - Integrate all gts-rust operations
@@ -124,12 +124,12 @@ impl Module for TypesRegistryModule {
         self.storage.store(Some(storage.clone()));
         
         // Create local client and register in ClientHub
-        let api: Arc<dyn TypesRegistryApi> = Arc::new(
+        let api: Arc<dyn TypesRegistryClient> = Arc::new(
             TypesRegistryLocalClient::new(storage)
         );
         
-        // Register in ClientHub directly - consumers use hub.get::<dyn TypesRegistryApi>()?
-        ctx.client_hub().register::<dyn TypesRegistryApi>(api);
+        // Register in ClientHub directly - consumers use hub.get::<dyn TypesRegistryClient>()?
+        ctx.client_hub().register::<dyn TypesRegistryClient>(api);
         
         tracing::info!("Types registry module initialized");
         Ok(())
@@ -181,7 +181,7 @@ pub struct TypesRegistryStorage {
 - After commit: `register()` validates immediately on each call
 
 ```rust
-impl TypesRegistryApi for TypesRegistryLocalClient {
+impl TypesRegistryClient for TypesRegistryLocalClient {
     async fn register(&self, ctx: &SecurityCtx, entities: Vec<Value>) -> Result<Vec<RegisterResult>, TypesRegistryError> {
         let mut results = Vec::with_capacity(entities.len());
         

--- a/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-module/proposal.md
+++ b/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-module/proposal.md
@@ -12,7 +12,7 @@ With the `types-registry-sdk` crate providing the public API contracts, we need 
 - Module declaration with `#[modkit::module(name = "types_registry", capabilities = [system, rest])]`
 - Two-phase storage (configuration + production) using gts-rust `GtsOps`
 - Domain service with business logic
-- Local client implementing `TypesRegistryApi` trait
+- Local client implementing `TypesRegistryClient` trait
 - REST API handlers, routes, and DTOs
 - ClientHub registration for inter-module access
 - Full gts-rust integration (OP#1-OP#11)

--- a/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-module/tasks.md
+++ b/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-module/tasks.md
@@ -24,7 +24,7 @@
 
 ## 4. Local Client
 
-- [x] 4.1 Implement `TypesRegistryApi` trait for local client
+- [x] 4.1 Implement `TypesRegistryClient` trait for local client
 - [x] 4.2 Wire local client to ClientHub
 
 ## 5. REST API Layer

--- a/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-sdk/design.md
+++ b/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-sdk/design.md
@@ -13,7 +13,7 @@ No implementation logic — that lives in the module crate.
 
 ## Goals
 
-- Define `TypesRegistryApi` trait for inter-module communication
+- Define `TypesRegistryClient` trait for inter-module communication
 - Provide `GtsEntity` model using gts-rust types
 - Define `ListQuery` for filtering operations
 - Define `TypesRegistryError` for error handling
@@ -37,11 +37,11 @@ No implementation logic — that lives in the module crate.
 
 ### 2. Async Trait with Object Safety
 
-**Decision**: Use `#[async_trait]` and ensure `TypesRegistryApi` is object-safe for `Arc<dyn TypesRegistryApi>`.
+**Decision**: Use `#[async_trait]` and ensure `TypesRegistryClient` is object-safe for `Arc<dyn TypesRegistryClient>`.
 
 ```rust
 #[async_trait]
-pub trait TypesRegistryApi: Send + Sync {
+pub trait TypesRegistryClient: Send + Sync {
     async fn register(&self, ctx: &SecurityCtx, entities: Vec<Value>) -> Result<Vec<RegisterResult>, TypesRegistryError>;
     async fn list(&self, ctx: &SecurityCtx, query: ListQuery) -> Result<Vec<GtsEntity>, TypesRegistryError>;
     async fn get(&self, ctx: &SecurityCtx, gts_id: &str) -> Result<GtsEntity, TypesRegistryError>;
@@ -49,7 +49,7 @@ pub trait TypesRegistryApi: Send + Sync {
 ```
 
 **Rationale**:
-- Enables ClientHub registration: `hub.register::<dyn TypesRegistryApi>(api)`
+- Enables ClientHub registration: `hub.register::<dyn TypesRegistryClient>(api)`
 - Consistent with other HyperSpot SDK traits
 - `register` returns `Vec<RegisterResult>` for per-item error reporting in batch operations
 
@@ -182,7 +182,7 @@ types-registry-sdk/
 ├── Cargo.toml
 └── src/
     ├── lib.rs          # Re-exports
-    ├── api.rs          # TypesRegistryApi trait
+    ├── api.rs          # TypesRegistryClient trait
     ├── models.rs       # GtsEntity, GtsEntityKind, ListQuery
     └── error.rs        # TypesRegistryError
 ```

--- a/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-sdk/proposal.md
+++ b/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-sdk/proposal.md
@@ -7,7 +7,7 @@ HyperSpot needs a lightweight SDK crate (`types-registry-sdk`) that defines the 
 ## What Changes
 
 **New Crate: `types-registry-sdk`**
-- `TypesRegistryApi` trait with 3 core methods: `register`, `list`, `get`
+- `TypesRegistryClient` trait with 3 core methods: `register`, `list`, `get`
 - `GtsEntity<C>` generic model using `GtsIdSegment` from gts-rust
 - `GtsEntityKind` enum (`Type` / `Instance`)
 - `TypeSchema` and `InstanceObject` newtype wrappers for semantic clarity

--- a/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-sdk/specs/types-registry-sdk/spec.md
+++ b/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-sdk/specs/types-registry-sdk/spec.md
@@ -2,9 +2,9 @@
 
 ## ADDED Requirements
 
-### Requirement: TypesRegistryApi Trait
+### Requirement: TypesRegistryClient Trait
 
-The SDK SHALL provide a `TypesRegistryApi` trait defining the public contract for types registry operations.
+The SDK SHALL provide a `TypesRegistryClient` trait defining the public contract for types registry operations.
 
 The trait SHALL define:
 - `register` — Register GTS entities (types or instances) in batch, returning per-item results
@@ -13,13 +13,13 @@ The trait SHALL define:
 
 #### Scenario: Trait is object-safe
 
-- **GIVEN** the `TypesRegistryApi` trait
-- **WHEN** used as `dyn TypesRegistryApi`
-- **THEN** the trait compiles and can be used with `Arc<dyn TypesRegistryApi>`
+- **GIVEN** the `TypesRegistryClient` trait
+- **WHEN** used as `dyn TypesRegistryClient`
+- **THEN** the trait compiles and can be used with `Arc<dyn TypesRegistryClient>`
 
 #### Scenario: Trait methods are async
 
-- **GIVEN** the `TypesRegistryApi` trait
+- **GIVEN** the `TypesRegistryClient` trait
 - **WHEN** implementing the trait
 - **THEN** all methods are async and return `Result` types
 

--- a/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-sdk/tasks.md
+++ b/modules/system/types-registry/openspec/changes/archive/2025-12-22-add-types-registry-sdk/tasks.md
@@ -5,7 +5,7 @@
 - [x] 1.1 Create `types-registry-sdk/Cargo.toml` with minimal dependencies
 - [x] 1.2 Define `GtsEntity` model using `GtsIdSegment` from gts-rust
 - [x] 1.3 Define `TypesRegistryError` enum
-- [x] 1.4 Define `TypesRegistryApi` trait with 3 methods:
+- [x] 1.4 Define `TypesRegistryClient` trait with 3 methods:
   - `register(&SecurityCtx, Vec<serde_json::Value>) -> Result<Vec<GtsEntity>>` (batch registration)
   - `list(&SecurityCtx, ListQuery) -> Result<Vec<GtsEntity>>`
   - `get(&SecurityCtx, &str) -> Result<GtsEntity>`

--- a/modules/system/types-registry/openspec/specs/types-registry-sdk/spec.md
+++ b/modules/system/types-registry/openspec/specs/types-registry-sdk/spec.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-The Types Registry SDK provides the public API contracts for the Types Registry module. It defines the `TypesRegistryApi` trait, data models (`GtsEntity`, `ListQuery`, `RegisterResult`), and error types that enable other HyperSpot modules to interact with the Types Registry without depending on the full implementation.
+The Types Registry SDK provides the public API contracts for the Types Registry module. It defines the `TypesRegistryClient` trait, data models (`GtsEntity`, `ListQuery`, `RegisterResult`), and error types that enable other HyperSpot modules to interact with the Types Registry without depending on the full implementation.
 ## Requirements
-### Requirement: TypesRegistryApi Trait
+### Requirement: TypesRegistryClient Trait
 
-The SDK SHALL provide a `TypesRegistryApi` trait defining the public contract for types registry operations.
+The SDK SHALL provide a `TypesRegistryClient` trait defining the public contract for types registry operations.
 
 The trait SHALL define:
 - `register` — Register GTS entities (types or instances) in batch, returning per-item results
@@ -15,13 +15,13 @@ The trait SHALL define:
 
 #### Scenario: Trait is object-safe
 
-- **GIVEN** the `TypesRegistryApi` trait
-- **WHEN** used as `dyn TypesRegistryApi`
-- **THEN** the trait compiles and can be used with `Arc<dyn TypesRegistryApi>`
+- **GIVEN** the `TypesRegistryClient` trait
+- **WHEN** used as `dyn TypesRegistryClient`
+- **THEN** the trait compiles and can be used with `Arc<dyn TypesRegistryClient>`
 
 #### Scenario: Trait methods are async
 
-- **GIVEN** the `TypesRegistryApi` trait
+- **GIVEN** the `TypesRegistryClient` trait
 - **WHEN** implementing the trait
 - **THEN** all methods are async and return `Result` types
 

--- a/modules/system/types-registry/types-registry-sdk/README.md
+++ b/modules/system/types-registry/types-registry-sdk/README.md
@@ -6,7 +6,7 @@ SDK crate for the Types Registry module, providing the public API contracts for 
 
 This crate defines the transport-agnostic interface for the Types Registry module:
 
-- **`TypesRegistryApi`** - Async trait for inter-module communication
+- **`TypesRegistryClient`** - Async trait for inter-module communication
 - **`GtsEntity`** - Model representing registered GTS entities (types and instances)
 - **`ListQuery`** - Query builder for filtering entity listings
 - **`TypesRegistryError`** - Error types for all operations
@@ -18,10 +18,10 @@ This crate defines the transport-agnostic interface for the Types Registry modul
 Consumers obtain the client from `ClientHub`:
 
 ```rust
-use types_registry_sdk::{TypesRegistryApi, ListQuery};
+use types_registry_sdk::{TypesRegistryClient, ListQuery};
 
 // Get the client from ClientHub
-let client = hub.get::<dyn TypesRegistryApi>()?;
+let client = hub.get::<dyn TypesRegistryClient>()?;
 ```
 
 ### Registering Entities

--- a/modules/system/types-registry/types-registry-sdk/src/api.rs
+++ b/modules/system/types-registry/types-registry-sdk/src/api.rs
@@ -19,7 +19,7 @@ use crate::models::{GtsEntity, ListQuery, RegisterResult};
 /// GTS schemas and instances are global resources (not tenant-scoped),
 /// so no security context is required for these operations.
 #[async_trait]
-pub trait TypesRegistryApi: Send + Sync {
+pub trait TypesRegistryClient: Send + Sync {
     /// Register GTS entities (types or instances) in batch.
     ///
     /// Each JSON value in the input should contain a valid GTS entity

--- a/modules/system/types-registry/types-registry-sdk/src/lib.rs
+++ b/modules/system/types-registry/types-registry-sdk/src/lib.rs
@@ -34,7 +34,7 @@ pub mod error;
 pub mod models;
 
 // Re-export main types at crate root for convenience
-pub use api::TypesRegistryApi;
+pub use api::TypesRegistryClient;
 pub use error::TypesRegistryError;
 pub use models::{
     DynGtsEntity, DynRegisterResult, GtsEntity, GtsInstanceEntity, GtsTypeEntity, InstanceObject,

--- a/modules/system/types-registry/types-registry/README.md
+++ b/modules/system/types-registry/types-registry/README.md
@@ -9,7 +9,7 @@ The `types-registry` module provides:
 - **Two-phase registration**: Configuration phase (no validation) → Production phase (full validation)
 - **GTS entity storage**: In-memory storage using `gts-rust` for Phase 1.1
 - **REST API**: Endpoints for registering, listing, and retrieving GTS entities
-- **ClientHub integration**: Other modules access via `hub.get::<dyn TypesRegistryApi>()?`
+- **ClientHub integration**: Other modules access via `hub.get::<dyn TypesRegistryClient>()?`
 
 ## Architecture
 
@@ -20,7 +20,7 @@ types-registry/
 │   ├── domain/            # Domain layer (error, repo trait, service)
 │   ├── infra/storage/     # Infrastructure (in-memory repository)
 │   ├── config.rs          # Module configuration
-│   ├── local_client.rs    # TypesRegistryApi implementation
+│   ├── local_client.rs    # TypesRegistryClient implementation
 │   ├── module.rs          # Module declaration
 │   └── lib.rs             # Crate root
 └── Cargo.toml
@@ -31,10 +31,10 @@ types-registry/
 ### Via ClientHub (Rust)
 
 ```rust
-use types_registry_sdk::TypesRegistryApi;
+use types_registry_sdk::TypesRegistryClient;
 
 // Get the client from ClientHub
-let client = hub.get::<dyn TypesRegistryApi>()?;
+let client = hub.get::<dyn TypesRegistryClient>()?;
 
 // Register entities
 let results = client.register(&ctx, entities).await?;

--- a/modules/system/types-registry/types-registry/src/api/rest/handlers.rs
+++ b/modules/system/types-registry/types-registry/src/api/rest/handlers.rs
@@ -88,6 +88,8 @@ mod tests {
     use gts::GtsConfig;
     use serde_json::json;
 
+    const JSON_SCHEMA_DRAFT_07: &str = "http://json-schema.org/draft-07/schema#";
+
     fn default_config() -> GtsConfig {
         crate::config::TypesRegistryConfig::default().to_gts_config()
     }
@@ -108,7 +110,7 @@ mod tests {
         let req = RegisterEntitiesRequest {
             entities: vec![json!({
                 "$id": "gts://gts.acme.core.events.user_created.v1~",
-                "$schema": "http://json-schema.org/draft-07/schema#",
+                "$schema": JSON_SCHEMA_DRAFT_07,
                 "type": "object"
             })],
         };
@@ -148,7 +150,7 @@ mod tests {
         let req = RegisterEntitiesRequest {
             entities: vec![json!({
                 "$id": "gts://gts.acme.core.events.user_created.v1~",
-                "$schema": "http://json-schema.org/draft-07/schema#",
+                "$schema": JSON_SCHEMA_DRAFT_07,
                 "type": "object"
             })],
         };
@@ -171,12 +173,12 @@ mod tests {
         let _ = service.register(vec![
             json!({
                 "$id": "gts://gts.acme.core.events.user_created.v1~",
-                "$schema": "http://json-schema.org/draft-07/schema#",
+                "$schema": JSON_SCHEMA_DRAFT_07,
                 "type": "object"
             }),
             json!({
                 "$id": "gts://gts.globex.core.events.order_placed.v1~",
-                "$schema": "http://json-schema.org/draft-07/schema#",
+                "$schema": JSON_SCHEMA_DRAFT_07,
                 "type": "object"
             }),
         ]);
@@ -197,7 +199,7 @@ mod tests {
         // Register entity via internal API (before ready)
         let _ = service.register(vec![json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         })]);
         service.switch_to_ready().unwrap();

--- a/modules/system/types-registry/types-registry/src/domain/local_client.rs
+++ b/modules/system/types-registry/types-registry/src/domain/local_client.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use types_registry_sdk::{
-    GtsEntity, ListQuery, RegisterResult, TypesRegistryApi, TypesRegistryError,
+    GtsEntity, ListQuery, RegisterResult, TypesRegistryClient, TypesRegistryError,
 };
 
 use crate::domain::service::TypesRegistryService;
@@ -27,7 +27,7 @@ impl TypesRegistryLocalClient {
 }
 
 #[async_trait]
-impl TypesRegistryApi for TypesRegistryLocalClient {
+impl TypesRegistryClient for TypesRegistryLocalClient {
     async fn register(
         &self,
         entities: Vec<serde_json::Value>,
@@ -51,6 +51,8 @@ mod tests {
     use gts::GtsConfig;
     use serde_json::json;
 
+    const JSON_SCHEMA_DRAFT_07: &str = "https://json-schema.org/draft-07/schema#";
+
     fn default_config() -> GtsConfig {
         crate::config::TypesRegistryConfig::default().to_gts_config()
     }
@@ -70,7 +72,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object",
             "properties": {
                 "userId": { "type": "string" }
@@ -96,12 +98,12 @@ mod tests {
 
         let type1 = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
         let type2 = json!({
             "$id": "gts://gts.globex.core.events.order_placed.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 

--- a/modules/system/types-registry/types-registry/src/domain/mod.rs
+++ b/modules/system/types-registry/types-registry/src/domain/mod.rs
@@ -5,6 +5,8 @@
 pub mod error;
 pub mod repo;
 pub mod service;
+// === LOCAL CLIENT ===
+pub mod local_client;
 
 pub use error::DomainError;
 pub use repo::GtsRepository;

--- a/modules/system/types-registry/types-registry/src/infra/storage/in_memory_repo.rs
+++ b/modules/system/types-registry/types-registry/src/infra/storage/in_memory_repo.rs
@@ -285,6 +285,8 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    const JSON_SCHEMA_DRAFT_07: &str = "http://json-schema.org/draft-07/schema#";
+
     fn default_config() -> GtsConfig {
         crate::config::TypesRegistryConfig::default().to_gts_config()
     }
@@ -295,7 +297,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object",
             "properties": {
                 "userId": { "type": "string" }
@@ -316,7 +318,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -333,13 +335,13 @@ mod tests {
 
         let entity1 = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
         let entity2 = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object",
             "description": "Different content"
         });
@@ -357,7 +359,7 @@ mod tests {
 
         let entity = json!({
             "$id": "invalid-gts-id",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -370,7 +372,7 @@ mod tests {
         let repo = InMemoryGtsRepository::new(default_config());
 
         let entity = json!({
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -384,7 +386,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object",
             "properties": {
                 "userId": { "type": "string" }
@@ -409,12 +411,12 @@ mod tests {
 
         let type1 = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
         let type2 = json!({
             "$id": "gts://gts.globex.core.events.order_placed.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -448,7 +450,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -466,7 +468,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -485,13 +487,13 @@ mod tests {
 
         let entity1 = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
         let entity2 = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object",
             "description": "Different content"
         });
@@ -507,7 +509,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -524,7 +526,7 @@ mod tests {
 
         let type_entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -546,7 +548,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -568,7 +570,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -590,7 +592,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -612,7 +614,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -632,7 +634,7 @@ mod tests {
 
         let entity = json!({
             "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object",
             "description": "A user created event"
         });
@@ -660,7 +662,7 @@ mod tests {
 
         let entity = json!({
             "gtsId": "gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 
@@ -674,7 +676,7 @@ mod tests {
 
         let entity = json!({
             "id": "gts.acme.core.events.user_created.v1~",
-            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$schema": JSON_SCHEMA_DRAFT_07,
             "type": "object"
         });
 

--- a/modules/system/types-registry/types-registry/src/lib.rs
+++ b/modules/system/types-registry/types-registry/src/lib.rs
@@ -15,16 +15,13 @@
 // === PUBLIC API (from SDK) ===
 pub use types_registry_sdk::{
     DynGtsEntity, DynRegisterResult, GtsEntity, GtsInstanceEntity, GtsTypeEntity, InstanceObject,
-    ListQuery, RegisterResult, RegisterSummary, SegmentMatchScope, TypeSchema, TypesRegistryApi,
+    ListQuery, RegisterResult, RegisterSummary, SegmentMatchScope, TypeSchema, TypesRegistryClient,
     TypesRegistryError,
 };
 
 // === MODULE DEFINITION ===
 pub mod module;
 pub use module::TypesRegistryModule;
-
-// === LOCAL CLIENT ===
-pub mod local_client;
 
 // === CONFIGURATION ===
 pub mod config;

--- a/modules/system/types-registry/types-registry/src/module.rs
+++ b/modules/system/types-registry/types-registry/src/module.rs
@@ -8,12 +8,12 @@ use modkit::contracts::SystemCapability;
 use modkit::gts::get_core_gts_schemas; // NOTE: This is temporary logic until <https://github.com/hypernetix/hyperspot/issues/156> resolved
 use modkit::{Module, ModuleCtx, RestApiCapability};
 use tracing::{debug, info};
-use types_registry_sdk::TypesRegistryApi;
+use types_registry_sdk::TypesRegistryClient;
 
 use crate::config::TypesRegistryConfig;
+use crate::domain::local_client::TypesRegistryLocalClient;
 use crate::domain::service::TypesRegistryService;
 use crate::infra::InMemoryGtsRepository;
-use crate::local_client::TypesRegistryLocalClient;
 
 /// Types Registry module.
 ///
@@ -72,7 +72,7 @@ impl Module for TypesRegistryModule {
 
         self.service.store(Some(service.clone()));
 
-        let api: Arc<dyn TypesRegistryApi> = Arc::new(TypesRegistryLocalClient::new(service));
+        let api: Arc<dyn TypesRegistryClient> = Arc::new(TypesRegistryLocalClient::new(service));
 
         // === REGISTER CORE GTS TYPES ===
         // NOTE: This is temporary logic until <https://github.com/hypernetix/hyperspot/issues/156> resolved
@@ -82,7 +82,7 @@ impl Module for TypesRegistryModule {
         api.register(core_schemas).await?;
         info!("Core GTS types registered");
 
-        ctx.client_hub().register::<dyn TypesRegistryApi>(api);
+        ctx.client_hub().register::<dyn TypesRegistryClient>(api);
 
         info!("Types registry module initialized");
         Ok(())


### PR DESCRIPTION
- rename DirectoryApi to DirectoryClient across modkit and system modules
- rename TypesRegistryApi to TypesRegistryClient across modkit and system modules
- Rename LocalDirectoryApi to LocalDirectoryClient
- Update re-exports and trait impls to match module_orchestrator_sdk naming
- Adjust docs/examples and client hub comments accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized internal service client interface naming conventions across multiple system modules for improved consistency.
  * Updated comprehensive documentation, code examples, and integration points to maintain alignment with naming changes.
  * Simplified test infrastructure by consolidating repeated constant values across the test suite.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->