### PR TITLE
docs: add READMEs and descriptions to credstore and credstore-sdk

### DIFF
--- a/modules/credstore/credstore-sdk/Cargo.toml
+++ b/modules/credstore/credstore-sdk/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "cf-credstore-sdk"
+description = "SDK for credstore module: API traits, models, and error definitions"
 version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "SDK for credstore module: API traits, models, and error definitions"
 repository.workspace = true
+rust-version.workspace = true
 readme = "README.md"
-keywords = ["cyberfabric"]
+keywords = ["cyberfabric", "cyberfabric-system"]
+categories = ["security"]
 
 [lib]
 name = "credstore_sdk"

--- a/modules/credstore/credstore-sdk/README.md
+++ b/modules/credstore/credstore-sdk/README.md
@@ -8,15 +8,13 @@ This crate defines the transport-agnostic interface for the CredStore module:
 
 - **`CredStoreClientV1`** — Async trait for consumers (get/put/delete secrets)
 - **`CredStorePluginClientV1`** — Async trait for backend storage plugin implementations
-- **`SecretRef`** / **`SecretValue`** / **`SharingMode`** / **`GetSecretResponse`** / **`SecretMetadata`** — Domain models
+- **`SecretRef`** / **`SecretValue`** / **`SharingMode`** / **`GetSecretResponse`** — Domain models
 - **`CredStoreError`** — Error types for all operations
 - **`CredStorePluginSpecV1`** — GTS schema for plugin registration
 
 ## Usage
 
-### Getting the Client
-
-Consumers obtain the client from `ClientHub`:
+### Getting the client
 
 ```rust
 use credstore_sdk::CredStoreClientV1;
@@ -24,96 +22,15 @@ use credstore_sdk::CredStoreClientV1;
 let credstore = hub.get::<dyn CredStoreClientV1>()?;
 ```
 
-### Store a Secret
+### Retrieving a secret
 
 ```rust
-use credstore_sdk::{SecretRef, SecretValue, SharingMode};
-
-let key = SecretRef::new("partner-openai-key")?;
-let value = SecretValue::from("sk-abc123");
-
-credstore.put(&ctx, &key, value, SharingMode::Tenant).await?;
-```
-
-### Retrieve a Secret
-
-```rust
-if let Some(resp) = credstore.get(&ctx, &key).await? {
+if let Some(resp) = credstore.get(&ctx, &SecretRef::new("my-api-key")?).await? {
     let bytes = resp.value.as_bytes();
-    // Check metadata
-    println!("sharing: {:?}, inherited: {}", resp.sharing, resp.is_inherited);
 }
 ```
 
-### Delete a Secret
-
-```rust
-credstore.delete(&ctx, &key).await?;
-```
-
-## Models
-
-### SecretRef
-
-Validated secret reference key. Format: `[a-zA-Z0-9_-]+`, max 255 characters.
-
-```rust
-let key = SecretRef::new("my-api-key")?;        // Ok
-let bad = SecretRef::new("my:key");              // Err — colons not allowed
-```
-
-### SecretValue
-
-Opaque byte wrapper with redacted `Debug`/`Display` output. Does not implement `Serialize`/`Deserialize` to prevent accidental secret leakage.
-
-```rust
-let val = SecretValue::from("secret-data");
-println!("{val:?}");  // prints: [REDACTED]
-```
-
-### SharingMode
-
-Controls secret visibility scope:
-
-- `SharingMode::Private` — Only the owner can access
-- `SharingMode::Tenant` (default) — All users in the owner's tenant
-- `SharingMode::Shared` — Accessible across tenant boundaries
-
-## Error Handling
-
-```rust
-use credstore_sdk::CredStoreError;
-
-match credstore.get(&ctx, &key).await {
-    Ok(Some(resp)) => { /* use resp.value, resp.sharing, resp.is_inherited */ },
-    Ok(None) => println!("Not found or inaccessible"),
-    Err(CredStoreError::NoPluginAvailable) => println!("No plugin registered"),
-    Err(e) => println!("Error: {e}"),
-}
-```
-
-Access denial is expressed as `Ok(None)` from `get`, not as an error — this prevents secret enumeration.
-
-## Implementing a Plugin
-
-Implement `CredStorePluginClientV1` and register with a GTS instance ID:
-
-```rust
-use async_trait::async_trait;
-use credstore_sdk::{CredStorePluginClientV1, CredStoreError, OwnerId, SecretMetadata, SecretRef, TenantId};
-use modkit_security::SecurityContext;
-
-struct MyPlugin { /* ... */ }
-
-#[async_trait]
-impl CredStorePluginClientV1 for MyPlugin {
-    async fn get(&self, ctx: &SecurityContext, tenant_id: &TenantId, key: &SecretRef, owner_id: Option<&OwnerId>)
-        -> Result<Option<SecretMetadata>, CredStoreError> {
-        // Your implementation
-    }
-    // ... other methods
-}
-```
+Access denial is expressed as `Ok(None)`, not as an error — this prevents secret enumeration.
 
 ## License
 

