### PR TITLE
feat(modkit-db): add Clone and Debug derives to secure wrapper types

### DIFF
--- a/libs/modkit-db/src/secure/db_ops.rs
+++ b/libs/modkit-db/src/secure/db_ops.rs
@@ -114,6 +114,7 @@ pub fn validate_tenant_in_scope(
 ///     .exec(conn)         // Now can execute
 ///     .await?;
 /// ```
+#[derive(Clone, Debug)]
 pub struct SecureUpdateMany<E: EntityTrait, S> {
     pub(crate) inner: sea_orm::UpdateMany<E>,
     pub(crate) _state: PhantomData<S>,
@@ -207,6 +208,7 @@ where
 ///     .exec(conn)         // Now can execute
 ///     .await?;
 /// ```
+#[derive(Clone, Debug)]
 pub struct SecureDeleteMany<E: EntityTrait, S> {
     pub(crate) inner: sea_orm::DeleteMany<E>,
     pub(crate) _state: PhantomData<S>,

--- a/libs/modkit-db/src/secure/select.rs
+++ b/libs/modkit-db/src/secure/select.rs
@@ -10,10 +10,12 @@ use crate::secure::{AccessScope, ScopableEntity};
 
 /// Typestate marker: query has not yet been scoped.
 /// Cannot execute queries in this state.
+#[derive(Debug, Clone, Copy)]
 pub struct Unscoped;
 
 /// Typestate marker: query has been scoped with access control.
 /// Can now execute queries safely.
+#[derive(Debug, Clone, Copy)]
 pub struct Scoped;
 
 /// A type-safe wrapper around `SeaORM`'s `Select` that enforces scoping.
@@ -37,6 +39,7 @@ pub struct Scoped;
 ///     .await?;
 /// ```
 #[must_use]
+#[derive(Clone, Debug)]
 pub struct SecureSelect<E: EntityTrait, S> {
     pub(crate) inner: sea_orm::Select<E>,
     pub(crate) _state: PhantomData<S>,

--- a/libs/modkit-db/src/secure/tx_error.rs
+++ b/libs/modkit-db/src/secure/tx_error.rs
@@ -9,7 +9,7 @@ use std::fmt;
 ///
 /// This wraps database errors (connection issues, constraint violations, etc.)
 /// in a type that does not expose `SeaORM` internals.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct InfraError {
     message: String,
 }
@@ -54,7 +54,7 @@ impl std::error::Error for InfraError {}
 ///
 /// let user = result.map_err(|e| e.into_domain(DomainError::database_infra))?;
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum TxError<E> {
     /// A domain error returned from the transaction callback.
     Domain(E),


### PR DESCRIPTION
Add Clone and Debug derives to SeaORM wrapper types in modkit-db/secure:
- SecureSelect<E, S>
- SecureUpdateMany<E, S>
- SecureDeleteMany<E, S>
- InfraError
- TxError<E>
- Unscoped and Scoped typestate markers

The underlying types implement both of these traits and LLMs generating code expect them to be present, requiring workarounds if a query needs to be duplicated or debugged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal database utilities so query and error types can be cloned and produce clearer debug output; this enhances debugging and developer workflow without changing runtime behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->