### PR TITLE
460: WIP Added Chat Prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CI := 1
 
-OPENAPI_URL ?= http://127.0.0.1:8087/openapi.json
+OPENAPI_URL ?= http://127.0.0.1:8087/chat/openapi.json
 OPENAPI_OUT ?= docs/api/api.json
 
 # E2E Docker args

--- a/libs/modkit/src/contracts.rs
+++ b/libs/modkit/src/contracts.rs
@@ -86,6 +86,7 @@ pub trait ApiGatewayCapability: Send + Sync + 'static {
         &self,
         ctx: &crate::context::ModuleCtx,
         router: Router,
+        module_router: Router,
     ) -> anyhow::Result<Router>;
 
     // Return OpenAPI registry of the module, e.g., to register endpoints

--- a/libs/modkit/src/registry.rs
+++ b/libs/modkit/src/registry.rs
@@ -1021,6 +1021,7 @@ mod tests {
             &self,
             _ctx: &crate::context::ModuleCtx,
             router: axum::Router,
+            _module_router: axum::Router,
         ) -> anyhow::Result<axum::Router> {
             Ok(router)
         }

--- a/libs/modkit/tests/macro_tests.rs
+++ b/libs/modkit/tests/macro_tests.rs
@@ -196,6 +196,7 @@ impl ApiGatewayCapability for TestApiGatewayModule {
         &self,
         _ctx: &modkit::context::ModuleCtx,
         router: axum::Router,
+        _module_router: axum::Router,
     ) -> anyhow::Result<axum::Router> {
         Ok(router)
     }

