### PR TITLE
chore(file_parser): switch to docx-rust from crates.io (instead of custom package)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,8 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "docx-rust"
-version = "0.1.10"
-source = "git+https://github.com/modcrafter77/docx-rs?branch=master#f4e4f20fbb92f6f47643822b6b69ab4fff8374b8"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384002ebe1137c2602121f43e7c1329b88cb5d78074e4a13b041db360b4e57f1"
 dependencies = [
  "derive_more 0.99.20",
  "hard-xml",
@@ -2809,9 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b484ba8d4f775eeca644c452a56650e544bf7e617f1d170fe7298122ead5222"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
 dependencies = [
  "zlib-rs",
 ]
@@ -7526,9 +7527,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36134c44663532e6519d7a6dfdbbe06f6f8192bde8ae9ed076e9b213f0e31df7"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -353,6 +353,7 @@ mime = "0.3"
 # Document parsing libraries
 tl = "0.7"
 pdf-extract = "0.10"
+docx-rust = "0.1.11"
 
 # Additional testing utilities
 tokio-test = "0.4"

--- a/libs/modkit/src/client_hub.rs
+++ b/libs/modkit/src/client_hub.rs
@@ -376,7 +376,9 @@ mod tests {
     #[test]
     fn try_get_scoped_returns_some_on_hit() {
         let hub = ClientHub::new();
-        let scope = ClientScope::gts_id("gts.x.core.modkit.plugins.v1~x.core.tenant_resolver.plugin.v1~contoso.app._.plugin.v1.0");
+        let scope = ClientScope::gts_id(
+            "gts.x.core.modkit.plugins.v1~x.core.tenant_resolver.plugin.v1~contoso.app._.plugin.v1.0",
+        );
         hub.register_scoped::<str>(scope.clone(), Arc::from("scoped"));
 
         let got = hub.try_get_scoped::<str>(&scope);
@@ -386,7 +388,9 @@ mod tests {
     #[test]
     fn try_get_scoped_returns_none_on_miss() {
         let hub = ClientHub::new();
-        let scope = ClientScope::gts_id("gts.x.core.modkit.plugins.v1~x.core.tenant_resolver.plugin.v1~fabrikam.app._.plugin.v1.0");
+        let scope = ClientScope::gts_id(
+            "gts.x.core.modkit.plugins.v1~x.core.tenant_resolver.plugin.v1~fabrikam.app._.plugin.v1.0",
+        );
 
         let got = hub.try_get_scoped::<str>(&scope);
         assert!(got.is_none());

--- a/libs/modkit/src/plugins/mod.rs
+++ b/libs/modkit/src/plugins/mod.rs
@@ -89,8 +89,8 @@ impl GtsPluginSelector {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[tokio::test]
     async fn resolve_called_once_returns_same_str() {

--- a/modules/file_parser/Cargo.toml
+++ b/modules/file_parser/Cargo.toml
@@ -56,12 +56,13 @@ tempfile = { workspace = true }
 # Document parsing libraries
 tl = { workspace = true }
 pdf-extract = { workspace = true }
-# Using local docx-rust with fixes for XML parsing issues
-docx-rust = { git = "https://github.com/modcrafter77/docx-rs", branch = "master" }
 
 # MIME type parsing
 mime = { workspace = true }
 
+docx-rust = { workspace = true }
+
 # Local dependencies
 modkit = { path = "../../libs/modkit" }
 modkit-auth = { path = "../../libs/modkit-auth" }
+


### PR DESCRIPTION
The known bug was fixed in 0.1.11: https://github.com/cstkingkey/docx-rs/pull/54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated and standardized the document-parsing dependency into the project's dependency management to simplify updates and improve maintainability.
* **Tests**
  * Minor test formatting cleanups with no behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->