### PR TITLE
docs: document DB ORM entity folder structure and repo pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,7 +413,7 @@ quickstart:
 
 ## Run server with example module
 example:
-	cargo run --bin hyperspot-server --features users-info-example,tenant-resolver-example -- --config config/quickstart.yaml run
+	cargo run --bin hyperspot-server --features users-info-example,static-tenants -- --config config/quickstart.yaml run
 
 oop-example:
 	cargo build -p calculator --features oop_module

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -310,4 +310,3 @@ tracing:
 #     # No database section - module won't get database access
 #     config:
 #       static_dir: "/var/www/static"
-


### PR DESCRIPTION
Fixes #174

## Summary

Updated NEW_MODULE.md guidelines to document the recommended structure for DB ORM entities: one file per entity inside an entity/ folder, with a single repo.rs (or per-aggregate *_repo.rs) for repository implementations.

## Changes

### Guidelines (NEW_MODULE.md)

- Updated canonical project layout to show entity/ as a folder
- Added detailed rules for the entity folder structure:
  - One SeaORM entity per file (user.rs, address.rs, etc.)
  - Central mod.rs for re-exports
  - Each entity derives Scopable for secure ORM integration
- Documented the repository pattern (repo.rs or *_repo.rs)
- Added a complete working example section with:
  - Step-by-step instructions to create entities
  - Full file contents for mod.rs, user.rs, address.rs
  - Verification commands with CRUD workflow demonstration

### Configuration (quickstart.yaml)

- Fixed module name mismatch: simple_user_settings to simple-user-settings
- Replaced fabrikam_tr_plugin config with static_tr_plugin

### Makefile

Changed example target to use static-tenants instead of tenant-resolver-example feature. The latter loaded fabrikam_tr_plugin (vendor Fabrikam) which mismatched tenant_resolver_gateway's hyperspot vendor, causing PluginNotFound errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines to reflect updated module organization patterns and repository structure.

* **Chores**
  * Updated build configuration for the example target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->