### PR TITLE
docs: add #[domain_model] to domain type examples

### DIFF
--- a/docs/ARCHITECTURE_MANIFEST.md
+++ b/docs/ARCHITECTURE_MANIFEST.md
@@ -318,7 +318,7 @@ Every HyperSpot module uses the **ModKit** framework, which provides:
 
  **Key ModKit libraries:**
  - `modkit` - Core module framework: lifecycle, REST host/contracts, OpenAPI registry, ClientHub, tracing helpers
- - `modkit-macros` - Procedural macros for module registration (`#[modkit::module(...)]`)
+ - `modkit-macros` - Procedural macros for module registration (`#[modkit::module(...)]`) and domain model enforcement (`#[domain_model]`)
  - `modkit-auth` - Authn/z plumbing for gateway and route policies
  - `modkit-security` - `SecurityContext` and security-scoping primitives used across modules (request-scoped context)
  - `modkit-errors` - Shared error types and RFC-9457 Problem modeling utilities

--- a/docs/modkit_unified_system/05_errors_rfc9457.md
+++ b/docs/modkit_unified_system/05_errors_rfc9457.md
@@ -31,8 +31,10 @@ ApiResult<T> = Result<T, Problem>  (handler return type)
 ## Domain Error (`<module>/src/domain/error.rs`)
 
 ```rust
+use modkit_macros::domain_model;
 use thiserror::Error;
 
+#[domain_model]
 #[derive(Error, Debug, Clone)]
 pub enum DomainError {
     #[error("User not found: {id}")]

--- a/docs/modkit_unified_system/10_checklists_and_templates.md
+++ b/docs/modkit_unified_system/10_checklists_and_templates.md
@@ -9,6 +9,7 @@ This section provides minimal checklists and code templates for common ModKit ta
 - [ ] Create `<module>-sdk` crate with `api.rs`, `models.rs`, `errors.rs`, `lib.rs`
 - [ ] Create `<module>` crate with `module.rs`, `api/rest/`, `domain/`, `infra/storage/`
 - [ ] Implement SDK trait with `async_trait` and `SecurityContext` first param
+- [ ] Add `#[domain_model]` on all `struct`/`enum` in `domain/` (import `modkit_macros::domain_model`)
 - [ ] Add `#[derive(ODataFilterable)]` on REST DTOs (import `modkit_odata_macros::ODataFilterable`)
 - [ ] Add `#[derive(Scopable)]` on SeaORM entities (import `modkit_db_macros::Scopable`)
 - [ ] Use `SecureConn` + `SecurityContext` for all DB operations
