### PR TITLE
docs(spec-templates): add UPSTREAM_REQS template and document it

### DIFF
--- a/docs/spec-templates/README.md
+++ b/docs/spec-templates/README.md
@@ -34,6 +34,7 @@ Templates work standalone or can be enhanced with FDD annotations (`fdd-id`) for
 | Template | Purpose | Layer |
 |----------|---------|-------|
 | [PRD.md](./PRD.md) | Product Requirements Document — vision, actors, capabilities, use cases, FR, NFR | Foundation |
+| [UPSTREAM_REQS.md](./UPSTREAM_REQS.md) | Upstream Requirements — technical requirements FROM other modules TO this module | Integration |
 | [DESIGN.md](./DESIGN.md) | Technical Design — architecture, principles, constraints, domain model, API contracts | System-level |
 | [ADR.md](./ADR.md) | Architecture Decision Record — capture decisions, options, trade-offs, consequences | Cross-cutting |
 | [FEATURE.md](./FEATURE.md) | Feature Specification — flows, algorithms, states, requirements (FDL format) | Feature-level |
@@ -64,6 +65,20 @@ Standards alignment:
   - ISO/IEC 15288 / 12207 (requirements definition)
 
 Note: Stakeholder needs (per ISO 29148) managed at project/task level by steering committee.
+
+### UPSTREAM_REQS.md
+**Per upstream module** (repeat for each upstream module):
+1. **UPSTREAM: {upstream module name}** — H1 section for each upstream module
+2. **System Actor Definition** — How the upstream module interacts with target module
+3. **Functional Requirements** — Capabilities the target module must provide
+4. **Non-Functional Requirements** — NFRs imposed by upstream module
+5. **Public Interface Requirements** — Interfaces that must be exposed
+
+Standards alignment:
+  - IEEE 830 / ISO/IEC/IEEE 29148:2018 (requirements specification)
+  - ISO/IEC 15288 / 12207 (interface requirements)
+
+Note: Optional document. UPSTREAM_REQS captures what OTHER modules need FROM this module. Each upstream module gets its own H1 section. Use when upstream requirements are known before the module's PRD is complete, or for API-first design.
 
 ### DESIGN.md
 1. **Architecture Overview** — Vision, drivers (functional + NFR allocation table), layers
@@ -109,6 +124,28 @@ Standards alignment:
 Architecture Decision Records capture **why** a technical decision was made, not just what was decided. Each ADR documents the context, problem statement, considered options, and the chosen solution with its trade-offs. This creates an institutional memory that prevents re-debating settled decisions and helps new team members understand the rationale behind the architecture.
 
 Use ADRs only when there was a meaningful discussion/debate and the rationale needs to be preserved as a historical decision record. Use ADRs for real decision dilemmas and final decision state. Decision history is in git; keep one ADR per decision.
+
+### About Upstream Requirements (UPSTREAM_REQS.md)
+
+Upstream Requirements documents are optional and capture technical requirements **imposed ON** a module **BY** other modules (consumers, dependencies, surrounding systems). This creates an external perspective complementing the internal perspective of PRD.md.
+
+**Key differences from PRD:**
+- **PRD.md**: "What does THIS module do?" (internal goals and capabilities)
+- **UPSTREAM_REQS.md**: "What do OTHER modules need FROM this module?" (external obligations)
+
+**When to use:**
+- **Early-stage development**: Upstream needs are known before the module's full PRD exists
+- **API-first design**: Consumers define interface requirements before implementation
+- **Integration planning**: Capture cross-module dependencies explicitly
+- **Incremental development**: Build features driven by actual consumer needs rather than speculation
+
+**Structure benefits:**
+- Requirements grouped by source module for clear ownership
+- Each upstream module has its own section with actors, FRs, NFRs, and interfaces
+- Cross-module requirements section for shared needs
+- Integration contract matrix for visibility across all consumers
+
+A single UPSTREAM_REQS.md can contain requirements from multiple upstream modules, making it a central integration point for the target module.
 
 ### About Feature Files (features/*.md)
 

