### PR TITLE
460: Added prefix to path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CI := 1
 
-OPENAPI_URL ?= http://127.0.0.1:8087/openapi.json
+OPENAPI_URL ?= http://127.0.0.1:8087/cf/openapi.json
 OPENAPI_OUT ?= docs/api/api.json
 
 # E2E feature set (single source of truth: config/e2e-features.txt)

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -90,7 +90,7 @@ modules:
       bind_addr: "127.0.0.1:8087"
       enable_docs: true
       cors_enabled: false
-
+      prefix_path: "/cf"
       # OpenAPI Documentation Configuration
       openapi:
         title: "HyperSpot API"

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -423,6 +423,7 @@ impl HostRuntime {
                         source: err,
                     }
                 })?;
+
                 router = rest
                     .register_rest(&ctx, router, registry)
                     .map_err(|source| RegistryError::RestRegister {

--- a/modules/system/api-gateway/src/config.rs
+++ b/modules/system/api-gateway/src/config.rs
@@ -41,6 +41,12 @@ pub struct ApiGatewayConfig {
     /// If true, routes without explicit security requirement still require authentication (AuthN-only).
     #[serde(default = "default_require_auth_by_default")]
     pub require_auth_by_default: bool,
+
+    /// Optional URL path prefix prepended to every route (e.g. `"/cf"` → `/cf/users`).
+    /// Must start with a leading slash; trailing slashes are stripped automatically.
+    /// Empty string (the default) means no prefix.
+    #[serde(default)]
+    pub prefix_path: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/modules/system/api-gateway/src/middleware/auth.rs
+++ b/modules/system/api-gateway/src/middleware/auth.rs
@@ -2,6 +2,8 @@ use axum::http::Method;
 use axum::response::IntoResponse;
 use std::{collections::HashMap, sync::Arc};
 
+use crate::middleware::common;
+
 use authn_resolver_sdk::{AuthNResolverClient, AuthNResolverError};
 use modkit::api::Problem;
 use modkit_security::SecurityContext;
@@ -204,7 +206,14 @@ pub async fn authn_middleware(
         return next.run(req).await;
     }
 
-    let requirement = state.route_policy.resolve(req.method(), req.uri().path());
+    let path = req
+        .extensions()
+        .get::<axum::extract::MatchedPath>()
+        .map_or_else(|| req.uri().path().to_owned(), |p| p.as_str().to_owned());
+
+    let path = common::resolve_path(&req, path.as_str());
+
+    let requirement = state.route_policy.resolve(req.method(), path.as_str());
 
     match requirement {
         AuthRequirement::None => {

--- a/modules/system/api-gateway/src/middleware/common.rs
+++ b/modules/system/api-gateway/src/middleware/common.rs
@@ -1,0 +1,76 @@
+use axum::extract::Request;
+
+pub fn resolve_path(req: &Request, matched_path: &str) -> String {
+    req.extensions()
+        .get::<axum::extract::NestedPath>()
+        .and_then(|np| strip_path_prefix(matched_path, np.as_str()))
+        .unwrap_or_else(|| matched_path.to_owned())
+}
+
+/// Strip `prefix` from `path` only at a segment boundary.
+///
+/// Returns `None` when the prefix doesn't match.  When it does match the
+/// result always starts with `/` (or is `/` when the path equals the prefix).
+fn strip_path_prefix(path: &str, prefix: &str) -> Option<String> {
+    let rest = path.strip_prefix(prefix)?;
+    if rest.is_empty() {
+        // path == prefix exactly  →  root
+        Some("/".to_owned())
+    } else if rest.starts_with('/') {
+        // clean segment boundary  →  keep the slash
+        Some(rest.to_owned())
+    } else {
+        // partial segment overlap (e.g. prefix="/cf", path="/cfish")  →  no match
+        None
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_match_returns_root() {
+        assert_eq!(strip_path_prefix("/cf", "/cf"), Some("/".to_owned()));
+    }
+
+    #[test]
+    fn segment_boundary_strips_correctly() {
+        assert_eq!(
+            strip_path_prefix("/cf/users", "/cf"),
+            Some("/users".to_owned())
+        );
+    }
+
+    #[test]
+    fn partial_segment_overlap_rejected() {
+        assert_eq!(strip_path_prefix("/cfish", "/cf"), None);
+    }
+
+    #[test]
+    fn no_prefix_match_returns_none() {
+        assert_eq!(strip_path_prefix("/other/path", "/cf"), None);
+    }
+
+    #[test]
+    fn nested_prefix_strips_correctly() {
+        assert_eq!(
+            strip_path_prefix("/api/v1/users", "/api/v1"),
+            Some("/users".to_owned())
+        );
+    }
+
+    #[test]
+    fn path_with_params_strips_correctly() {
+        assert_eq!(
+            strip_path_prefix("/cf/users/{id}", "/cf"),
+            Some("/users/{id}".to_owned())
+        );
+    }
+
+    #[test]
+    fn empty_prefix_returns_full_path() {
+        assert_eq!(strip_path_prefix("/users", ""), Some("/users".to_owned()));
+    }
+}

--- a/modules/system/api-gateway/src/middleware/license_validation.rs
+++ b/modules/system/api-gateway/src/middleware/license_validation.rs
@@ -4,9 +4,10 @@ use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use dashmap::DashMap;
 use http::Method;
+use modkit::api::{OperationSpec, Problem};
 use std::sync::Arc;
 
-use modkit::api::{OperationSpec, Problem};
+use crate::middleware::common;
 
 const BASE_FEATURE: &str = "gts.x.core.lic.feat.v1~x.core.global.base.v1";
 
@@ -53,6 +54,8 @@ pub async fn license_validation_middleware(
         .extensions()
         .get::<axum::extract::MatchedPath>()
         .map_or_else(|| req.uri().path().to_owned(), |p| p.as_str().to_owned());
+
+    let path = common::resolve_path(&req, path.as_str());
 
     let Some(required) = map.get(&method, &path) else {
         return next.run(req).await;

--- a/modules/system/api-gateway/src/middleware/mime_validation.rs
+++ b/modules/system/api-gateway/src/middleware/mime_validation.rs
@@ -9,6 +9,8 @@ use std::sync::Arc;
 
 use modkit::api::{OperationSpec, Problem};
 
+use crate::middleware::common;
+
 /// Map from (method, path) to allowed content types
 pub type MimeValidationMap = Arc<DashMap<(Method, String), Vec<&'static str>>>;
 
@@ -20,6 +22,7 @@ pub fn build_mime_validation_map(specs: &[OperationSpec]) -> MimeValidationMap {
     for spec in specs {
         if let Some(ref allowed) = spec.allowed_request_content_types {
             let key = (spec.method.clone(), spec.path.clone());
+
             map.insert(key, allowed.clone());
         }
     }
@@ -94,6 +97,8 @@ pub async fn mime_validation_middleware(
         .extensions()
         .get::<axum::extract::MatchedPath>()
         .map_or_else(|| req.uri().path().to_owned(), |p| p.as_str().to_owned());
+
+    let path = common::resolve_path(&req, path.as_str());
 
     // Check if this operation has MIME validation configured
     let Some(allowed_types) = validation_map.get(&(method.clone(), path.clone())) else {

--- a/modules/system/api-gateway/src/middleware/mod.rs
+++ b/modules/system/api-gateway/src/middleware/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod common;
 pub mod license_validation;
 pub mod mime_validation;
 pub mod rate_limit;

--- a/modules/system/api-gateway/src/middleware/rate_limit.rs
+++ b/modules/system/api-gateway/src/middleware/rate_limit.rs
@@ -14,6 +14,8 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 
+use crate::middleware::common;
+
 type RateLimitKey = (Method, String);
 type BucketMap = Arc<HashMap<RateLimitKey, Arc<BucketMapEntry>>>;
 type InflightMap = Arc<HashMap<RateLimitKey, Arc<Semaphore>>>;
@@ -66,6 +68,7 @@ impl RateLimiterMap {
                 ),
                 |r| (r.rps, r.burst, r.in_flight),
             );
+
             let key = (spec.method.clone(), spec.path.clone());
             buckets.insert(
                 key.clone(),
@@ -91,6 +94,9 @@ pub async fn rate_limit_middleware(map: RateLimiterMap, mut req: Request, next: 
         .extensions()
         .get::<axum::extract::MatchedPath>()
         .map_or_else(|| req.uri().path().to_owned(), |p| p.as_str().to_owned());
+
+    let path = common::resolve_path(&req, path.as_str());
+
     let key = (method, path);
 
     if let Some(bucker_map_entry) = map.buckets.get(&key) {

--- a/modules/system/api-gateway/src/module.rs
+++ b/modules/system/api-gateway/src/module.rs
@@ -77,6 +77,19 @@ impl Default for ApiGateway {
 }
 
 impl ApiGateway {
+    fn apply_prefix_nesting(mut router: Router, prefix: &str) -> Router {
+        if prefix.is_empty() {
+            return router;
+        }
+
+        let top = Router::new()
+            .route("/health", get(web::health_check))
+            .route("/healthz", get(|| async { "ok" }));
+
+        router = Router::new().nest(prefix, router);
+        top.merge(router)
+    }
+
     /// Create a new `ApiGateway` instance with the given configuration
     #[must_use]
     pub fn new(config: ApiGatewayConfig) -> Self {
@@ -125,11 +138,13 @@ impl ApiGateway {
         // Always mark built-in health check routes as public
         public_routes.insert((Method::GET, "/health".to_owned()));
         public_routes.insert((Method::GET, "/healthz".to_owned()));
+
         public_routes.insert((Method::GET, "/docs".to_owned()));
         public_routes.insert((Method::GET, "/openapi.json".to_owned()));
 
         for spec in &self.openapi_registry.operation_specs {
             let spec = spec.value();
+
             let route_key = (spec.method.clone(), spec.path.clone());
 
             if spec.authenticated {
@@ -156,6 +171,45 @@ impl ApiGateway {
         );
 
         Ok(route_policy)
+    }
+
+    fn normalize_prefix_path(raw: &str) -> Result<String> {
+        let trimmed = raw.trim();
+        // Collapse consecutive slashes then strip trailing slash(es).
+        let collapsed: String =
+            trimmed
+                .chars()
+                .fold(String::with_capacity(trimmed.len()), |mut acc, c| {
+                    if c == '/' && acc.ends_with('/') {
+                        // skip duplicate slash
+                    } else {
+                        acc.push(c);
+                    }
+                    acc
+                });
+        let prefix = collapsed.trim_end_matches('/');
+        let result = if prefix.is_empty() {
+            String::new()
+        } else if prefix.starts_with('/') {
+            prefix.to_owned()
+        } else {
+            format!("/{prefix}")
+        };
+        // Reject characters that are unsafe in URL paths or HTML attributes.
+        if !result
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'/' || b == b'_' || b == b'-' || b == b'.')
+        {
+            anyhow::bail!(
+                "prefix_path contains invalid characters (must match [a-zA-Z0-9/_\\-.]): {raw:?}"
+            );
+        }
+
+        if result.split('/').any(|seg| seg == "." || seg == "..") {
+            anyhow::bail!("prefix_path must not contain '.' or '..' segments: {raw:?}");
+        }
+
+        Ok(result)
     }
 
     /// Apply all middleware layers to a router (request ID, tracing, timeout, body limit, CORS, rate limiting, error mapping, auth)
@@ -189,6 +243,7 @@ impl ApiGateway {
 
         // 11) License validation
         let license_map = middleware::license_validation::LicenseRequirementMap::from_specs(&specs);
+
         router = router.layer(from_fn(
             move |req: axum::extract::Request, next: axum::middleware::Next| {
                 let map = license_map.clone();
@@ -236,6 +291,7 @@ impl ApiGateway {
 
         // 8) Per-route rate limiting & in-flight limits
         let rate_map = middleware::rate_limit::RateLimiterMap::from_specs(&specs, &config)?;
+
         router = router.layer(from_fn(
             move |req: axum::extract::Request, next: axum::middleware::Next| {
                 let map = rate_map.clone();
@@ -362,6 +418,10 @@ impl ApiGateway {
         // Apply all middleware layers including auth, above the router
         let authn_client = self.authn_client.lock().clone();
         router = self.apply_middleware_stack(router, authn_client)?;
+
+        let config = self.get_cached_config();
+        let prefix = Self::normalize_prefix_path(&config.prefix_path)?;
+        router = Self::apply_prefix_nesting(router, &prefix);
 
         // Cache the built router for future use
         self.router_cache.store(router.clone());
@@ -491,6 +551,9 @@ impl ApiGateway {
         );
 
         let openapi_doc = Arc::new(self.build_openapi()?);
+        let config = self.get_cached_config();
+        let prefix = Self::normalize_prefix_path(&config.prefix_path)?;
+        let html_doc = web::serve_docs(&prefix);
 
         router = router
             .route(
@@ -517,7 +580,7 @@ impl ApiGateway {
                     }
                 }),
             )
-            .route("/docs", get(web::serve_docs));
+            .route("/docs", get(move || async move { html_doc }));
 
         #[cfg(feature = "embed_elements")]
         {
@@ -594,6 +657,9 @@ impl modkit::contracts::ApiGatewayCapability for ApiGateway {
         tracing::debug!("Applying middleware stack to finalized router");
         let authn_client = self.authn_client.lock().clone();
         router = self.apply_middleware_stack(router, authn_client)?;
+
+        let prefix = Self::normalize_prefix_path(&config.prefix_path)?;
+        router = Self::apply_prefix_nesting(router, &prefix);
 
         // Keep the finalized router to be used by `serve()`
         *self.final_router.lock() = Some(router.clone());
@@ -680,6 +746,107 @@ mod tests {
         assert_eq!(info.get("title").unwrap(), "Test API");
         assert_eq!(info.get("version").unwrap(), "1.0.0");
         assert_eq!(info.get("description").unwrap(), "Test Description");
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod normalize_prefix_path_tests {
+    use super::*;
+
+    #[test]
+    fn empty_string_returns_empty() {
+        assert_eq!(ApiGateway::normalize_prefix_path("").unwrap(), "");
+    }
+
+    #[test]
+    fn sole_slash_returns_empty() {
+        assert_eq!(ApiGateway::normalize_prefix_path("/").unwrap(), "");
+    }
+
+    #[test]
+    fn multiple_slashes_return_empty() {
+        assert_eq!(ApiGateway::normalize_prefix_path("///").unwrap(), "");
+    }
+
+    #[test]
+    fn whitespace_only_returns_empty() {
+        assert_eq!(ApiGateway::normalize_prefix_path("   ").unwrap(), "");
+    }
+
+    #[test]
+    fn simple_prefix_preserved() {
+        assert_eq!(ApiGateway::normalize_prefix_path("/cf").unwrap(), "/cf");
+    }
+
+    #[test]
+    fn trailing_slash_stripped() {
+        assert_eq!(ApiGateway::normalize_prefix_path("/cf/").unwrap(), "/cf");
+    }
+
+    #[test]
+    fn leading_slash_prepended_when_missing() {
+        assert_eq!(ApiGateway::normalize_prefix_path("cf").unwrap(), "/cf");
+    }
+
+    #[test]
+    fn consecutive_leading_slashes_collapsed() {
+        assert_eq!(ApiGateway::normalize_prefix_path("//cf").unwrap(), "/cf");
+    }
+
+    #[test]
+    fn consecutive_slashes_mid_path_collapsed() {
+        assert_eq!(
+            ApiGateway::normalize_prefix_path("/api//v1").unwrap(),
+            "/api/v1"
+        );
+    }
+
+    #[test]
+    fn many_consecutive_slashes_collapsed() {
+        assert_eq!(
+            ApiGateway::normalize_prefix_path("///api///v1///").unwrap(),
+            "/api/v1"
+        );
+    }
+
+    #[test]
+    fn surrounding_whitespace_trimmed() {
+        assert_eq!(ApiGateway::normalize_prefix_path("  /cf  ").unwrap(), "/cf");
+    }
+
+    #[test]
+    fn nested_path_preserved() {
+        assert_eq!(
+            ApiGateway::normalize_prefix_path("/api/v1").unwrap(),
+            "/api/v1"
+        );
+    }
+
+    #[test]
+    fn dot_in_path_allowed() {
+        assert_eq!(
+            ApiGateway::normalize_prefix_path("/api/v1.0").unwrap(),
+            "/api/v1.0"
+        );
+    }
+
+    #[test]
+    fn rejects_html_injection() {
+        let result = ApiGateway::normalize_prefix_path(r#""><script>alert(1)</script>"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_spaces_in_path() {
+        let result = ApiGateway::normalize_prefix_path("/my path");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_query_string_chars() {
+        let result = ApiGateway::normalize_prefix_path("/api?foo=bar");
+        assert!(result.is_err());
     }
 }
 

--- a/modules/system/api-gateway/src/web.rs
+++ b/modules/system/api-gateway/src/web.rs
@@ -28,9 +28,14 @@ pub async fn health_check() -> Json<Value> {
 }
 
 #[cfg(not(feature = "embed_elements"))]
-pub async fn serve_docs() -> Html<&'static str> {
+pub fn serve_docs(prefix_path: &str) -> Html<String> {
+    let openapi_url = if prefix_path.is_empty() {
+        String::from("/openapi.json")
+    } else {
+        format!("{prefix_path}/openapi.json")
+    };
     // External mode: load from CDN @latest
-    Html(
+    Html(format!(
         r#"<!DOCTYPE html>
 <html>
 <head>
@@ -40,27 +45,41 @@ pub async fn serve_docs() -> Html<&'static str> {
   <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@latest/styles.min.css">
 </head>
 <body>
-  <elements-api apiDescriptionUrl="/openapi.json" router="hash" layout="sidebar"></elements-api>
+  <elements-api apiDescriptionUrl="{openapi_url}" router="hash" layout="sidebar"></elements-api>
 </body>
 </html>"#,
-    )
+    ))
 }
 
 #[cfg(feature = "embed_elements")]
-pub async fn serve_docs() -> Html<&'static str> {
+pub fn serve_docs(prefix_path: &str) -> Html<String> {
+    let (openapi_url, js_url, css_url) = if prefix_path.is_empty() {
+        (
+            String::from("/openapi.json"),
+            String::from("/docs/assets/web-components.min.js"),
+            String::from("/docs/assets/styles.min.css"),
+        )
+    } else {
+        (
+            format!("{prefix_path}/openapi.json"),
+            format!("{prefix_path}/docs/assets/web-components.min.js"),
+            format!("{prefix_path}/docs/assets/styles.min.css"),
+        )
+    };
+
     // Embedded mode: reference local embedded assets
-    Html(
+    Html(format!(
         r#"<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8"/>
   <title>API Docs</title>
-  <script src="/docs/assets/web-components.min.js"></script>
-  <link rel="stylesheet" href="/docs/assets/styles.min.css">
+  <script src="{js_url}"></script>
+  <link rel="stylesheet" href="{css_url}">
 </head>
 <body>
-  <elements-api apiDescriptionUrl="/openapi.json" router="hash" layout="sidebar"></elements-api>
+  <elements-api apiDescriptionUrl="{openapi_url}" router="hash" layout="sidebar"></elements-api>
 </body>
 </html>"#,
-    )
+    ))
 }

--- a/modules/system/api-gateway/tests/auth_middleware.rs
+++ b/modules/system/api-gateway/tests/auth_middleware.rs
@@ -297,6 +297,98 @@ async fn test_public_routes_accessible() {
 }
 
 #[tokio::test]
+async fn test_public_routes_with_prefix_accessible() {
+    // Create api-gateway with auth disabled and test prefixed public routes
+    let config = json!({
+        "api-gateway": {
+            "config": {
+                "bind_addr": "0.0.0.0:8080",
+                "enable_docs": true,
+                "cors_enabled": false,
+                "auth_disabled": true, // Using disabled for simplicity in test
+                "prefix_path": "/cf",
+            }
+        }
+    });
+
+    let api_ctx = create_api_gateway_ctx(config);
+    let test_ctx = create_test_module_ctx();
+
+    let api_gateway = api_gateway::ApiGateway::default();
+    api_gateway.init(&api_ctx).await.expect("Failed to init");
+
+    // First call rest_prepare to add built-in routes
+    let router = Router::new();
+    let router = api_gateway
+        .rest_prepare(&api_ctx, router)
+        .expect("Failed to prepare");
+
+    // Then register test module routes
+    let test_module = TestAuthModule;
+    let router = test_module
+        .register_rest(&test_ctx, router, &api_gateway)
+        .expect("Failed to register routes");
+
+    // Finally finalize
+    let router = api_gateway
+        .rest_finalize(&api_ctx, router)
+        .expect("Failed to finalize");
+
+    // Test built-in health endpoints
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Health endpoint should be accessible"
+    );
+
+    // Test OpenAPI endpoint
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/cf/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "OpenAPI endpoint should be accessible"
+    );
+
+    // Test OpenAPI endpoint
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/openapi.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "OpenAPI endpoint should be inaccessible without prefix"
+    );
+}
+
+#[tokio::test]
 async fn test_middleware_always_inserts_security_ctx() {
     // This test verifies that SecurityContext is always available in handlers
     let config = json!({
@@ -316,9 +408,9 @@ async fn test_middleware_always_inserts_security_ctx() {
     let api_gateway = api_gateway::ApiGateway::default();
     api_gateway.init(&api_ctx).await.expect("Failed to init");
 
-    let router = Router::new();
+    let mut router: Router = Router::new();
     let test_module = TestAuthModule;
-    let router = test_module
+    router = test_module
         .register_rest(&test_ctx, router, &api_gateway)
         .expect("Failed to register routes");
 
@@ -409,7 +501,7 @@ async fn test_openapi_includes_security_metadata() {
 #[tokio::test]
 async fn test_route_pattern_matching_with_path_params() {
     // This test verifies that routes with path parameters (e.g., /users/{id})
-    // are properly matched and authorization is enforced
+    // are properly matched under a configured prefix (auth disabled in this test)
     let config = json!({
         "api-gateway": {
             "config": {
@@ -427,9 +519,9 @@ async fn test_route_pattern_matching_with_path_params() {
     let api_gateway = api_gateway::ApiGateway::default();
     api_gateway.init(&api_ctx).await.expect("Failed to init");
 
-    let router = Router::new();
+    let mut router = Router::new();
     let test_module = TestAuthModule;
-    let router = test_module
+    router = test_module
         .register_rest(&test_ctx, router, &api_gateway)
         .expect("Failed to register routes");
 
@@ -460,6 +552,74 @@ async fn test_route_pattern_matching_with_path_params() {
         .oneshot(
             Request::builder()
                 .uri("/tests/v1/api/users/abc-def-456")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Route with different path parameter value should also be accessible"
+    );
+}
+
+#[tokio::test]
+async fn test_route_pattern_matching_with_prefix_path_params() {
+    // This test verifies that routes with path parameters (e.g., /users/{id})
+    // are properly matched and authorization is enforced
+    let config = json!({
+        "api-gateway": {
+            "config": {
+                "bind_addr": "0.0.0.0:8080",
+                "enable_docs": false,
+                "cors_enabled": false,
+                "auth_disabled": true, // Disabled for test simplicity
+                "prefix_path": "/cf",
+            }
+        }
+    });
+
+    let api_ctx = create_api_gateway_ctx(config);
+    let test_ctx = create_test_module_ctx();
+
+    let api_gateway = api_gateway::ApiGateway::default();
+    api_gateway.init(&api_ctx).await.expect("Failed to init");
+
+    let mut router = Router::new();
+    let test_module = TestAuthModule;
+    router = test_module
+        .register_rest(&test_ctx, router, &api_gateway)
+        .expect("Failed to register routes");
+
+    let router = api_gateway
+        .rest_finalize(&api_ctx, router)
+        .expect("Failed to finalize");
+
+    // Test that /tests/v1/api/users/123 is accessible (matches /tests/v1/api/users/{id})
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/cf/tests/v1/api/users/123")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Route with path parameter should be accessible and matched correctly"
+    );
+
+    // Test that /tests/v1/api/users/abc-def-456 is also accessible
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/cf/tests/v1/api/users/abc-def-456")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -541,19 +701,7 @@ impl RestApiCapability for TestAuthEnabledModule {
     }
 }
 
-/// Create a finalized router with auth **enabled** and the given mock `AuthN` client.
-async fn create_auth_enabled_router(mock: MockAuthNResolverClient, cors_enabled: bool) -> Router {
-    let config = json!({
-        "api-gateway": {
-            "config": {
-                "bind_addr": "0.0.0.0:8080",
-                "enable_docs": false,
-                "cors_enabled": cors_enabled,
-                "auth_disabled": false,
-            }
-        }
-    });
-
+async fn create_router(config: serde_json::Value, mock: MockAuthNResolverClient) -> Router {
     let hub = Arc::new(ClientHub::new());
     hub.register::<dyn AuthNResolverClient>(Arc::new(mock));
 
@@ -570,15 +718,50 @@ async fn create_auth_enabled_router(mock: MockAuthNResolverClient, cors_enabled:
     let api_gateway = api_gateway::ApiGateway::default();
     api_gateway.init(&api_ctx).await.expect("Failed to init");
 
-    let router = Router::new();
+    let mut router = Router::new();
     let test_module = TestAuthEnabledModule;
-    let router = test_module
+    router = test_module
         .register_rest(&test_ctx, router, &api_gateway)
         .expect("Failed to register routes");
 
     api_gateway
         .rest_finalize(&api_ctx, router)
         .expect("Failed to finalize")
+}
+
+/// Create a finalized router with auth **enabled** and the given mock `AuthN` client.
+async fn create_auth_enabled_router(mock: MockAuthNResolverClient, cors_enabled: bool) -> Router {
+    let config = json!({
+        "api-gateway": {
+            "config": {
+                "bind_addr": "0.0.0.0:8080",
+                "enable_docs": false,
+                "cors_enabled": cors_enabled,
+                "auth_disabled": false,
+            }
+        }
+    });
+
+    create_router(config, mock).await
+}
+
+async fn create_auth_enabled_with_prefix_router(
+    mock: MockAuthNResolverClient,
+    cors_enabled: bool,
+) -> Router {
+    let config = json!({
+        "api-gateway": {
+            "config": {
+                "bind_addr": "0.0.0.0:8080",
+                "enable_docs": false,
+                "cors_enabled": cors_enabled,
+                "auth_disabled": false,
+                "prefix_path": "/cf",
+            }
+        }
+    });
+
+    create_router(config, mock).await
 }
 
 /// Build a mock that accepts a specific token and returns a `SecurityContext` with known IDs.
@@ -790,6 +973,59 @@ async fn test_public_route_with_auth_enabled() {
         json["user_id"],
         Uuid::default().to_string(),
         "Public route should receive anonymous SecurityContext"
+    );
+}
+
+#[tokio::test]
+async fn test_public_route_with_prefix_auth_enabled() {
+    // Mock that would reject any token — proves it is never called for public routes
+    let mock =
+        mock_returning_error(|| AuthNResolverError::Internal("should not be called".to_owned()));
+    let router = create_auth_enabled_with_prefix_router(mock, false).await;
+
+    // No Authorization header on a public route
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/cf/tests/v1/api/public-ctx")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Public route should return 200 even with auth enabled and no token"
+    );
+
+    // Verify the handler received an anonymous SecurityContext (subject_id = Uuid::default)
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        json["user_id"],
+        Uuid::default().to_string(),
+        "Public route should receive anonymous SecurityContext"
+    );
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/tests/v1/api/public-ctx")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::NOT_FOUND,
+        "Public route should return 404 for unknown paths"
     );
 }
 

--- a/modules/system/api-gateway/tests/body_limit_tests.rs
+++ b/modules/system/api-gateway/tests/body_limit_tests.rs
@@ -158,7 +158,7 @@ async fn test_body_limit_with_cors() {
 async fn test_default_body_limit() {
     let config = wrap_config(&serde_json::json!({
         "bind_addr": "127.0.0.1:0",
-        "auth_disabled": true
+        "auth_disabled": true,
     }));
 
     let hub = Arc::new(modkit::ClientHub::new());

--- a/modules/system/api-gateway/tests/cors_tests.rs
+++ b/modules/system/api-gateway/tests/cors_tests.rs
@@ -178,7 +178,7 @@ async fn test_cors_disabled() {
     let config = wrap_config(&serde_json::json!({
         "bind_addr": "127.0.0.1:0",
         "cors_enabled": false,
-        "auth_disabled": true
+        "auth_disabled": true,
     }));
 
     let hub = Arc::new(modkit::ClientHub::new());

--- a/modules/system/api-gateway/tests/license_middleware.rs
+++ b/modules/system/api-gateway/tests/license_middleware.rs
@@ -135,7 +135,7 @@ async fn rejects_non_base_feature_requirement() {
                 "bind_addr": "0.0.0.0:8080",
                 "enable_docs": false,
                 "cors_enabled": false,
-                "auth_disabled": true
+                "auth_disabled": true,
             }
         }
     });
@@ -146,13 +146,13 @@ async fn rejects_non_base_feature_requirement() {
     let api_gateway = api_gateway::ApiGateway::default();
     api_gateway.init(&api_ctx).await.expect("Failed to init");
 
-    let router = Router::new();
+    let mut router = Router::new();
     let test_module = TestLicenseModule;
-    let router = test_module
+    router = test_module
         .register_rest(&test_ctx, router, &api_gateway)
         .expect("Failed to register routes");
 
-    let router = api_gateway
+    router = api_gateway
         .rest_finalize(&api_ctx, router)
         .expect("Failed to finalize");
 
@@ -170,6 +170,62 @@ async fn rejects_non_base_feature_requirement() {
 }
 
 #[tokio::test]
+async fn rejects_non_base_feature_requirement_with_prefix() {
+    let config = json!({
+        "api-gateway": {
+            "config": {
+                "bind_addr": "0.0.0.0:8080",
+                "enable_docs": false,
+                "cors_enabled": false,
+                "auth_disabled": true,
+                "prefix_path": "/cf",
+            }
+        }
+    });
+
+    let api_ctx = create_api_gateway_ctx(config);
+    let test_ctx = create_test_module_ctx();
+
+    let api_gateway = api_gateway::ApiGateway::default();
+    api_gateway.init(&api_ctx).await.expect("Failed to init");
+
+    let mut router = Router::new();
+    let test_module = TestLicenseModule;
+    router = test_module
+        .register_rest(&test_ctx, router, &api_gateway)
+        .expect("Failed to register routes");
+
+    router = api_gateway
+        .rest_finalize(&api_ctx, router)
+        .expect("Failed to finalize");
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/cf/tests/v1/license/bad")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/tests/v1/license/bad")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn allows_base_feature_requirement() {
     let config = json!({
         "api-gateway": {
@@ -177,7 +233,7 @@ async fn allows_base_feature_requirement() {
                 "bind_addr": "0.0.0.0:8080",
                 "enable_docs": false,
                 "cors_enabled": false,
-                "auth_disabled": true
+                "auth_disabled": true,
             }
         }
     });
@@ -212,14 +268,15 @@ async fn allows_base_feature_requirement() {
 }
 
 #[tokio::test]
-async fn allows_no_license_requirement() {
+async fn allows_base_feature_requirement_with_prefix() {
     let config = json!({
         "api-gateway": {
             "config": {
                 "bind_addr": "0.0.0.0:8080",
                 "enable_docs": false,
                 "cors_enabled": false,
-                "auth_disabled": true
+                "auth_disabled": true,
+                "prefix_path": "/cf",
             }
         }
     });
@@ -233,6 +290,48 @@ async fn allows_no_license_requirement() {
     let router = Router::new();
     let test_module = TestLicenseModule;
     let router = test_module
+        .register_rest(&test_ctx, router, &api_gateway)
+        .expect("Failed to register routes");
+
+    let router = api_gateway
+        .rest_finalize(&api_ctx, router)
+        .expect("Failed to finalize");
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/cf/tests/v1/license/good")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("Request failed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn allows_no_license_requirement() {
+    let config = json!({
+        "api-gateway": {
+            "config": {
+                "bind_addr": "0.0.0.0:8080",
+                "enable_docs": false,
+                "cors_enabled": false,
+                "auth_disabled": true,
+            }
+        }
+    });
+
+    let api_ctx = create_api_gateway_ctx(config);
+    let test_ctx = create_test_module_ctx();
+
+    let api_gateway = api_gateway::ApiGateway::default();
+    api_gateway.init(&api_ctx).await.expect("Failed to init");
+
+    let mut router = Router::new();
+    let test_module = TestLicenseModule;
+    router = test_module
         .register_rest(&test_ctx, router, &api_gateway)
         .expect("Failed to register routes");
 

--- a/modules/system/api-gateway/tests/middleware_order.rs
+++ b/modules/system/api-gateway/tests/middleware_order.rs
@@ -62,7 +62,7 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
                 "auth_disabled": true,
                 "defaults": {
                     "rate_limit": { "rps": 1, "burst": 1, "in_flight": 64 }
-                }
+                },
             }
         }
     });
@@ -72,10 +72,10 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
     api.init(&ctx).await?;
 
     // Register an endpoint that enables both MIME validation and rate limiting.
-    let router = Router::new();
+    let mut router = Router::new();
     let mut builder = OperationBuilder::post("/tests/v1/middleware-order");
     builder.require_rate_limit(1, 1, 64);
-    let router = builder
+    router = builder
         .operation_id("test:middleware-order")
         .summary("Middleware order test endpoint")
         .public()
@@ -165,6 +165,139 @@ async fn real_middlewares_observe_documented_order() -> Result<()> {
         StatusCode::TOO_MANY_REQUESTS,
         "Second valid request should be rate-limited (token consumed by Req2, not by Req1)"
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn real_middlewares_observe_documented_order_with_prefix() -> Result<()> {
+    // Configure strict + deterministic rate limiting for the test route.
+    let cfg = json!({
+        "api-gateway": {
+            "config": {
+                "bind_addr": "127.0.0.1:0",
+                "cors_enabled": true,
+                "auth_disabled": true,
+                "prefix_path": "/cf",
+                "defaults": {
+                    "rate_limit": { "rps": 1, "burst": 1, "in_flight": 64 }
+                },
+            }
+        }
+    });
+    let ctx = create_api_gateway_ctx(cfg);
+
+    let api = api_gateway::ApiGateway::default();
+    api.init(&ctx).await?;
+
+    // Register an endpoint that enables both MIME validation and rate limiting.
+    let mut router = Router::new();
+    let mut builder = OperationBuilder::post("/tests/v1/middleware-order");
+    builder.require_rate_limit(1, 1, 64);
+    router = builder
+        .operation_id("test:middleware-order")
+        .summary("Middleware order test endpoint")
+        .public()
+        .allow_content_types(&["application/json"]) // turns on MIME validation
+        .json_response(StatusCode::OK, "OK")
+        .handler(axum::routing::post(handler))
+        .register(router, &api);
+
+    // Apply the real gateway middleware stack.
+    let app = api.rest_finalize(&ctx, router)?;
+
+    // --------------------
+    // Req1: invalid Content-Type -> should be rejected by MIME validation (415),
+    // but MUST still have CORS headers (CORS wraps MIME).
+    // Also: x-request-id must be echoed (request-id is outermost).
+    // --------------------
+    let res1 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/cf/tests/v1/middleware-order")
+                .header("origin", "https://example.com")
+                .header("x-request-id", "fixed-req-1")
+                .header("content-type", "text/plain")
+                .body(Body::from("hi"))?,
+        )
+        .await?;
+    assert_eq!(res1.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    assert_eq!(
+        res1.headers()
+            .get("x-request-id")
+            .and_then(|v| v.to_str().ok()),
+        Some("fixed-req-1")
+    );
+    assert!(
+        res1.headers().get("access-control-allow-origin").is_some(),
+        "CORS header must be present on 415 => CORS wraps MIME validation"
+    );
+
+    // --------------------
+    // Req2: valid Content-Type -> should pass MIME + consume rate-limit token.
+    // Also handler must see request-id via extensions.
+    // --------------------
+    let res2 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/cf/tests/v1/middleware-order")
+                .header("origin", "https://example.com")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"ok":true}"#))?,
+        )
+        .await?;
+    assert_eq!(res2.status(), StatusCode::OK);
+    let res2_rid = res2
+        .headers()
+        .get("x-request-id")
+        .and_then(|v| v.to_str().ok())
+        .expect("x-request-id must be set on success")
+        .to_owned();
+    let body2 = axum::body::to_bytes(res2.into_body(), usize::MAX).await?;
+    let json2: serde_json::Value = serde_json::from_slice(&body2)?;
+    assert_eq!(
+        json2.get("request_id").and_then(|v| v.as_str()),
+        Some(res2_rid.as_str()),
+        "handler must receive request_id via extensions (push_req_id_to_extensions)"
+    );
+
+    // --------------------
+    // Req3: another valid request immediately -> must be rate-limited (429),
+    // proving Req1 didn't consume token (MIME before rate limit), while Req2 did.
+    // --------------------
+    let res3 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/cf/tests/v1/middleware-order")
+                .header("origin", "https://example.com")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"ok":true}"#))?,
+        )
+        .await?;
+    assert_eq!(
+        res3.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "Second valid request should be rate-limited (token consumed by Req2, not by Req1)"
+    );
+
+    let res1 = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tests/v1/middleware-order")
+                .header("origin", "https://example.com")
+                .header("x-request-id", "fixed-req-1")
+                .header("content-type", "text/plain")
+                .body(Body::from("hi"))?,
+        )
+        .await?;
+    assert_eq!(res1.status(), StatusCode::NOT_FOUND);
 
     Ok(())
 }

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -319,6 +319,7 @@ def kill_existing_server(port):
 
 def cmd_e2e(args):
     base_url = os.environ.get("E2E_BASE_URL", "http://localhost:8086")
+
     check_pytest()
 
     # Kill any existing server on the port before starting


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API Gateway supports a configurable prefix path so routes, docs, and OpenAPI can be served under a specified prefix (e.g., /cf).
* **Behavioral Fixes**
  * Route matching, MIME validation, license checks, authentication, and rate limits now honor the configured prefix.
* **Tests**
  * Expanded tests for prefixed routes, docs, middleware order, CORS, and path-parameter scenarios.
* **Chore**
  * Default OpenAPI URL updated to the prefix-aware path; minor formatting and test adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->