### PR TITLE
docs: rename HyperSpot to Cyber Fabric in authorization docs and add MFA open question

### DIFF
--- a/docs/arch/authorization/ADR/0001-pdp-pep-authorization-model.md
+++ b/docs/arch/authorization/ADR/0001-pdp-pep-authorization-model.md
@@ -8,27 +8,27 @@ decision-makers: Cyber Fabric Architects Committee
 
 ## Context and Problem Statement
 
-HyperSpot is a modular platform for building multi-tenant vendor platforms. Each vendor has its own identity provider (IdP), authorization model, tenant service, and policy manager. HyperSpot must integrate with these vendor-specific systems without assuming a particular policy model (RBAC/ABAC/ReBAC).
+Cyber Fabric is a modular platform for building multi-tenant vendor platforms. Each vendor has its own identity provider (IdP), authorization model, tenant service, and policy manager. Cyber Fabric must integrate with these vendor-specific systems without assuming a particular policy model (RBAC/ABAC/ReBAC).
 
 **Key requirements:**
 
-1. **Performance at scale** — Authorization must be efficient for all operations, including mass-management scenarios in multi-tenant environments (bulk updates, cross-tenant queries, hierarchical access). Access check complexity varies by vendor and should not bottleneck HyperSpot.
+1. **Performance at scale** — Authorization must be efficient for all operations, including mass-management scenarios in multi-tenant environments (bulk updates, cross-tenant queries, hierarchical access). Access check complexity varies by vendor and should not bottleneck Cyber Fabric.
 
-2. **Simplicity for module developers** — Authorization enforcement must be hard to get wrong. Authorization logic in modules should be minimal — ideally just "ask PDP, apply response". Complex policy evaluation belongs in vendor's PDP, not in HyperSpot code (even shared libraries are costly to update across deployments).
+2. **Simplicity for module developers** — Authorization enforcement must be hard to get wrong. Authorization logic in modules should be minimal — ideally just "ask PDP, apply response". Complex policy evaluation belongs in vendor's PDP, not in Cyber Fabric code (even shared libraries are costly to update across deployments).
 
-3. **Seamless vendor integration** — HyperSpot must integrate into vendor's existing infrastructure without requiring significant changes on their side:
-   - **No resource sync** — Resources stay in HyperSpot's DB; vendors don't need to replicate millions of resources or all their relationships to their authorization service
-   - **No policy format requirements** — Vendors keep their existing policy storage (RBAC tables, ReBAC tuples, custom DSL); HyperSpot only defines the response contract
+3. **Seamless vendor integration** — Cyber Fabric must integrate into vendor's existing infrastructure without requiring significant changes on their side:
+   - **No resource sync** — Resources stay in Cyber Fabric's DB; vendors don't need to replicate millions of resources or all their relationships to their authorization service
+   - **No policy format requirements** — Vendors keep their existing policy storage (RBAC tables, ReBAC tuples, custom DSL); Cyber Fabric only defines the response contract
    - **Leverage existing infrastructure** — Works with vendor's IdP, tenant service, and policy manager as-is
 
 ### PDP/PEP Architecture Model
 
 Industry best practices (NIST SP 800-162, XACML, AuthZEN) recommend separating authorization into:
 
-- **PDP (Policy Decision Point)** — Evaluates policies and returns access decisions. In HyperSpot, this is the vendor's authorization service accessed via AuthZ Resolver gateway.
-- **PEP (Policy Enforcement Point)** — Enforces PDP decisions at resource access points. In HyperSpot, domain modules act as PEPs, with ModKit providing shared enforcement infrastructure.
-- **PAP (Policy Administration Point)** — Where policies are authored and managed. This is entirely vendor-controlled (their admin UI, policy DSL, etc.). HyperSpot never sees or stores policies.
-- **PIP (Policy Information Point)** — Provides additional attributes for decision-making (user roles, tenant hierarchy, resource metadata). In HyperSpot, Tenant Resolver and Resource Group Resolver serve as PIPs.
+- **PDP (Policy Decision Point)** — Evaluates policies and returns access decisions. In Cyber Fabric, this is the vendor's authorization service accessed via AuthZ Resolver gateway.
+- **PEP (Policy Enforcement Point)** — Enforces PDP decisions at resource access points. In Cyber Fabric, domain modules act as PEPs, with ModKit providing shared enforcement infrastructure.
+- **PAP (Policy Administration Point)** — Where policies are authored and managed. This is entirely vendor-controlled (their admin UI, policy DSL, etc.). Cyber Fabric never sees or stores policies.
+- **PIP (Policy Information Point)** — Provides additional attributes for decision-making (user roles, tenant hierarchy, resource metadata). In Cyber Fabric, Tenant Resolver and Resource Group Resolver serve as PIPs.
 
 Benefits of PDP/PEP separation:
 
