### PR TITLE
chore: add DE0701/DE0702 lints for unscoped SeaORM queries and raw SQL

### DIFF
--- a/dylint_lints/Cargo.lock
+++ b/dylint_lints/Cargo.lock
@@ -1084,6 +1084,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "de0701_seaorm_no_unscoped_query"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "dylint_testing",
+ "lint_utils",
+ "sea-orm",
+]
+
+[[package]]
+name = "de0702_seaorm_no_execute_unprepared"
+version = "0.1.0"
+dependencies = [
+ "clippy_utils",
+ "dylint_linting",
+ "dylint_testing",
+ "lint_utils",
+ "sea-orm",
+]
+
+[[package]]
 name = "de0706_no_direct_sqlx"
 version = "0.1.0"
 dependencies = [

--- a/dylint_lints/Cargo.toml
+++ b/dylint_lints/Cargo.toml
@@ -13,6 +13,8 @@ members = [
     "de03_domain_layer/de0301_no_infra_in_domain",
     "de03_domain_layer/de0308_no_http_in_domain",
     "de05_client_layer/de0503_plugin_client_suffix",
+    "de07_security/de0701_seaorm_no_unscoped_query",
+    "de07_security/de0702_seaorm_no_execute_unprepared",
     "de07_security/de0706_no_direct_sqlx",
     "de08_rest_api_conventions/de0801_api_endpoint_version",
     "de08_rest_api_conventions/de0802_use_odata_ext",

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/.cargo/config.toml
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/.cargo/config.toml
@@ -1,0 +1,6 @@
+
+[target.'cfg(all())']
+rustflags = ["-C", "linker=dylint-link"]
+# For Rust versions 1.74.0 and onward, the following alternative can be used
+# (see https://github.com/rust-lang/cargo/pull/12535):
+# linker = "dylint-link"

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/Cargo.toml
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "de0701_seaorm_no_unscoped_query"
+version = "0.1.0"
+authors = ["Cyber Fabric"]
+description = "Prohibits unscoped SeaORM queries; use .secure().scope_with() instead (DE0701)"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[[example]]
+name = "unscoped_find_all"
+path = "ui/unscoped_find_all.rs"
+
+[[example]]
+name = "unscoped_find_one"
+path = "ui/unscoped_find_one.rs"
+
+[[example]]
+name = "unscoped_find_count"
+path = "ui/unscoped_find_count.rs"
+
+[[example]]
+name = "unscoped_update_delete"
+path = "ui/unscoped_update_delete.rs"
+
+[[example]]
+name = "secure_without_scope"
+path = "ui/secure_without_scope.rs"
+
+[[example]]
+name = "secure_patterns"
+path = "ui/secure_patterns.rs"
+
+[dependencies]
+clippy_utils.workspace = true
+dylint_linting.workspace = true
+lint_utils.workspace = true
+
+[dev-dependencies]
+dylint_testing.workspace = true
+sea-orm.workspace = true
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/rust-toolchain
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-09-18"
+components = ["llvm-tools-preview", "rustc-dev"]

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/src/lib.rs
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/src/lib.rs
@@ -1,0 +1,267 @@
+#![feature(rustc_private)]
+#![warn(unused_extern_crates)]
+
+extern crate rustc_hir;
+extern crate rustc_span;
+
+use lint_utils::{filename_str, is_temp_path};
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Detects unscoped SeaORM queries in module code. Specifically flags:
+    /// - `Entity::find().all(conn)` / `.one(conn)` / `.count(conn)` without `.secure().scope_with()`
+    /// - `Entity::update_many().exec(conn)` without `.secure().scope_with()`
+    /// - `Entity::delete_many().exec(conn)` without `.secure().scope_with()`
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Plain SeaORM queries bypass the Secure ORM layer (`SecureSelect`, `SecureUpdateMany`,
+    /// `SecureDeleteMany`), which enforces tenant isolation and access scoping via typestate.
+    /// Unscoped queries can leak data across tenants or allow unauthorized modifications.
+    ///
+    /// ### Known Exclusions
+    ///
+    /// This lint does NOT apply to:
+    /// - `libs/modkit-db/` — the secure wrapper library itself
+    /// - `libs/` in general — infrastructure libraries may need raw access
+    /// - `apps/hyperspot-server/` — server setup code
+    ///
+    /// ### Known Limitations
+    ///
+    /// This lint uses method-name matching on the HIR call chain, not DefId-based type
+    /// resolution. A local trait that defines `.secure()` and `.scope_with()` methods with
+    /// matching names would satisfy the lint without providing actual Secure ORM scoping.
+    /// This is an intentional tradeoff: full type resolution for cross-crate traits is not
+    /// reliably available in Dylint `LateLintPass`. The lint acts as a guardrail, not a
+    /// security boundary — deliberate circumvention is caught by code review.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// // Bad — unscoped read
+    /// let users = user::Entity::find().all(conn).await?;
+    ///
+    /// // Good — scoped read
+    /// let users = user::Entity::find()
+    ///     .secure()
+    ///     .scope_with(&scope)
+    ///     .all(conn)
+    ///     .await?;
+    /// ```
+    pub DE0701_SEAORM_NO_UNSCOPED_QUERY,
+    Deny,
+    "unscoped SeaORM query detected; use .secure().scope_with() instead (DE0701)"
+}
+
+/// Terminal methods on `Select` that execute a query.
+const SELECT_TERMINALS: &[&str] = &["all", "one", "count"];
+
+/// Terminal methods on `UpdateMany` / `DeleteMany` that execute a mutation.
+const EXEC_TERMINALS: &[&str] = &["exec"];
+
+/// Methods in the call chain that BOTH must be present to indicate secure usage.
+/// `.secure()` creates the typestate wrapper, `.scope_with()` applies the tenant filter.
+const SECURE_MARKERS: &[&str] = &["secure", "scope_with"];
+
+/// Entry-point methods that start a SeaORM query chain we care about.
+/// `find` → Select chain, `update_many` / `delete_many` → mutation chain.
+const CHAIN_ENTRY_POINTS: &[&str] = &["find", "find_by_id", "update_many", "delete_many"];
+
+/// Check if a file path should be linted.
+/// We only lint module crate code (under `modules/`).
+fn should_lint_file(source_map: &rustc_span::source_map::SourceMap, span: rustc_span::Span) -> bool {
+    let Some(path) = filename_str(source_map, span) else {
+        return false;
+    };
+
+    // Always lint files in temp directories (UI tests)
+    if is_temp_path(&path) {
+        return true;
+    }
+
+    // Normalize path separators for cross-platform compatibility (Windows uses `\`)
+    let normalized = path.replace('\\', "/");
+
+    // Skip migrations — they legitimately need raw DDL
+    if normalized.contains("migrations/") {
+        return false;
+    }
+
+    // Only lint files under modules/
+    normalized.contains("modules/")
+}
+
+/// Result of walking a method-call chain.
+struct ChainInfo<'tcx> {
+    /// Method names from root to terminal, e.g. `["find", "filter", "all"]`.
+    methods: Vec<&'tcx str>,
+    /// `true` when the root of the chain is an associated function call
+    /// (e.g. `Entity::find()`, `Model::find_by_id()`), meaning it has the
+    /// `Type::func()` form. This distinguishes SeaORM entry points from
+    /// arbitrary method calls that happen to share the same name.
+    root_is_associated_call: bool,
+}
+
+/// Walk a method-call chain backwards (from receiver to origin) collecting method names.
+/// Returns a [`ChainInfo`] with the ordered list and whether the root is an associated call.
+///
+/// For `Entity::find().filter(x).all(conn)`:
+///  → methods: `["find", "filter", "all"]`, root_is_associated_call: true
+fn collect_chain_info<'tcx>(expr: &'tcx Expr<'tcx>) -> ChainInfo<'tcx> {
+    let mut methods = Vec::new();
+    let mut current = expr;
+    let mut root_is_associated_call = false;
+
+    loop {
+        match &current.kind {
+            ExprKind::MethodCall(seg, receiver, _args, _span) => {
+                methods.push(seg.ident.name.as_str());
+                current = receiver;
+            }
+            ExprKind::Call(func, _args) => {
+                // Associated function call like Entity::find()
+                if let ExprKind::Path(qpath) = &func.kind {
+                    if let Some(last_seg) = last_path_segment(qpath) {
+                        methods.push(last_seg);
+                        root_is_associated_call = true;
+                    }
+                }
+                break;
+            }
+            _ => break,
+        }
+    }
+
+    methods.reverse();
+    ChainInfo { methods, root_is_associated_call }
+}
+
+/// Extract the last segment name from a QPath.
+fn last_path_segment<'tcx>(qpath: &'tcx rustc_hir::QPath<'tcx>) -> Option<&'tcx str> {
+    match qpath {
+        rustc_hir::QPath::Resolved(_, path) => {
+            path.segments.last().map(|s| s.ident.name.as_str())
+        }
+        rustc_hir::QPath::TypeRelative(_ty, seg) => Some(seg.ident.name.as_str()),
+        _ => None,
+    }
+}
+
+/// Determine if a method chain contains ALL required secure markers
+/// (both `.secure()` and `.scope_with()`).
+fn chain_has_secure_marker(methods: &[&str]) -> bool {
+    SECURE_MARKERS.iter().all(|marker| methods.contains(marker))
+}
+
+/// Determine if the chain starts with a SeaORM entry point we care about.
+/// Only matches when the root of the chain is an associated function call
+/// (e.g. `Entity::find()`) whose name is in [`CHAIN_ENTRY_POINTS`].
+fn chain_has_entry_point(info: &ChainInfo<'_>) -> bool {
+    info.root_is_associated_call
+        && info.methods.first().is_some_and(|m| CHAIN_ENTRY_POINTS.contains(m))
+}
+
+/// Get the operation-specific help message based on the entry point and terminal method.
+fn help_message(methods: &[&str], terminal: &str) -> &'static str {
+    if methods.contains(&"update_many") {
+        "use Entity::update_many().secure().scope_with(&scope).exec(conn) instead"
+    } else if methods.contains(&"delete_many") {
+        "use Entity::delete_many().secure().scope_with(&scope).exec(conn) instead"
+    } else {
+        match terminal {
+            "all" => "use Entity::find().secure().scope_with(&scope).all(conn) instead",
+            "one" => "use Entity::find().secure().scope_with(&scope).one(conn) instead",
+            "count" => "use Entity::find().secure().scope_with(&scope).count(conn) instead",
+            _ => "use Entity::find().secure().scope_with(&scope).all(conn) instead",
+        }
+    }
+}
+
+/// Get the terminal kind for the error message.
+fn terminal_kind(terminal: &str) -> &'static str {
+    match terminal {
+        "all" => "unscoped .all() query",
+        "one" => "unscoped .one() query",
+        "count" => "unscoped .count() query",
+        "exec" => "unscoped .exec() on update/delete",
+        _ => "unscoped query",
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for De0701SeaormNoUnscopedQuery {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        // Only check method calls
+        let ExprKind::MethodCall(method_seg, _receiver, _args, call_span) = &expr.kind else {
+            return;
+        };
+
+        let method_name = method_seg.ident.name.as_str();
+
+        // Quick check: is this a terminal method we care about?
+        let is_select_terminal = SELECT_TERMINALS.contains(&method_name);
+        let is_exec_terminal = EXEC_TERMINALS.contains(&method_name);
+
+        if !is_select_terminal && !is_exec_terminal {
+            return;
+        }
+
+        // Check file path filter
+        if !should_lint_file(cx.sess().source_map(), *call_span) {
+            return;
+        }
+
+        // Collect the full method chain
+        let info = collect_chain_info(expr);
+
+        // Must start with a SeaORM associated-call entry point
+        if !chain_has_entry_point(&info) {
+            return;
+        }
+
+        let chain = &info.methods;
+
+        // For .exec() terminals, only flag if chain contains update_many or delete_many
+        if is_exec_terminal
+            && !chain.contains(&"update_many")
+            && !chain.contains(&"delete_many")
+        {
+            return;
+        }
+
+        // If chain already has .secure() and .scope_with(), this is a properly scoped query
+        if chain_has_secure_marker(chain) {
+            return;
+        }
+
+        // Emit the lint
+        let kind = terminal_kind(method_name);
+        cx.span_lint(
+            DE0701_SEAORM_NO_UNSCOPED_QUERY,
+            expr.span,
+            |diag| {
+                diag.primary_message(format!("{kind} detected — bypasses Secure ORM scoping (DE0701)"));
+                diag.help(help_message(chain, method_name));
+                diag.note(
+                    "unscoped queries bypass tenant isolation; wrap with .secure().scope_with(&scope)",
+                );
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn ui_examples() {
+        dylint_testing::ui_test_examples(env!("CARGO_PKG_NAME"));
+    }
+
+    #[test]
+    fn test_comment_annotations_match_stderr() {
+        let ui_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
+        lint_utils::test_comment_annotations_match_stderr(&ui_dir, "DE0701", "unscoped query");
+    }
+}

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/secure_patterns.rs
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/secure_patterns.rs
@@ -1,0 +1,87 @@
+// Test file for DE0701: Secure patterns that should NOT trigger the lint
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use sea_orm::entity::prelude::*;
+
+// Minimal entity definition for testing
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    pub name: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+// ── Test-only shim ──────────────────────────────────────────────────────
+// The real secure extension traits (SecureEntityExt, SecureUpdateExt, …)
+// live in libs/modkit-db which belongs to the main workspace and cannot be
+// imported here.  This no-op shim provides `.secure()` and `.scope_with()`
+// method names so the code below compiles and the lint's name-based chain
+// detection sees them.
+//
+// Because DE0701 uses method-name matching (not DefId / type resolution),
+// any trait that exposes identically-named methods will satisfy the lint.
+// This is a documented known limitation (see lib.rs "Known Limitations").
+// The shim therefore correctly exercises the positive path of the lint —
+// if name-based detection ever changes to type-aware detection, this test
+// must be updated to use the real traits or a more faithful mock.
+// ────────────────────────────────────────────────────────────────────────
+trait SecureExt {
+    fn secure(self) -> Self;
+    fn scope_with(self, scope: &str) -> Self;
+}
+
+impl SecureExt for sea_orm::Select<Entity> {
+    fn secure(self) -> Self { self }
+    fn scope_with(self, _scope: &str) -> Self { self }
+}
+
+impl SecureExt for sea_orm::UpdateMany<Entity> {
+    fn secure(self) -> Self { self }
+    fn scope_with(self, _scope: &str) -> Self { self }
+}
+
+impl SecureExt for sea_orm::DeleteMany<Entity> {
+    fn secure(self) -> Self { self }
+    fn scope_with(self, _scope: &str) -> Self { self }
+}
+
+/// Scoped `Entity::find().secure().scope_with().all()` — should NOT trigger DE0701.
+async fn good_find_all_secure(conn: &impl ConnectionTrait) {
+    // Should not trigger DE0701 - unscoped query
+    let _ = Entity::find().secure().scope_with("scope").all(conn).await;
+}
+
+/// Scoped `Entity::find().secure().scope_with().one()` — should NOT trigger DE0701.
+async fn good_find_one_secure(conn: &impl ConnectionTrait) {
+    // Should not trigger DE0701 - unscoped query
+    let _ = Entity::find().secure().scope_with("scope").one(conn).await;
+}
+
+/// Scoped `Entity::find().secure().scope_with().count()` — should NOT trigger DE0701.
+async fn good_find_count_secure(conn: &impl ConnectionTrait) {
+    // Should not trigger DE0701 - unscoped query
+    let _ = Entity::find().secure().scope_with("scope").count(conn).await;
+}
+
+/// Scoped `Entity::update_many().secure().scope_with().exec()` — should NOT trigger DE0701.
+async fn good_update_many_secure(conn: &impl ConnectionTrait) {
+    // Should not trigger DE0701 - unscoped query
+    let _ = Entity::update_many().secure().scope_with("scope").exec(conn).await;
+}
+
+/// Scoped `Entity::delete_many().secure().scope_with().exec()` — should NOT trigger DE0701.
+async fn good_delete_many_secure(conn: &impl ConnectionTrait) {
+    // Should not trigger DE0701 - unscoped query
+    let _ = Entity::delete_many().secure().scope_with("scope").exec(conn).await;
+}
+
+/// Test entry point.
+fn main() {}

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/secure_without_scope.rs
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/secure_without_scope.rs
@@ -1,0 +1,58 @@
+// Test file for DE0701: .secure() without .scope_with() should still trigger
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use sea_orm::entity::prelude::*;
+
+// Minimal entity definition for testing
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    pub name: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+// Simulate the secure() method (without scope_with)
+trait SecureExt {
+    fn secure(self) -> Self;
+}
+
+impl SecureExt for sea_orm::Select<Entity> {
+    fn secure(self) -> Self { self }
+}
+
+impl SecureExt for sea_orm::UpdateMany<Entity> {
+    fn secure(self) -> Self { self }
+}
+
+impl SecureExt for sea_orm::DeleteMany<Entity> {
+    fn secure(self) -> Self { self }
+}
+
+/// `.secure()` without `.scope_with()` on `.all()` — should trigger DE0701.
+async fn bad_secure_without_scope_all(conn: &impl ConnectionTrait) {
+    // Should trigger DE0701 - unscoped query
+    let _ = Entity::find().secure().all(conn).await;
+}
+
+/// `.secure()` without `.scope_with()` on `.one()` — should trigger DE0701.
+async fn bad_secure_without_scope_one(conn: &impl ConnectionTrait) {
+    // Should trigger DE0701 - unscoped query
+    let _ = Entity::find().secure().one(conn).await;
+}
+
+/// `.secure()` without `.scope_with()` on `.exec()` — should trigger DE0701.
+async fn bad_secure_without_scope_exec(conn: &impl ConnectionTrait) {
+    // Should trigger DE0701 - unscoped query
+    let _ = Entity::update_many().secure().exec(conn).await;
+}
+
+/// Test entry point.
+fn main() {}

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/secure_without_scope.stderr
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/secure_without_scope.stderr
@@ -1,0 +1,30 @@
+error: unscoped .all() query detected — bypasses Secure ORM scoping (DE0701)
+  --> $DIR/secure_without_scope.rs:42:13
+   |
+LL |     let _ = Entity::find().secure().all(conn).await;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use Entity::find().secure().scope_with(&scope).all(conn) instead
+   = note: unscoped queries bypass tenant isolation; wrap with .secure().scope_with(&scope)
+   = note: `#[deny(de0701_seaorm_no_unscoped_query)]` on by default
+
+error: unscoped .one() query detected — bypasses Secure ORM scoping (DE0701)
+  --> $DIR/secure_without_scope.rs:48:13
+   |
+LL |     let _ = Entity::find().secure().one(conn).await;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use Entity::find().secure().scope_with(&scope).one(conn) instead
+   = note: unscoped queries bypass tenant isolation; wrap with .secure().scope_with(&scope)
+
+error: unscoped .exec() on update/delete detected — bypasses Secure ORM scoping (DE0701)
+  --> $DIR/secure_without_scope.rs:54:13
+   |
+LL |     let _ = Entity::update_many().secure().exec(conn).await;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use Entity::update_many().secure().scope_with(&scope).exec(conn) instead
+   = note: unscoped queries bypass tenant isolation; wrap with .secure().scope_with(&scope)
+
+error: aborting due to 3 previous errors
+

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_all.rs
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_all.rs
@@ -1,0 +1,35 @@
+// Test file for DE0701: Unscoped SeaORM .find().all() detection
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use sea_orm::entity::prelude::*;
+
+// Minimal entity definition for testing
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    pub name: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+/// Unscoped `Entity::find().all()` — should trigger DE0701.
+async fn bad_find_all(conn: &impl ConnectionTrait) {
+    // Should trigger DE0701 - unscoped query
+    let _ = Entity::find().all(conn).await;
+}
+
+/// Unscoped `Entity::find().filter().all()` — should trigger DE0701.
+async fn bad_find_all_with_filter(conn: &impl ConnectionTrait) {
+    // Should trigger DE0701 - unscoped query
+    let _ = Entity::find().filter(Column::Name.eq("test")).all(conn).await;
+}
+
+/// Test entry point.
+fn main() {}

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_all.stderr
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_all.stderr
@@ -1,0 +1,21 @@
+error: unscoped .all() query detected — bypasses Secure ORM scoping (DE0701)
+  --> $DIR/unscoped_find_all.rs:25:13
+   |
+LL |     let _ = Entity::find().all(conn).await;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use Entity::find().secure().scope_with(&scope).all(conn) instead
+   = note: unscoped queries bypass tenant isolation; wrap with .secure().scope_with(&scope)
+   = note: `#[deny(de0701_seaorm_no_unscoped_query)]` on by default
+
+error: unscoped .all() query detected — bypasses Secure ORM scoping (DE0701)
+  --> $DIR/unscoped_find_all.rs:31:13
+   |
+LL |     let _ = Entity::find().filter(Column::Name.eq("test")).all(conn).await;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use Entity::find().secure().scope_with(&scope).all(conn) instead
+   = note: unscoped queries bypass tenant isolation; wrap with .secure().scope_with(&scope)
+
+error: aborting due to 2 previous errors
+

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_count.rs
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_count.rs
@@ -1,0 +1,29 @@
+// Test file for DE0701: Unscoped SeaORM .find().count() detection
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use sea_orm::entity::prelude::*;
+
+// Minimal entity definition for testing
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    pub name: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+/// Unscoped `Entity::find().count()` — should trigger DE0701.
+async fn bad_find_count(conn: &impl ConnectionTrait) {
+    // Should trigger DE0701 - unscoped query
+    let _ = Entity::find().count(conn).await;
+}
+
+/// Test entry point.
+fn main() {}

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_count.stderr
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_count.stderr
@@ -1,0 +1,12 @@
+error: unscoped .count() query detected — bypasses Secure ORM scoping (DE0701)
+  --> $DIR/unscoped_find_count.rs:25:13
+   |
+LL |     let _ = Entity::find().count(conn).await;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use Entity::find().secure().scope_with(&scope).count(conn) instead
+   = note: unscoped queries bypass tenant isolation; wrap with .secure().scope_with(&scope)
+   = note: `#[deny(de0701_seaorm_no_unscoped_query)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_one.rs
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_one.rs
@@ -1,0 +1,29 @@
+// Test file for DE0701: Unscoped SeaORM .find().one() detection
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use sea_orm::entity::prelude::*;
+
+// Minimal entity definition for testing
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    pub name: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+/// Unscoped `Entity::find().one()` — should trigger DE0701.
+async fn bad_find_one(conn: &impl ConnectionTrait) {
+    // Should trigger DE0701 - unscoped query
+    let _ = Entity::find().one(conn).await;
+}
+
+/// Test entry point.
+fn main() {}

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_one.stderr
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_find_one.stderr
@@ -1,0 +1,12 @@
+error: unscoped .one() query detected — bypasses Secure ORM scoping (DE0701)
+  --> $DIR/unscoped_find_one.rs:25:13
+   |
+LL |     let _ = Entity::find().one(conn).await;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use Entity::find().secure().scope_with(&scope).one(conn) instead
+   = note: unscoped queries bypass tenant isolation; wrap with .secure().scope_with(&scope)
+   = note: `#[deny(de0701_seaorm_no_unscoped_query)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_update_delete.rs
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_update_delete.rs
@@ -1,0 +1,35 @@
+// Test file for DE0701: Unscoped SeaORM update_many/delete_many .exec() detection
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use sea_orm::entity::prelude::*;
+
+// Minimal entity definition for testing
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    pub name: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+/// Unscoped `Entity::update_many().exec()` — should trigger DE0701.
+async fn bad_update_many(conn: &impl ConnectionTrait) {
+    // Should trigger DE0701 - unscoped query
+    let _ = Entity::update_many().exec(conn).await;
+}
+
+/// Unscoped `Entity::delete_many().exec()` — should trigger DE0701.
+async fn bad_delete_many(conn: &impl ConnectionTrait) {
+    // Should trigger DE0701 - unscoped query
+    let _ = Entity::delete_many().exec(conn).await;
+}
+
+/// Test entry point.
+fn main() {}

--- a/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_update_delete.stderr
+++ b/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/unscoped_update_delete.stderr
@@ -1,0 +1,21 @@
+error: unscoped .exec() on update/delete detected — bypasses Secure ORM scoping (DE0701)
+  --> $DIR/unscoped_update_delete.rs:25:13
+   |
+LL |     let _ = Entity::update_many().exec(conn).await;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use Entity::update_many().secure().scope_with(&scope).exec(conn) instead
+   = note: unscoped queries bypass tenant isolation; wrap with .secure().scope_with(&scope)
+   = note: `#[deny(de0701_seaorm_no_unscoped_query)]` on by default
+
+error: unscoped .exec() on update/delete detected — bypasses Secure ORM scoping (DE0701)
+  --> $DIR/unscoped_update_delete.rs:31:13
+   |
+LL |     let _ = Entity::delete_many().exec(conn).await;
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use Entity::delete_many().secure().scope_with(&scope).exec(conn) instead
+   = note: unscoped queries bypass tenant isolation; wrap with .secure().scope_with(&scope)
+
+error: aborting due to 2 previous errors
+

--- a/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/.cargo/config.toml
+++ b/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/.cargo/config.toml
@@ -1,0 +1,6 @@
+
+[target.'cfg(all())']
+rustflags = ["-C", "linker=dylint-link"]
+# For Rust versions 1.74.0 and onward, the following alternative can be used
+# (see https://github.com/rust-lang/cargo/pull/12535):
+# linker = "dylint-link"

--- a/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/Cargo.toml
+++ b/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "de0702_seaorm_no_execute_unprepared"
+version = "0.1.0"
+authors = ["Cyber Fabric"]
+description = "Prohibits ConnectionTrait::execute_unprepared() and raw SQL via Statement::from_string (DE0702)"
+edition.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[[example]]
+name = "bad_execute_unprepared"
+path = "ui/bad_execute_unprepared.rs"
+
+[[example]]
+name = "bad_statement_from_string"
+path = "ui/bad_statement_from_string.rs"
+
+[[example]]
+name = "good_secure_queries"
+path = "ui/good_secure_queries.rs"
+
+[dependencies]
+clippy_utils.workspace = true
+dylint_linting.workspace = true
+lint_utils.workspace = true
+
+[dev-dependencies]
+dylint_testing.workspace = true
+sea-orm.workspace = true
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/rust-toolchain
+++ b/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-09-18"
+components = ["llvm-tools-preview", "rustc-dev"]

--- a/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/src/lib.rs
+++ b/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/src/lib.rs
@@ -1,0 +1,195 @@
+#![feature(rustc_private)]
+#![warn(unused_extern_crates)]
+
+extern crate rustc_hir;
+extern crate rustc_span;
+
+use lint_utils::{filename_str, is_temp_path};
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Detects raw SQL usage in module code:
+    /// - `ConnectionTrait::execute_unprepared(...)` — always denied
+    /// - `Statement::from_string(...)` — denied as it constructs raw SQL
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Raw SQL bypasses the Secure ORM layer entirely:
+    /// - No tenant isolation enforcement
+    /// - No access scope filtering
+    /// - Prone to SQL injection if inputs are not carefully sanitized
+    /// - Harder to audit and maintain
+    ///
+    /// ### Known Exclusions
+    ///
+    /// This lint does NOT apply to:
+    /// - `libs/modkit-db/` — the secure wrapper library itself
+    /// - `libs/` in general — infrastructure libraries may need raw SQL for migrations
+    /// - `apps/hyperspot-server/` — server setup code
+    ///
+    /// ### Known Limitations
+    ///
+    /// This lint uses method-name and path-segment matching, not DefId-based type resolution.
+    /// - `execute_unprepared` matches any method with that name regardless of the receiver type.
+    /// - `Statement::from_string` matches path segments as strings; aliasing (e.g.,
+    ///   `use sea_orm::Statement as Stmt; Stmt::from_string(...)`) is not detected.
+    ///
+    /// This is an intentional tradeoff: full cross-crate type resolution is not reliably
+    /// available in Dylint `LateLintPass`. The lint acts as a guardrail, not a security
+    /// boundary — deliberate circumvention is caught by code review.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// // Bad — raw SQL
+    /// conn.execute_unprepared("DELETE FROM users WHERE id = 1").await?;
+    ///
+    /// // Bad — raw SQL via Statement
+    /// let stmt = Statement::from_string(DbBackend::Postgres, "SELECT * FROM users");
+    /// conn.execute(stmt).await?;
+    ///
+    /// // Good — use Secure ORM
+    /// user::Entity::find().secure().scope_with(&scope).all(conn).await?;
+    /// ```
+    pub DE0702_SEAORM_NO_EXECUTE_UNPREPARED,
+    Deny,
+    "raw SQL usage detected; use Secure ORM queries instead (DE0702)"
+}
+
+/// Check if a file path should be linted.
+/// We only lint module crate code (under `modules/`).
+fn should_lint_file(source_map: &rustc_span::source_map::SourceMap, span: rustc_span::Span) -> bool {
+    let Some(path) = filename_str(source_map, span) else {
+        return false;
+    };
+
+    // Always lint files in temp directories (UI tests)
+    if is_temp_path(&path) {
+        return true;
+    }
+
+    // Normalize path separators for cross-platform compatibility (Windows uses `\`)
+    let normalized = path.replace('\\', "/");
+
+    // Skip migrations — they legitimately need raw DDL
+    if normalized.contains("migrations/") {
+        return false;
+    }
+
+    // Only lint files under modules/
+    normalized.contains("modules/")
+}
+
+/// Check if a QPath ends with a specific function name.
+fn qpath_ends_with(qpath: &rustc_hir::QPath<'_>, name: &str) -> bool {
+    match qpath {
+        rustc_hir::QPath::Resolved(_, path) => {
+            path.segments.last().is_some_and(|s| s.ident.name.as_str() == name)
+        }
+        rustc_hir::QPath::TypeRelative(_ty, seg) => seg.ident.name.as_str() == name,
+        _ => false,
+    }
+}
+
+/// Check if a QPath matches `Statement::from_string` or `sea_orm::Statement::from_string`.
+fn is_statement_from_string(qpath: &rustc_hir::QPath<'_>) -> bool {
+    match qpath {
+        rustc_hir::QPath::TypeRelative(ty, seg) => {
+            if seg.ident.name.as_str() != "from_string" {
+                return false;
+            }
+            // Check if the type is `Statement`
+            if let rustc_hir::TyKind::Path(inner_qpath) = &ty.kind {
+                return qpath_ends_with(inner_qpath, "Statement");
+            }
+            false
+        }
+        rustc_hir::QPath::Resolved(_, path) => {
+            let segments: Vec<&str> = path.segments.iter().map(|s| s.ident.name.as_str()).collect();
+            // Match Statement::from_string or sea_orm::Statement::from_string
+            segments.len() >= 2
+                && segments[segments.len() - 1] == "from_string"
+                && segments[segments.len() - 2] == "Statement"
+        }
+        _ => false,
+    }
+}
+
+impl<'tcx> LateLintPass<'tcx> for De0702SeaormNoExecuteUnprepared {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        match &expr.kind {
+            // Detect .execute_unprepared(...) method calls
+            ExprKind::MethodCall(seg, _receiver, _args, call_span) => {
+                let method_name = seg.ident.name.as_str();
+
+                if method_name != "execute_unprepared" {
+                    return;
+                }
+
+                if !should_lint_file(cx.sess().source_map(), *call_span) {
+                    return;
+                }
+
+                cx.span_lint(
+                    DE0702_SEAORM_NO_EXECUTE_UNPREPARED,
+                    expr.span,
+                    |diag| {
+                        diag.primary_message(
+                            "execute_unprepared() detected — raw SQL bypasses Secure ORM (DE0702)",
+                        );
+                        diag.help("use SecureSelect, SecureUpdateMany, or SecureDeleteMany instead");
+                        diag.note(
+                            "raw SQL bypasses tenant isolation and access scoping; use the Secure ORM layer",
+                        );
+                    },
+                );
+            }
+            // Detect Statement::from_string(...) calls
+            ExprKind::Call(func, _args) => {
+                if let ExprKind::Path(qpath) = &func.kind {
+                    if !is_statement_from_string(qpath) {
+                        return;
+                    }
+
+                    if !should_lint_file(cx.sess().source_map(), func.span) {
+                        return;
+                    }
+
+                    cx.span_lint(
+                        DE0702_SEAORM_NO_EXECUTE_UNPREPARED,
+                        expr.span,
+                        |diag| {
+                            diag.primary_message(
+                                "Statement::from_string() detected — raw SQL construction bypasses Secure ORM (DE0702)",
+                            );
+                            diag.help(
+                                "use Entity::find().secure().scope_with() or other Secure ORM wrappers instead",
+                            );
+                            diag.note(
+                                "raw SQL bypasses tenant isolation and access scoping; use the Secure ORM layer",
+                            );
+                        },
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn ui_examples() {
+        dylint_testing::ui_test_examples(env!("CARGO_PKG_NAME"));
+    }
+
+    #[test]
+    fn test_comment_annotations_match_stderr() {
+        let ui_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ui");
+        lint_utils::test_comment_annotations_match_stderr(&ui_dir, "DE0702", "raw SQL");
+    }
+}

--- a/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/ui/bad_execute_unprepared.rs
+++ b/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/ui/bad_execute_unprepared.rs
@@ -1,0 +1,26 @@
+// Test file for DE0702: execute_unprepared detection
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use sea_orm::ConnectionTrait;
+use sea_orm::DbBackend;
+
+// Simulate execute_unprepared — in real code this comes from ConnectionTrait
+struct FakeConn;
+
+impl FakeConn {
+    async fn execute_unprepared(&self, _sql: &str) -> Result<(), ()> {
+        Ok(())
+    }
+}
+
+/// Raw SQL via `execute_unprepared()` — should trigger DE0702.
+async fn bad_execute_unprepared() {
+    let conn = FakeConn;
+    // Should trigger DE0702 - raw SQL
+    conn.execute_unprepared("DELETE FROM users WHERE id = 1").await.ok();
+}
+
+/// Test entry point.
+fn main() {}

--- a/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/ui/bad_execute_unprepared.stderr
+++ b/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/ui/bad_execute_unprepared.stderr
@@ -1,0 +1,12 @@
+error: execute_unprepared() detected — raw SQL bypasses Secure ORM (DE0702)
+  --> $DIR/bad_execute_unprepared.rs:22:5
+   |
+LL |     conn.execute_unprepared("DELETE FROM users WHERE id = 1").await.ok();
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use SecureSelect, SecureUpdateMany, or SecureDeleteMany instead
+   = note: raw SQL bypasses tenant isolation and access scoping; use the Secure ORM layer
+   = note: `#[deny(de0702_seaorm_no_execute_unprepared)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/ui/bad_statement_from_string.rs
+++ b/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/ui/bad_statement_from_string.rs
@@ -1,0 +1,15 @@
+// Test file for DE0702: Statement::from_string detection
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use sea_orm::{ConnectionTrait, DbBackend, Statement};
+
+/// Raw SQL via `Statement::from_string()` — should trigger DE0702.
+async fn bad_statement_from_string() {
+    // Should trigger DE0702 - raw SQL
+    let _stmt = Statement::from_string(DbBackend::Postgres, "SELECT * FROM users");
+}
+
+/// Test entry point.
+fn main() {}

--- a/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/ui/bad_statement_from_string.stderr
+++ b/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/ui/bad_statement_from_string.stderr
@@ -1,0 +1,12 @@
+error: Statement::from_string() detected — raw SQL construction bypasses Secure ORM (DE0702)
+  --> $DIR/bad_statement_from_string.rs:11:17
+   |
+LL |     let _stmt = Statement::from_string(DbBackend::Postgres, "SELECT * FROM users");
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: use Entity::find().secure().scope_with() or other Secure ORM wrappers instead
+   = note: raw SQL bypasses tenant isolation and access scoping; use the Secure ORM layer
+   = note: `#[deny(de0702_seaorm_no_execute_unprepared)]` on by default
+
+error: aborting due to 1 previous error
+

--- a/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/ui/good_secure_queries.rs
+++ b/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/ui/good_secure_queries.rs
@@ -1,0 +1,27 @@
+// Test file for DE0702: Secure patterns that should NOT trigger the lint
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use sea_orm::entity::prelude::*;
+use sea_orm::ConnectionTrait;
+
+// Minimal entity definition for testing
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Uuid,
+    pub name: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}
+
+// Regular SeaORM methods that are NOT execute_unprepared or Statement::from_string
+// should not trigger. The unscoped query lint (DE0701) handles those separately.
+
+/// Test entry point.
+fn main() {}


### PR DESCRIPTION
## Add Dylint lints for unscoped SeaORM queries and raw SQL (DE0701, DE0702)

Adds two new Dylint security lints that flag unsafe SeaORM usage in module crates, catching bypasses of the Secure ORM layer in CI.

### New lints

- **DE0701 `seaorm_no_unscoped_query`** — flags unscoped SeaORM query chains:
  - `Entity::find().all/one/count(conn)` without [.secure().scope_with()](cci:1://file:///home/josephc/hyperspot/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/secure_patterns.rs:38:4-38:36)
  - `Entity::update_many/delete_many().exec(conn)` without [.secure().scope_with()](cci:1://file:///home/josephc/hyperspot/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/secure_patterns.rs:38:4-38:36)
- **DE0702 `seaorm_no_execute_unprepared`** — flags raw SQL usage:
  - [conn.execute_unprepared(...)](cci:1://file:///home/josephc/hyperspot/dylint_lints/de07_security/de0702_seaorm_no_execute_unprepared/ui/bad_execute_unprepared.rs:12:4-14:5) calls
  - `Statement::from_string(...)` construction

### Scope

- Only applies to `modules/**`
- Excludes `migrations/` directories (legitimate DDL usage)
- Does not lint `libs/`, `apps/`, or `examples/`

### Ergonomics

- Clear error messages with the exact secure alternative
- Supports `#[allow(...)]` for justified exceptions (e.g. internal admin ops)

### Testing

- UI tests for all bad patterns (unscoped find/update/delete, execute_unprepared, Statement::from_string)
- UI tests for secure patterns ([.secure().scope_with()](cci:1://file:///home/josephc/hyperspot/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/ui/secure_patterns.rs:38:4-38:36) chains)
- Comment annotation tests ([test_comment_annotations_match_stderr](cci:1://file:///home/josephc/hyperspot/dylint_lints/de07_security/de0701_seaorm_no_unscoped_query/src/lib.rs:225:4-229:5))
- `make dylint` passes cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DE0701: Detects unscoped SeaORM queries and enforces secure scoping (.secure().scope_with()).
  * DE0702: Flags raw SQL/execute_unprepared usage that bypasses the Secure ORM and recommends secure query alternatives.

* **Tests**
  * Added comprehensive UI test cases and diagnostic outputs demonstrating violations and suggested fixes for both lints.

* **Chores**
  * Added new lint crates to the workspace and included toolchain/configuration snippets for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->