### PR TITLE
feat: add REST API to list registered modules (#500)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,14 +1403,21 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
+ "cf-api-gateway",
  "cf-modkit",
+ "cf-modkit-macros",
  "cf-system-sdks",
  "inventory",
  "parking_lot",
  "serde",
+ "serde_json",
  "tokio",
  "tonic",
+ "tower",
  "tracing",
+ "utoipa",
+ "uuid",
 ]
 
 [[package]]

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -16,6 +16,7 @@
 use axum::Router;
 use std::collections::HashSet;
 use std::sync::Arc;
+
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 

--- a/modules/system/module-orchestrator/Cargo.toml
+++ b/modules/system/module-orchestrator/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [dependencies]
 cf-system-sdks = { workspace = true, features = ["directory_grpc"] }
 modkit = { workspace = true }
+modkit-macros = { workspace = true }
 parking_lot = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true, features = ["transport"] }
@@ -26,4 +27,13 @@ async-trait = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
+utoipa = { workspace = true }
+axum = { workspace = true }
+uuid = { workspace = true }
 inventory = { workspace = true }
+
+[dev-dependencies]
+tower = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+api_gateway = { path = "../api-gateway", package = "cf-api-gateway" }

--- a/modules/system/module-orchestrator/src/api/mod.rs
+++ b/modules/system/module-orchestrator/src/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod rest;