@@ -37,7 +37,7 @@ Benefits of PDP/PEP separation:
 - Separation of concerns (business logic vs authorization logic)
 - Easier security audits and compliance
 
-HyperSpot modules act as PEPs; AuthZ Resolver integrates with vendor's PDP; Tenant/RG Resolvers act as PIPs.
+Cyber Fabric modules act as PEPs; AuthZ Resolver integrates with vendor's PDP; Tenant/RG Resolvers act as PIPs.
 
 ## Decision Drivers
 
@@ -100,7 +100,7 @@ Each module implements its own authorization logic: extracts permissions/roles f
 - Bad, because authorization logic scattered across modules — hard to audit, easy to make mistakes
 - Bad, because each module must understand and correctly implement policy evaluation
 - Bad, because inconsistent enforcement across modules, difficult compliance audits
-- Bad, because complex authorization logic lives in HyperSpot (even if in shared library — bugs, versioning, update rollout across deployments)
+- Bad, because complex authorization logic lives in Cyber Fabric (even if in shared library — bugs, versioning, update rollout across deployments)
 
 ### Option B: Google Zanzibar / ReBAC
 
@@ -192,7 +192,7 @@ Option E provides a cleaner contract between PDP and PEP with less implementatio
   - OPA Documentation: https://www.openpolicyagent.org/docs/latest/
 - **Option E** (AuthZEN + Constraints - CHOSEN):
   - OpenID AuthZEN 1.0 (base): https://openid.net/specs/authorization-api-1_0.html
-  - HyperSpot constraint extension: [`DESIGN.md`](../DESIGN.md)
+  - Cyber Fabric constraint extension: [`DESIGN.md`](../DESIGN.md)
 
 **Prior Art (Data Filtering / Query-time Authorization):**
 

--- a/docs/arch/authorization/ADR/0002-split-authn-authz-resolvers.md
+++ b/docs/arch/authorization/ADR/0002-split-authn-authz-resolvers.md
@@ -8,7 +8,7 @@ decision-makers: Vasily
 
 ## Context and Problem Statement
 
-HyperSpot requires integration with vendor-specific identity and authorization infrastructure. This integration involves two distinct concerns:
+Cyber Fabric requires integration with vendor-specific identity and authorization infrastructure. This integration involves two distinct concerns:
 
 1. **Authentication (AuthN)** — Token validation (JWT signature verification, introspection), JWKS management, claim extraction, and SecurityContext production
 2. **Authorization (AuthZ)** — Policy Decision Point (PDP) functionality, policy evaluation, and constraint generation for Policy Enforcement Points (PEPs)
@@ -18,7 +18,7 @@ These are conceptually separate responsibilities governed by different standards
 - **AuthN** — OpenID Connect Core 1.0, RFC 7519 (JWT), RFC 7662 (Token Introspection)
 - **AuthZ** — OpenID AuthZEN Authorization API 1.0, NIST SP 800-162 (PDP/PEP model)
 
-**Key architectural question:** Should HyperSpot use a single unified resolver module (Auth Resolver) that handles both AuthN and AuthZ, or should these be split into two independent gateway modules (AuthN Resolver and AuthZ Resolver)?
+**Key architectural question:** Should Cyber Fabric use a single unified resolver module (Auth Resolver) that handles both AuthN and AuthZ, or should these be split into two independent gateway modules (AuthN Resolver and AuthZ Resolver)?
 
 This decision impacts deployment flexibility, vendor integration patterns, security boundaries, caching strategies, and component reusability.
 

