### PR TITLE
cleartext sensitive info in sqlitetest.rs

### DIFF
--- a/libs/modkit-db/tests/sqlite/sqlite_tests.rs
+++ b/libs/modkit-db/tests/sqlite/sqlite_tests.rs
@@ -380,7 +380,10 @@ async fn test_wal_pragma_validation() {
                 // Valid WAL value - connection should succeed
             }
             Err(err) => {
-                panic!("Expected successful connection with WAL value '{wal_value}', got: {err:?}");
+                panic!(
+                    "Expected successful connection with WAL value '{wal_value}', error type: {}",
+                    std::any::type_name_of_val(&err)
+                );
             }
         }
     }
@@ -449,7 +452,8 @@ async fn test_busy_timeout_pragma_validation() {
             }
             Err(err) => {
                 panic!(
-                    "Expected successful connection with timeout '{timeout_value}', got: {err:?}"
+                    "Expected successful connection with timeout '{timeout_value}', got: error type: {}",
+                    std::any::type_name_of_val(&err)
                 );
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved SQLite pragma tests (WAL and busy_timeout) with clearer failure diagnostics: when an unexpected connection error occurs the failure message now reports the concrete error type (rather than raw debug output). No behavioral changes—only clearer, more actionable test messages and minor formatting refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->