### PR TITLE
chore(cypilot): ignore serverless_runtime in validation

### DIFF
--- a/.cypilot-adapter/artifacts.json
+++ b/.cypilot-adapter/artifacts.json
@@ -97,6 +97,10 @@
     {
       "reason": "Ignore module 'file-parser' (not SDLC-documented yet: missing required PRD/DESIGN).",
       "patterns": ["modules/file-parser/*"]
+    },
+    {
+      "reason": "Ignore module 'serverless_runtime' (not SDLC-documented yet: missing required PRD/DESIGN and ID prefix alignment).",
+      "patterns": ["modules/serverless_runtime/*"]
     }
   ],
   "systems": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies and configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->