### PR TITLE
feat(modkit-auth): add outbound OAuth2 client-credentials token + bearer auth layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "aliri"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96607b3bbf9454cd1043e5c110e4f578dba8a4829a6e82f1cbce951cb98ff8dd"
+dependencies = [
+ "aliri_base64",
+ "aliri_braid",
+ "aliri_clock",
+ "once_cell",
+ "regex",
+ "ring",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "aliri_base64"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d87771969112cbfb21574d11935c2cc37b961b7b1e8e0f146bc1f327d175f4"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
+name = "aliri_braid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df233d014e7a9ad9693f08f17eb198251fb75d94c345dcfa4bdedfecc67f24fb"
+dependencies = [
+ "aliri_braid_impl",
+]
+
+[[package]]
+name = "aliri_braid_impl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1eb7c4fcde1858a6796c18a729b661346d38e05a207e2d9028bce822fc20283"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "aliri_clock"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c5710b7d6bf6988872bcd82a3e44d89859fe8338f7cd8120913093147cce034"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "aliri_tokens"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d352b7b80e4881473a66a50e4ee1e9563fa1ff9ea242ef0afcabbb8c3db5e66c"
+dependencies = [
+ "aliri",
+ "aliri_braid",
+ "aliri_clock",
+ "async-trait",
+ "rand 0.8.5",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,12 +1058,18 @@ dependencies = [
 name = "cf-modkit-auth"
 version = "0.2.2"
 dependencies = [
+ "aliri_clock",
+ "aliri_tokens",
  "arc-swap",
  "async-trait",
  "axum",
+ "base64 0.22.1",
+ "bytes",
  "cf-modkit-http",
  "cf-modkit-security",
+ "cf-modkit-utils",
  "http",
+ "http-body-util",
  "httpmock",
  "jsonwebtoken",
  "serde",
@@ -1001,7 +1080,9 @@ dependencies = [
  "tokio-util",
  "tower",
  "tracing",
+ "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -1237,6 +1318,7 @@ dependencies = [
  "humantime",
  "serde",
  "serde_json",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,6 +246,11 @@ async-trait = "0.1"
 dashmap = "6.1"
 arc-swap = "1.7"
 
+# Security
+zeroize = { version = "1", features = ["derive"] }
+aliri_tokens = { version = "0.3", default-features = false, features = ["rand"] }
+aliri_clock = "0.1"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [

--- a/docs/ARCHITECTURE_MANIFEST.md
+++ b/docs/ARCHITECTURE_MANIFEST.md
@@ -319,7 +319,9 @@ Every HyperSpot module uses the **ModKit** framework, which provides:
  **Key ModKit libraries:**
  - `modkit` - Core module framework: lifecycle, REST host/contracts, OpenAPI registry, ClientHub, tracing helpers
  - `modkit-macros` - Procedural macros for module registration (`#[modkit::module(...)]`) and domain model enforcement (`#[domain_model]`)
- - `modkit-auth` - Authn/z plumbing for gateway and route policies
+ - `modkit-auth` - Authentication and authorization: inbound JWT/OIDC validation with route policies, outbound OAuth2 client credentials with automatic token refresh and `Authorization: Bearer` injection ([ADR](adrs/modkit/0002-modkit-auth-client-with-aliri.md))
+ - `modkit-macros` - Procedural macros for module registration (`#[modkit::module(...)]`)
+ - `modkit-http` - First-party HTTP client (`hyper + tower`): TLS, retries, timeouts, concurrency limiting, decompression, OTel tracing, and extensible auth layer hook ([ADR](adrs/modkit/0001-modkit-hyper-tower-http-client.md))
  - `modkit-security` - `SecurityContext` and security-scoping primitives used across modules (request-scoped context)
  - `modkit-errors` - Shared error types and RFC-9457 Problem modeling utilities
  - `modkit-errors-macro` - Macros/codegen for error catalogs

--- a/docs/adrs/modkit/0001-modkit-hyper-tower-http-client.md
+++ b/docs/adrs/modkit/0001-modkit-hyper-tower-http-client.md
@@ -124,6 +124,7 @@ Prefer gRPC for inter-service calls and avoid building a REST HTTP client.
 
   * Transparent response decompression (gzip, brotli, deflate) via tower-http `DecompressionLayer`.
   * Secure redirect following with SSRF protection (same-origin default, header stripping, HTTPS downgrade blocking) via custom `SecureRedirectPolicy`.
+  * Generic auth layer hook via `HttpClientBuilder::with_auth_layer()` — accepts any `FnOnce(BoxCloneService) -> BoxCloneService` transform inserted between retry and timeout in the tower stack. This enables `modkit-auth` to inject `BearerAuthLayer` via an extension trait (`HttpClientBuilderExt::with_bearer_auth(token)`) without creating a circular dependency between the two crates.
 * Revisit criteria:
 
   * If requirements expand to general outbound HTTP client for external integrations, reassess whether a feature-gated reqwest-based crate is warranted (separate from `modkit-auth`), while keeping `modkit-auth` on `modkit-http`.

--- a/docs/adrs/modkit/0002-modkit-auth-client-with-aliri.md
+++ b/docs/adrs/modkit/0002-modkit-auth-client-with-aliri.md
@@ -1,0 +1,72 @@
+# Outbound OAuth2 Client Credentials for ModKit modules using aliri_tokens
+
+## Context
+
+ModKit modules call internal vendor REST services secured with OAuth2 Client Credentials.
+Each module gets:
+
+- `client_id`, `client_secret`
+- `token_endpoint` or `issuer_url`
+- `scopes` list
+
+The platform HTTP client is `modkit-http::HttpClient` (hyper + tower), which already provides retry with exponential backoff and jitter, OTel tracing, concurrency limiting, TLS-only transport, and a preconfigured `HttpClientConfig::token_endpoint()` profile.
+
+## Requirements
+
+- token acquisition + in-memory cache
+- refresh before expiry
+- jitter to avoid stampede
+- safe concurrency under load
+- automatic `Authorization: Bearer <token>` injection for outbound HTTP
+- no `reqwest` dependency (direct or transitive) in `modkit-auth`
+
+## Decision
+
+Use `aliri_tokens` as the token lifecycle engine, without its `oauth2` feature (so it does not pull `reqwest`). Implement OAuth2 Client Credentials exchange as a custom token source that uses `modkit-http::HttpClient` with `HttpClientConfig::token_endpoint()`.
+
+Outbound HTTP composition is hyper + tower. Authentication is implemented as a tower layer that composes with the existing `HttpClient` layer stack.
+
+## Consequences
+
+**Good:**
+
+- refresh scheduling, jitter, concurrency control, and backoff are delegated to `aliri_tokens`
+- token endpoint HTTP calls reuse `modkit-http::HttpClient` — retries, timeouts, rate limiting, OTel tracing, and TLS are handled by the existing tower stack; no duplicate implementation needed
+- `HttpClientConfig::token_endpoint()` already configures conservative retry (transport errors, timeout, 429 only) appropriate for token acquisition
+- outbound auth layer is a standard tower layer, composable with the existing `HttpClient` middleware
+- no `reqwest` in `modkit-auth`
+
+**Bad:**
+
+- small amount of glue code is needed: `AsyncTokenSource` implementation wrapping `HttpClient`, optional OIDC discovery, tower auth layer
+- `invalidate()` is not a native operation in `aliri_tokens` and must be implemented via watcher rotation
+
+## Implementation Status
+
+All components are implemented in `libs/modkit-auth/src/oauth2/` and `libs/modkit-http/src/builder.rs`.
+
+### Modules and public API
+
+| Module | Path | Public type | Description |
+|--------|------|-------------|-------------|
+| `config` | `oauth2/config.rs` | `OAuthClientConfig` | Configuration struct with `token_endpoint` / `issuer_url` (mutually exclusive), credentials, scopes, refresh policy, and optional `HttpClientConfig` override. `Debug` redacts `client_secret`. |
+| `types` | `oauth2/types.rs` | `ClientAuthMethod`, `SecretString` | Auth method enum (`Basic` / `Form`). `SecretString` re-exported from `modkit-utils` (backed by `Zeroizing<String>`). |
+| `error` | `oauth2/error.rs` | `TokenError` | `#[non_exhaustive]` error enum: `Http`, `InvalidResponse`, `UnsupportedTokenType`, `ConfigError`, `Unavailable`. All variants are secret-safe. |
+| `token` | `oauth2/token.rs` | `Token` | Handle for obtaining bearer tokens. `Clone + Send + Sync`. Background refresh via `aliri_tokens::TokenWatcher`. Lock-free reads via `ArcSwap`. `get()` returns `SecretString`, `invalidate()` rotates the watcher without repeating OIDC discovery. |
+| `layer` | `oauth2/layer.rs` | `BearerAuthLayer` | Tower `Layer` + `Service` that injects `Authorization: Bearer <token>` (or custom header) into outbound requests. |
+| `builder_ext` | `oauth2/builder_ext.rs` | `HttpClientBuilderExt` | Extension trait on `modkit_http::HttpClientBuilder` providing `.with_bearer_auth(token)` and `.with_bearer_auth_header(token, header_name)`. |
+| `discovery` | `oauth2/discovery.rs` | *(crate-internal)* | One-time OIDC discovery: fetches `{issuer_url}/.well-known/openid-configuration` and extracts `token_endpoint`. |
+| `source` | `oauth2/source.rs` | *(crate-internal)* | `AsyncTokenSource` implementation that exchanges client credentials for an access token via `modkit-http::HttpClient`. |
+
+All public types are re-exported from `modkit_auth::oauth2` and from the crate root (`modkit_auth::{...}`).
+
+### `modkit-http` integration
+
+`HttpClientBuilder::with_auth_layer(wrap)` accepts a generic `FnOnce(BoxCloneService) -> BoxCloneService` transform inserted between retry and timeout in the tower stack. This avoids a circular dependency (`modkit-auth` depends on `modkit-http`, not vice versa). The `HttpClientBuilderExt` extension trait in `modkit-auth` wraps `BearerAuthLayer` into this hook.
+
+### Architecture notes
+
+- **No circular dependency:** `modkit-http` has zero awareness of `modkit-auth`. The auth layer is injected via a generic hook (`with_auth_layer`) and an extension trait pattern.
+- **OIDC discovery is one-time:** Runs in `Token::new()`. The resolved `token_endpoint` is captured in the `source_factory` closure, so `invalidate()` rebuilds the watcher without re-running discovery.
+- **Secret safety:** `SecretString` uses `Zeroizing<String>` for secure memory cleanup. `Debug` and `Display` impls are redacted. Access tokens are only exposed transiently in `format!("Bearer {}", secret.expose())` within the auth layer.
+- **Stack order:** `Buffer -> OTel -> LoadShed -> Retry -> **Auth** -> Timeout -> UserAgent -> Decompress -> Redirect -> hyper`

--- a/docs/modkit_unified_system/README.md
+++ b/docs/modkit_unified_system/README.md
@@ -22,6 +22,8 @@ This folder contains the ModKit developer documentation, split by topic for focu
 | Out-of-Process / gRPC / SDK pattern | `09_oop_grpc_sdk_pattern.md` | |
 | Domain model macro, DDD enforcement | `02_module_layout_and_sdk_pattern.md` (§ Domain types) | `dylint_lints/de03_domain_layer/de0309_must_have_domain_model/README.md` |
 | Quick checklists, templates | `10_checklists_and_templates.md` | |
+| HTTP client (TLS, retries, timeouts, concurrency, OTel tracing, auth hook) | | `docs/adrs/modkit/0001-modkit-hyper-tower-http-client.md` |
+| Authentication (inbound JWT/OIDC policies, outbound OAuth2 client-credentials) | | `docs/adrs/modkit/0002-modkit-auth-client-with-aliri.md` |
 
 ## Core invariants (apply everywhere)
 
@@ -47,3 +49,8 @@ This folder contains the ModKit developer documentation, split by topic for focu
 - `08_lifecycle_stateful_tasks.md` – WithLifecycle, cancellation tokens, stateful module patterns.
 - `09_oop_grpc_sdk_pattern.md` – Out-of-Process modules, gRPC, SDK pattern for OoP, client utilities.
 - `10_checklists_and_templates.md` – Quick checklists per task, minimal code templates.
+
+### Related ADRs
+
+- `docs/adrs/modkit/0001-modkit-hyper-tower-http-client.md` – **modkit-http**: Hyper+Tower HTTP client with TLS, retries, timeouts, concurrency limiting, decompression, OTel tracing, and extensible auth layer hook.
+- `docs/adrs/modkit/0002-modkit-auth-client-with-aliri.md` – **modkit-auth**: Inbound JWT/OIDC route-level policies and outbound OAuth2 client-credentials flow with automatic token refresh and `Authorization: Bearer` injection.

--- a/libs/modkit-auth/Cargo.toml
+++ b/libs/modkit-auth/Cargo.toml
@@ -21,6 +21,10 @@ workspace = true
 name = "dispatcher_usage"
 path = "examples/dispatcher_usage.rs"
 
+[[example]]
+name = "oauth2_client_usage"
+path = "examples/oauth2_client_usage.rs"
+
 [dependencies]
 # Core dependencies
 uuid = { workspace = true }
@@ -41,8 +45,20 @@ modkit-security = { workspace = true }
 
 # HTTP client
 modkit-http = { workspace = true }
+url = { workspace = true }
+
+# OAuth2 token lifecycle
+aliri_tokens = { workspace = true }
+aliri_clock = { workspace = true }
+base64 = { workspace = true }
+
+# Shared utilities
+modkit-utils = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
+bytes = { workspace = true }
+http-body-util = { workspace = true }
 httpmock = { workspace = true }
 
 [features]

--- a/libs/modkit-auth/docs/design.md
+++ b/libs/modkit-auth/docs/design.md
@@ -1,0 +1,138 @@
+## Detailed design
+
+### Dependency policy
+
+`modkit-auth` depends on `aliri_tokens` without default features and without `oauth2`:
+
+```toml
+aliri_tokens = { version = "0.3", default-features = false, features = ["rand"] }
+```
+
+`modkit-auth` depends on `modkit-http` for token endpoint HTTP calls. This is acceptable because `modkit-http` is hyper-based and does not pull `reqwest`.
+
+### Public API
+
+Modules use a long-lived token capability:
+
+```rust
+#[derive(Clone)]
+pub struct Token {
+    inner: std::sync::Arc<TokenInner>,
+}
+
+impl Token {
+    pub fn get(&self) -> Result<SecretString, TokenError>;
+    pub async fn invalidate(&self);
+}
+```
+
+Rules:
+
+- modules never see client credentials
+- modules never store the token string beyond request construction
+- token is returned only as a transient `SecretString`
+
+### Token configuration
+
+**Required:**
+
+- `token_endpoint` or `issuer_url`
+- `client_id`, `client_secret`
+- `scopes` (normalized once, stable order)
+
+**Optional:**
+
+- extra headers for vendor quirks
+- client auth method: `Basic` (default) or `form`
+- refresh policy:
+    - refresh offset (default 30 minutes)
+    - jitter max (default 5 minutes)
+    - minimum refresh period (default 10 seconds)
+- safe default TTL if `expires_in` is missing
+- `HttpClientConfig` override for the token endpoint client (defaults to `HttpClientConfig::token_endpoint()`)
+
+### Token source (modkit-http based)
+
+Implement a custom `AsyncTokenSource` for `aliri_tokens`.
+
+The token source holds an `HttpClient` instance built with `HttpClientConfig::token_endpoint()`. This client provides:
+
+- retry with exponential backoff and jitter (transport errors, timeout, 429)
+- concurrency limiting (10 concurrent requests)
+- 30s request timeout
+- 1 MB response body limit
+- OTel tracing (when `otel` feature is enabled)
+- TLS-only transport (no accidental plaintext token requests)
+
+**Responsibilities:**
+
+- resolve token endpoint:
+    - use direct `token_endpoint`, or
+    - OIDC discovery from `issuer_url` using `/.well-known/openid-configuration`
+- do client credentials grant:
+    - `grant_type=client_credentials`
+    - optional `scope` (space-separated)
+    - `Basic` auth or form-based auth
+    - uses `HttpClient::post(url).form(&fields)` for the token request
+- attach extra headers (if configured) via `RequestBuilder::header()`
+- parse response via `HttpResponse::json::<TokenResponse>()`:
+    - `access_token` (required)
+    - `expires_in` (optional)
+    - `token_type` (optional)
+
+**Behavior rules:**
+
+- missing `expires_in` uses a safe default TTL (prevents hot loops)
+- if `token_type` exists and is not `Bearer`, fail token acquisition
+- HTTP error handling: `HttpClient` already retries on transport errors, timeouts, and 429; the token source maps non-2xx responses to `TokenError` using `HttpResponse::error_for_status()`
+- `Retry-After` header parsing uses `modkit_http::response::parse_retry_after()` when available in error context
+- sanitize errors: never log or include secrets (`client_secret`, token value) in error text
+
+### Token watcher
+
+Use `aliri_tokens` watcher created from the token source.
+
+Watcher responsibilities:
+
+- in-memory caching
+- refresh scheduling
+- jitter application
+- error backoff
+- concurrency control (avoid duplicate refresh under load)
+- optionally serve current token while refresh is in progress
+
+### Invalidate semantics
+
+`aliri_tokens` watcher has no explicit "drop cached token now" API.
+
+Implementation:
+
+- store the active watcher behind `ArcSwap` (preferred) or `RwLock<Arc<_>>`
+- `Token::invalidate()` creates a new watcher (same config) and swaps it in
+- old watcher is dropped when no longer referenced
+- next `get()` triggers a new fetch via the token source
+
+### Outbound auth layer (tower)
+
+Implement a tower layer that injects the `Authorization` header.
+
+**Behavior:**
+
+- on each request:
+    - call `Token::get()`
+    - set `Authorization: Bearer <token>`
+    - forward request
+- configurable header name if a vendor requires a non-standard header
+
+**Integration with `HttpClient`:** The auth layer is composed into the `HttpClient` tower stack at build time using a decoupled architecture:
+
+- `modkit-http` provides a generic `HttpClientBuilder::with_auth_layer()` hook that accepts any tower layer. This keeps modkit-http free of OAuth-specific knowledge and avoids circular dependencies.
+- `modkit-auth` provides an extension trait `HttpClientBuilderExt` with `.with_bearer_auth(token)` and `.with_bearer_auth_header(token, header_name)` methods. These wrap `BearerAuthLayer` and call `with_auth_layer()` internally.
+
+The auth layer is inserted between retry and timeout in the tower stack, so each retry re-acquires the token.
+
+### Integration rules
+
+- Token endpoint calls use a dedicated `HttpClient` built with `HttpClientConfig::token_endpoint()`. This client is internal to the token source and is not shared with module business logic.
+- Module outbound requests use `HttpClient` with the auth tower layer composed in. Tracing (OTel), retries, concurrency limits, and other middleware are already part of the `HttpClient` stack.
+- No migration or coexistence concerns — `TracedClient` has been removed; all outbound HTTP uses `modkit-http::HttpClient`.

--- a/libs/modkit-auth/docs/modkit-auth-client-impl.md
+++ b/libs/modkit-auth/docs/modkit-auth-client-impl.md
@@ -1,0 +1,793 @@
+# Implementation Plan — Outbound OAuth2 Client Credentials
+
+Reference: [0002-modkit-auth-client.md](./0002-modkit-auth-client.md)
+Required reading: [ModKit unified system](/docs/modkit_unified_system/README.md)
+
+Crate: `libs/modkit-auth`
+
+## Existing code to reuse
+
+Before starting, review the existing JWKS provider at
+`libs/modkit-auth/src/providers/jwks.rs`. It is the closest analog to the OAuth2
+token source and establishes patterns that must be followed:
+
+| Concern | JWKS (existing) | OAuth2 (new) |
+|---------|----------------|--------------|
+| HTTP client | `HttpClient::builder().timeout().retry(None).build()` | `HttpClientConfig::token_endpoint()` |
+| Lock-free cache | `Arc<ArcSwap<HashMap<String,DecodingKey>>>` | `ArcSwap<TokenInner>` |
+| Background refresh | `run_jwks_refresh_task` + `CancellationToken` | `aliri_tokens` watcher |
+| Backoff | Manual exponential in `calculate_backoff()` | Delegated to `aliri_tokens` |
+| Error mapping | `map_http_error(HttpError) -> ClaimsError` | Extract shared `map_http_error` or create parallel `map_http_error(HttpError) -> TokenError` |
+| Test scaffold | `httpmock` + `allow_insecure_http()` | Same pattern |
+
+Key reuse points:
+
+1. **`map_http_error`** — `jwks.rs:417-473` maps every `HttpError` variant.
+   Extract it into a shared helper `src/providers/http_error_mapping.rs` or
+   duplicate the pattern for `TokenError`. Extraction is preferred to keep the
+   exhaustive match in one place (HttpError is `#[non_exhaustive]`).
+2. **`ArcSwap` lock-free read pattern** — `jwks.rs` uses `keys.load()` for
+   reads and `keys.store(Arc::new(...))` for writes. Token must follow the
+   same pattern.
+3. **`HttpClient` construction** — `jwks.rs:86-89` builds a client with no
+   retries (JWKS handles its own). OAuth source uses
+   `HttpClientConfig::token_endpoint()` instead (retries are appropriate for
+   token acquisition).
+4. **Test pattern** — `jwks.rs:482-499` (`test_provider_with_http`) shows
+   how to build a test `HttpClient` with `allow_insecure_http()` for
+   `httpmock`. Reuse the same approach.
+5. **Dependencies already available** — `modkit-auth/Cargo.toml` already has
+   `arc-swap`, `modkit-http`, `tokio-util`, `httpmock` (dev). Only
+   `aliri_tokens` needs to be added.
+
+---
+
+## Phase 0 — Extract shared HTTP error mapping
+
+**Goal:** Extract `map_http_error` from JWKS into a reusable utility so both JWKS and OAuth2 can use it without duplicating the exhaustive match.
+
+### Prompt
+
+```
+Extract the HTTP error mapping function from the JWKS provider into a shared
+utility in libs/modkit-auth.
+
+Current state: `libs/modkit-auth/src/providers/jwks.rs` lines 417-473 contain
+`fn map_http_error(e: modkit_http::HttpError) -> ClaimsError` that exhaustively
+maps every HttpError variant. This pattern will be needed by the OAuth2 token
+source as well.
+
+1. Create `src/http_error.rs` with a generic mapping function:
+
+   pub fn format_http_error(e: &modkit_http::HttpError, prefix: &str) -> String
+
+   This function takes an HttpError reference and a context prefix (e.g. "JWKS",
+   "OAuth2 token") and returns a human-readable error message string. It must
+   handle every variant of HttpError (which is #[non_exhaustive]) with a
+   catch-all `_ =>` arm at the end.
+
+   Replicate the exact mapping logic from jwks.rs:417-473, but replace the
+   hardcoded "JWKS" prefix with the `prefix` parameter.
+
+2. Update `src/providers/jwks.rs`:
+   - Replace the local `map_http_error` function with a call to the shared one:
+
+     fn map_http_error(e: modkit_http::HttpError) -> ClaimsError {
+         ClaimsError::JwksFetchFailed(crate::http_error::format_http_error(&e, "JWKS"))
+     }
+
+   - Delete the old exhaustive match from jwks.rs.
+
+3. Wire `pub mod http_error` into src/lib.rs.
+
+4. Run `cargo test -p modkit-auth` — all existing JWKS tests must pass unchanged.
+
+The OAuth2 token source (Phase 2) will use the same shared function:
+    TokenError::Http(crate::http_error::format_http_error(&e, "OAuth2 token"))
+```
+
+### Guard
+
+```
+Verify Phase 0 (shared HTTP error mapping) in libs/modkit-auth.
+
+Check every item:
+
+1. FILE EXISTS: src/http_error.rs with pub fn format_http_error.
+
+2. EXHAUSTIVE MATCH: format_http_error handles these HttpError variants:
+   HttpStatus, Json, Timeout, DeadlineExceeded, Transport, BodyTooLarge,
+   Tls, RequestBuild, InvalidHeaderName, InvalidHeaderValue, FormEncode,
+   Overloaded, ServiceClosed, InvalidUri, InvalidScheme, plus a `_ =>` arm.
+
+3. PREFIX USED: Every match arm includes the prefix parameter in its output.
+   e.g. "{prefix} HTTP {status}" not "JWKS HTTP {status}".
+
+4. JWKS UNCHANGED: jwks.rs now calls format_http_error(&e, "JWKS").
+   The local exhaustive match is removed.
+   Run `cargo test -p modkit-auth` — all 11 existing JWKS tests pass.
+
+5. NO SECRET LEAKS: format_http_error never includes request body, auth
+   headers, or token values — only status codes, error messages, and URLs.
+
+6. COMPILATION: `cargo check -p modkit-auth` succeeds with no warnings.
+```
+
+---
+
+## Phase 1 — Foundation types
+
+**Goal:** Define configuration, error, and response types. No async code yet.
+
+### Prompt
+
+```
+Implement foundation types for outbound OAuth2 client credentials in
+libs/modkit-auth.
+
+Create a new module `src/oauth2/` with:
+
+1. `src/oauth2/mod.rs` — re-exports.
+
+2. `src/oauth2/config.rs` — `OAuthClientConfig`:
+   - `token_endpoint: Option<Url>` (direct endpoint)
+   - `issuer_url: Option<Url>` (for OIDC discovery, Phase 6)
+   - Exactly one of `token_endpoint` or `issuer_url` must be set; validate in a
+     `fn validate(&self) -> Result<(), TokenError>` method.
+   - `client_id: String`
+   - `client_secret: SecretString` (use the SecretString from this module)
+   - `scopes: Vec<String>`
+   - `auth_method: ClientAuthMethod` enum { Basic, Form } (default Basic)
+   - `extra_headers: Vec<(String, String)>` (default empty)
+   - `refresh_offset: Duration` (default 30 min)
+   - `jitter_max: Duration` (default 5 min)
+   - `min_refresh_period: Duration` (default 10 sec)
+   - `default_ttl: Duration` (default 5 min — used when expires_in missing)
+   - `http_config: Option<modkit_http::HttpClientConfig>` (override for token
+     endpoint client; defaults to HttpClientConfig::token_endpoint())
+   All durations use `std::time::Duration`. Derive `Clone`. Do NOT derive `Debug`
+   for the whole struct — implement `Debug` manually, redacting `client_secret`.
+
+3. `src/oauth2/error.rs` — `TokenError` enum (thiserror):
+   - `Http(String)` — transport/status errors (store formatted message, not
+     the raw HttpError, to avoid leaking internals; use the shared
+     `format_http_error` from Phase 0 when constructing)
+   - `InvalidResponse(String)` — malformed token response
+   - `UnsupportedTokenType(String)` — token_type is not Bearer
+   - `ConfigError(String)` — invalid config (e.g. both endpoints set)
+   - `Unavailable(String)` — watcher not ready / shutdown
+   Mark `#[non_exhaustive]`. Implement Display via thiserror. Ensure no variant
+   can ever contain secret values.
+   Follow the same pattern as `AuthError` in src/errors.rs.
+
+4. `src/oauth2/types.rs`:
+   - `SecretString` — newtype over `String` with `Debug` printing "[REDACTED]",
+     `Display` printing "[REDACTED]", `Clone`, and `Drop` that zeroizes the
+     inner buffer (use `unsafe { core::ptr::write_bytes }` on the Vec<u8>
+     backing buffer, or the `zeroize` crate if available in workspace).
+     Provide `fn expose(&self) -> &str` for controlled access.
+   - `TokenResponse` (serde `Deserialize`):
+     - `access_token: String`
+     - `expires_in: Option<u64>`
+     - `token_type: Option<String>`
+     Deserialize only — never derive Serialize. Use `#[serde(default)]` for
+     optional fields.
+   - `ClientAuthMethod` enum { Basic, Form } with `Default` = Basic.
+
+Wire `mod oauth2` into `src/lib.rs` and re-export `OAuthClientConfig`,
+`TokenError`, `SecretString`, `ClientAuthMethod` from the crate root
+(Token will be re-exported in Phase 3).
+
+Follow existing patterns in modkit-auth: thiserror for errors, no unwrap in
+library code, #[non_exhaustive] on public enums.
+```
+
+### Guard
+
+```
+Verify Phase 1 (foundation types) of the OAuth2 client credentials
+implementation in libs/modkit-auth/src/oauth2/.
+
+Check every item:
+
+1. FILES EXIST: mod.rs, config.rs, error.rs, types.rs under src/oauth2/.
+   `mod oauth2` is declared in src/lib.rs.
+
+2. SecretString:
+   - Debug and Display both print "[REDACTED]", never the inner value.
+   - `expose(&self) -> &str` is the only way to access the inner value.
+   - Clone is implemented.
+   - Drop zeroizes the buffer (write_bytes or zeroize).
+   - Write a unit test: create a SecretString, format with Debug and Display,
+     assert neither contains the original value. Assert expose() returns it.
+
+3. OAuthClientConfig:
+   - Has all fields from the design (token_endpoint, issuer_url, client_id,
+     client_secret, scopes, auth_method, extra_headers, refresh_offset,
+     jitter_max, min_refresh_period, default_ttl, http_config).
+   - Does NOT derive Debug — has manual Debug impl that redacts client_secret.
+   - validate() returns error if both token_endpoint and issuer_url are set,
+     or if neither is set.
+   - Write a unit test for validate() with both, neither, and exactly-one.
+
+4. TokenError:
+   - Is #[non_exhaustive].
+   - Has variants: Http, InvalidResponse, UnsupportedTokenType, ConfigError,
+     Unavailable.
+   - Display output for Http variant does NOT leak secrets.
+   - Write a test: format a TokenError::ConfigError, assert it renders.
+
+5. TokenResponse:
+   - Deserializes `{"access_token":"x","expires_in":3600,"token_type":"Bearer"}`.
+   - Deserializes `{"access_token":"x"}` (optional fields missing).
+   - Does NOT implement Serialize.
+   - Write tests for both cases.
+
+6. ClientAuthMethod: Default is Basic.
+
+7. COMPILATION: `cargo check -p modkit-auth` succeeds with no warnings.
+
+8. TESTS: `cargo test -p modkit-auth` — all new AND existing tests pass.
+
+9. NO SECRETS IN DEBUG: grep all new files for `impl Debug` — every manual
+   impl redacts client_secret / token values. No `#[derive(Debug)]` on types
+   containing secrets.
+```
+
+---
+
+## Phase 2 — Token source
+
+**Goal:** Implement `AsyncTokenSource` for `aliri_tokens` using `modkit-http::HttpClient`.
+
+### Prompt
+
+```
+Implement the OAuth2 token source in libs/modkit-auth/src/oauth2/source.rs.
+
+This struct implements aliri_tokens::AsyncTokenSource and performs the actual
+OAuth2 client credentials exchange using modkit-http::HttpClient.
+
+REFERENCE: Study libs/modkit-auth/src/providers/jwks.rs for the established
+patterns — especially how it constructs HttpClient (lines 86-89), how it calls
+client.get().send().await (lines 131-139), and how it maps errors via the
+shared format_http_error (Phase 0).
+
+1. Add `aliri_tokens` to modkit-auth/Cargo.toml:
+   aliri_tokens = { version = "0.3", default-features = false, features = ["rand"] }
+   Verify it does NOT pull reqwest (no oauth2 feature).
+
+2. Create `src/oauth2/source.rs` with struct `OAuthTokenSource`:
+   - Fields:
+     - `client: modkit_http::HttpClient` (built once from config)
+     - `token_endpoint: Url`
+     - `client_id: String`
+     - `client_secret: SecretString`
+     - `scopes: Option<String>` (pre-joined with spaces, None if empty)
+     - `auth_method: ClientAuthMethod`
+     - `extra_headers: Vec<(String, String)>`
+     - `default_ttl: Duration`
+
+   - Constructor `fn new(config: &OAuthClientConfig) -> Result<Self, TokenError>`:
+     - Build HttpClient from config.http_config (if set) or
+       HttpClientConfig::token_endpoint() (default).
+       Map the HttpError from build via format_http_error (Phase 0):
+       `TokenError::Http(format_http_error(&e, "OAuth2 token"))`
+     - For now, require config.token_endpoint to be Some (OIDC discovery is
+       Phase 6). Return TokenError::ConfigError if missing.
+     - Pre-join scopes into a space-separated string.
+
+   COMPARE with JWKS: JwksKeyProvider::new() builds the client at lines 86-89
+   with custom timeout and no retries. Here we use token_endpoint() config
+   which INCLUDES retries (appropriate for token POST, which is idempotent
+   for client_credentials).
+
+3. Implement `aliri_tokens::AsyncTokenSource` for `OAuthTokenSource`:
+   - `async fn request_token(&self) -> Result<TokenWithLifetime, BoxError>`:
+     a. Build form fields: grant_type=client_credentials, optional scope.
+     b. Build request via `self.client.post(url).form(&fields)?`
+        COMPARE with JWKS: jwks.rs uses `self.client.get(&self.jwks_uri).send()`
+        at line 131. Here we use POST with form body.
+     c. If auth_method is Basic: add Authorization header with
+        base64(client_id:client_secret) via .header().
+        If Form: add client_id and client_secret to form fields instead.
+     d. Add extra_headers via .header().
+     e. Call .send().await, then error_for_status().
+     f. Parse response as TokenResponse via .json().
+        COMPARE with JWKS: jwks.rs at line 139 does the same `.json().await`.
+     g. Validate: if token_type is Some and != "Bearer" (case-insensitive),
+        return Err(UnsupportedTokenType).
+     h. Compute lifetime: Duration::from_secs(expires_in) if present,
+        else self.default_ttl.
+     i. Return TokenWithLifetime { token: access_token, lifetime }.
+
+   - Map HttpError using format_http_error(&e, "OAuth2 token") (Phase 0).
+     Never include client_secret in error messages.
+
+4. Wire source.rs into src/oauth2/mod.rs. OAuthTokenSource is pub(crate) —
+   it is an internal implementation detail used by Token (Phase 3).
+
+DO NOT add:
+- Manual retry logic (HttpClient retries via RetryLayer).
+- Manual tracing spans (HttpClient traces via OtelLayer).
+- Manual timeout logic (HttpClient has request_timeout).
+- Manual TLS configuration (HttpClient enforces TLS-only).
+```
+
+### Guard
+
+```
+Verify Phase 2 (token source) of the OAuth2 client credentials implementation.
+
+Check every item:
+
+1. DEPENDENCY: `aliri_tokens` in modkit-auth/Cargo.toml with
+   `default-features = false, features = ["rand"]`.
+   Run: `cargo tree -p cf-modkit-auth | grep reqwest` — must return NOTHING.
+
+2. OAuthTokenSource: all fields private. Visibility is pub(crate).
+
+3. Constructor:
+   - Builds HttpClient from HttpClientConfig::token_endpoint() by default.
+   - Accepts http_config override from OAuthClientConfig.
+   - Maps HttpError from client build via format_http_error.
+   - Returns TokenError::ConfigError if token_endpoint is None.
+
+4. AsyncTokenSource::request_token():
+   - Form body includes grant_type=client_credentials.
+   - Scope included only when non-empty.
+   - Basic auth: header is "Basic {base64(id:secret)}".
+   - Form auth: client_id + client_secret in form body, no Authorization header.
+   - Extra headers applied.
+   - error_for_status() called before json().
+   - token_type validation case-insensitive.
+   - Missing expires_in falls back to default_ttl.
+   - Returned lifetime is Duration, not zero.
+
+5. SECRET SAFETY:
+   - grep source.rs for "client_secret" — only in struct field and
+     form body / Authorization header construction. Never in error messages,
+     tracing, or Debug output.
+   - access_token is never logged.
+
+6. ERROR MAPPING uses shared format_http_error from Phase 0
+   (not a local exhaustive match).
+
+7. NO DUPLICATE CONCERNS:
+   - No manual retry logic.
+   - No manual tracing spans.
+   - No manual timeout logic.
+   - No manual TLS configuration.
+
+8. COMPILATION: `cargo check -p modkit-auth` succeeds.
+
+9. TESTS (use httpmock + allow_insecure_http, same pattern as
+   jwks.rs test_provider_with_http at line 482):
+   - Mock server returns valid token response → assert access_token + lifetime.
+   - Mock returns response without expires_in → assert default_ttl used.
+   - Mock returns token_type: "mac" → assert error.
+   - Empty scopes → assert scope param absent from request body.
+   - Basic auth → assert Authorization header present in mock request.
+   - Form auth → assert client_id in form body, no Authorization header.
+```
+
+---
+
+## Phase 3 — Token handle (watcher + invalidate)
+
+**Goal:** Implement the public `Token` struct that wraps `aliri_tokens` watcher with `ArcSwap`-based invalidation.
+
+### Prompt
+
+```
+Implement the public Token handle in libs/modkit-auth/src/oauth2/token.rs.
+
+This is the public API that modules use to get bearer tokens. It wraps an
+aliri_tokens watcher and supports invalidation via ArcSwap rotation.
+
+REFERENCE: Study the ArcSwap usage in libs/modkit-auth/src/providers/jwks.rs:
+- jwks.rs:41 — `keys: Arc<ArcSwap<HashMap<String, DecodingKey>>>`
+- jwks.rs:190 — `self.keys.store(Arc::new(new_keys))` for atomic swap
+- jwks.rs:299 — `let keys = self.keys.load()` for lock-free read
+The Token handle follows the same pattern but swaps the entire watcher.
+
+1. Create `src/oauth2/token.rs` with:
+
+   struct TokenInner {
+       watcher: aliri_tokens::TokenWatcher<String>,
+   }
+
+   #[derive(Clone)]
+   pub struct Token {
+       inner: Arc<ArcSwap<TokenInner>>,
+       source_factory: Arc<dyn Fn() -> Result<OAuthTokenSource, TokenError> + Send + Sync>,
+       watcher_config: Arc<WatcherConfig>,
+   }
+
+   struct WatcherConfig {
+       refresh_offset: Duration,
+       jitter_max: Duration,
+       min_refresh_period: Duration,
+   }
+
+2. Constructor `Token::new(config: OAuthClientConfig) -> Result<Self, TokenError>`:
+   - Call config.validate().
+   - Create OAuthTokenSource::new(&config).
+   - Create aliri_tokens watcher from the source with the refresh parameters.
+   - Store a source_factory closure that captures the config and can
+     recreate the source for invalidation.
+   - Wrap the watcher in TokenInner, then Arc, then ArcSwap.
+
+3. `pub async fn get(&self) -> Result<SecretString, TokenError>`:
+   - `let guard = self.inner.load();` — lock-free read (compare jwks.rs:299).
+   - Call `guard.watcher.token().await` to get the cached/refreshed token.
+   - Wrap the raw String in SecretString immediately.
+   - Map aliri_tokens errors to TokenError::Unavailable.
+
+4. `pub async fn invalidate(&self)`:
+   - Call source_factory() to create a new OAuthTokenSource.
+   - Create a new watcher with same WatcherConfig.
+   - `self.inner.store(Arc::new(TokenInner { watcher }))` — atomic swap
+     (compare jwks.rs:190).
+   - Old watcher is dropped when last reference is released.
+   - If source_factory fails: log warning via `tracing::warn!`, do NOT swap,
+     do NOT panic.
+
+5. Re-export Token from src/oauth2/mod.rs and from the crate root.
+
+Use arc-swap from workspace (already in Cargo.toml).
+Token must be Clone + Send + Sync.
+```
+
+### Guard
+
+```
+Verify Phase 3 (Token handle) of the OAuth2 client credentials implementation.
+
+Check every item:
+
+1. Token is Clone + Send + Sync:
+   - Write a compile-time assertion:
+     fn _assert_token_traits() {
+         fn assert_send_sync_clone<T: Send + Sync + Clone>() {}
+         assert_send_sync_clone::<Token>();
+     }
+
+2. Token::new():
+   - Calls config.validate().
+   - Creates OAuthTokenSource.
+   - Creates aliri_tokens watcher with refresh_offset, jitter_max,
+     min_refresh_period from config.
+   - Returns Result, not panics.
+
+3. Token::get():
+   - Returns SecretString (not raw String).
+   - Uses self.inner.load() (lock-free read, same as jwks.rs:299).
+   - Maps watcher errors to TokenError::Unavailable.
+
+4. Token::invalidate():
+   - Creates a NEW watcher (does not reuse the old one).
+   - Uses self.inner.store() for atomic swap (same as jwks.rs:190).
+   - If source_factory fails: logs warning, does NOT swap, does NOT panic.
+   - Old watcher is eventually dropped (no leak).
+
+5. SECRET SAFETY:
+   - Token::get() wraps the raw token string in SecretString immediately.
+   - The raw String is never stored in Token or TokenInner beyond the watcher.
+   - No Debug impl on Token or TokenInner prints token values.
+
+6. ArcSwap PATTERN matches JWKS:
+   - Uses ArcSwap<TokenInner> (not RwLock).
+   - get() uses .load() (lock-free read).
+   - invalidate() uses .store() (atomic swap).
+
+7. COMPILATION: `cargo check -p modkit-auth` succeeds.
+
+8. TESTS (same httpmock pattern as JWKS tests):
+   - Token::new() with valid config succeeds.
+   - Token::new() with invalid config (both endpoints) returns Err.
+   - Token::get() returns SecretString whose expose() matches mock token.
+   - Token::invalidate() causes next get() to re-fetch (verify mock hit
+     count increments after invalidate).
+   - Two concurrent get() calls do not deadlock.
+```
+
+---
+
+## Phase 4 — Tower auth layer
+
+**Goal:** Implement `BearerAuthLayer` / `BearerAuthService` that injects `Authorization: Bearer <token>` on every request.
+
+### Prompt
+
+```
+Implement the outbound bearer auth tower layer in
+libs/modkit-auth/src/oauth2/layer.rs.
+
+REFERENCE: Follow the exact tower Layer + Service pattern used by modkit-http:
+- libs/modkit-http/src/layers/otel.rs — OtelLayer + OtelService (simplest async layer)
+- libs/modkit-http/src/layers/user_agent.rs — UserAgentLayer + UserAgentService
+  (synchronous header injection, closest conceptual match, but our layer needs
+  async because token.get() is async)
+
+NOTE: The existing bearer token EXTRACTION (inbound) is in
+libs/modkit-auth/src/axum_ext.rs:221-227 (extract_bearer_token). Our layer does
+the INVERSE — it INJECTS a bearer token into outbound requests.
+
+1. `BearerAuthLayer`:
+   - Fields:
+     - `token: Token`
+     - `header_name: http::header::HeaderName` (default: AUTHORIZATION)
+   - Constructors:
+     - `fn new(token: Token) -> Self` (uses AUTHORIZATION)
+     - `fn with_header_name(token: Token, header_name: HeaderName) -> Self`
+   - Implement `tower::Layer<S>` producing `BearerAuthService<S>`.
+   - Derive Clone.
+
+2. `BearerAuthService<S>`:
+   - Fields: inner: S, token: Token, header_name: HeaderName
+   - Derive Clone.
+   - Implement `tower::Service<http::Request<B>>` where
+     S: Service<Request<B>, Response = Response<ResBody>, Error = HttpError>:
+     - poll_ready: delegate to inner.
+     - call: return a boxed future (Pin<Box<dyn Future + Send>>) that:
+       a. Calls self.token.get().await.
+       b. On success: set header `{header_name}: Bearer {token.expose()}`
+          on the request. The expose() value must NOT be bound to a long-lived
+          variable.
+       c. On error: map TokenError to HttpError. Since HttpError is
+          #[non_exhaustive] and lives in modkit-http, map via
+          `HttpError::Transport(Box::new(token_error))` — this preserves the
+          error chain without modifying modkit-http's error enum.
+       d. Forward request to inner service.
+
+   Compare with OtelService (otel.rs) which also uses a boxed async future
+   in call() to handle async tracing operations.
+
+3. Re-export BearerAuthLayer from src/oauth2/mod.rs and the crate root.
+
+IMPORTANT: token.expose() is used only transiently for header value
+construction. Do not store it in any struct field or log it.
+```
+
+### Guard
+
+```
+Verify Phase 4 (tower auth layer) of the OAuth2 client credentials implementation.
+
+Check every item:
+
+1. LAYER PATTERN matches modkit-http conventions:
+   - BearerAuthLayer implements tower::Layer<S>.
+   - BearerAuthService<S> implements tower::Service<Request<B>>.
+   - Both derive Clone.
+
+2. HEADER INJECTION:
+   - Default header is AUTHORIZATION.
+   - Value format is "Bearer {token}" (with space, no extra whitespace).
+   - with_header_name allows custom header (e.g. "X-Api-Key").
+   - Header set BEFORE calling inner service.
+
+3. ASYNC HANDLING:
+   - call() returns a boxed future that is Send + 'static.
+   - token.get().await called inside the future (not synchronously in call()).
+   - poll_ready only checks inner readiness.
+
+4. ERROR HANDLING:
+   - TokenError mapped to HttpError::Transport(Box::new(token_error)).
+   - If token.get() fails, request is NOT forwarded to inner service.
+   - Error does not contain the token value.
+
+5. SECRET SAFETY:
+   - token.expose() called only in header value construction.
+   - grep layer.rs for "tracing" / "debug!" / "info!" / "warn!" — if present,
+     must NOT include the token value.
+
+6. INVERSE OF EXTRACTION: compare with axum_ext.rs:221 extract_bearer_token
+   which strips "Bearer " prefix for inbound. Our layer adds "Bearer " prefix
+   for outbound. Format is consistent.
+
+7. COMPILATION: `cargo check -p modkit-auth` succeeds.
+
+8. TESTS:
+   - Mock inner service captures request headers.
+   - Wrap with BearerAuthLayer, send request → assert Authorization header
+     is "Bearer {expected}".
+   - Custom header name → assert custom header set.
+   - Token error → assert request not forwarded, error returned.
+```
+
+---
+
+## Phase 5 — HttpClientBuilder integration
+
+**Goal:** Add `.with_bearer_auth(token)` to `HttpClientBuilder` so the auth layer is part of the composed tower stack.
+
+### Prompt
+
+```
+Add bearer auth support to modkit-http's HttpClientBuilder.
+
+REFERENCE: Read libs/modkit-http/src/builder.rs to understand the current tower
+stack composition. The stack order is:
+
+  Buffer → OTel → LoadShed/Concurrency → Retry → Timeout → UserAgent → Decompress → Redirect → hyper
+
+The auth layer must be inserted INSIDE retry but OUTSIDE timeout:
+
+  Buffer → OTel → LoadShed/Concurrency → Retry → **BearerAuth** → Timeout → UserAgent → ...
+
+This ensures: (a) retries re-acquire the token on each attempt, (b) token
+acquisition time counts toward the per-request timeout.
+
+1. Add modkit-auth as an OPTIONAL dependency of modkit-http behind a feature flag.
+
+   In libs/modkit-http/Cargo.toml:
+   [features]
+   oauth = ["dep:modkit-auth"]
+
+   [dependencies]
+   modkit-auth = { workspace = true, optional = true }
+
+2. In builder.rs, add field (feature-gated):
+   #[cfg(feature = "oauth")]
+   bearer_auth: Option<modkit_auth::oauth2::BearerAuthLayer>,
+
+   Initialize to None in HttpClientBuilder::new().
+
+3. Add builder methods (feature-gated):
+   #[cfg(feature = "oauth")]
+   pub fn with_bearer_auth(mut self, token: modkit_auth::Token) -> Self
+   #[cfg(feature = "oauth")]
+   pub fn with_bearer_auth_header(mut self, token: modkit_auth::Token, header_name: HeaderName) -> Self
+
+4. In build(), insert BearerAuthLayer conditionally.
+   Use tower::util::option_layer or manual Either wrapping.
+   The layer goes between RetryLayer and TimeoutLayer in the ServiceBuilder chain.
+
+   When oauth feature is disabled: no changes to build() at all (use #[cfg]).
+   When oauth feature is enabled but bearer_auth is None: layer is a passthrough.
+
+IMPORTANT: When the `oauth` feature is not enabled, there must be ZERO impact
+on compilation, binary size, or API surface. All oauth code behind
+#[cfg(feature = "oauth")].
+```
+
+### Guard
+
+```
+Verify Phase 5 (HttpClientBuilder integration) in libs/modkit-http.
+
+Check every item:
+
+1. FEATURE FLAG:
+   - modkit-http/Cargo.toml has `oauth = ["dep:modkit-auth"]` feature.
+   - modkit-auth listed as optional dependency.
+   - `cargo check -p cf-modkit-http` (no features) compiles cleanly.
+   - `cargo check -p cf-modkit-http --features oauth` compiles cleanly.
+
+2. BUILDER API (feature-gated):
+   - with_bearer_auth() and with_bearer_auth_header() exist only with
+     #[cfg(feature = "oauth")].
+   - Both return Self (fluent API, #[must_use]).
+
+3. LAYER POSITION in tower stack:
+   - Read build() — confirm BearerAuthLayer is composed AFTER RetryLayer
+     wraps the inner service (inside retry) and BEFORE TimeoutLayer
+     (outside timeout).
+   - Stack order:
+     Buffer → OTel → LoadShed → Retry → BearerAuth → Timeout → UserAgent → ...
+
+4. CONDITIONAL COMPILATION:
+   - Without oauth feature: no reference to modkit_auth in compiled code.
+   - With oauth feature but no with_bearer_auth() call: no auth layer in stack.
+
+5. COMPILATION:
+   - `cargo check -p cf-modkit-http` — OK.
+   - `cargo check -p cf-modkit-http --features oauth` — OK.
+   - `cargo check --workspace` — OK.
+
+6. TESTS (behind #[cfg(feature = "oauth")]):
+   - HttpClient with with_bearer_auth(mock_token) → mock server receives
+     Authorization: Bearer {token}.
+   - HttpClient WITHOUT with_bearer_auth() → no Authorization header.
+```
+
+---
+
+## Phase 6 — OIDC discovery
+
+**Goal:** Support `issuer_url` as an alternative to `token_endpoint` — resolve the token endpoint via `/.well-known/openid-configuration`.
+
+### Prompt
+
+```
+Add OIDC discovery support to OAuthTokenSource in
+libs/modkit-auth/src/oauth2/source.rs.
+
+REFERENCE: The JWKS provider (libs/modkit-auth/src/providers/jwks.rs) fetches
+a remote JSON document (JWKS) via HttpClient and parses it. OIDC discovery is
+the same pattern: fetch a JSON document and extract one field.
+
+Compare:
+- JWKS: GET {jwks_uri} → parse JwksResponse { keys: Vec<Jwk> }
+- OIDC: GET {issuer_url}/.well-known/openid-configuration → parse { token_endpoint }
+
+1. Create `src/oauth2/discovery.rs`:
+   - `OidcDiscoveryDoc` (serde Deserialize):
+     - `token_endpoint: String` (required)
+     - Other fields ignored (no deny_unknown_fields).
+   - `pub async fn discover_token_endpoint(
+         client: &HttpClient,
+         issuer_url: &Url,
+     ) -> Result<Url, TokenError>`:
+     - Build discovery URL: strip trailing slash from issuer_url, then append
+       `/.well-known/openid-configuration`.
+     - GET via client.get(url).send().await.
+     - Call error_for_status(), then .json::<OidcDiscoveryDoc>().
+     - Parse token_endpoint string as Url.
+     - On error: map via format_http_error (Phase 0) for HTTP errors,
+       TokenError::InvalidResponse for parse/missing field errors.
+
+   Follow the same HTTP call pattern as jwks.rs fetch_jwks() (lines 129-139).
+
+2. Update `OAuthTokenSource`:
+   - Add a constructor variant or make new() async:
+     `pub(crate) async fn new(config: &OAuthClientConfig) -> Result<Self, TokenError>`
+   - If config.token_endpoint is Some: use directly (no change).
+   - If config.issuer_url is Some: call discover_token_endpoint() to resolve.
+   - Store resolved URL. Discovery is ONE-TIME at construction.
+
+3. Update `Token::new()`:
+   - Becomes async: `pub async fn new(config: OAuthClientConfig) -> Result<Self, TokenError>`
+   - Discovery runs once in new(). The resolved token_endpoint is captured in
+     the source_factory closure so invalidation does NOT repeat discovery.
+
+4. Wire discovery.rs into src/oauth2/mod.rs.
+```
+
+### Guard
+
+```
+Verify Phase 6 (OIDC discovery) of the OAuth2 client credentials implementation.
+
+Check every item:
+
+1. DISCOVERY URL CONSTRUCTION:
+   - "https://auth.example.com" → ".../openid-configuration" (no double slash).
+   - "https://auth.example.com/" → ".../openid-configuration" (trailing slash stripped).
+   - Unit test for both cases.
+
+2. DISCOVERY HTTP PATTERN matches JWKS:
+   - Uses client.get(url).send().await (compare jwks.rs:131-136).
+   - Calls error_for_status() before json() (compare jwks.rs:137-139).
+   - Maps errors via format_http_error (Phase 0).
+
+3. ONE-TIME DISCOVERY:
+   - Discovery in Token::new() or OAuthTokenSource::new().
+   - Subsequent token requests use cached endpoint.
+   - Token::invalidate() does NOT repeat discovery.
+   - Test: mock discovery + mock token endpoint. Call get() multiple times,
+     invalidate() once. Discovery mock hit count = 1.
+
+4. CONFIG VALIDATION:
+   - token_endpoint only: no discovery.
+   - issuer_url only: discovery runs.
+   - Both set: error.
+   - Neither set: error.
+
+5. Token::new() IS ASYNC. All callers updated.
+
+6. SECRET SAFETY:
+   - Discovery URL does not contain secrets.
+   - Error messages from discovery do not contain secrets.
+
+7. COMPILATION: `cargo check -p modkit-auth` succeeds.
+
+8. TESTS (httpmock + allow_insecure_http, same pattern as JWKS tests):
+   - Integration: mock OIDC discovery + mock token endpoint → Token::get()
+     returns expected token.
+   - Unit: discover_token_endpoint with valid response.
+   - Unit: discover_token_endpoint with missing token_endpoint field → error.
+   - Unit: trailing slash handling.
+```

--- a/libs/modkit-auth/examples/oauth2_client_usage.rs
+++ b/libs/modkit-auth/examples/oauth2_client_usage.rs
@@ -1,0 +1,285 @@
+#![allow(clippy::use_debug)]
+#![allow(clippy::non_ascii_literal)]
+#![allow(clippy::expect_used)] // example code, not production
+#![allow(dead_code)] // IDP-dependent examples are commented out in main()
+
+/// Outbound `OAuth2` client credentials -- usage examples.
+///
+/// This is the Rust equivalent of the Go pattern:
+///
+/// ```go
+/// tokenProvider, _ := tokenprovider.New(idpURL, clientID, clientSecret, ...)
+/// resolverClient, _ := tenantsresolver.NewClient(address, tokenProvider, ...)
+/// ```
+///
+/// NOTE: This example requires a running IDP and target API to work.
+///       It is meant as a reference for how the API is used, not as a
+///       runnable demo.
+///
+/// Run with: `cargo run --example oauth2_client_usage`
+use modkit_auth::{
+    ClientAuthMethod, HttpClientBuilderExt, OAuthClientConfig, SecretString, Token, TokenError,
+};
+use modkit_http::HttpClientBuilder;
+
+// ---------------------------------------------------------------------------
+// Example 1: Direct token endpoint (simplest case)
+//
+// Go equivalent:
+//   tp, _ := tokenprovider.New(tokenURL, clientID, clientSecret, ...)
+//   client := &http.Client{Transport: authTransport(tp)}
+// ---------------------------------------------------------------------------
+async fn direct_token_endpoint() -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n=== Example 1: Direct token endpoint ===");
+
+    // Step 1 -- create token provider (like tokenprovider.New in Go)
+    let token = Token::new(OAuthClientConfig {
+        token_endpoint: Some("https://idp.example.com/oauth/token".parse()?),
+        client_id: "my-service".into(),
+        client_secret: SecretString::new("my-secret"),
+        scopes: vec!["tenants.read".into(), "tenants.write".into()],
+        ..Default::default()
+    })
+    .await?;
+
+    // Step 2 -- create HTTP client with automatic Bearer injection
+    // (like tenantsresolver.NewClient(addr, tokenProvider, ...) in Go)
+    let client = HttpClientBuilder::new().with_bearer_auth(token).build()?;
+
+    // Step 3 -- every request gets Authorization: Bearer <token> automatically
+    let _resp = client
+        .get("https://resolver.example.com/api/v1/tenants")
+        .send()
+        .await?;
+
+    println!("  Request sent with auto-injected Bearer token");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Example 2: OIDC discovery (issuer URL -> .well-known -> token_endpoint)
+//
+// Go equivalent:
+//   tp, _ := tokenprovider.New(issuerURL, clientID, clientSecret, ...)
+//   // internally calls fetchTokenURL -> /.well-known/openid-configuration
+// ---------------------------------------------------------------------------
+async fn oidc_discovery() -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n=== Example 2: OIDC discovery ===");
+
+    // Only provide the issuer URL -- the token endpoint is resolved
+    // automatically via {issuer_url}/.well-known/openid-configuration
+    let token = Token::new(OAuthClientConfig {
+        issuer_url: Some("https://idp.example.com".parse()?),
+        client_id: "my-service".into(),
+        client_secret: SecretString::new("my-secret"),
+        ..Default::default()
+    })
+    .await?;
+
+    let client = HttpClientBuilder::new().with_bearer_auth(token).build()?;
+
+    let _resp = client.get("https://api.example.com/data").send().await?;
+
+    println!("  Token endpoint discovered and token acquired");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Example 3: Shared token across multiple service clients
+//
+// Go equivalent:
+//   tp, _ := tokenprovider.New(...)
+//   resolverClient := tenantsresolver.NewClient(addr1, tp, ...)
+//   registryClient := typesregistry.NewClient(addr2, tp, ...)
+// ---------------------------------------------------------------------------
+async fn shared_token() -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n=== Example 3: Shared token across clients ===");
+
+    // One token provider -- shared via Clone (Arc inside, cheap)
+    let token = Token::new(OAuthClientConfig {
+        token_endpoint: Some("https://idp.example.com/oauth/token".parse()?),
+        client_id: "my-service".into(),
+        client_secret: SecretString::new("my-secret"),
+        scopes: vec!["api".into()],
+        ..Default::default()
+    })
+    .await?;
+
+    // Multiple clients reuse the same token
+    let resolver_client = HttpClientBuilder::new()
+        .with_bearer_auth(token.clone()) // cheap Arc clone
+        .build()?;
+
+    let registry_client = HttpClientBuilder::new()
+        .with_bearer_auth(token) // same token, same background refresh
+        .build()?;
+
+    let _r1 = resolver_client
+        .get("https://resolver.example.com/tenants")
+        .send()
+        .await?;
+    let _r2 = registry_client
+        .get("https://registry.example.com/types")
+        .send()
+        .await?;
+
+    println!("  Both clients used the same token provider");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Example 4: Token invalidation on 401 (force refresh)
+//
+// Go equivalent:
+//   resp := client.Do(req)
+//   if resp.StatusCode == 401 { tp.Invalidate() }
+// ---------------------------------------------------------------------------
+async fn invalidation_on_401() -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n=== Example 4: Invalidation on 401 ===");
+
+    let token = Token::new(OAuthClientConfig {
+        token_endpoint: Some("https://idp.example.com/oauth/token".parse()?),
+        client_id: "my-service".into(),
+        client_secret: SecretString::new("my-secret"),
+        ..Default::default()
+    })
+    .await?;
+
+    let client = HttpClientBuilder::new()
+        .with_bearer_auth(token.clone())
+        .build()?;
+
+    let resp = client
+        .get("https://api.example.com/resource")
+        .send()
+        .await?;
+
+    // send() returns Ok for ALL HTTP statuses (including 401).
+    // Check the status directly on the response.
+    if resp.status() == http::StatusCode::UNAUTHORIZED {
+        println!("  Got 401 -- invalidating token...");
+        token.invalidate().await;
+        // Retry with a fresh token (the client re-reads automatically)
+        let _retry = client
+            .get("https://api.example.com/resource")
+            .send()
+            .await?;
+        println!("  Retry succeeded with new token");
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Example 5: Form-based auth (some IdPs require credentials in POST body)
+// ---------------------------------------------------------------------------
+async fn form_auth() -> Result<(), Box<dyn std::error::Error>> {
+    println!("\n=== Example 5: Form-based authentication ===");
+
+    let token = Token::new(OAuthClientConfig {
+        token_endpoint: Some("https://idp.example.com/oauth/token".parse()?),
+        client_id: "my-service".into(),
+        client_secret: SecretString::new("my-secret"),
+        auth_method: ClientAuthMethod::Form, // credentials in POST body, not Basic header
+        ..Default::default()
+    })
+    .await?;
+
+    let client = HttpClientBuilder::new().with_bearer_auth(token).build()?;
+
+    let _resp = client.get("https://api.example.com/data").send().await?;
+
+    println!("  Used Form auth (client_id/client_secret in POST body)");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Example 6: Config overview (all fields with defaults)
+// ---------------------------------------------------------------------------
+fn config_overview() {
+    println!("\n=== Example 6: Configuration reference ===");
+
+    let config = OAuthClientConfig {
+        // Endpoint -- exactly one of these must be set:
+        token_endpoint: Some(
+            "https://idp.example.com/oauth/token"
+                .parse()
+                .expect("valid URL"),
+        ),
+        issuer_url: None, // mutually exclusive with token_endpoint
+
+        // Credentials:
+        client_id: "my-service".into(),
+        client_secret: SecretString::new("my-secret"),
+        scopes: vec!["api.read".into(), "api.write".into()],
+        auth_method: ClientAuthMethod::Basic, // or ClientAuthMethod::Form
+
+        // Vendor-specific headers (e.g. Azure requires a resource header):
+        extra_headers: vec![("x-vendor-id".into(), "acme-corp".into())],
+
+        // Refresh policy (defaults shown):
+        refresh_offset: std::time::Duration::from_secs(30 * 60), // 30 min before expiry
+        jitter_max: std::time::Duration::from_secs(5 * 60),      // up to 5 min random jitter
+        min_refresh_period: std::time::Duration::from_secs(10),  // min 10s between attempts
+        default_ttl: std::time::Duration::from_secs(5 * 60),     // fallback if no expires_in
+
+        // HTTP client override (None = use defaults):
+        http_config: None,
+    };
+
+    // Debug output redacts secrets:
+    println!("  {config:?}");
+
+    // Validate before use:
+    match config.validate() {
+        Ok(()) => println!("  Config is valid"),
+        Err(e) => println!("  Config error: {e}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Example 7: Error handling
+// ---------------------------------------------------------------------------
+async fn error_handling() {
+    println!("\n=== Example 7: Error handling ===");
+
+    let result = Token::new(OAuthClientConfig {
+        token_endpoint: Some(
+            "https://unreachable.example.com/token"
+                .parse()
+                .expect("valid URL"),
+        ),
+        client_id: "my-service".into(),
+        client_secret: SecretString::new("my-secret"),
+        ..Default::default()
+    })
+    .await;
+
+    match result {
+        Ok(_) => println!("  Token acquired"),
+        Err(TokenError::Http(msg)) => println!("  HTTP error: {msg}"),
+        Err(TokenError::InvalidResponse(msg)) => println!("  Bad response: {msg}"),
+        Err(TokenError::ConfigError(msg)) => println!("  Config error: {msg}"),
+        Err(e) => println!("  Other error: {e}"),
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    println!("OAuth2 Client Credentials -- Usage Examples");
+    println!("============================================");
+    println!();
+    println!("NOTE: Examples 1-5 require a running IDP and will fail without one.");
+    println!("      They demonstrate the API shape, not a runnable demo.");
+
+    // Config overview and error handling work without a real IDP
+    config_overview();
+    error_handling().await;
+
+    // These require a real IDP -- uncomment to test:
+    // direct_token_endpoint().await.unwrap();
+    // oidc_discovery().await.unwrap();
+    // shared_token().await.unwrap();
+    // invalidation_on_401().await.unwrap();
+    // form_auth().await.unwrap();
+}

--- a/libs/modkit-auth/src/http_error.rs
+++ b/libs/modkit-auth/src/http_error.rs
@@ -1,0 +1,120 @@
+/// Format an [`modkit_http::HttpError`] into a human-readable message with a
+/// context prefix.
+///
+/// The prefix identifies the caller context (e.g. `"JWKS"`, `"OAuth2 token"`)
+/// and is prepended to every message so log output is immediately attributable.
+///
+/// This function is the single place that handles the exhaustive (plus
+/// `#[non_exhaustive]` catch-all) match on `HttpError`, shared by JWKS key
+/// fetching, `OAuth2` token acquisition, and any future HTTP-based provider.
+///
+/// # Security
+///
+/// `HttpStatus` errors include only the status code — the response body is
+/// deliberately excluded to prevent server-side diagnostics from leaking
+/// into logs or error messages.
+#[must_use]
+pub fn format_http_error(e: &modkit_http::HttpError, prefix: &str) -> String {
+    use modkit_http::HttpError;
+
+    match e {
+        HttpError::HttpStatus { status, .. } => {
+            format!("{prefix} HTTP {status}")
+        }
+        HttpError::Json(err) => format!("{prefix} JSON parse failed: {err}"),
+        HttpError::Timeout(duration) => {
+            format!("{prefix} request timed out after {duration:?}")
+        }
+        HttpError::DeadlineExceeded(duration) => {
+            format!("{prefix} total deadline exceeded after {duration:?}")
+        }
+        HttpError::Transport(err) => format!("{prefix} transport error: {err}"),
+        HttpError::BodyTooLarge { limit, actual } => {
+            format!("{prefix} response too large: limit {limit} bytes, got {actual} bytes")
+        }
+        HttpError::Tls(err) => format!("{prefix} TLS error: {err}"),
+        HttpError::RequestBuild(err) => format!("{prefix} request build failed: {err}"),
+        HttpError::InvalidHeaderName(err) => format!("{prefix} invalid header name: {err}"),
+        HttpError::InvalidHeaderValue(err) => format!("{prefix} invalid header value: {err}"),
+        HttpError::FormEncode(err) => format!("{prefix} form encode error: {err}"),
+        HttpError::Overloaded => format!("{prefix} request rejected: service overloaded"),
+        HttpError::ServiceClosed => format!("{prefix} service unavailable"),
+        HttpError::InvalidUri { url, reason, .. } => {
+            format!("{prefix} invalid URL '{url}': {reason}")
+        }
+        HttpError::InvalidScheme { scheme, reason } => {
+            format!("{prefix} invalid scheme '{scheme}': {reason}")
+        }
+        // Future variants (HttpError is #[non_exhaustive]) — omit detail
+        // to avoid leaking sensitive data from unknown Display impls.
+        _ => format!("{prefix} request failed"),
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn http_status_without_body() {
+        let err = modkit_http::HttpError::HttpStatus {
+            status: http::StatusCode::NOT_FOUND,
+            body_preview: String::new(),
+            content_type: None,
+            retry_after: None,
+        };
+        let msg = format_http_error(&err, "TEST");
+        assert_eq!(msg, "TEST HTTP 404 Not Found");
+    }
+
+    #[test]
+    fn http_status_with_body_excludes_body() {
+        let err = modkit_http::HttpError::HttpStatus {
+            status: http::StatusCode::INTERNAL_SERVER_ERROR,
+            body_preview: "something broke".into(),
+            content_type: None,
+            retry_after: None,
+        };
+        let msg = format_http_error(&err, "JWKS");
+        // body_preview must NOT appear in the output (security)
+        assert_eq!(msg, "JWKS HTTP 500 Internal Server Error");
+        assert!(!msg.contains("something broke"));
+    }
+
+    #[test]
+    fn timeout_error() {
+        let err = modkit_http::HttpError::Timeout(Duration::from_secs(30));
+        let msg = format_http_error(&err, "OAuth2 token");
+        assert_eq!(msg, "OAuth2 token request timed out after 30s");
+    }
+
+    #[test]
+    fn overloaded_error() {
+        let err = modkit_http::HttpError::Overloaded;
+        let msg = format_http_error(&err, "PREFIX");
+        assert_eq!(msg, "PREFIX request rejected: service overloaded");
+    }
+
+    #[test]
+    fn service_closed_error() {
+        let err = modkit_http::HttpError::ServiceClosed;
+        let msg = format_http_error(&err, "PREFIX");
+        assert_eq!(msg, "PREFIX service unavailable");
+    }
+
+    #[test]
+    fn prefix_propagated_to_all_variants() {
+        // Verify the prefix appears in output for a sample of variants
+        let cases: Vec<modkit_http::HttpError> = vec![
+            modkit_http::HttpError::Overloaded,
+            modkit_http::HttpError::ServiceClosed,
+            modkit_http::HttpError::Timeout(Duration::from_secs(1)),
+        ];
+        for err in &cases {
+            let msg = format_http_error(err, "CTX");
+            assert!(msg.starts_with("CTX "), "Expected prefix 'CTX' in: {msg}");
+        }
+    }
+}

--- a/libs/modkit-auth/src/lib.rs
+++ b/libs/modkit-auth/src/lib.rs
@@ -4,6 +4,7 @@
 // Core modules
 pub mod claims;
 pub mod errors;
+pub mod http_error;
 pub mod traits;
 pub mod types;
 
@@ -21,6 +22,9 @@ pub mod plugins;
 pub mod providers;
 pub mod standard_claims;
 pub mod validation;
+
+// Outbound OAuth2 client credentials
+pub mod oauth2;
 
 #[cfg(feature = "axum-ext")]
 pub mod axum_ext;
@@ -41,3 +45,9 @@ pub use metrics::{AuthEvent, AuthMetricLabels, AuthMetrics, LoggingMetrics, NoOp
 pub use plugin_traits::{ClaimsPlugin, IntrospectionProvider, KeyProvider};
 pub use standard_claims::StandardClaim;
 pub use validation::ValidationConfig;
+
+// Outbound OAuth2 exports
+pub use oauth2::{
+    BearerAuthLayer, ClientAuthMethod, HttpClientBuilderExt, OAuthClientConfig, SecretString,
+    Token, TokenError,
+};

--- a/libs/modkit-auth/src/oauth2/builder_ext.rs
+++ b/libs/modkit-auth/src/oauth2/builder_ext.rs
@@ -1,0 +1,194 @@
+use http::header::HeaderName;
+use tower::ServiceExt;
+
+use super::layer::BearerAuthLayer;
+use super::token::Token;
+
+/// Extension trait for adding bearer auth to [`modkit_http::HttpClientBuilder`].
+///
+/// # Example
+///
+/// ```ignore
+/// use modkit_auth::HttpClientBuilderExt;
+///
+/// let token = Token::new(config).await?;
+/// let client = HttpClientBuilder::new()
+///     .with_bearer_auth(token)
+///     .build()?;
+/// ```
+pub trait HttpClientBuilderExt {
+    /// Add `Authorization: Bearer <token>` injection to the HTTP client.
+    #[must_use]
+    fn with_bearer_auth(self, token: Token) -> Self;
+
+    /// Add `<header_name>: Bearer <token>` injection to the HTTP client.
+    #[must_use]
+    fn with_bearer_auth_header(self, token: Token, header_name: HeaderName) -> Self;
+}
+
+impl HttpClientBuilderExt for modkit_http::HttpClientBuilder {
+    fn with_bearer_auth(self, token: Token) -> Self {
+        let layer = BearerAuthLayer::new(token);
+        self.with_auth_layer(move |svc| {
+            tower::ServiceBuilder::new()
+                .layer(layer)
+                .service(svc)
+                .boxed_clone()
+        })
+    }
+
+    fn with_bearer_auth_header(self, token: Token, header_name: HeaderName) -> Self {
+        let layer = BearerAuthLayer::with_header_name(token, header_name);
+        self.with_auth_layer(move |svc| {
+            tower::ServiceBuilder::new()
+                .layer(layer)
+                .service(svc)
+                .boxed_clone()
+        })
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use httpmock::prelude::*;
+    use modkit_utils::SecretString;
+    use std::time::Duration;
+    use url::Url;
+
+    use crate::oauth2::config::OAuthClientConfig;
+
+    /// Build a test config pointing at the given mock server for token acquisition.
+    fn token_config(server: &MockServer) -> OAuthClientConfig {
+        OAuthClientConfig {
+            token_endpoint: Some(
+                Url::parse(&format!("http://localhost:{}/token", server.port())).unwrap(),
+            ),
+            client_id: "test-client".into(),
+            client_secret: SecretString::new("test-secret"),
+            http_config: Some(modkit_http::HttpClientConfig::for_testing()),
+            jitter_max: Duration::from_millis(0),
+            min_refresh_period: Duration::from_millis(100),
+            ..Default::default()
+        }
+    }
+
+    fn token_json(token: &str, expires_in: u64) -> String {
+        format!(r#"{{"access_token":"{token}","expires_in":{expires_in},"token_type":"Bearer"}}"#)
+    }
+
+    #[tokio::test]
+    async fn with_bearer_auth_injects_header() {
+        // OAuth token endpoint
+        let oauth_server = MockServer::start();
+        let _token_mock = oauth_server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("tok-builder-ext", 3600));
+        });
+
+        // Target API server
+        let api_server = MockServer::start();
+        let api_mock = api_server.mock(|when, then| {
+            when.method(GET)
+                .path("/api/data")
+                .header("authorization", "Bearer tok-builder-ext");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true}"#);
+        });
+
+        let token = Token::new(token_config(&oauth_server)).await.unwrap();
+
+        let client = modkit_http::HttpClientBuilder::new()
+            .allow_insecure_http()
+            .with_bearer_auth(token)
+            .build()
+            .unwrap();
+
+        let _resp = client
+            .get(&format!("http://localhost:{}/api/data", api_server.port()))
+            .send()
+            .await
+            .unwrap();
+
+        api_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn with_bearer_auth_header_injects_custom_header() {
+        let oauth_server = MockServer::start();
+        let _token_mock = oauth_server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("tok-custom-hdr-ext", 3600));
+        });
+
+        let api_server = MockServer::start();
+        let api_mock = api_server.mock(|when, then| {
+            when.method(GET)
+                .path("/api/data")
+                .header("x-api-key", "Bearer tok-custom-hdr-ext");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"ok":true}"#);
+        });
+
+        let token = Token::new(token_config(&oauth_server)).await.unwrap();
+        let custom = HeaderName::from_static("x-api-key");
+
+        let client = modkit_http::HttpClientBuilder::new()
+            .allow_insecure_http()
+            .with_bearer_auth_header(token, custom)
+            .build()
+            .unwrap();
+
+        let _resp = client
+            .get(&format!("http://localhost:{}/api/data", api_server.port()))
+            .send()
+            .await
+            .unwrap();
+
+        api_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn without_bearer_auth_no_header() {
+        let api_server = MockServer::start();
+
+        // Mock that REQUIRES Authorization header — should NOT be hit.
+        let auth_mock = api_server.mock(|when, then| {
+            when.method(GET)
+                .path("/api/data")
+                .header_exists("authorization");
+            then.status(200).body("authed");
+        });
+
+        // Catch-all mock for the GET.
+        let fallback_mock = api_server.mock(|when, then| {
+            when.method(GET).path("/api/data");
+            then.status(200).body("no-auth");
+        });
+
+        let client = modkit_http::HttpClientBuilder::new()
+            .allow_insecure_http()
+            .build()
+            .unwrap();
+
+        let _resp = client
+            .get(&format!("http://localhost:{}/api/data", api_server.port()))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            auth_mock.calls(),
+            0,
+            "No Authorization header should be sent without bearer auth"
+        );
+        fallback_mock.assert();
+    }
+}

--- a/libs/modkit-auth/src/oauth2/config.rs
+++ b/libs/modkit-auth/src/oauth2/config.rs
@@ -1,0 +1,313 @@
+use std::fmt;
+use std::time::Duration;
+use url::Url;
+
+use super::error::TokenError;
+use super::types::{ClientAuthMethod, SecretString};
+
+/// Configuration for an outbound `OAuth2` client credentials flow.
+///
+/// Exactly one of [`token_endpoint`](Self::token_endpoint) or
+/// [`issuer_url`](Self::issuer_url) must be set.  Call
+/// [`validate`](Self::validate) to enforce this constraint.
+///
+/// `Debug` is manually implemented to redact [`client_secret`](Self::client_secret).
+pub struct OAuthClientConfig {
+    // ---- endpoint resolution ------------------------------------------------
+    /// Direct token endpoint URL (mutually exclusive with `issuer_url`).
+    pub token_endpoint: Option<Url>,
+
+    /// OIDC issuer URL for discovery (mutually exclusive with `token_endpoint`).
+    /// The actual token endpoint is resolved via
+    /// `{issuer_url}/.well-known/openid-configuration`.
+    pub issuer_url: Option<Url>,
+
+    // ---- credentials --------------------------------------------------------
+    /// `OAuth2` client identifier.
+    pub client_id: String,
+
+    /// `OAuth2` client secret (redacted in `Debug` output).
+    pub client_secret: SecretString,
+
+    /// Requested scopes (normalized once, stable order).
+    pub scopes: Vec<String>,
+
+    /// How client credentials are transmitted to the token endpoint.
+    pub auth_method: ClientAuthMethod,
+
+    /// Extra headers attached to every token request (vendor quirks).
+    pub extra_headers: Vec<(String, String)>,
+
+    // ---- refresh policy -----------------------------------------------------
+    /// How far before expiry the token should be refreshed (default: 30 min).
+    pub refresh_offset: Duration,
+
+    /// Maximum random jitter added to the refresh offset (default: 5 min).
+    pub jitter_max: Duration,
+
+    /// Minimum period between consecutive refresh attempts (default: 10 s).
+    pub min_refresh_period: Duration,
+
+    /// Fallback TTL when the token endpoint omits `expires_in` (default: 5 min).
+    pub default_ttl: Duration,
+
+    // ---- HTTP client --------------------------------------------------------
+    /// Override for the internal HTTP client configuration.
+    /// When `None`,
+    /// [`HttpClientConfig::token_endpoint()`](modkit_http::HttpClientConfig::token_endpoint)
+    /// is used.
+    pub http_config: Option<modkit_http::HttpClientConfig>,
+}
+
+impl OAuthClientConfig {
+    /// Validate that the configuration is self-consistent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TokenError::ConfigError`] if:
+    /// - both `token_endpoint` and `issuer_url` are set, or
+    /// - neither is set.
+    pub fn validate(&self) -> Result<(), TokenError> {
+        if self.client_id.trim().is_empty() {
+            return Err(TokenError::ConfigError(
+                "client_id must not be empty".into(),
+            ));
+        }
+        if self.client_secret.expose().is_empty() {
+            return Err(TokenError::ConfigError(
+                "client_secret must not be empty".into(),
+            ));
+        }
+        match (&self.token_endpoint, &self.issuer_url) {
+            (Some(_), Some(_)) => Err(TokenError::ConfigError(
+                "token_endpoint and issuer_url are mutually exclusive".into(),
+            )),
+            (None, None) => Err(TokenError::ConfigError(
+                "one of token_endpoint or issuer_url must be set".into(),
+            )),
+            _ => Ok(()),
+        }
+    }
+}
+
+impl Clone for OAuthClientConfig {
+    fn clone(&self) -> Self {
+        Self {
+            token_endpoint: self.token_endpoint.clone(),
+            issuer_url: self.issuer_url.clone(),
+            client_id: self.client_id.clone(),
+            client_secret: self.client_secret.clone(),
+            scopes: self.scopes.clone(),
+            auth_method: self.auth_method,
+            extra_headers: self.extra_headers.clone(),
+            refresh_offset: self.refresh_offset,
+            jitter_max: self.jitter_max,
+            min_refresh_period: self.min_refresh_period,
+            default_ttl: self.default_ttl,
+            http_config: self.http_config.clone(),
+        }
+    }
+}
+
+/// `Debug` redacts `client_secret` to prevent accidental exposure in logs.
+impl fmt::Debug for OAuthClientConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let redacted_headers: Vec<_> = self
+            .extra_headers
+            .iter()
+            .map(|(k, _)| (k.as_str(), "[REDACTED]"))
+            .collect();
+        f.debug_struct("OAuthClientConfig")
+            .field("token_endpoint", &self.token_endpoint)
+            .field("issuer_url", &self.issuer_url)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"[REDACTED]")
+            .field("scopes", &self.scopes)
+            .field("auth_method", &self.auth_method)
+            .field("extra_headers", &redacted_headers)
+            .field("refresh_offset", &self.refresh_offset)
+            .field("jitter_max", &self.jitter_max)
+            .field("min_refresh_period", &self.min_refresh_period)
+            .field("default_ttl", &self.default_ttl)
+            .field("http_config", &self.http_config)
+            .finish()
+    }
+}
+
+impl Default for OAuthClientConfig {
+    fn default() -> Self {
+        Self {
+            token_endpoint: None,
+            issuer_url: None,
+            client_id: String::new(),
+            client_secret: SecretString::new(String::new()),
+            scopes: Vec::new(),
+            auth_method: ClientAuthMethod::default(),
+            extra_headers: Vec::new(),
+            refresh_offset: Duration::from_secs(30 * 60),
+            jitter_max: Duration::from_secs(5 * 60),
+            min_refresh_period: Duration::from_secs(10),
+            default_ttl: Duration::from_secs(5 * 60),
+            http_config: None,
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    fn test_url(s: &str) -> Url {
+        Url::parse(s).unwrap()
+    }
+
+    // ---- validate -----------------------------------------------------------
+
+    /// Returns a minimal valid config (credentials + one endpoint).
+    fn valid_base() -> OAuthClientConfig {
+        OAuthClientConfig {
+            client_id: "my-client".into(),
+            client_secret: SecretString::new("my-secret"),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn validate_ok_with_token_endpoint_only() {
+        let cfg = OAuthClientConfig {
+            token_endpoint: Some(test_url("https://auth.example.com/token")),
+            ..valid_base()
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_ok_with_issuer_url_only() {
+        let cfg = OAuthClientConfig {
+            issuer_url: Some(test_url("https://auth.example.com")),
+            ..valid_base()
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_err_when_both_set() {
+        let cfg = OAuthClientConfig {
+            token_endpoint: Some(test_url("https://a.example.com/token")),
+            issuer_url: Some(test_url("https://b.example.com")),
+            ..valid_base()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("mutually exclusive"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_err_when_neither_set() {
+        let cfg = valid_base();
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("must be set"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_err_when_client_id_empty() {
+        let cfg = OAuthClientConfig {
+            token_endpoint: Some(test_url("https://auth.example.com/token")),
+            client_id: String::new(),
+            client_secret: SecretString::new("my-secret"),
+            ..Default::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("client_id"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_err_when_client_id_whitespace() {
+        let cfg = OAuthClientConfig {
+            token_endpoint: Some(test_url("https://auth.example.com/token")),
+            client_id: "   ".into(),
+            client_secret: SecretString::new("my-secret"),
+            ..Default::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("client_id"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_err_when_client_secret_empty() {
+        let cfg = OAuthClientConfig {
+            token_endpoint: Some(test_url("https://auth.example.com/token")),
+            client_id: "my-client".into(),
+            client_secret: SecretString::new(""),
+            ..Default::default()
+        };
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("client_secret"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // ---- Debug redaction ----------------------------------------------------
+
+    #[test]
+    fn debug_redacts_client_secret() {
+        let cfg = OAuthClientConfig {
+            token_endpoint: Some(test_url("https://auth.example.com/token")),
+            client_id: "my-client".into(),
+            client_secret: SecretString::new("super-secret"),
+            ..Default::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(dbg.contains("[REDACTED]"), "Debug must contain [REDACTED]");
+        assert!(
+            !dbg.contains("super-secret"),
+            "Debug must not contain the raw secret"
+        );
+        assert!(dbg.contains("my-client"), "Debug should contain client_id");
+    }
+
+    #[test]
+    fn debug_redacts_extra_header_values() {
+        let cfg = OAuthClientConfig {
+            token_endpoint: Some(test_url("https://auth.example.com/token")),
+            client_id: "my-client".into(),
+            client_secret: SecretString::new("s"),
+            extra_headers: vec![("x-api-key".into(), "secret-api-key-value".into())],
+            ..Default::default()
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(
+            dbg.contains("x-api-key"),
+            "Debug should contain header name"
+        );
+        assert!(
+            !dbg.contains("secret-api-key-value"),
+            "Debug must not contain header value"
+        );
+    }
+
+    // ---- Default ------------------------------------------------------------
+
+    #[test]
+    fn default_durations() {
+        let cfg = OAuthClientConfig::default();
+        assert_eq!(cfg.refresh_offset, Duration::from_secs(30 * 60));
+        assert_eq!(cfg.jitter_max, Duration::from_secs(5 * 60));
+        assert_eq!(cfg.min_refresh_period, Duration::from_secs(10));
+        assert_eq!(cfg.default_ttl, Duration::from_secs(5 * 60));
+        assert_eq!(cfg.auth_method, ClientAuthMethod::Basic);
+    }
+}

--- a/libs/modkit-auth/src/oauth2/discovery.rs
+++ b/libs/modkit-auth/src/oauth2/discovery.rs
@@ -1,0 +1,209 @@
+use serde::Deserialize;
+use url::Url;
+
+use super::error::TokenError;
+
+/// Minimal subset of the `OpenID` Connect discovery document.
+///
+/// Only `token_endpoint` is required; all other fields are silently ignored.
+#[derive(Deserialize)]
+struct OidcDiscoveryDoc {
+    token_endpoint: String,
+}
+
+/// Resolve the token endpoint from an OIDC issuer URL.
+///
+/// Fetches `{issuer_url}/.well-known/openid-configuration` and extracts
+/// the `token_endpoint` field. This is a one-time operation at startup.
+///
+/// # Errors
+///
+/// Returns [`TokenError::Http`] if the discovery request fails or returns a
+/// non-success status.
+/// Returns [`TokenError::InvalidResponse`] if the response body cannot be
+/// parsed, the `token_endpoint` field is missing, or it is not a valid URL.
+pub async fn discover_token_endpoint(
+    client: &modkit_http::HttpClient,
+    issuer_url: &Url,
+) -> Result<Url, TokenError> {
+    let base = issuer_url.as_str().trim_end_matches('/');
+    let discovery_url = format!("{base}/.well-known/openid-configuration");
+
+    let doc: OidcDiscoveryDoc = client
+        .get(&discovery_url)
+        .send()
+        .await
+        .map_err(|e| TokenError::Http(crate::http_error::format_http_error(&e, "OIDC discovery")))?
+        .error_for_status()
+        .map_err(|e| TokenError::Http(crate::http_error::format_http_error(&e, "OIDC discovery")))?
+        .json()
+        .await
+        .map_err(|e| {
+            TokenError::InvalidResponse(crate::http_error::format_http_error(&e, "OIDC discovery"))
+        })?;
+
+    Url::parse(&doc.token_endpoint).map_err(|e| {
+        TokenError::InvalidResponse(format!(
+            "invalid token_endpoint URL in discovery document: {e}"
+        ))
+    })
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use httpmock::prelude::*;
+
+    fn build_client(_server: &MockServer) -> modkit_http::HttpClient {
+        modkit_http::HttpClientBuilder::with_config(modkit_http::HttpClientConfig::for_testing())
+            .build()
+            .unwrap()
+    }
+
+    fn issuer_url(server: &MockServer) -> Url {
+        Url::parse(&format!("http://localhost:{}", server.port())).unwrap()
+    }
+
+    fn issuer_url_trailing_slash(server: &MockServer) -> Url {
+        Url::parse(&format!("http://localhost:{}/", server.port())).unwrap()
+    }
+
+    #[tokio::test]
+    async fn discover_valid_response() {
+        let server = MockServer::start();
+        let token_ep = format!("http://localhost:{}/oauth/token", server.port());
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(format!(r#"{{"token_endpoint":"{token_ep}"}}"#));
+        });
+
+        let client = build_client(&server);
+        let result = discover_token_endpoint(&client, &issuer_url(&server)).await;
+
+        let url = result.unwrap();
+        assert_eq!(url.as_str(), token_ep);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn discover_strips_trailing_slash() {
+        let server = MockServer::start();
+        let token_ep = format!("http://localhost:{}/oauth/token", server.port());
+
+        let mock = server.mock(|when, then| {
+            // Must NOT have a double slash — "/.well-known/..." not "//.well-known/..."
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(format!(r#"{{"token_endpoint":"{token_ep}"}}"#));
+        });
+
+        let client = build_client(&server);
+        let result = discover_token_endpoint(&client, &issuer_url_trailing_slash(&server)).await;
+
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result.err());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn discover_no_trailing_slash() {
+        let server = MockServer::start();
+        let token_ep = format!("http://localhost:{}/oauth/token", server.port());
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(format!(r#"{{"token_endpoint":"{token_ep}"}}"#));
+        });
+
+        let client = build_client(&server);
+        let result = discover_token_endpoint(&client, &issuer_url(&server)).await;
+
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result.err());
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn discover_missing_field() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"authorization_endpoint":"https://example.com/auth"}"#);
+        });
+
+        let client = build_client(&server);
+        let err = discover_token_endpoint(&client, &issuer_url(&server))
+            .await
+            .unwrap_err();
+
+        // serde deserialization error for missing required field → InvalidResponse
+        assert!(
+            matches!(err, TokenError::InvalidResponse(ref msg) if msg.contains("OIDC discovery")),
+            "expected InvalidResponse with OIDC discovery prefix, got: {err}"
+        );
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn discover_invalid_url() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"token_endpoint":"not a valid url"}"#);
+        });
+
+        let client = build_client(&server);
+        let err = discover_token_endpoint(&client, &issuer_url(&server))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                TokenError::InvalidResponse(ref msg)
+                    if msg.contains("invalid token_endpoint")
+            ),
+            "expected InvalidResponse, got: {err}"
+        );
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn discover_http_error() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(500)
+                .header("content-type", "application/json")
+                .body(r#"{"error":"server_error"}"#);
+        });
+
+        let client = build_client(&server);
+        let err = discover_token_endpoint(&client, &issuer_url(&server))
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                TokenError::Http(ref msg)
+                    if msg.contains("OIDC discovery")
+                        && msg.contains("500")
+            ),
+            "expected Http error with 500 status, got: {err}"
+        );
+        mock.assert();
+    }
+}

--- a/libs/modkit-auth/src/oauth2/error.rs
+++ b/libs/modkit-auth/src/oauth2/error.rs
@@ -1,0 +1,73 @@
+use thiserror::Error;
+
+/// Errors returned by the outbound `OAuth2` client credentials flow.
+///
+/// All variants are deliberately constructed so that secret values
+/// (`client_secret`, access tokens) can never appear in the formatted output.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum TokenError {
+    /// HTTP transport or status error during token acquisition.
+    ///
+    /// The inner string is produced by
+    /// [`format_http_error`](crate::http_error::format_http_error) and never
+    /// contains secrets.
+    #[error("{0}")]
+    Http(String),
+
+    /// The token endpoint returned an unparseable or incomplete response.
+    #[error("invalid token response: {0}")]
+    InvalidResponse(String),
+
+    /// The token endpoint returned a `token_type` that is not `Bearer`.
+    #[error("unsupported token type: {0}")]
+    UnsupportedTokenType(String),
+
+    /// Configuration is invalid (e.g. both `token_endpoint` and `issuer_url`
+    /// are set, or neither is set).
+    #[error("OAuth2 config error: {0}")]
+    ConfigError(String),
+
+    /// The token watcher is not ready or has been shut down.
+    #[error("token unavailable: {0}")]
+    Unavailable(String),
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_error_renders() {
+        let e = TokenError::ConfigError("both endpoints set".into());
+        assert_eq!(e.to_string(), "OAuth2 config error: both endpoints set");
+    }
+
+    #[test]
+    fn http_error_renders() {
+        let e = TokenError::Http("OAuth2 token HTTP 401 Unauthorized".into());
+        assert_eq!(e.to_string(), "OAuth2 token HTTP 401 Unauthorized");
+    }
+
+    #[test]
+    fn invalid_response_renders() {
+        let e = TokenError::InvalidResponse("missing access_token".into());
+        assert_eq!(
+            e.to_string(),
+            "invalid token response: missing access_token"
+        );
+    }
+
+    #[test]
+    fn unsupported_token_type_renders() {
+        let e = TokenError::UnsupportedTokenType("mac".into());
+        assert_eq!(e.to_string(), "unsupported token type: mac");
+    }
+
+    #[test]
+    fn unavailable_renders() {
+        let e = TokenError::Unavailable("watcher shut down".into());
+        assert_eq!(e.to_string(), "token unavailable: watcher shut down");
+    }
+}

--- a/libs/modkit-auth/src/oauth2/layer.rs
+++ b/libs/modkit-auth/src/oauth2/layer.rs
@@ -1,0 +1,320 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use http::header::{AUTHORIZATION, HeaderName};
+use http::{HeaderValue, Request, Response};
+use tower::{Layer, Service};
+
+use super::token::Token;
+use modkit_http::HttpError;
+
+/// Tower layer that injects a bearer token into outbound HTTP requests.
+///
+/// Wraps an [`Token`] handle and sets the `Authorization: Bearer <token>`
+/// header (or a custom header) on every request before forwarding it to the
+/// inner service.
+#[derive(Clone, Debug)]
+pub struct BearerAuthLayer {
+    token: Token,
+    header_name: HeaderName,
+}
+
+impl BearerAuthLayer {
+    /// Create a layer that injects `Authorization: Bearer <token>`.
+    #[must_use]
+    pub fn new(token: Token) -> Self {
+        Self {
+            token,
+            header_name: AUTHORIZATION,
+        }
+    }
+
+    /// Create a layer that injects `<header_name>: Bearer <token>`.
+    #[must_use]
+    pub fn with_header_name(token: Token, header_name: HeaderName) -> Self {
+        Self { token, header_name }
+    }
+}
+
+impl<S> Layer<S> for BearerAuthLayer {
+    type Service = BearerAuthService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        BearerAuthService {
+            inner,
+            token: self.token.clone(),
+            header_name: self.header_name.clone(),
+        }
+    }
+}
+
+/// Tower service that injects a bearer token header before forwarding the
+/// request to the inner service.
+///
+/// Created by [`BearerAuthLayer`].
+#[derive(Clone, Debug)]
+pub struct BearerAuthService<S> {
+    inner: S,
+    token: Token,
+    header_name: HeaderName,
+}
+
+impl<S, B, ResBody> Service<Request<B>> for BearerAuthService<S>
+where
+    S: Service<Request<B>, Response = Response<ResBody>, Error = HttpError>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+    B: Send + 'static,
+    ResBody: Send + 'static,
+{
+    type Response = Response<ResBody>;
+    type Error = HttpError;
+    type Future = Pin<Box<dyn Future<Output = Result<Response<ResBody>, HttpError>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<B>) -> Self::Future {
+        let mut bearer_value = match self.token.get() {
+            Ok(secret) => {
+                let raw = zeroize::Zeroizing::new(format!("Bearer {}", secret.expose()));
+                match HeaderValue::from_str(&raw) {
+                    Ok(v) => v,
+                    Err(e) => return Box::pin(async { Err(HttpError::InvalidHeaderValue(e)) }),
+                }
+            }
+            Err(e) => {
+                return Box::pin(async { Err(HttpError::Transport(Box::new(e))) });
+            }
+        };
+        bearer_value.set_sensitive(true);
+
+        req.headers_mut()
+            .insert(self.header_name.clone(), bearer_value);
+
+        // Clone-swap pattern (Tower Service contract).
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move { inner.call(req).await })
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use http::{Method, Request, Response, StatusCode};
+    use http_body_util::Full;
+    use httpmock::prelude::*;
+    use modkit_utils::SecretString;
+    use std::time::Duration;
+    use url::Url;
+
+    use crate::oauth2::config::OAuthClientConfig;
+
+    /// Build a test config pointing at the given mock server.
+    fn test_config(server: &MockServer) -> OAuthClientConfig {
+        OAuthClientConfig {
+            token_endpoint: Some(
+                Url::parse(&format!("http://localhost:{}/token", server.port())).unwrap(),
+            ),
+            client_id: "test-client".into(),
+            client_secret: SecretString::new("test-secret"),
+            http_config: Some(modkit_http::HttpClientConfig::for_testing()),
+            jitter_max: Duration::from_millis(0),
+            min_refresh_period: Duration::from_millis(100),
+            ..Default::default()
+        }
+    }
+
+    fn token_json(token: &str, expires_in: u64) -> String {
+        format!(r#"{{"access_token":"{token}","expires_in":{expires_in},"token_type":"Bearer"}}"#)
+    }
+
+    // -- mock inner service ---------------------------------------------------
+
+    /// Mock service that captures request headers and returns 200 OK.
+    #[derive(Clone)]
+    struct CaptureHeaderService {
+        expected_header: HeaderName,
+        expected_value: String,
+    }
+
+    impl Service<Request<Full<Bytes>>> for CaptureHeaderService {
+        type Response = Response<Full<Bytes>>;
+        type Error = HttpError;
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: Request<Full<Bytes>>) -> Self::Future {
+            let header = req
+                .headers()
+                .get(&self.expected_header)
+                .expect("expected header not found")
+                .to_str()
+                .unwrap()
+                .to_owned();
+            let expected = self.expected_value.clone();
+
+            Box::pin(async move {
+                assert_eq!(header, expected);
+                Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .body(Full::new(Bytes::new()))
+                    .unwrap())
+            })
+        }
+    }
+
+    // -- trait assertions -----------------------------------------------------
+
+    #[test]
+    fn bearer_auth_is_send_sync_clone() {
+        fn assert_traits<T: Send + Sync + Clone>() {}
+        assert_traits::<BearerAuthLayer>();
+        assert_traits::<BearerAuthService<CaptureHeaderService>>();
+    }
+
+    // -- header injection -----------------------------------------------------
+
+    #[tokio::test]
+    async fn injects_authorization_header() {
+        let server = MockServer::start();
+
+        let _mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("tok-layer-test", 3600));
+        });
+
+        let token = Token::new(test_config(&server)).await.unwrap();
+        let inner = CaptureHeaderService {
+            expected_header: AUTHORIZATION,
+            expected_value: "Bearer tok-layer-test".into(),
+        };
+
+        let layer = BearerAuthLayer::new(token);
+        let mut svc = layer.layer(inner);
+
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("http://example.com/api")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+
+        Service::call(&mut svc, req).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn custom_header_name() {
+        let server = MockServer::start();
+
+        let _mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("tok-custom-hdr", 3600));
+        });
+
+        let token = Token::new(test_config(&server)).await.unwrap();
+        let custom_header = HeaderName::from_static("x-api-key");
+        let inner = CaptureHeaderService {
+            expected_header: custom_header.clone(),
+            expected_value: "Bearer tok-custom-hdr".into(),
+        };
+
+        let layer = BearerAuthLayer::with_header_name(token, custom_header);
+        let mut svc = layer.layer(inner);
+
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("http://example.com/api")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+
+        Service::call(&mut svc, req).await.unwrap();
+    }
+
+    // -- error path -----------------------------------------------------------
+
+    #[tokio::test]
+    async fn returns_error_when_token_expired() {
+        let server = MockServer::start();
+
+        // Initial token fetch succeeds but with very short TTL.
+        let mut success_mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("tok-short-lived", 1));
+        });
+
+        let token = Token::new(test_config(&server)).await.unwrap();
+        assert_eq!(success_mock.calls(), 1);
+
+        // Remove the success mock; refresh attempts will now fail.
+        success_mock.delete();
+        let _fail_mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(500)
+                .header("content-type", "application/json")
+                .body(r#"{"error":"server_error"}"#);
+        });
+
+        // Wait for token to expire + refresh to fail.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let inner = CaptureHeaderService {
+            expected_header: AUTHORIZATION,
+            expected_value: String::new(), // won't be reached
+        };
+
+        let layer = BearerAuthLayer::new(token);
+        let mut svc = layer.layer(inner);
+
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("http://example.com/api")
+            .body(Full::new(Bytes::new()))
+            .unwrap();
+
+        let err = Service::call(&mut svc, req).await.unwrap_err();
+        assert!(
+            matches!(err, HttpError::Transport(_)),
+            "expected Transport error, got: {err:?}"
+        );
+    }
+
+    // -- debug safety ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn token_value_not_in_debug() {
+        let server = MockServer::start();
+
+        let _mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("super-secret-layer", 3600));
+        });
+
+        let token = Token::new(test_config(&server)).await.unwrap();
+        let layer = BearerAuthLayer::new(token);
+        let dbg = format!("{layer:?}");
+
+        assert!(
+            !dbg.contains("super-secret-layer"),
+            "Debug must not reveal token value: {dbg}"
+        );
+    }
+}

--- a/libs/modkit-auth/src/oauth2/mod.rs
+++ b/libs/modkit-auth/src/oauth2/mod.rs
@@ -1,0 +1,20 @@
+//! Outbound `OAuth2` client credentials flow.
+//!
+//! This module implements token acquisition, caching, and automatic injection
+//! for outbound HTTP requests to vendor services secured with `OAuth2`.
+
+pub mod builder_ext;
+pub mod config;
+pub(crate) mod discovery;
+pub mod error;
+pub mod layer;
+pub(crate) mod source;
+pub mod token;
+pub mod types;
+
+pub use builder_ext::HttpClientBuilderExt;
+pub use config::OAuthClientConfig;
+pub use error::TokenError;
+pub use layer::BearerAuthLayer;
+pub use token::Token;
+pub use types::{ClientAuthMethod, SecretString};

--- a/libs/modkit-auth/src/oauth2/source.rs
+++ b/libs/modkit-auth/src/oauth2/source.rs
@@ -1,0 +1,615 @@
+use std::time::Duration;
+
+use aliri_clock::DurationSecs;
+use aliri_tokens::sources::AsyncTokenSource;
+use aliri_tokens::{AccessToken, IdToken, TokenLifetimeConfig, TokenWithLifetime};
+use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose};
+use http::header::AUTHORIZATION;
+use url::Url;
+use zeroize::Zeroizing;
+
+use super::config::OAuthClientConfig;
+use super::error::TokenError;
+use super::types::ClientAuthMethod;
+use modkit_utils::SecretString;
+
+/// Token source that exchanges client credentials for an access token using
+/// `modkit-http::HttpClient`.
+///
+/// It implements [`aliri_tokens::AsyncTokenSource`] so that
+/// `aliri_tokens` can drive refresh scheduling, jitter, and backoff.
+pub struct OAuthTokenSource {
+    client: modkit_http::HttpClient,
+    token_endpoint: Url,
+    client_id: String,
+    client_secret: SecretString,
+    /// Pre-joined scopes (space-separated), or `None` when the scope list is
+    /// empty.
+    scopes: Option<String>,
+    auth_method: ClientAuthMethod,
+    extra_headers: Vec<(String, String)>,
+    default_ttl: Duration,
+    refresh_offset: Duration,
+    min_refresh_period: Duration,
+}
+
+impl OAuthTokenSource {
+    /// Build a new token source from the given configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TokenError::ConfigError`] if `token_endpoint` is `None`.
+    ///
+    /// Returns [`TokenError::Http`] if the underlying `HttpClient` fails to
+    /// build.
+    pub fn new(config: &OAuthClientConfig) -> Result<Self, TokenError> {
+        let token_endpoint = config
+            .token_endpoint
+            .clone()
+            .ok_or_else(|| TokenError::ConfigError("token_endpoint is required".into()))?;
+
+        let http_config = config
+            .http_config
+            .clone()
+            .unwrap_or_else(modkit_http::HttpClientConfig::token_endpoint);
+
+        let client = modkit_http::HttpClientBuilder::with_config(http_config)
+            .build()
+            .map_err(|e| {
+                TokenError::Http(crate::http_error::format_http_error(&e, "OAuth2 token"))
+            })?;
+
+        let scopes = if config.scopes.is_empty() {
+            None
+        } else {
+            Some(config.scopes.join(" "))
+        };
+
+        Ok(Self {
+            client,
+            token_endpoint,
+            client_id: config.client_id.clone(),
+            client_secret: config.client_secret.clone(),
+            scopes,
+            auth_method: config.auth_method,
+            extra_headers: config.extra_headers.clone(),
+            default_ttl: config.default_ttl,
+            refresh_offset: config.refresh_offset,
+            min_refresh_period: config.min_refresh_period,
+        })
+    }
+}
+
+#[async_trait]
+impl AsyncTokenSource for OAuthTokenSource {
+    type Error = TokenError;
+
+    async fn request_token(&mut self) -> Result<TokenWithLifetime, Self::Error> {
+        // -- build form fields ---------------------------------------------------
+        let mut fields: Vec<(&str, &str)> = vec![("grant_type", "client_credentials")];
+
+        if let Some(ref scope) = self.scopes {
+            fields.push(("scope", scope));
+        }
+
+        // For Form auth, credentials go into the form body.
+        // Wrap the temporary copy in `Zeroizing` so it is scrubbed on drop.
+        let secret_expose;
+        if self.auth_method == ClientAuthMethod::Form {
+            secret_expose = Zeroizing::new(self.client_secret.expose().to_owned());
+            fields.push(("client_id", &self.client_id));
+            fields.push(("client_secret", &secret_expose));
+        }
+
+        // -- build request -------------------------------------------------------
+        let mut builder = self.client.post(self.token_endpoint.as_str());
+
+        // For Basic auth, credentials go into the Authorization header.
+        // Wrap intermediates in `Zeroizing` so the plaintext is scrubbed on drop.
+        if self.auth_method == ClientAuthMethod::Basic {
+            let credentials = Zeroizing::new(format!(
+                "{}:{}",
+                self.client_id,
+                self.client_secret.expose()
+            ));
+            let encoded = Zeroizing::new(general_purpose::STANDARD.encode(credentials.as_bytes()));
+            let header_value = Zeroizing::new(format!("Basic {}", &*encoded));
+            builder = builder.header(AUTHORIZATION.as_str(), &header_value);
+        }
+
+        // Apply vendor-specific extra headers.
+        for (name, value) in &self.extra_headers {
+            builder = builder.header(name, value);
+        }
+
+        let response = builder
+            .form(fields.as_slice())
+            .map_err(|e| {
+                TokenError::Http(crate::http_error::format_http_error(&e, "OAuth2 token"))
+            })?
+            .send()
+            .await
+            .map_err(|e| {
+                TokenError::Http(crate::http_error::format_http_error(&e, "OAuth2 token"))
+            })?;
+
+        // -- check status, then parse response ------------------------------------
+        let token_resp: super::types::TokenResponse = response
+            .error_for_status()
+            .map_err(|e| {
+                TokenError::Http(crate::http_error::format_http_error(&e, "OAuth2 token"))
+            })?
+            .json()
+            .await
+            .map_err(|e| {
+                TokenError::Http(crate::http_error::format_http_error(&e, "OAuth2 token"))
+            })?;
+
+        // -- validate token_type -------------------------------------------------
+        if let Some(ref tt) = token_resp.token_type
+            && !tt.eq_ignore_ascii_case("bearer")
+        {
+            return Err(TokenError::UnsupportedTokenType(tt.clone()));
+        }
+
+        // -- compute lifetime ----------------------------------------------------
+        let lifetime_secs = token_resp.expires_in.unwrap_or(self.default_ttl.as_secs());
+
+        // Compute per-token refresh parameters so that the stale time
+        // never exceeds the expiry time, even for short-lived tokens.
+        let (freshness, min_stale) = refresh_params(
+            lifetime_secs,
+            &self.refresh_offset,
+            &self.min_refresh_period,
+        );
+        let lifetime_config = TokenLifetimeConfig::new(freshness, min_stale);
+
+        let access_token = AccessToken::new(token_resp.access_token);
+        let token = lifetime_config.create_token(
+            &access_token,
+            None::<&IdToken>,
+            DurationSecs(lifetime_secs),
+        );
+
+        Ok(token)
+    }
+}
+
+/// Compute refresh parameters for [`TokenLifetimeConfig`].
+///
+/// Returns `(freshness_period, min_staleness_period)` such that
+/// `max(lifetime × freshness_period, min_staleness_period) <= lifetime`,
+/// guaranteeing the stale time never exceeds the expiry time.
+///
+/// `min_refresh_period` is used as a **lower bound on the staleness
+/// window** (the minimum time the token spends in the "stale" state
+/// before expiry), not as a refresh deadline. It is capped to
+/// `desired_delay` so it can never push the stale time past expiry.
+/// In `aliri_tokens` terms it maps to `min_staleness_period`.
+///
+/// - Normal case (`offset < lifetime`): stale `offset` seconds before
+///   expiry.
+/// - Short-lived token (`offset >= lifetime`): stale at 50% of lifetime.
+/// - Zero lifetime: immediately stale.
+#[allow(clippy::integer_division, clippy::cast_precision_loss)]
+fn refresh_params(
+    lifetime_secs: u64,
+    refresh_offset: &Duration,
+    min_refresh_period: &Duration,
+) -> (f64, DurationSecs) {
+    if lifetime_secs == 0 {
+        return (0.0, DurationSecs(0));
+    }
+
+    let offset = refresh_offset.as_secs();
+    let desired_delay = if offset < lifetime_secs {
+        lifetime_secs - offset
+    } else {
+        // Fallback: stale at 50% of lifetime (truncation is fine).
+        lifetime_secs / 2
+    };
+
+    // Precision loss is negligible — token lifetimes are practical
+    // values well within f64 mantissa range.
+    let freshness = (desired_delay as f64) / (lifetime_secs as f64);
+    let min_stale = min_refresh_period.as_secs().min(desired_delay);
+
+    (freshness, DurationSecs(min_stale))
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use httpmock::prelude::*;
+
+    /// Build a minimal valid config pointing at the mock server.
+    fn test_config(server: &MockServer) -> OAuthClientConfig {
+        OAuthClientConfig {
+            token_endpoint: Some(
+                Url::parse(&format!("http://localhost:{}/token", server.port())).unwrap(),
+            ),
+            client_id: "test-client".into(),
+            client_secret: SecretString::new("test-secret"),
+            http_config: Some(modkit_http::HttpClientConfig::for_testing()),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn request_token_basic_auth_success() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/token")
+                .header_exists("authorization")
+                .body_includes("grant_type=client_credentials");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok-123","expires_in":3600,"token_type":"Bearer"}"#);
+        });
+
+        let mut source = OAuthTokenSource::new(&test_config(&server)).unwrap();
+        let token = source.request_token().await.unwrap();
+
+        assert_eq!(token.access_token().as_str(), "tok-123");
+        assert_eq!(token.lifetime(), DurationSecs(3600));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn missing_expires_in_uses_default_ttl() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok-456"}"#);
+        });
+
+        let mut source = OAuthTokenSource::new(&test_config(&server)).unwrap();
+        let token = source.request_token().await.unwrap();
+
+        // default_ttl from OAuthClientConfig::default() is 5 min = 300s
+        assert_eq!(token.lifetime(), DurationSecs(300));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn expires_in_zero_honoured() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok-zero","expires_in":0}"#);
+        });
+
+        let mut source = OAuthTokenSource::new(&test_config(&server)).unwrap();
+        let token = source.request_token().await.unwrap();
+
+        // Server-provided expires_in is honoured as-is; aliri handles refresh scheduling.
+        assert_eq!(token.lifetime(), DurationSecs(0));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn unsupported_token_type_returns_error() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok","token_type":"mac"}"#);
+        });
+
+        let mut source = OAuthTokenSource::new(&test_config(&server)).unwrap();
+        let err = source.request_token().await.unwrap_err();
+
+        assert!(
+            matches!(err, TokenError::UnsupportedTokenType(ref t) if t == "mac"),
+            "expected UnsupportedTokenType(\"mac\"), got: {err}"
+        );
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn empty_scopes_omits_scope_param() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/token")
+                .body_includes("grant_type=client_credentials")
+                .body_excludes("scope");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok"}"#);
+        });
+
+        let mut source = OAuthTokenSource::new(&test_config(&server)).unwrap();
+        source.request_token().await.unwrap();
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn scopes_are_space_joined() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/token")
+                .body_includes("scope=read+write");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok"}"#);
+        });
+
+        let mut cfg = test_config(&server);
+        cfg.scopes = vec!["read".into(), "write".into()];
+        let mut source = OAuthTokenSource::new(&cfg).unwrap();
+        source.request_token().await.unwrap();
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn basic_auth_header_present() {
+        let server = MockServer::start();
+
+        let expected = format!(
+            "Basic {}",
+            general_purpose::STANDARD.encode("test-client:test-secret")
+        );
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/token")
+                .header("authorization", &expected);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok"}"#);
+        });
+
+        let mut source = OAuthTokenSource::new(&test_config(&server)).unwrap();
+        source.request_token().await.unwrap();
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn form_auth_sends_credentials_in_body() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/token")
+                .body_includes("client_id=test-client")
+                .body_includes("client_secret=test-secret")
+                .body_includes("grant_type=client_credentials");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok"}"#);
+        });
+
+        let mut cfg = test_config(&server);
+        cfg.auth_method = ClientAuthMethod::Form;
+        let mut source = OAuthTokenSource::new(&cfg).unwrap();
+        source.request_token().await.unwrap();
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn form_auth_does_not_send_basic_header() {
+        let server = MockServer::start();
+
+        // Mock that REQUIRES a Basic auth header — should NOT be hit.
+        let basic_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/token")
+                .header_exists("authorization");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok"}"#);
+        });
+
+        // Catch-all mock for the POST.
+        let fallback_mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok"}"#);
+        });
+
+        let mut cfg = test_config(&server);
+        cfg.auth_method = ClientAuthMethod::Form;
+        let mut source = OAuthTokenSource::new(&cfg).unwrap();
+        source.request_token().await.unwrap();
+
+        assert_eq!(
+            basic_mock.calls(),
+            0,
+            "Form auth must not send Authorization header"
+        );
+        fallback_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn extra_headers_are_applied() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/token")
+                .header("x-vendor-key", "vendor-value");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok"}"#);
+        });
+
+        let mut cfg = test_config(&server);
+        cfg.extra_headers = vec![("x-vendor-key".into(), "vendor-value".into())];
+        let mut source = OAuthTokenSource::new(&cfg).unwrap();
+        source.request_token().await.unwrap();
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn http_error_mapped_via_format_http_error() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(401)
+                .header("content-type", "application/json")
+                .body(r#"{"error":"invalid_client"}"#);
+        });
+
+        let mut source = OAuthTokenSource::new(&test_config(&server)).unwrap();
+        let err = source.request_token().await.unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                TokenError::Http(ref msg)
+                    if msg.contains("OAuth2 token")
+                        && msg.contains("401")
+            ),
+            "expected Http error with OAuth2 token prefix and 401, got: {err}"
+        );
+        mock.assert();
+    }
+
+    #[test]
+    fn config_error_when_token_endpoint_missing() {
+        let cfg = OAuthClientConfig::default();
+        let result = OAuthTokenSource::new(&cfg);
+        let Err(err) = result else {
+            panic!("expected ConfigError, got Ok");
+        };
+        assert!(
+            matches!(err, TokenError::ConfigError(ref msg) if msg.contains("token_endpoint")),
+            "expected ConfigError about token_endpoint, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bearer_case_insensitive() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"access_token":"tok","token_type":"bEaReR"}"#);
+        });
+
+        let mut source = OAuthTokenSource::new(&test_config(&server)).unwrap();
+        let token = source.request_token().await.unwrap();
+
+        assert_eq!(token.access_token().as_str(), "tok");
+        mock.assert();
+    }
+
+    // -- refresh_params -------------------------------------------------------
+
+    /// Helper: verify that the aliri formula
+    /// `max(lifetime * freshness, min_stale) <= lifetime`
+    /// holds for the given params.
+    #[allow(clippy::cast_precision_loss)]
+    fn assert_stale_before_expiry(lifetime: u64, freshness: f64, min_stale: DurationSecs) {
+        let delay_a = (lifetime as f64) * freshness;
+        let delay_b = min_stale.0 as f64;
+        let delay = delay_a.max(delay_b);
+        assert!(
+            delay <= lifetime as f64,
+            "stale ({delay}) must not exceed lifetime ({lifetime})"
+        );
+    }
+
+    #[test]
+    fn refresh_normal_token() {
+        // 1-hour token, 30-min offset → stale at 50%
+        let (r, ms) = refresh_params(
+            3600,
+            &Duration::from_secs(30 * 60),
+            &Duration::from_secs(10),
+        );
+        assert!((r - 0.5).abs() < f64::EPSILON);
+        assert_eq!(ms, DurationSecs(10));
+        assert_stale_before_expiry(3600, r, ms);
+    }
+
+    #[test]
+    fn refresh_short_lived_token() {
+        // 20-min token, 30-min offset → fallback 0.5
+        let (r, ms) = refresh_params(
+            1200,
+            &Duration::from_secs(30 * 60),
+            &Duration::from_secs(10),
+        );
+        assert!((r - 0.5).abs() < f64::EPSILON);
+        assert_eq!(ms, DurationSecs(10));
+        assert_stale_before_expiry(1200, r, ms);
+    }
+
+    #[test]
+    fn refresh_equal_lifetime_and_offset() {
+        // 30-min token, 30-min offset → fallback 0.5
+        let (r, ms) = refresh_params(
+            1800,
+            &Duration::from_secs(30 * 60),
+            &Duration::from_secs(10),
+        );
+        assert!((r - 0.5).abs() < f64::EPSILON);
+        assert_stale_before_expiry(1800, r, ms);
+    }
+
+    #[test]
+    fn refresh_zero_lifetime() {
+        // Both values must be zero so stale == expiry.
+        let (r, ms) = refresh_params(0, &Duration::from_secs(30 * 60), &Duration::from_secs(10));
+        assert!((r - 0.0).abs() < f64::EPSILON);
+        assert_eq!(ms, DurationSecs(0));
+    }
+
+    #[test]
+    fn refresh_small_offset() {
+        // 5-min token, 1-min offset → stale at 80%
+        let (r, ms) = refresh_params(300, &Duration::from_secs(60), &Duration::from_secs(10));
+        assert!((r - 0.8).abs() < f64::EPSILON);
+        assert_eq!(ms, DurationSecs(10));
+        assert_stale_before_expiry(300, r, ms);
+    }
+
+    #[test]
+    fn refresh_zero_offset() {
+        // No offset → stale at 100% (only stale when expired)
+        let (r, ms) = refresh_params(3600, &Duration::from_secs(0), &Duration::from_secs(10));
+        assert!((r - 1.0).abs() < f64::EPSILON);
+        assert_eq!(ms, DurationSecs(10));
+        assert_stale_before_expiry(3600, r, ms);
+    }
+
+    #[test]
+    fn refresh_min_period_exceeds_lifetime() {
+        // min_refresh_period (600s) > lifetime (300s) — must be capped
+        let (r, ms) = refresh_params(300, &Duration::from_secs(60), &Duration::from_secs(600));
+        // desired_delay = 300 - 60 = 240
+        assert!((r - 0.8).abs() < f64::EPSILON);
+        // min_stale capped to desired_delay, not 600
+        assert_eq!(ms, DurationSecs(240));
+        assert_stale_before_expiry(300, r, ms);
+    }
+
+    #[test]
+    fn refresh_zero_lifetime_nonzero_min_period() {
+        // expires_in=0 with min_refresh_period=10 — both must be zero
+        let (r, ms) = refresh_params(0, &Duration::from_secs(30 * 60), &Duration::from_secs(10));
+        assert!((r - 0.0).abs() < f64::EPSILON);
+        assert_eq!(ms, DurationSecs(0));
+    }
+}

