### PR TITLE
doc(contributing) - add versioning section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -403,7 +403,7 @@ Removal of deprecated APIs is breaking and requires MAJOR.
 
 ## Workspace Policy (Monorepo)
 
-We use per-crate versioning, controlled via Cargo manifests and release automation. :contentReference[oaicite:1]{index=1}
+We use per-crate versioning, controlled via Cargo manifests and release automation.
 
 ### Publishable vs internal crates
 - `publish = false` means the crate is internal and must not be published.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -423,7 +423,7 @@ ModKit is released as a unified framework:
 
 We use release-plz:
 - Release PRs are labeled `release-plz`.
-- Repository-level `CHANGELOG.md` is the single changelog source. :contentReference[oaicite:3]{index=3}
+- Repository-level `CHANGELOG.md` is the single changelog source.
 - GitHub releases are enabled where configured.
 
 SemVer checks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -417,7 +417,7 @@ We use per-crate versioning, controlled via Cargo manifests and release automati
 
 ModKit is released as a unified framework:
 - Only `cf-modkit` produces changelog entries and GitHub releases.
-- Other `cf-modkit-*` crates are published to crates.io but do not create separate changelog entries/releases. :contentReference[oaicite:2]{index=2}
+- Other `cf-modkit-*` crates are published to crates.io but do not create separate changelog entries/releases.
 
 ## Release Process (Automation)
 
@@ -428,7 +428,7 @@ We use release-plz:
 
 SemVer checks:
 - We aim to run semver checks for published crates.
-- If temporarily disabled (bootstrap or tooling noise), do not use that as an excuse to sneak breaking changes into MINOR/PATCH. :contentReference[oaicite:4]{index=4}
+- If temporarily disabled (bootstrap or tooling noise), do not use that as an excuse to sneak breaking changes into MINOR/PATCH.
 
 ## How to Decide the Version Bump
 

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,8 @@ deny:
 	$(call check_tool,cargo-deny)
 	cargo deny check
 
+security: deny
+
 # -------- API and docs --------
 
 .PHONY: openapi


### PR DESCRIPTION
- add versioning section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Project renamed to "Cyber Fabric" across docs; Quick Start and prerequisites updated (protoc, Rust 1.92.0).
  * Expanded development, testing, fuzzing, sign-off, and CI guidance; e2e and coverage workflows clarified.
  * New comprehensive Versioning section: SemVer rules, breaking-change criteria, deprecation and release process, ModKit architecture and release rules, and kebab-case module naming requirement enforced in CI.
  * Added explicit Security policy reference.

* **Chores**
  * Added a convenience "security" entry that invokes the deny security checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->