### PR TITLE
chore: enable the SemVer checks

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -16,9 +16,7 @@ git_release_enable = true
 changelog_path = "CHANGELOG.md"
 
 # Enable semver checks by default (can be overridden per package if needed later).
-# NOTE: For the initial bootstrap (when crates may not exist on crates.io yet),
-# semver checks are noisy and can fail. Re-enable after the first successful publish.
-semver_check = false
+semver_check = true
 
 # To prevent crates.io throttling
 publish_timeout = "7m"


### PR DESCRIPTION
The initial bootstrap has been done. Because the SemVer checks are disabled, we already have multiple published versions of multiple library crates with SemVer violations, e.g.:

- https://docs.rs/cf-modkit-db/0.2.0/modkit_db/secure/struct.AccessScope.html#method.tenants_only | https://docs.rs/cf-modkit-db/0.2.12/modkit_db/secure/struct.AccessScope.html#method.tenants_only
- https://docs.rs/cf-modkit/0.2.0/modkit/api/operation_builder/trait.AuthReqAction.html | https://docs.rs/cf-modkit/0.2.12/modkit/api/operation_builder/trait.AuthReqAction.html

Affected versions should be [yanked](https://doc.rust-lang.org/cargo/commands/cargo-yank.html?highlight=yank#when-to-yank).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled semantic versioning checks by default in release configuration, while maintaining the ability to configure per-package overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->