### PR TITLE
ci(release): make release-plz PRs self-labeled and allow dirty checkouts

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -47,36 +47,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Label release PR
-        # release-plz PRs are the only ones that should trigger publishing.
-        # We add a stable label so the publish job can filter on it.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          prs="$(gh pr list \
-            --state open \
-            --base main \
-            --json number,headRefName,title,author \
-            --jq '.[]
-              | select(
-                  (.headRefName | startswith("release-plz-"))
-                  or (.author.login | test("release-plz"))
-                )
-              | .number
-            ')"
-
-          if [ -z "${prs}" ]; then
-            echo "No release PRs found to label."
-            exit 0
-          fi
-
-          for pr in ${prs}; do
-            echo "Adding label 'release-plz' to PR #${pr}"
-            gh pr edit "${pr}" --add-label "release-plz" || true
-          done
-
   release:
     name: Publish crates
     runs-on: ubuntu-latest

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,6 +2,13 @@
 # Keep the defaults simple and explicit. We rely on Cargo manifests for:
 # - which crates are publishable (`publish = false` disables)
 # - per-crate versioning (explicit `version = ...` for modules/sdks, and `version.workspace = true` for ModKit libs)
+#
+# NOTE: release-plz may temporarily checkout commits while computing diffs.
+# Some repos can end up "dirty" due to generated/normalized files, so we allow it.
+allow_dirty = true
+
+# Add a stable label to the release PR so the publish workflow can filter on it.
+pr_labels = ["release-plz"]
 changelog_update = true
 git_release_enable = true
 


### PR DESCRIPTION
- Configure release-plz to allow dirty worktrees (allow_dirty)
- Configure release-plz to apply `release-plz` label to Release PRs (pr_labels)
- Keep publishing gated on merged PRs with the `release-plz` label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified release workflow by consolidating PR labeling configuration into settings
  * Updated release automation to support dirty working copies during version computations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->