### PR TITLE
ci: add github workflow for e2e smoke-on-push and nightly runs with automatic failure ownership assignment

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,133 @@
+name: e2e
+
+on:
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: "0 2 * * *" # nightly full E2E at 02:00 UTC
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Test suite to run"
+        required: false
+        default: "smoke"
+        type: choice
+        options:
+          - smoke
+          - full
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.1
+        with:
+          python-version: "3.11"
+
+      - name: Install Python dependencies
+        run: pip install -r testing/e2e/requirements.txt
+
+      - name: Run E2E tests
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            make e2e-smoke
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.mode }}" = "smoke" ]; then
+            make e2e-smoke
+          else
+            make e2e
+          fi
+
+      - name: Create or update issue on smoke failure
+        if: failure() && github.event_name == 'push'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = context.sha;
+
+            let assignee = context.actor;
+            try {
+              const commit = await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: sha,
+              });
+              assignee =
+                commit.data.author?.login ||
+                commit.data.committer?.login ||
+                context.actor;
+            } catch (e) {
+              core.info(`Could not fetch commit author, falling back to actor: ${e.message}`);
+            }
+
+            async function tryAssign(issueNumber) {
+              try {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  assignees: [assignee],
+                });
+              } catch (e) {
+                core.warning(`Could not assign to ${assignee}: ${e.message}`);
+              }
+            }
+
+            const title = "E2E smoke failed on main";
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = [
+              "Smoke E2E tests failed on `main`.",
+              "",
+              `- Commit: ${sha}`,
+              `- Assigned to (latest commit author): @${assignee}`,
+              `- Workflow run: ${runUrl}`,
+            ].join("\n");
+
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue is:open in:title "${title}" label:e2e-smoke`,
+              per_page: 1,
+            });
+
+            if (search.data.items.length > 0) {
+              const issue = search.data.items[0];
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: `New failure detected.\n\n- Commit: ${sha}\n- Run: ${runUrl}`,
+              });
+              await tryAssign(issue.number);
+            } else {
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ["bug", "e2e-smoke", "ci"],
+              });
+              await tryAssign(created.data.number);
+            }
+
+      # cleans up stopped containers, dangling build cache, and unused networks.
+      - name: Docker cleanup
+        if: always()
+        run: docker system prune --force

--- a/Makefile
+++ b/Makefile
@@ -314,10 +314,14 @@ test-users-info-pg:
 
 # -------- E2E tests --------
 
-.PHONY: e2e e2e-local e2e-docker
+.PHONY: e2e e2e-local e2e-docker e2e-smoke
 
 # Run E2E tests in Docker (default)
 e2e: e2e-docker
+
+## Run E2E smoke tests in Docker (only tests marked @pytest.mark.smoke)
+e2e-smoke:
+	python3 scripts/ci.py e2e --docker $(E2E_ARGS) -- -m smoke
 
 # Run E2E tests locally
 e2e-local:

--- a/testing/e2e/modules/examples/tenant_resolver_gw/test_root.py
+++ b/testing/e2e/modules/examples/tenant_resolver_gw/test_root.py
@@ -6,6 +6,7 @@ import pytest
 from .helpers import TENANT_ROOT
 
 
+@pytest.mark.smoke
 @pytest.mark.asyncio
 async def test_get_root_tenant(base_url, auth_headers):
     async with httpx.AsyncClient(timeout=10.0) as client:

--- a/testing/e2e/modules/file_parser/test_file_parser_info.py
+++ b/testing/e2e/modules/file_parser/test_file_parser_info.py
@@ -3,6 +3,7 @@ import httpx
 import pytest
 
 
+@pytest.mark.smoke
 @pytest.mark.asyncio
 async def test_file_parser_info_basic(base_url, auth_headers):
     """

--- a/testing/e2e/modules/nodes_registry/test_nodes_registry_get.py
+++ b/testing/e2e/modules/nodes_registry/test_nodes_registry_get.py
@@ -4,6 +4,7 @@ import pytest
 import uuid
 
 
+@pytest.mark.smoke
 @pytest.mark.asyncio
 async def test_get_node_by_id(base_url, auth_headers):
     """

--- a/testing/e2e/modules/settings/test_settings_get.py
+++ b/testing/e2e/modules/settings/test_settings_get.py
@@ -3,6 +3,7 @@ import httpx
 import pytest
 
 
+@pytest.mark.smoke
 @pytest.mark.asyncio
 async def test_get_settings_returns_defaults(base_url, auth_headers):
     """

--- a/testing/e2e/modules/settings/test_settings_integration.py
+++ b/testing/e2e/modules/settings/test_settings_integration.py
@@ -3,6 +3,7 @@ import httpx
 import pytest
 
 
+@pytest.mark.smoke
 @pytest.mark.asyncio
 async def test_settings_full_workflow(base_url, auth_headers):
     """

--- a/testing/e2e/modules/types_registry/test_types_registry_get.py
+++ b/testing/e2e/modules/types_registry/test_types_registry_get.py
@@ -18,9 +18,11 @@ def unique_id(name: str) -> str:
 
 
 def make_schema_id(gts_id: str) -> str:
+    """Build a ``gts://`` schema ``$id`` from a GTS ID."""
     return "gts://" + gts_id
 
 
+@pytest.mark.smoke
 @pytest.mark.asyncio
 async def test_get_entity_by_id(base_url, auth_headers):
     """

--- a/testing/e2e/pytest.ini
+++ b/testing/e2e/pytest.ini
@@ -4,5 +4,7 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts = -v --tb=short
+markers =
+    smoke: critical path tests for post-merge smoke runs
 
 


### PR DESCRIPTION
Issue: #259
Depends on PR: #320

## Github Workflow for E2E smoke and nightly run
Implements the E2E execution strategy: smoke tests on every push to main, full suite nightly.

### What changed

**New workflow: [.github/workflows/e2e.yml]()**
- **Push to `main`** → runs `make e2e-smoke` (only `@pytest.mark.smoke` tests)
- **Nightly schedule** (02:00 UTC) → runs full `make e2e` suite
- **Manual dispatch** → choice of `smoke` or `full`
- **Auto-issue on smoke failure**: creates/updates a GitHub Issue labeled `bug`, `e2e-smoke`, `ci`, assigned to the latest commit author. If an issue already exists, adds a comment with the new failure details and reassigns instead of creating a duplicate.

**Makefile: `e2e-smoke` target**
- Runs E2E with smoke marker `-m smoke` to pytest

**Smoke test markers (6 tests across 5 modules)**

| Module | Test | Coverage |
|--------|------|----------|
| settings | [test_get_settings_returns_defaults](testing/e2e/modules/settings/test_settings_get.py:5:0-44:73) | read-only |
| settings | [test_settings_full_workflow](testing/e2e/modules/settings/test_settings_integration.py:5:0-81:49) | **write→read** (POST + PATCH + GET) |
| types-registry | [test_get_entity_by_id](testing/e2e/modules/types_registry/test_types_registry_get.py:23:0-88:68) | **write→read** (POST + GET) |
| nodes-registry | [test_get_node_by_id](testing/e2e/modules/nodes_registry/test_nodes_registry_get.py:6:0-54:61) | read-only |
| file-parser | `test_file_parser_info_basic` | read-only |
| tenant-resolver-gw | `test_get_root_tenant` | read-only |

### Design decisions
- Smoke suite kept intentionally small (~6 tests) for fast post-merge feedback
- Nightly failures do **not** auto-create issues to avoid noise
- `workflow_dispatch` supports mode selection for manual triage runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a smoke testing workflow running on push, nightly, and manual triggers.
  * Introduced a fast "smoke" test target for quick validation.
  * Automatic issue creation/commenting and cleanup when smoke runs fail on push.

* **Tests**
  * Marked key end-to-end tests as smoke tests across modules.
  * Added a pytest "smoke" marker for test selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->