### PR TITLE
test: revive the 'make all'

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,12 @@
 name: e2e
 
 on:
-  push:
-    branches: ["main"]
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'guidelines/**'
   schedule:
     - cron: "0 2 * * *" # nightly full E2E at 02:00 UTC
   workflow_dispatch:
@@ -47,16 +51,16 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            make e2e-smoke
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.mode }}" = "smoke" ]; then
-            make e2e-smoke
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            make e2e-local            # nightly — full suite
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.mode }}" = "full" ]; then
+            make e2e-local            # manual — full suite
           else
-            make e2e
+            make e2e-local            # PR / manual-smoke, TODO: switch to e2e-local-smoke later
           fi
 
-      - name: Create or update issue on smoke failure
-        if: failure() && github.event_name == 'push'
+      - name: Create or update issue on nightly failure
+        if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
@@ -92,10 +96,10 @@ jobs:
               }
             }
 
-            const title = "E2E smoke failed on main";
+            const title = "Nightly E2E failed";
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             const body = [
-              "Smoke E2E tests failed on `main`.",
+              "Nightly E2E tests failed.",
               "",
               `- Commit: ${sha}`,
               `- Assigned to (latest commit author): @${assignee}`,
@@ -103,7 +107,7 @@ jobs:
             ].join("\n");
 
             const search = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${owner}/${repo} is:issue is:open in:title "${title}" label:e2e-smoke`,
+              q: `repo:${owner}/${repo} is:issue is:open in:title "${title}" label:e2e-nightly`,
               per_page: 1,
             });
 
@@ -122,12 +126,7 @@ jobs:
                 repo,
                 title,
                 body,
-                labels: ["bug", "e2e-smoke", "ci"],
+                labels: ["bug", "e2e-nightly", "ci"],
               });
               await tryAssign(created.data.number);
             }
-
-      # cleans up stopped containers, dangling build cache, and unused networks.
-      - name: Docker cleanup
-        if: always()
-        run: docker system prune --force

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Set up Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.1
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,6 +64,17 @@ jobs:
             make e2e-local            # PR / manual-smoke, TODO: switch to e2e-local-smoke later
           fi
 
+      - name: Upload E2E logs
+        if: failure()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: e2e-logs-${{ github.run_id }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            ${{ github.workspace }}/tmp/e2e-logs/**
+            ${{ runner.home }}/.hyperspot/logs/**
+
       - name: Create or update issue on nightly failure
         if: failure() && github.event_name == 'schedule'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OPENAPI_URL ?= http://127.0.0.1:8087/openapi.json
 OPENAPI_OUT ?= docs/api/api.json
 
 # E2E Docker args
-E2E_ARGS ?= --features users-info-example
+E2E_ARGS ?= --features users-info-example,static-tenants,static-authz
 
 # -------- Utility macros --------
 
@@ -314,22 +314,26 @@ test-users-info-pg:
 
 # -------- E2E tests --------
 
-.PHONY: e2e e2e-local e2e-docker e2e-smoke
+.PHONY: e2e e2e-local e2e-local-smoke e2e-docker e2e-docker-smoke
 
 # Run E2E tests in Docker (default)
 e2e: e2e-docker
 
+## Run E2E tests in Docker environment
+e2e-docker:
+	python3 scripts/ci.py e2e-docker $(E2E_ARGS)
+
 ## Run E2E smoke tests in Docker (only tests marked @pytest.mark.smoke)
-e2e-smoke:
-	python3 scripts/ci.py e2e --docker $(E2E_ARGS) -- -m smoke
+e2e-docker-smoke:
+	python3 scripts/ci.py e2e-docker $(E2E_ARGS) -- -m smoke
 
 # Run E2E tests locally
 e2e-local:
-	python3 scripts/ci.py e2e
+	python3 scripts/ci.py e2e-local
 
-## Run E2E tests in Docker environment
-e2e-docker:
-	python3 scripts/ci.py e2e --docker $(E2E_ARGS)
+## Run E2E smoke tests locally (only tests marked @pytest.mark.smoke)
+e2e-local-smoke:
+	python3 scripts/ci.py e2e-local --smoke
 
 # -------- Code coverage --------
 

--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,7 @@ coverage-unit:
 
 ## Ensure needed packages and programs installed for local e2e testing
 check-prereq-e2e-local:
-	python scripts/check_local_env.py --mode e2e-local
+	python3 scripts/check_local_env.py --mode e2e-local
 
 # Generate code coverage report (e2e-local tests only)
 coverage-e2e-local: check-prereq-e2e-local

--- a/README.md
+++ b/README.md
@@ -272,18 +272,7 @@ make kani   # optional deep safety verification (Kani verifier)
 
 ### E2E Tests
 
-E2E tests require Python dependencies and pytest:
-
-```bash
-pip install -r testing/requirements.txt
-```
-
-```bash
-make e2e-local  # Run e2e tests locally against a running server
-make e2e-docker # Run e2e tests in a Docker container
-make coverage-e2e # Run e2e tests with code coverage
-make coverage # Run both unit and e2e tests with code coverage
-```
+See [E2E Tests](testing/e2e/README.md) for details.
 
 ## Contributing
 

--- a/config/e2e-features.txt
+++ b/config/e2e-features.txt
@@ -1,0 +1,1 @@
+users-info-example,static-tenants,static-authz

--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -94,7 +94,7 @@ modules:
   api-gateway:
     # No database needed for api-gateway
     config:
-      bind_addr: "127.0.0.1:8086"
+      bind_addr: "0.0.0.0:8086"
       enable_docs: true
       cors_enabled: false
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,304 @@
+# Testing Policy
+
+This document defines the test strategy, coverage requirements, and CI enforcement for
+Cyber Fabric.  It is the single source of truth for "what must be tested and how."
+
+---
+
+## 1. Test Pyramid
+
+| Layer | Scope | Tooling | Feature gate | Runs in CI |
+|-------|-------|---------|--------------|------------|
+| **Unit** | Single function / struct / module in isolation | `cargo test --workspace` | none (always compiled) | Every PR (`ci.yml` — `test` job, all OS) |
+| **Integration** | Cross-crate or DB-backed logic (SQLite, Postgres, MySQL) | `cargo test -p <pkg> --features integration` | `#[cfg(feature = "integration")]` | Every PR (`ci.yml` — `integration` job, Ubuntu) |
+| **E2E** | Full HTTP request → response through a running server | pytest + httpx against `hyperspot-server` | n/a (Python tests) | PRs to `main`, nightly schedule (`e2e.yml`) |
+| **Fuzz** | Parser / validator robustness against arbitrary input | `cargo-fuzz` (libFuzzer) | nightly toolchain | PRs + nightly (`clusterfuzzlite.yml`) |
+| **Static analysis** | Architectural rules, unsafe code, dependency licenses | clippy, dylint, cargo-deny, cargo-kani, cargo-geiger | varies | Every PR (`ci.yml` — `test`, `security`, `dylint` jobs) |
+
+```bash
+make check                  # full quality gate (fmt + clippy + test + security)
+```
+
+### Quick-reference commands
+
+```bash
+make test                  # unit tests (workspace, all OS)
+make test-sqlite           # integration — SQLite
+make test-pg               # integration — PostgreSQL
+make test-mysql            # integration — MySQL
+make test-db               # all DB integration tests
+make test-users-info-pg    # users-info module integration (Postgres)
+make e2e-docker            # E2E — Docker environment
+make e2e-docker-smoke      # E2E — Docker environment (smoke subset only)
+make e2e-local             # E2E — local server (builds + starts automatically)
+make e2e-local-smoke       # E2E — smoke subset only
+make fuzz                  # fuzz — 30 s smoke per target
+make check                 # full quality gate (fmt + clippy + test + security)
+make all                   # full pipeline (build + check + test-sqlite + e2e-local)
+```
+
+---
+
+## 2. Coverage
+
+### 2.1 Threshold
+
+The project-wide **line-coverage threshold is 80 %**.  The threshold is enforced in
+`scripts/coverage.py` (`COVERAGE_THRESHOLD`) and printed as a warning when any module
+or library falls below it.
+
+### 2.2 Coverage modes
+
+| Mode | Command | What it measures |
+|------|---------|------------------|
+| **Unit** | `make coverage-unit` | All `#[test]` functions across the workspace (compiled with `--all-features`) |
+| **E2E** | `make coverage-e2e-local` | Server code exercised by the pytest E2E suite via an instrumented binary |
+| **Combined** | `make coverage` | Unit + E2E accumulated into a single report |
+
+> **Why no separate "integration" coverage mode?**
+> Unit coverage already compiles with `--all-features`, which enables the `integration`
+> feature gate.  SQLite-backed integration tests therefore execute as part of
+> `make coverage-unit`.  A separate mode would re-run the same tests and produce
+> identical data — so it is intentionally omitted to avoid confusion.
+
+### 2.3 CI coverage
+
+The `coverage` job in `ci.yml` runs on every PR using `cargo-llvm-cov` (nightly) and
+uploads an LCOV report to Codecov.
+
+### 2.4 Reports
+
+Local coverage commands produce four report formats under `coverage/<mode>/`:
+
+| File | Format |
+|------|--------|
+| `html/index.html` | Interactive HTML (per-file, per-line) |
+| `summary.txt` | Text summary |
+| `lcov.info` | LCOV (for IDE plugins and CI upload) |
+| `coverage.json` | JSON (machine-readable, used by the custom report) |
+| `coverage_report.txt` | Custom per-module/per-library table |
+
+---
+
+## 3. Unit Tests
+
+### 3.1 Expectations
+
+- Every new public function, method, or behaviour **must** have at least one unit test.
+- Tests live next to the code they exercise, in a `#[cfg(test)] mod tests` block.
+- Use descriptive names: `test_<function>_<scenario>_<expected>`.
+- Prefer deterministic assertions — avoid sleeping or time-dependent checks.
+
+### 3.2 Running
+
+```bash
+cargo test --workspace          # all unit tests
+cargo test -p cf-oagw           # single package
+cargo test -p cf-modkit-db -- cursor  # filtered by name
+```
+
+---
+
+## 4. Integration Tests
+
+Integration tests verify cross-crate or database-backed behaviour.  They are gated
+behind the `integration` Cargo feature so that `cargo test --workspace` (without
+`--all-features`) does **not** require a running database.
+
+### 4.1 Feature gates
+
+| Package | Features | Backend |
+|---------|----------|---------|
+| `cf-modkit-db` | `sqlite,integration` | SQLite (in-process) |
+| `cf-modkit-db` | `pg,integration` | PostgreSQL (requires running instance) |
+| `cf-modkit-db` | `mysql,integration` | MySQL (requires running instance) |
+| `users-info` | `integration` | PostgreSQL |
+
+### 4.2 Running
+
+```bash
+make test-sqlite           # quick, no external services needed
+make test-pg               # requires Postgres
+make test-mysql            # requires MySQL
+make test-db               # all three
+make test-users-info-pg    # users-info Postgres integration
+```
+
+### 4.3 CI
+
+The `integration` job in `ci.yml` runs SQLite, Postgres, and MySQL integration tests
+plus macro UI tests on every PR (Ubuntu only).
+
+---
+
+## 5. End-to-End (E2E) Tests
+
+E2E tests exercise the full HTTP surface of `hyperspot-server` using Python (pytest +
+httpx).
+
+### 5.1 Expectations
+
+- Every user-facing REST endpoint **should** have at least one E2E smoke test.
+- Critical flows (CRUD, auth, error responses) **must** have full E2E coverage.
+- Mark lightweight, fast tests with `@pytest.mark.smoke` — these run on every PR.
+
+### 5.2 Modes
+
+| Mode | Backend | Use case |
+|------|---------|----------|
+| **Local** (`make e2e-local`) | Builds a release binary, starts it locally | Development, CI |
+| **Docker** (`make e2e-docker`) | Builds a Docker image, runs in container | Isolation, reproducibility |
+
+### 5.3 CI
+
+The `e2e.yml` workflow runs:
+- **On PRs to `main`**: full E2E suite (local mode).
+- **Nightly (02:00 UTC)**: full E2E suite.  Failures auto-create a GitHub issue
+  assigned to the last commit author.
+- **Manual dispatch**: smoke or full, selectable.
+
+### 5.4 Writing E2E tests
+
+See [`testing/e2e/README.md`](../testing/e2e/README.md) for fixtures, examples, and
+environment variables.
+
+---
+
+## 6. Fuzz Testing
+
+Fuzz testing targets parsers and validators to catch panics, logic bugs, and complexity
+attacks.
+
+### 6.1 When to fuzz
+
+- Before submitting changes to **parsers**, **validators**, or **deserialization** logic.
+- Nightly via ClusterFuzzLite in CI.
+
+### 6.2 Targets
+
+| Target | Priority | Component |
+|--------|----------|-----------|
+| `fuzz_odata_filter` | HIGH | OData `$filter` parser |
+| `fuzz_odata_cursor` | HIGH | Cursor pagination decoder |
+| `fuzz_yaml_config` | HIGH | YAML config parser |
+| `fuzz_html_parser` | MEDIUM | HTML document parser |
+| `fuzz_pdf_parser` | MEDIUM | PDF document parser |
+| `fuzz_json_config` | MEDIUM | JSON config parser |
+| `fuzz_odata_orderby` | MEDIUM | OData `$orderby` parser |
+| `fuzz_markdown_parser` | LOW | Markdown parser |
+
+### 6.3 Running
+
+```bash
+make fuzz                                # smoke (30 s per target)
+make fuzz-run FUZZ_TARGET=fuzz_odata_filter FUZZ_SECONDS=300  # longer run
+make fuzz-list                           # list all available targets
+make fuzz-build                          # build without running
+make fuzz-clean                          # remove fuzzing artifacts
+```
+
+Fuzzing runs automatically in CI via ClusterFuzzLite.
+See [`fuzz/README.md`](../fuzz/README.md) for corpus management and crash reproduction.
+
+---
+
+## 7. Static Analysis & Safety
+
+| Tool | Purpose | Command | CI job |
+|------|---------|---------|--------|
+| **clippy** | Lint for correctness and performance | `make clippy` | `test` |
+| **rustfmt** | Formatting enforcement | `make fmt` | `test` |
+| **dylint** | Project-specific architectural lints (layer separation, DTO placement) | `make dylint` | `dylint` |
+| **cargo-deny** | License compliance, advisories, banned crates | `make deny` | `security` |
+| **cargo-kani** | Formal verification of unsafe code and invariants | `make kani` | `test` (via `safety`) |
+| **cargo-geiger** | Audit of `unsafe` usage in dependencies | `make geiger` | manual |
+
+---
+
+## 8. CI / Development Commands
+
+Cyber Fabric uses a unified, cross-platform Python CI script (`scripts/ci.py`).
+This is the **primary entry point on Windows** where `make` is not available.
+Requires Python 3.9+.
+
+### 8.1 Cross-platform commands (`scripts/ci.py`)
+
+```bash
+python scripts/ci.py all            # build + full check suite + e2e
+python scripts/ci.py check          # fmt, clippy, test, audit, deny
+python scripts/ci.py fmt            # check formatting
+python scripts/ci.py fmt --fix      # auto-format code
+python scripts/ci.py clippy         # run linter
+python scripts/ci.py clippy --fix   # attempt to fix warnings
+python scripts/ci.py dylint         # custom project compliance lints
+python scripts/ci.py audit          # security audit
+python scripts/ci.py deny           # license & dependency checks
+python scripts/ci.py e2e-local      # build server + run E2E tests locally
+python scripts/ci.py e2e-local --smoke  # E2E smoke subset only
+python scripts/ci.py e2e-docker     # E2E in Docker
+python scripts/ci.py fuzz-build     # build fuzz targets
+python scripts/ci.py fuzz --seconds 60  # fuzz smoke run
+python scripts/ci.py fuzz-run fuzz_odata_filter --seconds 300  # single target
+```
+
+### 8.2 Makefile shortcuts (Unix / Linux / macOS)
+
+The `Makefile` wraps the same operations for convenience:
+
+```bash
+make all        # build + check + test-sqlite + e2e-local
+make check      # fmt + clippy + test + security
+make fmt        # formatting check (cargo fmt --all -- --check)
+make dev-fmt    # auto-format (cargo fmt --all)
+make clippy     # linting (clippy --workspace --all-targets --all-features)
+make lint       # compile with -D warnings
+make dylint     # custom architectural lints
+make deny       # cargo deny check
+make kani       # Kani formal verification (optional)
+make safety     # clippy + kani + lint + dylint
+```
+
+---
+
+## 9. CI Pipeline Summary
+
+```
+PR opened / updated
+  ├── ci.yml
+  │     ├── test          — fmt + clippy + unit tests (Ubuntu, macOS, Windows)
+  │     ├── integration   — DB integration tests (Ubuntu)
+  │     ├── security      — cargo-deny
+  │     ├── coverage      — cargo-llvm-cov → Codecov upload
+  │     └── dylint        — custom architectural lints
+  │
+  └── e2e.yml (PRs to main only)
+        └── e2e           — full E2E suite (local mode)
+
+Nightly (schedule)
+  ├── e2e.yml             — full E2E (auto-creates issue on failure)
+  └── clusterfuzzlite     — fuzz testing
+```
+
+---
+
+## 10. Contributor Checklist
+
+Before opening a PR, verify:
+
+- [ ] `make check` passes (fmt + clippy + unit tests + security)
+- [ ] New code has unit tests
+- [ ] Integration tests added/updated if DB logic changed
+- [ ] E2E tests added/updated if REST endpoints changed
+- [ ] `make coverage-unit` shows no regression below the 80 % threshold
+- [ ] Fuzz targets updated if parser/validator logic changed
+- [ ] No `#[allow(unused)]` or `#[allow(dead_code)]` without justification
+
+---
+
+## 11. Related Documents
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — development workflow, commit conventions, PR process
+- [testing/e2e/README.md](../testing/e2e/README.md) — E2E test guide, fixtures, advanced usage
+- [fuzz/README.md](../fuzz/README.md) — fuzz target reference, corpus management
+- [guidelines/SECURITY.md](../guidelines/SECURITY.md) — secure coding practices
+- [docs/QUICKSTART_GUIDE.md](./QUICKSTART_GUIDE.md) — getting started with the project

