### PR TITLE
ci: replace broken-md-links with lychee for markdown link checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,14 +544,10 @@ jobs:
         with:
           shared-key: markdown-links
 
-      - name: Install broken-md-links
+      - name: Install lychee
         uses: taiki-e/install-action@30eab0fabba9ea3f522099957e668b21876aa39e # v2.66.6
         with:
-          tool: broken-md-links
+          tool: lychee
 
       - name: Check markdown links
-        run: |
-          broken-md-links docs
-          broken-md-links examples
-          broken-md-links dylint_lints
-          broken-md-links guidelines
+        run: lychee docs examples dylint_lints guidelines

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,8 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/
+
+# Exclude paths from checking (templates with intentional placeholder links)
+exclude_path = ["docs/spec-templates/**"]
+
+# Only check local file links, not external URLs
+offline = true


### PR DESCRIPTION
- lychee supports exclude_path config for ignoring directories
- exclude docs/spec-templates (contains templates with placeholder links)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Switched link validation tool in CI pipeline to Lychee for improved link-checking efficiency
  * Added Lychee configuration to optimize validation across documentation and guidelines

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->