### PR TITLE
feat(resolvers): add system capability to authn/authz/tenant resolvers

### DIFF
--- a/modules/system/authn-resolver/authn-resolver/src/module.rs
+++ b/modules/system/authn-resolver/authn-resolver/src/module.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use authn_resolver_sdk::{AuthNResolverClient, AuthNResolverPluginSpecV1};
 use modkit::Module;
 use modkit::context::ModuleCtx;
+use modkit::contracts::SystemCapability;
 use tracing::info;
 use types_registry_sdk::{RegisterResult, TypesRegistryClient};
 
@@ -24,7 +25,7 @@ use crate::domain::{AuthNResolverLocalClient, Service};
 #[modkit::module(
     name = "authn-resolver",
     deps = ["types-registry"],
-    capabilities = []
+    capabilities = [system]
 )]
 pub(crate) struct AuthNResolver {
     service: OnceLock<Arc<Service>>,
@@ -37,6 +38,11 @@ impl Default for AuthNResolver {
         }
     }
 }
+
+// Marked as `system` so that init() runs in the system-module phase.
+// This ensures the AuthNResolver client is available in ClientHub before
+// other system modules that depend on it.
+impl SystemCapability for AuthNResolver {}
 
 #[async_trait]
 impl Module for AuthNResolver {

--- a/modules/system/authz-resolver/authz-resolver/src/module.rs
+++ b/modules/system/authz-resolver/authz-resolver/src/module.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverPluginSpecV1};
 use modkit::Module;
 use modkit::context::ModuleCtx;
+use modkit::contracts::SystemCapability;
 use tracing::info;
 use types_registry_sdk::{RegisterResult, TypesRegistryClient};
 
@@ -24,7 +25,7 @@ use crate::domain::{AuthZResolverLocalClient, Service};
 #[modkit::module(
     name = "authz-resolver",
     deps = ["types-registry"],
-    capabilities = []
+    capabilities = [system]
 )]
 pub(crate) struct AuthZResolver {
     service: OnceLock<Arc<Service>>,
@@ -37,6 +38,11 @@ impl Default for AuthZResolver {
         }
     }
 }
+
+// Marked as `system` so that init() runs in the system-module phase.
+// This ensures the AuthZResolver client is available in ClientHub before
+// other system modules that depend on it.
+impl SystemCapability for AuthZResolver {}
 
 #[async_trait]
 impl Module for AuthZResolver {

--- a/modules/system/tenant-resolver/tenant-resolver/src/module.rs
+++ b/modules/system/tenant-resolver/tenant-resolver/src/module.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, OnceLock};
 use async_trait::async_trait;
 use modkit::Module;
 use modkit::context::ModuleCtx;
+use modkit::contracts::SystemCapability;
 use tenant_resolver_sdk::{TenantResolverClient, TenantResolverPluginSpecV1};
 use tracing::info;
 use types_registry_sdk::{RegisterResult, TypesRegistryClient};
@@ -24,7 +25,7 @@ use crate::domain::{Service, TenantResolverLocalClient};
 #[modkit::module(
     name = "tenant-resolver",
     deps = ["types-registry"],
-    capabilities = []
+    capabilities = [system]
 )]
 pub(crate) struct TenantResolver {
     service: OnceLock<Arc<Service>>,
@@ -37,6 +38,11 @@ impl Default for TenantResolver {
         }
     }
 }
+
+// Marked as `system` so that init() runs in the system-module phase.
+// This ensures the TenantResolver client is available in ClientHub before
+// other system modules that depend on it.
+impl SystemCapability for TenantResolver {}
 
 #[async_trait]
 impl Module for TenantResolver {


### PR DESCRIPTION
Mark all three resolver modules as system modules so their init() runs in the system-module phase. This ensures resolver clients are registered in ClientHub before other system modules that depend on them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated system module declarations for authentication, authorization, and tenant resolvers so they initialize during the system-module phase, improving startup ordering and ensuring resolver clients are available for dependent modules, increasing initialization reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->