### PR TITLE
fix(modkit-db): add `engine` to DbConnConfig

### DIFF
--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -44,6 +44,7 @@ database:
     # Note: No DSN or file specified here - modules specify their own database files
     # This prevents accidental sharing of SQLite databases between modules
     sqlite_users:
+      engine: "sqlite"
       # SQLite PRAGMA parameters applied to all connections using this server
       params:
         WAL: "true"              # Enable Write-Ahead Logging for better concurrency

--- a/config/quickstart-windows.yaml
+++ b/config/quickstart-windows.yaml
@@ -44,6 +44,7 @@ database:
     # Note: No DSN or file specified here - modules specify their own database files
     # This prevents accidental sharing of SQLite databases between modules
     sqlite_users:
+      engine: "sqlite"
       # SQLite PRAGMA parameters applied to all connections using this server
       params:
         WAL: "true"              # Enable Write-Ahead Logging for better concurrency

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -44,6 +44,7 @@ database:
     # Note: No DSN or file specified here - modules specify their own database files
     # This prevents accidental sharing of SQLite databases between modules
     sqlite_users:
+      engine: "sqlite"
       # SQLite PRAGMA parameters applied to all connections using this server
       params:
         WAL: "true"              # Enable Write-Ahead Logging for better concurrency

--- a/config/static-tenants.yaml
+++ b/config/static-tenants.yaml
@@ -12,6 +12,7 @@ server:
 database:
   servers:
     sqlite_test:
+      engine: "sqlite"
       params:
         WAL: "true"
       pool:

--- a/libs/modkit-db/src/config.rs
+++ b/libs/modkit-db/src/config.rs
@@ -69,6 +69,15 @@ pub struct GlobalDatabaseConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct DbConnConfig {
+    /// Explicit database engine for this connection.
+    ///
+    /// This is required for configurations without `dsn`, where the engine cannot be inferred
+    /// reliably (e.g. distinguishing `MySQL` vs `PostgreSQL`, or selecting `SQLite` for file/path configs).
+    ///
+    /// If both `engine` and `dsn` are provided, they must not conflict (validated at runtime).
+    #[serde(default)]
+    pub engine: Option<DbEngineCfg>,
+
     // DSN-style (full, valid). Optional: can be absent and rely on fields.
     pub dsn: Option<String>,
 
@@ -92,6 +101,17 @@ pub struct DbConnConfig {
     // Module-level only: reference to a global server by name.
     // If absent, this module config must be fully self-sufficient (dsn or fields).
     pub server: Option<String>,
+}
+
+/// Serializable engine selector for configuration.
+///
+/// Keep this separate from `modkit_db::DbEngine` (runtime type) to avoid coupling it to serde.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DbEngineCfg {
+    Postgres,
+    Mysql,
+    Sqlite,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq)]

