### PR TITLE
Add production hardening changes to cyberfabric-core and hyperspot-server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
+  RUST_BACKTRACE: full
   # We do NOT set RUSTC_WRAPPER globally; we'll enable it per-job after probing sccache.
   # RUSTC_WRAPPER: sccache
   SCCACHE_CACHE_SIZE: "2G"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
+  RUST_BACKTRACE: full
 
 jobs:
   e2e:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,9 +139,6 @@ Helpful environment variables:
 export RUST_LOG=debug
 
 # Show backtraces on panic
-export RUST_BACKTRACE=1
-
-# Show full backtrace details
 export RUST_BACKTRACE=full
 ```
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ codegen-units = 16
 
 [profile.release]
 codegen-units = 1
+panic = "unwind"
+debug = 1
 
 [workspace]
 members = [

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -129,3 +129,4 @@ httpmock = { workspace = true }
 tempfile = { workspace = true }
 temp-env = { workspace = true }
 modkit-db = { workspace = true, features = ["sqlite"] }
+tracing-subscriber = { workspace = true }

--- a/libs/modkit/src/bootstrap/host/mod.rs
+++ b/libs/modkit/src/bootstrap/host/mod.rs
@@ -6,9 +6,11 @@
 //! Configuration types are now in the top-level `config` module.
 
 pub mod logging;
+pub mod panic;
 pub mod paths;
 pub mod signals;
 
 pub use logging::*;
+pub use panic::*;
 pub use paths::{HomeDirError, expand_tilde, normalize_path};
 pub use signals::*;

--- a/libs/modkit/src/bootstrap/host/panic.rs
+++ b/libs/modkit/src/bootstrap/host/panic.rs
@@ -1,0 +1,26 @@
+use std::sync::Once;
+
+static PANIC_HOOK_INIT: Once = Once::new();
+
+pub fn init_panic_tracing() {
+    PANIC_HOOK_INIT.call_once(|| {
+        std::panic::set_hook(Box::new(|panic_info| {
+            let backtrace = std::backtrace::Backtrace::force_capture();
+            let location = panic_info.location().map_or_else(
+                || "unknown location".to_owned(),
+                |loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()),
+            );
+            let payload = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+                (*s).to_owned()
+            } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "non-string panic payload".to_owned()
+            };
+
+            tracing::error!(%location, %payload, %backtrace, "PANIC");
+        }));
+
+        tracing::debug!("tracing of panic is initialized");
+    });
+}

--- a/libs/modkit/src/bootstrap/oop.rs
+++ b/libs/modkit/src/bootstrap/oop.rs
@@ -56,7 +56,7 @@ use super::config::{
     AppConfig, CliArgs, LoggingConfig, MODKIT_MODULE_CONFIG_ENV, RenderedDbConfig,
     RenderedModuleConfig,
 };
-use crate::bootstrap::host::init_logging_unified;
+use crate::bootstrap::host::{init_logging_unified, init_panic_tracing};
 use crate::runtime::{
     ClientRegistration, DbOptions, MODKIT_DIRECTORY_ENDPOINT_ENV, RunOptions, ShutdownOptions, run,
     shutdown,
@@ -472,6 +472,9 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
 
     // Initialize logging with MERGED config (master base + local override)
     init_logging_unified(&merged_logging, &config.server.home_dir, otel_layer);
+
+    // Register custom panic hook to reroute panic backtrace into tracing.
+    init_panic_tracing();
 
     // Now we can log - report what we received from master
     if let Some(ref rc) = rendered_config {

--- a/libs/modkit/tests/panic_tracing_tests.rs
+++ b/libs/modkit/tests/panic_tracing_tests.rs
@@ -1,0 +1,102 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "bootstrap")]
+
+//! Smoke tests for `init_panic_tracing`.
+
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use tracing::Level;
+use tracing_subscriber::layer::SubscriberExt;
+
+use modkit::bootstrap::host::init_panic_tracing;
+
+/// A minimal tracing layer that captures formatted event messages.
+#[derive(Clone, Default)]
+struct CapturedEvents {
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturedEvents {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        // Only capture ERROR-level events (the panic hook emits at ERROR).
+        if *event.metadata().level() != Level::ERROR {
+            return;
+        }
+
+        let mut visitor = FieldCollector(String::new());
+        event.record(&mut visitor);
+
+        // Prepend the static message so assertions can match on it.
+        let msg = format!("{} {}", event.metadata().name(), visitor.0);
+        self.events.lock().unwrap().push(msg);
+    }
+}
+
+/// Simple visitor that concatenates all field values into one string.
+struct FieldCollector(String);
+
+impl tracing::field::Visit for FieldCollector {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        use std::fmt::Write;
+        #[allow(clippy::use_debug)]
+        {
+            _ = write!(self.0, "{}={:?} ", field.name(), value);
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        use std::fmt::Write;
+        _ = write!(self.0, "{}={} ", field.name(), value);
+    }
+}
+
+#[test]
+fn panic_hook_emits_error_event_with_payload() {
+    let captured = CapturedEvents::default();
+    let events = captured.events.clone();
+
+    let subscriber = tracing_subscriber::registry().with(captured);
+
+    // Build a `Dispatch` so we can propagate it into the spawned thread.
+    // `with_default` only covers the current thread; the panic hook runs
+    // on the panicking thread, so we need the dispatch active there.
+    let dispatch = tracing::Dispatch::new(subscriber);
+
+    tracing::dispatcher::with_default(&dispatch, || {
+        // Install the panic hook while the test subscriber is active.
+        init_panic_tracing();
+    });
+
+    // Spawn a thread that carries the same dispatch, then panics.
+    let dispatch_clone = dispatch;
+    let handle = thread::spawn(move || {
+        tracing::dispatcher::with_default(&dispatch_clone, || {
+            panic!("test_panic_payload");
+        });
+    });
+
+    // The thread should finish (with a panic).
+    let result = handle.join();
+    assert!(result.is_err(), "spawned thread must have panicked");
+
+    let captured_events = events.lock().unwrap();
+    assert!(
+        !captured_events.is_empty(),
+        "expected at least one captured ERROR event from the panic hook"
+    );
+
+    let combined = captured_events.join("\n");
+    assert!(
+        combined.contains("PANIC"),
+        "expected 'PANIC' in captured events, got: {combined}"
+    );
+    assert!(
+        combined.contains("test_panic_payload"),
+        "expected panic payload 'test_panic_payload' in captured events, got: {combined}"
+    );
+}


### PR DESCRIPTION
Add production hardening changes to cyberfabric-core and hyperspot-server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Panic tracing added to capture and log full backtraces for improved error reporting.

* **Improvements**
  * Startup logs now include application and Rust version details.
  * Release builds include debug info and use an unwind panic strategy for better diagnostics.
  * CI and contributor docs updated to emit full backtraces in logs.

* **Tests**
  * Added an automated test verifying panic tracing emits error-level diagnostic events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->