### PR TITLE
docs(spec-templates): clarify FDD ID scope, add lightweight status/priority markers, relax reference keys list

### DIFF
--- a/docs/spec-templates/README.md
+++ b/docs/spec-templates/README.md
@@ -128,30 +128,26 @@ FDD IDs must be unique. When FDD tooling is connected, `fdd validate` will:
 
 ### Kind Reference
 
+These are **suggested** kind names for common artifact types. FDD does not enforce specific kind values — use whatever naming makes sense for your project. The important thing is consistency within your codebase.
+
 | Kind | Description |
 |------|-------------|
-| `actor` | Actor (human or system) |
-| `fr` | Functional requirement |
-| `nfr` | Non-functional requirement |
-| `usecase` | Use case |
+| `actor` | Stakeholder or system actor |
+| `req` | Requirement (functional or non-functional) |
+| `feature` | Feature specification |
 | `adr` | Architecture decision record |
-| `feature` | Feature |
-| `flow` | Actor flow (within feature) |
-| `algo` | Algorithm (within feature) |
-| `state` | State machine (within feature) |
-| `req` | Feature requirement |
-| `principle` | Design principle |
-| `constraint` | Constraint |
-| `context` | Additional context |
-| `db-table` | Database table |
-| `topology` | Topology |
-| `tech` | Tech stack |
+| `design` | Design element (component, API, schema, etc.) |
+| `flow` | Behavioral flow (use case, algorithm, state machine) |
 
 **Examples**:
 - `fdd-todo-app-actor-user` — Actor ID
-- `fdd-todo-app-fr-create-task` — Functional Requirement ID
+- `fdd-todo-app-req-create-task` — Requirement ID
+- `fdd-todo-app-req-response-time` — NFR (still uses `req`)
 - `fdd-todo-app-adr-local-storage` — ADR ID
 - `fdd-todo-app-feature-core` — Feature ID
+- `fdd-todo-app-design-task-api` — Design element ID
+
+> **Note**: You can use any slug that fits your domain. For example, `fdd-billing-uc-checkout` or `fdd-auth-nfr-token-expiry` are equally valid if your team prefers more specific kinds. FDD validation only checks that referenced IDs exist — it does not validate kind names.
 
 ## Example
 

--- a/docs/spec-templates/README.md
+++ b/docs/spec-templates/README.md
@@ -113,6 +113,49 @@ fdd-{module-name}-{kind}-{slug}
 
 **Placement**: Use `**ID**: \`fdd-...\`` in the artifact where the element is defined.
 
+### ID Scope
+
+An FDD ID covers the **markdown section where it's defined and all its subsections**:
+
+- ID on `#` (H1) → covers the entire document
+- ID on `##` (H2) → covers that section and all H3/H4/... within it
+- ID on `####` (H4) → covers only that specific element
+
+This allows flexible granularity — define IDs at whatever level makes sense for traceability.
+
+### Implementation Status and Priority
+
+Requirements and design elements can include **implementation status** and **priority** directly in the ID line. This bridges the gap between specifications and actual implementation — specs come first, and we need visibility into what's implemented and in what order.
+
+**Format**:
+```
+**ID**: [status] `priority` - `fdd-{module}-{kind}-{slug}`
+```
+
+| Element | Values | Description |
+|---------|--------|-------------|
+| Status | `[ ]` / `[x]` | Implementation checkbox — unchecked = pending, checked = done |
+| Priority | `p1` `p2` `p3` `p4` | Relative priority — p1 highest |
+
+**Examples**:
+```markdown
+#### User roles requirement
+
+**ID**: [ ] `p1` - `fdd-auth-fr-user-roles`
+
+The system must support 1-N user roles associated with the user...
+```
+
+```markdown
+#### Response time
+
+**ID**: [x] `p2` - `fdd-api-nfr-response-time`
+
+API responses must complete within 200ms at p95...
+```
+
+> **Note**: Implementation status and priority are **informative only** — they don't replace your issue tracking system. Keep them simple. The value is having spec-to-implementation traceability directly in version-controlled documentation, reducing uncertainty between what's specified and what's actually built.
+
 ### FDD ID Reference
 
 An FDD ID **reference** links to an element defined elsewhere. References create traceability between documents — for example, a Feature can reference Actors from PRD, or an ADR can reference Requirements it addresses.


### PR DESCRIPTION
docs(spec-templates): clarify FDD ID scope and add lightweight status/priority markers
docs(spec-templates): relax FDD reference keys to make it's adoption simpler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced comprehensive guidance and examples for FDD ID usage, covering scope, implementation status, priority formatting, and detailed reference tables.
  * Expanded and clarified Kind Reference taxonomy with renamed kinds and aligned examples.
  * Improved granularity and semantic clarity for ID specification and usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->