### PR TITLE
Add metrics recorder with cardinality limitation, REAL-163

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,6 +1165,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-metrics",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -7086,6 +7087,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c48227f311eaa0b0ae5860089860509d7249e0e5da8f7a5d17f4808a1ad387"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -280,8 +280,8 @@ tracing-opentelemetry = "0.32"
 tracing-error = "0.2"
 tracing-appender = "0.2"
 tracing-test = "0.2"
-opentelemetry = { version = "0.31", features = ["trace"] }
-opentelemetry_sdk = { version = "0.31", features = ["trace", "rt-tokio"] }
+opentelemetry = { version = "0.31", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.31", features = ["trace", "rt-tokio", "metrics"] }
 opentelemetry-otlp = { version = "0.31", features = [
     "grpc-tonic",
     "http-proto",
@@ -470,6 +470,9 @@ temp-env = "0.3"
 
 # Additional utilities
 nanoid = "0.4"
+
+# Metrics
+tokio-metrics = { version = "0.4", features = ["rt"] }
 
 # GTS dependencies
 jsonschema = "0.40"

--- a/apps/hyperspot-server/src/main.rs
+++ b/apps/hyperspot-server/src/main.rs
@@ -90,6 +90,14 @@ async fn main() -> Result<()> {
     // Register custom panic hook to reroute panic backtrace into tracing.
     init_panic_tracing();
 
+    // Initialize OpenTelemetry metrics (if configured and enabled)
+    #[cfg(feature = "otel")]
+    if config.tracing.metrics.enabled
+        && let Err(e) = modkit::bootstrap::host::init_metrics_provider(&config.tracing)
+    {
+        tracing::error!(error = %e, "OpenTelemetry metrics not initialized");
+    }
+
     // One-time connectivity probe
     #[cfg(feature = "otel")]
     if config.tracing.enabled

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -272,6 +272,15 @@ tracing:
   logs_correlation:
     inject_trace_ids_into_logs: true
 
+  # Metrics configuration
+  metrics:
+    enabled: false
+    exporter:
+      kind: "otlp_grpc"  # or "otlp_http"
+      endpoint: "http://127.0.0.1:4317"
+      timeout_ms: 5000
+    # cardinality_limit: 2000  # Max distinct attribute combinations per instrument (SDK default if omitted)
+
 # Example configurations for different database scenarios:
 #
 # Example 1: PostgreSQL server with multiple modules

--- a/config/server.yaml
+++ b/config/server.yaml
@@ -404,3 +404,22 @@ modules:
           verify_cert: true
         urls:
           - "https://api.openai.com"
+
+# OpenTelemetry tracing configuration
+tracing:
+  enabled: false
+  service_name: "hyperspot-api"
+
+  # OTLP exporter configuration
+  exporter:
+    kind: "otlp_grpc"  # or "otlp_http"
+    endpoint: "http://127.0.0.1:4317"
+    timeout_ms: 5000
+
+  # Metrics configuration
+  metrics:
+    enabled: false
+    exporter:
+      kind: "otlp_grpc"  # or "otlp_http"
+      endpoint: "http://127.0.0.1:4317"
+      timeout_ms: 5000

--- a/examples/modkit/users-info/users-info/Cargo.toml
+++ b/examples/modkit/users-info/users-info/Cargo.toml
@@ -73,6 +73,7 @@ modkit-errors-macro = { workspace = true }
 modkit-odata = { workspace = true, features = ["with-utoipa"] }
 modkit-sdk = { workspace = true }
 modkit-macros = { workspace = true }
+opentelemetry = { workspace = true }
 
 [dev-dependencies]
 tokio-util = { workspace = true }
@@ -85,5 +86,4 @@ testcontainers-modules = { workspace = true, features = ["postgres"] }
 tracing-test = { workspace = true }
 httpmock = { workspace = true }
 tokio-test = { workspace = true }
-opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }

--- a/examples/modkit/users-info/users-info/src/api/rest/handlers/addresses.rs
+++ b/examples/modkit/users-info/users-info/src/api/rest/handlers/addresses.rs
@@ -1,4 +1,7 @@
-use axum::response::{IntoResponse, Response};
+use axum::Extension;
+use axum::extract::Path;
+use axum::response::IntoResponse;
+use tracing::field::Empty;
 use uuid::Uuid;
 
 use super::{
@@ -6,10 +9,19 @@ use super::{
 };
 use crate::module::ConcreteAppServices;
 
-pub(super) async fn get_user_address(
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    user_id: Uuid,
+/// Get address for a specific user
+#[tracing::instrument(
+    skip(svc, ctx),
+    fields(
+        user.id = %user_id,
+        request_id = Empty,
+        requester.id = %ctx.subject_id()
+    )
+)]
+pub async fn get_user_address(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Path(user_id): Path<Uuid>,
 ) -> ApiResult<JsonBody<AddressDto>> {
     info!(
         user_id = %user_id,
@@ -25,12 +37,21 @@ pub(super) async fn get_user_address(
     Ok(Json(AddressDto::from(address)))
 }
 
-pub(super) async fn put_user_address(
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    user_id: Uuid,
-    req_body: PutAddressReq,
-) -> ApiResult<Response> {
+/// Upsert address for a specific user (PUT = create or replace)
+#[tracing::instrument(
+    skip(svc, req_body, ctx),
+    fields(
+        user.id = %user_id,
+        request_id = Empty,
+        updater.id = %ctx.subject_id()
+    )
+)]
+pub async fn put_user_address(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Path(user_id): Path<Uuid>,
+    Json(req_body): Json<PutAddressReq>,
+) -> ApiResult<impl IntoResponse> {
     info!(
         user_id = %user_id,
         updater_id = %ctx.subject_id(),
@@ -46,11 +67,20 @@ pub(super) async fn put_user_address(
     Ok(Json(AddressDto::from(address)).into_response())
 }
 
-pub(super) async fn delete_user_address(
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    user_id: Uuid,
-) -> ApiResult<Response> {
+/// Delete address for a specific user
+#[tracing::instrument(
+    skip(svc, ctx),
+    fields(
+        user.id = %user_id,
+        request_id = Empty,
+        deleter.id = %ctx.subject_id()
+    )
+)]
+pub async fn delete_user_address(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Path(user_id): Path<Uuid>,
+) -> ApiResult<impl IntoResponse> {
     info!(
         user_id = %user_id,
         deleter_id = %ctx.subject_id(),

--- a/examples/modkit/users-info/users-info/src/api/rest/handlers/cities.rs
+++ b/examples/modkit/users-info/users-info/src/api/rest/handlers/cities.rs
@@ -1,6 +1,11 @@
+use axum::Extension;
+use axum::extract::Path;
 use axum::http::Uri;
-use axum::response::{IntoResponse, Response};
+use axum::response::IntoResponse;
+use tracing::field::Empty;
 use uuid::Uuid;
+
+use modkit::api::odata::OData;
 
 use super::{
     ApiResult, CityDto, CreateCityReq, Json, JsonBody, JsonPage, SecurityContext, UpdateCityReq,
@@ -8,10 +13,19 @@ use super::{
 };
 use crate::module::ConcreteAppServices;
 
-pub(super) async fn list_cities(
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    query: modkit::api::odata::ODataQuery,
+/// List cities with cursor-based pagination and optional field projection via $select
+#[tracing::instrument(
+    skip(svc, query, ctx),
+    fields(
+        limit = query.limit,
+        request_id = Empty,
+        user.id = %ctx.subject_id()
+    )
+)]
+pub async fn list_cities(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    OData(query): OData,
 ) -> ApiResult<JsonPage<serde_json::Value>> {
     info!(
         user_id = %ctx.subject_id(),
@@ -24,11 +38,20 @@ pub(super) async fn list_cities(
     Ok(Json(page_to_projected_json(&page, query.selected_fields())))
 }
 
-pub(super) async fn get_city(
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    id: Uuid,
-    query: modkit::api::odata::ODataQuery,
+/// Get a specific city by ID with optional field projection via $select
+#[tracing::instrument(
+    skip(svc, ctx),
+    fields(
+        city.id = %id,
+        request_id = Empty,
+        requester.id = %ctx.subject_id()
+    )
+)]
+pub async fn get_city(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Path(id): Path<Uuid>,
+    OData(query): OData,
 ) -> ApiResult<JsonBody<serde_json::Value>> {
     info!(
         city_id = %id,
@@ -44,12 +67,23 @@ pub(super) async fn get_city(
     Ok(Json(projected))
 }
 
-pub(super) async fn create_city(
+/// Create a new city
+#[tracing::instrument(
+    skip(svc, req_body, ctx, uri),
+    fields(
+        city.name = %req_body.name,
+        city.country = %req_body.country,
+        city.tenant_id = %req_body.tenant_id,
+        request_id = Empty,
+        creator.id = %ctx.subject_id()
+    )
+)]
+pub async fn create_city(
     uri: Uri,
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    req_body: CreateCityReq,
-) -> ApiResult<Response> {
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Json(req_body): Json<CreateCityReq>,
+) -> ApiResult<impl IntoResponse> {
     info!(
         name = %req_body.name,
         country = %req_body.country,
@@ -64,11 +98,20 @@ pub(super) async fn create_city(
     Ok(created_json(CityDto::from(city), &uri, &id_str).into_response())
 }
 
-pub(super) async fn update_city(
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    id: Uuid,
-    req_body: UpdateCityReq,
+/// Update an existing city
+#[tracing::instrument(
+    skip(svc, req_body, ctx),
+    fields(
+        city.id = %id,
+        request_id = Empty,
+        updater.id = %ctx.subject_id()
+    )
+)]
+pub async fn update_city(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Path(id): Path<Uuid>,
+    Json(req_body): Json<UpdateCityReq>,
 ) -> ApiResult<JsonBody<CityDto>> {
     info!(
         city_id = %id,
@@ -81,11 +124,20 @@ pub(super) async fn update_city(
     Ok(Json(CityDto::from(city)))
 }
 
-pub(super) async fn delete_city(
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    id: Uuid,
-) -> ApiResult<Response> {
+/// Delete a city by ID
+#[tracing::instrument(
+    skip(svc, ctx),
+    fields(
+        city.id = %id,
+        request_id = Empty,
+        deleter.id = %ctx.subject_id()
+    )
+)]
+pub async fn delete_city(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<impl IntoResponse> {
     info!(
         city_id = %id,
         deleter_id = %ctx.subject_id(),

--- a/examples/modkit/users-info/users-info/src/api/rest/handlers/events.rs
+++ b/examples/modkit/users-info/users-info/src/api/rest/handlers/events.rs
@@ -1,8 +1,17 @@
-use axum::response::{IntoResponse, Response};
+use axum::Extension;
+use axum::response::IntoResponse;
+use tracing::field::Empty;
 
 use super::{SseBroadcaster, UserEvent, info};
 
-pub(super) fn users_events(sse: &SseBroadcaster<UserEvent>) -> Response {
+/// SSE endpoint returning a live stream of `UserEvent`.
+#[tracing::instrument(
+    skip(sse),
+    fields(request_id = Empty)
+)]
+pub async fn users_events(
+    Extension(sse): Extension<SseBroadcaster<UserEvent>>,
+) -> impl IntoResponse {
     info!("New SSE connection for user events");
     sse.sse_response_named("users_events").into_response()
 }

--- a/examples/modkit/users-info/users-info/src/api/rest/handlers/mod.rs
+++ b/examples/modkit/users-info/users-info/src/api/rest/handlers/mod.rs
@@ -1,17 +1,13 @@
-use axum::{Extension, extract::Path, http::Uri};
-use tracing::{field::Empty, info};
-use uuid::Uuid;
+use tracing::info;
 
 use crate::api::rest::dto::{
-    AddressDto, CityDto, CreateCityReq, CreateUserReq, PutAddressReq, UpdateCityReq, UpdateUserReq,
-    UserDto, UserEvent, UserFullDto,
+    AddressDto, CityDto, CreateCityReq, PutAddressReq, UpdateCityReq, UpdateUserReq, UserDto,
+    UserEvent, UserFullDto,
 };
 
-use modkit::api::odata::OData;
 use modkit::api::prelude::*;
 use modkit::api::select::{apply_select, page_to_projected_json};
 
-use crate::module::ConcreteAppServices;
 use modkit::SseBroadcaster;
 
 use modkit_security::SecurityContext;
@@ -23,273 +19,26 @@ mod users;
 
 // ==================== User Handlers ====================
 
-/// List users with cursor-based pagination and optional field projection via $select
-#[tracing::instrument(
-    skip(svc, query, ctx),
-    fields(
-        limit = query.limit,
-        request_id = Empty,
-        user.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn list_users(
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    OData(query): OData,
-) -> ApiResult<JsonPage<serde_json::Value>> {
-    users::list_users(ctx, svc, query).await
-}
-
-/// Get a specific user by ID with optional field projection via $select
-#[tracing::instrument(
-    skip(svc, ctx),
-    fields(
-        user.id = %id,
-        request_id = Empty,
-        requester.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn get_user(
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    Path(id): Path<Uuid>,
-    OData(query): OData,
-) -> ApiResult<JsonBody<serde_json::Value>> {
-    users::get_user(ctx, svc, id, query).await
-}
-
-/// Create a new user
-#[tracing::instrument(
-    skip(svc, req_body, ctx, uri),
-    fields(
-        user.email = %req_body.email,
-        user.display_name = %req_body.display_name,
-        user.tenant_id = %req_body.tenant_id,
-        request_id = Empty,
-        creator.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn create_user(
-    uri: Uri,
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    Json(req_body): Json<CreateUserReq>,
-) -> ApiResult<impl IntoResponse> {
-    info!(
-        email = %req_body.email,
-        display_name = %req_body.display_name,
-        tenant_id = %req_body.tenant_id,
-        creator_id = %ctx.subject_id(),
-        "Creating new user"
-    );
-
-    let CreateUserReq {
-        id,
-        tenant_id,
-        email,
-        display_name,
-    } = req_body;
-
-    let new_user = users_info_sdk::NewUser {
-        id,
-        tenant_id,
-        email,
-        display_name,
-    };
-
-    users::create_user(uri, ctx, svc, new_user).await
-}
-
-/// Update an existing user
-#[tracing::instrument(
-    skip(svc, req_body, ctx),
-    fields(
-        user.id = %id,
-        request_id = Empty,
-        updater.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn update_user(
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    Path(id): Path<Uuid>,
-    Json(req_body): Json<UpdateUserReq>,
-) -> ApiResult<JsonBody<UserDto>> {
-    users::update_user(ctx, svc, id, req_body).await
-}
-
-/// Delete a user by ID
-#[tracing::instrument(
-    skip(svc, ctx),
-    fields(
-        user.id = %id,
-        request_id = Empty,
-        deleter.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn delete_user(
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    Path(id): Path<Uuid>,
-) -> ApiResult<impl IntoResponse> {
-    users::delete_user(ctx, svc, id).await
-}
+pub(crate) use users::create_user;
+pub(crate) use users::delete_user;
+pub(crate) use users::get_user;
+pub(crate) use users::list_users;
+pub(crate) use users::update_user;
 
 // ==================== Event Handlers (SSE) ====================
 
-/// SSE endpoint returning a live stream of `UserEvent`.
-#[tracing::instrument(
-    skip(sse),
-    fields(request_id = Empty)
-)]
-pub(crate) async fn users_events(
-    Extension(sse): Extension<SseBroadcaster<UserEvent>>,
-) -> impl IntoResponse {
-    events::users_events(&sse)
-}
+pub(crate) use events::users_events;
 
 // ==================== City Handlers ====================
 
-/// List cities with cursor-based pagination and optional field projection via $select
-#[tracing::instrument(
-    skip(svc, query, ctx),
-    fields(
-        limit = query.limit,
-        request_id = Empty,
-        user.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn list_cities(
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    OData(query): OData,
-) -> ApiResult<JsonPage<serde_json::Value>> {
-    cities::list_cities(ctx, svc, query).await
-}
-
-/// Get a specific city by ID with optional field projection via $select
-#[tracing::instrument(
-    skip(svc, ctx),
-    fields(
-        city.id = %id,
-        request_id = Empty,
-        requester.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn get_city(
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    Path(id): Path<Uuid>,
-    OData(query): OData,
-) -> ApiResult<JsonBody<serde_json::Value>> {
-    cities::get_city(ctx, svc, id, query).await
-}
-
-/// Create a new city
-#[tracing::instrument(
-    skip(svc, req_body, ctx, uri),
-    fields(
-        city.name = %req_body.name,
-        city.country = %req_body.country,
-        city.tenant_id = %req_body.tenant_id,
-        request_id = Empty,
-        creator.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn create_city(
-    uri: Uri,
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    Json(req_body): Json<CreateCityReq>,
-) -> ApiResult<impl IntoResponse> {
-    cities::create_city(uri, ctx, svc, req_body).await
-}
-
-/// Update an existing city
-#[tracing::instrument(
-    skip(svc, req_body, ctx),
-    fields(
-        city.id = %id,
-        request_id = Empty,
-        updater.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn update_city(
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    Path(id): Path<Uuid>,
-    Json(req_body): Json<UpdateCityReq>,
-) -> ApiResult<JsonBody<CityDto>> {
-    cities::update_city(ctx, svc, id, req_body).await
-}
-
-/// Delete a city by ID
-#[tracing::instrument(
-    skip(svc, ctx),
-    fields(
-        city.id = %id,
-        request_id = Empty,
-        deleter.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn delete_city(
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    Path(id): Path<Uuid>,
-) -> ApiResult<impl IntoResponse> {
-    cities::delete_city(ctx, svc, id).await
-}
+pub(crate) use cities::create_city;
+pub(crate) use cities::delete_city;
+pub(crate) use cities::get_city;
+pub(crate) use cities::list_cities;
+pub(crate) use cities::update_city;
 
 // ==================== Address Handlers ====================
 
-/// Get address for a specific user
-#[tracing::instrument(
-    skip(svc, ctx),
-    fields(
-        user.id = %user_id,
-        request_id = Empty,
-        requester.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn get_user_address(
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    Path(user_id): Path<Uuid>,
-) -> ApiResult<JsonBody<AddressDto>> {
-    addresses::get_user_address(ctx, svc, user_id).await
-}
-
-/// Upsert address for a specific user (PUT = create or replace)
-#[tracing::instrument(
-    skip(svc, req_body, ctx),
-    fields(
-        user.id = %user_id,
-        request_id = Empty,
-        updater.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn put_user_address(
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    Path(user_id): Path<Uuid>,
-    Json(req_body): Json<PutAddressReq>,
-) -> ApiResult<impl IntoResponse> {
-    addresses::put_user_address(ctx, svc, user_id, req_body).await
-}
-
-/// Delete address for a specific user
-#[tracing::instrument(
-    skip(svc, ctx),
-    fields(
-        user.id = %user_id,
-        request_id = Empty,
-        deleter.id = %ctx.subject_id()
-    )
-)]
-pub(crate) async fn delete_user_address(
-    Extension(ctx): Extension<SecurityContext>,
-    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
-    Path(user_id): Path<Uuid>,
-) -> ApiResult<impl IntoResponse> {
-    addresses::delete_user_address(ctx, svc, user_id).await
-}
+pub(crate) use addresses::delete_user_address;
+pub(crate) use addresses::get_user_address;
+pub(crate) use addresses::put_user_address;

--- a/examples/modkit/users-info/users-info/src/api/rest/handlers/users.rs
+++ b/examples/modkit/users-info/users-info/src/api/rest/handlers/users.rs
@@ -1,17 +1,32 @@
+use axum::Extension;
+use axum::extract::Path;
 use axum::http::Uri;
-use axum::response::{IntoResponse, Response};
+use axum::response::IntoResponse;
+use tracing::field::Empty;
 use uuid::Uuid;
+
+use modkit::api::odata::OData;
 
 use super::{
     ApiResult, Json, JsonBody, JsonPage, SecurityContext, UpdateUserReq, UserDto, UserFullDto,
     apply_select, created_json, info, no_content, page_to_projected_json,
 };
+use crate::api::rest::dto::CreateUserReq;
 use crate::module::ConcreteAppServices;
 
-pub(super) async fn list_users(
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    query: modkit::api::odata::ODataQuery,
+/// List users with cursor-based pagination and optional field projection via $select
+#[tracing::instrument(
+    skip(svc, query, ctx),
+    fields(
+        limit = query.limit,
+        request_id = Empty,
+        user.id = %ctx.subject_id()
+    )
+)]
+pub async fn list_users(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    OData(query): OData,
 ) -> ApiResult<JsonPage<serde_json::Value>> {
     info!(
         user_id = %ctx.subject_id(),
@@ -24,11 +39,20 @@ pub(super) async fn list_users(
     Ok(Json(page_to_projected_json(&page, query.selected_fields())))
 }
 
-pub(super) async fn get_user(
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    id: Uuid,
-    query: modkit::api::odata::ODataQuery,
+/// Get a specific user by ID with optional field projection via $select
+#[tracing::instrument(
+    skip(svc, ctx),
+    fields(
+        user.id = %id,
+        request_id = Empty,
+        requester.id = %ctx.subject_id()
+    )
+)]
+pub async fn get_user(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Path(id): Path<Uuid>,
+    OData(query): OData,
 ) -> ApiResult<JsonBody<serde_json::Value>> {
     info!(
         user_id = %id,
@@ -42,22 +66,64 @@ pub(super) async fn get_user(
     Ok(Json(projected))
 }
 
-pub(super) async fn create_user(
+/// Create a new user
+#[tracing::instrument(
+    skip(svc, req_body, ctx, uri),
+    fields(
+        user.email = %req_body.email,
+        user.display_name = %req_body.display_name,
+        user.tenant_id = %req_body.tenant_id,
+        request_id = Empty,
+        creator.id = %ctx.subject_id()
+    )
+)]
+pub async fn create_user(
     uri: Uri,
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    new_user: users_info_sdk::NewUser,
-) -> ApiResult<Response> {
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Json(req_body): Json<CreateUserReq>,
+) -> ApiResult<impl IntoResponse> {
+    info!(
+        email = %req_body.email,
+        display_name = %req_body.display_name,
+        tenant_id = %req_body.tenant_id,
+        creator_id = %ctx.subject_id(),
+        "Creating new user"
+    );
+
+    let CreateUserReq {
+        id,
+        tenant_id,
+        email,
+        display_name,
+    } = req_body;
+
+    let new_user = users_info_sdk::NewUser {
+        id,
+        tenant_id,
+        email,
+        display_name,
+    };
+
     let user = svc.users.create_user(&ctx, new_user).await?;
     let id_str = user.id.to_string();
     Ok(created_json(UserDto::from(user), &uri, &id_str).into_response())
 }
 
-pub(super) async fn update_user(
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    id: Uuid,
-    req_body: UpdateUserReq,
+/// Update an existing user
+#[tracing::instrument(
+    skip(svc, req_body, ctx),
+    fields(
+        user.id = %id,
+        request_id = Empty,
+        updater.id = %ctx.subject_id()
+    )
+)]
+pub async fn update_user(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Path(id): Path<Uuid>,
+    Json(req_body): Json<UpdateUserReq>,
 ) -> ApiResult<JsonBody<UserDto>> {
     info!(
         user_id = %id,
@@ -70,11 +136,20 @@ pub(super) async fn update_user(
     Ok(Json(UserDto::from(user)))
 }
 
-pub(super) async fn delete_user(
-    ctx: SecurityContext,
-    svc: std::sync::Arc<ConcreteAppServices>,
-    id: Uuid,
-) -> ApiResult<Response> {
+/// Delete a user by ID
+#[tracing::instrument(
+    skip(svc, ctx),
+    fields(
+        user.id = %id,
+        request_id = Empty,
+        deleter.id = %ctx.subject_id()
+    )
+)]
+pub async fn delete_user(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<std::sync::Arc<ConcreteAppServices>>,
+    Path(id): Path<Uuid>,
+) -> ApiResult<impl IntoResponse> {
     info!(
         user_id = %id,
         deleter_id = %ctx.subject_id(),

--- a/examples/modkit/users-info/users-info/src/domain/ports/metrics.rs
+++ b/examples/modkit/users-info/users-info/src/domain/ports/metrics.rs
@@ -1,0 +1,7 @@
+/// Output port for recording domain-level metrics.
+///
+/// Implementations live in `infra/` (e.g. OpenTelemetry counters).
+/// Domain services and API handlers depend only on this trait.
+pub trait UsersMetricsPort: Send + Sync {
+    fn record_get_user(&self, result: &str);
+}

--- a/examples/modkit/users-info/users-info/src/domain/ports/mod.rs
+++ b/examples/modkit/users-info/users-info/src/domain/ports/mod.rs
@@ -1,6 +1,8 @@
 pub mod audit;
+pub mod metrics;
 
 pub use audit::AuditPort;
+pub use metrics::UsersMetricsPort;
 
 /// Output port: publish domain events (no knowledge of transport).
 pub trait EventPublisher<E>: Send + Sync + 'static {

--- a/examples/modkit/users-info/users-info/src/domain/service/mod.rs
+++ b/examples/modkit/users-info/users-info/src/domain/service/mod.rs
@@ -60,7 +60,7 @@ use std::sync::Arc;
 use modkit_macros::domain_model;
 
 use crate::domain::events::UserDomainEvent;
-use crate::domain::ports::{AuditPort, EventPublisher};
+use crate::domain::ports::{AuditPort, EventPublisher, UsersMetricsPort};
 use crate::domain::repos::{AddressesRepository, CitiesRepository, UsersRepository};
 use authz_resolver_sdk::AuthZResolverClient;
 use authz_resolver_sdk::PolicyEnforcer;
@@ -230,6 +230,7 @@ where
         audit: Arc<dyn AuditPort>,
         authz: Arc<dyn AuthZResolverClient>,
         config: ServiceConfig,
+        metrics: Arc<dyn UsersMetricsPort>,
     ) -> Self {
         let users_repo = Arc::new(users_repo);
         let cities_repo = Arc::new(cities_repo);
@@ -259,6 +260,7 @@ where
                 config,
                 cities.clone(),
                 addresses.clone(),
+                metrics,
             ),
             cities,
             addresses,

--- a/examples/modkit/users-info/users-info/src/domain/service/users.rs
+++ b/examples/modkit/users-info/users-info/src/domain/service/users.rs
@@ -5,7 +5,7 @@ use tracing::instrument;
 
 use crate::domain::error::DomainError;
 use crate::domain::events::UserDomainEvent;
-use crate::domain::ports::{AuditPort, EventPublisher};
+use crate::domain::ports::{AuditPort, EventPublisher, UsersMetricsPort};
 use crate::domain::repos::{AddressesRepository, CitiesRepository, UsersRepository};
 use crate::domain::service::DbProvider;
 use crate::domain::service::{AddressesService, CitiesService, ServiceConfig};
@@ -41,6 +41,7 @@ pub struct UsersService<R: UsersRepository + 'static, CR: CitiesRepository, AR: 
     config: ServiceConfig,
     cities: Arc<CitiesService<CR>>,
     addresses: Arc<AddressesService<AR, R>>,
+    metrics: Arc<dyn UsersMetricsPort>,
 }
 
 impl<R: UsersRepository + 'static, CR: CitiesRepository, AR: AddressesRepository>
@@ -56,6 +57,7 @@ impl<R: UsersRepository + 'static, CR: CitiesRepository, AR: AddressesRepository
         config: ServiceConfig,
         cities: Arc<CitiesService<CR>>,
         addresses: Arc<AddressesService<AR, R>>,
+        metrics: Arc<dyn UsersMetricsPort>,
     ) -> Self {
         Self {
             db,
@@ -66,6 +68,7 @@ impl<R: UsersRepository + 'static, CR: CitiesRepository, AR: AddressesRepository
             config,
             cities,
             addresses,
+            metrics,
         }
     }
 }
@@ -129,6 +132,7 @@ impl<R: UsersRepository + 'static, CR: CitiesRepository, AR: AddressesRepository
                 .ok_or_else(|| DomainError::user_not_found(id))?
         };
 
+        self.metrics.record_get_user("success");
         tracing::debug!("Successfully retrieved user");
         Ok(user)
     }

--- a/examples/modkit/users-info/users-info/src/infra/metrics.rs
+++ b/examples/modkit/users-info/users-info/src/infra/metrics.rs
@@ -1,0 +1,103 @@
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::{Counter, Meter};
+
+use crate::domain::ports::UsersMetricsPort;
+
+/// OpenTelemetry-backed implementation of [`UsersMetricsPort`].
+pub struct UsersMetricsMeter {
+    get_user_counter: Counter<u64>,
+}
+
+impl UsersMetricsMeter {
+    #[must_use]
+    pub fn new(meter: &Meter) -> Self {
+        Self {
+            get_user_counter: meter
+                .u64_counter("users_info.get_user")
+                .with_description("Number of get_user calls")
+                .build(),
+        }
+    }
+}
+
+impl UsersMetricsPort for UsersMetricsMeter {
+    fn record_get_user(&self, result: &str) {
+        self.get_user_counter
+            .add(1, &[KeyValue::new("result", result.to_owned())]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+    use opentelemetry_sdk::metrics::{
+        InMemoryMetricExporter, Instrument, PeriodicReader, SdkMeterProvider, Stream,
+    };
+
+    use crate::domain::ports::UsersMetricsPort;
+
+    const COUNTER_NAME: &str = "users_info.get_user";
+    const CARDINALITY_LIMIT: usize = 2000;
+
+    fn local_provider() -> (SdkMeterProvider, InMemoryMetricExporter) {
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(PeriodicReader::builder(exporter.clone()).build())
+            .with_view(|_: &Instrument| {
+                Stream::builder()
+                    .with_cardinality_limit(CARDINALITY_LIMIT)
+                    .build()
+                    .ok()
+            })
+            .build();
+        (provider, exporter)
+    }
+
+    fn extract_counter_value(exporter: &InMemoryMetricExporter, name: &str) -> u64 {
+        let metrics = exporter.get_finished_metrics().unwrap();
+        for resource_metrics in &metrics {
+            for scope_metrics in resource_metrics.scope_metrics() {
+                for metric in scope_metrics.metrics() {
+                    if metric.name() == name
+                        && let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data()
+                    {
+                        return sum
+                            .data_points()
+                            .map(opentelemetry_sdk::metrics::data::SumDataPoint::value)
+                            .sum();
+                    }
+                }
+            }
+        }
+        0
+    }
+
+    #[test]
+    fn test_record_get_user_increments_counter() {
+        let (provider, exporter) = local_provider();
+        let metrics = super::UsersMetricsMeter::new(&provider.meter("users-info"));
+
+        metrics.record_get_user("success");
+        metrics.record_get_user("success");
+        metrics.record_get_user("success");
+
+        provider.force_flush().unwrap();
+
+        let value = extract_counter_value(&exporter, COUNTER_NAME);
+        assert_eq!(value, 3, "expected counter == 3, got {value}");
+    }
+
+    #[test]
+    fn test_record_get_user_single_increment() {
+        let (provider, exporter) = local_provider();
+        let metrics = super::UsersMetricsMeter::new(&provider.meter("users-info"));
+
+        metrics.record_get_user("success");
+
+        provider.force_flush().unwrap();
+
+        let value = extract_counter_value(&exporter, COUNTER_NAME);
+        assert_eq!(value, 1, "expected counter == 1, got {value}");
+    }
+}

--- a/examples/modkit/users-info/users-info/src/infra/mod.rs
+++ b/examples/modkit/users-info/users-info/src/infra/mod.rs
@@ -1,2 +1,3 @@
 pub mod audit;
+pub mod metrics;
 pub mod storage;

--- a/examples/modkit/users-info/users-info/src/module.rs
+++ b/examples/modkit/users-info/users-info/src/module.rs
@@ -23,9 +23,10 @@ use crate::api::rest::sse_adapter::SseUserEventPublisher;
 use crate::config::UsersInfoConfig;
 use crate::domain::events::UserDomainEvent;
 use crate::domain::local_client::client::UsersInfoLocalClient;
-use crate::domain::ports::{AuditPort, EventPublisher};
+use crate::domain::ports::{AuditPort, EventPublisher, UsersMetricsPort};
 use crate::domain::service::{AppServices, ServiceConfig};
 use crate::infra::audit::HttpAuditClient;
+use crate::infra::metrics::UsersMetricsMeter;
 use crate::infra::storage::{OrmAddressesRepository, OrmCitiesRepository, OrmUsersRepository};
 
 /// Type alias for the concrete `AppServices` type used with ORM repositories.
@@ -110,6 +111,13 @@ impl Module for UsersInfo {
         let cities_repo = OrmCitiesRepository::new(limit_cfg);
         let addresses_repo = OrmAddressesRepository::new(limit_cfg);
 
+        // Create metrics adapter
+        let scope =
+            opentelemetry::InstrumentationScope::builder(Self::MODULE_NAME.to_owned()).build();
+        let metrics: Arc<dyn UsersMetricsPort> = Arc::new(UsersMetricsMeter::new(
+            &opentelemetry::global::meter_with_scope(scope),
+        ));
+
         // Create services with repository dependencies
         let services = Arc::new(AppServices::new(
             users_repo,
@@ -120,6 +128,7 @@ impl Module for UsersInfo {
             audit_adapter,
             authz,
             service_config,
+            metrics,
         ));
 
         self.service

--- a/examples/modkit/users-info/users-info/src/test_support.rs
+++ b/examples/modkit/users-info/users-info/src/test_support.rs
@@ -18,7 +18,7 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::domain::events::UserDomainEvent;
-use crate::domain::ports::{AuditPort, EventPublisher};
+use crate::domain::ports::{AuditPort, EventPublisher, UsersMetricsPort};
 use crate::domain::service::ServiceConfig;
 use crate::infra::storage::{OrmAddressesRepository, OrmCitiesRepository, OrmUsersRepository};
 use crate::module::ConcreteAppServices;
@@ -100,6 +100,11 @@ pub async fn seed_user(
 
 pub struct MockEventPublisher;
 pub struct MockAuditPort;
+pub struct MockUsersMetricsPort;
+
+impl UsersMetricsPort for MockUsersMetricsPort {
+    fn record_get_user(&self, _result: &str) {}
+}
 
 impl EventPublisher<UserDomainEvent> for MockEventPublisher {
     fn publish(&self, _event: &UserDomainEvent) {}
@@ -221,6 +226,7 @@ pub fn build_services_with_authz(
         Arc::new(MockAuditPort),
         authz,
         config,
+        Arc::new(MockUsersMetricsPort),
     ))
 }
 

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -130,3 +130,4 @@ tempfile = { workspace = true }
 temp-env = { workspace = true }
 modkit-db = { workspace = true, features = ["sqlite"] }
 tracing-subscriber = { workspace = true }
+tokio-metrics = { workspace = true }

--- a/libs/modkit/src/bootstrap/host/metrics_provider.rs
+++ b/libs/modkit/src/bootstrap/host/metrics_provider.rs
@@ -1,0 +1,128 @@
+use std::sync::OnceLock;
+
+use crate::telemetry::TracingConfig;
+
+#[cfg(feature = "otel")]
+use {
+    crate::telemetry::config::ExporterKind,
+    anyhow::Context,
+    opentelemetry_otlp::{Protocol, WithExportConfig, WithHttpConfig, WithTonicConfig},
+    opentelemetry_sdk::metrics::SdkMeterProvider,
+};
+
+#[cfg(feature = "otel")]
+static METRICS_INIT: OnceLock<Result<(), String>> = OnceLock::new();
+
+/// Build a [`SdkMeterProvider`] from [`MetricsConfig::exporter`] settings and
+/// register it as the global meter provider via [`init_metrics`].
+///
+/// The OTLP endpoint, headers, and timeout are taken from
+/// `TracingConfig::metrics.exporter`, allowing metrics to use a different
+/// collector endpoint than traces.
+///
+/// This function is guarded by [`OnceLock`] — the provider is built and
+/// registered at most once; subsequent calls return the cached result.
+///
+/// Returns `Ok(())` when metrics are successfully initialized, or an `Err` when
+/// metrics configuration is missing/disabled or the exporter fails to build.
+///
+/// # Errors
+///
+/// - Metrics `enabled == false` (propagated from `init_metrics`).
+/// - The OTLP metric exporter cannot be constructed.
+#[cfg(feature = "otel")]
+pub fn init_metrics_provider(cfg: &TracingConfig) -> anyhow::Result<()> {
+    METRICS_INIT
+        .get_or_init(|| do_init_metrics_provider(cfg).map_err(|e| e.to_string()))
+        .clone()
+        .map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+#[cfg(feature = "otel")]
+fn do_init_metrics_provider(cfg: &TracingConfig) -> anyhow::Result<()> {
+    let metrics_cfg = &cfg.metrics;
+
+    let (kind, endpoint, timeout) = {
+        let (k, ep) = metrics_cfg.exporter.as_ref().map_or_else(
+            || (ExporterKind::OtlpGrpc, "http://127.0.0.1:4317".to_owned()),
+            |e| {
+                (
+                    e.kind,
+                    e.endpoint
+                        .clone()
+                        .unwrap_or_else(|| "http://127.0.0.1:4317".to_owned()),
+                )
+            },
+        );
+        let t = metrics_cfg
+            .exporter
+            .as_ref()
+            .and_then(|e| e.timeout_ms)
+            .map(std::time::Duration::from_millis);
+        (k, ep, t)
+    };
+
+    // Build OTLP metric exporter matching the configured transport
+    let exporter = if matches!(kind, ExporterKind::OtlpHttp) {
+        let mut b = opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(&endpoint);
+        if let Some(t) = timeout {
+            b = b.with_timeout(t);
+        }
+        if let Some(headers) =
+            crate::telemetry::init::build_headers_from_cfg_and_env(metrics_cfg.exporter.as_ref())
+        {
+            b = b.with_headers(headers);
+        }
+        b.build().context("build OTLP HTTP metric exporter")?
+    } else {
+        let mut b = opentelemetry_otlp::MetricExporter::builder()
+            .with_tonic()
+            .with_endpoint(&endpoint);
+        if let Some(t) = timeout {
+            b = b.with_timeout(t);
+        }
+        if let Some(md) =
+            crate::telemetry::init::build_metadata_from_cfg_and_env(metrics_cfg.exporter.as_ref())
+        {
+            b = b.with_metadata(md);
+        }
+        b.build().context("build OTLP gRPC metric exporter")?
+    };
+
+    // Build resource with service name (reuse tracing helper)
+    let resource = crate::telemetry::init::build_resource(cfg);
+
+    // Build the SdkMeterProvider with periodic exporter
+    let mut builder = SdkMeterProvider::builder()
+        .with_periodic_exporter(exporter)
+        .with_resource(resource);
+
+    // Apply a global cardinality limit when configured
+    if let Some(limit) = metrics_cfg.cardinality_limit {
+        builder = builder.with_view(move |_: &opentelemetry_sdk::metrics::Instrument| {
+            opentelemetry_sdk::metrics::Stream::builder()
+                .with_cardinality_limit(limit)
+                .build()
+                .ok()
+        });
+    }
+
+    let provider = builder.build();
+
+    // Delegate to init_metrics which validates config and sets global provider
+    crate::telemetry::init::init_metrics(metrics_cfg, provider)?;
+
+    Ok(())
+}
+
+/// No-op when the `otel` feature is disabled.
+///
+/// # Errors
+/// Always returns an error indicating the feature is disabled.
+#[cfg(not(feature = "otel"))]
+pub fn init_metrics_provider(_cfg: &TracingConfig) -> anyhow::Result<()> {
+    Err(anyhow::anyhow!("otel feature is disabled"))
+}

--- a/libs/modkit/src/bootstrap/host/mod.rs
+++ b/libs/modkit/src/bootstrap/host/mod.rs
@@ -6,11 +6,13 @@
 //! Configuration types are now in the top-level `config` module.
 
 pub mod logging;
+pub mod metrics_provider;
 pub mod panic;
 pub mod paths;
 pub mod signals;
 
 pub use logging::*;
+pub use metrics_provider::*;
 pub use panic::*;
 pub use paths::{HomeDirError, expand_tilde, normalize_path};
 pub use signals::*;

--- a/libs/modkit/src/bootstrap/run.rs
+++ b/libs/modkit/src/bootstrap/run.rs
@@ -81,9 +81,12 @@ pub async fn run_server(config: AppConfig) -> anyhow::Result<()> {
 
     let result = run(run_options).await;
 
-    // Graceful shutdown - flush any remaining traces
+    // Graceful shutdown - flush remaining telemetry
     #[cfg(feature = "otel")]
-    crate::telemetry::init::shutdown_tracing();
+    {
+        crate::telemetry::init::shutdown_metrics();
+        crate::telemetry::init::shutdown_tracing();
+    }
 
     result
 }
@@ -150,9 +153,12 @@ pub async fn run_migrate(config: AppConfig) -> anyhow::Result<()> {
     // Run only the migration phases (pre-init + DB migration)
     let result = host.run_migration_phases().await;
 
-    // Graceful shutdown - flush any remaining traces
+    // Graceful shutdown - flush remaining telemetry
     #[cfg(feature = "otel")]
-    crate::telemetry::init::shutdown_tracing();
+    {
+        crate::telemetry::init::shutdown_metrics();
+        crate::telemetry::init::shutdown_tracing();
+    }
 
     result?;
 

--- a/libs/modkit/src/context.rs
+++ b/libs/modkit/src/context.rs
@@ -208,11 +208,6 @@ impl ModuleCtx {
         })
     }
 
-    #[must_use]
-    pub fn current_module(&self) -> Option<&str> {
-        Some(&self.module_name)
-    }
-
     /// Deserialize the module's config section into T, or use defaults if missing.
     ///
     /// This method uses lenient configuration loading: if the module is not present in config,

--- a/libs/modkit/src/telemetry/config.rs
+++ b/libs/modkit/src/telemetry/config.rs
@@ -1,6 +1,7 @@
-//! OpenTelemetry tracing configuration types
+//! OpenTelemetry tracing and metrics configuration types
 //!
-//! These types define the configuration structure for OpenTelemetry distributed tracing.
+//! These types define the configuration structure for OpenTelemetry distributed
+//! tracing and metrics.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -16,6 +17,20 @@ pub struct TracingConfig {
     pub resource: Option<HashMap<String, String>>,
     pub http: Option<HttpOpts>,
     pub logs_correlation: Option<LogsCorrelation>,
+    #[serde(default)]
+    pub metrics: MetricsConfig,
+}
+
+/// Metrics configuration for OpenTelemetry metrics collection
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct MetricsConfig {
+    pub enabled: bool,
+    pub exporter: Option<Exporter>,
+    /// Maximum number of distinct attribute combinations per instrument.
+    /// When the limit is reached, new combinations are folded into an
+    /// overflow data point.  `None` means the SDK default is used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cardinality_limit: Option<usize>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq, Copy)]

--- a/libs/modkit/src/telemetry/init.rs
+++ b/libs/modkit/src/telemetry/init.rs
@@ -21,6 +21,7 @@ use opentelemetry_sdk::{
     trace::{Sampler, SdkTracerProvider},
 };
 
+use super::config::MetricsConfig;
 #[cfg(feature = "otel")]
 use super::config::TracingConfig;
 #[cfg(feature = "otel")]
@@ -32,7 +33,7 @@ use tonic::metadata::{MetadataKey, MetadataMap, MetadataValue};
 
 /// Build resource with service name and custom attributes
 #[cfg(feature = "otel")]
-fn build_resource(cfg: &TracingConfig) -> Resource {
+pub(crate) fn build_resource(cfg: &TracingConfig) -> Resource {
     let service_name = cfg.service_name.as_deref().unwrap_or("hyperspot");
     let mut attrs = vec![KeyValue::new("service.name", service_name.to_owned())];
 
@@ -102,7 +103,7 @@ fn build_http_exporter(
     if let Some(t) = timeout {
         b = b.with_timeout(t);
     }
-    if let Some(hmap) = build_headers_from_cfg_and_env(cfg) {
+    if let Some(hmap) = build_headers_from_cfg_and_env(cfg.exporter.as_ref()) {
         b = b.with_headers(hmap);
     }
     #[allow(clippy::expect_used)]
@@ -122,7 +123,7 @@ fn build_grpc_exporter(
     if let Some(t) = timeout {
         b = b.with_timeout(t);
     }
-    if let Some(md) = build_metadata_from_cfg_and_env(cfg) {
+    if let Some(md) = build_metadata_from_cfg_and_env(cfg.exporter.as_ref()) {
         b = b.with_metadata(md);
     }
     b.build().context("build OTLP gRPC exporter")
@@ -185,14 +186,14 @@ pub fn init_tracing(
 }
 
 #[cfg(feature = "otel")]
-fn build_headers_from_cfg_and_env(
-    cfg: &TracingConfig,
+pub(crate) fn build_headers_from_cfg_and_env(
+    exporter: Option<&crate::telemetry::config::Exporter>,
 ) -> Option<std::collections::HashMap<String, String>> {
     use std::collections::HashMap;
     let mut out: HashMap<String, String> = HashMap::new();
 
     // From config file
-    if let Some(exp) = &cfg.exporter
+    if let Some(exp) = exporter
         && let Some(hdrs) = &exp.headers
     {
         for (k, v) in hdrs {
@@ -213,8 +214,11 @@ fn build_headers_from_cfg_and_env(
 }
 
 #[cfg(feature = "otel")]
-fn extend_metadata_from_source<'a, I>(md: &mut MetadataMap, source: I, context: &'static str)
-where
+pub(crate) fn extend_metadata_from_source<'a, I>(
+    md: &mut MetadataMap,
+    source: I,
+    context: &'static str,
+) where
     I: Iterator<Item = (&'a str, &'a str)>,
 {
     for (k, v) in source {
@@ -235,11 +239,13 @@ where
 }
 
 #[cfg(feature = "otel")]
-fn build_metadata_from_cfg_and_env(cfg: &TracingConfig) -> Option<MetadataMap> {
+pub(crate) fn build_metadata_from_cfg_and_env(
+    exporter: Option<&crate::telemetry::config::Exporter>,
+) -> Option<MetadataMap> {
     let mut md = MetadataMap::new();
 
     // From config file
-    if let Some(exp) = &cfg.exporter
+    if let Some(exp) = exporter
         && let Some(hdrs) = &exp.headers
     {
         let iter = hdrs.iter().map(|(k, v)| (k.as_str(), v.as_str()));
@@ -286,6 +292,55 @@ pub fn shutdown_tracing() {
     tracing::info!("Tracing shutdown (no-op)");
 }
 
+/// Gracefully shut down OpenTelemetry metrics.
+/// In opentelemetry 0.31 there is no global `shutdown_meter_provider()`.
+/// Keep a handle to `SdkMeterProvider` in your app state and call `shutdown()`
+/// during graceful shutdown. This function remains a no-op for compatibility.
+#[cfg(feature = "otel")]
+pub fn shutdown_metrics() {
+    tracing::info!("Metrics shutdown: no-op (keep a provider handle to call `shutdown()`).");
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn shutdown_metrics() {
+    tracing::info!("Metrics shutdown (no-op)");
+}
+
+// ===== init_metrics (feature = "otel") =========================================
+
+/// Initialize OpenTelemetry metrics by registering the given
+/// [`SdkMeterProvider`] as the global meter provider.
+///
+/// The provider is expected to be fully configured (exporter, views, resource,
+/// etc.) by the caller before being passed in — this function only makes it
+/// globally available.
+///
+/// # Errors
+/// Returns an error if [`MetricsConfig::enabled`] is `false`.
+#[cfg(feature = "otel")]
+#[allow(clippy::needless_pass_by_value)]
+pub fn init_metrics(
+    cfg: &MetricsConfig,
+    provider: opentelemetry_sdk::metrics::SdkMeterProvider,
+) -> anyhow::Result<()> {
+    if !cfg.enabled {
+        return Err(anyhow::anyhow!("metrics is disabled"));
+    }
+    global::set_meter_provider(provider);
+    tracing::info!("OpenTelemetry metrics initialized successfully");
+    Ok(())
+}
+
+/// Initialize OpenTelemetry metrics (no-op when otel feature is disabled).
+///
+/// # Errors
+/// This function always returns an error when the otel feature is disabled.
+#[cfg(not(feature = "otel"))]
+pub fn init_metrics(_cfg: &MetricsConfig, _provider: ()) -> anyhow::Result<()> {
+    tracing::info!("Metrics configuration provided but runtime feature is disabled");
+    Err(anyhow::anyhow!("otel feature is disabled"))
+}
+
 // ===== connectivity probe =====================================================
 
 /// Build a tiny, separate OTLP pipeline and export a single span to verify connectivity.
@@ -325,7 +380,7 @@ pub fn otel_connectivity_probe(cfg: &super::config::TracingConfig) -> anyhow::Re
             .with_http()
             .with_protocol(Protocol::HttpBinary)
             .with_endpoint(endpoint);
-        if let Some(h) = build_headers_from_cfg_and_env(cfg) {
+        if let Some(h) = build_headers_from_cfg_and_env(cfg.exporter.as_ref()) {
             b = b.with_headers(h);
         }
         b.build()
@@ -334,7 +389,7 @@ pub fn otel_connectivity_probe(cfg: &super::config::TracingConfig) -> anyhow::Re
         let mut b = opentelemetry_otlp::SpanExporter::builder()
             .with_tonic()
             .with_endpoint(endpoint);
-        if let Some(md) = build_metadata_from_cfg_and_env(cfg) {
+        if let Some(md) = build_metadata_from_cfg_and_env(cfg.exporter.as_ref()) {
             b = b.with_metadata(md);
         }
         b.build()
@@ -532,7 +587,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_headers_from_cfg_and_env(&cfg);
+        let result = build_headers_from_cfg_and_env(cfg.exporter.as_ref());
         // Should be None if no headers configured and no env var
         // (unless OTEL_EXPORTER_OTLP_HEADERS is set, which we can't control in tests)
         assert!(result.is_none() || result.is_some());
@@ -555,7 +610,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_headers_from_cfg_and_env(&cfg);
+        let result = build_headers_from_cfg_and_env(cfg.exporter.as_ref());
         assert!(result.is_some());
         let result_headers = result.unwrap();
         assert_eq!(
@@ -572,7 +627,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_metadata_from_cfg_and_env(&cfg);
+        let result = build_metadata_from_cfg_and_env(cfg.exporter.as_ref());
         // Should be None if no headers configured and no env var
         assert!(result.is_none() || result.is_some());
     }
@@ -594,7 +649,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_metadata_from_cfg_and_env(&cfg);
+        let result = build_metadata_from_cfg_and_env(cfg.exporter.as_ref());
         assert!(result.is_some());
         let metadata = result.unwrap();
         assert!(!metadata.is_empty());
@@ -618,7 +673,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_metadata_from_cfg_and_env(&cfg);
+        let result = build_metadata_from_cfg_and_env(cfg.exporter.as_ref());
         assert!(result.is_some());
         let metadata = result.unwrap();
         assert_eq!(metadata.len(), 2);
@@ -642,7 +697,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_metadata_from_cfg_and_env(&cfg);
+        let result = build_metadata_from_cfg_and_env(cfg.exporter.as_ref());
         assert!(result.is_some());
         let metadata = result.unwrap();
         // Should only have the valid header
@@ -653,5 +708,34 @@ mod tests {
     fn test_shutdown_tracing_does_not_panic() {
         // Should not panic regardless of feature state
         shutdown_tracing();
+    }
+
+    #[test]
+    #[cfg(feature = "otel")]
+    fn test_init_metrics_disabled() {
+        use crate::telemetry::config::MetricsConfig;
+        let cfg = MetricsConfig {
+            enabled: false,
+            exporter: None,
+            ..Default::default()
+        };
+        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder().build();
+        let result = init_metrics(&cfg, provider);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("disabled"));
+    }
+
+    #[test]
+    #[cfg(feature = "otel")]
+    fn test_init_metrics_enabled() {
+        use crate::telemetry::config::MetricsConfig;
+        let cfg = MetricsConfig {
+            enabled: true,
+            exporter: None,
+            ..Default::default()
+        };
+        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder().build();
+        let result = init_metrics(&cfg, provider);
+        assert!(result.is_ok());
     }
 }

--- a/libs/modkit/src/telemetry/mod.rs
+++ b/libs/modkit/src/telemetry/mod.rs
@@ -7,6 +7,10 @@ pub mod config;
 pub mod init;
 pub mod throttled_log;
 
-pub use config::{Exporter, HttpOpts, LogsCorrelation, Propagation, Sampler, TracingConfig};
+pub use config::{
+    Exporter, HttpOpts, LogsCorrelation, MetricsConfig, Propagation, Sampler, TracingConfig,
+};
+#[cfg(feature = "otel")]
+pub use init::init_metrics;
 pub use init::{init_tracing, shutdown_tracing};
 pub use throttled_log::ThrottledLog;


### PR DESCRIPTION
Add metrics recorder with cardinality limitation.

REAL-163

**Note**: current PR contains both metrics mechanism implementation for presentation and comparison discussion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry metrics collection and export added (disabled by default); startup attempts initialization and logs failures without aborting.
  * Example service now records a get_user counter and exposes metrics to the router.

* **Configuration**
  * New metrics subsections in server and quickstart configs with OTLP exporter options and timeout defaults.

* **Shutdown**
  * Graceful shutdown now flushes metrics before tracing.

* **Tests**
  * Added tests validating metric recording and provider behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->