### PR TITLE
feat(api_gateway): add Prometheus metrics support for HTTP observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "d1eb7c4fcde1858a6796c18a729b661346d38e05a207e2d9028bce822fc20283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -173,11 +173,12 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.11"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e4850548ff4a25a77ce3bda7241874e17fb702ea551f0cc62a2dbe052f1272"
+checksum = "c86cd1c51b95d71dde52bca69ed225008f6ff4c8cc825b08042aa1ef823e1980"
 dependencies = [
  "anstyle",
+ "memchr",
  "unicode-width",
 ]
 
@@ -233,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -295,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68650b7df54f0293fd061972a0fb05aaf4fc0879d3b3d21a638a182c5c543b9f"
+checksum = "7d67d43201f4d20c78bcda740c142ca52482d81da80681533d33bf3f0596c8e2"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -345,7 +346,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -356,7 +357,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -409,9 +410,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.4"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -494,7 +495,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -653,7 +654,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "tonic",
  "tonic-prost",
@@ -670,7 +671,7 @@ dependencies = [
  "bollard-buildkit-proto",
  "bytes",
  "chrono",
- "prost",
+ "prost 0.14.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -703,7 +704,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -729,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytecheck"
@@ -868,7 +869,7 @@ dependencies = [
  "cf-modkit-security",
  "cf-modkit-transport-grpc",
  "cf-system-sdks",
- "prost",
+ "prost 0.14.3",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -924,6 +925,7 @@ dependencies = [
  "cf-modkit-http",
  "cf-modkit-macros",
  "cf-modkit-security",
+ "cf-tenant-resolver-sdk",
  "chrono",
  "dashmap",
  "futures-core",
@@ -933,9 +935,12 @@ dependencies = [
  "matchit 0.9.1",
  "nanoid",
  "parking_lot",
+ "prometheus",
+ "prometheus-axum-middleware",
  "rust-embed",
  "serde",
  "serde_json",
+ "serial_test",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -1213,7 +1218,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "trybuild",
 ]
 
@@ -1237,7 +1242,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1281,7 +1286,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1348,7 +1353,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "trybuild",
  "uuid",
 ]
@@ -1639,7 +1644,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cf-modkit-transport-grpc",
- "prost",
+ "prost 0.14.3",
  "tokio",
  "tonic",
  "tonic-prost",
@@ -1791,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1801,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1820,7 +1825,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1879,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.36"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00828ba6fd27b45a448e57dbfe84f1029d4c9f26b368157e9a448a5f49a2ec2a"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "brotli",
  "compression-core",
@@ -2082,7 +2087,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2116,7 +2121,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2130,7 +2135,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2141,7 +2146,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2152,7 +2157,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2216,7 +2221,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2237,7 +2242,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2247,7 +2252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2260,7 +2265,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2281,7 +2286,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.115",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -2326,7 +2331,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2792,9 +2797,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2807,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2817,15 +2822,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2845,32 +2850,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -2880,9 +2885,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2892,7 +2897,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2914,8 +2918,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2954,7 +2960,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3062,7 +3068,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3700,7 +3706,7 @@ checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3721,9 +3727,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
 dependencies = [
  "rustversion",
 ]
@@ -4004,6 +4010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lzma-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4151,9 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5d26952a508f321b4d3d2e80e78fc2603eaefcdf0c30783867f19586518bdc"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -4192,7 +4204,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4471,7 +4483,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4530,7 +4542,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "reqwest",
  "thiserror 2.0.18",
  "tokio",
@@ -4546,7 +4558,7 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.3",
  "tonic",
  "tonic-prost",
 ]
@@ -4604,7 +4616,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4688,7 +4700,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4756,7 +4768,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4877,7 +4889,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5021,7 +5033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5061,7 +5073,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5081,9 +5093,63 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "prometheus-axum-middleware"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11b5589175a1bdeea9c91bac96af43cda626ca7b448f44581c4beaf2dc0425e1"
+dependencies = [
+ "axum",
+ "base64 0.22.1",
+ "prometheus",
+ "prometheus-reqwest-remote-write",
+ "reqwest",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "prometheus-reqwest-remote-write"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e855784e07cfc6abf2f89fe04e4c5fe00a17f1ac739838cbddb801cd653dda"
+dependencies = [
+ "prometheus",
+ "prost 0.13.5",
+ "reqwest",
+ "snap",
+ "tracing",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -5093,7 +5159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -5108,13 +5174,26 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.14.3",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.115",
+ "syn 2.0.117",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5127,7 +5206,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5136,7 +5215,27 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5211,6 +5310,61 @@ checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "encoding_rs",
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5374,7 +5528,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5456,6 +5610,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5463,6 +5619,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -5472,6 +5629,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5573,7 +5731,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.115",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -5674,6 +5832,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5732,6 +5891,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5775,7 +5943,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5783,6 +5951,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sea-bae"
@@ -5794,7 +5968,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5851,7 +6025,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.115",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -5908,7 +6082,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
@@ -5934,7 +6108,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5969,9 +6143,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
@@ -5982,9 +6156,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6061,7 +6235,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6072,7 +6246,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6118,7 +6292,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6170,7 +6344,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6184,6 +6358,32 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6316,6 +6516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6416,7 +6622,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6439,7 +6645,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.115",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -6620,7 +6826,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6631,7 +6837,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6668,9 +6874,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.115"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6694,14 +6900,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5792d209c2eac902426c0c4a166c9f72147db453af548cf9bf3242644c4d4fe3"
+checksum = "1efc19935b4b66baa6f654ac7924c192f55b175c00a7ab72410fc24284dacda8"
 dependencies = [
  "libc",
  "memchr",
@@ -6849,7 +7055,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6860,7 +7066,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6972,7 +7178,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7046,9 +7252,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.1+spec-1.1.0"
+version = "1.0.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe30f93627849fa362d4a602212d41bb237dc2bd0f8ba0b2ce785012e124220"
+checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
@@ -7091,9 +7297,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.8+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -7106,9 +7312,9 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f32a6f80051a4111560201420c7885d0082ba9efe2ab61875c587bb6b18b9a0"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
@@ -7135,39 +7341,39 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6d8958ed3be404120ca43ffa0fb1e1fc7be214e96c8d33bd43a131b6eebc9e"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f86539c0089bfd09b1f8c0ab0239d80392af74c21bc9e0f15e1b4aca4c1647f"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.14.3",
  "tonic",
 ]
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65873ace111e90344b8973e94a1fc817c924473affff24629281f90daed1cd2e"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "tempfile",
  "tonic-build",
 ]
@@ -7260,7 +7466,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7350,7 +7556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7469,9 +7675,9 @@ checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -7685,7 +7891,7 @@ checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "uuid",
 ]
 
@@ -7831,7 +8037,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -8029,7 +8235,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8040,7 +8246,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8415,7 +8621,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.115",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -8431,7 +8637,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -8482,7 +8688,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8556,7 +8762,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -8577,7 +8783,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8597,7 +8803,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -8618,7 +8824,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8651,7 +8857,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.115",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -8700,9 +8906,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
+checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,6 +295,8 @@ tower-http = { version = "0.6", features = [
 ] }
 uuid = { version = "1.19", features = ["serde"] }
 governor = "0.10"
+prometheus = "0.14"
+prometheus-axum-middleware = "0.1"
 
 # OpenAPI documentation (only for api-gateway)
 utoipa = { version = "5.4", features = [
@@ -458,6 +460,7 @@ pptx-to-md = "0.4"
 # Additional testing utilities
 tokio-test = "0.4"
 temp-env = "0.3"
+serial_test = "3.2"
 
 # Additional utilities
 nanoid = "0.4"

--- a/libs/modkit/src/bootstrap/config/mod.rs
+++ b/libs/modkit/src/bootstrap/config/mod.rs
@@ -113,18 +113,44 @@ impl ConfigProvider for AppConfig {
     fn get_module_config(&self, module_name: &str) -> Option<&serde_json::Value> {
         self.modules.get(module_name)
     }
+
+    fn app_config(&self) -> Option<&AppConfig> {
+        Some(self)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[serde(deny_unknown_fields, default)]
 pub struct ServerConfig {
     pub home_dir: PathBuf, // will be normalized to absolute path
+    /// Prometheus metrics configuration
+    pub prometheus: PrometheusConfig,
 }
 
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             home_dir: super::host::paths::default_home_dir().join(".cyberfabric"),
+            prometheus: PrometheusConfig::default(),
+        }
+    }
+}
+
+/// Prometheus metrics configuration
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct PrometheusConfig {
+    /// Enable Prometheus metrics collection and endpoint
+    pub enabled: bool,
+    /// Application name used as metrics prefix (e.g., "hyperspot" -> "`hyperspot_http_requests_total`")
+    pub app_name: String,
+}
+
+impl Default for PrometheusConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            app_name: "hyperspot".to_owned(),
         }
     }
 }