--- a/libs/modkit-auth/src/oauth2/token.rs
+++ b/libs/modkit-auth/src/oauth2/token.rs
@@ -1,0 +1,407 @@
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aliri_clock::DurationSecs;
+use aliri_tokens::backoff::ErrorBackoffConfig;
+use aliri_tokens::jitter::RandomEarlyJitter;
+use aliri_tokens::{TokenStatus, TokenWatcher};
+use arc_swap::ArcSwap;
+
+use super::config::OAuthClientConfig;
+use super::error::TokenError;
+use super::source::OAuthTokenSource;
+use modkit_utils::SecretString;
+
+/// Internal state holding the live watcher.
+///
+/// Wrapped in `Arc<ArcSwap<_>>` so that [`Token::invalidate`] can atomically
+/// swap in a replacement without blocking concurrent [`Token::get`] calls.
+struct TokenInner {
+    watcher: TokenWatcher,
+}
+
+/// Parameters needed to (re-)spawn a [`TokenWatcher`].
+struct WatcherConfig {
+    jitter_max: Duration,
+    min_refresh_period: Duration,
+}
+
+/// Handle for obtaining `OAuth2` bearer tokens.
+///
+/// Internally drives an `aliri_tokens::TokenWatcher` for background refresh and
+/// exposes lock-free reads via `ArcSwap` (same pattern as the JWKS key
+/// provider).
+///
+/// `Token` is [`Clone`] + [`Send`] + [`Sync`] — share freely across tasks.
+#[derive(Clone)]
+pub struct Token {
+    inner: Arc<ArcSwap<TokenInner>>,
+    source_factory: Arc<dyn Fn() -> Result<OAuthTokenSource, TokenError> + Send + Sync>,
+    watcher_config: Arc<WatcherConfig>,
+}
+
+impl fmt::Debug for Token {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Token").finish_non_exhaustive()
+    }
+}
+
+impl Token {
+    /// Create a new token handle and start background refresh.
+    ///
+    /// This performs an initial token fetch — if the token endpoint is
+    /// unreachable or returns an error, `new` will fail immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TokenError::ConfigError`] if the config is invalid.
+    /// Returns [`TokenError::Http`] if the initial token fetch fails.
+    pub async fn new(mut config: OAuthClientConfig) -> Result<Self, TokenError> {
+        config.validate()?;
+
+        // Resolve issuer_url → token_endpoint via OIDC discovery (one-time).
+        if let Some(issuer_url) = config.issuer_url.take() {
+            let http_config = config
+                .http_config
+                .clone()
+                .unwrap_or_else(modkit_http::HttpClientConfig::token_endpoint);
+            let client = modkit_http::HttpClientBuilder::with_config(http_config)
+                .build()
+                .map_err(|e| {
+                    TokenError::Http(crate::http_error::format_http_error(&e, "OIDC discovery"))
+                })?;
+            let resolved = super::discovery::discover_token_endpoint(&client, &issuer_url).await?;
+            config.token_endpoint = Some(resolved);
+        }
+
+        let watcher_config = Arc::new(WatcherConfig {
+            jitter_max: config.jitter_max,
+            min_refresh_period: config.min_refresh_period,
+        });
+
+        let source = OAuthTokenSource::new(&config)?;
+        let watcher = spawn_watcher(source, &watcher_config).await?;
+
+        let source_factory: Arc<dyn Fn() -> Result<OAuthTokenSource, TokenError> + Send + Sync> =
+            Arc::new(move || OAuthTokenSource::new(&config));
+
+        Ok(Self {
+            inner: Arc::new(ArcSwap::from_pointee(TokenInner { watcher })),
+            source_factory,
+            watcher_config,
+        })
+    }
+
+    /// Get the current bearer token.
+    ///
+    /// This is a lock-free read from the `ArcSwap`-cached watcher — it never
+    /// blocks on a network call.  The underlying watcher refreshes the token in
+    /// the background before it expires.
+    ///
+    /// The returned [`SecretString`] wraps the raw access-token value so it is
+    /// not accidentally logged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TokenError::Unavailable`] if the cached token has expired
+    /// (the background watcher has not yet refreshed it).
+    pub fn get(&self) -> Result<SecretString, TokenError> {
+        let guard = self.inner.load();
+        let borrowed = guard.watcher.token();
+        if matches!(borrowed.token_status(), TokenStatus::Expired) {
+            return Err(TokenError::Unavailable(
+                "token expired, refresh pending".into(),
+            ));
+        }
+        let raw = borrowed.access_token().as_str();
+        Ok(SecretString::new(raw))
+    }
+
+    /// Force-replace the internal watcher with a freshly-spawned one.
+    ///
+    /// Use this after receiving a 401 from a downstream service to immediately
+    /// discard a potentially revoked token.
+    ///
+    /// If recreating the source or the initial token fetch fails, a warning is
+    /// logged and the existing watcher is left in place.
+    pub async fn invalidate(&self) {
+        let source = match (self.source_factory)() {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("OAuth2 token invalidation: failed to create source: {e}");
+                return;
+            }
+        };
+
+        let watcher = match spawn_watcher(source, &self.watcher_config).await {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::warn!("OAuth2 token invalidation: initial fetch failed: {e}");
+                return;
+            }
+        };
+
+        self.inner.store(Arc::new(TokenInner { watcher }));
+    }
+}
+
+/// Spawn a [`TokenWatcher`] from the given source and config.
+async fn spawn_watcher(
+    source: OAuthTokenSource,
+    config: &WatcherConfig,
+) -> Result<TokenWatcher, TokenError> {
+    let jitter = RandomEarlyJitter::new(DurationSecs(config.jitter_max.as_secs()));
+    let backoff =
+        ErrorBackoffConfig::new(config.min_refresh_period, config.min_refresh_period * 30, 2);
+
+    TokenWatcher::spawn_from_token_source(source, jitter, backoff).await
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use httpmock::prelude::*;
+    use url::Url;
+
+    /// Build a test config pointing at the given mock server.
+    fn test_config(server: &MockServer) -> OAuthClientConfig {
+        OAuthClientConfig {
+            token_endpoint: Some(
+                Url::parse(&format!("http://localhost:{}/token", server.port())).unwrap(),
+            ),
+            client_id: "test-client".into(),
+            client_secret: SecretString::new("test-secret"),
+            http_config: Some(modkit_http::HttpClientConfig::for_testing()),
+            // Use short durations for tests.
+            jitter_max: Duration::from_millis(0),
+            min_refresh_period: Duration::from_millis(100),
+            ..Default::default()
+        }
+    }
+
+    fn token_json(token: &str, expires_in: u64) -> String {
+        format!(r#"{{"access_token":"{token}","expires_in":{expires_in},"token_type":"Bearer"}}"#)
+    }
+
+    // -- trait assertions -----------------------------------------------------
+
+    #[test]
+    fn token_is_send_sync_clone() {
+        fn assert_traits<T: Send + Sync + Clone>() {}
+        assert_traits::<Token>();
+    }
+
+    // -- new ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn new_with_valid_config() {
+        let server = MockServer::start();
+
+        let _mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("tok-new", 3600));
+        });
+
+        let token = Token::new(test_config(&server)).await;
+        assert!(
+            token.is_ok(),
+            "Token::new() should succeed: {:?}",
+            token.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn new_validates_config() {
+        let cfg = OAuthClientConfig {
+            token_endpoint: Some(Url::parse("https://a.example.com/token").unwrap()),
+            issuer_url: Some(Url::parse("https://b.example.com").unwrap()),
+            client_id: "test-client".into(),
+            client_secret: SecretString::new("test-secret"),
+            ..Default::default()
+        };
+        let err = Token::new(cfg).await.unwrap_err();
+        assert!(
+            matches!(err, TokenError::ConfigError(ref msg) if msg.contains("mutually exclusive")),
+            "expected ConfigError, got: {err}"
+        );
+    }
+
+    // -- get ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn get_returns_secret_string() {
+        let server = MockServer::start();
+
+        let _mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("tok-get-test", 3600));
+        });
+
+        let token = Token::new(test_config(&server)).await.unwrap();
+        let secret = token.get().unwrap();
+
+        assert_eq!(secret.expose(), "tok-get-test");
+    }
+
+    // -- invalidate -----------------------------------------------------------
+
+    #[tokio::test]
+    async fn invalidate_creates_new_watcher() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("tok-inv", 3600));
+        });
+
+        let token = Token::new(test_config(&server)).await.unwrap();
+        assert_eq!(mock.calls(), 1, "initial fetch");
+
+        token.invalidate().await;
+
+        // invalidate spawns a new watcher which fetches a fresh token
+        assert_eq!(mock.calls(), 2, "after invalidate");
+    }
+
+    // -- concurrency ----------------------------------------------------------
+
+    #[tokio::test]
+    async fn concurrent_get_no_deadlock() {
+        let server = MockServer::start();
+
+        let _mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("tok-conc", 3600));
+        });
+
+        let token = Token::new(test_config(&server)).await.unwrap();
+
+        let t1 = {
+            let token = token.clone();
+            tokio::spawn(async move { token.get() })
+        };
+        let t2 = {
+            let token = token.clone();
+            tokio::spawn(async move { token.get() })
+        };
+
+        let (r1, r2) = tokio::join!(t1, t2);
+        assert!(r1.unwrap().is_ok());
+        assert!(r2.unwrap().is_ok());
+    }
+
+    // -- OIDC discovery -------------------------------------------------------
+
+    #[tokio::test]
+    async fn new_with_issuer_url_discovery() {
+        let server = MockServer::start();
+
+        // Mock the OIDC discovery endpoint.
+        let token_ep = format!("http://localhost:{}/oauth/token", server.port());
+        let _discovery_mock = server.mock(|when, then| {
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(format!(r#"{{"token_endpoint":"{token_ep}"}}"#));
+        });
+
+        // Mock the resolved token endpoint.
+        let _token_mock = server.mock(|when, then| {
+            when.method(POST).path("/oauth/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("tok-discovered", 3600));
+        });
+
+        let cfg = OAuthClientConfig {
+            issuer_url: Some(Url::parse(&format!("http://localhost:{}", server.port())).unwrap()),
+            client_id: "test-client".into(),
+            client_secret: SecretString::new("test-secret"),
+            http_config: Some(modkit_http::HttpClientConfig::for_testing()),
+            jitter_max: Duration::from_millis(0),
+            min_refresh_period: Duration::from_millis(100),
+            ..Default::default()
+        };
+
+        let token = Token::new(cfg).await.unwrap();
+        let secret = token.get().unwrap();
+        assert_eq!(secret.expose(), "tok-discovered");
+    }
+
+    #[tokio::test]
+    async fn discovery_not_repeated_on_invalidate() {
+        let server = MockServer::start();
+
+        // Mock the OIDC discovery endpoint.
+        let token_ep = format!("http://localhost:{}/oauth/token", server.port());
+        let discovery_mock = server.mock(|when, then| {
+            when.method(GET).path("/.well-known/openid-configuration");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(format!(r#"{{"token_endpoint":"{token_ep}"}}"#));
+        });
+
+        // Mock the resolved token endpoint.
+        let token_mock = server.mock(|when, then| {
+            when.method(POST).path("/oauth/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("tok-disc-inv", 3600));
+        });
+
+        let cfg = OAuthClientConfig {
+            issuer_url: Some(Url::parse(&format!("http://localhost:{}", server.port())).unwrap()),
+            client_id: "test-client".into(),
+            client_secret: SecretString::new("test-secret"),
+            http_config: Some(modkit_http::HttpClientConfig::for_testing()),
+            jitter_max: Duration::from_millis(0),
+            min_refresh_period: Duration::from_millis(100),
+            ..Default::default()
+        };
+
+        let token = Token::new(cfg).await.unwrap();
+        assert_eq!(discovery_mock.calls(), 1, "discovery: initial");
+        assert_eq!(token_mock.calls(), 1, "token: initial");
+
+        // Invalidate should re-fetch the token but NOT re-run discovery.
+        token.invalidate().await;
+
+        assert_eq!(
+            discovery_mock.calls(),
+            1,
+            "discovery must NOT be repeated on invalidate"
+        );
+        assert_eq!(token_mock.calls(), 2, "token: after invalidate");
+    }
+
+    // -- debug safety ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn debug_does_not_reveal_tokens() {
+        let server = MockServer::start();
+
+        let _mock = server.mock(|when, then| {
+            when.method(POST).path("/token");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(token_json("super-secret-tok", 3600));
+        });
+
+        let token = Token::new(test_config(&server)).await.unwrap();
+        let dbg = format!("{token:?}");
+        assert!(
+            !dbg.contains("super-secret-tok"),
+            "Debug must not reveal token value: {dbg}"
+        );
+    }
+}

--- a/libs/modkit-auth/src/oauth2/types.rs
+++ b/libs/modkit-auth/src/oauth2/types.rs
@@ -1,0 +1,71 @@
+use serde::Deserialize;
+
+pub use modkit_utils::SecretString;
+
+/// `OAuth2` client authentication method.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ClientAuthMethod {
+    /// HTTP Basic authentication (RFC 6749 §2.3.1).
+    /// `Authorization: Basic base64(client_id:client_secret)`
+    #[default]
+    Basic,
+    /// Credentials in the request body (RFC 6749 §2.3.1 alternative).
+    /// `client_id` and `client_secret` as form fields.
+    Form,
+}
+
+/// Deserialized `OAuth2` token endpoint response.
+///
+/// Only the fields required by the client credentials flow are included.
+/// Unknown fields are silently ignored during deserialization.
+///
+/// **Intentionally `Deserialize`-only** — `Serialize` is not derived to
+/// prevent accidental serialization of access tokens into logs or
+/// error messages.
+#[derive(Deserialize)]
+pub(crate) struct TokenResponse {
+    /// The access token issued by the authorization server.
+    pub access_token: String,
+    /// The lifetime in seconds of the access token (optional per RFC 6749).
+    #[serde(default)]
+    pub expires_in: Option<u64>,
+    /// The type of the token issued (optional; must be "Bearer" if present).
+    #[serde(default)]
+    pub token_type: Option<String>,
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_auth_method_is_basic() {
+        assert_eq!(ClientAuthMethod::default(), ClientAuthMethod::Basic);
+    }
+
+    #[test]
+    fn deserialize_full_response() {
+        let json = r#"{"access_token":"tok","expires_in":3600,"token_type":"Bearer"}"#;
+        let r: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(r.access_token, "tok");
+        assert_eq!(r.expires_in, Some(3600));
+        assert_eq!(r.token_type.as_deref(), Some("Bearer"));
+    }
+
+    #[test]
+    fn deserialize_minimal_response() {
+        let json = r#"{"access_token":"tok"}"#;
+        let r: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(r.access_token, "tok");
+        assert!(r.expires_in.is_none());
+        assert!(r.token_type.is_none());
+    }
+
+    #[test]
+    fn deserialize_ignores_unknown_fields() {
+        let json = r#"{"access_token":"tok","scope":"read","refresh_token":"rt"}"#;
+        let r: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(r.access_token, "tok");
+    }
+}

--- a/libs/modkit-auth/tests/oauth2_integration.rs
+++ b/libs/modkit-auth/tests/oauth2_integration.rs
@@ -1,0 +1,150 @@
+//! Integration test for the full outbound `OAuth2` client-credentials flow.
+//!
+//! Wires up: mock token endpoint → `Token::new()` → `HttpClient` with bearer
+//! auth → mock downstream API → verifies the Authorization header is injected.
+
+use std::time::Duration;
+
+use httpmock::prelude::*;
+use modkit_auth::HttpClientBuilderExt;
+use modkit_auth::oauth2::config::OAuthClientConfig;
+use modkit_auth::oauth2::token::Token;
+use modkit_utils::SecretString;
+use url::Url;
+
+fn token_json(token: &str, expires_in: u64) -> String {
+    format!(r#"{{"access_token":"{token}","expires_in":{expires_in},"token_type":"Bearer"}}"#)
+}
+
+/// Full round-trip: token acquisition + authenticated downstream call.
+#[tokio::test]
+async fn full_oauth2_bearer_flow() {
+    // OAuth token endpoint
+    let oauth_server = MockServer::start();
+    let token_mock = oauth_server.mock(|when, then| {
+        when.method(POST).path("/token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(token_json("integration-tok", 3600));
+    });
+
+    // Downstream API
+    let api_server = MockServer::start();
+    let api_mock = api_server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/resource")
+            .header("authorization", "Bearer integration-tok");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(r#"{"status":"ok"}"#);
+    });
+
+    // Build token + client
+    let config = OAuthClientConfig {
+        token_endpoint: Some(
+            Url::parse(&format!("http://localhost:{}/token", oauth_server.port())).unwrap(),
+        ),
+        client_id: "int-test-client".into(),
+        client_secret: SecretString::new("int-test-secret"),
+        http_config: Some(modkit_http::HttpClientConfig::for_testing()),
+        jitter_max: Duration::from_millis(0),
+        min_refresh_period: Duration::from_millis(100),
+        ..Default::default()
+    };
+
+    let token = Token::new(config).await.unwrap();
+
+    let client = modkit_http::HttpClientBuilder::new()
+        .allow_insecure_http()
+        .with_bearer_auth(token)
+        .build()
+        .unwrap();
+
+    // Make downstream call
+    let resp = client
+        .get(&format!(
+            "http://localhost:{}/api/resource",
+            api_server.port()
+        ))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "ok");
+
+    // Assertions
+    token_mock.assert_calls(1);
+    api_mock.assert_calls(1);
+}
+
+/// Full round-trip with OIDC discovery: issuer URL → discover token
+/// endpoint → acquire token → authenticated downstream call.
+#[tokio::test]
+async fn full_oauth2_with_oidc_discovery() {
+    let server = MockServer::start();
+
+    // OIDC discovery
+    let token_ep = format!("http://localhost:{}/oauth/token", server.port());
+    let discovery_mock = server.mock(|when, then| {
+        when.method(GET).path("/.well-known/openid-configuration");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(format!(r#"{{"token_endpoint":"{token_ep}"}}"#));
+    });
+
+    // Token endpoint
+    let token_mock = server.mock(|when, then| {
+        when.method(POST).path("/oauth/token");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(token_json("disc-int-tok", 3600));
+    });
+
+    // Downstream API
+    let api_server = MockServer::start();
+    let api_mock = api_server.mock(|when, then| {
+        when.method(GET)
+            .path("/api/data")
+            .header("authorization", "Bearer disc-int-tok");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body(r#"{"discovered":true}"#);
+    });
+
+    // Build token + client
+    let config = OAuthClientConfig {
+        issuer_url: Some(Url::parse(&format!("http://localhost:{}", server.port())).unwrap()),
+        client_id: "disc-client".into(),
+        client_secret: SecretString::new("disc-secret"),
+        http_config: Some(modkit_http::HttpClientConfig::for_testing()),
+        jitter_max: Duration::from_millis(0),
+        min_refresh_period: Duration::from_millis(100),
+        ..Default::default()
+    };
+
+    let token = Token::new(config).await.unwrap();
+
+    let client = modkit_http::HttpClientBuilder::new()
+        .allow_insecure_http()
+        .with_bearer_auth(token)
+        .build()
+        .unwrap();
+
+    let resp = client
+        .get(&format!("http://localhost:{}/api/data", api_server.port()))
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["discovered"], true);
+
+    discovery_mock.assert_calls(1);
+    token_mock.assert_calls(1);
+    api_mock.assert_calls(1);
+}

--- a/libs/modkit-utils/Cargo.toml
+++ b/libs/modkit-utils/Cargo.toml
@@ -23,6 +23,7 @@ humantime-serde = ["dep:humantime", "dep:serde"]
 [dependencies]
 serde = { workspace = true, optional = true }
 humantime = { workspace = true, optional = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/libs/modkit-utils/src/lib.rs
+++ b/libs/modkit-utils/src/lib.rs
@@ -1,2 +1,6 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #[cfg(feature = "humantime-serde")]
 pub mod humantime_serde;
+
+pub mod secret_string;
+pub use secret_string::SecretString;

--- a/libs/modkit-utils/src/secret_string.rs
+++ b/libs/modkit-utils/src/secret_string.rs
@@ -1,0 +1,96 @@
+use std::fmt;
+
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// Opaque wrapper around a secret string value.
+///
+/// `Debug` and `Display` both print `[REDACTED]` — the inner value is never
+/// exposed through formatting traits.  Use [`expose`](Self::expose) for
+/// controlled access when constructing HTTP headers or form bodies.
+///
+/// On [`Drop`] the backing buffer is securely zeroed via the [`zeroize`] crate.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub struct SecretString(String);
+
+impl SecretString {
+    /// Create a new `SecretString` from a plain value.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Provide read-only access to the underlying secret.
+    ///
+    /// Callers must not log, store, or otherwise persist the returned slice.
+    #[must_use]
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Clone for SecretString {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+impl fmt::Display for SecretString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use zeroize::Zeroize;
+
+    #[test]
+    fn debug_is_redacted() {
+        let s = SecretString::new("hunter2");
+        assert_eq!(format!("{s:?}"), "[REDACTED]");
+    }
+
+    #[test]
+    fn display_is_redacted() {
+        let s = SecretString::new("hunter2");
+        assert_eq!(format!("{s}"), "[REDACTED]");
+    }
+
+    #[test]
+    fn debug_does_not_contain_secret() {
+        let secret = "super-secret-value-12345";
+        let s = SecretString::new(secret);
+        let dbg = format!("{s:?}");
+        assert!(!dbg.contains(secret), "Debug must not contain the secret");
+    }
+
+    #[test]
+    fn expose_returns_original_value() {
+        let s = SecretString::new("hunter2");
+        assert_eq!(s.expose(), "hunter2");
+    }
+
+    #[test]
+    fn clone_preserves_value() {
+        let s = SecretString::new("value");
+        #[allow(clippy::redundant_clone)]
+        let c = s.clone();
+        assert_eq!(c.expose(), "value");
+    }
+
+    #[test]
+    fn zeroize_clears_buffer() {
+        let mut s = SecretString::new("sensitive");
+        assert_eq!(s.expose(), "sensitive");
+
+        s.zeroize();
+        assert!(s.0.is_empty(), "buffer should be empty after zeroize");
+    }
+}


### PR DESCRIPTION
- extract shared HttpError formatting helper
- add oauth2 module: config, errors, secret handling, token response types
- implement aliri_tokens AsyncTokenSource over modkit-http HttpClient
- add Token handle with ArcSwap invalidation
- add tower BearerAuthLayer to inject Authorization: Bearer <token>
- support OIDC discovery via /.well-known/openid-configuration
- integrate optional oauth feature into modkit-http HttpClientBuilder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outbound OAuth2 client‑credentials with background refresh, token handle, and Authorization: Bearer injection; optional OIDC discovery and HTTP client extension to install auth layers.

* **Documentation**
  * Updated architecture manifest, ADRs, design and implementation docs for HTTP client and OAuth2 flows; added usage example.

* **Bug Fixes**
  * Centralized HTTP error formatting and improved error mapping for clearer, safer messages.

* **Chores**
  * Added security/token‑lifecycle dependencies and a SecretString type with automatic zeroization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->