--- a/modules/system/api-gateway/tests/auth_middleware.rs
+++ b/modules/system/api-gateway/tests/auth_middleware.rs
@@ -213,15 +213,16 @@ async fn test_auth_disabled_mode() {
     api_gateway.init(&api_ctx).await.expect("Failed to init");
 
     // Register test module
-    let router = Router::new();
+    let mut router = Router::new();
+    let module_router = Router::new();
     let test_module = TestAuthModule;
-    let router = test_module
-        .register_rest(&test_ctx, router, &api_gateway)
+    let module_router = test_module
+        .register_rest(&test_ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     // Finalize router (applies middleware)
-    let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+    router = api_gateway
+        .rest_finalize(&api_ctx, router, module_router)
         .expect("Failed to finalize");
 
     // Test protected route WITHOUT token (should work because auth is disabled)
@@ -229,7 +230,7 @@ async fn test_auth_disabled_mode() {
         .clone()
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/api/protected")
+                .uri("/chat/tests/v1/api/protected")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -246,7 +247,7 @@ async fn test_auth_disabled_mode() {
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/api/public")
+                .uri("/chat/tests/v1/api/public")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -288,13 +289,14 @@ async fn test_public_routes_accessible() {
 
     // Then register test module routes
     let test_module = TestAuthModule;
-    let router = test_module
-        .register_rest(&test_ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = test_module
+        .register_rest(&test_ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     // Finally finalize
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(&api_ctx, router, module_router)
         .expect("Failed to finalize");
 
     // Test built-in health endpoints
@@ -319,7 +321,7 @@ async fn test_public_routes_accessible() {
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/openapi.json")
+                .uri("/chat/openapi.json")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -355,19 +357,20 @@ async fn test_middleware_always_inserts_security_ctx() {
 
     let router = Router::new();
     let test_module = TestAuthModule;
-    let router = test_module
-        .register_rest(&test_ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = test_module
+        .register_rest(&test_ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(&api_ctx, router, module_router)
         .expect("Failed to finalize");
 
     // Make request to protected handler that extracts Authz(SecurityCtx)
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/api/protected")
+                .uri("/chat/tests/v1/api/protected")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -466,12 +469,13 @@ async fn test_route_pattern_matching_with_path_params() {
 
     let router = Router::new();
     let test_module = TestAuthModule;
-    let router = test_module
-        .register_rest(&test_ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = test_module
+        .register_rest(&test_ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(&api_ctx, router, module_router)
         .expect("Failed to finalize");
 
     // Test that /tests/v1/api/users/123 is accessible (matches /tests/v1/api/users/{id})
@@ -479,7 +483,7 @@ async fn test_route_pattern_matching_with_path_params() {
         .clone()
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/api/users/123")
+                .uri("/chat/tests/v1/api/users/123")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -496,7 +500,7 @@ async fn test_route_pattern_matching_with_path_params() {
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/api/users/abc-def-456")
+                .uri("/chat/tests/v1/api/users/abc-def-456")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/modules/system/api-gateway/tests/body_limit_tests.rs
+++ b/modules/system/api-gateway/tests/body_limit_tests.rs
@@ -117,12 +117,13 @@ async fn test_body_limit_configured() {
 
     let module = BodyLimitTestModule;
     let router = Router::new();
-    let router = module
-        .register_rest(&ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = module
+        .register_rest(&ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(&ctx, router, module_router)
         .expect("Failed to finalize router");
 
     // Verify router builds with custom body limit
@@ -142,12 +143,13 @@ async fn test_body_limit_with_cors() {
 
     let module = BodyLimitTestModule;
     let router = Router::new();
-    let router = module
-        .register_rest(&ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = module
+        .register_rest(&ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(&ctx, router, module_router)
         .expect("Failed to finalize router");
 
     // Both CORS and body limit should be active
@@ -183,12 +185,13 @@ async fn test_default_body_limit() {
 
     let module = BodyLimitTestModule;
     let router = Router::new();
-    let router = module
-        .register_rest(&ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = module
+        .register_rest(&ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(&ctx, router, module_router)
         .expect("Failed to finalize router");
 
     // Verify default body limit is applied (16MB)

--- a/modules/system/api-gateway/tests/cors_tests.rs
+++ b/modules/system/api-gateway/tests/cors_tests.rs
@@ -147,13 +147,14 @@ async fn test_cors_layer_builds_with_config() {
 
     let module = CorsTestModule;
     let router = Router::new();
-    let router = module
-        .register_rest(&ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = module
+        .register_rest(&ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     // Build the final router with CORS middleware
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(&ctx, router, module_router)
         .expect("Failed to finalize router");
 
     // Verify router builds successfully with CORS enabled
@@ -168,12 +169,13 @@ async fn test_cors_permissive_mode() {
 
     let module = CorsTestModule;
     let router = Router::new();
-    let router = module
-        .register_rest(&ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = module
+        .register_rest(&ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(&ctx, router, module_router)
         .expect("Failed to finalize router");
 
     // Verify permissive CORS builds successfully
@@ -204,12 +206,13 @@ async fn test_cors_disabled() {
 
     let module = CorsTestModule;
     let router = Router::new();
-    let router = module
-        .register_rest(&ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = module
+        .register_rest(&ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(&ctx, router, module_router)
         .expect("Failed to finalize router");
 
     // Verify router builds without CORS layer

--- a/modules/system/api-gateway/tests/license_middleware.rs
+++ b/modules/system/api-gateway/tests/license_middleware.rs
@@ -181,18 +181,19 @@ async fn rejects_non_base_feature_requirement() {
 
     let router = Router::new();
     let test_module = TestLicenseModule;
-    let router = test_module
-        .register_rest(&test_ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = test_module
+        .register_rest(&test_ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(&api_ctx, router, module_router)
         .expect("Failed to finalize");
 
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/license/bad")
+                .uri("/chat/tests/v1/license/bad")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -223,18 +224,19 @@ async fn allows_base_feature_requirement() {
 
     let router = Router::new();
     let test_module = TestLicenseModule;
-    let router = test_module
-        .register_rest(&test_ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = test_module
+        .register_rest(&test_ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(&api_ctx, router, module_router)
         .expect("Failed to finalize");
 
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/license/good")
+                .uri("/chat/tests/v1/license/good")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -265,18 +267,19 @@ async fn allows_no_license_requirement() {
 
     let router = Router::new();
     let test_module = TestLicenseModule;
-    let router = test_module
-        .register_rest(&test_ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = test_module
+        .register_rest(&test_ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     let router = api_gateway
-        .rest_finalize(&api_ctx, router)
+        .rest_finalize(&api_ctx, router, module_router)
         .expect("Failed to finalize");
 
     let response = router
         .oneshot(
             Request::builder()
-                .uri("/tests/v1/license/none")
+                .uri("/chat/tests/v1/license/none")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/modules/system/api-gateway/tests/middleware_order.rs
+++ b/modules/system/api-gateway/tests/middleware_order.rs
@@ -78,19 +78,20 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
 
     // Register an endpoint that enables both MIME validation and rate limiting.
     let router = Router::new();
+    let module_router = Router::new();
     let mut builder = OperationBuilder::post("/tests/v1/middleware-order");
     builder.require_rate_limit(1, 1, 64);
-    let router = builder
+    let module_router = builder
         .operation_id("test:middleware-order")
         .summary("Middleware order test endpoint")
         .public()
         .allow_content_types(&["application/json"]) // turns on MIME validation
         .json_response(StatusCode::OK, "OK")
         .handler(axum::routing::post(handler))
-        .register(router, &api);
+        .register(module_router, &api);
 
     // Apply the real gateway middleware stack.
-    let app = api.rest_finalize(&ctx, router)?;
+    let app = api.rest_finalize(&ctx, router, module_router)?;
 
     // --------------------
     // Req1: invalid Content-Type -> should be rejected by MIME validation (415),
@@ -102,7 +103,7 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/tests/v1/middleware-order")
+                .uri("/chat/tests/v1/middleware-order")
                 .header("origin", "https://example.com")
                 .header("x-request-id", "fixed-req-1")
                 .header("content-type", "text/plain")
@@ -130,7 +131,7 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/tests/v1/middleware-order")
+                .uri("/chat/tests/v1/middleware-order")
                 .header("origin", "https://example.com")
                 .header("content-type", "application/json")
                 .body(Body::from(r#"{"ok":true}"#))?,
@@ -159,7 +160,7 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/tests/v1/middleware-order")
+                .uri("/chat/tests/v1/middleware-order")
                 .header("origin", "https://example.com")
                 .header("content-type", "application/json")
                 .body(Body::from(r#"{"ok":true}"#))?,

--- a/modules/system/api-gateway/tests/rate_limit_tests.rs
+++ b/modules/system/api-gateway/tests/rate_limit_tests.rs
@@ -158,13 +158,14 @@ async fn test_rate_limit_enforcement() {
 
     let module = RateLimitedModule;
     let router = Router::new();
-    let router = module
-        .register_rest(&ctx, router, &api_gateway)
+    let module_router = Router::new();
+    let module_router = module
+        .register_rest(&ctx, module_router, &api_gateway)
         .expect("Failed to register routes");
 
     // Build the final router with middleware
     let _final_router = api_gateway
-        .rest_finalize(&ctx, router)
+        .rest_finalize(&ctx, router, module_router)
         .expect("Failed to finalize router");
 
     // Note: Full HTTP testing would require starting a server and making real requests

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -7,6 +7,7 @@ import sys
 import time
 from urllib.request import urlopen
 from urllib.error import URLError, HTTPError
+from urllib.parse import urlparse
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PYTHON = sys.executable or "python"
@@ -287,12 +288,14 @@ def kill_existing_server(port):
 
 
 def cmd_e2e(args):
-    base_url = os.environ.get("E2E_BASE_URL", "http://localhost:8086")
+    base_url = os.environ.get("E2E_BASE_URL", "http://localhost:8086/chat")
     check_pytest()
 
     # Kill any existing server on the port before starting
-    port = base_url.split(":")[-1]
-    kill_existing_server(port)
+    parsed = urlparse(base_url)
+    port = parsed.port
+    if port is not None:
+        kill_existing_server(str(port))
 
     docker_env_started = False
     server_process = None

--- a/testing/e2e/conftest.py
+++ b/testing/e2e/conftest.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(Path(__file__).parent / "helpers"))
 @pytest.fixture
 def base_url():
     """Provide base URL for the API from E2E_BASE_URL env var."""
-    return os.getenv("E2E_BASE_URL", "http://localhost:8086")
+    return os.getenv("E2E_BASE_URL", "http://localhost:8086/chat")
 
 
 @pytest.fixture


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API routes and OpenAPI now served under the /chat prefix; module-provided routes are registered separately and composed into the final API (OpenAPI endpoint moved to /chat/openapi.json).

* **Bug Fixes / Behavior**
  * License, MIME and rate-limit middlewares now use suffix-based longest-match path matching for more flexible and accurate endpoint matching.

* **Chores**
  * Tests and CI defaults updated to reflect the new /chat routing and endpoint locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->