--- a/dylint_lints/Cargo.lock
+++ b/dylint_lints/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db-macros"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-error2",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "axum 0.8.8",
  "http",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "base64",
  "bigdecimal",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-security",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-security"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "postcard",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-utils"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "humantime",
  "serde",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdk-directory"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdks"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "cf-system-sdk-directory",
 ]
@@ -1799,9 +1799,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gts"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35490554642cb0c546c2edc82a66a3d5347fb3796f06d686005bad6617861b88"
+checksum = "ce6f5841b1df050923040aeb9574cdd232eaba91e64202e1c37a00cea9175a76"
 dependencies = [
  "gts-id",
  "jsonschema",
@@ -1818,18 +1818,18 @@ dependencies = [
 
 [[package]]
 name = "gts-id"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc89697e279954ac55254a190d64b0aad8434b4b6e50c1578818228f0e17a47"
+checksum = "9e872c9c5344cd49f705d8a82f4d35dd952146f0df88e7b10e6e3ee5eab526d4"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gts-macros"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a988585f888bfd7233d72ba246c0e47a1fee7034bfc2e2eecaa09f03db97982"
+checksum = "36248d3c70926565f362c82ddfa44485d9ea553b7a4698acf808df784b960be4"
 dependencies = [
  "gts-id",
  "proc-macro2",

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -781,7 +781,7 @@ def cmd_all(args):
     step("Building release (stable)")
     run_cmd(["cargo", "+stable", "build", "--release"])
     step("Running e2e-local")
-    cmd_e2e(argparse.Namespace(docker=False, pytest_args=[]))
+    cmd_e2e(argparse.Namespace(docker=False, smoke=False, pytest_args=[]))
     print("All (full pipeline) completed")
 
 

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -455,6 +455,8 @@ def cmd_e2e(args):
         env["E2E_DOCKER_MODE"] = "1"
 
     pytest_cmd = [PYTHON, "-m", "pytest", "testing/e2e", "-vv"]
+    if args.smoke:
+        pytest_cmd.extend(["-m", "smoke"])
     if args.pytest_args:
         # argparse.REMAINDER includes the '--' separator if used
         # We need to strip it so pytest doesn't treat following flags as files
@@ -817,6 +819,11 @@ def build_parser():
         "--features",
         default="users-info-example",
         help="Cargo features to enable for Docker build (default: users-info-example)",
+    )
+    p_e2e.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Run only tests marked with @pytest.mark.smoke",
     )
     p_e2e.add_argument(
         "pytest_args",

--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -891,7 +891,10 @@ def generate_reports(output_dir, mode, threshold=COVERAGE_THRESHOLD, use_color=F
     # Generate HTML report
     print("Generating HTML report...")
     html_dir = output_dir / "html"
-    base = ["cargo", "llvm-cov", "report", "--workspace"]
+    # Use `--no-run --workspace` instead of the `report` subcommand so that
+    # all workspace crates appear in the generated reports.  The `report`
+    # subcommand does not support `--workspace`.
+    base = ["cargo", "llvm-cov", "--no-run", "--workspace"]
     run_cmd(
         base
         + [
@@ -1145,8 +1148,8 @@ def validate_environment(command):
         print("\nERROR: Environment validation failed for "
               "{} coverage.".format(command))
         print("Please install missing prerequisites and try again.")
-        print("You can run 'python scripts/check_test_env.py --mode core' "
-              "or 'python scripts/check_test_env.py --mode e2e' "
+        print("You can run 'python3 scripts/check_local_env.py --mode core' "
+              "or 'python3 scripts/check_local_env.py --mode e2e-local' "
               "to see detailed requirements.")
         sys.exit(1)
 

--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -242,8 +242,11 @@ def categorize_file(rel_path):
             return 'lib', parts[1]
         return 'file', None
     elif rel_path.startswith('modules/'):
-        # Extract module name: modules/api_gateway/... -> api_gateway
+        # modules/system/ contains nested submodules (oagw, api-gateway, …).
+        # Use the submodule name so each one gets its own report row.
         parts = rel_path.split('/')
+        if len(parts) >= 3 and parts[1] == 'system':
+            return 'module', parts[2]
         if len(parts) >= 2:
             return 'module', parts[1]
         return 'file', None
@@ -888,7 +891,7 @@ def generate_reports(output_dir, mode, threshold=COVERAGE_THRESHOLD, use_color=F
     # Generate HTML report
     print("Generating HTML report...")
     html_dir = output_dir / "html"
-    base = ["cargo", "llvm-cov", "report"]
+    base = ["cargo", "llvm-cov", "report", "--workspace"]
     run_cmd(
         base
         + [
@@ -1045,7 +1048,7 @@ def cmd_coverage_e2e(args):
 
 
 def cmd_coverage_combined(args):
-    """Generate combined coverage from both unit and e2e tests."""
+    """Generate combined coverage from unit and e2e tests."""
     output_dir = COVERAGE_DIR / "combined"
     config_file = args.config if args.config else "config/e2e-local.yaml"
     threshold = args.threshold if hasattr(args, 'threshold') else COVERAGE_THRESHOLD

--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -30,7 +30,7 @@ from lib.platform import (
 PROJECT_ROOT = Path(__file__).parent.parent.absolute()
 COVERAGE_DIR = PROJECT_ROOT / "coverage"
 PYTHON = sys.executable or "python3"
-COVERAGE_THRESHOLD = 70
+COVERAGE_THRESHOLD = 80
 
 E2E_SERVER_FEATURES = read_e2e_features(PROJECT_ROOT)
 

--- a/scripts/lib/platform.py
+++ b/scripts/lib/platform.py
@@ -1,0 +1,153 @@
+"""
+Cross-platform helpers for HyperSpot build scripts.
+
+Centralises OS-specific logic so that coverage.py, ci.py and similar
+tools stay platform-agnostic.
+"""
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+IS_WINDOWS: bool = sys.platform == "win32"
+
+# ---------------------------------------------------------------------------
+# E2E feature set
+# ---------------------------------------------------------------------------
+
+def read_e2e_features(project_root: Path) -> str:
+    """Read the E2E feature set from *config/e2e-features.txt*.
+
+    The file must exist (even if empty).  Aborts with a clear error
+    message when it is missing.
+    """
+    p = project_root / "config" / "e2e-features.txt"
+    if not p.is_file():
+        print(
+            f"ERROR: required file not found: {p}\n"
+            "Create it with the desired Cargo feature list "
+            "(one comma-separated line, may be empty).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return p.read_text(encoding="utf-8").strip()
+
+
+# ---------------------------------------------------------------------------
+# Binary helpers
+# ---------------------------------------------------------------------------
+
+def binary_name(name: str) -> str:
+    """Return *name* with ``.exe`` appended on Windows."""
+    return f"{name}.exe" if IS_WINDOWS else name
+
+
+def find_binary(target_dir: Path, profile: str, name: str) -> Path:
+    """Resolve the full path to a Cargo-produced binary.
+
+    Args:
+        target_dir: Cargo target directory (e.g. ``project/target``).
+        profile: Build profile directory name (``debug`` or ``release``).
+        name: Binary name **without** platform extension.
+    """
+    return target_dir / profile / binary_name(name)
+
+
+# ---------------------------------------------------------------------------
+# Process management
+# ---------------------------------------------------------------------------
+
+def popen_new_group(cmd, **kwargs) -> subprocess.Popen:
+    """Start a subprocess in its own process group (cross-platform).
+
+    On Unix this sets ``start_new_session=True``; on Windows it uses
+    ``CREATE_NEW_PROCESS_GROUP``.  All extra *kwargs* are forwarded to
+    :class:`subprocess.Popen`.
+    """
+    if IS_WINDOWS:
+        flags = kwargs.pop("creationflags", 0)
+        flags |= 0x00000200  # CREATE_NEW_PROCESS_GROUP
+        kwargs["creationflags"] = flags
+    else:
+        kwargs["start_new_session"] = True
+    return subprocess.Popen(cmd, **kwargs)
+
+
+def stop_process_tree(
+    process: subprocess.Popen,
+    timeout: int = 15,
+) -> None:
+    """Gracefully stop *process* and its children, then force-kill on timeout.
+
+    On Unix the whole process group receives ``SIGINT`` first and
+    ``SIGKILL`` as a last resort.  On Windows ``terminate()`` /
+    ``kill()`` are used instead (no process-group signals).
+    """
+    # --- graceful shutdown ---------------------------------------------------
+    try:
+        if IS_WINDOWS:
+            process.terminate()
+        else:
+            os.killpg(os.getpgid(process.pid), signal.SIGINT)
+    except Exception:
+        try:
+            process.terminate()
+        except Exception:
+            pass
+
+    # --- wait ----------------------------------------------------------------
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            if IS_WINDOWS:
+                process.kill()
+            else:
+                os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+        except Exception:
+            process.kill()
+        process.wait()
+
+
+def kill_port_holder(port: int) -> None:
+    """Best-effort kill of whatever process holds *port*.
+
+    Works on macOS (``lsof``), Linux (``fuser``) and Windows
+    (``netstat`` + ``taskkill``).  Failures are silently ignored.
+    """
+    try:
+        if IS_WINDOWS:
+            # netstat -ano | findstr :<port>  → … <pid>
+            result = subprocess.run(
+                ["netstat", "-ano"],
+                capture_output=True, text=True,
+            )
+            for line in result.stdout.splitlines():
+                if f":{port}" in line and "LISTENING" in line:
+                    pid = line.strip().split()[-1]
+                    subprocess.run(
+                        ["taskkill", "/F", "/PID", pid],
+                        capture_output=True,
+                    )
+                    time.sleep(1)
+        elif sys.platform == "darwin":
+            result = subprocess.run(
+                ["lsof", "-ti", f":{port}"],
+                capture_output=True, text=True,
+            )
+            if result.returncode == 0 and result.stdout:
+                for pid in result.stdout.strip().split():
+                    subprocess.run(
+                        ["kill", "-9", pid],
+                        capture_output=True,
+                    )
+                    time.sleep(1)
+        else:
+            subprocess.run(
+                ["fuser", "-k", f"{port}/tcp"],
+                capture_output=True,
+            )
+    except Exception:
+        pass

--- a/scripts/lib/prereq.py
+++ b/scripts/lib/prereq.py
@@ -474,6 +474,29 @@ class PrereqPytest(Prereq):
             return PRECHECK_ERROR
 
 
+class PrereqProtoc(Prereq):
+    def __init__(self):
+        super().__init__(
+            name="protoc (Protocol Buffers compiler) is installed",
+            remediation=(
+                "Install protoc (protobuf compiler). "
+                "macOS: 'brew install protobuf'; "
+                "Debian/Ubuntu: 'apt-get install protobuf-compiler'"
+            ),
+        )
+
+    def check(self) -> str:
+        try:
+            subprocess.check_output(
+                ["protoc", "--version"], stderr=subprocess.DEVNULL
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            logging.error("'protoc' command not found or not working")
+            logging.error(f"Possible remediation: {self.remediation}")
+            return PRECHECK_ERROR
+        return PRECHECK_OK
+
+
 class PrereqCargoLlvmCov(Prereq):
     def __init__(self):
         super().__init__(
@@ -508,6 +531,7 @@ class PrereqCargoLlvmCov(Prereq):
 # Core prerequisites needed for basic testing
 CORE_PREREQS = [
     PrereqCargo,
+    PrereqProtoc,
     PrereqPython,
     PrereqPytest,
     PrereqCargoLlvmCov,

--- a/scripts/lib/prereq.py
+++ b/scripts/lib/prereq.py
@@ -513,10 +513,14 @@ CORE_PREREQS = [
     PrereqCargoLlvmCov,
 ]
 
-# E2E testing prerequisites
+# E2E local testing prerequisites (no Docker required)
 E2E_LOCAL_PREREQS = [
-    PrereqDocker,
     PrereqHSSrvMock,
+] + CORE_PREREQS
+
+# E2E docker testing prerequisites
+E2E_DOCKER_PREREQS = [
+    PrereqDocker,
 ] + CORE_PREREQS
 
 # Full testing prerequisites
@@ -592,7 +596,8 @@ def check_environment_ready(env_type="full"):
     prerequisites for the given command.
 
     Args:
-        env_type: Type of environment to check ('core', 'e2e', 'full')
+        env_type: Type of environment to check
+            ('core', 'e2e-local', 'e2e-docker', 'full')
 
     Returns:
         bool: True if environment is ready, False otherwise
@@ -601,6 +606,8 @@ def check_environment_ready(env_type="full"):
         prereq_list = CORE_PREREQS
     elif env_type == "e2e-local":
         prereq_list = E2E_LOCAL_PREREQS
+    elif env_type == "e2e-docker":
+        prereq_list = E2E_DOCKER_PREREQS
     else:
         prereq_list = ALL_PREREQS
 

--- a/testing/e2e/README.md
+++ b/testing/e2e/README.md
@@ -4,65 +4,75 @@ This directory contains end-to-end tests for the Hyperspot server.
 
 ## Prerequisites
 
+- Python **3.9+** is required.
+- E2E tests must run on Python **3.9 and above**.
+
 Install Python dependencies:
 
 ```bash
-pip install -r e2e/requirements.txt
+pip install -r testing/e2e/requirements.txt
 ```
 
 ## Running E2E Tests
 
 The `scripts/ci.py` Python script supports two modes: **local** (default) and **Docker**.
 
-### Option 1: Local Mode (Default - Faster for Development)
-
-This approach runs tests against a locally running hyperspot-server:
-
-```bash
-# First, start the server in a separate terminal
-make example
-# OR
-cargo run --bin hyperspot-server --features users-info-example -- --config config/quickstart.yaml
-
-# Then, in another terminal, run the tests
-make e2e          # or make e2e-local
-# Or directly
-python3 scripts/ci.py e2e
-```
-
-### Option 2: Docker Mode (Recommended for CI)
+### Option 1: Docker Mode (Default, Recommended for CI)
 
 This approach builds a Docker image and runs tests in an isolated environment:
 
 ```bash
 # Using make
-make e2e-docker
+make e2e-docker  # all tests
+make e2e-docker-smoke  # smoke only tests (annotated with @pytest.mark.smoke)
 
 # Or directly
-python3 scripts/ci.py e2e --docker
+python3 scripts/ci.py e2e-docker
 ```
 
-## Configuration
+### Option 2: Local Mode (Faster for Development, advanced usage)
 
-### Environment Variables
-
-- **`E2E_BASE_URL`**: Base URL for the API (default: `http://localhost:8087`) - only used in local mode
-- **`E2E_AUTH_TOKEN`**: Optional authentication token for protected endpoints
-
-Examples:
+This approach runs tests against a locally running hyperspot-server.
+`scripts/ci.py e2e-local` will build and start the local server automatically.
 
 ```bash
-# Test against a different port (local mode)
-E2E_BASE_URL=http://localhost:9000 make e2e
+# Run local E2E (builds release artifacts and starts server automatically)
+make e2e-local  # all tests
+make e2e-local-smoke  # smoke only tests (annotated with @pytest.mark.smoke)
 
-# Test with authentication
-E2E_AUTH_TOKEN=your-token-here make e2e
+# Or directly
+python3 scripts/ci.py e2e-local
+```
 
-# Combine both
-E2E_BASE_URL=http://localhost:9000 E2E_AUTH_TOKEN=your-token python3 scripts/ci.py e2e
+#### Advanced Usage
 
-# Run in Docker mode with different base URL
-python3 scripts/ci.py e2e --docker
+Environment Variables:
+
+- **`E2E_BASE_URL`**: Base URL for the API (default: `http://localhost:8086`) - only used in local mode
+- **`E2E_AUTH_TOKEN`**: Optional authentication token for protected endpoints
+
+Why local E2E defaults to `8086`:
+
+- Local E2E uses `config/e2e-local.yaml` and a dedicated E2E-oriented build/run path, which may differ from the usual development default (`8087` via `quickstart`).
+- Keeping a stable, dedicated E2E port makes lifecycle management deterministic: `scripts/ci.py` can reliably start, health-check, and stop the service it launched.
+- This also makes it safer to kill/restart only the E2E-owned process during test runs, without interfering with another manually started server.
+
+#### Running Individual Tests Against a Running Service locally (w/o Docker)
+
+```bash
+# Run the server in one terminal:
+make quickstart
+
+# Run the tests in another terminal:
+E2E_BASE_URL=http://localhost:8087 python3 -m pytest testing/e2e/modules/nodes_registry
+# or for smoke tests only:
+E2E_BASE_URL=http://localhost:8087 python3 -m pytest testing/e2e/modules/nodes_registry -m smoke
+```
+
+#### Using auth token
+
+```bash
+E2E_BASE_URL=http://localhost:8087 E2E_AUTH_TOKEN=your-token python3 -m pytest testing/e2e/
 ```
 
 ### Command Line Options
@@ -70,77 +80,8 @@ python3 scripts/ci.py e2e --docker
 The `scripts/ci.py` Python script accepts the following options:
 
 - `--docker`: Run tests in Docker environment (default is local mode)
+- `--smoke`: Run only tests marked with `@pytest.mark.smoke`
 - `--help`: Show help message
-
-## Types Registry Test Suite
-
-The types-registry module has comprehensive E2E test coverage for GTS entity management:
-
-### Test Files
-
-- **`modules/types_registry/test_types_registry_register.py`**: Tests the `POST /types-registry/v1/entities` endpoint
-  - Single and batch entity registration
-  - Type and instance registration
-  - Invalid entity handling
-  - Mixed valid/invalid batch processing
-  
-- **`modules/types_registry/test_types_registry_list.py`**: Tests the `GET /types-registry/v1/entities` endpoint
-  - List all entities
-  - Filter by kind (type/instance)
-  - Filter by vendor, package, namespace
-  - Wildcard pattern matching
-  - Combined filters
-  
-- **`modules/types_registry/test_types_registry_get.py`**: Tests the `GET /types-registry/v1/entities/{gts_id}` endpoint
-  - Get entity by GTS ID
-  - 404 for non-existent entities
-  - Response structure validation
-  - UUID format verification
-  
-- **`modules/types_registry/test_types_registry_validation.py`**: Tests schema validation behavior
-  - Instance validation against type schemas
-  - Missing required fields
-  - Wrong field types
-  - Nested schema validation
-  
-- **`modules/types_registry/test_types_registry_error_handling.py`**: Tests error handling and edge cases
-  - RFC-9457 error response format
-  - Malformed requests
-  - Large batch handling
-  - Unicode content
-  - Deeply nested schemas
-
-## File Parser Test Suite
-
-The file-parser module has comprehensive E2E test coverage including golden-reference Markdown comparison:
-
-### Test Files
-
-- **`modules/file_parser/test_file_parser_info.py`**: Tests the `/file-parser/v1/info` endpoint
-- **`modules/file_parser/test_file_parser_upload.py`**: Tests the `/file-parser/v1/upload` endpoint (binary upload)
-- **`modules/file_parser/test_file_parser_upload_markdown.py`**: Tests the `/file-parser/v1/upload/markdown` endpoint (
-  multipart)
-- **`modules/file_parser/test_file_parser_parse_local.py`**: Tests the `/file-parser/v1/parse-local*` endpoints
-
-### Golden Markdown Generation
-
-Before running file-parser tests, you need to generate golden Markdown reference files:
-
-```bash
-# Make sure the server is running first
-make example
-
-# Generate golden markdown files
-python -m e2e.modules.file_parser.generate_file_parser_golden
-```
-
-This will:
-
-1. Scan `e2e/testdata/` for input files (PDFs, DOCX, etc.)
-2. Upload each file to the API with `render_markdown=true`
-3. Save the markdown responses to `e2e/testdata/md/<filename>.md`
-
-The tests will then compare API responses against these golden files.
 
 ## Writing Tests
 
@@ -173,11 +114,14 @@ async def test_my_endpoint(base_url, auth_headers):
 
 | Command                              | Mode   | Description                              |
 |--------------------------------------|--------|------------------------------------------|
-| `make e2e`                           | Local  | Default: Run tests against local server  |
-| `make e2e-local`                     | Local  | Explicit local mode (same as `make e2e`) |
+| `make e2e`                           | Docker | Default: Run tests in Docker              |
 | `make e2e-docker`                    | Docker | Run tests in Docker environment          |
-| `python3 scripts/ci.py e2e`          | Local  | Direct script execution (local)          |
-| `python3 scripts/ci.py e2e --docker` | Docker | Direct script execution (Docker)         |
+| `make e2e-docker-smoke`              | Docker | Run only smoke tests in Docker            |
+| `make e2e-local`                     | Local  | Run tests against auto-started local server |
+| `make e2e-local-smoke`               | Local  | Run only smoke tests locally              |
+| `python3 scripts/ci.py e2e-local`    | Local  | Direct script execution (local)          |
+| `python3 scripts/ci.py e2e-local --smoke` | Local | Direct script execution (smoke only) |
+| `python3 scripts/ci.py e2e-docker`   | Docker | Direct script execution (Docker)         |
 
 ## Troubleshooting
 
@@ -185,17 +129,18 @@ async def test_my_endpoint(base_url, auth_headers):
 
 If you see "Server not responding" when running local tests:
 
-1. Make sure hyperspot-server is running
-2. Check that it's listening on the correct port (default: 8087)
-3. Verify the health endpoint: `curl http://localhost:8087/healthz`
-4. Or use Docker mode: `make e2e-docker`
+1. Check build/startup logs in `logs/hyperspot-e2e.log` and `logs/hyperspot-e2e-error.log`
+2. Check that the API is reachable on the configured port (default: 8086)
+3. Verify the health endpoint: `curl http://localhost:8086/healthz`
+4. Rebuild release artifacts: `make build`
+5. Or use Docker mode: `make e2e-docker`
 
 ### pytest not found
 
 Install the required dependencies:
 
 ```bash
-pip install -r e2e/requirements.txt
+pip install -r testing/e2e/requirements.txt
 ```
 
 ### Docker build fails

--- a/testing/e2e/modules/nodes_registry/test_nodes_registry_get.py
+++ b/testing/e2e/modules/nodes_registry/test_nodes_registry_get.py
@@ -1,4 +1,5 @@
 """E2E tests for nodes_registry get node endpoint."""
+import os
 import httpx
 import pytest
 import uuid
@@ -94,23 +95,25 @@ async def test_get_node_by_id_with_details(base_url, auth_headers):
         # Validate sysinfo structure (comprehensive check)
         if node["sysinfo"] is not None:
             sysinfo = node["sysinfo"]
-            
+
             # OS information
             assert sysinfo["os"]["name"] != ""
             assert sysinfo["os"]["version"] != ""
             assert sysinfo["os"]["arch"] in ["x86_64", "aarch64", "x86", "arm"]
-            
+
             # CPU information
-            assert sysinfo["cpu"]["model"] != ""
+            cpu_model = sysinfo["cpu"]["model"]
+            if os.getenv("E2E_DOCKER_MODE", "").lower() not in ("1", "true", "yes"):
+                assert cpu_model != ""
             assert sysinfo["cpu"]["num_cpus"] > 0
             assert sysinfo["cpu"]["cores"] > 0
             assert sysinfo["cpu"]["frequency_mhz"] > 0
-            
+
             # Memory information
             assert sysinfo["memory"]["total_bytes"] > 0
             assert sysinfo["memory"]["used_percent"] <= 100
             assert sysinfo["memory"]["available_bytes"] <= sysinfo["memory"]["total_bytes"]
-            
+
             # Host information
             assert sysinfo["host"]["hostname"] != ""
             assert sysinfo["host"]["uptime_seconds"] >= 0

--- a/testing/e2e/modules/nodes_registry/test_nodes_registry_sysinfo.py
+++ b/testing/e2e/modules/nodes_registry/test_nodes_registry_sysinfo.py
@@ -1,4 +1,5 @@
 """E2E tests for nodes_registry sysinfo endpoint."""
+import os
 import httpx
 import pytest
 
@@ -89,7 +90,7 @@ async def test_get_node_sysinfo_os_details(base_url, auth_headers):
 
         # OS name should not be empty
         assert len(os_info["name"]) > 0
-        
+
         # Architecture should be a known value
         valid_archs = ["x86_64", "aarch64", "x86", "arm", "i686"]
         assert os_info["arch"] in valid_archs, (
@@ -129,7 +130,7 @@ async def test_get_node_sysinfo_cpu_details(base_url, auth_headers):
         # Validate CPU info
         cpu_info = sysinfo["cpu"]
         assert isinstance(cpu_info, dict)
-        
+
         # Required fields
         assert "model" in cpu_info
         assert "num_cpus" in cpu_info
@@ -138,16 +139,17 @@ async def test_get_node_sysinfo_cpu_details(base_url, auth_headers):
 
         # Validate values
         assert isinstance(cpu_info["model"], str)
-        assert len(cpu_info["model"]) > 0
-        
+        if os.getenv("E2E_DOCKER_MODE", "").lower() not in ("1", "true", "yes"):
+            assert len(cpu_info["model"]) > 0
+
         assert isinstance(cpu_info["num_cpus"], int)
         assert cpu_info["num_cpus"] > 0
         assert cpu_info["num_cpus"] <= 1024  # Reasonable upper bound
-        
+
         assert isinstance(cpu_info["cores"], int)
         assert cpu_info["cores"] > 0
         assert cpu_info["cores"] <= cpu_info["num_cpus"]  # Cores should not exceed logical CPUs
-        
+
         assert isinstance(cpu_info["frequency_mhz"], (int, float))
         assert cpu_info["frequency_mhz"] > 0
         assert cpu_info["frequency_mhz"] < 10000  # Reasonable upper bound (10 GHz)
@@ -185,7 +187,7 @@ async def test_get_node_sysinfo_memory_details(base_url, auth_headers):
         # Validate memory info
         mem_info = sysinfo["memory"]
         assert isinstance(mem_info, dict)
-        
+
         # Required fields
         assert "total_bytes" in mem_info
         assert "available_bytes" in mem_info
@@ -195,15 +197,15 @@ async def test_get_node_sysinfo_memory_details(base_url, auth_headers):
         # Validate values
         assert isinstance(mem_info["total_bytes"], int)
         assert mem_info["total_bytes"] > 0
-        
+
         assert isinstance(mem_info["available_bytes"], int)
         assert mem_info["available_bytes"] >= 0
         assert mem_info["available_bytes"] <= mem_info["total_bytes"]
-        
+
         assert isinstance(mem_info["used_bytes"], int)
         assert mem_info["used_bytes"] >= 0
         assert mem_info["used_bytes"] <= mem_info["total_bytes"]
-        
+
         assert isinstance(mem_info["used_percent"], int)
         assert mem_info["used_percent"] >= 0
         assert mem_info["used_percent"] <= 100
@@ -241,7 +243,7 @@ async def test_get_node_sysinfo_host_details(base_url, auth_headers):
         # Validate host info
         host_info = sysinfo["host"]
         assert isinstance(host_info, dict)
-        
+
         # Required fields
         assert "hostname" in host_info
         assert "uptime_seconds" in host_info
@@ -250,13 +252,13 @@ async def test_get_node_sysinfo_host_details(base_url, auth_headers):
         # Validate values
         assert isinstance(host_info["hostname"], str)
         assert len(host_info["hostname"]) > 0
-        
+
         assert isinstance(host_info["uptime_seconds"], int)
         assert host_info["uptime_seconds"] >= 0
-        
+
         assert isinstance(host_info["ip_addresses"], list)
         assert len(host_info["ip_addresses"]) > 0
-        
+
         # Validate IP addresses format (basic check)
         for ip in host_info["ip_addresses"]:
             assert isinstance(ip, str)
@@ -295,22 +297,22 @@ async def test_get_node_sysinfo_gpu_details(base_url, auth_headers):
         # Validate GPU info structure
         gpus = sysinfo["gpus"]
         assert isinstance(gpus, list)
-        
+
         # If GPUs are present, validate their structure
         for gpu in gpus:
             assert isinstance(gpu, dict)
             assert "model" in gpu
             assert isinstance(gpu["model"], str)
-            
+
             # Optional fields
             if "cores" in gpu and gpu["cores"] is not None:
                 assert isinstance(gpu["cores"], int)
                 assert gpu["cores"] > 0
-            
+
             if "total_memory_mb" in gpu and gpu["total_memory_mb"] is not None:
                 assert isinstance(gpu["total_memory_mb"], (int, float))
                 assert gpu["total_memory_mb"] > 0
-            
+
             if "used_memory_mb" in gpu and gpu["used_memory_mb"] is not None:
                 assert isinstance(gpu["used_memory_mb"], (int, float))
                 assert gpu["used_memory_mb"] >= 0

--- a/testing/e2e/modules/oagw/helpers.py
+++ b/testing/e2e/modules/oagw/helpers.py
@@ -1,6 +1,7 @@
 """Shared helpers for OAGW E2E tests."""
 import re
 import uuid
+from typing import Optional
 
 import httpx
 
@@ -126,7 +127,7 @@ async def create_upstream(
     base_url: str,
     headers: dict,
     mock_url: str,
-    alias: str | None = None,
+    alias: Optional[str] = None,
     **kwargs,
 ) -> dict:
     """Create an upstream via the Management API and return the response JSON.

--- a/testing/e2e/modules/oagw/mock_upstream.py
+++ b/testing/e2e/modules/oagw/mock_upstream.py
@@ -9,7 +9,7 @@ Uses only stdlib asyncio — no aiohttp dependency.
 import asyncio
 import json
 import re
-
+import logging
 
 # ---------------------------------------------------------------------------
 # Request/response helpers
@@ -213,7 +213,8 @@ class MockUpstreamServer:
                 try:
                     await writer.wait_closed()
                 except (ConnectionError, RuntimeError):
-                    pass
+                    # Ignore connection/loop errors during shutdown; the peer may have disconnected.
+                    logging.debug("Ignoring connection/loop error during writer.close()", exc_info=True)
 
         self._server = await asyncio.start_server(_client, self.host, self.port)
 

--- a/testing/requirements.txt
+++ b/testing/requirements.txt
@@ -1,6 +1,8 @@
 pytest
 pytest-asyncio
 httpx>=0.28.0
+requests>=2.31.0
 h11>=0.16.0 # not directly required, pinned by Snyk to avoid a vulnerability
 anyio>=4.4.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+PyYAML>=6.0

--- a/testing/requirements.txt
+++ b/testing/requirements.txt
@@ -1,7 +1,8 @@
 pytest
 pytest-asyncio
 httpx>=0.28.0
-requests>=2.31.0
+requests>=2.32.4
+urllib3>=2.6.3
 h11>=0.16.0 # not directly required, pinned by Snyk to avoid a vulnerability
 anyio>=4.4.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI/Makefile targets for running E2E tests locally or in Docker, configurable feature sets, smoke-test variants, and cross-platform process tooling.

* **Tests**
  * --smoke flag to run smoke tests; more robust startup/shutdown, improved health-checks, startup logs/PID printed, and Docker/local E2E flow refinements.

* **Chores**
  * Added E2E testing Python dependencies and coverage instrumentation support.

* **Documentation**
  * E2E docs moved to dedicated testing docs; commands, defaults, and ports updated for Docker-first workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->