--- a/modules/system/module-orchestrator/src/api/rest/dto.rs
+++ b/modules/system/module-orchestrator/src/api/rest/dto.rs
@@ -1,0 +1,106 @@
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use modkit::runtime::InstanceState;
+
+use crate::domain::model::{DeploymentMode, InstanceInfo, ModuleInfo};
+
+/// Deployment mode of a module
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub enum DeploymentModeDto {
+    /// Module is compiled into the host binary
+    CompiledIn,
+    /// Module runs as a separate process
+    OutOfProcess,
+}
+
+/// Response DTO for a single registered module
+#[modkit_macros::api_dto(response)]
+pub struct ModuleDto {
+    /// Module name
+    pub name: String,
+    /// Module version (if reported by a running instance)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Declared capabilities (e.g., "rest", "grpc", "system", "db")
+    pub capabilities: Vec<String>,
+    /// Module dependencies (other module names)
+    pub dependencies: Vec<String>,
+    /// Whether the module is compiled-in or out-of-process
+    pub deployment_mode: DeploymentModeDto,
+    /// Running instances of this module
+    pub instances: Vec<ModuleInstanceDto>,
+    /// Plugins provided by this module (reserved for follow-up implementation)
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub plugins: Vec<PluginDto>,
+}
+
+/// Response DTO for a running module instance
+#[modkit_macros::api_dto(response)]
+pub struct ModuleInstanceDto {
+    /// Unique instance ID
+    pub instance_id: Uuid,
+    /// Module version (if reported during registration)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// Current instance state (e.g., "registered", "healthy", "quarantined")
+    pub state: String,
+    /// gRPC services provided by this instance (service name -> endpoint URI)
+    pub grpc_services: HashMap<String, String>,
+}
+
+/// Response DTO for a plugin (reserved for follow-up implementation)
+#[modkit_macros::api_dto(response)]
+pub struct PluginDto {
+    /// Plugin GTS identifier
+    pub gts_id: String,
+    /// Plugin version
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+impl From<&ModuleInfo> for ModuleDto {
+    fn from(module: &ModuleInfo) -> Self {
+        // Derive module-level version from the first instance that reports one
+        let version = module
+            .instances
+            .iter()
+            .find_map(|inst| inst.version.clone());
+
+        Self {
+            name: module.name.clone(),
+            version,
+            capabilities: module.capabilities.clone(),
+            dependencies: module.dependencies.clone(),
+            deployment_mode: match module.deployment_mode {
+                DeploymentMode::CompiledIn => DeploymentModeDto::CompiledIn,
+                DeploymentMode::OutOfProcess => DeploymentModeDto::OutOfProcess,
+            },
+            instances: module
+                .instances
+                .iter()
+                .map(ModuleInstanceDto::from)
+                .collect(),
+            plugins: vec![],
+        }
+    }
+}
+
+impl From<&InstanceInfo> for ModuleInstanceDto {
+    fn from(instance: &InstanceInfo) -> Self {
+        Self {
+            instance_id: instance.instance_id,
+            version: instance.version.clone(),
+            state: match instance.state {
+                InstanceState::Registered => "registered",
+                InstanceState::Ready => "ready",
+                InstanceState::Healthy => "healthy",
+                InstanceState::Quarantined => "quarantined",
+                InstanceState::Draining => "draining",
+            }
+            .to_owned(),
+            grpc_services: instance.grpc_services.clone(),
+        }
+    }
+}

--- a/modules/system/module-orchestrator/src/api/rest/handlers.rs
+++ b/modules/system/module-orchestrator/src/api/rest/handlers.rs
@@ -1,0 +1,18 @@
+use axum::Extension;
+use modkit::api::prelude::*;
+use std::sync::Arc;
+
+use super::dto::ModuleDto;
+use crate::domain::service::ModulesService;
+
+/// List all registered modules with their capabilities, instances, and deployment mode.
+///
+/// # Errors
+///
+/// Returns `ApiError` if the response cannot be constructed.
+pub async fn list_modules(
+    Extension(svc): Extension<Arc<ModulesService>>,
+) -> ApiResult<Json<Vec<ModuleDto>>> {
+    let modules: Vec<ModuleDto> = svc.list_modules().iter().map(ModuleDto::from).collect();
+    Ok(Json(modules))
+}

--- a/modules/system/module-orchestrator/src/api/rest/mod.rs
+++ b/modules/system/module-orchestrator/src/api/rest/mod.rs
@@ -1,0 +1,3 @@
+pub mod dto;
+pub mod handlers;
+pub mod routes;

--- a/modules/system/module-orchestrator/src/api/rest/routes.rs
+++ b/modules/system/module-orchestrator/src/api/rest/routes.rs
@@ -1,0 +1,40 @@
+use axum::http;
+use axum::{Extension, Router};
+use modkit::api::{OpenApiRegistry, OperationBuilder};
+use std::sync::Arc;
+
+use super::dto::ModuleDto;
+use super::handlers;
+use crate::domain::service::ModulesService;
+
+/// Register all REST routes for the module orchestrator
+#[allow(clippy::needless_pass_by_value)]
+pub fn register_routes(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    service: Arc<ModulesService>,
+) -> Router {
+    // GET /module-orchestrator/v1/modules - List all registered modules
+    router = OperationBuilder::get("/module-orchestrator/v1/modules")
+        .operation_id("module_orchestrator.list_modules")
+        .summary("List all registered modules")
+        .description(
+            "Returns a list of all compiled-in and out-of-process modules with their \
+         capabilities, dependencies, running instances, and deployment mode.",
+        )
+        .tag("module-orchestrator")
+        .authenticated()
+        .no_license_required()
+        .handler(handlers::list_modules)
+        .json_response_with_schema::<Vec<ModuleDto>>(
+            openapi,
+            http::StatusCode::OK,
+            "List of registered modules",
+        )
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    router = router.layer(Extension(service));
+
+    router
+}

--- a/modules/system/module-orchestrator/src/domain/mod.rs
+++ b/modules/system/module-orchestrator/src/domain/mod.rs
@@ -1,0 +1,2 @@
+pub mod model;
+pub mod service;

--- a/modules/system/module-orchestrator/src/domain/model.rs
+++ b/modules/system/module-orchestrator/src/domain/model.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use modkit::runtime::InstanceState;
+use modkit_macros::domain_model;
+
+/// Deployment mode of a module.
+#[domain_model]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeploymentMode {
+    CompiledIn,
+    OutOfProcess,
+}
+
+/// Domain model for a registered module.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct ModuleInfo {
+    pub name: String,
+    pub capabilities: Vec<String>,
+    pub dependencies: Vec<String>,
+    pub deployment_mode: DeploymentMode,
+    pub instances: Vec<InstanceInfo>,
+}
+
+/// Domain model for a running module instance.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct InstanceInfo {
+    pub instance_id: Uuid,
+    pub version: Option<String>,
+    pub state: InstanceState,
+    pub grpc_services: HashMap<String, String>,
+}

