### PR TITLE
chore(cypilot): align make target name for artifact validation

### DIFF
--- a/.cypilot-adapter/kits/cf-sdlc/artifacts/ADR/rules.md
+++ b/.cypilot-adapter/kits/cf-sdlc/artifacts/ADR/rules.md
@@ -27,5 +27,5 @@ ADR IDs MUST be referenced from DESIGN (ensure the DESIGN includes backtick refe
 ## Validation Checklist
 
 - [ ] `python3 {cypilot_path}/skills/cypilot/scripts/cypilot.py validate --artifact <path>`
-- [ ] `make validate-artifacts`
+- [ ] `make validate-cypilot-artifacts`
 - [ ] Review against `docs/checklists/ADR.md`

--- a/.cypilot-adapter/kits/cf-sdlc/artifacts/DECOMPOSITION/rules.md
+++ b/.cypilot-adapter/kits/cf-sdlc/artifacts/DECOMPOSITION/rules.md
@@ -35,5 +35,5 @@ Each `feature` ID is expected to be covered by FEATURE artifacts according to co
 ## Validation Checklist
 
 - [ ] `python3 {cypilot_path}/skills/cypilot/scripts/cypilot.py validate --artifact <path>`
-- [ ] `make validate-artifacts`
+- [ ] `make validate-cypilot-artifacts`
 - [ ] Review against `docs/checklists/DECOMPOSITION.md`.

--- a/.cypilot-adapter/kits/cf-sdlc/artifacts/DESIGN/rules.md
+++ b/.cypilot-adapter/kits/cf-sdlc/artifacts/DESIGN/rules.md
@@ -35,5 +35,5 @@ ADR IDs MUST be referenced from DESIGN (i.e., DESIGN should include backtick ref
 ## Validation Checklist
 
 - [ ] `python3 {cypilot_path}/skills/cypilot/scripts/cypilot.py validate --artifact <path>`
-- [ ] `make validate-artifacts`
+- [ ] `make validate-cypilot-artifacts`
 - [ ] Review against `docs/checklists/DESIGN.md`.

--- a/.cypilot-adapter/kits/cf-sdlc/artifacts/FEATURE/rules.md
+++ b/.cypilot-adapter/kits/cf-sdlc/artifacts/FEATURE/rules.md
@@ -37,5 +37,5 @@ Optional ID kinds allowed in FEATURE:
 ## Validation Checklist
 
 - [ ] `python3 {cypilot_path}/skills/cypilot/scripts/cypilot.py validate --artifact <path>`
-- [ ] `make validate-artifacts`
+- [ ] `make validate-cypilot-artifacts`
 - [ ] Review against `docs/checklists/FEATURE.md`.

--- a/.cypilot-adapter/kits/cf-sdlc/artifacts/PRD/rules.md
+++ b/.cypilot-adapter/kits/cf-sdlc/artifacts/PRD/rules.md
@@ -42,5 +42,5 @@ PRD MUST NOT reference IDs from prohibited artifact kinds using backticks:
 ## Validation Checklist
 
 - [ ] `python3 {cypilot_path}/skills/cypilot/scripts/cypilot.py validate --artifact <path>`
-- [ ] `make validate-artifacts`
+- [ ] `make validate-cypilot-artifacts`
 - [ ] Review against `docs/checklists/PRD.md`.

--- a/.github/workflows/cypilot.yml
+++ b/.github/workflows/cypilot.yml
@@ -36,4 +36,4 @@ jobs:
           python-version: '3.11'
 
       - name: Validate artifacts
-        run: make validate-artifacts
+        run: make validate-cypilot-artifacts

--- a/Makefile
+++ b/Makefile
@@ -110,9 +110,9 @@ clippy:
 	$(call check_rustup_component,clippy)
 	cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf
 
-.PHONY: validate-artifacts
+.PHONY: validate-cypilot-artifacts
 
-validate-artifacts:
+validate-cypilot-artifacts:
 	@if git -C .cypilot rev-parse --is-inside-work-tree >/dev/null 2>&1 && git -C .cypilot symbolic-ref -q HEAD >/dev/null 2>&1; then \
 		echo "Skipping .cypilot update (branch checkout detected)"; \
 	else \
@@ -446,5 +446,5 @@ build:
 	cargo +stable build --release
 
 # Run all necessary quality checks and tests and then build the release binary
-all: build check validate-artifacts test-sqlite e2e-local
+all: build check validate-cypilot-artifacts test-sqlite e2e-local
 	@echo "consider to run 'make test-db' as well"


### PR DESCRIPTION
rename make target to `validate-cypilot-artifacts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact validation command naming across build configuration and documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->