### PR TITLE
chore (github caches): optimize GitHub Actions caches with per-OS keys and add weekly cleanup workflow

### DIFF
--- a/.github/workflows/api_contracts.yml
+++ b/.github/workflows/api_contracts.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
-          shared-key: api-json
+          cache-bin: false
+          shared-key: pr-${{ runner.os }}-api-json
 
       - name: Fetch previous API spec from base branch
         env:

--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -1,0 +1,118 @@
+name: Cache Cleanup
+
+on:
+  schedule:
+    - cron: "0 3 * * 0" # every week Sunday
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    name: Prune PR shared caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old PR caches
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const keyPrefix = 'pr-';
+            const keepNewestPerKey = 3;
+            const retentionDays = 7;
+            const maxDeletes = 200;
+
+            const nowMs = Date.now();
+            const msPerDay = 1000 * 60 * 60 * 24;
+            const ageDays = (iso) => (nowMs - new Date(iso).getTime()) / msPerDay;
+
+            let page = 1;
+            const perPage = 100;
+            const allCaches = [];
+
+            while (true) {
+              let res;
+              try {
+                res = await github.rest.actions.getActionsCacheList({
+                  owner,
+                  repo,
+                  per_page: perPage,
+                  page,
+                });
+              } catch (err) {
+                core.error(`Failed to fetch cache list page ${page}: ${err.message}`);
+                throw new Error(`getActionsCacheList failed on page ${page}: ${err.message}`);
+              }
+
+              const batch = res.data.actions_caches ?? [];
+              allCaches.push(...batch);
+
+              if (batch.length < perPage) break;
+              page += 1;
+              if (page > 50) break;
+            }
+
+            const prCaches = allCaches.filter((c) => (c.key ?? '').startsWith(keyPrefix));
+
+            const groups = new Map();
+            for (const c of prCaches) {
+              const key = c.key ?? '';
+              if (!groups.has(key)) groups.set(key, []);
+              groups.get(key).push(c);
+            }
+
+            const toDelete = [];
+
+            for (const [key, caches] of groups.entries()) {
+              caches.sort((a, b) => {
+                const aTs = new Date(a.last_accessed_at ?? a.created_at).getTime();
+                const bTs = new Date(b.last_accessed_at ?? b.created_at).getTime();
+                return bTs - aTs;
+              });
+
+              const keep = new Set(caches.slice(0, keepNewestPerKey).map((c) => c.id));
+
+              for (const c of caches.slice(keepNewestPerKey)) {
+                const ts = c.last_accessed_at ?? c.created_at;
+                if (ts && ageDays(ts) > retentionDays) {
+                  toDelete.push({
+                    id: c.id,
+                    key,
+                    created_at: c.created_at,
+                    last_accessed_at: c.last_accessed_at,
+                    size_in_bytes: c.size_in_bytes,
+                  });
+                }
+              }
+            }
+
+            toDelete.sort((a, b) => {
+              const aTs = new Date(a.last_accessed_at ?? a.created_at).getTime();
+              const bTs = new Date(b.last_accessed_at ?? b.created_at).getTime();
+              return aTs - bTs;
+            });
+
+            const limited = toDelete.slice(0, maxDeletes);
+
+            core.info(`Found ${allCaches.length} total caches; ${prCaches.length} pr-* caches.`);
+            core.info(`Deleting ${limited.length} caches (max ${maxDeletes}) older than ${retentionDays} days, keeping newest ${keepNewestPerKey} per key.`);
+
+            for (const c of limited) {
+              core.info(`Deleting cache id=${c.id} key=${c.key} size=${c.size_in_bytes} created_at=${c.created_at} last_accessed_at=${c.last_accessed_at}`);
+              try {
+                await github.rest.actions.deleteActionsCacheById({
+                  owner,
+                  repo,
+                  cache_id: c.id,
+                });
+              } catch (err) {
+                core.error(`Failed to delete cache id=${c.id} key=${c.key}: ${err.message}`);
+                throw new Error(`deleteActionsCacheById failed for cache id=${c.id} key=${c.key}: ${err.message}`);
+              }
+            }
+
+            core.info('Cache cleanup complete.');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-bin: false
+          shared-key: pr-${{ runner.os }}-stable-1.92
 
       # Install sccache (cross-platform)
       - name: Install sccache
@@ -118,6 +119,7 @@ jobs:
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-bin: false
+          shared-key: pr-${{ runner.os }}-macros-stable-1.92
 
       # Install sccache (cross-platform)
       - name: Install sccache
@@ -182,6 +184,7 @@ jobs:
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-bin: false
+          shared-key: pr-${{ runner.os }}-nightly-${{ env.RUSTUP_TOOLCHAIN }}-llvm-cov
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@30eab0fabba9ea3f522099957e668b21876aa39e # v2.66.6
@@ -229,6 +232,7 @@ jobs:
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-bin: false
+          shared-key: pr-${{ runner.os }}-db-${{ matrix.backend }}-stable-1.92
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
@@ -271,6 +275,7 @@ jobs:
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-bin: false
+          shared-key: pr-${{ runner.os }}-users-info-pg-stable-1.92
 
       - name: Install sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
@@ -321,6 +326,7 @@ jobs:
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-bin: false
+          shared-key: pr-${{ runner.os }}-nightly-${{ env.RUSTUP_TOOLCHAIN }}-dylint
 
       - name: Run dylint tests
         working-directory: dylint_lints


### PR DESCRIPTION
- cache using is optimized (one cache for all PRs for single OS)
- cache cleanup task is added (every Sunday)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI caching to use per-runner/OS-specific keys for more reliable, effective cache hits.
  * Added a scheduled cache cleanup workflow to prune stale PR caches automatically, keeping build infrastructure lean and reducing intermittent CI issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->