### PR TITLE
refactor: reduce cognitive complexity threshold to 20 for modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,9 +623,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -34,8 +34,8 @@ disallowed-methods = [
 
 # Type complexity threshold (default is 250)
 type-complexity-threshold = 190
-# Type complexity threshold (default is 25)
-cognitive-complexity-threshold = 25
+# Cognitive complexity threshold (default is 25)
+cognitive-complexity-threshold = 20
 
 # Function length threshold (default is 100)
 too-many-lines-threshold = 200

--- a/modules/simple_user_settings/simple_user_settings/src/api/rest/error.rs
+++ b/modules/simple_user_settings/simple_user_settings/src/api/rest/error.rs
@@ -10,42 +10,74 @@ pub fn domain_error_to_problem(e: &DomainError, instance: &str) -> Problem {
         .map(|id| id.into_u64().to_string());
 
     match e {
-        DomainError::NotFound => ErrorCode::settings_simple_user_settings_not_found_v1()
-            .with_context("Settings not found", instance, trace_id),
+        DomainError::NotFound => build_not_found_problem(instance, trace_id),
         DomainError::Validation { field, message } => {
-            ErrorCode::settings_simple_user_settings_validation_v1().with_context(
-                format!("Validation error on '{field}': {message}"),
-                instance,
-                trace_id,
-            )
+            build_validation_problem(field, message, instance, trace_id)
         }
-        DomainError::Forbidden(msg) => {
-            tracing::warn!(error = ?e, "Access forbidden: {}", msg);
-            // TODO: Add settings_simple_user_settings_forbidden_v1 to errors catalog
-            // For now, use not_found to avoid exposing sensitive scope information
-            ErrorCode::settings_simple_user_settings_not_found_v1().with_context(
-                "Settings not found or not accessible",
-                instance,
-                trace_id,
-            )
-        }
-        DomainError::Internal(msg) => {
-            tracing::error!(error = ?e, "Internal error: {}", msg);
-            ErrorCode::settings_simple_user_settings_internal_database_v1().with_context(
-                "An internal error occurred",
-                instance,
-                trace_id,
-            )
-        }
-        DomainError::Database(_) => {
-            tracing::error!(error = ?e, "Database error occurred");
-            ErrorCode::settings_simple_user_settings_internal_database_v1().with_context(
-                "An internal database error occurred",
-                instance,
-                trace_id,
-            )
-        }
+        DomainError::Forbidden(msg) => build_forbidden_problem(e, msg, instance, trace_id),
+        DomainError::Internal(msg) => build_internal_problem(e, msg, instance, trace_id),
+        DomainError::Database(_) => build_database_problem(e, instance, trace_id),
     }
+}
+
+fn build_not_found_problem(instance: &str, trace_id: Option<String>) -> Problem {
+    ErrorCode::settings_simple_user_settings_not_found_v1().with_context(
+        "Settings not found",
+        instance,
+        trace_id,
+    )
+}
+
+fn build_validation_problem(
+    field: &str,
+    message: &str,
+    instance: &str,
+    trace_id: Option<String>,
+) -> Problem {
+    ErrorCode::settings_simple_user_settings_validation_v1().with_context(
+        format!("Validation error on '{field}': {message}"),
+        instance,
+        trace_id,
+    )
+}
+
+fn build_forbidden_problem(
+    e: &DomainError,
+    msg: &str,
+    instance: &str,
+    trace_id: Option<String>,
+) -> Problem {
+    tracing::warn!(error = ?e, "Access forbidden: {}", msg);
+    // TODO: Add settings_simple_user_settings_forbidden_v1 to errors catalog
+    // For now, use not_found to avoid exposing sensitive scope information
+    ErrorCode::settings_simple_user_settings_not_found_v1().with_context(
+        "Settings not found or not accessible",
+        instance,
+        trace_id,
+    )
+}
+
+fn build_internal_problem(
+    e: &DomainError,
+    msg: &str,
+    instance: &str,
+    trace_id: Option<String>,
+) -> Problem {
+    tracing::error!(error = ?e, "Internal error: {}", msg);
+    ErrorCode::settings_simple_user_settings_internal_database_v1().with_context(
+        "An internal error occurred",
+        instance,
+        trace_id,
+    )
+}
+
+fn build_database_problem(e: &DomainError, instance: &str, trace_id: Option<String>) -> Problem {
+    tracing::error!(error = ?e, "Database error occurred");
+    ErrorCode::settings_simple_user_settings_internal_database_v1().with_context(
+        "An internal database error occurred",
+        instance,
+        trace_id,
+    )
 }
 
 /// Implement From<DomainError> for Problem so `?` works in handlers


### PR DESCRIPTION
Closes #61 
# Cognitive Complexity Refactoring Summary

## Overview
Reduced cognitive complexity threshold from 25 to 20 for all workspace modules (excluding libs). This required refactoring 5 functions across 4 files to comply with the new threshold.

## Configuration Changes
### `clippy.toml`
- Changed `cognitive-complexity-threshold` from **25 → 20**
- Applies to all workspace crates except libs (which maintains threshold of 55)

## Refactored Functions
### 1. `apps/hyperspot-server/src/main.rs` (2 functions)
#### `resolve_db_options()` - Complexity 22 → <20
**Before**: Single function handling both mock and standard DB configuration  
**After**: Extracted helper functions
- `create_mock_db_manager()` - Creates mock database manager
- `create_standard_db_manager()` - Creates standard database manager with connection pool

#### `build_oop_spawn_options()` - Complexity 22 → <20
**Before**: Single function building OOP module configuration  
**After**: Extracted helper function
- `try_build_oop_module_config()` - Constructs OOP module config from resolved path

### 2. `modules/system/types_registry/types_registry/src/infra/storage/debug_diagnostics.rs` (1 function)

#### `log_schema_chain_recursive()` - Complexity 25 → <20
**Before**: Single recursive function with multiple responsibilities  
**After**: Extracted helper functions
- `check_and_mark_visited()` - Cycle detection logic
- `try_get_schema()` - Schema retrieval with error handling
- `log_schema_content()` - Schema content logging

### 3. `modules/system/api_gateway/src/module.rs` (2 functions)

#### `rest_finalize()` - Complexity 23 → <20
**Before**: Single function finalizing REST API with OpenAPI route registration  
**After**: Extracted helper function
- `add_openapi_routes()` - Adds OpenAPI documentation routes to router

#### `register_operation()` - Complexity 23 → <20
**Before**: Single function with multiple validation checks  
**After**: Extracted helper functions
- `check_duplicate_handler()` - Validates no duplicate handlers for operation ID
- `check_duplicate_route()` - Validates no duplicate routes for same path/method
- `log_operation_registration()` - Logs successful operation registration

### 4. `modules/simple_user_settings/simple_user_settings/src/api/rest/error.rs` (1 function)

#### `domain_error_to_problem()` - Complexity 23 → <20
**Before**: Single function mapping all domain errors to RFC9457 Problems  
**After**: Extracted helper functions
- `build_not_found_problem()` - Maps NotFound errors
- `build_validation_problem()` - Maps ValidationFailed errors
- `build_forbidden_problem()` - Maps Forbidden errors
- `build_internal_problem()` - Maps InternalError errors
- `build_database_problem()` - Maps DatabaseError errors

## Updates
### Security fix: 
Updated bytes from 1.11.0 to 1.11.1 to address RUSTSEC-2026-0007
integer overflow vulnerability in BytesMut::reserve."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modularized database manager and out-of-process module configuration creation.
  * Centralized API documentation registration flow and duplicate-detection for registrations.
  * Reworked error-to-problem mapping via dedicated helpers.
  * Improved schema diagnostics with cycle detection and clearer logging.

* **New / Improved**
  * OpenAPI and docs routes now register and wire more robustly.

* **Chores**
  * Tightened code-quality configuration threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->