@@ -207,6 +208,9 @@ pub struct UserDto {
 ### Domain error template
 
 ```rust
+use modkit_macros::domain_model;
+
+#[domain_model]
 #[derive(Error, Debug, Clone)]
 pub enum DomainError {
     #[error("User not found: {id}")]

--- a/docs/modkit_unified_system/README.md
+++ b/docs/modkit_unified_system/README.md
@@ -20,6 +20,7 @@ This folder contains the ModKit developer documentation, split by topic for focu
 | Errors, RFC-9457 Problem | `05_errors_rfc9457.md` | |
 | Lifecycle, background tasks, cancellation | `08_lifecycle_stateful_tasks.md` | |
 | Out-of-Process / gRPC / SDK pattern | `09_oop_grpc_sdk_pattern.md` | |
+| Domain model macro, DDD enforcement | `02_module_layout_and_sdk_pattern.md` (§ Domain types) | `dylint_lints/de03_domain_layer/de0309_must_have_domain_model/README.md` |
 | Quick checklists, templates | `10_checklists_and_templates.md` | |
 
 ## Core invariants (apply everywhere)
@@ -31,6 +32,7 @@ This folder contains the ModKit developer documentation, split by topic for focu
 - **OData macros are in `modkit-odata-macros`**: Use `modkit_odata_macros::ODataFilterable`.
 - **ClientHub registration**: `ctx.client_hub().register::<dyn MyModuleApi>(api)`; `ctx.client_hub().get::<dyn MyModuleApi>()?`.
 - **Cancellation**: Pass `CancellationToken` to background tasks for cooperative shutdown.
+- **Domain model enforcement**: All `struct`/`enum` in `domain/` must have `#[domain_model]` (`modkit_macros::domain_model`). CI lint DE0309 enforces this.
 - **GTS schema**: Use `gts_schema_with_refs_as_string()` for faster, correct schema generation.
 
 ## File overview

--- a/guidelines/NEW_MODULE.md
+++ b/guidelines/NEW_MODULE.md
@@ -478,6 +478,9 @@ Error design rules:
 
 ```rust
 // src/domain/error.rs
+use modkit_macros::domain_model;
+
+#[domain_model]
 #[derive(Debug, thiserror::Error)]
 pub enum DomainError {
     #[error("User not found: {id}")]
@@ -864,9 +867,11 @@ All service methods receive `&SecurityContext` for authorization and access cont
 
    ```rust
    // Example from users_info
+   use modkit_macros::domain_model;
    use time::OffsetDateTime;
    use uuid::Uuid;
 
+   #[domain_model]
    #[derive(Debug, Clone)]
    pub enum UserDomainEvent {
        Created { id: Uuid, at: OffsetDateTime },
@@ -953,6 +958,7 @@ All service methods receive `&SecurityContext` for authorization and access cont
    ```rust
    // Example from users_info
    use std::sync::Arc;
+   use modkit_macros::domain_model;
    use modkit_security::SecurityContext;
    use uuid::Uuid;
 
@@ -964,12 +970,14 @@ All service methods receive `&SecurityContext` for authorization and access cont
    use user_info_sdk::models::{NewUser, User, UserPatch};
    use modkit_odata::{ODataQuery, Page};
 
+   #[domain_model]
    pub struct ServiceConfig {
        pub max_display_name_length: usize,
        pub default_page_size: u64,
        pub max_page_size: u64,
    }
 
+   #[domain_model]
    pub struct Service {
        repo: Arc<dyn UsersRepository>,
        events: Arc<dyn EventPublisher<UserDomainEvent>>,
@@ -1854,6 +1862,7 @@ The local client implements the SDK trait and forwards calls to domain service m
 
 ```rust
 // Example: users_info/src/domain/local_client.rs
+use modkit_macros::domain_model;
 use async_trait::async_trait;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -1871,6 +1880,7 @@ use modkit_security::SecurityContext;
 
 /// Local client adapter implementing the SDK API trait.
 /// Registered in ClientHub during module init().
+#[domain_model]
 pub struct UsersInfoLocalClient {
     service: Arc<Service>,
 }
@@ -2724,8 +2734,10 @@ use std::sync::Arc;
 
 use modkit::client_hub::{ClientHub, ClientScope};
 use modkit::plugins::GtsPluginSelector;
+use modkit_macros::domain_model;
 use types_registry_sdk::{ListQuery, TypesRegistryClient};
 
+#[domain_model]
 pub struct Service {
     hub: Arc<ClientHub>,
     vendor: String,


### PR DESCRIPTION
## Summary

Follow-up to PR #451 — update documentation code examples to include the required `#[domain_model]` attribute on all domain-layer types.

- `docs/modkit_unified_system/05_errors_rfc9457.md` — domain error example
- `docs/modkit_unified_system/10_checklists_and_templates.md` — domain error template
- `guidelines/NEW_MODULE.md` — domain error, events, service, local client, gateway service examples

## Context

PR #451 introduced the DE0309 lint requiring `#[domain_model]` on all domain types and updated `02_module_layout_and_sdk_pattern.md`. This PR covers the remaining documentation files.

Relates to #68
Follow-up to #451

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for a new domain-model annotation, its usage, constraints, and examples.
  * Updated templates and checklists to require annotating domain-layer types and show examples for errors, events, service config, service construction, and local clients.
  * Expanded allowed/forbidden types, compile-time error examples, CI enforcement notes, and manifest/README entries to reflect the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->