--- a/docs/spec-templates/UPSTREAM_REQS.md
+++ b/docs/spec-templates/UPSTREAM_REQS.md
@@ -1,0 +1,137 @@
+# UPSTREAM_REQS — {Target Module Name}
+
+<!--
+=============================================================================
+UPSTREAM REQUIREMENTS DOCUMENT
+=============================================================================
+PURPOSE: Optional document to capture technical requirements IMPOSED
+ON this module BY upstream modules (dependencies, consumers, surrounding systems).
+
+CONTEXT: When a module is being designed or its PRD is still emerging,
+upstream modules may need specific capabilities from it. This document
+captures those requirements from the perspective of upstream modules.
+
+SCOPE:
+  ✓ Requirements FROM upstream modules TO this module
+  ✓ Public interfaces this module must expose
+  ✓ Functional requirements imposed by upstream consumers
+  ✓ Non-functional requirements from upstream dependencies
+  ✓ Integration contracts this module must fulfill
+
+STRUCTURE:
+  - Each upstream module has its own section
+  - Requirements are grouped by upstream module source
+  - Clear ownership: each requirement states which module needs it
+
+RELATIONSHIP TO OTHER DOCS:
+  - PRD.md: Defines what THIS module does (internal perspective)
+  - UPSTREAM_REQS.md: Defines what OTHERS need from THIS module (external perspective)
+  - DESIGN.md: Technical implementation of both sets of requirements
+
+USE CASES:
+  - Early-stage development: upstream needs known before full PRD exists
+  - API-first design: consumers define interface requirements
+  - Integration planning: capture cross-module dependencies
+  - Incremental development: build features driven by actual consumer needs
+
+STANDARDS ALIGNMENT:
+  - IEEE 830 / ISO/IEC/IEEE 29148:2018 (requirements specification)
+  - ISO/IEC 15288 / 12207 (interface requirements)
+
+REQUIREMENT LANGUAGE:
+  - Use "MUST" or "SHALL" for mandatory requirements (implicit default)
+  - Do not use "SHOULD" or "MAY" — use priority p2/p3 instead
+  - Be specific and clear; no fluff, bloat, duplication, or emoji
+=============================================================================
+-->
+
+# UPSTREAM: {name of the upstream module from which requirements are imposed}
+
+## System Actor Definition
+
+**ID**: `fdd-{target-module}-upstream-actor-{slug}`
+
+**Role**: {Description of how the upstream module interacts with target module}
+**Integration Pattern**: {e.g., REST API client, SDK consumer, Event subscriber, Direct library import}
+
+## Functional Requirements
+
+Requirements that the upstream module needs the target module to fulfill.
+
+### {Requirement Name}
+
+- [ ] `p1` - **ID**: `fdd-{target-module}-upstream-req-{slug}`
+
+The target module **MUST** {specific capability or behavior needed by upstream}.
+
+**Rationale**: {Why the upstream module needs this capability}
+**Use Case**: {How the upstream module will use this capability}
+**Integration Point**: {e.g., REST endpoint, SDK method, Event topic}
+
+### {Another Requirement}
+
+- [ ] `p2` - **ID**: `fdd-{target-module}-upstream-req-{slug}`
+
+The target module **MUST** {another specific requirement}.
+
+**Rationale**: {Why this is needed}
+**Use Case**: {Usage scenario}
+
+## Non-Functional Requirements
+
+NFRs that the upstream module requires from the target module.
+
+### {NFR Name}
+
+- [ ] `p1` - **ID**: `fdd-{target-module}-upstream-nfr-{slug}`
+
+The target module **MUST** {measurable NFR with specific thresholds}.
+
+**Threshold**: {Quantitative target with units, e.g., "respond within 100ms at p95"}
+**Rationale**: {Why this NFR is required by upstream}
+**Impact on Upstream**: {What happens if this NFR is not met}
+
+## Public Interface Requirements
+
+Interfaces that must be exposed to the upstream module.
+
+### {Interface Name}
+
+- [ ] `p1` - **ID**: `fdd-{target-module}-upstream-interface-{slug}`
+
+**Type**: {REST API | gRPC | SDK method | Event | Data format}
+**Stability Required**: {stable | unstable acceptable}
+**Contract**: {Detailed interface contract or link to OpenAPI spec}
+
+**Description**: {What this interface must provide}
+**Input**: {Expected input parameters/format}
+**Output**: {Expected output/response}
+**Error Handling**: {Required error scenarios and responses}
+
+---
+
+# UPSTREAM: {name of the upstream module from which requirements are imposed}
+
+## System Actor Definition
+...
+
+## Functional Requirements
+...
+
+### {Requirement Name}
+...
+
+### {Another Requirement}
+...
+
+## Non-Functional Requirements
+...
+
+### {NFR Name}
+...
+
+## Public Interface Requirements
+...
+
+### {Interface Name}
+...


### PR DESCRIPTION
Added docs/spec-templates/UPSTREAM_REQS.md as a new optional template for capturing technical requirements imposed on a target module by upstream modules (consumers/dependencies).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new template and comprehensive documentation for capturing upstream requirements, including standardized structure for documenting functional, non-functional, and interface requirements from upstream modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->