### PR TITLE
[Docs] Add ADR for universal lazy layer approcah to solving fragile OoP module wiring

### DIFF
--- a/docs/adrs/modkit/0003-modkit-universal-lazy-layer.md
+++ b/docs/adrs/modkit/0003-modkit-universal-lazy-layer.md
@@ -1,0 +1,976 @@
+# Proposal: Universal Lazy Typed Clients for OoP gRPC Modules
+
+## Executive Summary
+
+This proposal details the implementation of **universal lazy typed clients** for out-of-process (OoP) gRPC modules in ModKit. The solution eliminates fragile eager wiring during module startup, enabling graceful degradation when OoP dependencies are unavailable.
+
+**Chosen approach**: Universal lazy layer in ModKit + code generation macro + `clients` declarations in `#[modkit::module]`.
+
+## Problem Statement
+
+The current OoP client wiring pattern has several issues:
+
+1. **Eager wiring is fragile**: Consumer modules call `wire_client()` in `init()`, which fails if the OoP dependency is not yet available.
+2. **Startup coupling**: The entire module fails to start if any OoP dependency is temporarily unavailable.
+3. **Boilerplate duplication**: Each SDK repeats the same resolve/connect/cache logic.
+4. **No graceful degradation**: Missing dependencies cause module-level failures instead of per-operation failures (HTTP 424).
+
+### Current Pattern (calculator_gateway example)
+
+```rust
+// Current: Consumer must wire client manually, and it happens eagerly
+pub async fn wire_client(hub: &ClientHub, resolver: &dyn DirectoryClient) -> Result<()> {
+    let endpoint = resolver.resolve_grpc_service(SERVICE_NAME).await?;  // Fails if OoP not ready
+    let client = CalculatorGrpcClient::connect(&endpoint.uri).await?;   // Fails if network issue
+    hub.register::<dyn CalculatorClientV1>(Arc::new(client));
+    Ok(())
+}
+```
+
+## Proposed Solution
+
+### Architecture Overview
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           SDK Crate (calculator-sdk)                    │
+├─────────────────────────────────────────────────────────────────────────┤
+│  CalculatorClientDescriptor                                             │
+│    - MODULE_NAME: "calculator"                                          │
+│    - SERVICE_NAME: "calculator.v1.CalculatorService"                    │
+│    - Api: dyn CalculatorClientV1                                        │
+│    - Availability: Optional (default)                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│  CalculatorGrpcClient (existing)                                        │
+│    - Implements CalculatorClientV1                                      │
+│    - Direct gRPC calls                                                  │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                           ModKit (libs/modkit)                          │
+├─────────────────────────────────────────────────────────────────────────┤
+│  GrpcClientProvider                                                     │
+│    - Lazy resolution via DirectoryClient                                │
+│    - Connection caching with eviction on error                          │
+│    - Backoff/rate-limiting for reconnects                               │
+│    - Transport middleware (timeouts, keepalive, tracing)                │
+├─────────────────────────────────────────────────────────────────────────┤
+│  LazyGrpcClient<D: GrpcClientDescriptor>                                │
+│    - Generated wrapper implementing D::Api                              │
+│    - Request-scoped middleware (SecurityContext propagation)            │
+│    - Error mapping to SDK error types                                   │
+├─────────────────────────────────────────────────────────────────────────┤
+│  #[modkit::module] macro extension                                      │
+│    - clients = [CalculatorClientDescriptor]                             │
+│    - Auto-registers LazyGrpcClient into ClientHub                       │
+│    - Auto-injects MODULE_NAME from each descriptor into deps            │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                      Consumer Module (calculator_gateway)               │
+├─────────────────────────────────────────────────────────────────────────┤
+│  #[modkit::module(                                                      │
+│      name = "calculator_gateway",                                       │
+│      capabilities = [rest],                                             │
+│      clients = [calculator_sdk::CalculatorClientDescriptor],            │
+│      // deps auto-injected: ["calculator"] from descriptor              │
+│  )]                                                                     │
+│                                                                         │
+│  // No wire_client() call needed!                                       │
+│  // Client is always available from ClientHub                           │
+│  let calc = hub.get::<dyn CalculatorClientV1>()?;                       │
+│  calc.add(ctx, a, b).await?;  // Lazy connect on first call             │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Detailed Implementation
+
+### Phase 1: GrpcClientDescriptor Trait (SDK-side)
+
+**Location**: `libs/modkit/src/clients/descriptor.rs`
+
+```rust
+//! Client descriptor traits for typed OoP client metadata.
+
+use std::time::Duration;
+
+/// Availability policy for OoP clients.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ClientAvailability {
+    /// Client is optional; operations fail gracefully with SDK error (maps to HTTP 424).
+    #[default]
+    Optional,
+    /// Client is required; module readiness may depend on availability.
+    Required,
+}
+
+/// Configuration for gRPC client behavior.
+#[derive(Debug, Clone)]
+pub struct GrpcClientConfig {
+    /// Connection timeout for initial connect.
+    pub connect_timeout: Duration,
+    /// Request timeout for individual RPC calls.
+    pub request_timeout: Duration,
+    /// Keepalive interval.
+    pub keepalive_interval: Option<Duration>,
+    /// Maximum backoff duration between reconnect attempts.
+    pub max_backoff: Duration,
+    /// Availability policy.
+    pub availability: ClientAvailability,
+}
+
+impl Default for GrpcClientConfig {
+    fn default() -> Self {
+        Self {
+            connect_timeout: Duration::from_secs(5),
+            request_timeout: Duration::from_secs(30),
+            keepalive_interval: Some(Duration::from_secs(30)),
+            max_backoff: Duration::from_secs(60),
+            availability: ClientAvailability::Optional,
+        }
+    }
+}
+
+/// Descriptor for a gRPC client, defined in SDK crates.
+///
+/// This trait binds compile-time type information to runtime metadata
+/// needed for lazy client resolution and registration.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// pub struct CalculatorClientDescriptor;
+///
+/// impl GrpcClientDescriptor for CalculatorClientDescriptor {
+///     type Api = dyn CalculatorClientV1;
+///     type GrpcClient = CalculatorGrpcClient;
+///
+///     const MODULE_NAME: &'static str = "calculator";
+///     const SERVICE_NAME: &'static str = "calculator.v1.CalculatorService";
+///
+///     fn config() -> GrpcClientConfig {
+///         GrpcClientConfig::default()
+///     }
+/// }
+/// ```
+pub trait GrpcClientDescriptor: Send + Sync + 'static {
+    /// The SDK API trait type (e.g., `dyn CalculatorClientV1`).
+    type Api: ?Sized + Send + Sync + 'static;
+
+    /// The concrete gRPC client type that implements `Api`.
+    /// Must be constructible from a Channel.
+    type GrpcClient: From<tonic::transport::Channel> + Send + Sync + 'static;
+
+    /// Module name for dependency graph (used in `deps`).
+    const MODULE_NAME: &'static str;
+
+    /// gRPC service name for Directory resolution.
+    const SERVICE_NAME: &'static str;
+
+    /// Client configuration (timeouts, backoff, availability).
+    fn config() -> GrpcClientConfig {
+        GrpcClientConfig::default()
+    }
+}
+```
+
+### Phase 2: GrpcClientProvider (ModKit Core)
+
+**Location**: `libs/modkit/src/clients/grpc_provider.rs`
+
+```rust
+//! Universal lazy gRPC client provider.
+//!
+//! Encapsulates endpoint resolution, connection management, caching,
+//! and reconnection logic for any gRPC client.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+use tokio::sync::Semaphore;
+use tonic::transport::Channel;
+
+use crate::client_hub::ClientHub;
+use crate::directory::DirectoryClient;
+use crate::clients::descriptor::GrpcClientConfig;
+
+/// Error type for provider operations.
+#[derive(Debug, thiserror::Error)]
+pub enum GrpcProviderError {
+    #[error("service not found in directory: {service_name}")]
+    ServiceNotFound { service_name: &'static str },
+
+    #[error("connection failed: {0}")]
+    ConnectionFailed(#[source] tonic::transport::Error),
+
+    #[error("directory resolution failed: {0}")]
+    DirectoryError(#[source] anyhow::Error),
+
+    #[error("service temporarily unavailable (backoff active)")]
+    Backoff { retry_after: Duration },
+}
+
+/// Cached connection state.
+struct CachedConnection {
+    channel: Channel,
+    connected_at: Instant,
+}
+
+/// Internal state for the provider.
+struct ProviderState {
+    cached: Option<CachedConnection>,
+    last_failure: Option<Instant>,
+    failure_count: u32,
+}
+
+/// Universal lazy gRPC client provider.
+///
+/// This provider handles:
+/// - Lazy endpoint resolution via DirectoryClient
+/// - Connection caching with automatic eviction on errors
+/// - Exponential backoff for reconnection attempts
+/// - Rate limiting to prevent thundering herds
+pub struct GrpcClientProvider {
+    service_name: &'static str,
+    config: GrpcClientConfig,
+    hub: Arc<ClientHub>,
+    state: RwLock<ProviderState>,
+    connect_semaphore: Semaphore,
+}
+
+impl GrpcClientProvider {
+    /// Create a new provider for the given service.
+    pub fn new(
+        service_name: &'static str,
+        config: GrpcClientConfig,
+        hub: Arc<ClientHub>,
+    ) -> Self {
+        Self {
+            service_name,
+            config,
+            hub,
+            state: RwLock::new(ProviderState {
+                cached: None,
+                last_failure: None,
+                failure_count: 0,
+            }),
+            connect_semaphore: Semaphore::new(1),
+        }
+    }
+
+    /// Get a connected channel, resolving and connecting lazily.
+    ///
+    /// Returns a cached channel if available, otherwise resolves the endpoint
+    /// and establishes a new connection.
+    pub async fn get_channel(&self) -> Result<Channel, GrpcProviderError> {
+        // Fast path: return cached connection
+        {
+            let state = self.state.read();
+            if let Some(ref cached) = state.cached {
+                return Ok(cached.channel.clone());
+            }
+
+            // Check backoff
+            if let Some(last_failure) = state.last_failure {
+                let backoff = self.calculate_backoff(state.failure_count);
+                let elapsed = last_failure.elapsed();
+                if elapsed < backoff {
+                    return Err(GrpcProviderError::Backoff {
+                        retry_after: backoff - elapsed,
+                    });
+                }
+            }
+        }
+
+        // Slow path: acquire semaphore and connect
+        let _permit = self.connect_semaphore.acquire().await
+            .expect("semaphore is never closed");
+
+        // Double-check after acquiring semaphore
+        {
+            let state = self.state.read();
+            if let Some(ref cached) = state.cached {
+                return Ok(cached.channel.clone());
+            }
+        }
+
+        // Resolve and connect
+        self.connect_internal().await
+    }
+
+    /// Evict the cached connection (call on transport errors).
+    pub fn evict(&self) {
+        let mut state = self.state.write();
+        state.cached = None;
+        state.last_failure = Some(Instant::now());
+        state.failure_count = state.failure_count.saturating_add(1);
+        tracing::warn!(
+            service = self.service_name,
+            failure_count = state.failure_count,
+            "Evicted cached gRPC connection"
+        );
+    }
+
+    /// Reset failure state (call on successful RPC).
+    pub fn reset_failures(&self) {
+        let mut state = self.state.write();
+        if state.failure_count > 0 {
+            state.failure_count = 0;
+            state.last_failure = None;
+            tracing::debug!(service = self.service_name, "Reset failure state after success");
+        }
+    }
+
+    async fn connect_internal(&self) -> Result<Channel, GrpcProviderError> {
+        // Resolve endpoint from DirectoryClient
+        let directory = self
+            .hub
+            .get::<dyn DirectoryClient>()
+            .map_err(|e| GrpcProviderError::DirectoryError(e.into()))?;
+
+        let endpoint = directory
+            .resolve_grpc_service(self.service_name)
+            .await
+            .map_err(|e| GrpcProviderError::DirectoryError(e))?;
+
+        tracing::debug!(
+            service = self.service_name,
+            uri = %endpoint.uri,
+            "Resolved service endpoint"
+        );
+
+        // Connect with configured timeouts
+        let channel = Channel::from_shared(endpoint.uri.clone())
+            .map_err(GrpcProviderError::ConnectionFailed)?
+            .connect_timeout(self.config.connect_timeout)
+            .timeout(self.config.request_timeout);
+
+        let channel = if let Some(keepalive) = self.config.keepalive_interval {
+            channel
+                .http2_keep_alive_interval(keepalive)
+                .keep_alive_timeout(Duration::from_secs(20))
+        } else {
+            channel
+        };
+
+        let channel = channel
+            .connect()
+            .await
+            .map_err(GrpcProviderError::ConnectionFailed)?;
+
+        // Cache the connection
+        {
+            let mut state = self.state.write();
+            state.cached = Some(CachedConnection {
+                channel: channel.clone(),
+                connected_at: Instant::now(),
+            });
+            state.failure_count = 0;
+            state.last_failure = None;
+        }
+
+        tracing::info!(
+            service = self.service_name,
+            uri = %endpoint.uri,
+            "Established gRPC connection"
+        );
+
+        Ok(channel)
+    }
+
+    fn calculate_backoff(&self, failure_count: u32) -> Duration {
+        let base = Duration::from_millis(100);
+        let max = self.config.max_backoff;
+        let backoff = base.saturating_mul(2u32.saturating_pow(failure_count.min(10)));
+        backoff.min(max)
+    }
+}
+```
+
+### Phase 3: LazyGrpcClient Wrapper (Generated or Manual)
+
+**Location**: `libs/modkit/src/clients/lazy_client.rs`
+
+For the initial implementation, we provide a manual wrapper pattern. The macro generation can be added later.
+
+```rust
+//! Lazy gRPC client wrapper that implements SDK traits.
+//!
+//! This wrapper delegates to GrpcClientProvider for connection management
+//! and handles SecurityContext propagation.
+
+use std::sync::Arc;
+
+use crate::clients::grpc_provider::{GrpcClientProvider, GrpcProviderError};
+use crate::clients::descriptor::GrpcClientDescriptor;
+
+/// Error returned by lazy clients when the OoP dependency is unavailable.
+#[derive(Debug, thiserror::Error)]
+pub enum LazyClientError {
+    #[error("service unavailable: {service_name}")]
+    Unavailable {
+        service_name: &'static str,
+        #[source]
+        source: GrpcProviderError,
+    },
+
+    #[error("RPC failed: {0}")]
+    RpcFailed(#[source] tonic::Status),
+}
+
+impl LazyClientError {
+    /// Returns true if this error indicates the service is temporarily unavailable.
+    /// REST handlers should map this to HTTP 424 Failed Dependency.
+    pub fn is_dependency_unavailable(&self) -> bool {
+        matches!(self, LazyClientError::Unavailable { .. })
+    }
+}
+
+/// Macro to generate a lazy client wrapper for a GrpcClientDescriptor.
+///
+/// This generates a struct that:
+/// - Implements the SDK API trait
+/// - Uses GrpcClientProvider for lazy connection management
+/// - Propagates SecurityContext via gRPC metadata
+/// - Maps transport errors to SDK error types
+///
+/// # Example
+///
+/// ```rust,ignore
+/// modkit::lazy_grpc_client! {
+///     /// Lazy client for Calculator service.
+///     pub struct LazyCalculatorClient for calculator_sdk::CalculatorClientDescriptor {
+///         // Method implementations are generated based on the trait
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! lazy_grpc_client {
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident for $descriptor:ty {
+            $(
+                async fn $method:ident(
+                    &self,
+                    ctx: &SecurityContext
+                    $(, $arg:ident : $arg_ty:ty)*
+                ) -> Result<$ret:ty, $err:ty> $body:block
+            )*
+        }
+    ) => {
+        $(#[$meta])*
+        $vis struct $name {
+            provider: std::sync::Arc<$crate::clients::grpc_provider::GrpcClientProvider>,
+        }
+
+        impl $name {
+            pub fn new(provider: std::sync::Arc<$crate::clients::grpc_provider::GrpcClientProvider>) -> Self {
+                Self { provider }
+            }
+        }
+
+        // Trait implementation would be generated here
+        // For now, this is a placeholder showing the pattern
+    };
+}
+```
+
+### Phase 4: SDK Crate Updates (calculator-sdk example)
+
+**Location**: `examples/oop-modules/calculator/calculator-sdk/src/descriptor.rs`
+
+```rust
+//! Client descriptor for Calculator SDK.
+
+use modkit::clients::descriptor::{GrpcClientDescriptor, GrpcClientConfig, ClientAvailability};
+use crate::api::CalculatorClientV1;
+use crate::client::CalculatorGrpcClient;
+
+/// Descriptor for the Calculator gRPC client.
+///
+/// Used by consumer modules to declare their dependency on the Calculator service
+/// via `#[modkit::module(clients = [CalculatorClientDescriptor])]`.
+pub struct CalculatorClientDescriptor;
+
+impl GrpcClientDescriptor for CalculatorClientDescriptor {
+    type Api = dyn CalculatorClientV1;
+    type GrpcClient = CalculatorGrpcClient;
+
+    const MODULE_NAME: &'static str = "calculator";
+    const SERVICE_NAME: &'static str = crate::SERVICE_NAME;
+
+    fn config() -> GrpcClientConfig {
+        GrpcClientConfig {
+            availability: ClientAvailability::Optional,
+            ..Default::default()
+        }
+    }
+}
+```
+
+**Updated SDK lib.rs**:
+
+```rust
+// ... existing exports ...
+
+// Client descriptor for lazy wiring
+mod descriptor;
+pub use descriptor::CalculatorClientDescriptor;
+```
+
+### Phase 5: Lazy Client Implementation for Calculator
+
+**Location**: `examples/oop-modules/calculator/calculator-sdk/src/lazy_client.rs`
+
+```rust
+//! Lazy gRPC client for Calculator service.
+//!
+//! This client wraps GrpcClientProvider and implements CalculatorClientV1,
+//! providing lazy connection management and graceful degradation.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit::clients::grpc_provider::GrpcClientProvider;
+use modkit_security::SecurityContext;
+use tonic::metadata::MetadataMap;
+
+use crate::api::{CalculatorClientV1, CalculatorError};
+use crate::client::CalculatorGrpcClient;
+use crate::proto;
+
+/// Lazy client for Calculator service.
+///
+/// This client:
+/// - Resolves the Calculator endpoint lazily on first call
+/// - Caches the connection for subsequent calls
+/// - Handles reconnection with backoff on failures
+/// - Propagates SecurityContext via gRPC metadata
+pub struct LazyCalculatorClient {
+    provider: Arc<GrpcClientProvider>,
+}
+
+impl LazyCalculatorClient {
+    /// Create a new lazy client with the given provider.
+    pub fn new(provider: Arc<GrpcClientProvider>) -> Self {
+        Self { provider }
+    }
+}
+
+#[async_trait]
+impl CalculatorClientV1 for LazyCalculatorClient {
+    async fn add(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, CalculatorError> {
+        // Get channel (lazy connect)
+        let channel = self.provider.get_channel().await.map_err(|e| {
+            tracing::warn!(error = %e, "Calculator service unavailable");
+            CalculatorError::Unavailable {
+                message: format!("Calculator service unavailable: {}", e),
+            }
+        })?;
+
+        // Create the gRPC client using the descriptor's GrpcClient type.
+        // CalculatorGrpcClient wraps the proto client and implements From<Channel>.
+        let client = CalculatorGrpcClient::from(channel);
+
+        // Propagate security context via metadata
+        let mut request = tonic::Request::new(proto::AddRequest { a, b });
+        inject_security_context(ctx, request.metadata_mut());
+
+        // Make the call
+        let response = client.add(request).await.map_err(|status| {
+            // Evict connection on transport errors
+            if is_transport_error(&status) {
+                self.provider.evict();
+            }
+            map_status_to_error(status)
+        })?;
+
+        // Reset failure state on success
+        self.provider.reset_failures();
+
+        Ok(response.into_inner().result)
+    }
+
+    async fn subtract(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, CalculatorError> {
+        let channel = self.provider.get_channel().await.map_err(|e| {
+            CalculatorError::Unavailable {
+                message: format!("Calculator service unavailable: {}", e),
+            }
+        })?;
+
+        let client = CalculatorGrpcClient::from(channel);
+        let mut request = tonic::Request::new(proto::SubtractRequest { a, b });
+        inject_security_context(ctx, request.metadata_mut());
+
+        let response = client.subtract(request).await.map_err(|status| {
+            if is_transport_error(&status) {
+                self.provider.evict();
+            }
+            map_status_to_error(status)
+        })?;
+
+        self.provider.reset_failures();
+        Ok(response.into_inner().result)
+    }
+
+    // ... other methods follow the same pattern ...
+}
+
+/// Inject SecurityContext into gRPC metadata.
+fn inject_security_context(ctx: &SecurityContext, metadata: &mut MetadataMap) {
+    if let Some(tenant_id) = ctx.tenant_id() {
+        if let Ok(value) = tenant_id.to_string().parse() {
+            metadata.insert("x-tenant-id", value);
+        }
+    }
+    if let Some(user_id) = ctx.user_id() {
+        if let Ok(value) = user_id.to_string().parse() {
+            metadata.insert("x-user-id", value);
+        }
+    }
+    // Add other context fields as needed
+}
+
+/// Check if the error is a transport-level error (connection lost, etc.)
+fn is_transport_error(status: &tonic::Status) -> bool {
+    matches!(
+        status.code(),
+        tonic::Code::Unavailable | tonic::Code::Unknown | tonic::Code::Internal
+    )
+}
+
+/// Map tonic Status to SDK error type.
+fn map_status_to_error(status: tonic::Status) -> CalculatorError {
+    match status.code() {
+        tonic::Code::InvalidArgument => CalculatorError::InvalidArgument {
+            message: status.message().to_string(),
+        },
+        tonic::Code::NotFound => CalculatorError::NotFound {
+            message: status.message().to_string(),
+        },
+        tonic::Code::Unavailable => CalculatorError::Unavailable {
+            message: status.message().to_string(),
+        },
+        _ => CalculatorError::Internal {
+            message: status.message().to_string(),
+        },
+    }
+}
+```
+
+### Phase 6: Module Macro Extension
+
+**Location**: `libs/modkit-macros/src/module.rs` (extension)
+
+The `#[modkit::module]` macro will be extended to support `clients = [...]`:
+
+```rust
+// Conceptual macro expansion for:
+// #[modkit::module(
+//     name = "calculator_gateway",
+//     capabilities = [rest],
+//     clients = [calculator_sdk::CalculatorClientDescriptor],
+//     // Note: deps is auto-injected from clients; no need to specify manually.
+// )]
+
+// Generated code (simplified):
+impl CalculatorGateway {
+    fn __register_lazy_clients(ctx: &ModuleCtx) -> anyhow::Result<()> {
+        use modkit::clients::descriptor::GrpcClientDescriptor;
+
+        // For each descriptor in `clients`:
+        {
+            type D = calculator_sdk::CalculatorClientDescriptor;
+            let config = D::config();
+            let provider = std::sync::Arc::new(
+                modkit::clients::grpc_provider::GrpcClientProvider::new(
+                    D::SERVICE_NAME,
+                    config,
+                    ctx.client_hub(),
+                )
+            );
+            let lazy_client: std::sync::Arc<<D as GrpcClientDescriptor>::Api> =
+                std::sync::Arc::new(calculator_sdk::LazyCalculatorClient::new(provider));
+            ctx.client_hub().register::<<D as GrpcClientDescriptor>::Api>(lazy_client);
+        }
+
+        Ok(())
+    }
+}
+
+// The macro also ensures deps includes the module_name from each descriptor
+// (validated at compile time or augmented automatically)
+```
+
+### Phase 7: Registry Extension for Soft OoP Deps
+
+**Location**: `libs/modkit/src/registry.rs` (extension)
+
+```rust
+/// Extended dependency resolution for OoP modules.
+impl ModuleRegistry {
+    /// Resolve dependencies, treating unknown deps as potential OoP soft deps.
+    ///
+    /// - If dep is a registered core module → hard dep (topo-sort)
+    /// - If dep is configured as `runtime.type = oop` → soft dep (no topo-sort)
+    /// - Otherwise → error (unknown dependency)
+    pub fn resolve_dependencies_with_oop(
+        &self,
+        module_name: &str,
+        deps: &[&str],
+        config: &AppConfig,
+    ) -> Result<ResolvedDeps, RegistryError> {
+        let mut hard_deps = Vec::new();
+        let mut soft_deps = Vec::new();
+
+        for dep in deps {
+            if self.has_module(dep) {
+                // Known in-process module
+                hard_deps.push(*dep);
+            } else if config.is_oop_module(dep) {
+                // OoP module declared in config
+                soft_deps.push(*dep);
+            } else {
+                return Err(RegistryError::UnknownDependency {
+                    module: module_name.to_string(),
+                    dependency: dep.to_string(),
+                });
+            }
+        }
+
+        Ok(ResolvedDeps { hard_deps, soft_deps })
+    }
+}
+
+/// Result of dependency resolution.
+pub struct ResolvedDeps {
+    /// Hard dependencies (in-process, participate in topo-sort).
+    pub hard_deps: Vec<&'static str>,
+    /// Soft dependencies (OoP, do not block startup).
+    pub soft_deps: Vec<&'static str>,
+}
+```
+
+---
+
+## Consumer Module Changes (calculator_gateway)
+
+### Before (current pattern)
+
+```rust
+#[modkit::module(
+    name = "calculator_gateway",
+    capabilities = [rest],
+    deps = ["calculator"]
+)]
+pub struct CalculatorGateway;
+
+#[async_trait]
+impl modkit::Module for CalculatorGateway {
+    async fn init(&self, ctx: &ModuleCtx) -> Result<()> {
+        // Must wire client manually - FAILS if calculator not ready
+        let directory = ctx.client_hub().get::<dyn DirectoryClient>()?;
+        calculator_sdk::wire_client(ctx.client_hub(), &*directory).await?;
+        // ...
+    }
+}
+```
+
+### After (proposed pattern)
+
+```rust
+#[modkit::module(
+    name = "calculator_gateway",
+    capabilities = [rest],
+    // deps is auto-injected from clients: the macro reads MODULE_NAME
+    // from each descriptor and adds it as a soft OoP dep.
+    clients = [calculator_sdk::CalculatorClientDescriptor],
+)]
+pub struct CalculatorGateway;
+
+#[async_trait]
+impl modkit::Module for CalculatorGateway {
+    async fn init(&self, ctx: &ModuleCtx) -> Result<()> {
+        // No wire_client() needed!
+        // LazyCalculatorClient is auto-registered by the macro.
+        let service = Arc::new(Service::new(ctx.client_hub()));
+        ctx.client_hub().register::<Service>(service);
+        Ok(())
+    }
+}
+
+// In domain service - unchanged!
+impl Service {
+    pub async fn add(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, ServiceError> {
+        let calculator = self.client_hub.get::<dyn CalculatorClientV1>()?;
+        // Lazy connect happens here on first call
+        calculator.add(ctx, a, b).await.map_err(|e| {
+            // CalculatorError::Unavailable maps to HTTP 424
+            ServiceError::RemoteError(e.to_string())
+        })
+    }
+}
+```
+
+---
+
+## Error Handling and HTTP 424
+
+The lazy client returns `CalculatorError::Unavailable` when the OoP service cannot be reached. REST handlers should map this to HTTP 424 Failed Dependency:
+
+```rust
+// In REST handler error mapping
+// Use a typed error variant instead of string matching
+impl From<ServiceError> for Problem {
+    fn from(err: ServiceError) -> Self {
+        match err {
+            ServiceError::DependencyUnavailable { service, source } => {
+                Problem::failed_dependency()
+                    .with_detail(format!("{} unavailable: {}", service, source))
+            }
+            ServiceError::RemoteError(msg) => {
+                Problem::bad_gateway()
+                    .with_detail(msg)
+            }
+            ServiceError::Internal(msg) => {
+                Problem::internal_server_error()
+                    .with_detail(msg)
+            }
+        }
+    }
+}
+
+// ServiceError should have a typed variant for dependency failures:
+#[derive(Debug, thiserror::Error)]
+pub enum ServiceError {
+    #[error("dependency unavailable: {service}")]
+    DependencyUnavailable {
+        service: &'static str,
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+    #[error("remote error: {0}")]
+    RemoteError(String),
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+// In domain service, map SDK errors to the typed variant:
+impl Service {
+    pub async fn add(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, ServiceError> {
+        let calculator = self.client_hub.get::<dyn CalculatorClientV1>()?;
+        calculator.add(ctx, a, b).await.map_err(|e| match e {
+            CalculatorError::Unavailable { message } => ServiceError::DependencyUnavailable {
+                service: "calculator",
+                source: message.into(),
+            },
+            other => ServiceError::RemoteError(other.to_string()),
+        })
+    }
+}
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core Infrastructure (Week 1-2)
+1. Add `GrpcClientDescriptor` trait to `libs/modkit/src/clients/descriptor.rs`
+2. Implement `GrpcClientProvider` in `libs/modkit/src/clients/grpc_provider.rs`
+3. Add `LazyClientError` type and helper utilities
+4. Unit tests for provider (mock DirectoryClient)
+
+### Phase 2: SDK Updates (Week 2-3)
+1. Add `CalculatorClientDescriptor` to calculator-sdk
+2. Implement `LazyCalculatorClient` manually
+3. Update calculator-sdk exports
+4. Integration tests with mock gRPC server
+
+### Phase 3: Macro Extension (Week 3-4)
+1. Extend `#[modkit::module]` to parse `clients = [...]`
+2. Generate lazy client registration code
+3. Auto-augment `deps` with module names from descriptors
+4. Compile-time validation of descriptor types
+
+### Phase 4: Registry Extension (Week 4)
+1. Implement soft OoP dep resolution in registry
+2. Update topo-sort to exclude soft deps
+3. Add config validation for OoP modules
+4. Integration tests for startup ordering
+
+### Phase 5: Migration & Documentation (Week 5)
+1. Update calculator_gateway example
+2. Update `docs/modkit_unified_system/09_oop_grpc_sdk_pattern.md` (primary migration doc)
+3. Add migration guide for existing SDKs to `09_oop_grpc_sdk_pattern.md`
+4. Update checklists
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- `GrpcClientProvider`: connection caching, backoff, eviction
+- `LazyCalculatorClient`: error mapping, context propagation
+- Registry: soft dep resolution
+
+### Integration Tests
+- Startup with unavailable OoP → module starts successfully
+- First call triggers lazy connect
+- Connection failure → backoff → retry
+- Successful call → failure state reset
+
+### E2E Tests
+- calculator_gateway starts without calculator OoP
+- REST call returns 424 when calculator unavailable
+- REST call succeeds after calculator becomes available
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Macro complexity | Start with manual lazy client impl; add codegen later |
+| Breaking existing SDKs | Backward-compatible: `wire_client()` still works |
+| Performance overhead | Provider uses fast-path caching; no overhead on hot path |
+| Debugging difficulty | Detailed tracing in provider and lazy client |
+
+---
+
+## Success Criteria
+
+1. **No eager wiring**: Consumer modules do not call `wire_client()` in `init()`
+2. **Graceful startup**: Modules start even if OoP dependencies are unavailable
+3. **Per-operation degradation**: Missing OoP → HTTP 424 for affected endpoints only
+4. **Single source of truth**: `clients = [...]` declares all OoP dependencies
+5. **Consistent behavior**: All gRPC clients use the same provider infrastructure
+
+---
+
+## Appendix: File Structure
+
+```text
+libs/modkit/src/
+├── clients/
+│   ├── mod.rs              # Module exports
+│   ├── descriptor.rs       # GrpcClientDescriptor trait
+│   ├── grpc_provider.rs    # GrpcClientProvider implementation
+│   └── lazy_client.rs      # LazyClientError and utilities
+├── lib.rs                  # Add `pub mod clients;`
+└── ...
+
+libs/modkit-macros/src/
+├── module.rs               # Extended to parse `clients = [...]`
+└── ...
+
+examples/oop-modules/calculator/calculator-sdk/src/
+├── descriptor.rs           # CalculatorClientDescriptor
+├── lazy_client.rs          # LazyCalculatorClient
+├── lib.rs                  # Updated exports
+└── ...
+```

--- a/docs/adrs/modkit/0003-modkit-universal-lazy-layer.md
+++ b/docs/adrs/modkit/0003-modkit-universal-lazy-layer.md
@@ -1,10 +1,32 @@
-# Proposal: Universal Lazy Typed Clients for OoP gRPC Modules
+# ADR-0003: Universal Lazy Typed REST Clients for OoP Modules
 
 ## Executive Summary
 
-This proposal details the implementation of **universal lazy typed clients** for out-of-process (OoP) gRPC modules in ModKit. The solution eliminates fragile eager wiring during module startup, enabling graceful degradation when OoP dependencies are unavailable.
+This proposal outlines a migration from gRPC to REST as the default transport for out-of-process (OoP) modules and introduces a **universal lazy typed client layer** for OoP module communication in ModKit. The implementation is structured in phases:
 
-**Chosen approach**: Universal lazy layer in ModKit + code generation macro + `clients` declarations in `#[modkit::module]`.
+1. **Phase 1 - REST as default transport**: Establish REST as the default OoP transport; gRPC becomes opt-in
+2. **Phase 2 - ClientDescriptor trait**: SDK-defined metadata binding compile-time types to runtime resolution
+3. **Phase 3 - ClientProvider**: Lazy resolution, caching, backoff, and reconnection infrastructure
+4. **Phase 4 - Macro extension**: `clients = [...]` auto-registers lazy clients into `ClientHub`
+5. **Phase 5 - Soft OoP deps**: Dependencies on OoP modules don't block startup
+6. **Phase 6 - Registry extension**: Soft OoP dep resolution:  
+
+**Current pattern** (problematic):
+```rust
+// Consumer must wire client manually in init() - FAILS if OoP module is not ready
+calculator_sdk::wire_client(hub, &*directory).await?;
+```
+
+**Proposed pattern**:
+```rust
+#[modkit::module(
+    name = "calculator_gateway",
+    clients = [calculator_sdk::CalculatorClientDescriptor],  // REST by default
+)]
+// No wire_client() needed - lazy client auto-registered
+```
+
+---
 
 ## Problem Statement
 
@@ -14,6 +36,7 @@ The current OoP client wiring pattern has several issues:
 2. **Startup coupling**: The entire module fails to start if any OoP dependency is temporarily unavailable.
 3. **Boilerplate duplication**: Each SDK repeats the same resolve/connect/cache logic.
 4. **No graceful degradation**: Missing dependencies cause module-level failures instead of per-operation failures (HTTP 424).
+5. **gRPC complexity**: Binary protobuf payloads are hard to debug; requires specialized tooling.
 
 ### Current Pattern (calculator_gateway example)
 
@@ -27,6 +50,8 @@ pub async fn wire_client(hub: &ClientHub, resolver: &dyn DirectoryClient) -> Res
 }
 ```
 
+---
+
 ## Proposed Solution
 
 ### Architecture Overview
@@ -37,33 +62,31 @@ pub async fn wire_client(hub: &ClientHub, resolver: &dyn DirectoryClient) -> Res
 ├─────────────────────────────────────────────────────────────────────────┤
 │  CalculatorClientDescriptor                                             │
 │    - MODULE_NAME: "calculator"                                          │
-│    - SERVICE_NAME: "calculator.v1.CalculatorService"                    │
 │    - Api: dyn CalculatorClientV1                                        │
-│    - Availability: Optional (default)                                   │
+│    - Transport: Rest (default) | Grpc (opt-in)                          │
+│    - Availability Policy: Optional (default)                            │
 ├─────────────────────────────────────────────────────────────────────────┤
-│  CalculatorGrpcClient (existing)                                        │
+│  LazyCalculatorClient                                                   │
 │    - Implements CalculatorClientV1                                      │
-│    - Direct gRPC calls                                                  │
+│    - Delegates to ClientProvider for lazy connection                    │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
                                     ▼
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                           ModKit (libs/modkit)                          │
 ├─────────────────────────────────────────────────────────────────────────┤
-│  GrpcClientProvider                                                     │
+│  ClientProvider (transport-agnostic interface)                          │
 │    - Lazy resolution via DirectoryClient                                │
-│    - Connection caching with eviction on error                          │
+│    - Endpoint/connection caching with eviction on error                 │
 │    - Backoff/rate-limiting for reconnects                               │
-│    - Transport middleware (timeouts, keepalive, tracing)                │
+│    - Transport middleware (timeouts, retries, tracing)                  │
 ├─────────────────────────────────────────────────────────────────────────┤
-│  LazyGrpcClient<D: GrpcClientDescriptor>                                │
-│    - Generated wrapper implementing D::Api                              │
-│    - Request-scoped middleware (SecurityContext propagation)            │
-│    - Error mapping to SDK error types                                   │
+│  RestClientProvider (default) | GrpcClientProvider (feature = "grpc")   │
+│    - Transport-specific implementations                                 │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  #[modkit::module] macro extension                                      │
 │    - clients = [CalculatorClientDescriptor]                             │
-│    - Auto-registers LazyGrpcClient into ClientHub                       │
+│    - Auto-registers LazyClient into ClientHub                           │
 │    - Auto-injects MODULE_NAME from each descriptor into deps            │
 └─────────────────────────────────────────────────────────────────────────┘
                                     │
@@ -89,7 +112,228 @@ pub async fn wire_client(hub: &ClientHub, resolver: &dyn DirectoryClient) -> Res
 
 ## Detailed Implementation
 
-### Phase 1: GrpcClientDescriptor Trait (SDK-side)
+### Phase 1: REST as Default Transport
+
+**Rationale**: REST is simpler to debug, requires no code generation, and is sufficient for most OoP calls. gRPC remains available for streaming or high-throughput use cases.
+
+| Factor          | REST                            | gRPC                         |
+|-----------------|---------------------------------|------------------------------|
+| Debuggability   | ✅ curl, browser, any HTTP tool | ❌ Requires specialized tools |
+| Simplicity      | ✅ JSON, standard HTTP          | ❌ Protobuf, code generation  |
+| Browser support | ✅ Native                       | ❌ Requires gRPC-Web proxy    |
+| API reuse       | ✅ Same as public REST API      | ❌ Separate interface         |
+| Streaming       | ❌ Requires SSE/WebSocket       | ✅ Native support             |
+| Performance     | ⚠️ JSON overhead                | ✅ Binary, efficient          |
+
+#### 1.1 Transport Enum
+
+**Location**: `libs/modkit/src/clients/transport.rs`
+
+```rust
+/// Transport protocol for OoP communication.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Transport {
+    /// REST with JSON serialization (default).
+    #[default]
+    Rest,
+    /// gRPC with protobuf serialization (opt-in, requires feature = "grpc").
+    #[cfg(feature = "grpc")]
+    Grpc,
+}
+```
+
+#### 1.2 REST Service Discovery Infrastructure
+
+REST service discovery requires extending the existing `ModuleInstance`, `ModuleManager`, and `DirectoryClient` to track and resolve REST endpoints.
+
+##### 1.2.1 Extend `ModuleInstance` to track REST endpoints
+
+**Location**: `libs/modkit/src/runtime/module_manager.rs`
+
+```rust
+/// Represents a single instance of a module
+#[derive(Debug)]
+pub struct ModuleInstance {
+    pub module: String,
+    pub instance_id: Uuid,
+    pub control: Option<Endpoint>,
+    pub grpc_services: HashMap<String, Endpoint>,
+    pub rest_endpoint: Option<Endpoint>,  // NEW: REST base URL for this instance
+    pub version: Option<String>,
+    inner: Arc<parking_lot::RwLock<InstanceRuntimeState>>,
+}
+
+impl ModuleInstance {
+    // ... existing methods ...
+
+    /// Set the REST endpoint for this instance
+    pub fn with_rest_endpoint(mut self, ep: Endpoint) -> Self {
+        self.rest_endpoint = Some(ep);
+        self
+    }
+}
+```
+
+##### 1.2.2 Extend `ModuleManager` with REST discovery
+
+**Location**: `libs/modkit/src/runtime/module_manager.rs`
+
+```rust
+impl ModuleManager {
+    /// Pick a REST endpoint for a module using round-robin selection.
+    /// Returns (module_name, instance, endpoint) if found.
+    #[must_use]
+    pub fn pick_rest_endpoint_round_robin(
+        &self,
+        module_name: &str,
+    ) -> Option<(String, Arc<ModuleInstance>, Endpoint)> {
+        let instances_entry = self.inner.get(module_name)?;
+        let instances = instances_entry.value();
+
+        // Filter to instances with REST endpoints and healthy/ready state
+        let candidates: Vec<_> = instances
+            .iter()
+            .filter(|inst| {
+                inst.rest_endpoint.is_some()
+                    && matches!(inst.state(), InstanceState::Healthy | InstanceState::Ready)
+            })
+            .cloned()
+            .collect();
+
+        if candidates.is_empty() {
+            return None;
+        }
+
+        let len = candidates.len();
+        let rr_key = format!("rest:{}", module_name);
+        let mut counter = self.rr_counters.entry(rr_key).or_insert(0);
+        let idx = *counter % len;
+        *counter = (*counter + 1) % len;
+
+        candidates.get(idx).map(|inst| {
+            (
+                module_name.to_owned(),
+                inst.clone(),
+                inst.rest_endpoint.clone().expect("filtered above"),
+            )
+        })
+    }
+}
+```
+
+##### 1.2.3 Extend `DirectoryClient` trait
+
+**Location**: `cf_system_sdks/src/directory.rs` (upstream crate — requires update)
+
+```rust
+#[async_trait]
+pub trait DirectoryClient: Send + Sync {
+    /// Resolve REST endpoint for a module (default for OoP).
+    async fn resolve_rest_service(&self, module_name: &str) -> Result<RestEndpoint>;
+
+    /// Resolve gRPC endpoint for a module (opt-in).
+    async fn resolve_grpc_service(&self, service_name: &str) -> Result<ServiceEndpoint>;
+
+    // ... existing methods (list_instances, register_instance, etc.) ...
+}
+
+/// REST endpoint for a module
+#[derive(Debug, Clone)]
+pub struct RestEndpoint {
+    /// Base URL for the module's REST API (e.g., "http://calculator:8080")
+    pub base_url: String,
+}
+
+impl RestEndpoint {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self { base_url: base_url.into() }
+    }
+
+    pub fn http(host: &str, port: u16) -> Self {
+        Self { base_url: format!("http://{}:{}", host, port) }
+    }
+}
+```
+
+##### 1.2.4 Implement `resolve_rest_service` in `LocalDirectoryClient`
+
+**Location**: `libs/modkit/src/directory.rs`
+
+```rust
+#[async_trait]
+impl DirectoryClient for LocalDirectoryClient {
+    async fn resolve_rest_service(&self, module_name: &str) -> Result<RestEndpoint> {
+        if let Some((_, _, ep)) = self.mgr.pick_rest_endpoint_round_robin(module_name) {
+            return Ok(RestEndpoint::new(ep.uri));
+        }
+
+        anyhow::bail!("REST service not found or no healthy instances: {module_name}")
+    }
+
+    // ... existing methods unchanged ...
+}
+```
+
+##### 1.2.5 Extend `RegisterInstanceInfo` for REST registration
+
+**Location**: `cf_system_sdks/src/directory.rs`
+
+```rust
+/// Information needed to register a module instance
+#[derive(Debug, Clone)]
+pub struct RegisterInstanceInfo {
+    pub module: String,
+    pub instance_id: String,
+    pub grpc_services: Vec<(String, ServiceEndpoint)>,
+    pub rest_endpoint: Option<RestEndpoint>,  // NEW
+    pub version: Option<String>,
+}
+```
+
+##### 1.2.6 OoP Module REST Registration
+
+When an OoP module starts, it registers its REST endpoint with the DirectoryService:
+
+**Location**: `libs/modkit/src/bootstrap/oop.rs`
+
+```rust
+async fn register_with_directory(
+    directory: &dyn DirectoryClient,
+    module_name: &str,
+    instance_id: Uuid,
+    rest_port: u16,
+    grpc_services: Vec<(String, ServiceEndpoint)>,
+) -> Result<()> {
+    let info = RegisterInstanceInfo {
+        module: module_name.to_owned(),
+        instance_id: instance_id.to_string(),
+        grpc_services,
+        rest_endpoint: Some(RestEndpoint::http("0.0.0.0", rest_port)),
+        version: Some(env!("CARGO_PKG_VERSION").to_owned()),
+    };
+
+    directory.register_instance(info).await
+}
+```
+
+##### 1.2.7 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **One REST endpoint per instance** | Unlike gRPC (multiple services per instance), REST modules expose a single base URL with path-based routing |
+| **Module-name based resolution** | REST discovery uses `module_name` (e.g., "calculator"), not service name |
+| **Reuse existing health tracking** | REST endpoints use the same `InstanceState` and heartbeat mechanism as gRPC |
+| **Symmetric API** | `resolve_rest_service()` mirrors `resolve_grpc_service()` for consistency |
+
+##### 1.2.8 Migration Notes
+
+1. **`cf_system_sdks` must be updated first** — Add `RestEndpoint`, extend `RegisterInstanceInfo`, and add `resolve_rest_service()` to `DirectoryClient`
+2. **`ModuleInstance` is extended** — Existing code continues to work; `rest_endpoint` defaults to `None`
+3. **OoP modules must register REST endpoints** — Update bootstrap to include REST port in registration
+
+---
+
+### Phase 2: ClientDescriptor Trait
 
 **Location**: `libs/modkit/src/clients/descriptor.rs`
 
@@ -100,7 +344,7 @@ use std::time::Duration;
 
 /// Availability policy for OoP clients.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum ClientAvailability {
+pub enum ClientAvailabilityPolicy {
     /// Client is optional; operations fail gracefully with SDK error (maps to HTTP 424).
     #[default]
     Optional,
@@ -108,105 +352,97 @@ pub enum ClientAvailability {
     Required,
 }
 
-/// Configuration for gRPC client behavior.
+/// Configuration for client behavior.
 #[derive(Debug, Clone)]
-pub struct GrpcClientConfig {
+pub struct ClientConfig {
+    /// Transport protocol (REST default, gRPC opt-in).
+    pub transport: Transport,
     /// Connection timeout for initial connect.
     pub connect_timeout: Duration,
-    /// Request timeout for individual RPC calls.
+    /// Request timeout for individual calls.
     pub request_timeout: Duration,
-    /// Keepalive interval.
-    pub keepalive_interval: Option<Duration>,
     /// Maximum backoff duration between reconnect attempts.
     pub max_backoff: Duration,
     /// Availability policy.
-    pub availability: ClientAvailability,
+    pub availability_policy: ClientAvailabilityPolicy,
 }
 
-impl Default for GrpcClientConfig {
+impl Default for ClientConfig {
     fn default() -> Self {
         Self {
+            transport: Transport::Rest,
             connect_timeout: Duration::from_secs(5),
             request_timeout: Duration::from_secs(30),
-            keepalive_interval: Some(Duration::from_secs(30)),
             max_backoff: Duration::from_secs(60),
-            availability: ClientAvailability::Optional,
+            availability_policy: ClientAvailabilityPolicy::Optional,
         }
     }
 }
 
-/// Descriptor for a gRPC client, defined in SDK crates.
+impl ClientConfig {
+    /// Create a REST client config (default).
+    pub fn rest() -> Self {
+        Self::default()
+    }
+
+    /// Create a gRPC client config (opt-in).
+    #[cfg(feature = "grpc")]
+    pub fn grpc() -> Self {
+        Self {
+            transport: Transport::Grpc,
+            ..Self::default()
+        }
+    }
+}
+
+/// Descriptor for an OoP client, defined in SDK crates.
 ///
 /// This trait binds compile-time type information to runtime metadata
 /// needed for lazy client resolution and registration.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// pub struct CalculatorClientDescriptor;
-///
-/// impl GrpcClientDescriptor for CalculatorClientDescriptor {
-///     type Api = dyn CalculatorClientV1;
-///     type GrpcClient = CalculatorGrpcClient;
-///
-///     const MODULE_NAME: &'static str = "calculator";
-///     const SERVICE_NAME: &'static str = "calculator.v1.CalculatorService";
-///
-///     fn config() -> GrpcClientConfig {
-///         GrpcClientConfig::default()
-///     }
-/// }
-/// ```
-pub trait GrpcClientDescriptor: Send + Sync + 'static {
+pub trait ClientDescriptor: Send + Sync + 'static {
     /// The SDK API trait type (e.g., `dyn CalculatorClientV1`).
     type Api: ?Sized + Send + Sync + 'static;
 
-    /// The concrete gRPC client type that implements `Api`.
-    /// Must be constructible from a Channel.
-    type GrpcClient: From<tonic::transport::Channel> + Send + Sync + 'static;
-
-    /// Module name for dependency graph (used in `deps`).
+    /// Module name for dependency graph and Directory resolution.
     const MODULE_NAME: &'static str;
 
-    /// gRPC service name for Directory resolution.
-    const SERVICE_NAME: &'static str;
-
-    /// Client configuration (timeouts, backoff, availability).
-    fn config() -> GrpcClientConfig {
-        GrpcClientConfig::default()
+    /// Client configuration (transport, timeouts, backoff, availability).
+    fn config() -> ClientConfig {
+        ClientConfig::default()
     }
 }
 ```
 
-### Phase 2: GrpcClientProvider (ModKit Core)
+---
 
-**Location**: `libs/modkit/src/clients/grpc_provider.rs`
+### Phase 3: ClientProvider Infrastructure
+
+#### 3.1 RestClientProvider (Default)
+
+**Location**: `libs/modkit/src/clients/rest_provider.rs`
 
 ```rust
-//! Universal lazy gRPC client provider.
-//!
-//! Encapsulates endpoint resolution, connection management, caching,
-//! and reconnection logic for any gRPC client.
+//! Universal lazy REST client provider (default transport).
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use parking_lot::RwLock;
 use tokio::sync::Semaphore;
-use tonic::transport::Channel;
 
 use crate::client_hub::ClientHub;
 use crate::directory::DirectoryClient;
-use crate::clients::descriptor::GrpcClientConfig;
+use crate::clients::descriptor::ClientConfig;
+use modkit_http::HttpClient;
 
-/// Error type for provider operations.
+/// Error type for REST provider operations.
 #[derive(Debug, thiserror::Error)]
-pub enum GrpcProviderError {
-    #[error("service not found in directory: {service_name}")]
-    ServiceNotFound { service_name: &'static str },
+pub enum RestProviderError {
+    #[error("service not found in directory: {module_name}")]
+    ServiceNotFound { module_name: &'static str },
 
-    #[error("connection failed: {0}")]
-    ConnectionFailed(#[source] tonic::transport::Error),
+    #[error("HTTP request failed: {0}")]
+    HttpError(#[source] modkit_http::HttpError),
 
     #[error("directory resolution failed: {0}")]
     DirectoryError(#[source] anyhow::Error),
@@ -215,64 +451,65 @@ pub enum GrpcProviderError {
     Backoff { retry_after: Duration },
 }
 
-/// Cached connection state.
-struct CachedConnection {
-    channel: Channel,
-    connected_at: Instant,
+struct CachedEndpoint {
+    base_url: String,
+    resolved_at: Instant,
 }
 
-/// Internal state for the provider.
 struct ProviderState {
-    cached: Option<CachedConnection>,
+    cached: Option<CachedEndpoint>,
     last_failure: Option<Instant>,
     failure_count: u32,
 }
 
-/// Universal lazy gRPC client provider.
+/// Universal lazy REST client provider.
 ///
-/// This provider handles:
+/// Handles:
 /// - Lazy endpoint resolution via DirectoryClient
-/// - Connection caching with automatic eviction on errors
+/// - Base URL caching with automatic eviction on errors
 /// - Exponential backoff for reconnection attempts
 /// - Rate limiting to prevent thundering herds
-pub struct GrpcClientProvider {
-    service_name: &'static str,
-    config: GrpcClientConfig,
+pub struct RestClientProvider {
+    module_name: &'static str,
+    config: ClientConfig,
     hub: Arc<ClientHub>,
+    http_client: HttpClient,
     state: RwLock<ProviderState>,
-    connect_semaphore: Semaphore,
+    resolve_semaphore: Semaphore,
 }
 
-impl GrpcClientProvider {
-    /// Create a new provider for the given service.
+impl RestClientProvider {
     pub fn new(
-        service_name: &'static str,
-        config: GrpcClientConfig,
+        module_name: &'static str,
+        config: ClientConfig,
         hub: Arc<ClientHub>,
     ) -> Self {
+        let http_client = HttpClient::builder()
+            .timeout(config.request_timeout)
+            .connect_timeout(config.connect_timeout)
+            .build();
+
         Self {
-            service_name,
+            module_name,
             config,
             hub,
+            http_client,
             state: RwLock::new(ProviderState {
                 cached: None,
                 last_failure: None,
                 failure_count: 0,
             }),
-            connect_semaphore: Semaphore::new(1),
+            resolve_semaphore: Semaphore::new(1),
         }
     }
 
-    /// Get a connected channel, resolving and connecting lazily.
-    ///
-    /// Returns a cached channel if available, otherwise resolves the endpoint
-    /// and establishes a new connection.
-    pub async fn get_channel(&self) -> Result<Channel, GrpcProviderError> {
-        // Fast path: return cached connection
+    /// Get the base URL for the service, resolving lazily.
+    pub async fn get_base_url(&self) -> Result<String, RestProviderError> {
+        // Fast path: return cached endpoint
         {
             let state = self.state.read();
             if let Some(ref cached) = state.cached {
-                return Ok(cached.channel.clone());
+                return Ok(cached.base_url.clone());
             }
 
             // Check backoff
@@ -280,107 +517,84 @@ impl GrpcClientProvider {
                 let backoff = self.calculate_backoff(state.failure_count);
                 let elapsed = last_failure.elapsed();
                 if elapsed < backoff {
-                    return Err(GrpcProviderError::Backoff {
+                    return Err(RestProviderError::Backoff {
                         retry_after: backoff - elapsed,
                     });
                 }
             }
         }
 
-        // Slow path: acquire semaphore and connect
-        let _permit = self.connect_semaphore.acquire().await
+        // Slow path: acquire semaphore and resolve
+        let _permit = self.resolve_semaphore.acquire().await
             .expect("semaphore is never closed");
 
         // Double-check after acquiring semaphore
         {
             let state = self.state.read();
             if let Some(ref cached) = state.cached {
-                return Ok(cached.channel.clone());
+                return Ok(cached.base_url.clone());
             }
         }
 
-        // Resolve and connect
-        self.connect_internal().await
+        self.resolve_internal().await
     }
 
-    /// Evict the cached connection (call on transport errors).
+    /// Get the HTTP client for making requests.
+    pub fn http_client(&self) -> &HttpClient {
+        &self.http_client
+    }
+
+    /// Evict the cached endpoint (call on transport errors).
     pub fn evict(&self) {
         let mut state = self.state.write();
         state.cached = None;
         state.last_failure = Some(Instant::now());
         state.failure_count = state.failure_count.saturating_add(1);
         tracing::warn!(
-            service = self.service_name,
+            module = self.module_name,
             failure_count = state.failure_count,
-            "Evicted cached gRPC connection"
+            "Evicted cached REST endpoint"
         );
     }
 
-    /// Reset failure state (call on successful RPC).
+    /// Reset failure state (call on successful request).
     pub fn reset_failures(&self) {
         let mut state = self.state.write();
         if state.failure_count > 0 {
             state.failure_count = 0;
             state.last_failure = None;
-            tracing::debug!(service = self.service_name, "Reset failure state after success");
+            tracing::debug!(module = self.module_name, "Reset failure state after success");
         }
     }
 
-    async fn connect_internal(&self) -> Result<Channel, GrpcProviderError> {
-        // Resolve endpoint from DirectoryClient
+    async fn resolve_internal(&self) -> Result<String, RestProviderError> {
         let directory = self
             .hub
             .get::<dyn DirectoryClient>()
-            .map_err(|e| GrpcProviderError::DirectoryError(e.into()))?;
+            .map_err(|e| RestProviderError::DirectoryError(e.into()))?;
 
         let endpoint = directory
-            .resolve_grpc_service(self.service_name)
+            .resolve_rest_service(self.module_name)
             .await
-            .map_err(|e| GrpcProviderError::DirectoryError(e))?;
+            .map_err(RestProviderError::DirectoryError)?;
 
         tracing::debug!(
-            service = self.service_name,
-            uri = %endpoint.uri,
-            "Resolved service endpoint"
+            module = self.module_name,
+            base_url = %endpoint.base_url,
+            "Resolved REST endpoint"
         );
 
-        // Connect with configured timeouts
-        let channel = Channel::from_shared(endpoint.uri.clone())
-            .map_err(GrpcProviderError::ConnectionFailed)?
-            .connect_timeout(self.config.connect_timeout)
-            .timeout(self.config.request_timeout);
-
-        let channel = if let Some(keepalive) = self.config.keepalive_interval {
-            channel
-                .http2_keep_alive_interval(keepalive)
-                .keep_alive_timeout(Duration::from_secs(20))
-        } else {
-            channel
-        };
-
-        let channel = channel
-            .connect()
-            .await
-            .map_err(GrpcProviderError::ConnectionFailed)?;
-
-        // Cache the connection
         {
             let mut state = self.state.write();
-            state.cached = Some(CachedConnection {
-                channel: channel.clone(),
-                connected_at: Instant::now(),
+            state.cached = Some(CachedEndpoint {
+                base_url: endpoint.base_url.clone(),
+                resolved_at: Instant::now(),
             });
             state.failure_count = 0;
             state.last_failure = None;
         }
 
-        tracing::info!(
-            service = self.service_name,
-            uri = %endpoint.uri,
-            "Established gRPC connection"
-        );
-
-        Ok(channel)
+        Ok(endpoint.base_url)
     }
 
     fn calculate_backoff(&self, failure_count: u32) -> Duration {
@@ -392,35 +606,40 @@ impl GrpcClientProvider {
 }
 ```
 
-### Phase 3: LazyGrpcClient Wrapper (Generated or Manual)
+#### 3.2 GrpcClientProvider (Optional)
 
-**Location**: `libs/modkit/src/clients/lazy_client.rs`
+**Location**: `libs/modkit/src/clients/grpc_provider.rs`
 
-For the initial implementation, we provide a manual wrapper pattern. The macro generation can be added later.
+> Feature-gated behind `feature = "grpc"` for streaming/high-throughput use cases.
 
 ```rust
-//! Lazy gRPC client wrapper that implements SDK traits.
-//!
-//! This wrapper delegates to GrpcClientProvider for connection management
-//! and handles SecurityContext propagation.
+#[cfg(feature = "grpc")]
+//! Lazy gRPC client provider (optional transport).
 
-use std::sync::Arc;
+// Implementation follows same pattern as RestClientProvider
+// but manages tonic::transport::Channel instead of base URL
+```
 
-use crate::clients::grpc_provider::{GrpcClientProvider, GrpcProviderError};
-use crate::clients::descriptor::GrpcClientDescriptor;
+#### 3.3 LazyClientError
 
+**Location**: `libs/modkit/src/clients/error.rs`
+
+```rust
 /// Error returned by lazy clients when the OoP dependency is unavailable.
 #[derive(Debug, thiserror::Error)]
 pub enum LazyClientError {
-    #[error("service unavailable: {service_name}")]
+    #[error("service unavailable: {module_name}")]
     Unavailable {
-        service_name: &'static str,
+        module_name: &'static str,
         #[source]
-        source: GrpcProviderError,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[error("RPC failed: {0}")]
-    RpcFailed(#[source] tonic::Status),
+    #[error("request failed: {0}")]
+    RequestFailed(String),
+
+    #[error("response parsing failed: {0}")]
+    ParseError(#[source] serde_json::Error),
 }
 
 impl LazyClientError {
@@ -430,134 +649,66 @@ impl LazyClientError {
         matches!(self, LazyClientError::Unavailable { .. })
     }
 }
-
-/// Macro to generate a lazy client wrapper for a GrpcClientDescriptor.
-///
-/// This generates a struct that:
-/// - Implements the SDK API trait
-/// - Uses GrpcClientProvider for lazy connection management
-/// - Propagates SecurityContext via gRPC metadata
-/// - Maps transport errors to SDK error types
-///
-/// # Example
-///
-/// ```rust,ignore
-/// modkit::lazy_grpc_client! {
-///     /// Lazy client for Calculator service.
-///     pub struct LazyCalculatorClient for calculator_sdk::CalculatorClientDescriptor {
-///         // Method implementations are generated based on the trait
-///     }
-/// }
-/// ```
-#[macro_export]
-macro_rules! lazy_grpc_client {
-    (
-        $(#[$meta:meta])*
-        $vis:vis struct $name:ident for $descriptor:ty {
-            $(
-                async fn $method:ident(
-                    &self,
-                    ctx: &SecurityContext
-                    $(, $arg:ident : $arg_ty:ty)*
-                ) -> Result<$ret:ty, $err:ty> $body:block
-            )*
-        }
-    ) => {
-        $(#[$meta])*
-        $vis struct $name {
-            provider: std::sync::Arc<$crate::clients::grpc_provider::GrpcClientProvider>,
-        }
-
-        impl $name {
-            pub fn new(provider: std::sync::Arc<$crate::clients::grpc_provider::GrpcClientProvider>) -> Self {
-                Self { provider }
-            }
-        }
-
-        // Trait implementation would be generated here
-        // For now, this is a placeholder showing the pattern
-    };
-}
 ```
+
+---
 
 ### Phase 4: SDK Crate Updates (calculator-sdk example)
 
-**Location**: `examples/oop-modules/calculator/calculator-sdk/src/descriptor.rs`
+#### 4.1 Descriptor
+
+**Location**: `calculator-sdk/src/descriptor.rs`
 
 ```rust
-//! Client descriptor for Calculator SDK.
-
-use modkit::clients::descriptor::{GrpcClientDescriptor, GrpcClientConfig, ClientAvailability};
+use modkit::clients::descriptor::{ClientDescriptor, ClientConfig};
 use crate::api::CalculatorClientV1;
-use crate::client::CalculatorGrpcClient;
 
-/// Descriptor for the Calculator gRPC client.
-///
-/// Used by consumer modules to declare their dependency on the Calculator service
-/// via `#[modkit::module(clients = [CalculatorClientDescriptor])]`.
+/// Descriptor for the Calculator client (REST by default).
 pub struct CalculatorClientDescriptor;
 
-impl GrpcClientDescriptor for CalculatorClientDescriptor {
+impl ClientDescriptor for CalculatorClientDescriptor {
     type Api = dyn CalculatorClientV1;
-    type GrpcClient = CalculatorGrpcClient;
-
     const MODULE_NAME: &'static str = "calculator";
-    const SERVICE_NAME: &'static str = crate::SERVICE_NAME;
 
-    fn config() -> GrpcClientConfig {
-        GrpcClientConfig {
-            availability: ClientAvailability::Optional,
-            ..Default::default()
-        }
+    fn config() -> ClientConfig {
+        ClientConfig::rest()  // Default: REST transport
+    }
+}
+
+// Optional: gRPC descriptor for high-throughput use cases
+#[cfg(feature = "grpc")]
+pub struct CalculatorGrpcClientDescriptor;
+
+#[cfg(feature = "grpc")]
+impl ClientDescriptor for CalculatorGrpcClientDescriptor {
+    type Api = dyn CalculatorClientV1;
+    const MODULE_NAME: &'static str = "calculator";
+
+    fn config() -> ClientConfig {
+        ClientConfig::grpc()  // Opt-in: gRPC transport
     }
 }
 ```
 
-**Updated SDK lib.rs**:
+#### 4.2 Lazy Client Implementation
+
+**Location**: `calculator-sdk/src/lazy_client.rs`
 
 ```rust
-// ... existing exports ...
-
-// Client descriptor for lazy wiring
-mod descriptor;
-pub use descriptor::CalculatorClientDescriptor;
-```
-
-### Phase 5: Lazy Client Implementation for Calculator
-
-**Location**: `examples/oop-modules/calculator/calculator-sdk/src/lazy_client.rs`
-
-```rust
-//! Lazy gRPC client for Calculator service.
-//!
-//! This client wraps GrpcClientProvider and implements CalculatorClientV1,
-//! providing lazy connection management and graceful degradation.
-
 use std::sync::Arc;
-
 use async_trait::async_trait;
-use modkit::clients::grpc_provider::GrpcClientProvider;
+use modkit::clients::rest_provider::RestClientProvider;
 use modkit_security::SecurityContext;
-use tonic::metadata::MetadataMap;
 
 use crate::api::{CalculatorClientV1, CalculatorError};
-use crate::client::CalculatorGrpcClient;
-use crate::proto;
 
-/// Lazy client for Calculator service.
-///
-/// This client:
-/// - Resolves the Calculator endpoint lazily on first call
-/// - Caches the connection for subsequent calls
-/// - Handles reconnection with backoff on failures
-/// - Propagates SecurityContext via gRPC metadata
+/// Lazy client for Calculator service (REST transport).
 pub struct LazyCalculatorClient {
-    provider: Arc<GrpcClientProvider>,
+    provider: Arc<RestClientProvider>,
 }
 
 impl LazyCalculatorClient {
-    /// Create a new lazy client with the given provider.
-    pub fn new(provider: Arc<GrpcClientProvider>) -> Self {
+    pub fn new(provider: Arc<RestClientProvider>) -> Self {
         Self { provider }
     }
 }
@@ -565,160 +716,125 @@ impl LazyCalculatorClient {
 #[async_trait]
 impl CalculatorClientV1 for LazyCalculatorClient {
     async fn add(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, CalculatorError> {
-        // Get channel (lazy connect)
-        let channel = self.provider.get_channel().await.map_err(|e| {
+        let base_url = self.provider.get_base_url().await.map_err(|e| {
             tracing::warn!(error = %e, "Calculator service unavailable");
             CalculatorError::Unavailable {
                 message: format!("Calculator service unavailable: {}", e),
             }
         })?;
 
-        // Create the gRPC client using the descriptor's GrpcClient type.
-        // CalculatorGrpcClient wraps the proto client and implements From<Channel>.
-        let client = CalculatorGrpcClient::from(channel);
+        let url = format!("{}/api/v1/calculator/add", base_url);
+        let response = self.provider.http_client()
+            .post(&url)
+            .header("x-tenant-id", ctx.tenant_id().map(|t| t.to_string()).unwrap_or_default())
+            .json(&serde_json::json!({ "a": a, "b": b }))
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_connect() || e.is_timeout() {
+                    self.provider.evict();
+                }
+                CalculatorError::Unavailable {
+                    message: format!("HTTP request failed: {}", e),
+                }
+            })?;
 
-        // Propagate security context via metadata
-        let mut request = tonic::Request::new(proto::AddRequest { a, b });
-        inject_security_context(ctx, request.metadata_mut());
+        if !response.status().is_success() {
+            return Err(map_http_error(response.status(), &response.text().await.unwrap_or_default()));
+        }
 
-        // Make the call
-        let response = client.add(request).await.map_err(|status| {
-            // Evict connection on transport errors
-            if is_transport_error(&status) {
-                self.provider.evict();
-            }
-            map_status_to_error(status)
-        })?;
-
-        // Reset failure state on success
-        self.provider.reset_failures();
-
-        Ok(response.into_inner().result)
-    }
-
-    async fn subtract(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, CalculatorError> {
-        let channel = self.provider.get_channel().await.map_err(|e| {
-            CalculatorError::Unavailable {
-                message: format!("Calculator service unavailable: {}", e),
-            }
-        })?;
-
-        let client = CalculatorGrpcClient::from(channel);
-        let mut request = tonic::Request::new(proto::SubtractRequest { a, b });
-        inject_security_context(ctx, request.metadata_mut());
-
-        let response = client.subtract(request).await.map_err(|status| {
-            if is_transport_error(&status) {
-                self.provider.evict();
-            }
-            map_status_to_error(status)
+        let result: AddResponse = response.json().await.map_err(|e| {
+            CalculatorError::Internal { message: format!("Failed to parse response: {}", e) }
         })?;
 
         self.provider.reset_failures();
-        Ok(response.into_inner().result)
+        Ok(result.result)
     }
 
     // ... other methods follow the same pattern ...
 }
 
-/// Inject SecurityContext into gRPC metadata.
-fn inject_security_context(ctx: &SecurityContext, metadata: &mut MetadataMap) {
-    if let Some(tenant_id) = ctx.tenant_id() {
-        if let Ok(value) = tenant_id.to_string().parse() {
-            metadata.insert("x-tenant-id", value);
-        }
-    }
-    if let Some(user_id) = ctx.user_id() {
-        if let Ok(value) = user_id.to_string().parse() {
-            metadata.insert("x-user-id", value);
-        }
-    }
-    // Add other context fields as needed
-}
+#[derive(serde::Deserialize)]
+struct AddResponse { result: i64 }
 
-/// Check if the error is a transport-level error (connection lost, etc.)
-fn is_transport_error(status: &tonic::Status) -> bool {
-    matches!(
-        status.code(),
-        tonic::Code::Unavailable | tonic::Code::Unknown | tonic::Code::Internal
-    )
-}
-
-/// Map tonic Status to SDK error type.
-fn map_status_to_error(status: tonic::Status) -> CalculatorError {
-    match status.code() {
-        tonic::Code::InvalidArgument => CalculatorError::InvalidArgument {
-            message: status.message().to_string(),
-        },
-        tonic::Code::NotFound => CalculatorError::NotFound {
-            message: status.message().to_string(),
-        },
-        tonic::Code::Unavailable => CalculatorError::Unavailable {
-            message: status.message().to_string(),
-        },
-        _ => CalculatorError::Internal {
-            message: status.message().to_string(),
-        },
+/// Maps HTTP status codes to SDK errors.
+#[derive(serde::Deserialize)]
+struct AddResponse { result: i64 }
+/// Maps HTTP status codes to SDK errors.
+/// Note: Signature should use http::StatusCode to match modkit_http::HttpClient shown above.
+fn map_http_error(status: http::StatusCode, body: &str) -> CalculatorError {
+    match status.as_u16() {
+        400 => CalculatorError::InvalidArgument { message: body.to_string() },
+        404 => CalculatorError::NotFound { message: body.to_string() },
+        503 => CalculatorError::Unavailable { message: body.to_string() },
+        _ => CalculatorError::Internal { message: format!("HTTP {}: {}", status, body) },
     }
 }
 ```
 
-### Phase 6: Module Macro Extension
+---
 
-**Location**: `libs/modkit-macros/src/module.rs` (extension)
+### Phase 5: Module Macro Extension
 
-The `#[modkit::module]` macro will be extended to support `clients = [...]`:
+**Location**: `libs/modkit-macros/src/module.rs`
+
+The `#[modkit::module]` macro is extended to support `clients = [...]`:
 
 ```rust
-// Conceptual macro expansion for:
-// #[modkit::module(
-//     name = "calculator_gateway",
-//     capabilities = [rest],
-//     clients = [calculator_sdk::CalculatorClientDescriptor],
-//     // Note: deps is auto-injected from clients; no need to specify manually.
-// )]
+#[modkit::module(
+    name = "calculator_gateway",
+    capabilities = [rest],
+    clients = [calculator_sdk::CalculatorClientDescriptor],
+    // Note: deps is auto-injected from clients; no need to specify manually.
+)]
+pub struct CalculatorGateway;
+```
 
-// Generated code (simplified):
+**Generated code** (simplified):
+
+```rust
 impl CalculatorGateway {
     fn __register_lazy_clients(ctx: &ModuleCtx) -> anyhow::Result<()> {
-        use modkit::clients::descriptor::GrpcClientDescriptor;
+        use modkit::clients::descriptor::{ClientDescriptor, Transport};
 
-        // For each descriptor in `clients`:
-        {
-            type D = calculator_sdk::CalculatorClientDescriptor;
-            let config = D::config();
-            let provider = std::sync::Arc::new(
-                modkit::clients::grpc_provider::GrpcClientProvider::new(
-                    D::SERVICE_NAME,
+        type D = calculator_sdk::CalculatorClientDescriptor;
+        let config = D::config();
+
+        let lazy_client: Arc<<D as ClientDescriptor>::Api> = match config.transport {
+            Transport::Rest => {
+                let provider = Arc::new(RestClientProvider::new(
+                    D::MODULE_NAME,
                     config,
                     ctx.client_hub(),
-                )
-            );
-            let lazy_client: std::sync::Arc<<D as GrpcClientDescriptor>::Api> =
-                std::sync::Arc::new(calculator_sdk::LazyCalculatorClient::new(provider));
-            ctx.client_hub().register::<<D as GrpcClientDescriptor>::Api>(lazy_client);
-        }
+                ));
+                Arc::new(calculator_sdk::LazyCalculatorClient::new(provider))
+            }
+            #[cfg(feature = "grpc")]
+            Transport::Grpc => {
+                let provider = Arc::new(GrpcClientProvider::new(
+                    D::MODULE_NAME,
+                    config,
+                    ctx.client_hub(),
+                ));
+                Arc::new(calculator_sdk::LazyCalculatorGrpcClient::new(provider))
+            }
+        };
 
+        ctx.client_hub().register::<<D as ClientDescriptor>::Api>(lazy_client);
         Ok(())
     }
 }
-
-// The macro also ensures deps includes the module_name from each descriptor
-// (validated at compile time or augmented automatically)
 ```
 
-### Phase 7: Registry Extension for Soft OoP Deps
+---
 
-**Location**: `libs/modkit/src/registry.rs` (extension)
+### Phase 6: Registry Extension for Soft OoP Deps
+
+**Location**: `libs/modkit/src/registry.rs`
 
 ```rust
-/// Extended dependency resolution for OoP modules.
 impl ModuleRegistry {
     /// Resolve dependencies, treating unknown deps as potential OoP soft deps.
-    ///
-    /// - If dep is a registered core module → hard dep (topo-sort)
-    /// - If dep is configured as `runtime.type = oop` → soft dep (no topo-sort)
-    /// - Otherwise → error (unknown dependency)
     pub fn resolve_dependencies_with_oop(
         &self,
         module_name: &str,
@@ -730,11 +846,9 @@ impl ModuleRegistry {
 
         for dep in deps {
             if self.has_module(dep) {
-                // Known in-process module
-                hard_deps.push(*dep);
+                hard_deps.push(*dep);  // In-process → topo-sort
             } else if config.is_oop_module(dep) {
-                // OoP module declared in config
-                soft_deps.push(*dep);
+                soft_deps.push(*dep);  // OoP → no topo-sort, lazy resolution
             } else {
                 return Err(RegistryError::UnknownDependency {
                     module: module_name.to_string(),
@@ -747,30 +861,22 @@ impl ModuleRegistry {
     }
 }
 
-/// Result of dependency resolution.
 pub struct ResolvedDeps {
-    /// Hard dependencies (in-process, participate in topo-sort).
     pub hard_deps: Vec<&'static str>,
-    /// Soft dependencies (OoP, do not block startup).
     pub soft_deps: Vec<&'static str>,
 }
 ```
 
 ---
 
-## Consumer Module Changes (calculator_gateway)
+## Consumer Module Changes
 
-### Before (current pattern)
+### Before
 
 ```rust
-#[modkit::module(
-    name = "calculator_gateway",
-    capabilities = [rest],
-    deps = ["calculator"]
-)]
+#[modkit::module(name = "calculator_gateway", capabilities = [rest], deps = ["calculator"])]
 pub struct CalculatorGateway;
 
-#[async_trait]
 impl modkit::Module for CalculatorGateway {
     async fn init(&self, ctx: &ModuleCtx) -> Result<()> {
         // Must wire client manually - FAILS if calculator not ready
@@ -781,38 +887,22 @@ impl modkit::Module for CalculatorGateway {
 }
 ```
 
-### After (proposed pattern)
+### After
 
 ```rust
 #[modkit::module(
     name = "calculator_gateway",
     capabilities = [rest],
-    // deps is auto-injected from clients: the macro reads MODULE_NAME
-    // from each descriptor and adds it as a soft OoP dep.
     clients = [calculator_sdk::CalculatorClientDescriptor],
 )]
 pub struct CalculatorGateway;
 
-#[async_trait]
 impl modkit::Module for CalculatorGateway {
     async fn init(&self, ctx: &ModuleCtx) -> Result<()> {
-        // No wire_client() needed!
-        // LazyCalculatorClient is auto-registered by the macro.
+        // No wire_client() needed! LazyCalculatorClient is auto-registered.
         let service = Arc::new(Service::new(ctx.client_hub()));
         ctx.client_hub().register::<Service>(service);
         Ok(())
-    }
-}
-
-// In domain service - unchanged!
-impl Service {
-    pub async fn add(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, ServiceError> {
-        let calculator = self.client_hub.get::<dyn CalculatorClientV1>()?;
-        // Lazy connect happens here on first call
-        calculator.add(ctx, a, b).await.map_err(|e| {
-            // CalculatorError::Unavailable maps to HTTP 424
-            ServiceError::RemoteError(e.to_string())
-        })
     }
 }
 ```
@@ -821,11 +911,9 @@ impl Service {
 
 ## Error Handling and HTTP 424
 
-The lazy client returns `CalculatorError::Unavailable` when the OoP service cannot be reached. REST handlers should map this to HTTP 424 Failed Dependency:
+Lazy clients return typed errors that map to HTTP 424 Failed Dependency:
 
 ```rust
-// In REST handler error mapping
-// Use a typed error variant instead of string matching
 impl From<ServiceError> for Problem {
     fn from(err: ServiceError) -> Self {
         match err {
@@ -834,18 +922,15 @@ impl From<ServiceError> for Problem {
                     .with_detail(format!("{} unavailable: {}", service, source))
             }
             ServiceError::RemoteError(msg) => {
-                Problem::bad_gateway()
-                    .with_detail(msg)
+                Problem::bad_gateway().with_detail(msg)
             }
             ServiceError::Internal(msg) => {
-                Problem::internal_server_error()
-                    .with_detail(msg)
+                Problem::internal_server_error().with_detail(msg)
             }
         }
     }
 }
 
-// ServiceError should have a typed variant for dependency failures:
 #[derive(Debug, thiserror::Error)]
 pub enum ServiceError {
     #[error("dependency unavailable: {service}")]
@@ -859,69 +944,54 @@ pub enum ServiceError {
     #[error("internal error: {0}")]
     Internal(String),
 }
-
-// In domain service, map SDK errors to the typed variant:
-impl Service {
-    pub async fn add(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, ServiceError> {
-        let calculator = self.client_hub.get::<dyn CalculatorClientV1>()?;
-        calculator.add(ctx, a, b).await.map_err(|e| match e {
-            CalculatorError::Unavailable { message } => ServiceError::DependencyUnavailable {
-                service: "calculator",
-                source: message.into(),
-            },
-            other => ServiceError::RemoteError(other.to_string()),
-        })
-    }
-}
 ```
 
 ---
 
-## Implementation Phases
+## Implementation Timeline
 
-### Phase 1: Core Infrastructure (Week 1-2)
-1. Add `GrpcClientDescriptor` trait to `libs/modkit/src/clients/descriptor.rs`
-2. Implement `GrpcClientProvider` in `libs/modkit/src/clients/grpc_provider.rs`
-3. Add `LazyClientError` type and helper utilities
-4. Unit tests for provider (mock DirectoryClient)
+### Week 1-2: Phase 1 (REST as Default)
+1. Add `Transport` enum to `libs/modkit/src/clients/transport.rs`
+2. Extend `DirectoryClient` with `resolve_rest_service()` method
+3. Update config structures for transport selection
 
-### Phase 2: SDK Updates (Week 2-3)
-1. Add `CalculatorClientDescriptor` to calculator-sdk
-2. Implement `LazyCalculatorClient` manually
-3. Update calculator-sdk exports
-4. Integration tests with mock gRPC server
+### Week 2-3: Phase 2-3 (Descriptor + Provider)
+1. Add `ClientDescriptor` trait to `libs/modkit/src/clients/descriptor.rs`
+2. Implement `RestClientProvider` in `libs/modkit/src/clients/rest_provider.rs`
+3. Add `LazyClientError` type
+4. (Optional) Implement `GrpcClientProvider` behind feature flag
+5. Unit tests for providers (mock DirectoryClient)
 
-### Phase 3: Macro Extension (Week 3-4)
+### Week 3-4: Phase 4 (SDK Updates)
+1. Add `CalculatorClientDescriptor` to calculator-sdk (REST by default)
+2. Implement `LazyCalculatorClient` with REST transport
+3. Integration tests with mock HTTP server
+
+### Week 4-5: Phase 5 (Macro Extension)
 1. Extend `#[modkit::module]` to parse `clients = [...]`
-2. Generate lazy client registration code
+2. Generate lazy client registration code with transport selection
 3. Auto-augment `deps` with module names from descriptors
-4. Compile-time validation of descriptor types
 
-### Phase 4: Registry Extension (Week 4)
+### Week 5-6: Phase 6 (Registry + Migration)
 1. Implement soft OoP dep resolution in registry
-2. Update topo-sort to exclude soft deps
-3. Add config validation for OoP modules
-4. Integration tests for startup ordering
-
-### Phase 5: Migration & Documentation (Week 5)
-1. Update calculator_gateway example
-2. Update `docs/modkit_unified_system/09_oop_grpc_sdk_pattern.md` (primary migration doc)
-3. Add migration guide for existing SDKs to `09_oop_grpc_sdk_pattern.md`
-4. Update checklists
+2. Update calculator_gateway example
+3. Rename `docs/modkit_unified_system/09_oop_grpc_sdk_pattern.md` to `09_oop_sdk_pattern.md`
+4. Add migration guide
 
 ---
 
 ## Testing Strategy
 
 ### Unit Tests
-- `GrpcClientProvider`: connection caching, backoff, eviction
+- `RestClientProvider`: endpoint caching, backoff, eviction
+- `GrpcClientProvider` (feature-gated): channel caching, backoff, eviction
 - `LazyCalculatorClient`: error mapping, context propagation
 - Registry: soft dep resolution
 
 ### Integration Tests
 - Startup with unavailable OoP → module starts successfully
-- First call triggers lazy connect
-- Connection failure → backoff → retry
+- First REST call triggers lazy endpoint resolution
+- HTTP error → backoff → retry
 - Successful call → failure state reset
 
 ### E2E Tests
@@ -939,6 +1009,7 @@ impl Service {
 | Breaking existing SDKs | Backward-compatible: `wire_client()` still works |
 | Performance overhead | Provider uses fast-path caching; no overhead on hot path |
 | Debugging difficulty | Detailed tracing in provider and lazy client |
+| JSON overhead vs protobuf | Acceptable for most use cases; gRPC available for high-throughput |
 
 ---
 
@@ -948,7 +1019,8 @@ impl Service {
 2. **Graceful startup**: Modules start even if OoP dependencies are unavailable
 3. **Per-operation degradation**: Missing OoP → HTTP 424 for affected endpoints only
 4. **Single source of truth**: `clients = [...]` declares all OoP dependencies
-5. **Consistent behavior**: All gRPC clients use the same provider infrastructure
+5. **REST by default**: All OoP clients use REST transport unless explicitly configured for gRPC
+6. **Consistent behavior**: All clients (REST or gRPC) use the same provider infrastructure
 
 ---
 
@@ -958,9 +1030,11 @@ impl Service {
 libs/modkit/src/
 ├── clients/
 │   ├── mod.rs              # Module exports
-│   ├── descriptor.rs       # GrpcClientDescriptor trait
-│   ├── grpc_provider.rs    # GrpcClientProvider implementation
-│   └── lazy_client.rs      # LazyClientError and utilities
+│   ├── transport.rs        # Transport enum
+│   ├── descriptor.rs       # ClientDescriptor trait, ClientConfig
+│   ├── rest_provider.rs    # RestClientProvider (default)
+│   ├── grpc_provider.rs    # GrpcClientProvider (feature = "grpc")
+│   └── error.rs            # LazyClientError, ProviderError
 ├── lib.rs                  # Add `pub mod clients;`
 └── ...
 


### PR DESCRIPTION
Added ADR document detailing decision process and implementation details of a universal lazy layer in modkit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Descriptor-driven lazy OOP clients with connection caching, backoff/retry and per-call resolution; REST default, gRPC opt-in.
  * ClientDescriptor/ClientConfig, provider APIs, lazy client examples (e.g., LazyCalculatorClient) and macro-driven auto-registration into modules and ClientHub.
  * Registry support for hard vs soft out-of-process dependencies and REST discovery endpoints; ServiceError → HTTP 424 mapping.

* **Documentation**
  * Expanded design docs, examples, migration and phased rollout guidance.

* **Tests**
  * Added unit, integration, and E2E tests for providers, backoff, discovery, and unavailable dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->