### PR TITLE
fix: agent instructions with path of .cypilot

### DIFF
--- a/.claude/commands/cypilot.md
+++ b/.claude/commands/cypilot.md
@@ -3,4 +3,4 @@ description: "Template-based artifacts (PRD/DESIGN/ADR/DECOMPOSITION/SPEC) + che
 ---
 
 
-ALWAYS open and follow `../../.cypilot/skills/cypilot/SKILL.md`
+ALWAYS open and follow `@/.cypilot/skills/cypilot/SKILL.md`

--- a/.claude/skills/cypilot/SKILL.md
+++ b/.claude/skills/cypilot/SKILL.md
@@ -7,4 +7,4 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task, WebFetch
 ---
 
 
-ALWAYS open and follow `../../../.cypilot/skills/cypilot/SKILL.md`
+ALWAYS open and follow `@/.cypilot/skills/cypilot/SKILL.md`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
 # Cypilot
 
 
-ALWAYS open and follow `../.cypilot/skills/cypilot/SKILL.md`
+ALWAYS open and follow `@/.cypilot/skills/cypilot/SKILL.md`

--- a/.windsurf/skills/cypilot/SKILL.md
+++ b/.windsurf/skills/cypilot/SKILL.md
@@ -4,4 +4,4 @@ description: "Template-based artifacts (PRD/DESIGN/ADR/DECOMPOSITION/SPEC) + che
 ---
 
 
-ALWAYS open and follow `../../../.cypilot/skills/cypilot/SKILL.md`
+ALWAYS open and follow `@/.cypilot/skills/cypilot/SKILL.md`

--- a/.windsurf/workflows/cypilot.md
+++ b/.windsurf/workflows/cypilot.md
@@ -1,4 +1,4 @@
 # /cypilot
 
 
-ALWAYS open and follow `../../.cypilot/skills/cypilot/SKILL.md`
+ALWAYS open and follow `@/.cypilot/skills/cypilot/SKILL.md`


### PR DESCRIPTION
copilot-instructions are misleading

```
**Opening SKILL and guidelines files**

  I'm opening the SKILL.md from the parent repo's .cypilot/skills directory and the guidelines/README.md in the current repo in parallel to review base instructions before proceeding.

✗ Read ~/workspace/github/hypernetix/.cypilot/skills/cypilot/SKILL.md
...
Yes—your custom instruction explicitly says “ALWAYS open and follow ../.cypilot/skills/cypilot/SKILL.md,” so I followed that path verbatim. That path resolves to the parent directory of the repo, which is why I tried to open it
  there. If that instruction should target the in-repo .cypilot/skills/cypilot/SKILL.md, tell me and I’ll use that instead.

❯ Where these instructions are located

● Grep "ALWAYS open and follow `\.\./\.cypilot/skills/cypilot/SKILL\.md`" (/home/pavel/workspace/github/hypernetix/hyperspot)
  └ 1 line found

● The instruction is in .github/copilot-instructions.md (line 4).

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration path references across instruction and skill files for standardized path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->