### PR TITLE
fix(authz-resolver): use valid crates.io category for Cargo metadata

### DIFF
--- a/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver-sdk/Cargo.toml
@@ -7,8 +7,8 @@ authors.workspace = true
 description = "SDK for authz_resolver module: evaluation API, constraints, PEP compiler"
 repository.workspace = true
 readme = "README.md"
-keywords = ["cyberfabric", "cyberfabric-system"]
-categories = ["authorization"]
+keywords = ["cyberfabric", "cyberfabric-system", "authorization"]
+categories = ["authentication"]
 
 [lib]
 name = "authz_resolver_sdk"

--- a/modules/system/authz-resolver/authz-resolver/Cargo.toml
+++ b/modules/system/authz-resolver/authz-resolver/Cargo.toml
@@ -7,8 +7,8 @@ authors.workspace = true
 description = "AuthZ resolver module - discovers and routes to plugins"
 repository.workspace = true
 readme = "README.md"
-keywords = ["cyberfabric", "cyberfabric-system"]
-categories = ["authorization"]
+keywords = ["cyberfabric", "cyberfabric-system", "authorization"]
+categories = ["authentication"]
 
 [lib]
 name = "authz_resolver"

--- a/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
+++ b/modules/system/authz-resolver/plugins/static-authz-plugin/Cargo.toml
@@ -7,8 +7,8 @@ authors.workspace = true
 description = "AuthZ resolver plugin with static tenant-scoped policy for development and testing"
 repository.workspace = true
 readme = "README.md"
-keywords = ["cyberfabric", "cyberfabric-system"]
-categories = ["authorization"]
+keywords = ["cyberfabric", "cyberfabric-system", "authorization"]
+categories = ["authentication"]
 
 [lib]
 name = "static_authz_plugin"


### PR DESCRIPTION
"authorization" is not a valid crates.io category. Move it to keywords and use "authentication" as the category instead.