### PR TITLE
chore(governance): add PR review enforcement with Telegram notifications

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -177,7 +177,11 @@ jobs:
               );
 
               const author =
-                reviewData.repository.pullRequest.author.login;
+                reviewData.repository.pullRequest.author?.login;
+              if (!author) {
+                console.log(`Skipping PR #${pr.number} - author is null`);
+                continue;
+              }
 
               const threads =
                 reviewData.repository.pullRequest.reviewThreads.nodes;

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,256 @@
+name: PR Governance
+
+on:
+  pull_request:
+    types: [opened]
+
+  schedule:
+    - cron: "0 8 * * *"
+    - cron: "0 13 * * *"
+
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+
+  reviewers-after-10-min:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Wait 5 minutes
+        run: sleep 300
+
+      - name: Check reviewers and notify
+        uses: actions/github-script@v7
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const title = pr.title.toLowerCase();
+
+            if (title.startsWith("chore: release")) {
+              console.log("Release PR ignored");
+              return;
+            }
+
+            const ignoredReviewers = new Set([
+              "coderabbitai[bot]",
+              "graphite-app[bot]",
+              "dependabot[bot]"
+            ]);
+
+            const prData = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pr.number
+            });
+
+            const humanReviewers =
+              prData.data.requested_reviewers
+                .map(r => r.login)
+                .filter(login =>
+                  !login.endsWith("[bot]") &&
+                  !ignoredReviewers.has(login)
+                );
+
+            const humanTeams =
+              prData.data.requested_teams || [];
+
+            const hasValidReviewers =
+              humanReviewers.length > 0 ||
+              humanTeams.length > 0;
+
+            if (hasValidReviewers) {
+              console.log("Human reviewers present");
+              return;
+            }
+
+            const prUrl = pr.html_url;
+
+            const message =
+              "PR has no human reviewers assigned 5 minutes after creation.\n\n" +
+              "Repository: " + owner + "/" + repo + "\n" +
+              "PR: #" + pr.number + "\n" +
+              "Title: " + pr.title + "\n" +
+              "URL: " + prUrl + "\n" +
+              prUrl;
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pr.number,
+              body:
+                "PR was created more than 5 minutes ago but has no human reviewers assigned"
+            });
+
+            const fetch = require("node-fetch");
+
+            await fetch(
+              "https://api.telegram.org/bot" +
+                process.env.TELEGRAM_BOT_TOKEN +
+                "/sendMessage",
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  chat_id: process.env.TELEGRAM_CHAT_ID,
+                  text: message
+                })
+              }
+            );
+
+  unanswered-review-check:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Scan unanswered review comments
+        uses: actions/github-script@v7
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const ignoredBots = new Set([
+              "coderabbitai[bot]",
+              "graphite-app[bot]",
+              "dependabot[bot]"
+            ]);
+
+            const prs = await github.paginate(
+              github.rest.pulls.list,
+              {
+                owner,
+                repo,
+                state: "open",
+                per_page: 100
+              }
+            );
+
+            const fetch = require("node-fetch");
+
+            for (const pr of prs) {
+
+              const title = pr.title.toLowerCase();
+
+              if (title.startsWith("chore: release")) {
+                continue;
+              }
+
+              const reviewData = await github.graphql(
+                `
+                query($owner:String!, $repo:String!, $number:Int!) {
+                  repository(owner:$owner, name:$repo) {
+                    pullRequest(number:$number) {
+                      author { login }
+                      reviewThreads(first:100) {
+                        nodes {
+                          isResolved
+                          comments(last:10) {
+                            totalCount
+                            nodes {
+                              author { login }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                `,
+                {
+                  owner,
+                  repo,
+                  number: pr.number
+                }
+              );
+
+              const author =
+                reviewData.repository.pullRequest.author.login;
+
+              const threads =
+                reviewData.repository.pullRequest.reviewThreads.nodes;
+
+              let unanswered = 0;
+              let unresolvedComments = 0;
+
+              for (const thread of threads) {
+                if (thread.isResolved) continue;
+
+                const comments = thread.comments.nodes;
+                if (!comments.length) continue;
+
+                unresolvedComments += thread.comments.totalCount;
+
+                const lastHuman =
+                  [...comments]
+                    .reverse()
+                    .find(c => {
+                      const login = c.author?.login;
+                      return (
+                        !!login &&
+                        !login.endsWith("[bot]") &&
+                        !ignoredBots.has(login)
+                      );
+                    });
+
+                if (!lastHuman) continue;
+
+                const lastHumanLogin = lastHuman.author.login;
+
+                if (lastHumanLogin !== author) {
+                  unanswered++;
+                }
+              }
+
+              if (unanswered === 0) continue;
+
+              const prUrl = pr.html_url;
+
+              const message =
+                "PR has unanswered reviewer comments.\n\n" +
+                "Repository: " + owner + "/" + repo + "\n" +
+                "PR: #" + pr.number + "\n" +
+                "Title: " + pr.title + "\n" +
+                "Unanswered threads: " + unanswered + "\n" +
+                "Unresolved comments: " + unresolvedComments + "\n" +
+                "URL: " + prUrl + "\n" +
+                prUrl;
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body:
+                  "There are unresolved review comments awaiting response.\n\n" +
+                  "Unanswered human review threads: " + unanswered + "\n" +
+                  "Unresolved comments: " + unresolvedComments
+              });
+
+              await fetch(
+                "https://api.telegram.org/bot" +
+                  process.env.TELEGRAM_BOT_TOKEN +
+                  "/sendMessage",
+                {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    chat_id: process.env.TELEGRAM_CHAT_ID,
+                    text: message
+                  })
+                }
+              );
+            }

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -108,7 +108,7 @@ jobs:
             );
 
   unanswered-review-check:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
 
   reviewers-after-10-min:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -93,12 +93,10 @@ jobs:
                 "PR was created more than 5 minutes ago but has no human reviewers assigned"
             });
 
-            const fetch = require("node-fetch");
-
             await fetch(
-              "https://api.telegram.org/bot" +
-                process.env.TELEGRAM_BOT_TOKEN +
-                "/sendMessage",
+              `https://api.telegram.org/bot${
+                process.env.TELEGRAM_BOT_TOKEN
+              }/sendMessage`,
               {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
Introduce automated pull request governance checks:

- remind authors 5 minutes after PR creation if no human reviewers are assigned
- ignore bot reviewers and automated release PRs
- detect unresolved review threads with unanswered reviewer comments
- notify both in PR comments and Telegram group
- run unanswered-review checks on scheduled cron (08:00 and 13:00 GMT)

This improves review hygiene, reduces stalled pull requests, and enforces consistent SDLC governance without blocking merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced an automated PR governance workflow to monitor pull request review status.
  * On new PRs, waits briefly then notifies when no human reviewers are assigned (ignores bot reviewers and release chore PRs).
  * Added scheduled scans that detect unresolved review threads and count unanswered human reviewer comments per PR, posting summaries and alerts.
  * Notifications delivered via Telegram.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->