### PR TITLE
chore: Update Makefile to not auto install missing tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,13 @@ E2E_ARGS ?= --features users-info-example
 
 # -------- Utility macros --------
 
-define ensure_tool
-	@command -v $(1) >/dev/null || (echo "Installing $(1)..." && cargo install $(1))
+define check_tool
+    @command -v $(1) >/dev/null || (echo "ERROR: $(1) is not installed. Run 'make setup' to install required tools." && exit 1)
+endef
+
+define check_rustup_component
+    @command -v rustup >/dev/null || (echo "ERROR: rustup not installed. Install rustup or run 'make setup'." && exit 1)
+	@rustup component list --installed | grep -q '^$(1)' || (echo "ERROR: $(1) component not installed. Run 'rustup component add $(1)' or 'make setup'." && exit 1)
 endef
 
 # -------- Defaults --------
@@ -17,6 +22,31 @@ endef
 # Show the help message with list of commands (default target)
 help:
 	@python3 scripts/make_help.py Makefile
+
+
+# -------- Set up --------
+
+.PHONY: setup
+
+## Install all required development tools
+setup:
+	@echo "Installing required development tools..."
+	rustup component add clippy
+	cargo install lychee
+	cargo install cargo-geiger
+	cargo install cargo-deny
+	cargo install cargo-dylint
+	cargo install dylint-link
+	cargo install cargo-fuzz
+	@if echo "$$OS" | grep -iq windows || [ -n "$$COMSPEC" ]; then \
+		echo "WARNING: kani-verifier and cargo-llvm-cov installation skipped on Windows."; \
+		echo "These tools are not supported on Windows. Use WSL2 or Docker to install instead."; \
+	else \
+		cargo install --locked kani-verifier && \
+		cargo kani setup && \
+		cargo install cargo-llvm-cov; \
+	fi
+	@echo "Setup complete. All tools installed."
 
 # -------- Code formatting --------
 
@@ -73,24 +103,22 @@ fmt:
 
 # Run clippy linter (excludes gts-rust submodule which has its own lint settings)
 clippy:
-	$(call ensure_tool,cargo-clippy)
+	$(call check_rustup_component,clippy)
 	cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf
 
 # Run markdown checks with 'lychee'
 lychee:
-	$(call ensure_tool,lychee)
+	$(call check_tool,lychee)
 	lychee docs examples dylint_lints guidelines
 
 ## The Kani Rust Verifier for checking safety of the code
 kani:
-	@command -v kani >/dev/null || \
-		(echo "Installing Kani verifier..." && \
-		 cargo install --locked kani-verifier)
+	$(call check_tool,kani)
 	cargo kani --workspace --all-features
 
 ## Run Geiger scanner for unsafe code in dependencies
 geiger:
-	$(call ensure_tool,cargo-geiger)
+	$(call check_tool,cargo-geiger)
 	cd apps/hyperspot-server && cargo geiger --all-features
 
 ## Check there are no compile time warnings
@@ -152,8 +180,8 @@ dylint-test:
 
 # Run project compliance dylint lints on the workspace (see `make dylint-list`)
 dylint:
-	@command -v cargo-dylint >/dev/null || (echo "Installing cargo-dylint..." && cargo install cargo-dylint)
-	@command -v dylint-link >/dev/null || (echo "Installing dylint-link..." && cargo install dylint-link)
+	$(call check_tool,cargo-dylint)
+	$(call check_tool,dylint-link)
 	@cd dylint_lints && cargo build --release
 	@TOOLCHAIN=$$(rustc --version --verbose | grep 'host:' | cut -d' ' -f2); \
 	RUSTUP_TOOLCHAIN=$$(cat dylint_lints/rust-toolchain.toml 2>/dev/null | grep 'channel' | cut -d'"' -f2 || echo "nightly"); \
@@ -190,7 +218,7 @@ safety: clippy kani lint dylint # geiger
 
 ## Check licenses and dependencies
 deny:
-	$(call ensure_tool,cargo-deny)
+	$(call check_tool,cargo-deny)
 	cargo deny check
 
 # Run all security checks
@@ -295,12 +323,12 @@ e2e-docker:
 
 # Generate code coverage report (unit + e2e-local tests)
 coverage:
-	@command -v cargo-llvm-cov >/dev/null || (echo "Installing cargo-llvm-cov..." && cargo install cargo-llvm-cov)
+	$(call check_tool,cargo-llvm-cov)
 	python3 scripts/coverage.py combined
 
 # Generate code coverage report (unit tests only)
 coverage-unit:
-	@command -v cargo-llvm-cov >/dev/null || (echo "Installing cargo-llvm-cov..." && cargo install cargo-llvm-cov)
+	$(call check_tool,cargo-llvm-cov)
 	python3 scripts/coverage.py unit
 
 ## Ensure needed packages and programs installed for local e2e testing
@@ -309,17 +337,16 @@ check-prereq-e2e-local:
 
 # Generate code coverage report (e2e-local tests only)
 coverage-e2e-local: check-prereq-e2e-local
-	@command -v cargo-llvm-cov >/dev/null || (echo "Installing cargo-llvm-cov..." && cargo install cargo-llvm-cov)
+	$(call check_tool,cargo-llvm-cov)
 	python3 scripts/coverage.py e2e-local
 
 # -------- Fuzzing --------
 
 .PHONY: fuzz fuzz-build fuzz-list fuzz-run fuzz-clean fuzz-corpus
 
-## Install cargo-fuzz (required for fuzzing)
+## Check cargo-fuzz is installed (required for fuzzing)
 fuzz-install:
-	@command -v cargo-fuzz >/dev/null || \
-		(echo "Installing cargo-fuzz..." && cargo install cargo-fuzz)
+	$(call check_tool,cargo-fuzz)
 
 ## Build all fuzz targets
 fuzz-build: fuzz-install


### PR DESCRIPTION
1. Replace `ensure_tools` with `check_tools` instead
2. Added new `setup` target to install any missing tools 
3. Replace all automatic installs with `check_tools`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public setup target to install required development tools, with Windows-aware handling and a completion message.

* **Chores**
  * Presence checks for required tools and Rust components now fail with clear error messages directing users to run setup.
  * Fuzzing and other tooling targets updated to rely on the new checks and improved setup/help messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->