### PR TITLE
tech: migrate modules from ArcSwapOption to OnceLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,7 +1017,6 @@ name = "cf-file-parser"
 version = "0.1.3"
 dependencies = [
  "anyhow",
- "arc-swap",
  "async-trait",
  "axum",
  "base64 0.22.1",
@@ -1416,7 +1415,6 @@ name = "cf-nodes-registry"
 version = "0.1.3"
 dependencies = [
  "anyhow",
- "arc-swap",
  "async-trait",
  "axum",
  "cf-modkit",
@@ -1447,7 +1445,6 @@ name = "cf-simple-user-settings"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arc-swap",
  "async-trait",
  "axum",
  "cf-authz-resolver-sdk",
@@ -1629,7 +1626,6 @@ name = "cf-types-registry"
 version = "0.1.3"
 dependencies = [
  "anyhow",
- "arc-swap",
  "async-trait",
  "axum",
  "cf-modkit",
@@ -7286,7 +7282,6 @@ name = "users-info"
 version = "0.2.10"
 dependencies = [
  "anyhow",
- "arc-swap",
  "async-trait",
  "axum",
  "cf-api-gateway",

--- a/examples/modkit/users-info/users-info/Cargo.toml
+++ b/examples/modkit/users-info/users-info/Cargo.toml
@@ -48,8 +48,6 @@ url = { workspace = true }
 # UUID support
 uuid = { workspace = true }
 
-# Lock-free atomic swaps
-arc-swap = { workspace = true }
 
 # Database - SeaORM
 sea-orm = { workspace = true, features = [

--- a/examples/oop-modules/calculator-gateway/calculator-gateway/src/module.rs
+++ b/examples/oop-modules/calculator-gateway/calculator-gateway/src/module.rs
@@ -36,7 +36,7 @@ impl Default for CalculatorGateway {
 #[async_trait]
 impl modkit::Module for CalculatorGateway {
     async fn init(&self, ctx: &ModuleCtx) -> Result<()> {
-        tracing::info!("Initializing calculator_gateway module");
+        tracing::info!("Initializing {} module", Self::MODULE_NAME);
 
         // Create domain service with ClientHub for dependency resolution
         let service = Arc::new(Service::new(ctx.client_hub()));
@@ -44,7 +44,7 @@ impl modkit::Module for CalculatorGateway {
         // Register Service in ClientHub for SDK's wire_client() to access
         ctx.client_hub().register::<Service>(service);
 
-        tracing::info!("calculator_gateway module initialized");
+        tracing::info!("{} module initialized successfully", Self::MODULE_NAME);
         Ok(())
     }
 }

--- a/examples/oop-modules/calculator/calculator/src/module.rs
+++ b/examples/oop-modules/calculator/calculator/src/module.rs
@@ -34,7 +34,7 @@ impl Default for CalculatorModule {
 #[async_trait]
 impl modkit::Module for CalculatorModule {
     async fn init(&self, ctx: &ModuleCtx) -> Result<()> {
-        tracing::info!("Initializing calculator module");
+        tracing::info!("Initializing {} module", Self::MODULE_NAME);
 
         // Create domain service
         let service = Arc::new(Service::new());
@@ -42,7 +42,7 @@ impl modkit::Module for CalculatorModule {
         // Register Service in ClientHub for gRPC layer to use
         ctx.client_hub().register::<Service>(service);
 
-        tracing::info!("calculator module initialized");
+        tracing::info!("{} module initialized successfully", Self::MODULE_NAME);
         Ok(())
     }
 }

--- a/modules/file-parser/Cargo.toml
+++ b/modules/file-parser/Cargo.toml
@@ -39,8 +39,6 @@ time = { workspace = true }
 # UUID support
 uuid = { workspace = true }
 
-# Lock-free atomic swaps
-arc-swap = { workspace = true }
 
 # Error handling
 thiserror = { workspace = true }

--- a/modules/simple-user-settings/simple-user-settings/Cargo.toml
+++ b/modules/simple-user-settings/simple-user-settings/Cargo.toml
@@ -33,7 +33,6 @@ serde_json = { workspace = true }
 utoipa = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
 uuid = { workspace = true }
-arc-swap = { workspace = true }
 sea-orm = { workspace = true, features = [
     "sqlx-sqlite",
     "runtime-tokio-rustls",

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/src/module.rs
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/src/module.rs
@@ -41,7 +41,7 @@ impl Default for StaticAuthNPlugin {
 #[async_trait]
 impl Module for StaticAuthNPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        info!("Initializing static_authn_plugin");
+        info!("Initializing {} module", Self::MODULE_NAME);
 
         // Load configuration
         let cfg: StaticAuthNPluginConfig = ctx.config()?;
@@ -83,7 +83,7 @@ impl Module for StaticAuthNPlugin {
         let service = Arc::new(Service::from_config(&cfg));
         self.service
             .set(service.clone())
-            .map_err(|_| anyhow::anyhow!("Service already initialized"))?;
+            .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
 
         // Register scoped client in ClientHub
         let api: Arc<dyn AuthNResolverPluginClient> = service;
@@ -93,7 +93,7 @@ impl Module for StaticAuthNPlugin {
                 api,
             );
 
-        info!(instance_id = %instance_id, "Static authn plugin initialized");
+        info!(instance_id = %instance_id, "{} module initialized successfully", Self::MODULE_NAME);
         Ok(())
     }
 }

--- a/modules/system/authz-resolver/authz-resolver/src/module.rs
+++ b/modules/system/authz-resolver/authz-resolver/src/module.rs
@@ -44,7 +44,7 @@ impl Module for AuthZResolver {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         let cfg: AuthZResolverConfig = ctx.config()?;
         tracing::Span::current().record("vendor", cfg.vendor.as_str());
-        info!(vendor = %cfg.vendor, "Initializing authz_resolver");
+        info!(vendor = %cfg.vendor, "Initializing {} module", Self::MODULE_NAME);
 
         // Register plugin schema in types-registry
         let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
@@ -60,15 +60,15 @@ impl Module for AuthZResolver {
         // Create service
         let hub = ctx.client_hub();
         let svc = Arc::new(Service::new(hub, cfg.vendor));
+        self.service
+            .set(svc.clone())
+            .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
 
         // Register client in ClientHub
-        let api: Arc<dyn AuthZResolverClient> =
-            Arc::new(AuthZResolverLocalClient::new(svc.clone()));
+        let api: Arc<dyn AuthZResolverClient> = Arc::new(AuthZResolverLocalClient::new(svc));
         ctx.client_hub().register::<dyn AuthZResolverClient>(api);
 
-        self.service
-            .set(svc)
-            .map_err(|_| anyhow::anyhow!("Service already initialized"))?;
+        info!("{} module initialized successfully", Self::MODULE_NAME);
 
         Ok(())
     }

--- a/modules/system/authz-resolver/plugins/static-authz-plugin/src/module.rs
+++ b/modules/system/authz-resolver/plugins/static-authz-plugin/src/module.rs
@@ -34,7 +34,7 @@ impl Default for StaticAuthZPlugin {
 #[async_trait]
 impl Module for StaticAuthZPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        info!("Initializing static_authz_plugin");
+        info!("Initializing {} module", Self::MODULE_NAME);
 
         let cfg: StaticAuthZPluginConfig = ctx.config()?;
         info!(
@@ -65,7 +65,7 @@ impl Module for StaticAuthZPlugin {
         let service = Arc::new(Service::new());
         self.service
             .set(service.clone())
-            .map_err(|_| anyhow::anyhow!("Service already initialized"))?;
+            .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
 
         // Register scoped client in ClientHub
         let api: Arc<dyn AuthZResolverPluginClient> = service;
@@ -75,7 +75,7 @@ impl Module for StaticAuthZPlugin {
                 api,
             );
 
-        info!(instance_id = %instance_id, "Static authz plugin initialized");
+        info!(instance_id = %instance_id, "{} module initialized successfully", Self::MODULE_NAME);
         Ok(())
     }
 }

--- a/modules/system/nodes-registry/nodes-registry/Cargo.toml
+++ b/modules/system/nodes-registry/nodes-registry/Cargo.toml
@@ -26,7 +26,6 @@ utoipa = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
 chrono = { workspace = true, features = ["serde"] }
 uuid = { workspace = true }
-arc-swap = { workspace = true }
 thiserror = { workspace = true }
 
 modkit = { workspace = true }

--- a/modules/system/nodes-registry/nodes-registry/src/module.rs
+++ b/modules/system/nodes-registry/nodes-registry/src/module.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use modkit::Module;
 use modkit::context::ModuleCtx;
@@ -10,27 +10,19 @@ use crate::domain::local_client::NodesRegistryLocalClient;
 use crate::domain::service::Service;
 use nodes_registry_sdk::NodesRegistryClient;
 
-/// Nodes Registry Module
-///
-/// Manages node information in the Hyperspot deployment.
-/// Provides REST API endpoints for:
-/// - Listing nodes
-/// - Getting node details
-/// - Accessing node system information (sysinfo)
-/// - Accessing node system capabilities (syscap)
 #[modkit::module(
     name = "nodes-registry",
     capabilities = [rest],
     client = nodes_registry_sdk::NodesRegistryClient
 )]
 pub struct NodesRegistry {
-    service: arc_swap::ArcSwapOption<Service>,
+    service: OnceLock<Arc<Service>>,
 }
 
 impl Default for NodesRegistry {
     fn default() -> Self {
         Self {
-            service: arc_swap::ArcSwapOption::empty(),
+            service: OnceLock::new(),
         }
     }
 }
@@ -38,20 +30,19 @@ impl Default for NodesRegistry {
 #[async_trait]
 impl Module for NodesRegistry {
     async fn init(&self, ctx: &ModuleCtx) -> Result<()> {
-        // let cfg: NodesRegistryConfig = ctx.config()?; not needed for now
+        tracing::info!("Initializing {} module", Self::MODULE_NAME);
 
         // Create the service
-        let service = Service::new();
-        self.service.store(Some(Arc::new(service.clone())));
+        let service = Arc::new(Service::new());
+        self.service
+            .set(service.clone())
+            .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
 
         // Expose the client to the ClientHub
-        let api: Arc<dyn NodesRegistryClient> =
-            Arc::new(NodesRegistryLocalClient::new(Arc::new(service)));
-
-        // Register in ClientHub directly
+        let api: Arc<dyn NodesRegistryClient> = Arc::new(NodesRegistryLocalClient::new(service));
         ctx.client_hub().register::<dyn NodesRegistryClient>(api);
 
-        tracing::info!("Nodes registry module initialized");
+        tracing::info!("{} module initialized successfully", Self::MODULE_NAME);
         Ok(())
     }
 }
@@ -65,8 +56,7 @@ impl RestApiCapability for NodesRegistry {
     ) -> Result<axum::Router> {
         let service = self
             .service
-            .load()
-            .as_ref()
+            .get()
             .ok_or_else(|| anyhow::anyhow!("Service not initialized"))?
             .clone();
 

--- a/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/src/module.rs
+++ b/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/src/module.rs
@@ -39,7 +39,7 @@ impl Default for SingleTenantTrPlugin {
 #[async_trait]
 impl Module for SingleTenantTrPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        info!("Initializing single_tenant_tr_plugin");
+        info!("Initializing {} module", Self::MODULE_NAME);
 
         // Generate plugin instance ID
         let instance_id = TenantResolverPluginSpecV1::gts_make_instance_id(
@@ -72,7 +72,7 @@ impl Module for SingleTenantTrPlugin {
             instance_id = %instance_id,
             vendor = VENDOR,
             priority = PRIORITY,
-            "Single-tenant plugin initialized"
+            "{} module initialized successfully", Self::MODULE_NAME
         );
         Ok(())
     }

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/src/module.rs
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/src/module.rs
@@ -41,7 +41,7 @@ impl Default for StaticTrPlugin {
 #[async_trait]
 impl Module for StaticTrPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        info!("Initializing static_tr_plugin");
+        info!("Initializing {} module", Self::MODULE_NAME);
 
         // Load configuration
         let cfg: StaticTrPluginConfig = ctx.config()?;
@@ -74,7 +74,7 @@ impl Module for StaticTrPlugin {
         let service = Arc::new(Service::from_config(&cfg));
         self.service
             .set(service.clone())
-            .map_err(|_| anyhow::anyhow!("Service already initialized"))?;
+            .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
 
         // Register scoped client in ClientHub
         let api: Arc<dyn TenantResolverPluginClient> = service;
@@ -84,7 +84,7 @@ impl Module for StaticTrPlugin {
                 api,
             );
 
-        info!(instance_id = %instance_id, "Static plugin initialized");
+        info!(instance_id = %instance_id, "{} module initialized successfully", Self::MODULE_NAME);
         Ok(())
     }
 }

--- a/modules/system/tenant-resolver/tenant-resolver/src/module.rs
+++ b/modules/system/tenant-resolver/tenant-resolver/src/module.rs
@@ -44,7 +44,7 @@ impl Module for TenantResolver {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         let cfg: TenantResolverConfig = ctx.config()?;
         tracing::Span::current().record("vendor", cfg.vendor.as_str());
-        info!(vendor = %cfg.vendor, "Initializing tenant_resolver module");
+        info!(vendor = %cfg.vendor, "Initializing {} module", Self::MODULE_NAME);
 
         // Register plugin schema in types-registry
         let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
@@ -60,15 +60,15 @@ impl Module for TenantResolver {
         // Create service
         let hub = ctx.client_hub();
         let svc = Arc::new(Service::new(hub, cfg.vendor));
+        self.service
+            .set(svc.clone())
+            .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
 
         // Register local client in ClientHub
-        let api: Arc<dyn TenantResolverClient> =
-            Arc::new(TenantResolverLocalClient::new(svc.clone()));
+        let api: Arc<dyn TenantResolverClient> = Arc::new(TenantResolverLocalClient::new(svc));
         ctx.client_hub().register::<dyn TenantResolverClient>(api);
 
-        self.service
-            .set(svc)
-            .map_err(|_| anyhow::anyhow!("Service already initialized"))?;
+        info!("{} module initialized successfully", Self::MODULE_NAME);
 
         Ok(())
     }

--- a/modules/system/types-registry/types-registry/Cargo.toml
+++ b/modules/system/types-registry/types-registry/Cargo.toml
@@ -35,7 +35,6 @@ serde_json = { workspace = true }
 utoipa = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
 uuid = { workspace = true, features = ["v5"] }
-arc-swap = { workspace = true }
 thiserror = { workspace = true }
 parking_lot = { workspace = true }
 

--- a/modules/system/types/src/module.rs
+++ b/modules/system/types/src/module.rs
@@ -50,7 +50,7 @@ impl Default for Types {
 #[async_trait]
 impl Module for Types {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        info!("Initializing types module");
+        info!("Initializing {} module", Self::MODULE_NAME);
 
         // Get the types registry client
         let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
@@ -74,7 +74,7 @@ impl Module for Types {
         let api: Arc<dyn TypesClient> = Arc::new(client);
         ctx.client_hub().register::<dyn TypesClient>(api);
 
-        info!("Types module initialized");
+        info!("{} module initialized successfully", Self::MODULE_NAME);
 
         Ok(())
     }


### PR DESCRIPTION
Replace `arc_swap::ArcSwapOption<Service>` with `OnceLock<Arc<Service>>` across all remaining modules. OnceLock precisely expresses set-once semantics, is part of std (no external dep), and provides a simpler API.

closes #639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized service initialization across modules using a once-initialization mechanism for more reliable startup and safer service access.

* **Chores**
  * Removed an unused dependency from several module manifests.
  * Harmonized initialization and error log messages to include module names for clearer runtime feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->