--- a/docs/arch/authorization/ADR/0003-authn-resolver-minimalist-interface.md
+++ b/docs/arch/authorization/ADR/0003-authn-resolver-minimalist-interface.md
@@ -21,7 +21,7 @@ Different IdPs use different protocols and token formats:
 
 ## Decision Drivers
 
-- **Vendor Neutrality** — HyperSpot must integrate with any vendor's IdP without assuming specific protocols
+- **Vendor Neutrality** — Cyber Fabric must integrate with any vendor's IdP without assuming specific protocols
 - **Plugin Flexibility** — Plugins should choose validation strategies based on their IdP's capabilities
 - **Separation of Concerns** — Gateway defines *what* authentication produces, plugins define *how* tokens are validated
 - **Caching Autonomy** — Different validation methods have different caching strategies (JWKS caching vs introspection result caching)

--- a/docs/arch/authorization/AUTHN_JWT_OIDC_PLUGIN.md
+++ b/docs/arch/authorization/AUTHN_JWT_OIDC_PLUGIN.md
@@ -10,7 +10,7 @@ This document describes the **reference implementation** of an AuthN Resolver pl
 
 **Scope:** This is ONE possible implementation of the `AuthNResolverPluginClient` trait. Vendors may implement different authentication strategies (mTLS, API keys, custom protocols) without following this design.
 
