### PR TITLE
feat(log): add build configuration to logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,11 +818,13 @@ dependencies = [
  "calculator-sdk",
  "cf-grpc-hub",
  "cf-modkit",
+ "cf-modkit-build",
  "cf-modkit-macros",
  "cf-modkit-security",
  "cf-modkit-transport-grpc",
  "clap",
  "inventory",
+ "shadow-rs",
  "tokio",
  "tonic",
  "tracing",
@@ -1004,6 +1006,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
+ "cf-modkit-build",
  "cf-modkit-db",
  "cf-modkit-errors",
  "cf-modkit-macros",
@@ -1083,6 +1086,14 @@ dependencies = [
  "url",
  "uuid",
  "zeroize",
+]
+
+[[package]]
+name = "cf-modkit-build"
+version = "0.2.8"
+dependencies = [
+ "shadow-rs",
+ "tracing",
 ]
 
 [[package]]
@@ -1736,6 +1747,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -2768,6 +2799,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3261,6 +3305,7 @@ dependencies = [
  "cf-file-parser",
  "cf-grpc-hub",
  "cf-modkit",
+ "cf-modkit-build",
  "cf-module-orchestrator",
  "cf-nodes-registry",
  "cf-simple-user-settings",
@@ -3274,6 +3319,7 @@ dependencies = [
  "mimalloc",
  "serde-saphyr",
  "serde_json",
+ "shadow-rs",
  "tempfile",
  "tenant-resolver-gw",
  "tokio",
@@ -3508,6 +3554,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_debug"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe266d2e243c931d8190177f20bf7f24eed45e96f39e87dc49a27b32d12d407"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3653,6 +3705,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.3+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,6 +3760,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -5865,6 +5941,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadow-rs"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9967e7c3cd89d19cd533d8fceb3e5dcee28cf97fe76441481abe1d32723039"
+dependencies = [
+ "const_format",
+ "git2",
+ "is_debug",
+ "time",
+ "tzdb",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7051,6 +7140,32 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "uuid",
+]
+
+[[package]]
+name = "tz-rs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc6c929ffa10fb34f4a3c7e9a73620a83ef2e85e47f9ec3381b8289e6762f42"
+
+[[package]]
+name = "tzdb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d4e985b6dda743ae7fd4140c28105316ffd75bc58258ee6cc12934e3eb7a0c"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+ "tzdb_data",
+]
+
+[[package]]
+name = "tzdb_data"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42302a846dea7ab786f42dc5f519387069045acff793e1178d9368414168fe95"
+dependencies = [
+ "tz-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "libs/modkit-odata",
     "libs/modkit-node-info",
     "libs/modkit-transport-grpc",
+    "libs/modkit-build",
     "libs/modkit-utils",
     "libs/system-sdks",
     "libs/system-sdks/sdks/directory",
@@ -458,6 +459,10 @@ nanoid = "0.4"
 jsonschema = "0.40"
 walkdir = "2.5"
 shellexpand = "3.1"
+
+# Build metadata
+shadow-rs = "1"
+cf-modkit-build = { version = "0.2.8", path = "libs/modkit-build", default-features = false }
 
 # GTS library
 gts = "0.7.8"

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -49,6 +49,8 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }
+shadow-rs = { workspace = true }
+cf-modkit-build = { workspace = true }
 
 # Optional example module
 users-info = { path = "../../examples/modkit/users-info/users-info", optional = true }
@@ -59,6 +61,9 @@ calculator = { path = "../../examples/oop-modules/calculator/calculator", option
 tenant-resolver-gw-example = { package = "tenant-resolver-gw", path = "../../examples/plugin-modules/tenant-resolver/tenant-resolver-gw", optional = true }
 contoso-tr-plugin = { path = "../../examples/plugin-modules/tenant-resolver/plugins/contoso-tr-plugin", optional = true }
 fabrikam-tr-plugin = { path = "../../examples/plugin-modules/tenant-resolver/plugins/fabrikam-tr-plugin", optional = true }
+
+[build-dependencies]
+cf-modkit-build = { workspace = true, features = ["shadow-rs"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/apps/hyperspot-server/build.rs
+++ b/apps/hyperspot-server/build.rs
@@ -1,0 +1,3 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    cf_modkit_build::emit()
+}

--- a/apps/hyperspot-server/src/main.rs
+++ b/apps/hyperspot-server/src/main.rs
@@ -1,6 +1,7 @@
 mod registered_modules;
 
 use anyhow::Result;
+use cf_modkit_build::log_build_metadata;
 use clap::{Parser, Subcommand};
 use mimalloc::MiMalloc;
 use modkit::bootstrap::{
@@ -9,6 +10,8 @@ use modkit::bootstrap::{
 };
 
 use std::path::PathBuf;
+
+shadow_rs::shadow!(shadow);
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -94,6 +97,9 @@ async fn main() -> Result<()> {
     // Initialize logging + otel in one Registry
     let logging_config = config.logging.clone().unwrap_or_default();
     init_logging_unified(&logging_config, &config.server.home_dir, otel_layer);
+
+    // Log build metadata for production investigations
+    log_build_metadata(&cf_modkit_build::build_metadata!());
 
     // One-time connectivity probe
     #[cfg(feature = "otel")]

--- a/examples/oop-modules/calculator/calculator/Cargo.toml
+++ b/examples/oop-modules/calculator/calculator/Cargo.toml
@@ -36,6 +36,11 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 clap = { workspace = true }
 inventory = { workspace = true }
+shadow-rs = { workspace = true }
+cf-modkit-build = { workspace = true }
+
+[build-dependencies]
+cf-modkit-build = { workspace = true, features = ["shadow-rs"] }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/examples/oop-modules/calculator/calculator/build.rs
+++ b/examples/oop-modules/calculator/calculator/build.rs
@@ -1,0 +1,3 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    cf_modkit_build::emit()
+}

--- a/examples/oop-modules/calculator/calculator/src/main.rs
+++ b/examples/oop-modules/calculator/calculator/src/main.rs
@@ -9,6 +9,8 @@
 
 mod registered_modules;
 
+shadow_rs::shadow!(shadow);
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     use clap::Parser;
@@ -34,6 +36,7 @@ async fn main() -> anyhow::Result<()> {
         module_name: "calculator".to_string(),
         verbose: cli.verbose,
         config_path: cli.config,
+        build_metadata: Some(cf_modkit_build::build_metadata!()),
         ..Default::default()
     };
 

--- a/libs/modkit-build/Cargo.toml
+++ b/libs/modkit-build/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cf-modkit-build"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Build metadata types and build-script helper for binary crates"
+
+[features]
+default = ["shadow-rs"]
+
+[dependencies]
+tracing = { workspace = true }
+shadow-rs = { workspace = true, optional = true }

--- a/libs/modkit-build/src/lib.rs
+++ b/libs/modkit-build/src/lib.rs
@@ -1,0 +1,141 @@
+//! Build metadata types and build-script helper for binary crates.
+//!
+//! # Binary crates (full setup)
+//!
+//! Binary crates that want to log build metadata on startup need **three**
+//! pieces:
+//!
+//! 1. A **build-dependency** with the `shadow-rs` feature so `emit()` is
+//!    available in `build.rs`:
+//!
+//!    ```toml
+//!    [build-dependencies]
+//!    cf-modkit-build = { workspace = true, features = ["shadow-rs"] }
+//!    ```
+//!
+//! 2. A **runtime dependency** (types + macro only, no heavy deps):
+//!
+//!    ```toml
+//!    [dependencies]
+//!    cf-modkit-build = { workspace = true }
+//!    ```
+//!
+//! 3. A `build.rs` that calls [`emit`]:
+//!
+//!    ```rust,ignore
+//!    fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!        cf_modkit_build::emit()
+//!    }
+//!    ```
+//!
+//! Then in `main.rs`:
+//!
+//! ```rust,ignore
+//! shadow_rs::shadow!(shadow);
+//!
+//! fn main() {
+//!     // ...initialise logging...
+//!     log_build_metadata(&cf_modkit_build::build_metadata!());
+//! }
+//! ```
+
+// ── Runtime types (always available) ────────────────────────────────────
+
+/// Build-time metadata collected by `shadow-rs` in each binary crate.
+#[derive(Debug, Clone)]
+pub struct BuildMetadata<'a> {
+    /// Package version from `Cargo.toml` (e.g. `"0.2.8"`).
+    pub version: &'a str,
+    /// Full git commit hash.
+    pub commit_hash: &'a str,
+    /// Git branch name.
+    pub branch: &'a str,
+    /// Build timestamp (RFC 3339).
+    pub build_time: &'a str,
+    /// Rust compiler version string.
+    pub rust_version: &'a str,
+    /// Compilation target triple (e.g. `x86_64-unknown-linux-gnu`).
+    pub build_target: &'a str,
+    /// Comma-separated list of enabled Cargo feature flags.
+    pub features: &'a str,
+}
+
+/// Log build metadata at `INFO` level.
+///
+/// Call this once after the tracing subscriber has been installed.
+pub fn log_build_metadata(meta: &BuildMetadata<'_>) {
+    let features = if meta.features.is_empty() {
+        "(none)"
+    } else {
+        meta.features
+    };
+
+    tracing::info!(
+        version = %meta.version,
+        commit = %meta.commit_hash,
+        branch = %meta.branch,
+        build_time = %meta.build_time,
+        rust = %meta.rust_version,
+        target = %meta.build_target,
+        features = %features,
+        "Build metadata"
+    );
+}
+
+/// Construct a [`BuildMetadata`] from the `shadow!(shadow)` module constants
+/// and the `ENABLED_FEATURES` / `BUILD_TARGET` env vars emitted by [`emit`].
+///
+/// # Prerequisites
+///
+/// - The crate's `build.rs` must call [`emit`] (sets `ENABLED_FEATURES` and
+///   `BUILD_TARGET` env vars).
+/// - `shadow_rs::shadow!(shadow);` must appear at module scope in the caller.
+#[macro_export]
+macro_rules! build_metadata {
+    () => {
+        $crate::BuildMetadata {
+            version: shadow::PKG_VERSION,
+            commit_hash: shadow::COMMIT_HASH,
+            branch: shadow::BRANCH,
+            build_time: shadow::BUILD_TIME_3339,
+            rust_version: shadow::RUST_VERSION,
+            build_target: env!("BUILD_TARGET"),
+            features: env!("ENABLED_FEATURES"),
+        }
+    };
+}
+
+// ── Build-script helper (requires `shadow-rs` feature) ─────────────────
+
+/// Run shadow-rs and emit extra compile-time environment variables.
+///
+/// After this call the binary crate has access to:
+/// - All standard `shadow-rs` constants via `shadow_rs::shadow!(shadow);`
+/// - `env!("ENABLED_FEATURES")` — comma-separated list of enabled Cargo features
+/// - `env!("BUILD_TARGET")` — full target triple (e.g. `x86_64-unknown-linux-gnu`)
+///
+/// # Errors
+///
+/// Returns an error if shadow-rs initialisation fails.
+#[cfg(feature = "shadow-rs")]
+#[allow(unknown_lints, de1301_no_print_macros)] // for special usage in build.rs
+pub fn emit() -> Result<(), Box<dyn std::error::Error>> {
+    shadow_rs::ShadowBuilder::builder().build()?;
+
+    // Collect enabled Cargo features into a compile-time env var.
+    let mut features: Vec<String> = std::env::vars()
+        .filter_map(|(key, _)| {
+            key.strip_prefix("CARGO_FEATURE_")
+                .map(|f| f.to_lowercase().replace('_', "-"))
+        })
+        .collect();
+    features.sort();
+    println!("cargo:rustc-env=ENABLED_FEATURES={}", features.join(", "));
+
+    // Expose the full target triple (e.g. x86_64-unknown-linux-gnu).
+    if let Ok(target) = std::env::var("TARGET") {
+        println!("cargo:rustc-env=BUILD_TARGET={target}");
+    }
+
+    Ok(())
+}

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -45,6 +45,7 @@ bootstrap = [
     "dep:regex",
     "dep:url",
     "dep:dsn",
+    "dep:cf-modkit-build",
 ]
 
 [dependencies]
@@ -56,6 +57,7 @@ sea-orm-migration = { workspace = true, optional = true }
 modkit-odata = { workspace = true, features = ["with-odata-params"] }
 modkit-sdk = { workspace = true }
 cf-system-sdks = { workspace = true, features = ["directory"] }
+cf-modkit-build = { workspace = true, optional = true }
 
 # Core deps
 anyhow = { workspace = true }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emits build metadata to logs at application startup.
  * Runtime options can accept and display optional build metadata when provided.

* **Chores**
  * Added a workspace build-helper crate and integrated build-time metadata emission across relevant binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Example: 
```
2026-02-12T23:37:02.7036724Z  INFO cf_modkit_build: Build metadata version=0.2.8 commit=584581845cd8d5043c2763ec176262ac5aa4b203 branch=add_rust_configuration_to_logs build_time=2026-02-12T16:34:19-07:00 rust=rustc 1.93.0 (254b59607 2026-01-19) target=x86_64-pc-windows-msvc features=default
 ```

Partly fix
https://github.com/cyberfabric/cyberfabric-core/issues/572