### PR TITLE
OAGW Unskip Failing Tests

### DIFF
--- a/modules/system/oagw/oagw/tests/e2e_smoke_test.rs
+++ b/modules/system/oagw/oagw/tests/e2e_smoke_test.rs
@@ -4,7 +4,6 @@ use oagw::test_support::{
 
 // 10.1: E2E — create upstream, create route, proxy chat completion, verify round-trip.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn e2e_chat_completion_round_trip() {
     let h = AppHarness::builder()
         .with_credentials(vec![("cred://openai-key".into(), "sk-e2e-test-key".into())])
@@ -65,7 +64,6 @@ async fn e2e_chat_completion_round_trip() {
 
 // 10.2: E2E — SSE streaming round-trip via dynamic MockGuard route.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn e2e_sse_streaming() {
     let mut guard = MockGuard::new();
 
@@ -141,7 +139,6 @@ async fn e2e_sse_streaming() {
 
 // 10.3: E2E — auth injection round-trip.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn e2e_auth_injection() {
     let h = AppHarness::builder()
         .with_credentials(vec![("cred://openai-key".into(), "sk-e2e-test-key".into())])
@@ -207,7 +204,6 @@ async fn e2e_auth_injection() {
 
 // 10.4: E2E — error scenarios.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn e2e_nonexistent_alias_returns_404() {
     let h = AppHarness::builder()
         .with_credentials(vec![("cred://openai-key".into(), "sk-e2e-test-key".into())])
@@ -224,7 +220,6 @@ async fn e2e_nonexistent_alias_returns_404() {
 }
 
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn e2e_disabled_upstream_returns_503() {
     let h = AppHarness::builder()
         .with_credentials(vec![("cred://openai-key".into(), "sk-e2e-test-key".into())])
@@ -252,7 +247,6 @@ async fn e2e_disabled_upstream_returns_503() {
 }
 
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn e2e_upstream_500_passthrough() {
     let h = AppHarness::builder()
         .with_credentials(vec![("cred://openai-key".into(), "sk-e2e-test-key".into())])
@@ -304,7 +298,6 @@ async fn e2e_upstream_500_passthrough() {
 
 // 10.4: E2E — rate limit exceeded.
 #[tokio::test]
-#[ignore = "timing-sensitive — will stabilize later"]
 async fn e2e_rate_limit_returns_429() {
     let h = AppHarness::builder()
         .with_credentials(vec![("cred://openai-key".into(), "sk-e2e-test-key".into())])
@@ -368,7 +361,6 @@ async fn e2e_rate_limit_returns_429() {
 
 // 10.5: E2E — management lifecycle.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn e2e_management_lifecycle() {
     let h = AppHarness::builder()
         .with_credentials(vec![("cred://openai-key".into(), "sk-e2e-test-key".into())])
@@ -449,7 +441,6 @@ async fn e2e_management_lifecycle() {
 
 // 8.11: Content-Length with non-integer value returns 400.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn e2e_invalid_content_length_returns_400() {
     let h = AppHarness::builder()
         .with_credentials(vec![("cred://openai-key".into(), "sk-e2e-test-key".into())])
@@ -504,7 +495,6 @@ async fn e2e_invalid_content_length_returns_400() {
 
 // 8.11: Content-Length exceeding 100MB returns 413.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn e2e_body_exceeding_limit_returns_413() {
     let h = AppHarness::builder()
         .with_credentials(vec![("cred://openai-key".into(), "sk-e2e-test-key".into())])
@@ -561,7 +551,6 @@ async fn e2e_body_exceeding_limit_returns_413() {
 // Uses multi_thread runtime so the timer driver runs on a dedicated thread,
 // preventing stalls when other test binaries compete for CPU.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "timing-sensitive — will stabilize later"]
 async fn e2e_upstream_timeout_returns_504() {
     let mut guard = MockGuard::new();
     // Register a gated route that will never respond (sender kept alive but not signaled).

--- a/modules/system/oagw/oagw/tests/management_api_test.rs
+++ b/modules/system/oagw/oagw/tests/management_api_test.rs
@@ -3,7 +3,6 @@ use uuid::Uuid;
 
 // 7.8: POST upstream with valid body -> 201 + GTS id + alias generated.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn create_upstream_success() {
     let h = AppHarness::builder().build().await;
 
@@ -29,7 +28,6 @@ async fn create_upstream_success() {
 
 // 7.8: POST with missing server -> 422 (serde deserialization error).
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn create_upstream_missing_server_returns_422() {
     let h = AppHarness::builder().build().await;
 
@@ -44,7 +42,6 @@ async fn create_upstream_missing_server_returns_422() {
 
 // 7.9: GET upstream by GTS id -> 200.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn get_upstream_by_gts_id() {
     let h = AppHarness::builder().build().await;
 
@@ -76,7 +73,6 @@ async fn get_upstream_by_gts_id() {
 
 // 7.9: GET with invalid GTS format -> 400.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn get_upstream_invalid_gts_returns_400() {
     let h = AppHarness::builder().build().await;
 
@@ -95,7 +91,6 @@ async fn get_upstream_invalid_gts_returns_400() {
 
 // 7.9: GET nonexistent -> 404.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn get_upstream_nonexistent_returns_404() {
     let h = AppHarness::builder().build().await;
     let fake_id = format_upstream_gts(Uuid::new_v4());
@@ -105,7 +100,6 @@ async fn get_upstream_nonexistent_returns_404() {
 
 // 7.10: PUT upstream -> 200 with updated fields, id unchanged.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn update_upstream_preserves_id() {
     let h = AppHarness::builder().build().await;
 
@@ -145,7 +139,6 @@ async fn update_upstream_preserves_id() {
 
 // 7.10: DELETE upstream -> 204 + routes cascade deleted.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn delete_upstream_returns_204() {
     let h = AppHarness::builder().build().await;
 
@@ -176,7 +169,6 @@ async fn delete_upstream_returns_204() {
 
 // 7.11: POST route -> 201 referencing existing upstream.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn create_route_success() {
     let h = AppHarness::builder().build().await;
 
@@ -229,7 +221,6 @@ async fn create_route_success() {
 
 // 7.12: GET upstreams with pagination.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn list_upstreams_with_pagination() {
     let h = AppHarness::builder().build().await;
 
@@ -270,7 +261,6 @@ async fn list_upstreams_with_pagination() {
 
 // 7.13: Error mapper produces correct Problem Details.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn error_mapper_produces_problem_details() {
     let h = AppHarness::builder().build().await;
     let fake_id = format_upstream_gts(Uuid::new_v4());
@@ -294,7 +284,6 @@ fn gts_uuid(gts_id: &str) -> String {
 
 // 13.3: GET route by ID -> 200 with correct fields.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn get_route_by_gts_id() {
     let h = AppHarness::builder().build().await;
 
@@ -352,7 +341,6 @@ async fn get_route_by_gts_id() {
 
 // 13.1: PUT route -> 200 with updated fields.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn update_route_changes_fields() {
     let h = AppHarness::builder().build().await;
 
@@ -414,7 +402,6 @@ async fn update_route_changes_fields() {
 
 // 13.2: DELETE route -> 204, then GET returns 404.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn delete_route_returns_204_then_get_returns_404() {
     let h = AppHarness::builder().build().await;
 
@@ -466,7 +453,6 @@ async fn delete_route_returns_204_then_get_returns_404() {
 
 // 13.4: List routes by upstream returns only that upstream's routes.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn list_routes_filters_by_upstream() {
     let h = AppHarness::builder().build().await;
 

--- a/modules/system/oagw/oagw/tests/proxy_integration.rs
+++ b/modules/system/oagw/oagw/tests/proxy_integration.rs
@@ -70,7 +70,6 @@ async fn setup_openai_mock() -> AppHarness {
 
 // 6.13: Full pipeline — proxy POST /v1/chat/completions with JSON body.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_chat_completion_round_trip() {
     let h = setup_openai_mock().await;
 
@@ -98,7 +97,6 @@ async fn proxy_chat_completion_round_trip() {
 
 // 6.13 (auth): Verify the mock received the Authorization header.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_injects_auth_header() {
     let mut guard = MockGuard::new();
     guard.mock(
@@ -201,7 +199,6 @@ async fn proxy_injects_auth_header() {
 
 // 6.14: SSE streaming — proxy to dynamic SSE mock via MockGuard.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_sse_streaming() {
     let mut guard = MockGuard::new();
 
@@ -289,7 +286,6 @@ async fn proxy_sse_streaming() {
 
 // 6.15: Upstream 500 error passthrough.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_upstream_500_passthrough() {
     let h = setup_openai_mock().await;
 
@@ -313,7 +309,6 @@ async fn proxy_upstream_500_passthrough() {
 
 // 6.17: Pipeline abort — nonexistent alias returns 404 without calling mock.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_nonexistent_alias_returns_404() {
     let h = setup_openai_mock().await;
 
@@ -337,7 +332,6 @@ async fn proxy_nonexistent_alias_returns_404() {
 
 // 6.17: Pipeline abort — disabled upstream returns 503.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_disabled_upstream_returns_503() {
     let h = setup_openai_mock().await;
     let ctx = h.security_context().clone();
@@ -379,7 +373,6 @@ async fn proxy_disabled_upstream_returns_503() {
 
 // 6.17: Pipeline abort — rate limit exceeded returns 429.
 #[tokio::test]
-#[ignore = "timing-sensitive — will stabilize later"]
 async fn proxy_rate_limit_exceeded_returns_429() {
     let h = AppHarness::builder().build().await;
     let ctx = h.security_context().clone();
@@ -464,7 +457,6 @@ async fn proxy_rate_limit_exceeded_returns_429() {
 // Uses multi_thread runtime so the timer driver runs on a dedicated thread,
 // preventing stalls when other test binaries compete for CPU.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "timing-sensitive — will stabilize later"]
 async fn proxy_upstream_timeout_returns_504() {
     let mut guard = MockGuard::new();
     // Register a gated route that will never respond (sender kept alive but not signaled).
@@ -540,7 +532,6 @@ async fn proxy_upstream_timeout_returns_504() {
 
 // 8.9: Query allowlist enforcement.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_query_allowlist_allowed_param_succeeds() {
     let h = AppHarness::builder().build().await;
     let ctx = h.security_context().clone();
@@ -595,7 +586,6 @@ async fn proxy_query_allowlist_allowed_param_succeeds() {
 }
 
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_query_allowlist_unknown_param_rejected() {
     let h = AppHarness::builder().build().await;
     let ctx = h.security_context().clone();
@@ -656,7 +646,6 @@ async fn proxy_query_allowlist_unknown_param_rejected() {
 
 // 13.5: Non-existent auth plugin ID returns error through proxy pipeline.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_nonexistent_auth_plugin_returns_error() {
     let h = AppHarness::builder().build().await;
     let ctx = h.security_context().clone();
@@ -722,7 +711,6 @@ async fn proxy_nonexistent_auth_plugin_returns_error() {
 
 // 13.6: Assert on recorded_requests() URI and body content.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_recorded_request_has_correct_uri_and_body() {
     let mut guard = MockGuard::new();
     guard.mock(
@@ -804,7 +792,6 @@ async fn proxy_recorded_request_has_correct_uri_and_body() {
 
 // Response header sanitization: hop-by-hop and x-oagw-* headers stripped from upstream response.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_response_headers_sanitized() {
     let h = AppHarness::builder().build().await;
     let ctx = h.security_context().clone();
@@ -897,7 +884,6 @@ async fn proxy_response_headers_sanitized() {
 
 // 8.10: path_suffix_mode=disabled rejects suffix; append succeeds.
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_path_suffix_disabled_rejects_extra_path() {
     let h = AppHarness::builder().build().await;
     let ctx = h.security_context().clone();
@@ -968,7 +954,6 @@ async fn proxy_path_suffix_disabled_rejects_extra_path() {
 
 // Demonstrate MockGuard pattern for custom per-test responses
 #[tokio::test]
-#[ignore = "temporarily disabled — investigating hangs"]
 async fn proxy_with_mock_guard_custom_response() {
     // Create a MockGuard for test-isolated mock responses
     let mut guard = MockGuard::new();


### PR DESCRIPTION
~/projects/cyberfabric-core$ bash test_stability.sh 
Run 1: PASSED (1 passed, 0 failed)
Run 2: PASSED (2 passed, 0 failed)
Run 3: PASSED (3 passed, 0 failed)
Run 4: PASSED (4 passed, 0 failed)
Run 5: PASSED (5 passed, 0 failed)
Run 6: PASSED (6 passed, 0 failed)
Run 7: PASSED (7 passed, 0 failed)
Run 8: PASSED (8 passed, 0 failed)
Run 9: PASSED (9 passed, 0 failed)
Run 10: PASSED (10 passed, 0 failed)
Run 11: PASSED (11 passed, 0 failed)
Run 12: PASSED (12 passed, 0 failed)
Run 13: PASSED (13 passed, 0 failed)
Run 14: PASSED (14 passed, 0 failed)
Run 15: PASSED (15 passed, 0 failed)
Run 16: PASSED (16 passed, 0 failed)
Run 17: PASSED (17 passed, 0 failed)
Run 18: PASSED (18 passed, 0 failed)
Run 19: PASSED (19 passed, 0 failed)
Run 20: PASSED (20 passed, 0 failed)
Run 21: PASSED (21 passed, 0 failed)
Run 22: PASSED (22 passed, 0 failed)
Run 23: PASSED (23 passed, 0 failed)
Run 24: PASSED (24 passed, 0 failed)
Run 25: PASSED (25 passed, 0 failed)
Run 26: PASSED (26 passed, 0 failed)
Run 27: PASSED (27 passed, 0 failed)
Run 28: PASSED (28 passed, 0 failed)
Run 29: PASSED (29 passed, 0 failed)
Run 30: PASSED (30 passed, 0 failed)
Run 31: PASSED (31 passed, 0 failed)
Run 32: PASSED (32 passed, 0 failed)
Run 33: PASSED (33 passed, 0 failed)
Run 34: PASSED (34 passed, 0 failed)
Run 35: PASSED (35 passed, 0 failed)
Run 36: PASSED (36 passed, 0 failed)
Run 37: PASSED (37 passed, 0 failed)
Run 38: PASSED (38 passed, 0 failed)
Run 39: PASSED (39 passed, 0 failed)
Run 40: PASSED (40 passed, 0 failed)
Run 41: PASSED (41 passed, 0 failed)
Run 42: PASSED (42 passed, 0 failed)
Run 43: PASSED (43 passed, 0 failed)
Run 44: PASSED (44 passed, 0 failed)
Run 45: PASSED (45 passed, 0 failed)
Run 46: PASSED (46 passed, 0 failed)
Run 47: PASSED (47 passed, 0 failed)
Run 48: PASSED (48 passed, 0 failed)
Run 49: PASSED (49 passed, 0 failed)
Run 50: PASSED (50 passed, 0 failed)
Run 51: PASSED (51 passed, 0 failed)
Run 52: PASSED (52 passed, 0 failed)
Run 53: PASSED (53 passed, 0 failed)
Run 54: PASSED (54 passed, 0 failed)
Run 55: PASSED (55 passed, 0 failed)
Run 56: PASSED (56 passed, 0 failed)
Run 57: PASSED (57 passed, 0 failed)
Run 58: PASSED (58 passed, 0 failed)
Run 59: PASSED (59 passed, 0 failed)
Run 60: PASSED (60 passed, 0 failed)
Run 61: PASSED (61 passed, 0 failed)
Run 62: PASSED (62 passed, 0 failed)
Run 63: PASSED (63 passed, 0 failed)
Run 64: PASSED (64 passed, 0 failed)
Run 65: PASSED (65 passed, 0 failed)
Run 66: PASSED (66 passed, 0 failed)
Run 67: PASSED (67 passed, 0 failed)
Run 68: PASSED (68 passed, 0 failed)
Run 69: PASSED (69 passed, 0 failed)
Run 70: PASSED (70 passed, 0 failed)
Run 71: PASSED (71 passed, 0 failed)
Run 72: PASSED (72 passed, 0 failed)
Run 73: PASSED (73 passed, 0 failed)
Run 74: PASSED (74 passed, 0 failed)
Run 75: PASSED (75 passed, 0 failed)
Run 76: PASSED (76 passed, 0 failed)
Run 77: PASSED (77 passed, 0 failed)
Run 78: PASSED (78 passed, 0 failed)
Run 79: PASSED (79 passed, 0 failed)
Run 80: PASSED (80 passed, 0 failed)
Run 81: PASSED (81 passed, 0 failed)
Run 82: PASSED (82 passed, 0 failed)
Run 83: PASSED (83 passed, 0 failed)
Run 84: PASSED (84 passed, 0 failed)
Run 85: PASSED (85 passed, 0 failed)
Run 86: PASSED (86 passed, 0 failed)
Run 87: PASSED (87 passed, 0 failed)
Run 88: PASSED (88 passed, 0 failed)
Run 89: PASSED (89 passed, 0 failed)
Run 90: PASSED (90 passed, 0 failed)
Run 91: PASSED (91 passed, 0 failed)
Run 92: PASSED (92 passed, 0 failed)
Run 93: PASSED (93 passed, 0 failed)
Run 94: PASSED (94 passed, 0 failed)
Run 95: PASSED (95 passed, 0 failed)
Run 96: PASSED (96 passed, 0 failed)
Run 97: PASSED (97 passed, 0 failed)
Run 98: PASSED (98 passed, 0 failed)
Run 99: PASSED (99 passed, 0 failed)
Run 100: PASSED (100 passed, 0 failed)

=== Final Results ===
Passed: 100/100
Failed: 0/100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled integration and smoke test suite.

* **Refactor**
  * Updated alias management handling mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->