### PR TITLE
fix: standardize simple user settings naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ See the full architecture [MANIFEST](docs/ARCHITECTURE_MANIFEST.md) for more det
 
 ### Prerequisites
 
-- Rust stable with Cargo
+- Rust stable with Cargo ([Install via rustup](https://rustup.rs/))
+- Protocol Buffers compiler (`protoc`):
+  - macOS: `brew install protobuf`
+  - Linux: `apt-get install protobuf-compiler`
+  - Windows: Download from https://github.com/protocolbuffers/protobuf/releases
 - MariaDB/PostgreSQL/SQLite or in-memory database
 
 ### CI/Development Commands

--- a/apps/hyperspot-server/tests/cli_smoke_tests.rs
+++ b/apps/hyperspot-server/tests/cli_smoke_tests.rs
@@ -211,14 +211,14 @@ server:
   home_dir: "{}"
 
 modules:
-  api_gateway:
-    config:
-      bind_addr: "127.0.0.1:{}"
-      enable_docs: false
-      cors_enabled: false
-      auth_disabled: true
-  users_info: {{}}
-  simple-user-settings: {{}}
+    api_gateway:
+        config:
+            bind_addr: "127.0.0.1:{}"
+            enable_docs: false
+            cors_enabled: false
+            auth_disabled: true
+    users_info: {{}}
+    simple_user_settings: {{}}
 "#,
         temp_dir
             .path()

--- a/modules/simple_user_settings/simple_user_settings/src/errors.rs
+++ b/modules/simple_user_settings/simple_user_settings/src/errors.rs
@@ -1,4 +1,4 @@
-//! Generated, strongly-typed error catalog for `simple-user-settings`.
+//! Generated, strongly-typed error catalog for `simple_user_settings`.
 //! Source of truth: gts/errors.json
 
 use modkit_errors_macro::declare_errors;

--- a/modules/simple_user_settings/simple_user_settings/src/lib.rs
+++ b/modules/simple_user_settings/simple_user_settings/src/lib.rs
@@ -1,6 +1,6 @@
 //! Settings Module Implementation
 //!
-//! The public API is defined in `simple-user-settings-sdk` and re-exported here.
+//! The public API is defined in `simple_user_settings_sdk` and re-exported here.
 
 pub use simple_user_settings_sdk::{
     SettingsError, SimpleUserSettings, SimpleUserSettingsClient, SimpleUserSettingsPatch,

--- a/modules/simple_user_settings/simple_user_settings/src/lib.rs
+++ b/modules/simple_user_settings/simple_user_settings/src/lib.rs
@@ -1,6 +1,6 @@
 //! Settings Module Implementation
 //!
-//! The public API is defined in `simple_user_settings_sdk` and re-exported here.
+//! The public API is defined in `simple_user_settings-sdk` and re-exported here.
 
 pub use simple_user_settings_sdk::{
     SettingsError, SimpleUserSettings, SimpleUserSettingsClient, SimpleUserSettingsPatch,

--- a/modules/simple_user_settings/simple_user_settings/src/module.rs
+++ b/modules/simple_user_settings/simple_user_settings/src/module.rs
@@ -15,7 +15,7 @@ use crate::domain::service::{Service, ServiceConfig};
 use crate::infra::storage::sea_orm_repo::SeaOrmSettingsRepository;
 
 #[modkit::module(
-    name = "simple-user-settings",
+    name = "simple_user_settings",
     capabilities = [rest, db]
 )]
 pub struct SettingsModule {


### PR DESCRIPTION
This commit updates the simple user settings module and related REST routes to use snake_case naming for consistency with other modules. It also updates the project README to clarify installation prerequisites, including Rust, Cargo, and protoc (Protocol Buffers compiler).

Changes:
- Use snake_case for module registration and all REST routes
- Update code and documentation references accordingly
- Add installation prerequisites to README for first-time setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README prerequisites with rustup install guidance and added protoc (Protocol Buffers) setup instructions for macOS, Linux, and Windows.
* **Style / Metadata**
  * Standardized module and error catalog names to snake_case (cosmetic; no API or behavior changes).
* **Tests**
  * Updated example CLI/config snippets to use snake_case module keys to match updated naming in examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->