--- a/modules/credstore/credstore/Cargo.toml
+++ b/modules/credstore/credstore/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "cf-credstore"
+description = "credstore gateway module"
 version = "0.1.0"
-publish = false
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
-description = "CredStore gateway module"
 repository.workspace = true
+rust-version.workspace = true
 readme = "README.md"
-keywords = ["cyberfabric"]
+keywords = ["cyberfabric", "cyberfabric-system"]
+categories = ["security"]
 
 [lib]
 name = "credstore"

--- a/modules/credstore/credstore/README.md
+++ b/modules/credstore/credstore/README.md
@@ -1,0 +1,39 @@
+# CredStore
+
+Credential storage gateway module. Discovers storage backend plugins via the types registry and routes secret operations through the selected plugin with hierarchical tenant resolution.
+
+## Overview
+
+The `cf-credstore` module provides:
+
+- **Plugin discovery** — finds storage backend plugins via the types registry using a configured vendor
+- **Secret routing** — delegates `get`/`put`/`delete` to the active plugin
+- **Hierarchical resolution** — walks the tenant hierarchy to resolve inherited secrets
+- **ClientHub integration** — registers `CredStoreClientV1` for inter-module use
+
+This module depends on `types-registry`. All storage logic lives in the plugin (e.g. `cf-static-credstore-plugin`).
+
+## Usage
+
+Consumers obtain the client from `ClientHub`:
+
+```rust
+use credstore_sdk::CredStoreClientV1;
+
+let credstore = ctx.client_hub().get::<dyn CredStoreClientV1>()?;
+
+if let Some(resp) = credstore.get(&ctx, &SecretRef::new("my-api-key")?).await? {
+    // resp.value, resp.sharing, resp.is_inherited
+}
+```
+
+## Configuration
+
+```toml
+[credstore]
+vendor = "x"   # GTS vendor used to discover the storage plugin
+```
+
+## License
+
+Apache-2.0

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/lib.rs"
 test-utils = ["axum/ws", "dep:async-stream", "dep:futures", "dep:tower", "tokio/net", "tokio/sync", "tokio/rt"]
 
 [dependencies]
-cf-oagw-sdk = { path = "../oagw-sdk", features = ["axum"] }
+oagw-sdk = { path = "../oagw-sdk", package="cf-oagw-sdk", version = "0.1.0", features = ["axum"] }
 modkit = { workspace = true }
 modkit-security = { workspace = true }
 modkit-macros = { workspace = true }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined credstore SDK docs with updated usage examples and clarified domain models.
  * Added credstore gateway documentation covering plugin discovery, secret routing, hierarchical tenant resolution, and client integration.

* **Chores**
  * Updated package metadata across credstore modules: added descriptions, Rust workspace version flags, expanded keywords and categories.
  * Adjusted a local dependency declaration to use an aliased package form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->