### PR TITLE
test: fix the modkit-macros-tests tests reference stderr message

### DIFF
--- a/libs/modkit-macros-tests/tests/ui/fail/module_name_consecutive_hyphens.stderr
+++ b/libs/modkit-macros-tests/tests/ui/fail/module_name_consecutive_hyphens.stderr
@@ -4,7 +4,7 @@ error: module name must not contain consecutive hyphens
 6 |     name = "file--parser",  // Should fail: consecutive hyphens
   |            ^^^^^^^^^^^^^^
 
-error[E0425]: cannot find type `TestModule` in this scope
+error[E0412]: cannot find type `TestModule` in this scope
   --> tests/ui/fail/module_name_consecutive_hyphens.rs:11:17
    |
 11 | impl Module for TestModule {

--- a/libs/modkit-macros-tests/tests/ui/fail/module_name_ends_hyphen.stderr
+++ b/libs/modkit-macros-tests/tests/ui/fail/module_name_ends_hyphen.stderr
@@ -4,7 +4,7 @@ error: module name must not end with a hyphen
 6 |     name = "parser-",  // Should fail: ends with hyphen
   |            ^^^^^^^^^
 
-error[E0425]: cannot find type `TestModule` in this scope
+error[E0412]: cannot find type `TestModule` in this scope
   --> tests/ui/fail/module_name_ends_hyphen.rs:11:17
    |
 11 | impl Module for TestModule {

--- a/libs/modkit-macros-tests/tests/ui/fail/module_name_snake_case.stderr
+++ b/libs/modkit-macros-tests/tests/ui/fail/module_name_snake_case.stderr
@@ -5,7 +5,7 @@ error: module name must use kebab-case, not snake_case
 6 |     name = "file_parser",  // Should fail: uses snake_case instead of kebab-case
   |            ^^^^^^^^^^^^^
 
-error[E0425]: cannot find type `TestModule` in this scope
+error[E0412]: cannot find type `TestModule` in this scope
   --> tests/ui/fail/module_name_snake_case.rs:11:17
    |
 11 | impl Module for TestModule {

--- a/libs/modkit-macros-tests/tests/ui/fail/module_name_starts_hyphen.stderr
+++ b/libs/modkit-macros-tests/tests/ui/fail/module_name_starts_hyphen.stderr
@@ -4,7 +4,7 @@ error: module name must start with a lowercase letter, found '-'
 6 |     name = "-parser",  // Should fail: starts with hyphen
   |            ^^^^^^^^^
 
-error[E0425]: cannot find type `TestModule` in this scope
+error[E0412]: cannot find type `TestModule` in this scope
   --> tests/ui/fail/module_name_starts_hyphen.rs:11:17
    |
 11 | impl Module for TestModule {

--- a/libs/modkit-macros-tests/tests/ui/fail/module_name_uppercase.stderr
+++ b/libs/modkit-macros-tests/tests/ui/fail/module_name_uppercase.stderr
@@ -4,7 +4,7 @@ error: module name must start with a lowercase letter, found 'F'
 6 |     name = "FileParser",  // Should fail: contains uppercase letters
   |            ^^^^^^^^^^^^
 
-error[E0425]: cannot find type `TestModule` in this scope
+error[E0412]: cannot find type `TestModule` in this scope
   --> tests/ui/fail/module_name_uppercase.rs:11:17
    |
 11 | impl Module for TestModule {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 ﻿[toolchain]
-channel = "stable"
+channel = "1.92.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 ﻿[toolchain]
 channel = "1.92.0"
-components = ["rustfmt"]
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 ﻿[toolchain]
 channel = "1.92.0"
+components = ["rustfmt"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for module-name validation: compiler diagnostic classification changed (error code E0425 → E0412) across multiple cases, keeping messages and locations unchanged.
* **Chores**
  * Updated Rust toolchain to version 1.92.0 and added formatting/linting components (rustfmt, clippy).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->