### PR TITLE
fix make e2e-docker failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ CI := 1
 OPENAPI_URL ?= http://127.0.0.1:8087/openapi.json
 OPENAPI_OUT ?= docs/api/api.json
 
+# E2E Docker args
+E2E_ARGS ?= --features users-info-example
+
 # -------- Utility macros --------
 
 define ensure_tool
@@ -243,7 +246,7 @@ e2e-local:
 
 ## Run E2E tests in Docker environment
 e2e-docker:
-	python3 scripts/ci.py e2e --docker
+	python3 scripts/ci.py e2e --docker $(E2E_ARGS)
 
 # -------- Code coverage --------
 

--- a/config/quickstart-windows.yaml
+++ b/config/quickstart-windows.yaml
@@ -131,7 +131,7 @@ modules:
         #   - Configure system modules for OoP process (e.g., grpc_hub.listen_addr)
         #   - Override settings from master (MODKIT_MODULE_CONFIG)
         #   - Run in standalone mode (without master host)
-        args: [ "--config", "C:/projects/hyperspot-MikeFalcon/config/oop-example.yaml" ]
+        args: [ "--config", "./config/oop-example.yaml" ]
         working_directory: "."
         environment: { }
     config:

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -165,36 +165,37 @@ modules:
       tenants:
         # Root tenant (company level)
         - id: "00000000000000000000000000000001"
+          parent_id: null
           status: ACTIVE
           is_accessible_by_parent: true
 
         # Division 1: Engineering
-        - id: "00000000000000000000000000000010"
+        - id: "00000000000000000000000000000002"
           parent_id: "00000000000000000000000000000001"
           status: ACTIVE
           is_accessible_by_parent: true
 
         # Division 2: Sales
-        - id: "00000000000000000000000000000011"
+        - id: "00000000000000000000000000000005"
           parent_id: "00000000000000000000000000000001"
           status: ACTIVE
           is_accessible_by_parent: true
 
-        # Department under Engineering: Backend
-        - id: "00000000000000000000000000000100"
-          parent_id: "00000000000000000000000000000010"
-          status: ACTIVE
-          is_accessible_by_parent: true
-
         # Department under Engineering: Frontend (soft-deleted, not accessible)
-        - id: "00000000000000000000000000000101"
-          parent_id: "00000000000000000000000000000010"
+        - id: "00000000000000000000000000000003"
+          parent_id: "00000000000000000000000000000002"
           status: SOFT_DELETED
           is_accessible_by_parent: false
 
+        # Department under Engineering: Backend
+        - id: "00000000000000000000000000000004"
+          parent_id: "00000000000000000000000000000002"
+          status: ACTIVE
+          is_accessible_by_parent: true
+
         # Department under Sales: Enterprise
-        - id: "00000000000000000000000000000110"
-          parent_id: "00000000000000000000000000000011"
+        - id: "00000000000000000000000000000006"
+          parent_id: "00000000000000000000000000000005"
           status: ACTIVE
           is_accessible_by_parent: true
 

--- a/testing/docker/docker-compose.yml
+++ b/testing/docker/docker-compose.yml
@@ -16,16 +16,16 @@ services:
     image: hyperspot-api:e2e
     build:
       context: ../..
-      dockerfile: hyperspot.Dockerfile
+      dockerfile: testing/docker/hyperspot.Dockerfile
     ports:
-      - "8087:8087"
+      - "8086:8086"
     extra_hosts:
       # Allow container to access host machine via host.docker.internal
       - "host.docker.internal:host-gateway"
     environment:
       # No external dependencies needed for file_parser module
       - RUST_LOG=info
-      - APP__MODULES__api_gateway__CONFIG__BIND_ADDR=0.0.0.0:8087
+      - APP__MODULES__api_gateway__CONFIG__BIND_ADDR=0.0.0.0:8086
       - APP__MODULES__api_gateway__CONFIG__ENABLE_DOCS=true
       - APP__MODULES__api_gateway__CONFIG__CORS_ENABLED=true
     depends_on:

--- a/testing/docker/hyperspot.Dockerfile
+++ b/testing/docker/hyperspot.Dockerfile
@@ -1,10 +1,13 @@
 # Multi-stage build for hyperspot-server API backend
 # Stage 1: Builder
-FROM rust:1.89 AS builder
+FROM rust:1.92-bookworm AS builder
+
+# Build arguments for cargo features
+ARG CARGO_FEATURES
 
 # Install protobuf-compiler for prost-build
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends protobuf-compiler && \
+    apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
@@ -19,12 +22,18 @@ COPY libs ./libs
 COPY modules ./modules
 COPY examples ./examples
 COPY config ./config
+COPY proto ./proto
 
 # Build the hyperspot-server binary in release mode
 # Using --bin to build only the specific binary
-RUN cargo build --bin hyperspot-server --features users-info-example
+# Features can be customized via CARGO_FEATURES build arg
+RUN if [ -n "$CARGO_FEATURES" ]; then \
+        cargo build --bin hyperspot-server --package=hyperspot-server --features "$CARGO_FEATURES"; \
+    else \
+        cargo build --bin hyperspot-server --package=hyperspot-server; \
+    fi
 
-# Stage 2: Runtime
+# Stage 2: Runtime - must match builder's base OS
 FROM debian:bookworm-slim
 
 WORKDIR /app
@@ -34,8 +43,8 @@ COPY --from=builder /build/target/debug/hyperspot-server /app/hyperspot-server
 # Copy config used in CMD
 COPY --from=builder /build/config /app/config
 
-# Expose the HTTP port (default 8080 for E2E)
-EXPOSE 8087
+# Expose the HTTP port for E2E tests
+EXPOSE 8086
 
 # Run the binary with minimal config suitable for E2E tests
 # Using --mock flag to use in-memory SQLite for any modules that need DB

--- a/testing/e2e/conftest.py
+++ b/testing/e2e/conftest.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).parent / "helpers"))
 @pytest.fixture
 def base_url():
     """Provide base URL for the API from E2E_BASE_URL env var."""
-    return os.getenv("E2E_BASE_URL", "http://localhost:8087")
+    return os.getenv("E2E_BASE_URL", "http://localhost:8086")
 
 
 @pytest.fixture

--- a/testing/e2e/modules/file_parser/generate_file_parser_golden.py
+++ b/testing/e2e/modules/file_parser/generate_file_parser_golden.py
@@ -10,7 +10,7 @@ Usage:
     python -m e2e.modules.file_parser.generate_file_parser_golden
 
 Environment Variables:
-    E2E_BASE_URL: Base URL for the API (default: http://127.0.0.1:8087)
+    E2E_BASE_URL: Base URL for the API (default: http://127.0.0.1:8086)
     E2E_AUTH_TOKEN: Optional bearer token for authentication
 """
 
@@ -22,7 +22,7 @@ import httpx
 
 def get_base_url():
     """Get base URL from environment or use default."""
-    return os.getenv("E2E_BASE_URL", "http://127.0.0.1:8087")
+    return os.getenv("E2E_BASE_URL", "http://127.0.0.1:8086")
 
 
 def get_auth_headers():


### PR DESCRIPTION
#92 #255

Ran command `make e2e-docker E2E_ARGS="--features users-info-example,tenant-resolver-example"` successfully. 
All e2e tests passed ✅
- testing/e2e/modules/examples/tenant_resolver_gw/
- testing/e2e/modules/file_parser/
- testing/e2e/modules/nodes_registry/
- testing/e2e/modules/types_registry/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * E2E runs now accept customizable feature flags and arguments for flexible test/build selection.

* **Bug Fixes**
  * More robust server health checks with improved retry reporting and expanded error handling.

* **Chores**
  * Test/runtime port standardized to 8086 across configs and tests.
  * Windows quickstart updated to use relative config paths.
  * Tenant/division/department configuration reorganized (IDs, parents, and a soft-deleted entry).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->