### PR TITLE
feat(modkit): add GtsPluginSelector and ThrottledLog for lazy plugin resolution

### DIFF
--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/api/rest/error.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/api/rest/error.rs
@@ -12,10 +12,10 @@ impl From<DomainError> for Problem {
                 "PluginNotFound",
                 format!("No plugin instances found for vendor '{vendor}'"),
             ),
-            DomainError::PluginClientNotFound { gts_id } => Problem::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "PluginClientNotFound",
-                format!("Plugin client not found in ClientHub for '{gts_id}'"),
+            DomainError::PluginUnavailable { gts_id, reason } => Problem::new(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "PluginUnavailable",
+                format!("Plugin '{gts_id}' is not available: {reason}"),
             ),
             DomainError::InvalidPluginInstance { gts_id, reason } => Problem::new(
                 StatusCode::BAD_REQUEST,

--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/domain/error.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-gw/src/domain/error.rs
@@ -10,8 +10,8 @@ pub enum DomainError {
     #[error("invalid plugin instance content for '{gts_id}': {reason}")]
     InvalidPluginInstance { gts_id: String, reason: String },
 
-    #[error("plugin client not registered in ClientHub for '{gts_id}'")]
-    PluginClientNotFound { gts_id: String },
+    #[error("plugin not available for '{gts_id}': {reason}")]
+    PluginUnavailable { gts_id: String, reason: String },
 
     #[error("tenant not found: {0}")]
     TenantNotFound(String),
@@ -33,6 +33,10 @@ impl From<tenant_resolver_sdk::TenantResolverError> for DomainError {
             TenantResolverError::PermissionDenied(msg) | TenantResolverError::Unauthorized(msg) => {
                 Self::PermissionDenied(msg)
             }
+            TenantResolverError::ServiceUnavailable(msg) => Self::PluginUnavailable {
+                gts_id: "unknown".to_owned(),
+                reason: msg,
+            },
             TenantResolverError::Internal(msg) => Self::Internal(msg),
         }
     }
@@ -65,8 +69,8 @@ impl From<DomainError> for tenant_resolver_sdk::TenantResolverError {
             DomainError::InvalidPluginInstance { gts_id, reason } => {
                 Self::Internal(format!("invalid plugin instance '{gts_id}': {reason}"))
             }
-            DomainError::PluginClientNotFound { gts_id } => {
-                Self::Internal(format!("plugin client not registered for '{gts_id}'"))
+            DomainError::PluginUnavailable { gts_id, reason } => {
+                Self::ServiceUnavailable(format!("plugin not available for '{gts_id}': {reason}"))
             }
             DomainError::TenantNotFound(msg) => Self::NotFound(msg),
             DomainError::PermissionDenied(msg) => Self::PermissionDenied(msg),

--- a/examples/plugin-modules/tenant_resolver/tenant_resolver-sdk/src/error.rs
+++ b/examples/plugin-modules/tenant_resolver/tenant_resolver-sdk/src/error.rs
@@ -12,6 +12,9 @@ pub enum TenantResolverError {
     #[error("not found: {0}")]
     NotFound(String),
 
+    #[error("service unavailable: {0}")]
+    ServiceUnavailable(String),
+
     #[error("internal error: {0}")]
     Internal(String),
 }

--- a/libs/modkit/src/client_hub.rs
+++ b/libs/modkit/src/client_hub.rs
@@ -216,6 +216,23 @@ impl ClientHub {
         })
     }
 
+    /// Try to fetch a scoped client by interface type `T` and scope.
+    ///
+    /// Returns `None` if not found or if the stored type doesn't match.
+    pub fn try_get_scoped<T>(&self, scope: &ClientScope) -> Option<Arc<T>>
+    where
+        T: ?Sized + Send + Sync + 'static,
+    {
+        let key = ScopedKey {
+            type_key: TypeKey::of::<T>(),
+            scope: scope.clone(),
+        };
+        let r = self.scoped_map.read();
+        let boxed = r.get(&key)?;
+
+        boxed.downcast_ref::<Arc<T>>().cloned()
+    }
+
     /// Remove a client by interface type; returns the removed client if it was present.
     pub fn remove<T>(&self) -> Option<Arc<T>>
     where
@@ -348,5 +365,24 @@ mod tests {
 
         assert_eq!(&*hub.get::<str>().unwrap(), "global");
         assert_eq!(&*hub.get_scoped::<str>(&scope).unwrap(), "scoped");
+    }
+
+    #[test]
+    fn try_get_scoped_returns_some_on_hit() {
+        let hub = ClientHub::new();
+        let scope = ClientScope::gts_id("gts.x.core.modkit.plugins.v1~x.core.tenant_resolver.plugin.v1~contoso.app._.plugin.v1.0");
+        hub.register_scoped::<str>(scope.clone(), Arc::from("scoped"));
+
+        let got = hub.try_get_scoped::<str>(&scope);
+        assert_eq!(got.as_deref(), Some("scoped"));
+    }
+
+    #[test]
+    fn try_get_scoped_returns_none_on_miss() {
+        let hub = ClientHub::new();
+        let scope = ClientScope::gts_id("gts.x.core.modkit.plugins.v1~x.core.tenant_resolver.plugin.v1~fabrikam.app._.plugin.v1.0");
+
+        let got = hub.try_get_scoped::<str>(&scope);
+        assert!(got.is_none());
     }
 }

