### PR TITLE
cypilot: ignore authn/authz resolver modules

### DIFF
--- a/.cypilot-adapter/artifacts.json
+++ b/.cypilot-adapter/artifacts.json
@@ -35,6 +35,14 @@
       "patterns": ["modules/system"]
     },
     {
+      "reason": "Ignore 'modules/system/authn-resolver' (not SDLC-documented yet: missing required PRD/DESIGN).",
+      "patterns": ["modules/system/authn-resolver/*"]
+    },
+    {
+      "reason": "Ignore 'modules/system/authz-resolver' (not SDLC-documented yet: missing required PRD/DESIGN).",
+      "patterns": ["modules/system/authz-resolver/*"]
+    },
+    {
       "reason": "Ignore module 'api-gateway' (not SDLC-documented yet: missing required PRD/DESIGN).",
       "patterns": ["modules/system/api-gateway/*"]
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration files for system module handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->