--- a/modules/system/module-orchestrator/src/domain/service.rs
+++ b/modules/system/module-orchestrator/src/domain/service.rs
@@ -1,0 +1,276 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use modkit::registry::ModuleRegistry;
+use modkit::runtime::ModuleManager;
+use modkit_macros::domain_model;
+
+use super::model::{DeploymentMode, InstanceInfo, ModuleInfo};
+
+/// Lightweight compiled-module metadata (owned data, no trait objects).
+#[domain_model]
+struct CompiledModule {
+    name: String,
+    capabilities: Vec<String>,
+    deps: Vec<String>,
+}
+
+/// Service that assembles module information from catalog and runtime data.
+#[domain_model]
+pub struct ModulesService {
+    /// Compiled modules snapshot (built once at init, immutable after).
+    compiled: Vec<CompiledModule>,
+    /// Runtime module manager for live instance queries.
+    module_manager: Arc<ModuleManager>,
+}
+
+impl ModulesService {
+    /// Build from a live `ModuleRegistry` and a `ModuleManager`.
+    ///
+    /// Extracts module metadata (names, deps, capability labels) from the registry
+    /// and drops the registry afterwards — no trait objects are kept.
+    #[must_use]
+    pub fn new(registry: &ModuleRegistry, module_manager: Arc<ModuleManager>) -> Self {
+        let compiled: Vec<CompiledModule> = registry
+            .modules()
+            .iter()
+            .map(|entry| CompiledModule {
+                name: entry.name().to_owned(),
+                capabilities: entry
+                    .caps()
+                    .labels()
+                    .iter()
+                    .map(|s| (*s).to_owned())
+                    .collect(),
+                deps: entry.deps().iter().map(|d| (*d).to_owned()).collect(),
+            })
+            .collect();
+
+        Self {
+            compiled,
+            module_manager,
+        }
+    }
+
+    /// List all registered modules, merging compile-time catalog data with runtime instances.
+    #[must_use]
+    pub fn list_modules(&self) -> Vec<ModuleInfo> {
+        let mut modules = Vec::new();
+        let mut seen_names = HashSet::new();
+
+        // 1. Emit all compiled-in modules from the catalog.
+        for cm in &self.compiled {
+            seen_names.insert(cm.name.clone());
+
+            let instances = self.get_module_instances(&cm.name);
+
+            modules.push(ModuleInfo {
+                name: cm.name.clone(),
+                capabilities: cm.capabilities.clone(),
+                dependencies: cm.deps.clone(),
+                deployment_mode: DeploymentMode::CompiledIn,
+                instances,
+            });
+        }
+
+        // 2. Add any dynamically registered modules from ModuleManager
+        //    that are not in the compiled catalog (external / out-of-process).
+        for instance in self.module_manager.all_instances() {
+            if seen_names.contains(&instance.module) {
+                continue;
+            }
+            seen_names.insert(instance.module.clone());
+
+            let instances = self.get_module_instances(&instance.module);
+
+            modules.push(ModuleInfo {
+                name: instance.module.clone(),
+                capabilities: vec![],
+                dependencies: vec![],
+                deployment_mode: DeploymentMode::OutOfProcess,
+                instances,
+            });
+        }
+
+        // Sort by name for deterministic output
+        modules.sort_by(|a, b| a.name.cmp(&b.name));
+
+        modules
+    }
+
+    fn get_module_instances(&self, module_name: &str) -> Vec<InstanceInfo> {
+        self.module_manager
+            .instances_of(module_name)
+            .into_iter()
+            .map(|inst| {
+                let grpc_services = inst
+                    .grpc_services
+                    .iter()
+                    .map(|(name, ep)| (name.clone(), ep.uri.clone()))
+                    .collect();
+
+                InstanceInfo {
+                    instance_id: inst.instance_id,
+                    version: inst.version.clone(),
+                    state: inst.state(),
+                    grpc_services,
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use modkit::registry::RegistryBuilder;
+    use modkit::runtime::{Endpoint, InstanceState, ModuleInstance, ModuleManager};
+    use uuid::Uuid;
+
+    // ---- Test helpers ----
+
+    // (name, deps, has_rest, has_system)
+    type ModuleSpec = (&'static str, &'static [&'static str], bool, bool);
+
+    #[domain_model]
+    #[derive(Default)]
+    struct DummyCore;
+    #[async_trait::async_trait]
+    impl modkit::Module for DummyCore {
+        async fn init(&self, _ctx: &modkit::context::ModuleCtx) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[domain_model]
+    #[derive(Default, Clone)]
+    struct DummyRest;
+    impl modkit::contracts::RestApiCapability for DummyRest {
+        fn register_rest(
+            &self,
+            _ctx: &modkit::context::ModuleCtx,
+            _router: axum::Router,
+            _openapi: &dyn modkit::api::OpenApiRegistry,
+        ) -> anyhow::Result<axum::Router> {
+            Ok(axum::Router::new())
+        }
+    }
+
+    #[domain_model]
+    #[derive(Default)]
+    struct DummySystem;
+    #[async_trait::async_trait]
+    impl modkit::contracts::SystemCapability for DummySystem {}
+
+    fn build_registry(modules: &[ModuleSpec]) -> ModuleRegistry {
+        let mut b = RegistryBuilder::default();
+        for &(name, deps, has_rest, has_system) in modules {
+            b.register_core_with_meta(name, deps, Arc::new(DummyCore));
+            if has_rest {
+                b.register_rest_with_meta(name, Arc::new(DummyRest));
+            }
+            if has_system {
+                b.register_system_with_meta(name, Arc::new(DummySystem));
+            }
+        }
+        b.build_topo_sorted().unwrap()
+    }
+
+    // ---- Tests ----
+
+    #[test]
+    fn list_compiled_in_modules_from_registry() {
+        let registry = build_registry(&[
+            ("api_gateway", &[], true, true),
+            ("nodes_registry", &["api_gateway"], true, false),
+        ]);
+        let manager = Arc::new(ModuleManager::new());
+        let svc = ModulesService::new(&registry, manager);
+        let modules = svc.list_modules();
+
+        assert_eq!(modules.len(), 2);
+        // Sorted by name
+        assert_eq!(modules[0].name, "api_gateway");
+        assert_eq!(modules[0].deployment_mode, DeploymentMode::CompiledIn);
+        assert!(modules[0].capabilities.contains(&"rest".to_owned()));
+        assert!(modules[0].capabilities.contains(&"system".to_owned()));
+        assert!(modules[0].instances.is_empty());
+
+        assert_eq!(modules[1].name, "nodes_registry");
+        assert_eq!(modules[1].dependencies, vec!["api_gateway"]);
+    }
+
+    #[test]
+    fn dynamic_external_instances_appear_as_out_of_process() {
+        let registry = build_registry(&[]);
+        let manager = Arc::new(ModuleManager::new());
+
+        let instance = Arc::new(
+            ModuleInstance::new("external_svc", Uuid::new_v4())
+                .with_version("2.0.0")
+                .with_grpc_service("ext.Service", Endpoint::http("127.0.0.1", 9001)),
+        );
+        manager.register_instance(instance);
+
+        let svc = ModulesService::new(&registry, manager);
+        let modules = svc.list_modules();
+
+        assert_eq!(modules.len(), 1);
+        assert_eq!(modules[0].name, "external_svc");
+        assert_eq!(modules[0].deployment_mode, DeploymentMode::OutOfProcess);
+        assert_eq!(modules[0].instances.len(), 1);
+        assert_eq!(modules[0].instances[0].version, Some("2.0.0".to_owned()));
+        assert!(
+            modules[0].instances[0]
+                .grpc_services
+                .contains_key("ext.Service")
+        );
+    }
+
+    #[test]
+    fn compiled_in_modules_show_instances_from_manager() {
+        let registry = build_registry(&[("grpc_hub", &[], false, true)]);
+        let manager = Arc::new(ModuleManager::new());
+
+        let instance =
+            Arc::new(ModuleInstance::new("grpc_hub", Uuid::new_v4()).with_version("0.1.0"));
+        manager.register_instance(instance);
+
+        let svc = ModulesService::new(&registry, manager);
+        let modules = svc.list_modules();
+
+        assert_eq!(modules.len(), 1);
+        assert_eq!(modules[0].name, "grpc_hub");
+        assert_eq!(modules[0].deployment_mode, DeploymentMode::CompiledIn);
+        assert_eq!(modules[0].instances.len(), 1);
+    }
+
+    #[test]
+    fn instance_state_maps_correctly() {
+        let registry = build_registry(&[]);
+        let manager = Arc::new(ModuleManager::new());
+
+        let instance = Arc::new(ModuleInstance::new("svc", Uuid::new_v4()));
+        // Default state is Registered
+        manager.register_instance(instance);
+
+        let svc = ModulesService::new(&registry, manager);
+        let modules = svc.list_modules();
+
+        assert_eq!(modules[0].instances[0].state, InstanceState::Registered);
+    }
+
+    #[test]
+    fn result_is_sorted_by_name() {
+        let registry =
+            build_registry(&[("zebra", &[], false, false), ("alpha", &[], false, false)]);
+        let manager = Arc::new(ModuleManager::new());
+
+        let svc = ModulesService::new(&registry, manager);
+        let modules = svc.list_modules();
+
+        assert_eq!(modules[0].name, "alpha");
+        assert_eq!(modules[1].name, "zebra");
+    }
+}

--- a/modules/system/module-orchestrator/src/lib.rs
+++ b/modules/system/module-orchestrator/src/lib.rs
@@ -8,7 +8,9 @@
 pub mod module;
 pub use module::{ModuleOrchestrator, ModuleOrchestratorConfig};
 
-// === INTERNAL MODULES ===
+// === INTERNAL MODULES (pub for integration tests) ===
+pub mod api;
+pub mod domain;
 mod server;
 
 // === RE-EXPORTS ===

--- a/modules/system/module-orchestrator/src/module.rs
+++ b/modules/system/module-orchestrator/src/module.rs
@@ -7,12 +7,17 @@ use tokio::sync::RwLock;
 
 use modkit::DirectoryClient;
 use modkit::context::ModuleCtx;
-use modkit::contracts::{GrpcServiceCapability, RegisterGrpcServiceFn, SystemCapability};
+use modkit::contracts::{
+    GrpcServiceCapability, OpenApiRegistry, RegisterGrpcServiceFn, RestApiCapability,
+    SystemCapability,
+};
 use modkit::directory::LocalDirectoryClient;
+use modkit::registry::ModuleRegistry;
 use modkit::runtime::ModuleManager;
 
 use cf_system_sdks::directory::DIRECTORY_SERVICE_NAME;
 
+use crate::domain::service::ModulesService;
 use crate::server;
 
 /// Configuration for the module orchestrator
@@ -25,15 +30,17 @@ pub struct ModuleOrchestratorConfig;
 /// - Provides `DirectoryClient` to the `ClientHub` for in-process modules
 /// - Exposes `DirectoryService` gRPC service via `grpc-hub`
 /// - Tracks module instances and provides service resolution
+/// - Exposes REST API to list all registered modules
 #[modkit::module(
     name = "module-orchestrator",
-    capabilities = [grpc, system],
+    capabilities = [grpc, system, rest],
     client = cf_system_sdks::directory::DirectoryClient
 )]
 pub struct ModuleOrchestrator {
     config: RwLock<ModuleOrchestratorConfig>,
     directory_api: OnceLock<Arc<dyn DirectoryClient>>,
     module_manager: OnceLock<Arc<ModuleManager>>,
+    modules_service: OnceLock<Arc<ModulesService>>,
 }
 
 impl Default for ModuleOrchestrator {
@@ -42,6 +49,7 @@ impl Default for ModuleOrchestrator {
             config: RwLock::new(ModuleOrchestratorConfig),
             directory_api: OnceLock::new(),
             module_manager: OnceLock::new(),
+            modules_service: OnceLock::new(),
         }
     }
 }
@@ -69,7 +77,8 @@ impl modkit::Module for ModuleOrchestrator {
                 anyhow::anyhow!("ModuleManager not wired into ModuleOrchestrator")
             })?;
 
-        let api_impl: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(manager));
+        let api_impl: Arc<dyn DirectoryClient> =
+            Arc::new(LocalDirectoryClient::new(manager.clone()));
 
         // Register in ClientHub directly
         ctx.client_hub()
@@ -79,9 +88,37 @@ impl modkit::Module for ModuleOrchestrator {
             .set(api_impl)
             .map_err(|_| anyhow::anyhow!("DirectoryClient already set (init called twice?)"))?;
 
+        // Build compiled-module catalog from inventory and create the ModulesService
+        let registry = ModuleRegistry::discover_and_build()
+            .map_err(|e| anyhow::anyhow!("Failed to build module registry: {e}"))?;
+        let modules_service = Arc::new(ModulesService::new(&registry, manager));
+        self.modules_service
+            .set(modules_service)
+            .map_err(|_| anyhow::anyhow!("ModulesService already set (init called twice?)"))?;
+
         tracing::info!("ModuleOrchestrator initialized");
 
         Ok(())
+    }
+}
+
+impl RestApiCapability for ModuleOrchestrator {
+    fn register_rest(
+        &self,
+        _ctx: &ModuleCtx,
+        router: axum::Router,
+        openapi: &dyn OpenApiRegistry,
+    ) -> Result<axum::Router> {
+        let service = Arc::clone(
+            self.modules_service
+                .get()
+                .ok_or_else(|| anyhow::anyhow!("ModulesService not initialized"))?,
+        );
+
+        let router = crate::api::rest::routes::register_routes(router, openapi, service);
+
+        tracing::info!("ModuleOrchestrator REST routes registered");
+        Ok(router)
     }
 }
 

--- a/modules/system/module-orchestrator/tests/list_modules_e2e.rs
+++ b/modules/system/module-orchestrator/tests/list_modules_e2e.rs
@@ -1,0 +1,240 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! End-to-end tests for the `GET /module-orchestrator/v1/modules` REST endpoint.
+//!
+//! These tests build a real axum `Router` with the module orchestrator's routes
+//! registered via `OperationBuilder`, then send HTTP requests using `tower::ServiceExt::oneshot`.
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode};
+use modkit::registry::RegistryBuilder;
+use modkit::runtime::{Endpoint, ModuleInstance, ModuleManager};
+use module_orchestrator::api::rest;
+use std::sync::Arc;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use module_orchestrator::domain::service::ModulesService;
+
+// ---- Test helpers ----
+
+#[derive(Default)]
+struct DummyCore;
+#[async_trait::async_trait]
+impl modkit::Module for DummyCore {
+    async fn init(&self, _ctx: &modkit::context::ModuleCtx) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Default, Clone)]
+struct DummyRest;
+impl modkit::contracts::RestApiCapability for DummyRest {
+    fn register_rest(
+        &self,
+        _ctx: &modkit::context::ModuleCtx,
+        _router: axum::Router,
+        _openapi: &dyn modkit::api::OpenApiRegistry,
+    ) -> anyhow::Result<axum::Router> {
+        Ok(axum::Router::new())
+    }
+}
+
+#[derive(Default)]
+struct DummySystem;
+#[async_trait::async_trait]
+impl modkit::contracts::SystemCapability for DummySystem {}
+
+// (name, deps, has_rest, has_system)
+type ModuleSpec = (&'static str, &'static [&'static str], bool, bool);
+
+fn build_router_with(modules: &[ModuleSpec], manager: Arc<ModuleManager>) -> Router {
+    let mut b = RegistryBuilder::default();
+    for &(name, deps, has_rest, has_system) in modules {
+        b.register_core_with_meta(name, deps, Arc::new(DummyCore));
+        if has_rest {
+            b.register_rest_with_meta(name, Arc::new(DummyRest));
+        }
+        if has_system {
+            b.register_system_with_meta(name, Arc::new(DummySystem));
+        }
+    }
+    let registry = b.build_topo_sorted().unwrap();
+
+    let svc = Arc::new(ModulesService::new(&registry, manager));
+    let openapi = api_gateway::ApiGateway::default();
+    rest::routes::register_routes(Router::new(), &openapi, svc)
+}
+
+async fn get_modules(router: Router) -> (StatusCode, serde_json::Value) {
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/module-orchestrator/v1/modules")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    (status, json)
+}
+
+#[tokio::test]
+async fn returns_200_with_empty_catalog() {
+    let router = build_router_with(&[], Arc::new(ModuleManager::new()));
+
+    let (status, json) = get_modules(router).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(json.as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn returns_compiled_in_modules_with_capabilities() {
+    let router = build_router_with(
+        &[
+            ("api_gateway", &[], true, true),
+            ("grpc_hub", &[], false, false),
+        ],
+        Arc::new(ModuleManager::new()),
+    );
+
+    let (status, json) = get_modules(router).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let modules = json.as_array().unwrap();
+    assert_eq!(modules.len(), 2);
+
+    // Sorted by name
+    assert_eq!(modules[0]["name"], "api_gateway");
+    assert_eq!(modules[0]["deployment_mode"], "compiled_in");
+    assert!(
+        modules[0]["capabilities"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("rest"))
+    );
+    assert!(
+        modules[0]["capabilities"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!("system"))
+    );
+
+    assert_eq!(modules[1]["name"], "grpc_hub");
+    assert_eq!(modules[1]["deployment_mode"], "compiled_in");
+}
+
+#[tokio::test]
+async fn dynamic_instances_without_catalog_entry_appear_as_out_of_process() {
+    let manager = Arc::new(ModuleManager::new());
+    let instance =
+        Arc::new(ModuleInstance::new("dynamic_svc", Uuid::new_v4()).with_version("0.5.0"));
+    manager.register_instance(instance);
+
+    let router = build_router_with(&[], manager);
+
+    let (status, json) = get_modules(router).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let module = &json.as_array().unwrap()[0];
+    assert_eq!(module["name"], "dynamic_svc");
+    assert_eq!(module["deployment_mode"], "out_of_process");
+    assert_eq!(module["version"], "0.5.0");
+    assert!(module["capabilities"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn includes_running_instances_with_grpc_services() {
+    let manager = Arc::new(ModuleManager::new());
+    let instance_id = Uuid::new_v4();
+    let instance = Arc::new(
+        ModuleInstance::new("my_module", instance_id)
+            .with_version("1.2.3")
+            .with_grpc_service("my.Service", Endpoint::http("127.0.0.1", 9000)),
+    );
+    manager.register_instance(instance);
+
+    let router = build_router_with(&[("my_module", &[], false, false)], manager);
+
+    let (status, json) = get_modules(router).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let module = &json.as_array().unwrap()[0];
+    assert_eq!(module["name"], "my_module");
+    // Module-level version derived from first instance
+    assert_eq!(module["version"], "1.2.3");
+
+    let instances = module["instances"].as_array().unwrap();
+    assert_eq!(instances.len(), 1);
+    assert_eq!(instances[0]["instance_id"], instance_id.to_string());
+    assert_eq!(instances[0]["version"], "1.2.3");
+    assert_eq!(instances[0]["state"], "registered");
+    assert!(
+        instances[0]["grpc_services"]["my.Service"]
+            .as_str()
+            .unwrap()
+            .contains("127.0.0.1")
+    );
+}
+
+#[tokio::test]
+async fn plugins_field_omitted_when_empty() {
+    let router = build_router_with(
+        &[("test", &[], false, false)],
+        Arc::new(ModuleManager::new()),
+    );
+
+    let (status, json) = get_modules(router).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let module = &json.as_array().unwrap()[0];
+    // plugins field should be absent (skip_serializing_if = Vec::is_empty)
+    assert!(module.get("plugins").is_none());
+}
+
+#[tokio::test]
+async fn version_omitted_when_no_instances() {
+    let router = build_router_with(
+        &[("no_instances", &[], false, false)],
+        Arc::new(ModuleManager::new()),
+    );
+
+    let (status, json) = get_modules(router).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let module = &json.as_array().unwrap()[0];
+    // version should be absent when no instances report one
+    assert!(module.get("version").is_none());
+}
+
+#[tokio::test]
+async fn modules_are_sorted_alphabetically() {
+    let router = build_router_with(
+        &[
+            ("zebra", &[], false, false),
+            ("alpha", &[], false, false),
+            ("middle", &[], false, false),
+        ],
+        Arc::new(ModuleManager::new()),
+    );
+
+    let (status, json) = get_modules(router).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let names: Vec<&str> = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|m| m["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["alpha", "middle", "zebra"]);
+}


### PR DESCRIPTION
## Summary

- Add `GET /module-orchestrator/v1/modules` endpoint that returns all registered modules
- Each module shows: name, capabilities, dependencies, deployment mode (compiled_in / out_of_process), running instances with version/state/gRPC services
- Plugins field reserved in API contract (not yet populated, deferred to follow-up)

### Changes

**modkit (libs/modkit)**
- `registry.rs`: Add `ModuleRegistrySnapshot`, `ModuleSnapshot`, `CapabilitySet::labels()`, public getters on `ModuleEntry`
- `system_context.rs`: Extend `SystemContext` with `registry_snapshot` and `oop_module_names`
- `host_runtime.rs`: Build snapshot at startup, pass through `SystemContext`

**module_orchestrator**
- Add `rest` capability alongside existing `grpc` and `system`
- New `api/rest/` layer (dto, handlers, routes) following `OperationBuilder` pattern
- New `domain/` layer (model, service) with proper domain ↔ DTO separation
- 7 unit tests covering: compiled-in, OoP, dynamic instances, dual-mode modules, state mapping, deterministic ordering

## Test plan

- [x] `cargo check` — compiles cleanly
- [x] `cargo test -p cf-modkit` — 199 tests pass
- [x] `cargo test -p cf-module-orchestrator` — 7 tests pass
- [x] `cargo clippy --workspace` — no warnings
- [x] Manual: `curl http://localhost:8087/module-orchestrator/v1/modules` returns 200 with all modules

Closes #500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * REST endpoint to list registered modules (capabilities, dependencies, deployment mode, instances, service endpoints) with OpenAPI.
  * ModulesService for deterministic, sorted module listings aggregated from registry snapshot, runtime manager, and out-of-process sources.
  * Runtime introspection: registry snapshots and out-of-process module tracking available via runtime/system context.

* **Tests**
  * Added tests for capability labels, registry snapshots, module listing behavior, and instance state mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->