@@ -139,6 +165,39 @@ impl ServerConfig {
         .context("home_dir normalization failed")?;
 
         std::fs::create_dir_all(&self.home_dir).context("Failed to create home_dir")?;
+
+        Ok(())
+    }
+}
+
+impl PrometheusConfig {
+    /// Validates that `app_name` conforms to Prometheus metric naming rules.
+    ///
+    /// Prometheus metric names must match: [a-zA-Z_][a-zA-Z0-9_]*
+    /// - First character: letter (a-z, A-Z) or underscore (_)
+    /// - Subsequent characters: letter, digit, or underscore
+    ///
+    /// Invalid characters like hyphens will cause runtime panics when registering metrics.
+    ///
+    /// # Errors
+    /// Returns an error if `app_name` is empty or contains invalid characters.
+    fn validate_app_name(&self) -> Result<()> {
+        let re = regex::Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$")?;
+
+        ensure!(
+            !self.app_name.is_empty(),
+            "server.prometheus.app_name cannot be empty"
+        );
+
+        ensure!(
+            re.is_match(&self.app_name),
+            "server.prometheus.app_name '{}' contains invalid characters. \
+             Prometheus metric names must start with a letter or underscore, \
+             followed by letters, digits, or underscores. \
+             Invalid characters include hyphens (-), dots (.), colons (:), spaces, etc. \
+             Example valid names: 'hyperspot', 'my_app', 'app_gateway_v2'",
+            self.app_name
+        );
 
         Ok(())
     }
@@ -292,6 +351,15 @@ impl AppConfig {
             .normalize_home_dir_inplace()
             .context("Failed to resolve server.home_dir")?;
 
+        // Validate app_name for Prometheus compatibility (only if enabled).
+        if config.server.prometheus.enabled {
+            config
+                .server
+                .prometheus
+                .validate_app_name()
+                .context("Invalid Prometheus metrics configuration")?;
+        }
+
         // Merge module files if modules_dir is specified.
         if let Some(dir) = config.modules_dir.as_ref() {
             merge_module_files(&mut config.modules, dir)?;
@@ -318,6 +386,12 @@ impl AppConfig {
             c.server
                 .normalize_home_dir_inplace()
                 .context("Failed to resolve server.home_dir (defaults)")?;
+            if c.server.prometheus.enabled {
+                c.server
+                    .prometheus
+                    .validate_app_name()
+                    .context("Invalid Prometheus metrics configuration")?;
+            }
             Ok(c)
         }
     }
@@ -1342,6 +1416,99 @@ server:
         // Optional sections default to None
         assert!(config.database.is_none());
         assert!(config.modules.is_empty());
+    }
+
+    #[test]
+    fn test_app_name_validation_valid() {
+        let valid_names = vec![
+            "hyperspot",
+            "my_app",
+            "app_gateway_v2",
+            "_internal",
+            "A1",
+            "CamelCase",
+            "snake_case_name",
+        ];
+
+        for name in valid_names {
+            let config = PrometheusConfig {
+                enabled: true,
+                app_name: name.to_owned(),
+            };
+            assert!(
+                config.validate_app_name().is_ok(),
+                "Expected '{name}' to be valid"
+            );
+        }
+    }
+
+    #[test]
+    fn test_app_name_validation_invalid() {
+        let invalid_cases = vec![
+            ("my-app", "hyphen"),
+            ("app.gateway", "dot"),
+            ("my app", "space"),
+            ("123app", "starts with digit"),
+            ("app@gateway", "special char"),
+            ("app:name", "colon"),
+            ("", "empty string"),
+        ];
+
+        for (name, reason) in invalid_cases {
+            let config = PrometheusConfig {
+                enabled: true,
+                app_name: name.to_owned(),
+            };
+            let result = config.validate_app_name();
+            assert!(
+                result.is_err(),
+                "Expected '{name}' to be invalid ({reason})"
+            );
+
+            // Verify error message is descriptive
+            let err_msg = result.unwrap_err().to_string();
+            if !name.is_empty() {
+                assert!(
+                    err_msg.contains(name),
+                    "Error should mention the invalid value"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_load_config_rejects_invalid_app_name() {
+        let tmp = tempdir().unwrap();
+        let cfg_path = tmp.path().join("cfg.yaml");
+
+        let yaml = r#"
+server:
+  home_dir: "~/.test"
+  prometheus:
+    enabled: true
+    app_name: "my-app"
+"#;
+        fs::write(&cfg_path, yaml).unwrap();
+
+        let result = AppConfig::load_layered(&cfg_path);
+        assert!(result.is_err(), "Should reject invalid app_name");
+
+        // Format with {:#} to get the full error chain including causes
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            err_msg.contains("my-app") && err_msg.contains("invalid"),
+            "Error message should be clear: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn test_default_app_name_is_valid() {
+        let config = PrometheusConfig::default();
+        assert!(
+            config.validate_app_name().is_ok(),
+            "Default app_name '{}' must be valid",
+            config.app_name
+        );
     }
 
     #[test]

--- a/libs/modkit/src/bootstrap/oop_tests.rs
+++ b/libs/modkit/src/bootstrap/oop_tests.rs
@@ -7,8 +7,9 @@
 
 use super::*;
 use crate::bootstrap::config::{
-    AppConfig, ConsoleFormat, GlobalDatabaseConfig, LoggingConfig, RenderedDbConfig,
-    RenderedModuleConfig, Section, SectionFile, ServerConfig, default_logging_config,
+    AppConfig, ConsoleFormat, GlobalDatabaseConfig, LoggingConfig, PrometheusConfig,
+    RenderedDbConfig, RenderedModuleConfig, Section, SectionFile, ServerConfig,
+    default_logging_config,
 };
 use modkit_db::{DbConnConfig, PoolCfg};
 use std::collections::HashMap;
@@ -20,6 +21,10 @@ fn minimal_app_config() -> AppConfig {
     AppConfig {
         server: ServerConfig {
             home_dir: std::env::temp_dir().join("modkit_test"),
+            prometheus: PrometheusConfig {
+                enabled: false,
+                app_name: "test_app".to_owned(),
+            },
         },
         database: None,
         logging: default_logging_config(),

--- a/libs/modkit/src/config.rs
+++ b/libs/modkit/src/config.rs
@@ -33,6 +33,13 @@ pub enum ConfigError {
 pub trait ConfigProvider: Send + Sync {
     /// Returns raw JSON section for the module, if any.
     fn get_module_config(&self, module_name: &str) -> Option<&serde_json::Value>;
+
+    /// Returns the full app config for accessing server-level configuration.
+    /// This is used by system modules (like `api_gateway`) that need access to server-level settings.
+    #[cfg(feature = "bootstrap")]
+    fn app_config(&self) -> Option<&crate::bootstrap::AppConfig> {
+        None
+    }
 }
 
 /// Lenient configuration loader that falls back to defaults.

--- a/modules/system/api-gateway/Cargo.toml
+++ b/modules/system/api-gateway/Cargo.toml
@@ -51,15 +51,21 @@ utoipa = { workspace = true }
 http = { workspace = true }
 rust-embed = { workspace = true }
 
+prometheus = { workspace = true, optional = true }
+prometheus-axum-middleware = { workspace = true, optional = true }
+
 [dev-dependencies]
 futures-core = { workspace = true }
 uuid = { workspace = true }
+tenant-resolver-sdk = { workspace = true }
+serial_test = { workspace = true }
 
 [features]
 grpc = []
 debug-errors = []
 embed_elements = []
 otel = []
+prometheus-metrics = ["prometheus", "prometheus-axum-middleware", "modkit/bootstrap"]
 
 [build-dependencies]
 ureq = { workspace = true }

--- a/modules/system/api-gateway/src/lib.rs
+++ b/modules/system/api-gateway/src/lib.rs
@@ -17,5 +17,8 @@ pub mod middleware;
 mod router_cache;
 mod web;
 
+#[cfg(feature = "prometheus-metrics")]
+pub mod metrics;
+
 // === RE-EXPORTS ===
 pub use config::{ApiGatewayConfig, CorsConfig};

--- a/modules/system/api-gateway/src/metrics.rs
+++ b/modules/system/api-gateway/src/metrics.rs
@@ -1,0 +1,55 @@
+//! Prometheus metrics collection for the API Gateway.
+//!
+//! This module provides HTTP metrics collection when the `prometheus-metrics` feature is enabled.
+//! Metrics are exposed at `/metrics` in Prometheus text format.
+//!
+//! Collected metrics (prefix is `server.app_name` from `AppConfig`, default: `hyperspot`):
+//! - `<app_name>_http_request_total`: Total HTTP requests (counter)
+//! - `<app_name>_http_requests_duration_seconds`: Request latency (histogram)
+//! - `<app_name>_http_requests_pending`: Current in-flight requests (gauge)
+//!
+//! All metrics include labels: method, endpoint (matched route), and status code.
+
+use axum::routing::get;
+use prometheus_axum_middleware::PrometheusAxumLayer;
+
+/// Initializes the Prometheus metrics configuration.
+///
+/// This must be called before creating the metrics layer.
+/// Sets up:
+/// - Metric prefix: typically `server.app_name` from `AppConfig` (default: `hyperspot`)
+///
+/// # Arguments
+///
+/// * `prefix` - The metric name prefix to use (e.g., "hyperspot")
+///
+/// Note: Path exclusion is not supported by prometheus-axum-middleware 0.1.1.
+/// High-frequency endpoints should be excluded using middleware ordering instead.
+pub fn init_metrics(prefix: &str) {
+    prometheus_axum_middleware::set_prefix(prefix);
+    tracing::info!("Prometheus metrics initialized with prefix: {}", prefix);
+}
+
+/// Creates the Prometheus metrics middleware layer.
+///
+/// This layer collects HTTP request metrics with the configured prefix:
+/// - Counter: `<prefix>_http_request_total` (method, endpoint, status)
+/// - Histogram: `<prefix>_http_requests_duration_seconds` (method, endpoint, status)
+/// - Gauge: `<prefix>_http_requests_pending` (method, endpoint)
+///
+/// Note: `init_metrics(prefix)` must be called before using this layer to set the prefix.
+///
+/// # Returns
+///
+/// The Prometheus metrics layer.
+#[must_use]
+pub fn create_metrics_layer() -> PrometheusAxumLayer {
+    PrometheusAxumLayer::new()
+}
+
+/// Handler for the `/metrics` endpoint.
+///
+/// Returns Prometheus-formatted metrics in text format.
+pub fn metrics_endpoint() -> axum::routing::MethodRouter {
+    get(prometheus_axum_middleware::render)
+}

--- a/modules/system/api-gateway/src/module.rs
+++ b/modules/system/api-gateway/src/module.rs
@@ -4,6 +4,8 @@
 
 use async_trait::async_trait;
 use std::sync::Arc;
+#[cfg(feature = "prometheus-metrics")]
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
@@ -59,6 +61,10 @@ pub struct ApiGateway {
     // Duplicate detection (per (method, path) and per handler id)
     pub(crate) registered_routes: DashMap<(Method, String), ()>,
     pub(crate) registered_handlers: DashMap<String, ()>,
+
+    // Prometheus metrics configuration from server config
+    #[cfg(feature = "prometheus-metrics")]
+    pub(crate) prometheus_enabled: AtomicBool,
 }
 
 impl Default for ApiGateway {
@@ -72,6 +78,8 @@ impl Default for ApiGateway {
             authn_client: Mutex::new(None),
             registered_routes: DashMap::new(),
             registered_handlers: DashMap::new(),
+            #[cfg(feature = "prometheus-metrics")]
+            prometheus_enabled: AtomicBool::new(false),
         }
     }
 }
@@ -89,6 +97,8 @@ impl ApiGateway {
             authn_client: Mutex::new(None),
             registered_routes: DashMap::new(),
             registered_handlers: DashMap::new(),
+            #[cfg(feature = "prometheus-metrics")]
+            prometheus_enabled: AtomicBool::new(false),
         }
     }
 
@@ -127,6 +137,10 @@ impl ApiGateway {
         public_routes.insert((Method::GET, "/healthz".to_owned()));
         public_routes.insert((Method::GET, "/docs".to_owned()));
         public_routes.insert((Method::GET, "/openapi.json".to_owned()));
+
+        // Mark Prometheus metrics endpoint as public (feature-gated)
+        #[cfg(feature = "prometheus-metrics")]
+        public_routes.insert((Method::GET, "/metrics".to_owned()));
 
         for spec in &self.openapi_registry.operation_specs {
             let spec = spec.value();
@@ -187,7 +201,7 @@ impl ApiGateway {
             .map(|e| e.value().clone())
             .collect();
 
-        // 11) License validation
+        // 12) License validation
         let license_map = middleware::license_validation::LicenseRequirementMap::from_specs(&specs);
         router = router.layer(from_fn(
             move |req: axum::extract::Request, next: axum::middleware::Next| {
@@ -196,7 +210,7 @@ impl ApiGateway {
             },
         ));
 
-        // 10) Auth
+        // 11) Auth
         if config.auth_disabled {
             // Build security contexts for compatibility during migration
             let default_security_context = SecurityContext::builder()
@@ -231,10 +245,10 @@ impl ApiGateway {
             ));
         }
 
-        // 9) Error mapping (outer to auth so it can translate auth/handler errors)
+        // 10) Error mapping (outer to auth so it can translate auth/handler errors)
         router = router.layer(from_fn(modkit::api::error_layer::error_mapping_middleware));
 
-        // 8) Per-route rate limiting & in-flight limits
+        // 9) Per-route rate limiting & in-flight limits
         let rate_map = middleware::rate_limit::RateLimiterMap::from_specs(&specs, &config)?;
         router = router.layer(from_fn(
             move |req: axum::extract::Request, next: axum::middleware::Next| {
@@ -243,7 +257,7 @@ impl ApiGateway {
             },
         ));
 
-        // 7) MIME type validation
+        // 8) MIME type validation
         let mime_map = middleware::mime_validation::build_mime_validation_map(&specs);
         router = router.layer(from_fn(
             move |req: axum::extract::Request, next: axum::middleware::Next| {
@@ -252,23 +266,31 @@ impl ApiGateway {
             },
         ));
 
-        // 6) CORS (must be outer to auth/limits so OPTIONS preflight short-circuits)
+        // 7) CORS (must be outer to auth/limits so OPTIONS preflight short-circuits)
         if config.cors_enabled {
             router = router.layer(crate::cors::build_cors_layer(&config));
         }
 
-        // 5) Body limit
+        // 6) Body limit
         router = router.layer(RequestBodyLimitLayer::new(config.defaults.body_limit_bytes));
         router = router.layer(DefaultBodyLimit::max(config.defaults.body_limit_bytes));
 
-        // 4) Timeout
+        // 5) Timeout
         router = router.layer(TimeoutLayer::with_status_code(
             axum::http::StatusCode::GATEWAY_TIMEOUT,
             Duration::from_secs(30),
         ));
 
-        // 3) Record request_id into span + extensions (requires span to exist first => must be inner to Trace)
+        // 4) Record request_id into span + extensions (requires span to exist first => must be inner to Trace)
         router = router.layer(from_fn(middleware::request_id::push_req_id_to_extensions));
+
+        // 3) Prometheus metrics layer (feature-gated, after Trace so route info is available)
+        #[cfg(feature = "prometheus-metrics")]
+        {
+            if self.prometheus_enabled.load(Ordering::Relaxed) {
+                router = router.layer(crate::metrics::create_metrics_layer());
+            }
+        }
 
         // 2) Trace (outer to push_req_id_to_extensions)
         router = router.layer({
@@ -556,6 +578,17 @@ impl modkit::Module for ApiGateway {
             tracing::info!("AuthN Resolver client resolved from ClientHub");
         }
 
+        // Initialize Prometheus metrics (must be done before first request)
+        #[cfg(feature = "prometheus-metrics")]
+        {
+            if let Some(app_config) = ctx.config_provider().app_config()
+                && app_config.server.prometheus.enabled
+            {
+                crate::metrics::init_metrics(&app_config.server.prometheus.app_name);
+                self.prometheus_enabled.store(true, Ordering::Relaxed);
+            }
+        }
+
         Ok(())
     }
 }
@@ -579,15 +612,26 @@ impl modkit::contracts::ApiGatewayCapability for ApiGateway {
         Ok(router)
     }
 
+    #[cfg_attr(not(feature = "prometheus-metrics"), allow(unused_variables))]
     fn rest_finalize(
         &self,
-        _ctx: &modkit::context::ModuleCtx,
+        ctx: &modkit::context::ModuleCtx,
         mut router: axum::Router,
     ) -> anyhow::Result<axum::Router> {
         let config = self.get_cached_config();
 
         if config.enable_docs {
             router = self.add_openapi_routes(router)?;
+        }
+
+        // Register Prometheus metrics endpoint (feature-gated)
+        #[cfg(feature = "prometheus-metrics")]
+        {
+            if let Some(app_config) = ctx.config_provider().app_config()
+                && app_config.server.prometheus.enabled
+            {
+                router = router.route("/metrics", crate::metrics::metrics_endpoint());
+            }
         }
 
         // Apply middleware stack (including auth) to the final router

--- a/modules/system/api-gateway/tests/metrics_tests.rs
+++ b/modules/system/api-gateway/tests/metrics_tests.rs
@@ -1,0 +1,728 @@
+#![cfg(feature = "prometheus-metrics")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Integration tests for Prometheus metrics collection
+
+use anyhow::Result;
+use async_trait::async_trait;
+use axum::{Router, extract::Json, routing::get};
+use modkit::{
+    Module, ModuleCtx, RestApiCapability,
+    api::OperationBuilder,
+    bootstrap::{AppConfig, ServerConfig, config::PrometheusConfig},
+    config::ConfigProvider,
+    contracts::{ApiGatewayCapability, OpenApiRegistry},
+};
+use modkit_security::SecurityContext;
+use serde::{Deserialize, Serialize};
+use serial_test::serial;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tenant_resolver_sdk::{
+    GetAncestorsOptions, GetAncestorsResponse, GetDescendantsOptions, GetDescendantsResponse,
+    GetTenantsOptions, IsAncestorOptions, TenantId, TenantInfo, TenantResolverClient,
+    TenantResolverError, TenantStatus,
+};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+struct MockTenantResolver;
+
+#[async_trait]
+impl TenantResolverClient for MockTenantResolver {
+    async fn get_tenant(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+    ) -> std::result::Result<TenantInfo, TenantResolverError> {
+        Ok(TenantInfo {
+            id,
+            name: format!("Tenant {id}"),
+            status: TenantStatus::Active,
+            tenant_type: None,
+            parent_id: None,
+            self_managed: false,
+        })
+    }
+
+    async fn get_tenants(
+        &self,
+        _ctx: &SecurityContext,
+        _ids: &[TenantId],
+        _options: &GetTenantsOptions,
+    ) -> std::result::Result<Vec<TenantInfo>, TenantResolverError> {
+        Ok(vec![])
+    }
+
+    async fn get_ancestors(
+        &self,
+        _ctx: &SecurityContext,
+        _id: TenantId,
+        _options: &GetAncestorsOptions,
+    ) -> std::result::Result<GetAncestorsResponse, TenantResolverError> {
+        Ok(GetAncestorsResponse {
+            tenant: tenant_resolver_sdk::TenantRef {
+                id: _id,
+                status: TenantStatus::Active,
+                tenant_type: None,
+                parent_id: None,
+                self_managed: false,
+            },
+            ancestors: vec![],
+        })
+    }
+
+    async fn get_descendants(
+        &self,
+        _ctx: &SecurityContext,
+        _id: TenantId,
+        _options: &GetDescendantsOptions,
+    ) -> std::result::Result<GetDescendantsResponse, TenantResolverError> {
+        Ok(GetDescendantsResponse {
+            tenant: tenant_resolver_sdk::TenantRef {
+                id: _id,
+                status: TenantStatus::Active,
+                tenant_type: None,
+                parent_id: None,
+                self_managed: false,
+            },
+            descendants: vec![],
+        })
+    }
+
+    async fn is_ancestor(
+        &self,
+        _ctx: &SecurityContext,
+        _ancestor_id: TenantId,
+        _descendant_id: TenantId,
+        _options: &IsAncestorOptions,
+    ) -> std::result::Result<bool, TenantResolverError> {
+        Ok(false)
+    }
+}
+
+struct TestConfigProvider {
+    module_config: serde_json::Value,
+    app_config: AppConfig,
+}
+
+impl ConfigProvider for TestConfigProvider {
+    fn get_module_config(&self, module: &str) -> Option<&serde_json::Value> {
+        if module == "api_gateway" {
+            Some(&self.module_config)
+        } else {
+            None
+        }
+    }
+
+    fn app_config(&self) -> Option<&AppConfig> {
+        Some(&self.app_config)
+    }
+}
+
+fn wrap_config(config: &serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "config": config
+    })
+}
+
+fn create_test_module_ctx_with_config(
+    api_gateway_config: &serde_json::Value,
+    prometheus_enabled: bool,
+) -> ModuleCtx {
+    create_test_module_ctx_with_app_name(api_gateway_config, prometheus_enabled, "hyperspot")
+}
+
+fn create_test_module_ctx_with_app_name(
+    api_gateway_config: &serde_json::Value,
+    prometheus_enabled: bool,
+    app_name: &str,
+) -> ModuleCtx {
+    let wrapped_config = wrap_config(api_gateway_config);
+    let hub = Arc::new(modkit::ClientHub::new());
+    hub.register::<dyn TenantResolverClient>(Arc::new(MockTenantResolver));
+
+    let app_config = AppConfig {
+        server: ServerConfig {
+            home_dir: std::path::PathBuf::from("/tmp"),
+            prometheus: PrometheusConfig {
+                enabled: prometheus_enabled,
+                app_name: app_name.to_owned(),
+            },
+        },
+        database: None,
+        logging: HashMap::default(),
+        tracing: None,
+        modules_dir: None,
+        modules: HashMap::default(),
+    };
+
+    ModuleCtx::new(
+        "api_gateway",
+        Uuid::new_v4(),
+        Arc::new(TestConfigProvider {
+            module_config: wrapped_config,
+            app_config,
+        }),
+        hub,
+        tokio_util::sync::CancellationToken::new(),
+        None,
+    )
+}
+
+#[derive(Serialize, Deserialize, ToSchema, Debug, Clone)]
+struct TestResponse {
+    message: String,
+}
+
+/// Test module with various routes for metrics collection
+pub struct MetricsTestModule;
+
+#[async_trait]
+impl Module for MetricsTestModule {
+    async fn init(&self, _ctx: &modkit::ModuleCtx) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl RestApiCapability for MetricsTestModule {
+    fn register_rest(
+        &self,
+        _ctx: &modkit::ModuleCtx,
+        router: axum::Router,
+        openapi: &dyn OpenApiRegistry,
+    ) -> Result<axum::Router> {
+        // Public route that should appear in metrics
+        let router = OperationBuilder::get("/tests/v1/public")
+            .operation_id("test:public")
+            .summary("Public endpoint")
+            .public()
+            .json_response(http::StatusCode::OK, "Success")
+            .handler(get(public_handler))
+            .register(router, openapi);
+
+        // Route that returns 404
+        let router = OperationBuilder::get("/tests/v1/notfound")
+            .operation_id("test:notfound")
+            .summary("Not found endpoint")
+            .public()
+            .json_response(http::StatusCode::NOT_FOUND, "Not found")
+            .handler(get(notfound_handler))
+            .register(router, openapi);
+
+        // Route that returns 500
+        let router = OperationBuilder::get("/tests/v1/error")
+            .operation_id("test:error")
+            .summary("Error endpoint")
+            .public()
+            .json_response(http::StatusCode::INTERNAL_SERVER_ERROR, "Error")
+            .handler(get(error_handler))
+            .register(router, openapi);
+
+        Ok(router)
+    }
+}
+
+async fn public_handler() -> Json<TestResponse> {
+    Json(TestResponse {
+        message: "public".to_owned(),
+    })
+}
+
+async fn notfound_handler() -> (http::StatusCode, Json<TestResponse>) {
+    (
+        http::StatusCode::NOT_FOUND,
+        Json(TestResponse {
+            message: "not found".to_owned(),
+        }),
+    )
+}
+
+async fn error_handler() -> (http::StatusCode, Json<TestResponse>) {
+    (
+        http::StatusCode::INTERNAL_SERVER_ERROR,
+        Json(TestResponse {
+            message: "error".to_owned(),
+        }),
+    )
+}
+
+/// Test module with a parameterized route for cardinality testing
+struct ParameterizedModule;
+
+#[async_trait]
+impl Module for ParameterizedModule {
+    async fn init(&self, _ctx: &modkit::ModuleCtx) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl RestApiCapability for ParameterizedModule {
+    fn register_rest(
+        &self,
+        _ctx: &modkit::ModuleCtx,
+        router: axum::Router,
+        _openapi: &dyn modkit::contracts::OpenApiRegistry,
+    ) -> anyhow::Result<axum::Router> {
+        use axum::routing::get;
+        // Add a route with a path parameter (Axum 0.8 uses {param} syntax)
+        Ok(router.route(
+            "/test/users/{user_id}",
+            get(
+                |axum::extract::Path(user_id): axum::extract::Path<String>| async move {
+                    format!("User {user_id}")
+                },
+            ),
+        ))
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_metrics_endpoint_accessible() {
+    let config = serde_json::json!({
+        "bind_addr": "127.0.0.1:0",
+        "cors_enabled": false,
+        "auth_disabled": true,
+    });
+
+    let api_gateway = api_gateway::ApiGateway::default();
+    let ctx = create_test_module_ctx_with_config(&config, true);
+    api_gateway.init(&ctx).await.expect("Failed to init");
+
+    let module = MetricsTestModule;
+    let router = Router::new();
+    let router = module
+        .register_rest(&ctx, router, &api_gateway)
+        .expect("Failed to register routes");
+
+    let router = api_gateway
+        .rest_finalize(&ctx, router)
+        .expect("Failed to finalize");
+
+    // First, make a test request to generate some metrics
+    let test_req = axum::http::Request::builder()
+        .uri("/test")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create test request");
+
+    let _test_response = tower::ServiceExt::oneshot(router.clone(), test_req)
+        .await
+        .expect("Failed to get test response");
+
+    // Now request the metrics endpoint
+    let req = axum::http::Request::builder()
+        .uri("/metrics")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router, req)
+        .await
+        .expect("Failed to get response");
+
+    assert_eq!(response.status(), http::StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("Failed to convert to string");
+
+    // Should contain Prometheus metrics (prefix + metric name)
+    // Actual metric names: hyperspot_http_requests_duration_seconds (using server.app_name as prefix)
+    // or hyperspot_http_requests_pending
+    assert!(
+        body_str.contains("hyperspot_http_requests") || body_str.contains("# TYPE"),
+        "Body did not contain expected metrics. Body: {body_str}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_metrics_counter_increments() {
+    let config = serde_json::json!({
+        "bind_addr": "127.0.0.1:0",
+        "cors_enabled": false,
+        "auth_disabled": true,
+    });
+
+    let api_gateway = api_gateway::ApiGateway::default();
+    let ctx = create_test_module_ctx_with_config(&config, true);
+    api_gateway.init(&ctx).await.expect("Failed to init");
+
+    let module = MetricsTestModule;
+    let router = Router::new();
+    let router = module
+        .register_rest(&ctx, router, &api_gateway)
+        .expect("Failed to register routes");
+
+    let router = api_gateway
+        .rest_finalize(&ctx, router)
+        .expect("Failed to finalize");
+
+    // Make a request to the public endpoint
+    let req = axum::http::Request::builder()
+        .uri("/tests/v1/public")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router.clone(), req)
+        .await
+        .expect("Failed to get response");
+
+    assert_eq!(response.status(), http::StatusCode::OK);
+
+    // Request metrics
+    let req = axum::http::Request::builder()
+        .uri("/metrics")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router, req)
+        .await
+        .expect("Failed to get response");
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("Failed to convert to string");
+
+    // Should contain metrics - at minimum the # TYPE and # HELP lines
+    // Note: Metrics may not always be present immediately due to how prometheus collects them
+    assert!(body_str.contains("# TYPE") || body_str.contains("# HELP"));
+}
+
+#[tokio::test]
+#[serial]
+async fn test_metrics_histogram_present() {
+    let config = serde_json::json!({
+        "bind_addr": "127.0.0.1:0",
+        "cors_enabled": false,
+        "auth_disabled": true,
+    });
+
+    let api_gateway = api_gateway::ApiGateway::default();
+    let ctx = create_test_module_ctx_with_config(&config, true);
+    api_gateway.init(&ctx).await.expect("Failed to init");
+
+    let module = MetricsTestModule;
+    let router = Router::new();
+    let router = module
+        .register_rest(&ctx, router, &api_gateway)
+        .expect("Failed to register routes");
+
+    let router = api_gateway
+        .rest_finalize(&ctx, router)
+        .expect("Failed to finalize");
+
+    // Make a request
+    let req = axum::http::Request::builder()
+        .uri("/tests/v1/public")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router.clone(), req)
+        .await
+        .expect("Failed to get response");
+
+    assert_eq!(response.status(), http::StatusCode::OK);
+
+    // Request metrics
+    let req = axum::http::Request::builder()
+        .uri("/metrics")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router, req)
+        .await
+        .expect("Failed to get response");
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("Failed to convert to string");
+
+    // Should contain histogram metrics - check for the metric type rather than specific prefix
+    // since Prometheus global registry may persist metrics from previous test runs
+    assert!(
+        body_str.contains("http_requests_duration_seconds"),
+        "Metrics should contain histogram metric (http_requests_duration_seconds with any prefix). Body: {body_str}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_metrics_error_status_codes() {
+    let config = serde_json::json!({
+        "bind_addr": "127.0.0.1:0",
+        "cors_enabled": false,
+        "auth_disabled": true,
+    });
+
+    let api_gateway = api_gateway::ApiGateway::default();
+    let ctx = create_test_module_ctx_with_config(&config, true);
+    api_gateway.init(&ctx).await.expect("Failed to init");
+
+    let module = MetricsTestModule;
+    let router = Router::new();
+    let router = module
+        .register_rest(&ctx, router, &api_gateway)
+        .expect("Failed to register routes");
+
+    let router = api_gateway
+        .rest_finalize(&ctx, router)
+        .expect("Failed to finalize");
+
+    // Make requests with different status codes
+    let req = axum::http::Request::builder()
+        .uri("/tests/v1/notfound")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router.clone(), req)
+        .await
+        .expect("Failed to get response");
+
+    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+
+    let req = axum::http::Request::builder()
+        .uri("/tests/v1/error")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router.clone(), req)
+        .await
+        .expect("Failed to get response");
+
+    assert_eq!(response.status(), http::StatusCode::INTERNAL_SERVER_ERROR);
+
+    // Request metrics
+    let req = axum::http::Request::builder()
+        .uri("/metrics")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router, req)
+        .await
+        .expect("Failed to get response");
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("Failed to convert to string");
+
+    // Metrics should track different status codes
+    // At minimum should have prometheus format
+    assert!(body_str.contains("# TYPE") || body_str.contains("# HELP"));
+}
+
+#[tokio::test]
+async fn test_metrics_disabled_route_not_registered() {
+    let config = serde_json::json!({
+        "bind_addr": "127.0.0.1:0",
+        "cors_enabled": false,
+        "auth_disabled": true,
+    });
+
+    let api_gateway = api_gateway::ApiGateway::default();
+    let ctx = create_test_module_ctx_with_config(&config, false);
+    api_gateway.init(&ctx).await.expect("Failed to init");
+
+    let module = MetricsTestModule;
+    let router = Router::new();
+    let router = module
+        .register_rest(&ctx, router, &api_gateway)
+        .expect("Failed to register routes");
+
+    let router = api_gateway
+        .rest_finalize(&ctx, router)
+        .expect("Failed to finalize");
+
+    // Request the metrics endpoint (should not be registered when disabled)
+    let req = axum::http::Request::builder()
+        .uri("/metrics")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router, req)
+        .await
+        .expect("Failed to get response");
+
+    // Should return 404 since the route is not registered
+    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_metrics_uses_route_patterns_not_raw_urls() {
+    // CRITICAL TEST: Verify endpoint label uses route patterns (low cardinality)
+    // rather than raw URLs (high cardinality explosion risk)
+
+    let config = serde_json::json!({
+        "bind_addr": "127.0.0.1:0",
+        "cors_enabled": false,
+        "auth_disabled": true,
+    });
+
+    let api_gateway = api_gateway::ApiGateway::default();
+    let ctx = create_test_module_ctx_with_config(&config, true);
+    api_gateway.init(&ctx).await.expect("Failed to init");
+
+    let module = ParameterizedModule;
+    let router = Router::new();
+    let router = module
+        .register_rest(&ctx, router, &api_gateway)
+        .expect("Failed to register routes");
+
+    let router = api_gateway
+        .rest_finalize(&ctx, router)
+        .expect("Failed to finalize");
+
+    // Make requests with DIFFERENT user IDs to test cardinality
+    let user_ids = ["123", "456", "789", "abc", "xyz"];
+
+    for user_id in &user_ids {
+        let req = axum::http::Request::builder()
+            .uri(format!("/test/users/{user_id}"))
+            .method("GET")
+            .body(axum::body::Body::empty())
+            .expect("Failed to create request");
+
+        let response = tower::ServiceExt::oneshot(router.clone(), req)
+            .await
+            .expect("Failed to get response");
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+    }
+
+    // Now fetch metrics
+    let req = axum::http::Request::builder()
+        .uri("/metrics")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router, req)
+        .await
+        .expect("Failed to get response");
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("Failed to convert to string");
+
+    // CRITICAL ASSERTIONS: Verify cardinality safety
+
+    // Print a sample of the metrics to document label format
+    eprintln!("\n=== SAMPLE METRICS OUTPUT (for documentation) ===");
+    for line in body_str.lines().take(20) {
+        if line.contains("/test/users") {
+            eprintln!("{line}");
+        }
+    }
+    eprintln!("=================================================\n");
+
+    // Should contain the route PATTERN with parameter placeholder
+    // Axum 0.8+ uses {param} syntax: /test/users/{user_id}
+    let contains_pattern = body_str.contains("/test/users/{user_id}")
+        || body_str.contains("endpoint=\"/test/users/{user_id}\"");
+
+    // Should NOT contain individual user IDs as separate endpoints
+    let contains_raw_ids = user_ids
+        .iter()
+        .any(|id| body_str.contains(&format!("/test/users/{id}\"")));
+
+    assert!(
+        contains_pattern,
+        "Metrics should use route pattern (e.g., /test/users/{{user_id}}), not raw URLs. \
+         This is CRITICAL for preventing cardinality explosion!"
+    );
+
+    assert!(
+        !contains_raw_ids,
+        "Metrics MUST NOT contain individual user IDs (123, 456, etc.) as separate endpoints. \
+         Found raw IDs in metrics, which will cause cardinality explosion!"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_metrics_custom_prefix_config() {
+    // This test verifies that custom app_name is used as the metrics prefix.
+    // Note: Due to Prometheus using a global registry and set_prefix() needing to be called
+    // before ANY metrics are registered, testing multiple prefixes in the same test suite
+    // is not feasible. This test verifies the configuration is parsed and accepted.
+
+    let custom_app_name = "my_custom_gateway";
+    let config = serde_json::json!({
+        "bind_addr": "127.0.0.1:0",
+        "cors_enabled": false,
+        "auth_disabled": true,
+    });
+
+    let api_gateway = api_gateway::ApiGateway::default();
+    let ctx = create_test_module_ctx_with_app_name(&config, true, custom_app_name);
+
+    // Should initialize without errors
+    api_gateway
+        .init(&ctx)
+        .await
+        .expect("Failed to init with custom prefix");
+
+    let module = MetricsTestModule;
+    let router = Router::new();
+    let router = module
+        .register_rest(&ctx, router, &api_gateway)
+        .expect("Failed to register routes");
+
+    let router = api_gateway
+        .rest_finalize(&ctx, router)
+        .expect("Failed to finalize");
+
+    // Make a request to generate metrics
+    let req = axum::http::Request::builder()
+        .uri("/tests/v1/public")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router.clone(), req)
+        .await
+        .expect("Failed to get response");
+
+    assert_eq!(response.status(), http::StatusCode::OK);
+
+    // Request metrics endpoint
+    let req = axum::http::Request::builder()
+        .uri("/metrics")
+        .method("GET")
+        .body(axum::body::Body::empty())
+        .expect("Failed to create request");
+
+    let response = tower::ServiceExt::oneshot(router, req)
+        .await
+        .expect("Failed to get response");
+
+    // Metrics endpoint should still be accessible with custom prefix config
+    assert_eq!(response.status(), http::StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("Failed to read body");
+    let body_str = String::from_utf8(body.to_vec()).expect("Failed to convert to string");
+
+    // Should contain Prometheus metrics (either prefix due to global registry)
+    assert!(
+        body_str.contains("# TYPE") && body_str.contains("# HELP"),
+        "Metrics endpoint should return Prometheus format data"
+    );
+}


### PR DESCRIPTION
Implements HTTP metrics collection for API Gateway to enable monitoring and observability through Prometheus. Metrics are exposed at /api/api-gateway/v1/metrics endpoint in Prometheus text format.

Features:
- Feature-gated behind 'prometheus-metrics' flag for optional compilation
- Runtime toggle via configuration (prometheus.enabled)
- Collects request counters, latency histograms, and in-flight gauges
- All metrics include method, endpoint, and status code labels
- Public endpoint (no authentication required) for Prometheus scraping
- Comprehensive integration tests

Metrics exposed:
- hyperspot_api_gateway_axum_http_request_total (counter)
- hyperspot_api_gateway_axum_http_requests_duration_seconds (histogram)
- hyperspot_api_gateway_axum_http_requests_pending (gauge)

Implementation uses prometheus-axum-middleware for low-overhead collection with middleware integration after TraceLayer to capture route information.

Resolves #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-gated Prometheus metrics for the API Gateway: configurable metrics layer, activation toggle, and a /metrics endpoint.
  * New server config options: app-name and Prometheus enablement with validation and default values.
  * Optional instrumentation dependencies added to enable Prometheus integration.

* **Tests**
  * Extensive tests covering metrics exposure, route-labeling, status-code tracking, cardinality safety, and config-driven enable/disable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->