-**Use case:** This plugin is suitable for vendors with standard OIDC-compliant Identity Providers that issue JWTs and support token introspection. It ships as part of HyperSpot's standard distribution and can be configured for most OAuth 2.0 / OIDC providers.
+**Use case:** This plugin is suitable for vendors with standard OIDC-compliant Identity Providers that issue JWTs and support token introspection. It ships as part of Cyber Fabric's standard distribution and can be configured for most OAuth 2.0 / OIDC providers.
 
 **Standards:**
 - [RFC 7519: JSON Web Token (JWT)](https://datatracker.ietf.org/doc/html/rfc7519)
@@ -381,7 +381,7 @@ Discovered introspection endpoint URLs caching (per-issuer).
 
 ## OpenID Connect Integration
 
-HyperSpot leverages OpenID Connect standards for authentication:
+Cyber Fabric leverages OpenID Connect standards for authentication:
 
 - **JWT validation** per OpenID Connect Core 1.0 — signature verification, claim validation
 - **Discovery** via `.well-known/openid-configuration` (OpenID Connect Discovery 1.0) — automatic endpoint configuration
@@ -392,7 +392,7 @@ HyperSpot leverages OpenID Connect standards for authentication:
 
 The `trusted_issuers` map is required for JWT validation. This separation exists because:
 
-1. **Trust anchor** — HyperSpot must know which issuers to trust before receiving tokens
+1. **Trust anchor** — Cyber Fabric must know which issuers to trust before receiving tokens
 2. **Flexible mapping** — `iss` claim may differ from discovery URL (e.g., custom identifiers)
 3. **Bootstrap problem** — to validate JWT, we need JWKS; to get JWKS, we need discovery URL
 
@@ -421,7 +421,7 @@ jwt:
 
 ### Discovery
 
-Discovery is performed lazily on the first authenticated request (not at startup). HyperSpot fetches the OpenID configuration from `{issuer}/.well-known/openid-configuration` and extracts:
+Discovery is performed lazily on the first authenticated request (not at startup). Cyber Fabric fetches the OpenID configuration from `{issuer}/.well-known/openid-configuration` and extracts:
 
 - `jwks_uri` — for fetching signing keys
 - `introspection_endpoint` — for opaque token validation (optional)

--- a/docs/arch/authorization/RESOURCE_GROUP_MODEL.md
+++ b/docs/arch/authorization/RESOURCE_GROUP_MODEL.md
@@ -1,6 +1,6 @@
 # Resource Group Model
 
-This document describes HyperSpot's resource group model for authorization: group topology, membership mechanisms, and how groups are used in access control.
+This document describes Cyber Fabric's resource group model for authorization: group topology, membership mechanisms, and how groups are used in access control.
 
 ## Table of Contents
 
@@ -19,7 +19,7 @@ This document describes HyperSpot's resource group model for authorization: grou
 
 ## Overview
 
-HyperSpot uses **resource groups** as an optional organizational layer for grouping resources. The primary purpose is **access control** — granting permissions at the group level rather than per-resource.
+Cyber Fabric uses **resource groups** as an optional organizational layer for grouping resources. The primary purpose is **access control** — granting permissions at the group level rather than per-resource.
 
 Vendors may implement various group types depending on their domain. Examples include:
 
@@ -28,7 +28,7 @@ Vendors may implement various group types depending on their domain. Examples in
 - Folders (document organization with nesting)
 - Teams, Departments, Campaigns, etc.
 
-The specific group types and their semantics are vendor-defined. HyperSpot provides the infrastructure for hierarchical grouping and membership resolution without prescribing what groups represent.
+The specific group types and their semantics are vendor-defined. Cyber Fabric provides the infrastructure for hierarchical grouping and membership resolution without prescribing what groups represent.
 
 ```
 Tenant T1
@@ -80,9 +80,9 @@ Tenant T2:
 
 ## Resource Group Properties
 
-Resource groups are stored on the **vendor side** (in the vendor's Resource Group service). HyperSpot does not store the full group entity — only local projections for authorization (closure and membership tables).
+Resource groups are stored on the **vendor side** (in the vendor's Resource Group service). Cyber Fabric does not store the full group entity — only local projections for authorization (closure and membership tables).
 
-The following properties are the **minimum** HyperSpot expects from the vendor's group model:
+The following properties are the **minimum** Cyber Fabric expects from the vendor's group model:
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -90,7 +90,7 @@ The following properties are the **minimum** HyperSpot expects from the vendor's
 | `tenant_id` | UUID | Owning tenant (groups are tenant-scoped) |
 | `parent_id` | UUID? | Parent group (NULL for root groups) |
 
-Vendors typically maintain additional fields (name, description, type, status, metadata, etc.) in their own systems. HyperSpot's RG Resolver plugin syncs only the hierarchy structure needed for authorization.
+Vendors typically maintain additional fields (name, description, type, status, metadata, etc.) in their own systems. Cyber Fabric's RG Resolver plugin syncs only the hierarchy structure needed for authorization.
 
 ---
 

--- a/docs/arch/authorization/TENANT_MODEL.md
+++ b/docs/arch/authorization/TENANT_MODEL.md
@@ -1,6 +1,6 @@
 # Tenant Model
 
-This document describes HyperSpot's multi-tenancy model, tenant topology, and isolation mechanisms.
+This document describes Cyber Fabric's multi-tenancy model, tenant topology, and isolation mechanisms.
 
 ## Table of Contents
 
@@ -19,7 +19,7 @@ This document describes HyperSpot's multi-tenancy model, tenant topology, and is
 
 ## Overview
 
-HyperSpot uses a **hierarchical multi-tenancy** model where tenants form a forest (multiple independent trees). Each tenant can have child tenants, creating organizational structures like:
+Cyber Fabric uses a **hierarchical multi-tenancy** model where tenants form a forest (multiple independent trees). Each tenant can have child tenants, creating organizational structures like:
 
 ```
 Vendor
@@ -179,7 +179,7 @@ Many operations need to query "all resources in tenant T and its children". This
 | Explicit ID list from PDP | Simple SQL | Doesn't scale (thousands of IDs) |
 | Closure table | O(1) JOIN, scales well | Requires sync, storage overhead |
 
-HyperSpot recommends **closure tables** for production deployments with hierarchical tenants.
+Cyber Fabric recommends **closure tables** for production deployments with hierarchical tenants.
 
 **Tenant scope parameters (in `context.tenant_context`):**
 


### PR DESCRIPTION
- Rename all "HyperSpot" references to "Cyber Fabric" across authorization architecture docs and ADRs
- Add open question on MFA support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authorization architecture documentation, including design guides, architecture decision records, and reference models to reflect current branding terminology throughout authentication, authorization, resource group, and tenant configuration descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->