### PR TITLE
chore(Makefile): replace broken-md-links by lychee in Makefile as it's done in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,17 @@ fmt:
 # |             | - Use 'make dylint-list' to see all available custom lints           |
 # +-------------+----------------------------------------------------------------------+
 
-.PHONY: clippy kani geiger safety lint dylint dylint-list dylint-test gts-docs gts-docs-vendor gts-docs-release gts-docs-vendor-release gts-docs-test
+.PHONY: clippy lychee kani geiger safety lint dylint dylint-list dylint-test gts-docs gts-docs-vendor gts-docs-release gts-docs-vendor-release gts-docs-test
 
 # Run clippy linter (excludes gts-rust submodule which has its own lint settings)
 clippy:
 	$(call ensure_tool,cargo-clippy)
 	cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf
+
+# Run markdown checks with 'lychee'
+lychee:
+	$(call ensure_tool,lychee)
+	lychee docs examples dylint_lints guidelines
 
 ## The Kani Rust Verifier for checking safety of the code
 kani:
@@ -284,12 +289,6 @@ e2e-local:
 e2e-docker:
 	python3 scripts/ci.py e2e --docker $(E2E_ARGS)
 
-markdown-check:
-	broken-md-links docs
-	broken-md-links examples
-	broken-md-links dylint_lints
-	broken-md-links guidelines
-
 # -------- Code coverage --------
 
 .PHONY: coverage coverage-unit coverage-e2e-local check-prereq-e2e-local
@@ -386,7 +385,7 @@ oop-example:
 	cargo run --bin hyperspot-server --features oop-example,users-info-example,tenant-resolver-example -- --config config/quickstart.yaml run
 
 # Run all quality checks
-check: fmt clippy security dylint-test dylint gts-docs test
+check: fmt clippy lychee security dylint-test dylint gts-docs test
 
 # Run CI pipeline
 ci: check


### PR DESCRIPTION
Add $(call ensure_tool,lychee) to the lychee target to automatically install lychee if missing, following the same pattern as other cargo tools like cargo-clippy. This ensures the markdown link checking tool is available when running 'make lychee' without requiring manual installation.

Also removes the deprecated markdown-check target that used broken-md-links and adds lychee to the main check target. The reason is that:

1. Lychee is a real link checker: it validates markdown links, actual HTTP/HTTPS links, handles redirects, retries, timeouts, and scales well in CI.

2. broken-md-links is a Markdown linter: good for simple local links, weak and flaky for external URLs.

For Rust-style, CI-grade, reproducible builds, Lychee is the better default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline quality checks with improved markdown validation tooling. Removed legacy markdown check process and streamlined the check target dependency sequence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->