--- a/libs/modkit-db/src/manager.rs
+++ b/libs/modkit-db/src/manager.rs
@@ -141,6 +141,11 @@ impl DbManager {
     ) -> DbConnConfig {
         // Start with server config as base, then apply module overrides
 
+        // Engine: module takes precedence (important for field-based configs)
+        if module_cfg.engine.is_none() {
+            module_cfg.engine = server_cfg.engine;
+        }
+
         // DSN: module takes precedence
         if module_cfg.dsn.is_none() {
             module_cfg.dsn = server_cfg.dsn;

--- a/libs/modkit-db/tests/config_tests.rs
+++ b/libs/modkit-db/tests/config_tests.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 #[test]
 fn test_dbconnconfig_serialization() {
     let config = DbConnConfig {
+        engine: None,
         dsn: Some("postgresql://user:pass@localhost/db".to_owned()),
         host: Some("localhost".to_owned()),
         port: Some(5432),
@@ -48,6 +49,7 @@ fn test_dbconnconfig_serialization() {
 #[test]
 fn test_dbconnconfig_defaults() {
     let config = DbConnConfig::default();
+    assert!(config.engine.is_none());
     assert!(config.dsn.is_none());
     assert!(config.host.is_none());
     assert!(config.port.is_none());
@@ -165,6 +167,7 @@ fn test_deny_unknown_fields() {
 fn test_minimal_configs() {
     // Test minimal SQLite config
     let sqlite_config = DbConnConfig {
+        engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
         file: Some("data.db".to_owned()),
         ..Default::default()
     };
@@ -174,6 +177,7 @@ fn test_minimal_configs() {
 
     // Test minimal server reference config
     let server_ref_config = DbConnConfig {
+        engine: Some(modkit_db::config::DbEngineCfg::Postgres),
         server: Some("main_db".to_owned()),
         dbname: Some("myapp".to_owned()),
         ..Default::default()

--- a/libs/modkit-db/tests/manager_tests.rs
+++ b/libs/modkit-db/tests/manager_tests.rs
@@ -49,6 +49,7 @@ async fn test_dbmanager_server_merge() {
     servers.insert(
         "test_server".to_owned(),
         DbConnConfig {
+            engine: None,
             dsn: None,
             host: Some("localhost".to_owned()),
             port: Some(5432),

--- a/libs/modkit-db/tests/options_tests.rs
+++ b/libs/modkit-db/tests/options_tests.rs
@@ -7,6 +7,7 @@
 async fn test_build_db_handle_postgres_missing_dbname() {
     use modkit_db::{DbConnConfig, build_db_handle};
     let config = DbConnConfig {
+        engine: Some(modkit_db::config::DbEngineCfg::Postgres),
         server: Some("postgres".to_owned()),
         host: Some("localhost".to_owned()),
         port: Some(5432),

--- a/libs/modkit-db/tests/precedence_tests.rs
+++ b/libs/modkit-db/tests/precedence_tests.rs
@@ -18,6 +18,7 @@ async fn test_precedence_module_fields_override_server() {
             servers.insert(
                 "sqlite_server".to_owned(),
                 DbConnConfig {
+                    engine: Some(DbEngineCfg::Sqlite),
                     params: Some({
                         let mut params = HashMap::new();
                         params.insert("synchronous".to_owned(), "FULL".to_owned());
@@ -38,6 +39,7 @@ async fn test_precedence_module_fields_override_server() {
                 "test_module": {
                     "database": {
                         "server": "sqlite_server",
+                        "engine": "sqlite",
                         "file": format!("precedence_test_{}.db", std::process::id()),
                         "params": {
                             "synchronous": "NORMAL",    // Should override server value
@@ -87,6 +89,7 @@ async fn test_precedence_module_dsn_override_server() {
             servers.insert(
                 "sqlite_server".to_owned(),
                 DbConnConfig {
+                    engine: Some(DbEngineCfg::Sqlite),
                     dsn: Some(format!("sqlite://{}?synchronous=FULL", server_db.display())),
                     ..Default::default()
                 },
@@ -102,6 +105,7 @@ async fn test_precedence_module_dsn_override_server() {
             "test_module": {
                 "database": {
                     "server": "sqlite_server",
+                    "engine": "sqlite",
                     "dsn": format!("sqlite://{}?synchronous=NORMAL", module_db.display())  // Should completely override server DSN
                 }
             }
@@ -261,6 +265,7 @@ async fn test_file_and_path_handling() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": format!("file_path_test_{}.db", std::process::id()),            // Should be used (converted to absolute)
                     "path": absolute_path         // Should be ignored in favor of 'file'
                 }
@@ -325,6 +330,7 @@ async fn test_feature_disabled_error() {
         "modules": {
                 "test_module": {
                     "database": {
+                        "engine": "sqlite",
                         "file": format!("feature_test_{}.db", std::process::id())
                     }
                 }

--- a/libs/modkit-db/tests/sqlite/concurrency_tests.rs
+++ b/libs/modkit-db/tests/sqlite/concurrency_tests.rs
@@ -18,6 +18,7 @@ async fn test_concurrent_get_same_module() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": format!("concurrent_same_{}.db", std::process::id())
                 }
             }
@@ -55,11 +56,13 @@ async fn test_concurrent_get_different_modules() {
         "modules": {
             "module_a": {
                 "database": {
+                    "engine": "sqlite",
                     "file": format!("module_a_{}.db", std::process::id())
                 }
             },
             "module_b": {
                 "database": {
+                    "engine": "sqlite",
                     "file": format!("module_b_{}.db", std::process::id())
                 }
             }
@@ -101,6 +104,7 @@ async fn test_caching_behavior() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": format!("caching_test_{}.db", std::process::id())
                 }
             }
@@ -138,6 +142,7 @@ async fn test_unknown_module_behavior() {
         "modules": {
             "known_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": format!("known_{}.db", std::process::id())
                 }
             }
@@ -170,11 +175,13 @@ async fn test_concurrent_mixed_scenarios() {
         "modules": {
             "valid_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": format!("valid_{}.db", std::process::id())
                 }
             },
             "invalid_module": {
                 "database": {
+                    "engine": "sqlite",
                     "dsn": format!("sqlite:file:mixed_invalid_{}.db", std::process::id()),
                     "host": "localhost"  // Conflict: SQLite DSN with host field
                 }
@@ -215,6 +222,7 @@ async fn test_concurrent_performance() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": format!("perf_test_{}.db", std::process::id())
                 }
             }
@@ -266,6 +274,7 @@ async fn test_cache_isolation_across_managers() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": format!("isolation_test_{}.db", std::process::id())
                 }
             }
@@ -334,6 +343,7 @@ async fn test_concurrent_slow_initialization() {
         "modules": {
             "slow_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": format!("slow_test_{}.db", std::process::id()),
                     "pool": {
                         "max_conns": 1,           // Force serialization

--- a/libs/modkit-db/tests/sqlite/manager.rs
+++ b/libs/modkit-db/tests/sqlite/manager.rs
@@ -14,6 +14,7 @@ async fn test_dbmanager_sqlite_with_file() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": db_filename,
                     "params": {
                         "journal_mode": "WAL"
@@ -44,6 +45,7 @@ async fn test_dbmanager_sqlite_with_path() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "path": db_path,
                     "params": {
                         "journal_mode": "DELETE"
@@ -72,6 +74,7 @@ async fn test_dbmanager_caching() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "dsn": "sqlite::memory:",
                     "params": {
                         "journal_mode": "WAL"
@@ -110,6 +113,7 @@ async fn test_dbmanager_sqlite_server_without_dsn() {
             servers.insert(
                 "sqlite_server".to_owned(),
                 DbConnConfig {
+                    engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
                     params: Some({
                         let mut params = HashMap::new();
                         params.insert("WAL".to_owned(), "true".to_owned());
@@ -134,6 +138,7 @@ async fn test_dbmanager_sqlite_server_without_dsn() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "server": "sqlite_server",
                     "file": format!("module_{}.db", std::process::id())  // Should be placed in module home directory
                 }

--- a/libs/modkit-db/tests/sqlite/pooling_tests.rs
+++ b/libs/modkit-db/tests/sqlite/pooling_tests.rs
@@ -16,6 +16,7 @@ async fn test_pool_cfg_options_applied() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "dsn": "sqlite::memory:",
                     "pool": {
                         "max_conns": 20,
@@ -79,6 +80,7 @@ async fn test_module_pool_overrides_server_pool() {
             "test_module": {
                 "database": {
                     "server": "sqlite_server",
+                    "engine": "sqlite",
                     "dsn": "sqlite::memory:",
                     "pool": {
                         "max_conns": 25,          // Should override server value (10)
@@ -138,8 +140,8 @@ async fn test_pool_config_inheritance() {
             "test_module": {
                 "database": {
                     "server": "sqlite_server",
-                        "dsn": "sqlite::memory:"
-                    // No pool config - should inherit from server
+                    "engine": "sqlite",
+                    "dsn": "sqlite::memory:"
                 }
             }
         }

--- a/libs/modkit-db/tests/sqlite/sqlite_tests.rs
+++ b/libs/modkit-db/tests/sqlite/sqlite_tests.rs
@@ -17,6 +17,7 @@ async fn test_sqlite_relative_path_resolution() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": db_filename
                 }
             }
@@ -53,6 +54,7 @@ async fn test_sqlite_absolute_path() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "path": db_path
                 }
             }
@@ -133,6 +135,7 @@ async fn test_invalid_pragma_values() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": db_filename,
                     "params": {
                         "synchronous": "INVALID_VALUE"
@@ -166,6 +169,7 @@ async fn test_unknown_pragma_parameters() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": db_filename,
                     "params": {
                         "unknown_pragma": "some_value"
@@ -201,6 +205,7 @@ async fn test_auto_provision_creates_directories() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "path": nested_path.join("test.db")
                 }
             }
@@ -240,6 +245,7 @@ async fn test_auto_provision_disabled() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": "nested/directories/test.db"  // This requires creating nested dirs
                 }
             }
@@ -275,6 +281,7 @@ async fn test_sqlite_memory_database() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "dsn": "sqlite::memory:"
                 }
             }
@@ -313,6 +320,7 @@ async fn test_sqlite_shared_memory_database() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "dsn": format!(
                         "sqlite://{}?mode=memory&cache=shared",
                         memdb_path.display()
@@ -355,6 +363,7 @@ async fn test_wal_pragma_validation() {
             "modules": {
                 "test_module": {
                     "database": {
+                        "engine": "sqlite",
                         "file": db_filename,
                         "params": {
                             "wal": wal_value
@@ -386,6 +395,7 @@ async fn test_wal_pragma_validation() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": db_filename,
                     "params": {
                         "wal": "invalid"
@@ -421,6 +431,7 @@ async fn test_busy_timeout_pragma_validation() {
             "modules": {
                 "test_module": {
                     "database": {
+                        "engine": "sqlite",
                         "file": db_filename,
                         "params": {
                             "busy_timeout": timeout_value
@@ -454,6 +465,7 @@ async fn test_busy_timeout_pragma_validation() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": db_filename,
                     "params": {
                         "busy_timeout": "-1000"
@@ -483,6 +495,7 @@ async fn test_busy_timeout_pragma_validation() {
         "modules": {
             "test_module": {
                 "database": {
+                    "engine": "sqlite",
                     "file": db_filename,
                     "params": {
                         "busy_timeout": "not_a_number"

--- a/libs/modkit/src/bootstrap/config/mod.rs
+++ b/libs/modkit/src/bootstrap/config/mod.rs
@@ -1861,6 +1861,7 @@ logging:
         servers.insert(
             "sqlite_users".to_owned(),
             DbConnConfig {
+                engine: None,
                 dsn: Some(
                     "sqlite://users_info.db?WAL=true&synchronous=NORMAL&busy_timeout=5000"
                         .to_owned(),

--- a/libs/modkit/src/bootstrap/oop_tests.rs
+++ b/libs/modkit/src/bootstrap/oop_tests.rs
@@ -359,6 +359,7 @@ mod database_merge {
         servers.insert(
             "sqlite_main".to_owned(),
             DbConnConfig {
+                engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
                 server: None,
                 dsn: None,
                 host: None,
@@ -387,6 +388,7 @@ mod database_merge {
 
     fn create_module_db_config() -> DbConnConfig {
         DbConnConfig {
+            engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
             server: Some("sqlite_main".to_owned()),
             dsn: None,
             host: None,
@@ -565,6 +567,7 @@ mod database_merge {
         new_servers.insert(
             "new_server".to_owned(),
             DbConnConfig {
+                engine: Some(modkit_db::config::DbEngineCfg::Sqlite),
                 server: None,
                 dsn: Some("sqlite://new.db".to_owned()),
                 host: None,


### PR DESCRIPTION
- Require `engine` when `dsn` is not provided
- Error on `engine`/`dsn` scheme mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit database engine selection (sqlite, postgres, mysql) can be declared in configs or inferred from connection strings; validation enforces consistency.
  * Public DB configuration now accepts an optional engine field for explicit engine selection.

* **Chores**
  * Quickstart and example configuration templates updated to include explicit engine entries.

* **Tests**
  * Test suite extended and adjusted to cover engine inference, validation, and SQLite-specific scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->