### PR TITLE
feat(modkit): add JSON console output format for logging

### DIFF
--- a/libs/modkit/src/bootstrap/config/mod.rs
+++ b/libs/modkit/src/bootstrap/config/mod.rs
@@ -129,6 +129,17 @@ impl ServerConfig {
     }
 }
 
+/// Console output format for the logging layer.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConsoleFormat {
+    /// Human-readable text output (default).
+    #[default]
+    Text,
+    /// Structured JSON output (useful for container log collectors).
+    Json,
+}
+
 /// Logging configuration - maps subsystem names to their logging settings.
 /// Key "default" is the catch-all for logs that don't match explicit subsystems.
 pub type LoggingConfig = HashMap<String, Section>;
@@ -178,6 +189,8 @@ pub struct Section {
         with = "optional_level_serde"
     )]
     pub console_level: Option<Level>,
+    #[serde(default)]
+    pub console_format: ConsoleFormat,
     pub file: String, // "logs/api.log"
     #[serde(
         default = "optional_level_serde::default",
@@ -199,6 +212,7 @@ pub fn default_logging_config() -> LoggingConfig {
         "default".to_owned(),
         Section {
             console_level: Some(Level::INFO),
+            console_format: ConsoleFormat::default(),
             file: "logs/hyperspot.log".to_owned(),
             file_level: Some(Level::DEBUG),
             max_age_days: Some(7),

--- a/libs/modkit/src/bootstrap/host/logging.rs
+++ b/libs/modkit/src/bootstrap/host/logging.rs
@@ -1,4 +1,4 @@
-use super::super::config::{LoggingConfig, Section};
+use super::super::config::{ConsoleFormat, LoggingConfig, Section};
 use anyhow::Context;
 use std::collections::HashMap;
 use std::io;
@@ -216,7 +216,18 @@ pub fn init_logging_unified(cfg: &LoggingConfig, base_dir: &Path, otel_layer: Op
         },
     );
 
-    install_subscriber(&console_targets, &file_targets, file_router, otel_layer);
+    let console_format = data
+        .default_section
+        .map(|s| s.console_format)
+        .unwrap_or_default();
+
+    install_subscriber(
+        &console_targets,
+        &file_targets,
+        file_router,
+        console_format,
+        otel_layer,
+    );
 }
 
 // ================= generic targets builder =================
@@ -398,6 +409,7 @@ fn install_subscriber(
     console_targets: &tracing_subscriber::filter::Targets,
     file_targets: &tracing_subscriber::filter::Targets,
     file_router: MultiFileRouter,
+    console_format: ConsoleFormat,
     #[cfg_attr(not(feature = "otel"), allow(unused_variables))] otel_layer: Option<OtelLayer>,
 ) {
     use tracing_subscriber::{EnvFilter, Registry, fmt, layer::SubscriberExt};
@@ -410,14 +422,35 @@ fn install_subscriber(
     let (nb_stderr, guard) = tracing_appender::non_blocking(std::io::stderr());
     _ = CONSOLE_GUARD.set(guard);
 
-    // Console fmt layer (human-friendly)
-    let console_layer = fmt::layer()
-        .with_writer(nb_stderr)
-        .with_ansi(stderr_supports_ansi())
-        .with_target(true)
-        .with_level(true)
-        .with_timer(fmt::time::UtcTime::rfc_3339())
-        .with_filter(console_targets.clone());
+    // Console fmt layers: text (human-friendly) or JSON (structured).
+    // Only one is active at a time; the other is None.
+    let (console_text, console_json) = match console_format {
+        ConsoleFormat::Text => (
+            Some(
+                fmt::layer()
+                    .with_writer(nb_stderr)
+                    .with_ansi(stderr_supports_ansi())
+                    .with_target(true)
+                    .with_level(true)
+                    .with_timer(fmt::time::UtcTime::rfc_3339())
+                    .with_filter(console_targets.clone()),
+            ),
+            None,
+        ),
+        ConsoleFormat::Json => (
+            None,
+            Some(
+                fmt::layer()
+                    .json()
+                    .with_writer(nb_stderr)
+                    .with_ansi(false)
+                    .with_target(true)
+                    .with_level(true)
+                    .with_timer(fmt::time::UtcTime::rfc_3339())
+                    .with_filter(console_targets.clone()),
+            ),
+        ),
+    };
 
     // File fmt layer (JSON) if router is not empty
     let file_layer_opt = if file_router.is_empty() {
@@ -439,7 +472,7 @@ fn install_subscriber(
     // 1) OTEL first (because your OtelLayer is bound to `Registry`);
     //    also filter OTEL by the SAME console targets from YAML.
     // 2) Then EnvFilter (caps console/file if RUST_LOG is set).
-    // 3) Then console + file fmt layers.
+    // 3) Then console (text or json) + file fmt layers.
     let subscriber = {
         let base = Registry::default();
 
@@ -452,7 +485,9 @@ fn install_subscriber(
         let base = base;
 
         let base = base.with(env);
-        base.with(console_layer).with(file_layer_opt)
+        base.with(console_text)
+            .with(console_json)
+            .with(file_layer_opt)
     };
 
     _ = subscriber.try_init();

--- a/libs/modkit/src/bootstrap/mod.rs
+++ b/libs/modkit/src/bootstrap/mod.rs
@@ -21,9 +21,10 @@ pub mod oop;
 
 // Re-export commonly used config types at crate root for convenience
 pub use config::{
-    AppConfig, CliArgs, LoggingConfig, MODKIT_MODULE_CONFIG_ENV, ModuleConfig, ModuleRuntime,
-    RenderedModuleConfig, RuntimeKind, Section, ServerConfig, dump_effective_modules_config_json,
-    dump_effective_modules_config_yaml, list_module_names, render_effective_modules_config,
+    AppConfig, CliArgs, ConsoleFormat, LoggingConfig, MODKIT_MODULE_CONFIG_ENV, ModuleConfig,
+    ModuleRuntime, RenderedModuleConfig, RuntimeKind, Section, ServerConfig,
+    dump_effective_modules_config_json, dump_effective_modules_config_yaml, list_module_names,
+    render_effective_modules_config,
 };
 
 // Re-export host types for convenience

--- a/libs/modkit/src/bootstrap/oop_tests.rs
+++ b/libs/modkit/src/bootstrap/oop_tests.rs
@@ -7,8 +7,8 @@
 
 use super::*;
 use crate::bootstrap::config::{
-    AppConfig, GlobalDatabaseConfig, LoggingConfig, RenderedDbConfig, RenderedModuleConfig,
-    Section, ServerConfig,
+    AppConfig, ConsoleFormat, GlobalDatabaseConfig, LoggingConfig, RenderedDbConfig,
+    RenderedModuleConfig, Section, ServerConfig,
 };
 use modkit_db::{DbConnConfig, PoolCfg};
 use std::collections::HashMap;
@@ -33,6 +33,7 @@ fn minimal_app_config() -> AppConfig {
 fn logging_section(console_level: Option<Level>, file: &str) -> Section {
     Section {
         console_level,
+        console_format: ConsoleFormat::default(),
         file: file.to_owned(),
         file_level: Some(Level::DEBUG),
         max_age_days: Some(7),


### PR DESCRIPTION
- Introduce ConsoleFormat enum (text/json) in logging config
- When console_format is set to \"json\", console layer emits structured JSON instead of human-readable text (useful for container log collectors)

closes #661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Console logging format is now configurable. Users can select between text-based output for human-readable logs or JSON-based output for structured logging, enabling integration with log aggregation systems and monitoring platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->