### PR TITLE
chore(serverless-runtime): fix module naming in artifacts.json

### DIFF
--- a/.cypilot-adapter/artifacts.json
+++ b/.cypilot-adapter/artifacts.json
@@ -100,7 +100,7 @@
     },
     {
       "reason": "Ignore module 'serverless_runtime' (not SDLC-documented yet: missing required PRD/DESIGN and ID prefix alignment).",
-      "patterns": ["modules/serverless_runtime/*"]
+      "patterns": ["modules/serverless-runtime/*"]
     }
   ],
   "systems": [

--- a/.cypilot-adapter/artifacts.json
+++ b/.cypilot-adapter/artifacts.json
@@ -99,7 +99,7 @@
       "patterns": ["modules/file-parser/*"]
     },
     {
-      "reason": "Ignore module 'serverless_runtime' (not SDLC-documented yet: missing required PRD/DESIGN and ID prefix alignment).",
+      "reason": "Ignore module 'serverless-runtime' (not SDLC-documented yet: missing required PRD/DESIGN and ID prefix alignment).",
       "patterns": ["modules/serverless-runtime/*"]
     }
   ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration naming pattern for consistency: an internal module name and its ignore pattern were standardized from using an underscore to a hyphen. No user-facing behavior changes expected; this aligns internal tooling and reduces potential mismatches in build/ignore processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->