--- a/libs/modkit/src/lib.rs
+++ b/libs/modkit/src/lib.rs
@@ -115,6 +115,7 @@ pub mod telemetry;
 
 pub mod backends;
 pub mod lifecycle;
+pub mod plugins;
 pub mod runtime;
 
 // Error catalog runtime support
@@ -142,6 +143,7 @@ pub use backends::{
     OopModuleConfig, OopSpawnConfig,
 };
 pub use lifecycle::{Lifecycle, Runnable, Status, StopReason, WithLifecycle};
+pub use plugins::GtsPluginSelector;
 pub use runtime::{
     run, DbOptions, Endpoint, ModuleInstance, ModuleManager, OopModuleSpawnConfig, OopSpawnOptions,
     RunOptions, ShutdownOptions,

--- a/libs/modkit/src/plugins/mod.rs
+++ b/libs/modkit/src/plugins/mod.rs
@@ -1,0 +1,208 @@
+use std::future::Future;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use tokio::sync::Mutex;
+
+/// A resettable, allocation-friendly selector for GTS plugin instance IDs.
+///
+/// Uses a single-flight pattern to ensure that the resolve function is called
+/// at most once even under concurrent callers. The selected instance ID is
+/// cached as `Arc<str>` to avoid allocations on the happy path.
+pub struct GtsPluginSelector {
+    /// Cached selected instance ID (sync lock for fast access and sync reset).
+    cached: RwLock<Option<Arc<str>>>,
+    /// Mutex to ensure single-flight resolution.
+    resolve_lock: Mutex<()>,
+}
+
+impl Default for GtsPluginSelector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GtsPluginSelector {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            cached: RwLock::new(None),
+            resolve_lock: Mutex::new(()),
+        }
+    }
+
+    /// Returns the cached instance ID, or resolves it using the provided function.
+    ///
+    /// Uses a single-flight pattern: even under concurrent callers, the resolve
+    /// function is called at most once. Returns `Arc<str>` to avoid allocations
+    /// on the happy path.
+    /// # Errors
+    ///
+    /// Returns `Err(E)` if the provided `resolve` future fails.
+    pub async fn get_or_init<F, Fut, E>(&self, resolve: F) -> Result<Arc<str>, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<String, E>>,
+    {
+        // Fast path: check if already cached (sync lock, no await)
+        {
+            let guard = self.cached.read();
+            if let Some(ref id) = *guard {
+                return Ok(Arc::clone(id));
+            }
+        }
+
+        // Slow path: acquire resolve lock for single-flight
+        let _resolve_guard = self.resolve_lock.lock().await;
+
+        // Re-check after acquiring resolve lock (another caller may have resolved)
+        {
+            let guard = self.cached.read();
+            if let Some(ref id) = *guard {
+                return Ok(Arc::clone(id));
+            }
+        }
+
+        // Resolve and cache
+        let id_string = resolve().await?;
+        let id: Arc<str> = id_string.into();
+
+        {
+            let mut guard = self.cached.write();
+            *guard = Some(Arc::clone(&id));
+        }
+
+        Ok(id)
+    }
+
+    /// Clears the cached selected instance ID.
+    ///
+    /// Returns `true` if there was a cached value, `false` otherwise.
+    pub async fn reset(&self) -> bool {
+        let _resolve_guard = self.resolve_lock.lock().await;
+        let mut guard = self.cached.write();
+        guard.take().is_some()
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn resolve_called_once_returns_same_str() {
+        let selector = GtsPluginSelector::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let calls_a = calls.clone();
+        let id_a = selector
+            .get_or_init(|| async move {
+                calls_a.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, std::convert::Infallible>(
+                    "gts.x.core.modkit.plugin.v1~x.core.test.plugin.v1~a.test._.plugin.v1"
+                        .to_owned(),
+                )
+            })
+            .await
+            .unwrap();
+
+        let calls_b = calls.clone();
+        let id_b = selector
+            .get_or_init(|| async move {
+                calls_b.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, std::convert::Infallible>(
+                    "gts.x.core.modkit.plugin.v1~x.core.test.plugin.v1~b.test._.plugin.v1"
+                        .to_owned(),
+                )
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(id_a, id_b);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn reset_triggers_reselection() {
+        let selector = GtsPluginSelector::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let calls_a = calls.clone();
+        let id_a = selector
+            .get_or_init(|| async move {
+                calls_a.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, std::convert::Infallible>(
+                    "gts.x.core.modkit.plugin.v1~x.core.test.plugin.v1~a.test._.plugin.v1"
+                        .to_owned(),
+                )
+            })
+            .await;
+        assert_eq!(
+            &*id_a.unwrap(),
+            "gts.x.core.modkit.plugin.v1~x.core.test.plugin.v1~a.test._.plugin.v1"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(selector.reset().await);
+
+        let calls_b = calls.clone();
+        let id_b = selector
+            .get_or_init(|| async move {
+                calls_b.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, std::convert::Infallible>(
+                    "gts.x.core.modkit.plugin.v1~x.core.test.plugin.v1~b.test._.plugin.v1"
+                        .to_owned(),
+                )
+            })
+            .await;
+        assert_eq!(
+            &*id_b.unwrap(),
+            "gts.x.core.modkit.plugin.v1~x.core.test.plugin.v1~b.test._.plugin.v1"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_get_or_init_resolves_once() {
+        let selector = Arc::new(GtsPluginSelector::new());
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let selector = Arc::clone(&selector);
+            let calls = Arc::clone(&calls);
+            handles.push(tokio::spawn(async move {
+                selector
+                    .get_or_init(|| async {
+                        // Small delay to increase chance of concurrent access
+                        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        Ok::<_, std::convert::Infallible>(
+                            "gts.x.core.modkit.plugin.v1~x.core.test.plugin.v1~concurrent.test._.plugin.v1"
+                                .to_owned(),
+                        )
+                    })
+                    .await
+            }));
+        }
+
+        // Await each handle in a loop (no futures_util dependency)
+        let mut results = Vec::new();
+        for handle in handles {
+            results.push(handle.await.unwrap().unwrap());
+        }
+
+        // All results should be the same
+        for id in &results {
+            assert_eq!(
+                &**id,
+                "gts.x.core.modkit.plugin.v1~x.core.test.plugin.v1~concurrent.test._.plugin.v1"
+            );
+        }
+
+        // Resolve should have been called exactly once
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/libs/modkit/src/telemetry/mod.rs
+++ b/libs/modkit/src/telemetry/mod.rs
@@ -5,6 +5,8 @@
 
 pub mod config;
 pub mod init;
+pub mod throttled_log;
 
 pub use config::{Exporter, HttpOpts, LogsCorrelation, Propagation, Sampler, TracingConfig};
 pub use init::{init_tracing, shutdown_tracing};
+pub use throttled_log::ThrottledLog;

--- a/libs/modkit/src/telemetry/throttled_log.rs
+++ b/libs/modkit/src/telemetry/throttled_log.rs
@@ -1,0 +1,86 @@
+//! Lock-free throttled logging helper.
+//!
+//! Provides a reusable mechanism to limit log frequency without
+//! performing any logging itself.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+/// A lock-free helper that decides whether logging is allowed at the current moment.
+///
+/// Uses monotonic time (`Instant`) and atomic operations to ensure correct
+/// behavior under concurrency without any locks or allocations on the hot path.
+///
+/// # Example
+///
+/// ```
+/// use std::time::Duration;
+/// use modkit::telemetry::ThrottledLog;
+///
+/// let throttle = ThrottledLog::new(Duration::from_secs(10));
+///
+/// if throttle.should_log() {
+///     // Perform logging here
+/// }
+/// ```
+pub struct ThrottledLog {
+    /// Monotonic start time for computing elapsed milliseconds.
+    start: Instant,
+    /// Next allowed log time in milliseconds since `start`.
+    next_log_ms: AtomicU64,
+    /// Throttle interval in milliseconds.
+    throttle_ms: u64,
+}
+
+fn u64_millis(d: Duration) -> u64 {
+    let ms: u128 = d.as_millis();
+    u64::try_from(ms).unwrap_or(u64::MAX)
+}
+
+impl ThrottledLog {
+    /// Creates a new throttled log helper with the given throttle interval.
+    #[must_use]
+    pub fn new(throttle: Duration) -> Self {
+        Self {
+            start: Instant::now(),
+            next_log_ms: AtomicU64::new(0),
+            throttle_ms: u64_millis(throttle),
+        }
+    }
+
+    /// Returns `true` if logging is allowed at the current moment.
+    ///
+    /// Uses compare-and-swap to ensure that under concurrent calls,
+    /// only one caller per throttle interval receives `true`.
+    pub fn should_log(&self) -> bool {
+        let now_ms = u64_millis(self.start.elapsed());
+        let next = self.next_log_ms.load(Ordering::Relaxed);
+
+        if now_ms < next {
+            return false;
+        }
+
+        let new_next = now_ms.saturating_add(self.throttle_ms);
+        self.next_log_ms
+            .compare_exchange(next, new_next, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_call_returns_true() {
+        let throttle = ThrottledLog::new(Duration::from_secs(10));
+        assert!(throttle.should_log());
+    }
+
+    #[test]
+    fn second_call_within_interval_returns_false() {
+        let throttle = ThrottledLog::new(Duration::from_secs(10));
+        assert!(throttle.should_log());
+        assert!(!throttle.should_log());
+    }
+}

--- a/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/error.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/error.rs
@@ -15,8 +15,8 @@ pub enum DomainError {
     #[error("invalid plugin instance content for '{gts_id}': {reason}")]
     InvalidPluginInstance { gts_id: String, reason: String },
 
-    #[error("plugin client not registered in ClientHub for '{gts_id}'")]
-    PluginClientNotFound { gts_id: String },
+    #[error("plugin not available for '{gts_id}': {reason}")]
+    PluginUnavailable { gts_id: String, reason: String },
 
     #[error("tenant not found: {tenant_id}")]
     TenantNotFound { tenant_id: Uuid },
@@ -60,6 +60,10 @@ impl From<TenantResolverError> for DomainError {
             TenantResolverError::NoPluginAvailable => Self::PluginNotFound {
                 vendor: "unknown".to_owned(),
             },
+            TenantResolverError::ServiceUnavailable(msg) => Self::PluginUnavailable {
+                gts_id: "unknown".to_owned(),
+                reason: msg,
+            },
             TenantResolverError::Internal(msg) => Self::Internal(msg),
         }
     }
@@ -72,8 +76,8 @@ impl From<DomainError> for TenantResolverError {
             DomainError::InvalidPluginInstance { gts_id, reason } => {
                 Self::Internal(format!("invalid plugin instance '{gts_id}': {reason}"))
             }
-            DomainError::PluginClientNotFound { gts_id } => {
-                Self::Internal(format!("plugin client not registered for '{gts_id}'"))
+            DomainError::PluginUnavailable { gts_id, reason } => {
+                Self::ServiceUnavailable(format!("plugin not available for '{gts_id}': {reason}"))
             }
             DomainError::TenantNotFound { tenant_id } => Self::TenantNotFound { tenant_id },
             DomainError::AccessDenied { target_tenant } => Self::AccessDenied { target_tenant },

--- a/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/service.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-gw/src/domain/service.rs
@@ -4,6 +4,7 @@
 //! types-registry is ready.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use hs_tenant_resolver_sdk::{
     AccessOptions, TenantFilter, TenantId, TenantInfo, TenantResolverPluginClient,
@@ -11,19 +12,17 @@ use hs_tenant_resolver_sdk::{
 };
 use modkit::client_hub::{ClientHub, ClientScope};
 use modkit::gts::BaseModkitPluginV1;
+use modkit::plugins::GtsPluginSelector;
+use modkit::telemetry::ThrottledLog;
 use modkit_security::SecurityContext;
-use tokio::sync::OnceCell;
 use tracing::info;
 use types_registry_sdk::{GtsEntity, ListQuery, TypesRegistryClient};
 use uuid::Uuid;
 
 use super::error::DomainError;
 
-/// Cached result of plugin resolution.
-struct ResolvedPlugin {
-    gts_id: String,
-    scope: ClientScope,
-}
+/// Throttle interval for unavailable plugin warnings.
+const UNAVAILABLE_LOG_THROTTLE: Duration = Duration::from_secs(10);
 
 /// Tenant resolver gateway service.
 ///
@@ -31,8 +30,10 @@ struct ResolvedPlugin {
 pub struct Service {
     hub: Arc<ClientHub>,
     vendor: String,
-    /// Lazily resolved plugin (cached after first call).
-    resolved: OnceCell<ResolvedPlugin>,
+    /// Shared selector for plugin instance IDs.
+    selector: GtsPluginSelector,
+    /// Throttle for plugin unavailable warnings.
+    unavailable_log_throttle: ThrottledLog,
 }
 
 impl Service {
@@ -42,27 +43,39 @@ impl Service {
         Self {
             hub,
             vendor,
-            resolved: OnceCell::new(),
+            selector: GtsPluginSelector::new(),
+            unavailable_log_throttle: ThrottledLog::new(UNAVAILABLE_LOG_THROTTLE),
         }
     }
 
     /// Lazily resolves and returns the plugin client.
     async fn get_plugin(&self) -> Result<Arc<dyn TenantResolverPluginClient>, DomainError> {
-        let resolved = self
-            .resolved
-            .get_or_try_init(|| self.resolve_plugin())
-            .await?;
+        let instance_id = self.selector.get_or_init(|| self.resolve_plugin()).await?;
+        let scope = ClientScope::gts_id(instance_id.as_ref());
 
-        self.hub
-            .get_scoped::<dyn TenantResolverPluginClient>(&resolved.scope)
-            .map_err(|_| DomainError::PluginClientNotFound {
-                gts_id: resolved.gts_id.clone(),
+        if let Some(client) = self
+            .hub
+            .try_get_scoped::<dyn TenantResolverPluginClient>(&scope)
+        {
+            Ok(client)
+        } else {
+            if self.unavailable_log_throttle.should_log() {
+                tracing::warn!(
+                    plugin_gts_id = %instance_id,
+                    vendor = %self.vendor,
+                    "Plugin client not registered yet"
+                );
+            }
+            Err(DomainError::PluginUnavailable {
+                gts_id: instance_id.to_string(),
+                reason: "client not registered yet".into(),
             })
+        }
     }
 
     /// Resolves the plugin instance from types-registry.
     #[tracing::instrument(skip_all, fields(vendor = %self.vendor))]
-    async fn resolve_plugin(&self) -> Result<ResolvedPlugin, DomainError> {
+    async fn resolve_plugin(&self) -> Result<String, DomainError> {
         info!("Resolving tenant resolver plugin");
 
         let registry = self
@@ -83,8 +96,7 @@ impl Service {
         let gts_id = choose_plugin_instance(&self.vendor, &instances)?;
         info!(plugin_gts_id = %gts_id, "Selected tenant resolver plugin instance");
 
-        let scope = ClientScope::gts_id(&gts_id);
-        Ok(ResolvedPlugin { gts_id, scope })
+        Ok(gts_id)
     }
 
     /// Get tenant information by ID.

--- a/modules/system/tenant_resolver/tenant_resolver-sdk/src/error.rs
+++ b/modules/system/tenant_resolver/tenant_resolver-sdk/src/error.rs
@@ -30,6 +30,10 @@ pub enum TenantResolverError {
     #[error("no plugin available")]
     NoPluginAvailable,
 
+    /// The plugin is not available yet.
+    #[error("service unavailable: {0}")]
+    ServiceUnavailable(String),
+
     /// An internal error occurred.
     #[error("internal error: {0}")]
     Internal(String),


### PR DESCRIPTION
- Provide reusable single-flight selector for GTS plugin instances
- Add lock-free throttled logging helper
- Extend ClientHub with try_get_scoped for optional client lookup
- Update tenant-resolver gateway to use lazy resolution and 503 semantics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New explicit "service unavailable" error to surface plugin unavailability with a reason.
  * Improved lazy plugin resolution and scoped client lookup for more reliable plugin access.

* **Bug Fixes**
  * Replaced generic plugin-missing errors with detailed, user-facing messages.
  * Added throttled warning logs to reduce repeated notification spam when plugins are not yet available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->