### PR TITLE
ci(workflows): run fmt in dedicated workflow and remove from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,6 @@ jobs:
             echo "sccache failed, falling back to plain rustc"
           fi
 
-      - name: cargo fmt (check)
-        run: make fmt
-
       - name: cargo clippy
         run: make clippy
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,37 @@
+name: Fmt
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - '**/*.rs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  fmt:
+    name: cargo fmt (check)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
+
+      - name: Cache Cargo/target
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          cache-bin: false
+          cache-targets: false
+          shared-key: pr-fmt-stable-1.92
+
+      - name: cargo fmt (check)
+        run: make fmt

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -490,6 +490,29 @@ Provide monitoring primitives and integrations: health checks, alerts, and opera
 - TODO: API link
 - TODO: SDK link
 
+### Simple Resource Registry
+#### Responsibility
+Provide generic CRUD storage for typed resources that do not warrant a dedicated module, using a fixed schema envelope (identity, ownership, timestamps) and a flexible JSON payload governed by GTS type definitions.
+#### High Level Scenarios
+- [ ] p1 - create, read, update, and soft-delete typed resources with tenant isolation and GTS type-based access control
+- [ ] p1 - OData $filter/$orderby and cursor-based pagination on schema fields
+- [ ] p1 - GTS type existence validation via Types Registry
+- [ ] p1 - pluggable storage backend (Relational Database plugin via SecureORM as default)
+- [ ] p1 - configurable soft-delete retention with background purge task
+- [ ] p2 - batch CRUD operations (POST /resources:batch, POST /resources:batch-get) per DNA BATCH.md
+- [ ] p2 - per-resource-type lifecycle notification events (created/updated/deleted) via Events Broker
+- [ ] p2 - per-resource-type audit events via Audit Module
+- [ ] p3 - alternative storage plugins (search engines, vendor-provided backends) with per-type routing
+- [ ] p3 - resource groups for lifecycle-linked collections
+- [ ] p4 - table partitioning by resource type for Relational Database plugin
+- [ ] p5 - full-text search API with search-capable plugin support
+#### More details
+- [PRD](../modules/simple-resource-registry/docs/PRD.md)
+- [Design](../modules/simple-resource-registry/docs/DESIGN.md)
+- TODO: Scenarios link
+- TODO: API link
+- TODO: SDK link
+
 ## Core Platform Integration Modules
 
 **Core Platform Integration Modules** provide a thin abstraction layer between HyperSpot and external or enterprise-grade platform services such as identity providers, license managers, credential stores, and outbound traffic governance systems. These modules expose minimal, stable interfaces that HyperSpot modules can depend on without being coupled to a specific vendor, protocol, or deployment environment.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -504,8 +504,7 @@ Provide generic CRUD storage for typed resources that do not warrant a dedicated
 - [ ] p2 - per-resource-type audit events via Audit Module
 - [ ] p3 - alternative storage plugins (search engines, vendor-provided backends) with per-type routing
 - [ ] p3 - resource groups for lifecycle-linked collections
-- [ ] p4 - table partitioning by resource type for Relational Database plugin
-- [ ] p5 - full-text search API with search-capable plugin support
+- [ ] p4 - full-text search API with search-capable plugin support
 #### More details
 - [PRD](../modules/simple-resource-registry/docs/PRD.md)
 - [Design](../modules/simple-resource-registry/docs/DESIGN.md)

--- a/modules/simple-resource-registry/docs/ADR/0001-cpt-cf-srr-adr-plugin-storage.md
+++ b/modules/simple-resource-registry/docs/ADR/0001-cpt-cf-srr-adr-plugin-storage.md
@@ -1,0 +1,103 @@
+---
+status: accepted
+date: 2026-02-24
+---
+# ADR-0001: Plugin-Based Multi-Backend Storage Architecture
+
+**ID**: `cpt-cf-srr-adr-plugin-storage`
+
+## Context and Problem Statement
+
+Simple Resource Registry must work across diverse deployment targets — edge devices (SQLite), cloud infrastructure (PostgreSQL, MariaDB), and enterprise on-premises environments with existing asset stores (CMDBs, configuration databases). The registry needs a strategy for supporting multiple storage backends that can coexist simultaneously, with different resource types routed to different backends. How should the storage layer be structured to support this range of environments while keeping the consumer-facing API stable?
+
+## Decision Drivers
+
+* Must support edge (SQLite), cloud (PostgreSQL, MariaDB), and enterprise (existing vendor stores, including NoSQL storages) without API changes
+* Platform vendors must be able to provide their own storage backends to bridge the registry to existing platform components
+* Multiple backends must coexist simultaneously — different resource types may live in different stores
+* Must align with the established ModKit plugin pattern used across CyberFabric
+* Plugin implementations must remain thin — security, authorization, and event emission are centralized in the main module
+* Must allow adding new backends without modifying the main module code
+
+## Considered Options
+
+* Single monolithic storage implementation
+* Plugin-based architecture with GTS-based discovery
+* Abstract storage interface without runtime discovery
+
+## Decision Outcome
+
+Chosen option: "Plugin-based architecture with GTS-based discovery", because it enables vendor-extensible, multi-backend coexistence while aligning with the ModKit plugin pattern already established across CyberFabric. The `ResourceStoragePluginClient` trait provides a minimal contract that keeps plugins thin, while GTS-based discovery and scoped ClientHub registration enable runtime resolution of the correct backend per resource type.
+
+### Consequences
+
+* Good, because vendors can implement custom backends to bridge existing platform storage without forking the module
+* Good, because multiple backends coexist — relational DB for transactional workloads, search engines for full-text queries, vendor stores for existing data
+* Good, because the same API serves all backends — consumers are unaware of which backend stores their resources
+* Good, because aligns with ModKit plugin pattern — consistent with other CyberFabric modules
+* Bad, because plugin interface becomes a stability contract — breaking changes require coordination across all plugin implementors
+* Bad, because adds indirection (router → plugin resolution → scoped client lookup) compared to direct storage access
+* Bad, because each plugin must independently implement idempotency deduplication and other storage-level concerns
+
+### Confirmation
+
+* Default relational DB plugin ships with the module and passes all acceptance criteria
+* Plugin interface is versioned with major-version bumps for breaking changes
+* At least one alternative plugin (search engine) can be wired without modifying the main module
+* Code review verifies that security logic (auth, tenant scoping, GTS type checks) is not duplicated in plugins
+
+## Pros and Cons of the Options
+
+### Single monolithic storage implementation
+
+One storage implementation compiled into the module; swap the entire implementation per deployment.
+
+* Good, because simplest architecture — no plugin discovery, no routing, no trait indirection
+* Good, because all storage logic is co-located and easy to debug
+* Bad, because cannot support multiple backends simultaneously (e.g., relational DB + search engine)
+* Bad, because vendors cannot extend storage without forking the module
+* Bad, because swapping storage requires recompilation and deployment, not configuration
+
+### Plugin-based architecture with GTS-based discovery
+
+Trait-based plugin interface (`ResourceStoragePluginClient`) with GTS-based plugin discovery via Types Registry and scoped ClientHub registration. Per-resource-type routing directs operations to the configured backend.
+
+* Good, because supports multi-backend coexistence through per-type routing
+* Good, because vendor-extensible — new backends are separate modules registered via GTS
+* Good, because aligns with ModKit plugin pattern (scoped clients, GTS instance IDs)
+* Good, because plugins are thin — main module handles auth, events, audit centrally
+* Bad, because plugin interface is a long-term stability contract
+* Bad, because adds routing and discovery overhead per request
+* Bad, because each plugin must implement idempotency independently
+
+### Abstract storage interface without runtime discovery
+
+Generic Rust trait for storage, but without GTS-based discovery or ClientHub registration. Backends are wired at compile time via dependency injection.
+
+* Good, because simpler than full plugin architecture — no GTS discovery overhead
+* Good, because compile-time safety for backend wiring
+* Bad, because cannot add new backends without recompiling the main module
+* Bad, because no runtime multi-backend coexistence
+* Bad, because does not align with ModKit plugin pattern — inconsistent with platform conventions
+
+## More Information
+
+The plugin architecture follows the standard ModKit plugin pattern documented in `MODKIT_PLUGINS.md`:
+
+- Each plugin registers a GTS instance in Types Registry and a scoped client in ClientHub via `ClientScope::gts_id(&instance_id)`
+- The main module discovers plugins via GTS-based lookup and resolves the correct plugin per resource type through a routing configuration
+- Plugin GTS instance ID pattern: `gts.x.core.modkit.plugin.v1~x.cf.simple_resource_registry.plugin.v1~<vendor>.<plugin_name>._.plugin.v1`
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+
+This decision directly addresses the following requirements or design elements:
+
+* `cpt-cf-srr-fr-multi-backend-storage` — Enables multiple interchangeable storage backends via the plugin trait
+* `cpt-cf-srr-fr-default-storage-backend` — Default relational DB backend is the first plugin implementation
+* `cpt-cf-srr-fr-storage-routing` — Per-resource-type routing maps GTS types to plugin instances
+* `cpt-cf-srr-fr-search-api` — Search-capable plugins declare `search_support` capability
+* `cpt-cf-srr-principle-plugin-isolation` — Plugins handle only persistence; security is centralized
+* `cpt-cf-srr-component-storage-router` — Router resolves plugin per resource type via GTS discovery

--- a/modules/simple-resource-registry/docs/ADR/0002-cpt-cf-srr-adr-db-security-filtering.md
+++ b/modules/simple-resource-registry/docs/ADR/0002-cpt-cf-srr-adr-db-security-filtering.md
@@ -1,0 +1,93 @@
+---
+status: accepted
+date: 2026-02-24
+---
+# ADR-0002: DB-Level Security Filtering for Resource Access Control
+
+**ID**: `cpt-cf-srr-adr-db-security-filtering`
+
+## Context and Problem Statement
+
+Every resource operation (GET, PUT, DELETE, LIST) must enforce three orthogonal access control dimensions: tenant isolation, owner scoping (when `is_per_owner_resource=true`), and GTS type scope (from token permissions). The system needs a strategy for enforcing these checks that is both secure and does not leak information about the existence of resources the caller cannot access. Should access control be checked at the application level (fetch first, then check) or at the database query level (inject predicates into every query)?
+
+## Decision Drivers
+
+* Must not leak resource existence to unauthorized callers (no 403 revealing "resource exists but you lack access")
+* Must align with CyberFabric's SecureORM pattern for tenant isolation
+* Must produce consistent behavior across GET, PUT, DELETE, and LIST operations
+* Must avoid double-query patterns (fetch → check → re-fetch) for performance
+* Must work across all storage backends (not just relational databases)
+
+## Considered Options
+
+* Application-level ACL checks (fetch then check)
+* DB-level query filtering (inject predicates)
+
+## Decision Outcome
+
+Chosen option: "DB-level query filtering", because it provides zero information leakage (unauthorized resources return 404, not 403), aligns with SecureORM, uses a single query path, and produces consistent behavior across all CRUD operations.
+
+**Exception**: POST (create) and LIST (type-scope-only) use pre-query checks because there is no existing resource to filter — 403 is returned when the requested type is not in the caller's token scope.
+
+### Consequences
+
+* Good, because no information leakage — callers cannot distinguish "does not exist" from "not authorized" for individual resources
+* Good, because single query path — tenant, owner, and type filters are WHERE predicates, no double-fetch
+* Good, because aligns with SecureORM's established pattern for tenant scoping
+* Good, because consistent behavior across GET/PUT/DELETE/LIST — all use the same filter mechanism
+* Bad, because debugging access issues is harder — callers see 404 and cannot tell if it's a permission problem
+* Bad, because storage backends must support predicate-based filtering (trivial for SQL, may be less natural for non-relational stores)
+
+### Confirmation
+
+* Integration tests verify that GET/PUT/DELETE on a resource belonging to another tenant or owner returns 404 (not 403)
+* Integration tests verify that POST with out-of-scope type returns 403
+* Integration tests verify that LIST with no-intersection type scope returns 403
+* Code review confirms all storage backend queries include tenant_id, owner_id, and type scope predicates
+
+## Pros and Cons of the Options
+
+### Application-level ACL checks (fetch then check)
+
+Fetch the resource first, then check tenant/owner/type scope in application code. Return 403 if access is denied.
+
+* Good, because clear error reporting — callers know exactly why access was denied
+* Good, because straightforward implementation — no complex query construction
+* Bad, because leaks resource existence — 403 confirms the resource exists but caller lacks permission
+* Bad, because double-query pattern — must fetch to check, then re-fetch or use the cached result
+* Bad, because inconsistent with SecureORM's query-level tenant scoping
+* Bad, because each storage backend would need both a raw fetch and a filtered fetch path
+
+### DB-level query filtering (inject predicates)
+
+Inject `tenant_id = ctx.subject_tenant_id`, `type IN (permitted_types)`, and `owner_id = ctx.subject_id` (when applicable) as WHERE clause predicates on every query. If no rows match, return 404.
+
+* Good, because zero information leakage — 404 for both "not found" and "not authorized"
+* Good, because single query — all filters applied in one database round-trip
+* Good, because aligns with SecureORM tenant scoping pattern
+* Good, because consistent across all operations — same predicate mechanism for GET/PUT/DELETE/LIST
+* Bad, because harder to debug access issues for callers
+* Bad, because storage backends must support predicate injection
+
+## More Information
+
+The 403 response is reserved for two pre-query scenarios where no resource lookup is involved:
+
+1. **POST create**: The requested resource `type` is not in the caller's token GTS scope → 403 `gts-type-not-in-scope`
+2. **LIST no-intersection**: The requested type filter has zero intersection with the caller's permitted GTS types → 403 `gts-type-not-in-scope`
+
+In both cases, 403 is appropriate because no resource-level information is being leaked — the denial is based purely on the type, not on any specific resource's existence.
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+
+This decision directly addresses the following requirements or design elements:
+
+* `cpt-cf-srr-fr-gts-access-control` — GTS type-based access control enforcement strategy
+* `cpt-cf-srr-fr-read-resource` — GET returns 404 when filtered out by security predicates
+* `cpt-cf-srr-fr-update-resource` — PUT returns 404 when filtered out
+* `cpt-cf-srr-fr-delete-resource` — DELETE returns 404 when filtered out
+* `cpt-cf-srr-fr-list-resources` — LIST applies DB filters; empty result set is valid (not error)
+* `cpt-cf-srr-principle-plugin-isolation` — Plugins receive already-authorized predicates from the domain layer

--- a/modules/simple-resource-registry/docs/ADR/0003-cpt-cf-srr-adr-search-strategy.md
+++ b/modules/simple-resource-registry/docs/ADR/0003-cpt-cf-srr-adr-search-strategy.md
@@ -1,0 +1,83 @@
+---
+status: accepted
+date: 2026-02-24
+---
+# ADR-0003: Search Capability is Backend-Defined and Routed Per Resource Type
+
+**ID**: `cpt-cf-srr-adr-search-strategy`
+
+## Context and Problem Statement
+
+Simple Resource Registry supports multiple storage backends (plugins) and per-resource-type storage routing. Some resource types require full-text search across content (typically payload fields), while other types do not. There are multiple ways to provide search:
+
+- A storage backend could maintain its own dedicated index and execute search internally.
+- Search could be implemented via an external indexing system that indexes content from all backends.
+
+The system needs a clear architectural stance on whether search is a universal requirement (and how it is implemented) or a capability that varies by backend and by resource type.
+
+## Decision Drivers
+
+* Search needs vary by resource type; not all resources require full-text search
+* Storage technologies differ: some backends can natively support search, others cannot
+* The platform must support heterogeneous backends coexisting at the same time
+* The system must remain portable across deployments (edge/cloud/enterprise)
+* The main module should not require indexing assumptions about payloads (payload is opaque at the SRR contract level)
+
+## Considered Options
+
+* Require every backend to provide its own dedicated index
+* Require a single external index for all content across all backends
+* Make search a backend capability, enabled or disabled per resource type via routing
+
+## Decision Outcome
+
+Chosen option: "Make search a backend capability, enabled or disabled per resource type via routing", because it preserves multi-backend flexibility and allows search-heavy resource types to be routed to a search-capable backend while keeping other types on simpler backends.
+
+Search is therefore **not universally available**. It is available only when the resolved backend for a resource type declares `search_support` capability. The main module may expose a search API that returns 501 Not Implemented when the selected backend does not support search.
+
+### Consequences
+
+* Good, because search is optional and per-resource-type — types that do not need search avoid unnecessary indexing cost
+* Good, because backends remain free to choose the best search strategy (internal index vs external system)
+* Good, because aligns with multi-backend routing — search can be enabled by routing search-heavy types to a search backend
+* Bad, because search semantics may differ between backends (ranking, analyzers, query language)
+* Bad, because platform operators must manage search-capable backends explicitly (deployment + routing)
+
+### Confirmation
+
+* The search API returns 501 when `search_support` is false for the resolved backend
+* At least one search-capable backend can be integrated without changing SRR API contracts
+* Per-resource-type routing can enable search for only selected types
+
+## Pros and Cons of the Options
+
+### Require every backend to provide its own dedicated index
+
+* Good, because search is always available
+* Bad, because forces indexing complexity onto all backends, including those where it is unnatural or inefficient
+* Bad, because increases implementation burden for vendor-provided backends
+
+### Require a single external index for all content across all backends
+
+* Good, because uniform search behavior across resource types
+* Good, because decouples indexing from persistence backends
+* Bad, because requires a universal indexing pipeline and consistency model
+* Bad, because increases operational complexity and is not suitable for all deployments (e.g., edge)
+
+### Make search a backend capability, enabled or disabled per resource type via routing
+
+* Good, because flexible and aligns with plugin architecture
+* Good, because avoids universal indexing cost
+* Bad, because search behavior is not necessarily uniform across all backends
+
+## Traceability
+
+- **PRD**: [../PRD.md](../PRD.md)
+- **DESIGN**: [../DESIGN.md](../DESIGN.md)
+
+This decision directly relates to:
+
+* `cpt-cf-srr-fr-search-api` — search endpoint depends on backend capability
+* `cpt-cf-srr-fr-multi-backend-storage` — different backends provide different capabilities
+* `cpt-cf-srr-fr-storage-routing` — per-type routing enables selecting a search-capable backend
+* `cpt-cf-srr-adr-plugin-storage` — plugin-based architecture enables heterogeneous implementations

--- a/modules/simple-resource-registry/docs/DESIGN.md
+++ b/modules/simple-resource-registry/docs/DESIGN.md
@@ -18,7 +18,7 @@ Resource type definitions are managed through GTS (Global Type System) via the T
 
 | Requirement | Design Response |
 | --- | --- |
-| `cpt-cf-srr-fr-create-resource` | API layer extracts tenant/user from SecurityContext; domain layer assigns UUID and timestamps; delegates to storage plugin |
+| `cpt-cf-srr-fr-idempotent-resource-create` | API layer extracts tenant/user from SecurityContext; domain layer assigns UUID and timestamps; delegates to storage plugin; ensure idempotency |
 | `cpt-cf-srr-fr-read-resource` | ResourceService resolves permitted GTS types, then storage plugin applies backend-level filters (tenant, type scope, owner_id for per-user types) integrated with standard authz; returns 404 when no match is found |
 | `cpt-cf-srr-fr-list-resources` | OData parser translates query params to backend query filters on schema columns; plugin executes scoped query |
 | `cpt-cf-srr-fr-update-resource` | ResourceService resolves permitted GTS types, storage plugin fetches target resource with backend-level security filters, then domain layer validates payload and updates `updated_at` |
@@ -515,7 +515,7 @@ pub trait SimpleResourceRegistryClient: Send + Sync {
 
 | Method | Path | Description | FR | Stability |
 | --- | --- | --- | --- | --- |
-| `POST` | `/resources` | Create a new resource | `cpt-cf-srr-fr-create-resource` | stable |
+| `POST` | `/resources` | Create a new resource | `cpt-cf-srr-fr-idempotent-resource-create` | stable |
 | `GET` | `/resources/{id}` | Get a single resource by ID | `cpt-cf-srr-fr-read-resource` | stable |
 | `GET` | `/resources` | List resources (OData filtering) | `cpt-cf-srr-fr-list-resources` | stable |
 | `PUT` | `/resources/{id}` | Update a resource | `cpt-cf-srr-fr-update-resource` | stable |
@@ -888,7 +888,7 @@ Notes:
 | --- | --- | --- | --- |
 | Types Registry | Types Registry SDK (ClientHub) | Resolve GTS type definitions, validate type, read behavioral flags | `cpt-cf-srr-fr-gts-type-registration`, `cpt-cf-srr-fr-gts-type-validation` |
 | modkit-db | SecurityContext-based tenant scoping | Tenant-scoped database access infrastructure (indirect — used by database-backed storage plugins, not by the main module directly) | `cpt-cf-srr-fr-default-storage-backend` |
-| gts-rust | Rust crate (library) | GTS ID generation, schema utilities, payload validation against GTS type schemas | `cpt-cf-srr-fr-gts-type-registration`, `cpt-cf-srr-fr-create-resource`, `cpt-cf-srr-fr-update-resource` |
+| gts-rust | Rust crate (library) | GTS ID generation, schema utilities, payload validation against GTS type schemas | `cpt-cf-srr-fr-gts-type-registration`, `cpt-cf-srr-fr-idempotent-resource-create`, `cpt-cf-srr-fr-update-resource` |
 | Events Broker | Events Broker SDK (ClientHub) | Emit domain events for resource lifecycle (fixed schema: id, type, subject_type, subject_id) | `cpt-cf-srr-fr-notification-events` |
 | Audit Module | Audit SDK (ClientHub) | Emit audit events for compliance (fixed schema: id, type, subject_type, subject_id, previous_payload, new_payload) | `cpt-cf-srr-fr-audit-events` |
 

--- a/modules/simple-resource-registry/docs/DESIGN.md
+++ b/modules/simple-resource-registry/docs/DESIGN.md
@@ -370,7 +370,7 @@ graph TB
 
 - [ ] `p1` - **ID**: `cpt-cf-srr-component-storage-router`
 
-  - **Storage Router**: Resolves the correct storage plugin for a given resource type based on configuration. At p1, the router always returns the default Relational Database plugin (`cpt-cf-srr-component-relational-db-plugin`); per-type routing configuration is introduced at p3 (`cpt-cf-srr-fr-storage-routing`) to enable multi-plugin resolution based on GTS type ID patterns.
+  - **Storage Router**: Resolves the correct storage plugin for a given resource type based on the `cpt-cf-srr-fr-storage-routing` configuration. For each request, the router matches the resource GTS type ID against configured type ID patterns and returns the associated plugin instance. When no per-type rule matches, the router falls back to the default Relational Database plugin (`cpt-cf-srr-component-relational-db-plugin`).
 
 - [ ] `p1` - **ID**: `cpt-cf-srr-component-relational-db-plugin`
 

--- a/modules/simple-resource-registry/docs/DESIGN.md
+++ b/modules/simple-resource-registry/docs/DESIGN.md
@@ -1,0 +1,1296 @@
+# Technical Design — Simple Resource Registry
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+Simple Resource Registry follows a layered architecture with a pluggable storage backend. The module exposes a single REST API surface for CRUD operations on typed resources. All resources share a common schema envelope (identity, ownership, timestamps) and an opaque JSON payload. Schema envelope fields are queryable via OData; payload content is opaque and not queryable.
+
+The resource `type` field contains the resource's GTS type identifier in GTS ID format. In other words, the resource `type` value is the same identifier as the resource's GTS schema ID (GTS type ID).
+
+The storage layer is abstracted behind a `ResourceStoragePluginClient` trait, allowing the same API to serve different backends. The default implementation is a relational backend (`cpt-cf-srr-fr-default-storage-backend`) described in the [plugin DESIGN](../plugins/srr-rdb-plugin/docs/DESIGN.md). The interface is intentionally minimal: the core module handles authentication, authorization, GTS type resolution, and event/audit emission, while backends handle persistence and query execution. Multiple backends can coexist with per-resource-type routing.
+
+Resource type definitions are managed through GTS (Global Type System) via the Types Registry module. A base GTS schema defines the common envelope and behavioral flags (event/audit configuration). Derived types extend the base schema with type-specific payload definitions. This approach enables runtime discoverability of registered resource types and decouples type definition from storage implementation.
+
+### 1.2 Architecture Drivers
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+| --- | --- |
+| `cpt-cf-srr-fr-create-resource` | API layer extracts tenant/user from SecurityContext; domain layer assigns UUID and timestamps; delegates to storage plugin |
+| `cpt-cf-srr-fr-read-resource` | ResourceService resolves permitted GTS types, then storage plugin applies DB-level filters (tenant, type scope, owner_id for per-user types); returns 404 when no row matches |
+| `cpt-cf-srr-fr-list-resources` | OData parser translates query params to backend query filters on schema columns; plugin executes scoped query |
+| `cpt-cf-srr-fr-update-resource` | ResourceService resolves permitted GTS types, storage plugin fetches target row with DB-level security filters, then domain layer validates payload and updates `updated_at` |
+| `cpt-cf-srr-fr-delete-resource` | Soft-delete via deleted_at timestamp; storage plugin filters soft-deleted records from list queries |
+| `cpt-cf-srr-fr-gts-type-registration` | Base GTS schema registered at module startup; derived types registered by consumer modules via Types Registry SDK |
+| `cpt-cf-srr-fr-default-storage-backend` | Default relational DB backend implemented as a separate plugin module (`srr-rdb-plugin`); declares `odata_support` capability |
+| `cpt-cf-srr-nfr-scalability` | 100M resources / 100 writes·s⁻¹ / 1000 reads-by-ID·s⁻¹ — achieved via proper indexing in the default backend; storage optimization is a per-backend concern |
+| `cpt-cf-srr-fr-odata-schema-fields` | OData $filter/$orderby limited to schema columns; cursor-based pagination (limit, cursor); payload column excluded from query support |
+| `cpt-cf-srr-fr-gts-access-control` | ResourceService checks caller `Permission` entries (`resource_pattern` + action). Returns 403 for pre-query denials (POST, LIST no-intersection). For individual resources (GET/PUT/DELETE), permissions are enforced via DB filters and unmatched scope results in 404 |
+| `cpt-cf-srr-fr-gts-wildcard-filtering` | GET list accepts GTS wildcard in `type` filter (trailing `*`); uses `GtsWildcard::new()` + `gts_id.wildcard_match()` for matching; results intersected with caller's permitted GTS types |
+| `cpt-cf-srr-fr-gts-type-validation` | ResourceService calls Types Registry SDK to verify GTS type existence; returns 400 `gts-type-not-found` if missing |
+| `cpt-cf-srr-fr-deleted-retention` | Jobs Manager job hard-deletes rows where `deleted_at + deleted_resource_retention_days < now()` for soft-deleted resources |
+| `cpt-cf-srr-fr-notification-events` | Domain layer checks GTS type behavioral flags; emits fixed-schema events (id, type, subject_type, subject_id) via Events Broker SDK when enabled |
+| `cpt-cf-srr-fr-audit-events` | Domain layer checks GTS type audit flags (including inherited flags from parent GTS types); emits fixed-schema audit events (id, type, subject_type, subject_id, previous_payload, new_payload) via Audit SDK when enabled |
+| `cpt-cf-srr-fr-multi-backend-storage` | `ResourceStoragePluginClient` trait enables additional backends including vendor-provided plugins for existing platform storage; GTS-based plugin discovery and scoped ClientHub clients per ModKit plugin pattern |
+| `cpt-cf-srr-fr-storage-routing` | Configuration maps GTS type IDs to storage plugin instances; router resolves plugin per request |
+| `cpt-cf-srr-fr-batch-operations` | Batch endpoints (POST /resources:batch, POST /resources:batch-get) delegate per-item to ResourceService with shared SecurityContext; 207 Multi-Status with per-item results per DNA BATCH.md; configurable batch size cap |
+| `cpt-cf-srr-fr-resource-groups` | Many-to-many group membership model; group-level batch operations (list, delete); group lifecycle |
+| `cpt-cf-srr-fr-idempotent-create` | POST requires `idempotency_key`; plugin atomically checks and persists the key+resource in one transaction; `CreateOutcome::Duplicate` returned for duplicate key within retention window → 409 with existing resource id |
+
+#### ADR Drivers
+
+| ADR | Decision Summary |
+| --- | --- |
+| `cpt-cf-srr-adr-plugin-storage` | Plugin-based multi-backend storage architecture — trait-based plugin interface with GTS-based discovery; enables vendor extensibility and multi-backend coexistence |
+| `cpt-cf-srr-adr-db-security-filtering` | DB-level security filtering — tenant, owner, and GTS type scope enforced as query predicates (404 for filtered-out resources); 403 reserved for pre-query type-scope denials |
+| `cpt-cf-srr-adr-search-strategy` | Search is backend capability-driven (`search_support`) and enabled per resource type via routing; 501 when unsupported |
+
+#### NFR Allocation
+
+| NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
+| --- | --- | --- | --- | --- |
+| `cpt-cf-srr-nfr-read-latency` | Single-resource GET < 50ms p95 | Storage Backend, Database | ID-based lookup with tenant scoping; backend-internal indexing; connection pooling; ResourceTypeConfig (behavioral flags + retention) cached in-process using `Arc<RwLock<HashMap<String, ResourceTypeConfig>>>` to avoid repeated Types Registry SDK round-trips per request | Load test with p95 measurement |
+| `cpt-cf-srr-nfr-payload-size` | Payload ≤ 64 KB | API Layer | Request body size validation before deserialization | Unit test with oversized payloads |
+| `cpt-cf-srr-nfr-scalability` | 100M resources; 100 writes/s; 1000 reads-by-ID/s | Storage Backend | Proper indexing on schema fields; storage optimization is backend-internal | Load test with sustained throughput measurement |
+
+### 1.3 Architecture Layers
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                   API Layer                              │
+│   REST endpoints, OpenAPI, request validation            │
+├──────────────────────────────────────────────────────────┤
+│                Application Layer                         │
+│   ResourceService: orchestration, auth, events           │
+├──────────────────────────────────────────────────────────┤
+│                 Domain Layer                             │
+│   Resource entity, GTS type resolution,                  │
+│   behavioral flags, storage plugin trait                 │
+├──────────────────────────────────────────────────────────┤
+│              Infrastructure Layer                        │
+│   Default Storage Plugin │ Future plugins                │
+│   Events Broker SDK │ Audit SDK │ Types Registry         │
+└──────────────────────────────────────────────────────────┘
+```
+
+| Layer | Responsibility | Technology |
+| --- | --- | --- |
+| API | REST endpoints, request/response serialization, OData query parsing, OpenAPI spec | modkit REST, OpenAPI 3.0 |
+| Application | Request orchestration, SecurityContext propagation, GTS type resolution, event/audit emission | Rust async services |
+| Domain | Resource entity model, storage plugin trait definition, behavioral flag evaluation | Rust traits, GTS schemas |
+| Infrastructure | Storage implementations, external module SDK clients | Storage Plugin(s), Events Broker SDK, Audit SDK, Types Registry SDK |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Schema-Payload Separation
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-principle-schema-payload-separation`
+
+All resources share fixed schema columns (id, tenant_id, owner_id, type, timestamps) and an opaque payload column. Schema columns are indexed and queryable via OData. Payload is stored and returned as-is without indexing or query support.
+
+This principle keeps the storage model simple and avoids per-type table proliferation while still enabling meaningful filtering on structural fields.
+
+#### Plugin Isolation
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-principle-plugin-isolation`
+
+**ADRs**: `cpt-cf-srr-adr-plugin-storage`
+
+Storage plugins implement only persistence and query execution. They receive already-validated, already-authorized requests from the domain layer. Plugins do not perform authentication, authorization, GTS type resolution, or event emission. This keeps plugin implementations thin and ensures security logic is centralized. The trait is designed so that platform vendors can implement custom plugins to bridge the registry API to existing platform storage components, allowing the registry to act as a unified façade without requiring data migration.
+
+#### GTS-First Type System
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-principle-gts-first`
+
+All resource types are defined and registered through GTS. The base resource type and derived types use GTS schema inheritance. Type behavioral flags (event/audit configuration) are stored in the GTS type definition, not in module configuration. This ensures type metadata is discoverable, versionable, and consistent across the platform.
+
+### 2.2 Constraints
+
+#### Backend-Internal Storage Model
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-constraint-single-table`
+
+Storage layout and optimization (table design, indexing, partitioning) are backend-internal concerns documented in each backend's own DESIGN and ADRs. The main module makes no assumptions about the physical storage structure beyond what the `ResourceStoragePluginClient` trait contract requires. For resource types requiring specialized storage (full-text search, dedicated indexing), per-resource-type routing (`cpt-cf-srr-fr-multi-backend-storage`) enables alternative backends.
+
+#### No Payload Querying
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-constraint-no-payload-query`
+
+OData queries cannot target payload fields. Consumers requiring payload-level queries must either promote frequently queried fields to the schema level (by extending the module) or use search-capable storage backends (`cpt-cf-srr-fr-search-api`). This constraint is a deliberate trade-off for simplicity and predictable performance.
+
+#### Soft-Delete with Configurable Retention Purge
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-constraint-soft-delete`
+
+Resources are soft-deleted via the API (deleted_at timestamp set). Soft-deleted resources are permanently purged by a Jobs Manager job after a configurable retention period (default 30 days, overridable per resource type via GTS type definition). The module does **not** support automatic soft-deletion of active resources based on a TTL — this is intentionally excluded as error-prone.
+
+#### Payload Size Limit
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-constraint-payload-size`
+
+Resource payloads are limited to 64 KB. This prevents storage abuse and ensures predictable query performance. Consumers needing to store large binary data should use File Storage and reference files by URL in the payload.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: GTS (JSON Schema), Rust structs
+
+**Core Entities**:
+
+| Entity | Description |
+| --- | --- |
+| Resource | A stored object with schema envelope + JSON payload |
+| ResourceType | GTS type definition containing behavioral flags and payload schema |
+| BaseResourceType | The GTS base schema shared by all resource types |
+
+**Base Resource Type GTS Schema** (major-version-only):
+
+Behavioral flags (event/audit configuration, user-scoping, retention) are defined as **GTS schema traits** via `x-gts-traits-schema` per GTS spec §9.7. Traits are not part of the instance data model — they configure cross-cutting system behavior. Derived resource types provide concrete trait values via `x-gts-traits`.
+
+```json
+{
+  "$id": "gts://gts.x.core.srr.resource.v1~",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SimpleResource",
+  "type": "object",
+  "x-gts-traits-schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "is_per_owner_resource": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, resources of this type are user-scoped (owner_id is set from SecurityContext)."
+      },
+      "is_create_event_needed": {
+        "type": "boolean",
+        "default": false,
+        "description": "Emit a notification event on resource creation."
+      },
+      "is_update_event_needed": {
+        "type": "boolean",
+        "default": false,
+        "description": "Emit a notification event on resource update."
+      },
+      "is_delete_event_needed": {
+        "type": "boolean",
+        "default": false,
+        "description": "Emit a notification event on resource deletion."
+      },
+      "is_create_audit_event_needed": {
+        "type": "boolean",
+        "default": false,
+        "description": "Emit an audit event on resource creation."
+      },
+      "is_update_audit_event_needed": {
+        "type": "boolean",
+        "default": false,
+        "description": "Emit an audit event on resource update."
+      },
+      "is_delete_audit_event_needed": {
+        "type": "boolean",
+        "default": false,
+        "description": "Emit an audit event on resource deletion."
+      },
+      "deleted_resource_retention_days": {
+        "type": ["integer", "null"],
+        "minimum": 0,
+        "default": null,
+        "description": "Days to retain soft-deleted resources before purge. null = system default (30 days). 0 = immediate hard-delete."
+      }
+    }
+  },
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "type": { "type": "string" },
+    "tenant_id": { "type": "string", "format": "uuid" },
+    "owner_id": { "type": ["string", "null"], "format": "uuid" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "updated_at": { "type": "string", "format": "date-time" },
+    "deleted_at": { "type": ["string", "null"], "format": "date-time" },
+    "payload": {
+      "type": "object",
+      "description": "The resource payload. Schema is defined by the derived GTS type."
+    }
+  },
+  "additionalProperties": false,
+  "required": ["id", "type", "tenant_id"]
+}
+```
+
+**Example Derived Resource Type** (with `x-gts-traits` providing concrete trait values):
+
+```json
+{
+  "$id": "gts://gts.x.core.srr.resource.v1~acme.crm._.contact.v1~",
+  "allOf": [
+    { "$ref": "gts://gts.x.core.srr.resource.v1~" },
+    {
+      "x-gts-traits": {
+        "is_per_owner_resource": false,
+        "is_create_event_needed": true,
+        "is_update_event_needed": true,
+        "is_delete_event_needed": true,
+        "is_create_audit_event_needed": true,
+        "is_update_audit_event_needed": true,
+        "is_delete_audit_event_needed": false,
+        "deleted_resource_retention_days": 90
+      },
+      "properties": {
+        "payload": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "email": { "type": "string", "format": "email" }
+          },
+          "required": ["name"]
+        }
+      }
+    }
+  ]
+}
+```
+
+**GTS Schema Struct** (in SDK crate, generates the base GTS JSON Schema at compile time):
+
+```rust
+use gts_macros::struct_to_gts_schema;
+
+/// Base GTS schema for Simple Resource Registry resources.
+/// Derived resource types extend this base via GTS schema inheritance
+/// and provide concrete trait values (behavioral flags, retention config)
+/// via `x-gts-traits`.
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.x.core.srr.resource.v1~",
+    description = "Base schema for Simple Resource Registry resources",
+    properties = "id,type,tenant_id,owner_id,created_at,updated_at,deleted_at,payload"
+)]
+pub struct BaseSimpleResourceV1 {
+    pub id: Uuid,
+    pub r#type: String,
+    pub tenant_id: Uuid,
+    pub owner_id: Option<Uuid>,
+    pub created_at: DateTimeUtc,
+    pub updated_at: DateTimeUtc,
+    pub deleted_at: Option<DateTimeUtc>,
+    pub payload: serde_json::Value,
+}
+```
+
+**Rust Domain Structs** (conceptual, in `domain/` layer with `#[domain_model]`):
+
+```rust
+use modkit_macros::domain_model;
+
+/// Schema envelope stored as dedicated DB columns.
+/// Internal domain representation — not the GTS schema definition.
+#[domain_model]
+pub struct Resource {
+    pub id: Uuid,
+    pub r#type: String,
+    pub tenant_id: Uuid,
+    pub owner_id: Option<Uuid>,
+    pub created_at: DateTimeUtc,
+    pub updated_at: DateTimeUtc,
+    pub deleted_at: Option<DateTimeUtc>,
+    pub payload: serde_json::Value,
+}
+
+/// Resolved effective GTS traits for a resource type.
+/// Built by merging `x-gts-traits` values along the GTS inheritance chain
+/// per GTS spec §9.7.5. Audit flags are effective if enabled on the type
+/// itself or any parent GTS type.
+#[domain_model]
+pub struct ResourceTypeConfig {
+    pub r#type: String,
+    pub is_per_owner_resource: bool,
+    pub is_create_event_needed: bool,
+    pub is_delete_event_needed: bool,
+    pub is_update_event_needed: bool,
+    pub is_create_audit_event_needed: bool,
+    pub is_update_audit_event_needed: bool,
+    pub is_delete_audit_event_needed: bool,
+    /// Days to retain soft-deleted resources. None = system default (30 days). 0 = immediate.
+    pub deleted_resource_retention_days: Option<u32>,
+}
+```
+
+**Relationships**:
+
+- Resource → ResourceType: Each resource references a GTS type via type
+- ResourceType → BaseResourceType: Derived types extend the base type via GTS inheritance
+- Resource → Tenant: Every resource belongs to exactly one tenant (mandatory)
+- Resource → User: Resources optionally belong to a user (when is_per_owner_resource=true)
+
+### 3.2 Component Model
+
+```mermaid
+graph TB
+    Consumer[Consumer / REST Client] --> API[API Layer]
+    SDK[SDK Client via ClientHub] --> SVC[ResourceService]
+    API --> SVC
+    SVC --> ACL[GTS Access Control]
+    ACL --> TR[Types Registry SDK]
+    SVC --> Cache[GTS Type Cache]
+    Cache --> TR
+    SVC --> Router[Storage Router]
+    Router --> DefaultPlugin[Default Storage Plugin]
+    Router --> ES[Search Plugin]
+    SVC --> EB[Events Broker SDK]
+    SVC --> AU[Audit SDK]
+    DefaultPlugin --> DB[(Database)]
+    RetentionJob[Retention Purge Jobs Manager job] --> Router
+    RetentionJob --> TR
+```
+
+**Components**:
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-component-api-layer`
+
+  - **API Layer**: REST endpoint handlers, request/response DTOs, OData query parsing, OpenAPI spec generation. Implements `cpt-cf-srr-interface-rest-api`. Extracts SecurityContext and delegates to ResourceService.
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-component-resource-service`
+
+  - **ResourceService**: Core application service. Delegates to GTS Access Control for permission checks and effective type scope resolution, validates GTS type existence via Types Registry (with in-process GTS Type Cache for performance), applies DB-filter-based access semantics (tenant, user, type), evaluates behavioral flags (including flags inherited from parent GTS types), orchestrates storage plugin calls, emits events (`cpt-cf-srr-contract-events`) and audit (`cpt-cf-srr-contract-audit`) per `cpt-cf-srr-fr-notification-events` and `cpt-cf-srr-fr-audit-events`. Exposed to other modules via ClientHub as `SimpleResourceRegistryClient` (`cpt-cf-srr-interface-sdk-client`) through a `LocalClient` adapter (per ModKit DDD-light pattern).
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-component-gts-access-control`
+
+  - **GTS Access Control**: Checks the caller's `SecurityContext.permissions()` for `Permission` entries whose `resource_pattern` matches GTS types (using GTS wildcard matching) and whose `action` matches the operation (read/create/update/delete). For POST, validates requested type is allowed. For list queries, computes the intersection of requested pattern and permitted patterns. For individual resource operations, returns effective permitted type filters used by DB queries.
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-component-gts-type-cache`
+
+  - **GTS Type Cache**: In-process cache of resolved `ResourceTypeConfig` values (behavioral flags + retention config) keyed by GTS type ID string. Implemented as `Arc<RwLock<HashMap<String, ResourceTypeConfig>>>` following the `gts-rust` in-memory registry pattern. Cache is populated on first access and used before calling the Types Registry SDK.
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-component-storage-router`
+
+  - **Storage Router**: Resolves the correct storage plugin for a given resource type based on configuration. At p1, the router always returns the default Relational Database plugin (`cpt-cf-srr-component-relational-db-plugin`); per-type routing configuration is introduced at p3 (`cpt-cf-srr-fr-storage-routing`) to enable multi-plugin resolution based on GTS type ID patterns.
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-component-relational-db-plugin`
+
+  - **Relational Database Backend (**`relational-db`**)**: Default implementation of `ResourceStoragePluginClient`. Registers as a scoped client in ClientHub with its GTS instance ID. Declares `odata_support: true`, `search_support: false`. See [plugin DESIGN](../plugins/srr-rdb-plugin/docs/DESIGN.md) for implementation details.
+
+- [ ] `p3` - **ID**: `cpt-cf-srr-component-retention-purge-task`
+
+  - **Retention Purge Jobs Manager job**: Jobs Manager job that periodically scans for soft-deleted resources whose `deleted_at` exceeds their type's `deleted_resource_retention_days` and permanently hard-deletes them from storage. Uses the system default (30 days) when no type-level override is specified.
+
+- [ ] `p5` - **ID**: `cpt-cf-srr-component-search-plugin`
+
+  - **Search Plugin**: Future implementation of `ResourceStoragePluginClient` for search-heavy resource types (e.g., ElasticSearch, OpenSearch). Provides full-text search within payload fields. Declares `search_support` capability.
+
+**Plugin Architecture** (per MODKIT_PLUGINS.md):
+
+The storage plugin system follows the standard ModKit plugin pattern:
+
+- **SDK crate** (`simple-resource-registry-sdk`): Defines the public `SimpleResourceRegistryClient` trait (`cpt-cf-srr-interface-sdk-client`), the `ResourceStoragePluginClient` backend trait (`cpt-cf-srr-interface-storage-backend`), and the `ResourceStoragePluginSpecV1` GTS schema type for backend instances.
+- **Main module** (`simple-resource-registry`): Registers the plugin GTS schema in Types Registry during `init()`, resolves plugins via GTS-based discovery, and registers a public client in ClientHub.
+- **Plugin modules** (e.g., `srr-rdb-plugin`): Each plugin registers a GTS instance in Types Registry and a scoped client in ClientHub via `ClientScope::gts_id(&instance_id)`.
+
+Plugin discovery uses the standard pattern:
+
+```
+GTS plugin instance ID: gts.x.core.modkit.plugin.v1~x.cf.simple_resource_registry.plugin.v1~<vendor>.<plugin_name>._.plugin.v1
+```
+
+**Plugin API Trait** (defined in SDK crate):
+
+```rust
+/// Plugin capabilities that determine which API operations are supported.
+/// Declared by each plugin to enable capability-aware routing at the API layer.
+pub struct PluginCapabilities {
+    pub odata_support: bool,
+    pub search_support: bool,
+}
+
+/// Result of a create operation — distinguishes a newly created resource from a duplicate.
+pub enum CreateOutcome {
+    /// Resource was newly created and persisted.
+    Created(Resource),
+    /// A resource with this idempotency_key already exists for this tenant; returns its id.
+    Duplicate(Uuid),
+}
+
+/// Plugin API — implemented by plugin modules, called by the main module.
+/// Registered WITH scope (GTS instance ID) in ClientHub.
+#[async_trait]
+pub trait ResourceStoragePluginClient: Send + Sync {
+    /// Return the capabilities supported by this plugin
+    fn capabilities(&self) -> PluginCapabilities;
+
+    /// Persist a new resource and atomically record the idempotency key.
+    /// Returns Duplicate(existing_id) if idempotency_key was already used within this tenant.
+    async fn create(&self, ctx: &SecurityContext, resource: &Resource, idempotency_key: &str) -> Result<CreateOutcome>;
+
+    /// Get a single resource by ID
+    async fn get(&self, ctx: &SecurityContext, id: Uuid) -> Result<Option<Resource>>;
+
+    /// List resources with OData query parameters.
+    /// Only called if capabilities().odata_support == true.
+    async fn list(
+        &self,
+        ctx: &SecurityContext,
+        r#type: &str,
+        odata: &ODataQuery,
+    ) -> Result<PagedResult<Resource>>;
+
+    /// Search resources with full-text query.
+    /// Only called if capabilities().search_support == true.
+    async fn search(
+        &self,
+        ctx: &SecurityContext,
+        r#type: &str,
+        query: &SearchQuery,
+    ) -> Result<PagedResult<Resource>>;
+
+    /// Update an existing resource
+    async fn update(&self, ctx: &SecurityContext, resource: &Resource) -> Result<Resource>;
+
+    /// Soft-delete a resource by setting deleted_at = now()
+    async fn delete(&self, ctx: &SecurityContext, id: Uuid) -> Result<()>;
+
+    /// Immediately hard-delete a single resource by ID (used when retention_days == 0).
+    async fn hard_delete(&self, ctx: &SecurityContext, id: Uuid) -> Result<()>;
+
+    /// Hard-delete resources that were soft-deleted before the cutoff timestamp.
+    /// Used by the retention purge Jobs Manager job.
+    async fn purge_deleted_before(
+        &self,
+        r#type: &str,
+        cutoff: DateTimeUtc,
+        batch_size: u32,
+    ) -> Result<u64>;
+}
+```
+
+**Public API Trait** (defined in SDK crate):
+
+```rust
+/// Public API — exposed by the module to other modules.
+/// Registered WITHOUT scope in ClientHub.
+#[async_trait]
+pub trait SimpleResourceRegistryClient: Send + Sync {
+    async fn create_resource(&self, ctx: &SecurityContext, r#type: &str, idempotency_key: &str, payload: Value) -> Result<Resource, SrrError>;
+    async fn get_resource(&self, ctx: &SecurityContext, id: Uuid) -> Result<Resource, SrrError>;
+    async fn list_resources(&self, ctx: &SecurityContext, r#type: &str, odata: &ODataQuery) -> Result<PagedResult<Resource>, SrrError>;
+    async fn update_resource(&self, ctx: &SecurityContext, id: Uuid, payload: Value) -> Result<Resource, SrrError>;
+    async fn delete_resource(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), SrrError>;
+}
+```
+
+**Plugin Resolution** (in main module `ResourceService`):
+
+```rust
+// Storage Router resolves plugin per resource type via GTS-based discovery:
+// 1. Looks up routing config for type
+// 2. Resolves the target plugin's GTS instance ID
+// 3. Gets the scoped client: hub.get_scoped::<dyn ResourceStoragePluginClient>(&scope)
+```
+
+### 3.3 API Contracts
+
+**Technology**: REST/OpenAPI 3.0
+
+**Base Path**: `/simple-resource-registry/v1`
+
+**Endpoints Overview**:
+
+| Method | Path | Description | FR | Stability |
+| --- | --- | --- | --- | --- |
+| `POST` | `/resources` | Create a new resource | `cpt-cf-srr-fr-create-resource` | stable |
+| `GET` | `/resources/{id}` | Get a single resource by ID | `cpt-cf-srr-fr-read-resource` | stable |
+| `GET` | `/resources` | List resources (OData filtering) | `cpt-cf-srr-fr-list-resources` | stable |
+| `PUT` | `/resources/{id}` | Update a resource | `cpt-cf-srr-fr-update-resource` | stable |
+| `DELETE` | `/resources/{id}` | Soft-delete a resource | `cpt-cf-srr-fr-delete-resource` | stable |
+| `POST` | `/resources:batch` | Batch CRUD operations (create/update/delete) | `cpt-cf-srr-fr-batch-operations` | stable |
+| `POST` | `/resources:batch-get` | Batch get resources by IDs | `cpt-cf-srr-fr-batch-operations` | stable |
+| `POST` | `/resources:search` | Full-text search resources | `cpt-cf-srr-fr-search-api` | experimental |
+
+**Request/Response Schemas**:
+
+#### POST /resources — Create Resource
+
+**Request Body**:
+
+```json
+{
+  "type": "string (GTS type ID of the derived resource type)",
+  "idempotency_key": "string (required, caller-supplied deduplication UUID)",
+  "payload": { }
+}
+```
+
+**Response** (201 Created):
+
+```json
+{
+  "id": "uuid",
+  "type": "string",
+  "tenant_id": "uuid",
+  "owner_id": "uuid | null",
+  "created_at": "datetime",
+  "updated_at": "datetime",
+  "deleted_at": null,
+  "payload": { }
+}
+```
+
+Notes:
+
+- `tenant_id` is set from `SecurityContext.subject_tenant_id` (Subject Owner Tenant)
+- `owner_id` is set from `SecurityContext.subject_id` (only when `is_per_owner_resource=true`)
+- `id` is always system-generated; callers must not include it in the request
+- `created_at`, `updated_at` are system-generated
+- `201 Created` response includes `Location: /simple-resource-registry/v1/resources/{id}`
+- `idempotency_key` is required; a second POST with the same key within the same tenant returns 409 with the existing resource `id` instead of creating a duplicate
+- Idempotency keys are scoped to `(tenant_id, idempotency_key)` — the same key in different tenants is treated as distinct
+- The plugin atomically records the idempotency key alongside resource creation; the idempotency storage mechanism is plugin-internal
+
+#### GET /resources/{id} — Get Resource
+
+**Response** (200 OK):
+
+```json
+{
+  "id": "uuid",
+  "type": "string",
+  "tenant_id": "uuid",
+  "owner_id": "uuid | null",
+  "created_at": "datetime",
+  "updated_at": "datetime",
+  "deleted_at": null,
+  "payload": { }
+}
+```
+
+#### GET /resources — List Resources
+
+**Query Parameters**:
+
+- `$filter` — OData filter on schema fields (e.g., `type eq 'my-type' and owner_id eq '...'`). Supports GTS wildcard matching on `type` with trailing `*` per GTS spec (e.g., `type eq 'gts.x.core.srr.resource.v1~acme.*'`)
+- `$orderby` — OData ordering on schema fields (e.g., `created_at desc`)
+- `limit` — Maximum number of results (default: 50, max: 1000)
+- `cursor` — Opaque, versioned cursor for cursor-based pagination
+- `$select` — **Not supported**. All schema fields and payload are always returned. Field projection is not applicable because the payload is an opaque JSON object whose structure varies by resource type.
+
+**Response** (200 OK):
+
+```json
+{
+  "items": [
+    {
+      "id": "uuid",
+      "type": "string",
+      "tenant_id": "uuid",
+      "owner_id": "uuid | null",
+      "created_at": "datetime",
+      "updated_at": "datetime",
+      "deleted_at": null,
+      "payload": { }
+    }
+  ],
+  "page_info": {
+    "limit": 20,
+    "next_cursor": "opaque-cursor-string | null",
+    "prev_cursor": "opaque-cursor-string | null"
+  }
+}
+```
+
+Notes:
+
+- Results are always scoped to the caller's tenant (enforced by the storage backend)
+- Soft-deleted resources are always excluded from list and get results; there is no API mechanism to retrieve soft-deleted resources (the `deleted_at` field is not exposed as a user-facing filter). Soft-deleted resources are only accessible via the retention purge Jobs Manager job.
+- Filtering on `payload` fields is not supported and returns 400 Bad Request
+- When `type` filter uses a wildcard (trailing `*`), results are intersected with the caller's permitted GTS types from token permissions
+- GTS wildcard must appear only once, at the end, per GTS spec section 10
+
+**Access Control Model** (applies to GET, LIST, UPDATE, DELETE):
+
+All access checks are applied as **DB query filters**, not as post-fetch in-memory checks. The storage plugin query always includes:
+- `tenant_id = ctx.subject_tenant_id` (`subject_tenant_id` is the Subject Owner Tenant from `SecurityContext`)
+- `type IN (permitted GTS types from token claims)`
+- `owner_id = ctx.subject_id` (only when `is_per_owner_resource=true`; `subject_id` is the authenticated subject identifier from `SecurityContext`)
+- `deleted_at IS NULL` (exclude soft-deleted)
+
+This means **403 is never returned for individual resource operations** (GET, UPDATE, DELETE) — if the caller lacks access, the resource is simply not found and the system returns 404. The caller cannot distinguish between "does not exist" and "not authorized." 403 is only returned in two cases: (1) on POST when the resource type is not in the caller's GTS token scope (pre-query check), and (2) on LIST when the requested type filter has zero intersection with the caller's permitted GTS types.
+
+#### PUT /resources/{id} — Update Resource
+
+**Request Body**:
+
+```json
+{
+  "payload": { }
+}
+```
+
+**Response** (200 OK): Full resource object with updated payload and updated_at.
+
+Notes:
+
+- Only `payload` can be updated; schema fields (type, tenant_id, owner_id) are immutable after creation
+- `updated_at` is automatically set
+
+#### DELETE /resources/{id} — Soft-Delete Resource
+
+**Response** (204 No Content)
+
+Notes:
+
+- Sets `deleted_at` to current timestamp
+- Resource remains in storage but is excluded from list queries
+
+**Error Responses** (RFC 9457 Problem Details):
+
+All error responses use the RFC 9457 Problem Details format (`application/problem+json`). Problem Details `type` is a stable error URI; table entries below use short slugs for readability.
+
+| HTTP Status | Problem type slug | Description |
+| --- | --- | --- |
+| 400 | `invalid-gts-wildcard` | GTS wildcard pattern in $filter is malformed (e.g., `*` not at end, multiple wildcards) |
+| 400 | `invalid-odata-query` | OData query references payload fields or has invalid syntax |
+| 400 | `payload-too-large` | Payload exceeds 64 KB limit |
+| 400 | `batch-size-exceeded` | Batch request exceeds the maximum allowed items (default: 100) |
+| 400 | `gts-type-not-found` | Referenced resource `type` (GTS schema ID / GTS type ID) does not exist in Types Registry. Response includes the unresolved GTS type ID |
+| 401 | `unauthenticated` | Missing or invalid authentication |
+| 403 | `forbidden` | Caller lacks general permission for this operation |
+| 403 | `gts-type-not-in-scope` | Caller's token permissions do not include a matching GTS resource_pattern for the target resource type. Returned as a pre-query check on POST, or when no permitted types match on LIST. Extensions include the required GTS type and action |
+| 404 | `not-found` | Resource does not exist, or was filtered out by DB-level security filters (tenant scope, owner_id scope for per-user resources, GTS type scope). Because all access checks are applied as DB query filters, a mismatch on any dimension results in 404 — the caller cannot distinguish between "does not exist" and "not authorized" for individual resources |
+| 409 | `duplicate-idempotency-key` | A resource was already successfully created with the same `idempotency_key` within the same tenant. Response body includes the `id` of the existing resource |
+| 422 | `validation-error` | On POST: resource type requires owner_id (`is_per_owner_resource=true`) but none available in SecurityContext. On POST/PUT: payload fails GTS schema validation. Other semantic validation failures |
+| 501 | `search-not-supported` | The storage plugin for this resource type does not support search operations |
+
+**Example Error Response** (403):
+
+```json
+{
+  "type": "https://api.hyperspot.io/errors/gts-type-not-in-scope",
+  "title": "GTS type not in scope",
+  "status": 403,
+  "detail": "Caller lacks 'create' permission for GTS type 'gts.x.core.srr.resource.v1~acme.widget'",
+  "instance": "/simple-resource-registry/v1/resources",
+  "trace_id": "01J..."
+}
+```
+
+#### POST /resources:search — Search Resources (`cpt-cf-srr-fr-search-api`)
+
+**Request Body**:
+
+```json
+{
+  "type": "string (GTS type ID or wildcard pattern)",
+  "query": "string (full-text search query)",
+  "filters": {
+    "owner_id": "uuid (optional)",
+    "created_after": "datetime (optional)",
+    "created_before": "datetime (optional)"
+  },
+  "limit": 50,
+  "cursor": "opaque-cursor-string (optional)"
+}
+```
+
+**Response** (200 OK):
+
+```json
+{
+  "items": [
+    { "...full resource object..." }
+  ],
+  "page_info": {
+    "limit": 50,
+    "next_cursor": "opaque-cursor-string | null",
+    "prev_cursor": null
+  }
+}
+```
+
+**Response** (501 Not Implemented — RFC 9457 Problem Details):
+
+```json
+{
+  "type": "https://api.hyperspot.io/errors/search-not-supported",
+  "title": "Search not supported by plugin",
+  "status": 501,
+  "detail": "The storage plugin for resource type 'gts.x.srr.resource.v1~acme.widget' does not support search operations",
+  "trace_id": "01J..."
+}
+```
+
+Notes:
+
+- Tenant scoping is automatically applied from SecurityContext (not a request field)
+- The API checks the target plugin's `search_support` capability before routing
+- If the plugin lacks `search_support`, returns 501 Not Implemented
+- GTS type-based access control applies (same as GET list)
+- Full-text search is performed within resource payloads
+
+#### POST /resources:batch-get — Batch Get Resources (`cpt-cf-srr-fr-batch-operations`)
+
+**Request Body**:
+
+```json
+{
+  "items": [
+    { "data": { "id": "uuid" } },
+    { "data": { "id": "uuid" } }
+  ]
+}
+```
+
+**Response** (207 Multi-Status):
+
+```json
+{
+  "items": [
+    { "index": 0, "status": 200, "data": { "...full resource object..." } },
+    { "index": 1, "status": 404, "error": { "type": "https://api.hyperspot.io/errors/not-found", "title": "Resource not found", "status": 404, "detail": "Resource with id '01J...' does not exist", "trace_id": "01J...-item-1" } }
+  ]
+}
+```
+
+Notes:
+
+- Each item is independently resolved with tenant scoping and GTS access control
+- Items that fail access control or do not exist return per-item errors (RFC 9457 Problem Details)
+- Maximum batch size: configurable (default 100)
+
+#### POST /resources:batch — Batch Create/Update/Delete Resources (`cpt-cf-srr-fr-batch-operations`)
+
+**Request Body** (create example):
+
+```json
+{
+  "items": [
+    {
+      "idempotency_key": "req-1-uuid",
+      "data": { "action": "create", "type": "string", "payload": { } }
+    },
+    {
+      "idempotency_key": "req-2-uuid",
+      "data": { "action": "update", "id": "uuid", "payload": { } }
+    },
+    {
+      "idempotency_key": "req-3-uuid",
+      "data": { "action": "delete", "id": "uuid" }
+    }
+  ]
+}
+```
+
+**Response** (207 Multi-Status):
+
+```json
+{
+  "items": [
+    {
+      "index": 0,
+      "idempotency_key": "req-1-uuid",
+      "status": 201,
+      "location": "/simple-resource-registry/v1/resources/01J...",
+      "data": { "...full resource object..." }
+    },
+    {
+      "index": 1,
+      "idempotency_key": "req-2-uuid",
+      "status": 200,
+      "data": { "...full updated resource object..." }
+    },
+    {
+      "index": 2,
+      "idempotency_key": "req-3-uuid",
+      "status": 404,
+      "error": {
+        "type": "gts.x.core.errors.err.v1~x.core.http.not_found.v1~",
+        "title": "Resource not found",
+        "status": 404,
+        "detail": "Resource with id '01J...' does not exist or is not accessible",
+        "trace_id": "01J...-item-2"
+      }
+    }
+  ]
+}
+```
+
+Notes:
+
+- Follows DNA BATCH.md conventions: `POST /resources:batch`, `207 Multi-Status`, per-item `index`/`status`/`data`/`error`
+- Each item is validated and processed independently (best-effort semantics)
+- GTS type validation, access control, and behavioral flag evaluation are applied per item
+- For item-level GET/PUT/DELETE semantics, inaccessible resources return 404 because tenant/user/type checks are applied as DB filters
+- Partial success is allowed — some items may succeed while others fail
+- `idempotency_key` is required for items with `action: "create"`; optional for `update`/`delete` items (used for batch-level retry safety only)
+- Error responses use RFC 9457 Problem Details per item
+- Event/audit emission applies per successfully processed item
+- Maximum batch size: configurable (default 100)
+
+### 3.4 Internal Dependencies
+
+| Dependency Module | Interface Used | Purpose | Needed By |
+| --- | --- | --- | --- |
+| Types Registry | Types Registry SDK (ClientHub) | Resolve GTS type definitions, validate type, read behavioral flags | `cpt-cf-srr-fr-gts-type-registration`, `cpt-cf-srr-fr-gts-type-validation` |
+| modkit-db | SecurityContext-based tenant scoping | Tenant-scoped database access infrastructure (used by storage backends) | `cpt-cf-srr-fr-default-storage-backend` |
+| gts-rust | Rust crate (library) | GTS ID generation, schema utilities, payload validation against GTS type schemas | `cpt-cf-srr-fr-gts-type-registration`, `cpt-cf-srr-fr-create-resource`, `cpt-cf-srr-fr-update-resource` |
+| Events Broker | Events Broker SDK (ClientHub) | Emit domain events for resource lifecycle (fixed schema: id, type, subject_type, subject_id) | `cpt-cf-srr-fr-notification-events` |
+| Audit Module | Audit SDK (ClientHub) | Emit audit events for compliance (fixed schema: id, type, subject_type, subject_id, previous_payload, new_payload) | `cpt-cf-srr-fr-audit-events` |
+
+**Dependency Rules** (per project conventions):
+
+- No circular dependencies
+- Always use SDK modules for inter-module communication
+- No cross-category sideways deps except through contracts
+- `SecurityContext` must be propagated across all in-process calls
+
+### 3.5 External Dependencies
+
+None. Simple Resource Registry does not communicate with external systems directly. All external interactions (if any) are mediated by other CyberFabric modules.
+
+### 3.6 Event and Audit Schemas (`cpt-cf-srr-fr-notification-events`, `cpt-cf-srr-fr-audit-events`)
+
+#### Notification Event Schema
+
+**Event Types**: `resource.created`, `resource.updated`, `resource.deleted`
+
+**Fixed Schema**:
+
+```json
+{
+  "id": "string (event id)",
+  "type": "string (gtx.x.core.events.event.v1~ ... created | updated | deleted)",
+  "subject_type": "string (GTS type ID of the resource)",
+  "subject_id": "uuid (resource identifier)"
+}
+```
+
+**Design Rationale**: The event schema is intentionally minimal and does not include the full resource payload. This keeps events lightweight and prevents event bus saturation. Consumers that need the full resource state can fetch it via GET /resources/{id} using the provided id. The fixed schema ensures consistent event handling across all resource types without requiring per-type event definitions.
+
+#### Audit Event Schema
+
+**Event Types**: `resource.created`, `resource.updated`, `resource.deleted`
+
+**Fixed Schema**:
+
+```json
+{
+  "id": "string (event id)",
+  "type": "string (gtx.x.core.events.event.v1~x.core.audit.event.v1~ created | updated | deleted)",
+  "subject_type": "GTS string (GTS type ID of the resource)",
+  "subject_id": "uuid (resource identifier)",
+  "previous_payload": "object | null (resource payload before operation; null for create)",
+  "new_payload": "object | null (resource payload after operation; null for delete)"
+}
+```
+
+**Design Rationale**: Audit events include full before/after payloads to enable complete audit trail reconstruction without requiring access to the live resource. For create operations, `previous_payload` is null. For delete operations, `new_payload` is null. For update operations, both fields are populated, enabling diff-based audit reporting. The fixed schema ensures consistent audit event structure across all resource types.
+
+### 3.7 Interactions & Sequences
+
+#### Create Resource
+
+**ID**: `cpt-cf-srr-seq-create`
+
+**Use cases**: `cpt-cf-srr-usecase-store-workflow-object`
+
+**Actors**: any API
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant API as API Layer
+    participant SVC as ResourceService
+    participant ACL as GTS Access Control
+    participant Cache as GTS Type Cache
+    participant TR as Types Registry
+    participant SP as Storage Plugin
+    participant EB as Events Broker
+    participant AU as Audit Module
+
+    C->>API: POST /resources {type, idempotency_key, payload}
+    API->>API: Extract SecurityContext
+    API->>API: Validate request body (required fields, payload size)
+    API->>SVC: create_resource(ctx, type, idempotency_key, payload)
+    SVC->>Cache: get_type_config(type)
+    alt Cache miss
+        Cache->>TR: get_gts_entity(type)
+        alt GTS type not found
+            TR-->>Cache: not found
+            Cache-->>SVC: not found
+            SVC-->>API: 400 gts-type-not-found
+            API-->>C: 400 Bad Request
+        end
+        TR-->>Cache: ResourceTypeConfig
+        Cache->>Cache: store with TTL
+    end
+    Cache-->>SVC: ResourceTypeConfig (flags + retention)
+    SVC->>ACL: check_permission(ctx, type, "create")
+    alt Type not in caller's token GTS scope
+        ACL-->>SVC: denied
+        SVC-->>API: 403 gts-type-not-in-scope
+        API-->>C: 403 Forbidden
+    end
+    ACL-->>SVC: allowed
+    alt is_per_owner_resource=true and no subject_id in SecurityContext
+        SVC-->>API: 422 validation-error
+        API-->>C: 422 Unprocessable Entity
+    end
+    SVC->>SVC: Validate payload against GTS type schema (gts crate)
+    alt Payload validation fails
+        SVC-->>API: 422 validation-error
+        API-->>C: 422 Unprocessable Entity
+    end
+    SVC->>SVC: Assign UUID, set tenant_id=ctx.subject_tenant_id,<br/>owner_id=ctx.subject_id (if per_owner), set timestamps
+    SVC->>SP: create(ctx, resource, idempotency_key)
+    Note over SP: Plugin atomically checks idempotency_key in its dedup store<br/>and persists resource + idempotency record in one transaction
+    alt CreateOutcome::Duplicate
+        SP-->>SVC: Duplicate(existing_id)
+        SVC-->>API: 409 duplicate-idempotency-key + existing id
+        API-->>C: 409 Conflict
+    end
+    SP-->>SVC: Created(resource)
+    alt Event flags enabled (cpt-cf-srr-fr-notification-events)
+        SVC->>EB: emit(resource.created)
+    end
+    alt Audit flags enabled on type or parent type (cpt-cf-srr-fr-audit-events)
+        SVC->>AU: emit(resource.created audit)
+    end
+    SVC-->>API: created resource
+    API-->>C: 201 Created
+```
+
+#### Get Single Resource
+
+**ID**: `cpt-cf-srr-seq-get`
+
+**Use cases**: `cpt-cf-srr-usecase-reflect-external`
+
+**Actors**: any API
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant API as API Layer
+    participant SVC as ResourceService
+    participant ACL as GTS Access Control
+    participant SP as Storage Plugin
+
+    C->>API: GET /resources/{id}
+    API->>API: Extract SecurityContext
+    API->>SVC: get_resource(ctx, id)
+    SVC->>ACL: get_permitted_types(ctx, "read")
+    ACL-->>SVC: permitted GTS types from token claims
+    SVC->>SP: get(ctx, id)
+    Note over SP: DB query applies all filters:<br/>- tenant_id = ctx.subject_tenant_id<br/>- type IN (permitted GTS types)<br/>- owner_id = ctx.subject_id (if is_per_owner_resource)<br/>- deleted_at IS NULL
+    SP-->>SVC: resource | None
+    alt Resource found
+        SVC-->>API: resource
+        API-->>C: 200 OK
+    else Not found (filtered out or does not exist)
+        SVC-->>API: 404 not-found
+        API-->>C: 404 Not Found
+    end
+```
+
+#### List Resources with OData
+
+**ID**: `cpt-cf-srr-seq-list`
+
+**Use cases**: `cpt-cf-srr-usecase-query-odata`
+
+**Actors**: any API
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant API as API Layer
+    participant SVC as ResourceService
+    participant ACL as GTS Access Control
+    participant SP as Storage Plugin
+
+    C->>API: GET /resources?$filter=...&$orderby=...&limit=20
+    API->>API: Extract SecurityContext
+    API->>API: Parse OData query parameters
+    API->>API: Validate: no payload field references
+    API->>SVC: list_resources(ctx, type_filter, odata)
+    SVC->>ACL: check_list_permission(ctx, type_filter, "read")
+    Note over ACL: If type_filter contains wildcard (*),<br/>compute intersection with caller's permitted GTS types
+    alt No permitted types match
+        ACL-->>SVC: denied
+        SVC-->>API: 403 gts-type-not-in-scope
+        API-->>C: 403 Forbidden
+    end
+    ACL-->>SVC: allowed (effective_gts_filter)
+    SVC->>SP: list(ctx, effective_gts_filter, odata)
+    Note over SP: DB query applies all filters:<br/>- tenant_id = ctx.subject_tenant_id<br/>- type IN (effective_gts_filter)<br/>- owner_id = ctx.subject_id (if is_per_owner_resource)<br/>- deleted_at IS NULL<br/>- OData $filter on schema columns<br/>- $orderby, limit, cursor
+    SP-->>SVC: PagedResult<Resource>
+    SVC-->>API: paged result
+    API-->>C: 200 OK {items: [...], page_info: {...}}
+```
+
+#### Update Resource
+
+**ID**: `cpt-cf-srr-seq-update`
+
+**Actors**: any API
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant API as API Layer
+    participant SVC as ResourceService
+    participant ACL as GTS Access Control
+    participant Cache as GTS Type Cache
+    participant TR as Types Registry
+    participant SP as Storage Plugin
+    participant EB as Events Broker
+    participant AU as Audit Module
+
+    C->>API: PUT /resources/{id} {payload}
+    API->>API: Extract SecurityContext
+    API->>SVC: update_resource(ctx, id, payload)
+    SVC->>ACL: get_permitted_types(ctx, "update")
+    ACL-->>SVC: permitted GTS types from token claims
+    SVC->>SP: get(ctx, id)
+    Note over SP: DB query applies all filters:<br/>- tenant_id = ctx.subject_tenant_id<br/>- type IN (permitted GTS types)<br/>- owner_id = ctx.subject_id (if is_per_owner_resource)<br/>- deleted_at IS NULL
+    SP-->>SVC: existing resource | None
+    alt Not found (filtered out or does not exist)
+        SVC-->>API: 404 not-found
+        API-->>C: 404 Not Found
+    end
+    SVC->>Cache: get_type_config(resource.type)
+    alt Cache miss
+        Cache->>TR: get_gts_entity(resource.type)
+        TR-->>Cache: ResourceTypeConfig
+        Cache->>Cache: store with TTL
+    end
+    Cache-->>SVC: ResourceTypeConfig (flags + retention)
+    SVC->>SVC: Validate payload against GTS type schema (gts crate)
+    alt Payload validation fails
+        SVC-->>API: 422 validation-error
+        API-->>C: 422 Unprocessable Entity
+    end
+    SVC->>SVC: Update payload, set updated_at
+    SVC->>SP: update(ctx, resource)
+    SP-->>SVC: updated resource
+    alt Update event flag enabled (cpt-cf-srr-fr-notification-events)
+        SVC->>EB: emit(resource.updated)
+    end
+    alt Update audit flag enabled on type or parent type (cpt-cf-srr-fr-audit-events)
+        SVC->>AU: emit(resource.updated audit)
+    end
+    SVC-->>API: updated resource
+    API-->>C: 200 OK
+```
+
+#### Delete Resource
+
+**ID**: `cpt-cf-srr-seq-delete`
+
+**Actors**: any API
+
+```mermaid
+sequenceDiagram
+    participant C as Consumer
+    participant API as API Layer
+    participant SVC as ResourceService
+    participant ACL as GTS Access Control
+    participant Cache as GTS Type Cache
+    participant TR as Types Registry
+    participant SP as Storage Plugin
+    participant EB as Events Broker
+    participant AU as Audit Module
+
+    C->>API: DELETE /resources/{id}
+    API->>API: Extract SecurityContext
+    API->>SVC: delete_resource(ctx, id)
+    SVC->>ACL: get_permitted_types(ctx, "delete")
+    ACL-->>SVC: permitted GTS types from token claims
+    SVC->>SP: get(ctx, id)
+    Note over SP: DB query applies all filters:<br/>- tenant_id = ctx.subject_tenant_id<br/>- type IN (permitted GTS types)<br/>- owner_id = ctx.subject_id (if is_per_owner_resource)<br/>- deleted_at IS NULL
+    SP-->>SVC: existing resource | None
+    alt Not found (filtered out or does not exist)
+        SVC-->>API: 404 not-found
+        API-->>C: 404 Not Found
+    end
+    SVC->>Cache: get_type_config(resource.type)
+    alt Cache miss
+        Cache->>TR: get_gts_entity(resource.type)
+        TR-->>Cache: ResourceTypeConfig
+        Cache->>Cache: store with TTL
+    end
+    Cache-->>SVC: ResourceTypeConfig (flags + retention)
+    alt retention_days == 0 (immediate hard-delete)
+        SVC->>SP: hard_delete(ctx, id)
+        Note over SVC,SP: Permanently deletes the single resource row — no soft-delete step
+        SP-->>SVC: ok
+    else Normal soft-delete
+        SVC->>SP: delete(ctx, id)
+        SP->>SP: Set deleted_at = now()
+        SP-->>SVC: ok
+    end
+    alt Delete event flag enabled (cpt-cf-srr-fr-notification-events)
+        SVC->>EB: emit(resource.deleted)
+    end
+    alt Delete audit flag enabled on type or parent type (cpt-cf-srr-fr-audit-events)
+        SVC->>AU: emit(resource.deleted audit)
+    end
+    SVC-->>API: ok
+    API-->>C: 204 No Content
+```
+
+#### Storage Routing (`cpt-cf-srr-fr-storage-routing`)
+
+**ID**: `cpt-cf-srr-seq-storage-routing`
+
+**Actors**: any API
+
+```mermaid
+sequenceDiagram
+    participant SVC as ResourceService
+    participant Router as Storage Router
+    participant Config as Routing Config
+    participant RelDB as Relational DB Plugin
+    participant SP as Search Plugin
+
+    SVC->>Router: resolve_plugin(type)
+    Router->>Config: lookup(type)
+    alt Mapped to search plugin
+        Config-->>Router: search-engine
+        Router-->>SVC: Search Plugin
+        SVC->>SP: operation(ctx, ...)
+    else Default (Relational DB)
+        Config-->>Router: relational-db (default)
+        Router-->>SVC: Relational DB Plugin
+        SVC->>RelDB: operation(ctx, ...)
+    end
+```
+
+#### Retention Purge (Jobs Manager)
+
+**ID**: `cpt-cf-srr-seq-retention-purge`
+
+**Actors**: System (Jobs Manager job)
+
+```mermaid
+sequenceDiagram
+    participant JM as Jobs Manager
+    participant Task as Retention Purge Jobs Manager job
+    participant TR as Types Registry
+    participant SP as Storage Plugin
+
+    loop Periodic (e.g., every 1 hour)
+        JM->>Task: run(job)
+        Task->>TR: list_gts_entities(base_resource_type pattern)
+        TR-->>Task: ResourceTypeConfig[] (with retention settings)
+        loop For each resource type
+            Task->>Task: Compute cutoff = now() - retention_days
+            Note over Task: retention_days from type config,<br/>or system default (30 days) if null
+            Task->>SP: purge_deleted_before(type, cutoff, batch_size)
+            SP->>SP: Hard-delete matching resources<br/>where type matches and deleted_at < cutoff
+            SP-->>Task: purged_count
+        end
+    end
+```
+
+### 3.8 Database Schemas & Tables
+
+Database schema design is the responsibility of each storage backend (plugin). The main module defines only the logical `Resource` entity and `ResourceTypeConfig` (see §3.1 Domain Model); physical schema, indexing strategy, and storage optimizations are backend-internal concerns.
+
+For the default relational database backend, see:
+
+- **Plugin DESIGN**: [`plugins/srr-rdb-plugin/docs/DESIGN.md`](../plugins/srr-rdb-plugin/docs/DESIGN.md) — table schemas, indexes, idempotency table, group memberships table
+- **Storage optimization ADR**: [`plugins/srr-rdb-plugin/docs/ADR/0001-cpt-cf-srr-rdb-adr-storage-optimization.md`](../plugins/srr-rdb-plugin/docs/ADR/0001-cpt-cf-srr-rdb-adr-storage-optimization.md) — rationale for single-table with indexes over partitioning or per-type tables
+
+Other storage backends **MUST** implement equivalent persistence for the `Resource` entity and idempotency deduplication (see `CreateOutcome` in §3.2), but may use any internal data structure appropriate to their storage technology.
+
+## 4. Additional Context
+
+### 4.1 Known Design-Level Limitations
+
+1. **No payload querying**: The JSON payload is stored as an opaque blob. Consumers cannot filter, sort, or search within payload fields via the API. This is a deliberate trade-off for simplicity and predictable performance. For search-heavy use cases, the search API (`cpt-cf-srr-fr-search-api`) with a search-capable plugin is the intended solution.
+
+2. **Default backend scalability**: The default relational DB backend targets up to 100M resources (`cpt-cf-srr-nfr-scalability`). Beyond this threshold, per-resource-type storage routing (`cpt-cf-srr-fr-storage-routing`) enables dedicated backends for high-volume types. Storage optimization strategy is a per-backend concern — see the [plugin DESIGN](../plugins/srr-rdb-plugin/docs/DESIGN.md) and its ADRs.
+
+3. **No cross-type queries (except via wildcard)**: The API does not support querying resources across arbitrary, unrelated GTS types in a single request. GTS wildcard filtering (trailing `*`) enables querying within a type hierarchy, but consumers needing views across unrelated types must make multiple requests or use an aggregation layer.
+
+4. **Payload validation at API boundary**: The Simple Resource Registry service validates resource payloads against the derived GTS type's JSON Schema at create and update time, using the `gts` crate's standard schema validation. Validation failures return 422 Unprocessable Entity. This ensures that all persisted resources conform to their declared GTS type schema, regardless of whether the request originates from the REST API or the SDK client.
+
+5. **No resource versioning**: The module does not maintain a history of resource changes. Only the current state is stored. Consumers needing change history should use audit events (`cpt-cf-srr-fr-audit-events`) for traceability.
+
+6. **Retention purge is background-only**: The retention purge task runs periodically, so soft-deleted resources may persist slightly beyond their configured retention period depending on task frequency and batch size. Operators should size the purge interval and batch size appropriately for their workload.
+
+7. **No auto-deletion of active resources**: The module intentionally does not support automatic soft-deletion of active resources based on a TTL. This is an intentional safety decision — automatic deletion of live data is error-prone and must not be accidentally enabled. Consumers requiring resource TTL must implement their own cleanup logic or use workflows.
+
+8. **GTS access control depends on Permission quality**: If the caller's token lacks properly scoped GTS `resource_pattern` entries, all operations will be denied. This is by design — permissive tokens (e.g., `resource_pattern: "*"`) are the responsibility of the identity provider and policy engine.
+
+### 4.2 Potential Use Cases
+
+| Use Case | Description |
+| --- | --- | --- |
+| Workflow artifacts | Custom objects generated by workflow automation steps |
+| External object reflections | Entries representing objects from external systems (CRM contacts, ticketing issues) |
+| Domain model consistency | Partial representations of external resources for internal domain model coherence |
+| Agent execution artifacts | Intermediate or final results from agent pipeline execution |
+| Tenant configuration objects | Custom tenant-level settings not covered by dedicated modules |
+| User preferences | Per-user settings or state for platform features |
+
+### 4.3 Storage Routing Configuration (`cpt-cf-srr-fr-storage-routing`)
+
+```yaml
+simple_resource_registry:
+  storage:
+    default_plugin: relational-db
+    routes:
+      - type: "gts.x.core.srr.resource.v1~vendor.pkg.*"
+        plugin: search-engine
+      - type: "gts.x.core.srr.resource.v1~x.core.*"
+        plugin: relational-db
+      # Vendor-provided plugin bridging to an existing platform CMDB
+      - type: "gts.x.core.srr.resource.v1~vendor1.*"
+        plugin: vendor1-cmdb-adapter
+```
+
+The routing configuration maps resource `type` patterns (GTS schema IDs / GTS type IDs) to storage plugin instances. Glob patterns enable grouping related types to the same backend. Unmatched types fall back to the default plugin. Platform vendors can register their own plugin implementations (e.g., `vendor-cmdb-adapter`) to bridge resource operations to existing platform storage components, enabling multiple coexisting plugins for different resource families.
+
+### 4.4 Alignment with Platform Architecture (`docs/arch`) and `gts-rust`
+
+This section records findings from cross-referencing this design against `docs/arch/authorization/DESIGN.md` and the `gts-rust` library.
+
+#### SecurityContext Field Names
+
+Per `docs/arch/authorization/DESIGN.md`, the canonical `SecurityContext` struct fields are:
+
+```rust
+SecurityContext {
+    subject_id: String,                    // unique subject identifier (maps to resource.owner_id)
+    subject_type: Option<GtsTypeId>,       // optional vendor subject type
+    subject_tenant_id: TenantId,           // Subject Owner Tenant (maps to resource.tenant_id)
+    token_scopes: Vec<String>,             // capability ceiling (["*"] for first-party)
+    bearer_token: Option<Secret<String>>,  // original token for PDP forwarding
+}
+```
+
+Throughout this document, `ctx.subject_tenant_id` is used for `resource.tenant_id` (mandatory) and `ctx.subject_id` for `resource.owner_id` (when `is_per_owner_resource=true`).
+
+#### Permission Model Field Name
+
+`docs/arch/authorization/DESIGN.md` defines `Permission` as `{ resource_type, action }`. This design uses `resource_pattern` in place of `resource_type` to emphasize GTS wildcard-based pattern matching semantics (see `GtsWildcard` in `gts-rust`). These are the same concept; `resource_pattern` is the SRR-specific terminology for a `resource_type` value that may contain a GTS trailing wildcard (`*`).
+
+#### GTS Rust Library Alignment
+
+- **ID validation**: uses `GtsID::new(id)` from `gts-rust/gts/src/gts.rs`; GTS type IDs end with `~` (e.g., `gts.x.core.srr.resource.v1~`)
+- **Wildcard matching**: uses `GtsWildcard::new(pattern)` + `gts_id.wildcard_match(&pattern)` from `gts-rust/gts/src/gts.rs`
+- **Schema validation**: uses `gts` crate instance validation (OP#6) per `gts-rust` README
+- **In-memory cache**: follows `Arc<RwLock<HashMap<String, V>>>` pattern from `gts-rust/gts/src/store.rs`; aligns with the "In-memory entities registry" feature of `gts-rust`
+- **GTS URI prefix**: JSON Schema `$id` fields use `gts://` prefix (`GTS_URI_PREFIX` in `gts-rust`); confirmed in base schema definition
+
+## 5. Traceability
+
+- **PRD**: [PRD.md](./PRD.md)
+- **ADRs**: [ADR/](./ADR/)
+- **Features**: [features/](./features/)

--- a/modules/simple-resource-registry/docs/DESIGN.md
+++ b/modules/simple-resource-registry/docs/DESIGN.md
@@ -19,7 +19,7 @@ Resource type definitions are managed through GTS (Global Type System) via the T
 | Requirement | Design Response |
 | --- | --- |
 | `cpt-cf-srr-fr-create-resource` | API layer extracts tenant/user from SecurityContext; domain layer assigns UUID and timestamps; delegates to storage plugin |
-| `cpt-cf-srr-fr-read-resource` | ResourceService resolves permitted GTS types, then storage plugin applies backend-level filters (tenant, type scope, owner_id for per-user types); returns 404 when no match found |
+| `cpt-cf-srr-fr-read-resource` | ResourceService resolves permitted GTS types, then storage plugin applies backend-level filters (tenant, type scope, owner_id for per-user types) integrated with standard authz; returns 404 when no match is found |
 | `cpt-cf-srr-fr-list-resources` | OData parser translates query params to backend query filters on schema columns; plugin executes scoped query |
 | `cpt-cf-srr-fr-update-resource` | ResourceService resolves permitted GTS types, storage plugin fetches target resource with backend-level security filters, then domain layer validates payload and updates `updated_at` |
 | `cpt-cf-srr-fr-delete-resource` | Soft-delete via deleted_at timestamp; storage plugin filters soft-deleted records from list queries |
@@ -37,7 +37,7 @@ Resource type definitions are managed through GTS (Global Type System) via the T
 | `cpt-cf-srr-fr-storage-routing` | Configuration maps GTS type IDs to storage plugin instances; router resolves plugin per request |
 | `cpt-cf-srr-fr-batch-operations` | Batch endpoints (POST /resources:batch, POST /resources:batch-get) delegate per-item to ResourceService with shared SecurityContext; 207 Multi-Status with per-item results per DNA BATCH.md; configurable batch size cap |
 | `cpt-cf-srr-fr-resource-groups` | Many-to-many group membership model; group-level batch operations (list, delete); group lifecycle |
-| `cpt-cf-srr-fr-idempotent-create` | POST requires `idempotency_key`; plugin atomically checks and persists the key+resource in one transaction; `CreateOutcome::Duplicate` returned for duplicate key within retention window → 409 with existing resource id |
+| `cpt-cf-srr-fr-idempotent-resource-create` | POST requires `idempotency_key`; plugin atomically checks and persists the key+resource in one transaction; `CreateOutcome::Duplicate` returned for duplicate key within retention window → 409 with existing resource id |
 
 #### ADR Drivers
 

--- a/modules/simple-resource-registry/docs/PRD.md
+++ b/modules/simple-resource-registry/docs/PRD.md
@@ -138,7 +138,7 @@ Platform users, API clients, and CyberFabric modules can define derived types an
 
 #### Create Resource
 
-- [ ] `p1` - **ID**: `cpt-cf-srr-fr-create-resource`
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-idempotent-resource-create`
 
 The system **MUST** allow authenticated users, modules, and API clients to create a new resource by specifying a resource `type` (a GTS type ID), a mandatory `idempotency_key` (UUID), and a JSON payload.
 

--- a/modules/simple-resource-registry/docs/PRD.md
+++ b/modules/simple-resource-registry/docs/PRD.md
@@ -1,0 +1,527 @@
+# PRD — Simple Resource Registry
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Simple Resource Registry is a universal, environment-agnostic CRUD storage layer for resource types that are too simple to justify their own CyberFabric module. It exposes a single, consistent API for creating, reading, updating, and deleting typed resources, using a fixed envelope (identity, ownership, timestamps) plus a flexible JSON payload validated against GTS type definitions. The registry is designed to run on any deployment target — edge devices (SQLite), cloud infrastructure (PostgreSQL, MariaDB), and enterprise on-premises environments — adapting its storage backend to the deployment constraints without changing the consumer-facing API.
+
+The module solves a recurring problem in modular SaaS platforms: many features need secure, schema-aware object storage with proper authorization (by tenant, owner/user, and resource type), but do not require the complexity of a full domain-specific service. Instead of building custom modules or relying on ad-hoc storage with inconsistent security and governance, one can use the Simple Resource Registry for cases such as simple objects storage, workflow-generated objects, projections of external system entities, partial models used for internal consistency, tenant-level configuration data, and auxiliary artifacts produced by agent execution.
+
+This module is designed for lightweight structured data sets, on the order of up to ~1M items per resource type and ~100M total, and is not intended to serve as a general-purpose database for the entire platform.
+
+Optionally, the registry can emit lifecycle notification events (created, updated, deleted) for configured resource types, allowing these resources to participate directly in workflows and to act as workflow triggers.
+
+### 1.2 Background / Problem Statement
+
+In a modular SaaS platform like CyberFabric, first-class domain objects (chat messages, model definitions, events, settings, files) are managed by dedicated modules with rich APIs and domain-specific behavior. However, many resource types lack the complexity to justify a dedicated module — they need simple CRUD semantics with tenant isolation and standard governance hooks (audit, events).
+
+Without a generic registry, teams face two poor choices: either build a new module for every simple resource type (high cost, code duplication) or store resources in ad-hoc locations (inconsistent APIs, missing security controls, no traceability). Simple Resource Registry eliminates this by providing a single, extensible storage layer that any module or workflow can use for structured data that conforms to a GTS-registered type.
+
+The storage layer is abstracted behind a well-defined interface, allowing the same API to serve relational database-backed resources today and alternative backends (search engines, object stores) in the future, without changing consumers. Platform vendors can also implement their own storage backends to integrate with existing platform components that already store the appropriate resources, effectively using Simple Resource Registry as a unified API façade over heterogeneous storage systems. Multiple storage backends can coexist, with different resource types routed to different backends via configuration.
+
+### 1.3 Goals (Business Outcomes)
+
+- Reduce time-to-ship for features that require simple resource storage from days to hours by eliminating the need for a dedicated module
+- Provide a single, consistent CRUD API surface for generic resources across the platform
+- Validate resource payloads against GTS type definitions to ensure schema consistency and safe extensibility
+- Enforce tenant and owner isolation, authentication, and GTS-driven attribute-based access control (ABAC) uniformly for all registered resource types
+- Enable governance (audit and lifecycle events) for all resource operations without per-type implementation effort
+
+### 1.4 Glossary
+
+| Term | Definition |
+|------|------------|
+| Resource | A single stored object managed by the registry, consisting of a fixed GTS schema envelope and a type-specific JSON payload |
+| Resource Type (`type`)| A GTS-registered type definition that describes the schema of a resource's payload and its behavioral flags (event/audit configuration). The resource `type` value is a GTS type identifier in GTS ID format — i.e., resource type == resource type ID == GTS schema ID. |
+| Resource Tenant (`tenant_id`) | The platform tenant (organization / workspace) that owns the resource. Set from `SecurityContext.subject_tenant_id` and never caller-supplied. Every resource must belong to exactly one tenant. Tenant isolation is enforced at the storage query level. |
+| Resource Owner (`owner_id`) | The subject (typically a human user or a registered API client identified by their `subject_id`) that created or is associated with the resource. Set from `SecurityContext.subject_id`. Populated only when `is_per_owner_resource=true` on the resource type. When set, owner-scoped resources are filtered by `owner_id = ctx.subject_id` at the DB level, restricting visibility to that subject within the tenant. |
+| Base Resource Type | The GTS schema defining the common envelope fields shared by all resources (id, tenant, timestamps, etc.) |
+| Derived Resource Type | A GTS type that extends the base resource type with a specific payload schema and behavioral configuration |
+| Storage Backend | An interchangeable storage implementation responsible for persisting and querying resources. The registry abstracts storage behind a well-defined interface, allowing different backends (relational databases, search engines, vendor-provided stores) to be used depending on deployment environment and resource type needs. |
+| Schema Fields | The fixed set of envelope fields (id, tenant_id, owner_id, type, timestamps) stored as dedicated database columns and queryable via OData |
+| Payload | A JSON object stored alongside schema fields, whose structure is defined by the resource's GTS type; not queryable via OData |
+| Deleted Resource Retention | Configurable period after which soft-deleted resources are permanently purged from storage (default: 30 days) |
+| GTS Type-Based Access Control | Authorization mechanism that checks whether the caller's token permissions include a matching GTS resource_pattern and action for the target resource type |
+| Resource Group | A logical grouping of resources that share a common lifecycle or ownership context (`cpt-cf-srr-fr-resource-groups`) |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Platform User
+
+**ID**: `cpt-cf-srr-actor-platform-user`
+
+**Role**: Authenticated user interacting with CyberFabric applications or UI components that store and retrieve resources through the Simple Resource Registry.
+**Needs**: Reliable and secure storage of application data. Predictable behavior and access control aligned with tenant and user permissions. Ability to create, view, update, and delete resources through UI workflows
+
+#### API Client
+
+**ID**: `cpt-cf-srr-actor-api-client`
+
+**Role**: External or internal consumer calling the Simple Resource Registry REST API directly (e.g., third-party integrations, CLI tools, automated scripts).
+**Needs**: OData-capable query interface for filtering, ordering, and paginating resources by schema fields. Predictable HTTP semantics and standard error responses.
+
+### 2.2 System Actors
+
+#### Consumer Module
+
+**ID**: `cpt-cf-srr-actor-consumer-module`
+
+**Role**: Internal CyberFabric module that creates, reads, updates, or deletes resources via the SDK client (e.g., Workflows engine storing custom objects, Agent Runtime storing execution artifacts).
+
+## 3. Operational Concept & Environment
+
+No module-specific environment constraints beyond project defaults. The module operates within the standard CyberFabric modkit lifecycle and uses the platform's shared database infrastructure.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- CRUD REST API for generic resources with fixed schema envelope + JSON payload
+- GTS-based resource type definition (base type + derived types)
+- Tenant-scoped storage with mandatory tenant isolation via SecurityContext
+- Optional user-scoped resources (per-user ownership when resource type requires it)
+- OData $filter/$orderby and cursor-based pagination for schema fields (id, tenant_id, owner_id, type, created_at, updated_at, deleted_at)
+- GTS type-based access control on all CRUD operations (permissions checked against token's GTS resource_pattern + action)
+- GTS wildcard filtering on resource listing (trailing `*` per GTS spec)
+- Multi-backend storage architecture with interchangeable storage implementations; relational database as the default backend
+- Per-resource-type event emission (created, updated, deleted) via Events Broker
+- Per-resource-type audit event emission via Audit Module
+- SDK client for in-process consumption by other modules
+- Soft-delete support via deleted_at timestamp
+- Configurable deleted resource retention with automatic purge of soft-deleted resources (default: 30 days, type-level override)
+- Dedicated search API with backend capability checks (`cpt-cf-srr-fr-search-api`)
+- Batch CRUD operations per DNA BATCH.md (`cpt-cf-srr-fr-batch-operations`)
+- Resource groups support (`cpt-cf-srr-fr-resource-groups`)
+
+### 4.2 Out of Scope
+
+- OData query support for payload fields (payload is opaque JSON; filtering/ordering within it is not supported)
+- Full-text search across payload content (use external index if needed)
+- Resource versioning or change history tracking
+- Cross-resource-type queries (e.g., all resources regardless of type in a single request)
+- Resource relationships or foreign key enforcement between resources
+- Complex business logic or domain-specific validation beyond JSON Schema
+- Real-time streaming or SSE for resource changes (consumers use Events Broker for notifications)
+- File or binary attachment storage (use File Storage module)
+- UI components or admin dashboards
+- Automatic resource soft-deletion based on TTL / auto-deletion retention (error-prone; must not be accidentally enabled)
+- OData `$select` field projection (not applicable — all schema fields and payload are always returned; the payload is an opaque JSON object whose structure varies by resource type)
+
+## 5. Functional Requirements
+
+### 5.1 Core CRUD and Storage
+
+> IMPORTANT NOTE: All API endpoints in this section must enforce tenant access scope, user access scope (when applicable), and GTS type access scope filtering.
+
+#### Create Resource
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-create-resource`
+
+The system **MUST** allow authenticated users to create a new resource by specifying a resource `type` (a GTS type identifier / GTS schema ID), a mandatory `idempotency_key` (UUID), and a JSON payload. The system **MUST** automatically assign a UUID (if not provided), set `tenant_id` from `SecurityContext.subject_tenant_id`, set `owner_id` from `SecurityContext.subject_id` (when `is_per_owner_resource=true`), and set `created_at` and `updated_at` timestamps. If the target resource type is per-owner (`is_per_owner_resource=true`) and `SecurityContext.subject_id` is absent, the system **MUST** return 422 Unprocessable Entity. The system **MUST** validate the payload against the derived GTS type's JSON Schema (using the `gts` crate) and return 422 Unprocessable Entity if validation fails.
+
+**Rationale**: Core functionality — all consumers need to persist typed resources.
+**Actors**: `cpt-cf-srr-actor-platform-user`, `cpt-cf-srr-actor-consumer-module`
+
+#### Idempotent Resource Creation
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-idempotent-create`
+
+The system **MUST** require a `idempotency_key` in every POST /resources request body. The storage plugin **MUST** atomically check for an existing `(tenant_id, idempotency_key)` record and persist the resource + idempotency record in a single transaction. If a matching record exists and is within the retention window (default 24 h), the plugin returns `CreateOutcome::Duplicate` and the system **MUST** return 409 Conflict with the `id` of the previously created resource. Idempotency keys are scoped per tenant — the same key in different tenants is independent. Idempotency deduplication is storage-backend-owned; callers must always supply a unique key (e.g., a UUID) per intended creation.
+
+**Rationale**: Distributed consumers and workflow engines frequently retry failed HTTP requests. Without idempotency, retries after network failures create duplicate resources. The idempotency key lets callers safely retry POST requests without risk of double-creation.
+**Actors**: `cpt-cf-srr-actor-consumer-module`, `cpt-cf-srr-actor-platform-user`
+
+#### Read Single Resource
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-read-resource`
+
+The system **MUST** allow authenticated users to retrieve a single resource by ID. All access checks — tenant scope, GTS type scope (from token claims), and owner_id scope (when `is_per_owner_resource=true`) — are applied as DB query filters. If the resource does not exist or is filtered out by any of these security filters, the system **MUST** return 404 Not Found. The caller cannot distinguish between "does not exist" and "not authorized" for individual resources.
+
+**Rationale**: Core functionality — consumers need to fetch individual resources.
+**Actors**: `cpt-cf-srr-actor-platform-user`
+
+#### List Resources
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-list-resources`
+
+The system **MUST** allow authenticated users to list resources filtered by resource `type` (a GTS type identifier / GTS schema ID), with OData query support ($filter, $orderby) and cursor-based pagination (limit, cursor) on schema fields. All access checks — tenant scope, GTS type scope (from token claims), and owner_id scope (when `is_per_owner_resource=true`) — are applied as DB query filters. If the requested type filter does not intersect with the caller's permitted GTS types, the system **MUST** return 403 Forbidden. Otherwise, results are filtered at the DB level and an empty result set is a valid response (not an error).
+
+**Rationale**: Consumers need to discover and paginate through resources of a given type.
+**Actors**: `cpt-cf-srr-actor-platform-user`
+
+#### Update Resource
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-update-resource`
+
+The system **MUST** allow authenticated users to update the payload of an existing resource. The system **MUST** update the updated_at timestamp. All access checks — tenant scope, GTS type scope (from token claims), and `owner_id` scope (when `is_per_owner_resource=true`) — are applied as DB query filters. If the resource does not exist or is filtered out by any of these security filters, the system **MUST** return 404 Not Found.
+
+**Rationale**: Core functionality — consumers need to modify resource data.
+**Actors**: `cpt-cf-srr-actor-platform-user`, `cpt-cf-srr-actor-consumer-module`
+
+#### Delete Resource
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-delete-resource`
+
+The system **MUST** allow authenticated users to soft-delete a resource by setting the deleted_at timestamp. All access checks — tenant scope, GTS type scope (from token claims), and `owner_id` scope (when `is_per_owner_resource=true`) — are applied as DB query filters. If the resource does not exist or is filtered out by any of these security filters, the system **MUST** return 404 Not Found. Soft-deleted resources **MUST** be excluded from list results by default.
+
+**Rationale**: Core functionality — consumers need to remove resources while maintaining audit trail.
+**Actors**: `cpt-cf-srr-actor-platform-user`, `cpt-cf-srr-actor-consumer-module`
+
+#### GTS Resource Type Registration
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-gts-type-registration`
+
+The system **MUST** define a base GTS resource type schema with major-version-only versioning. Derived resource types **MUST** extend the base type via GTS schema inheritance. The base type **MUST** include:
+- Behavioral flags: is_per_owner_resource, is_create_event_needed, is_delete_event_needed, is_update_event_needed, is_create_audit_event_needed, is_update_audit_event_needed, is_delete_audit_event_needed
+- Hard-delete retention configuration: deleted_resource_retention_days (integer or null; default 30 if null; 0 means immediate hard-delete on soft-delete)
+
+**Rationale**: GTS type system ensures consistency, discoverability, and validation for all resource types. Embedding the deleted-resource retention policy in the type definition keeps it co-located with other behavioral configuration.
+
+#### Default Storage Backend
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-default-storage-backend`
+
+The system **MUST** ship with a default storage backend that uses a relational database as its persistence layer. The default backend **MUST** store schema fields as dedicated queryable columns and the payload as a JSON column. The default backend **MUST** support OData query operations on schema fields and **MUST** work on PostgreSQL, MariaDB, and SQLite without requiring database-specific configuration.
+
+**Rationale**: Relational databases are the standard CyberFabric storage tier, providing ACID guarantees and existing infrastructure across all deployment targets (edge, cloud, enterprise). OData support enables standard filtering and pagination.
+
+#### OData Query Support for Schema Fields
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-odata-schema-fields`
+
+The system **MUST** support OData $filter and $orderby operations, plus cursor-based pagination (limit, cursor) on schema fields (id, tenant_id, owner_id, type, created_at, updated_at, deleted_at). OData operations on payload fields are explicitly not supported. List responses **MUST** use the `items`/`page_info` envelope per DNA API guidelines.
+
+**Rationale**: Consumers need standard query capabilities for resource discovery and pagination without requiring module-specific code.
+**Actors**: `cpt-cf-srr-actor-api-client`, `cpt-cf-srr-actor-platform-user`
+
+#### GTS Type-Based Access Control
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-gts-access-control`
+
+All CRUD operations (GET, POST, PUT, DELETE) **MUST** enforce GTS type-based access control using token `Permission` entries (`resource_pattern` + `action`, where action is `read`/`create`/`update`/`delete`). GTS wildcard matching rules apply: a permission with `resource_pattern` = `gts.x.srr.resource.v1~acme.*` grants access to all derived types under the `acme` vendor namespace. For POST, if the requested resource `type` is not in scope, the system **MUST** return 403 Forbidden with error code `gts-type-not-in-scope`. For LIST, if the requested type filter has no intersection with the caller's permitted GTS types, the system **MUST** return 403 Forbidden with error code `gts-type-not-in-scope`. For individual resource operations (GET/PUT/DELETE), type scope is enforced via DB query filters (together with tenant and user filters), so out-of-scope resources are not returned and the API **MUST** return 404 Not Found.
+
+**Rationale**: Resources in the registry represent diverse data types with different sensitivity levels. GTS type-based access control ensures that API consumers can only operate on resource types explicitly granted in their token, preventing unauthorized access to resource families the consumer was not designed or approved to use.
+**Actors**: `cpt-cf-srr-actor-platform-user`, `cpt-cf-srr-actor-consumer-module`
+
+#### GTS Wildcard Filtering on List
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-gts-wildcard-filtering`
+
+The GET /resources list endpoint **MUST** support filtering by GTS type ID with trailing wildcard (`*`) per GTS spec section 10. The wildcard **MUST** appear only once, at the end of the pattern, and is greedy (matches through `~` chain separator). Example: `type eq 'gts.x.srr.resource.v1~acme.*'` matches all derived types under the `acme` vendor. When a wildcard filter is used, the system **MUST** only return resources whose GTS types fall within the caller's permitted scope (intersection of wildcard query with token permissions).
+
+**Rationale**: Consumers often need to discover resources across a family of related types (e.g., all resources from a vendor namespace) without knowing every specific derived type.
+**Actors**: `cpt-cf-srr-actor-platform-user`, `cpt-cf-srr-actor-consumer-module`
+
+#### GTS Type Existence Validation
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-fr-gts-type-validation`
+
+On POST (create) and any operation that references a resource `type` (a GTS type identifier / GTS schema ID), the system **MUST** verify that the specified GTS type exists in the Types Registry. If the GTS type is not found, the system **MUST** return 400 Bad Request with appropriate error code and include the unresolved GTS type ID in the error response.
+
+**Rationale**: Prevents creation of orphaned resources with invalid type references and provides clear error feedback.
+**Actors**: `cpt-cf-srr-actor-platform-user`, `cpt-cf-srr-actor-consumer-module`
+
+#### Deleted Resource Retention
+
+- [ ] `p3` - **ID**: `cpt-cf-srr-fr-deleted-retention`
+
+The system **MUST** support configurable retention for soft-deleted resources. The default retention period is 30 days, but it must be configurable globally on service level. Individual resource types **MAY** override the default by specifying `deleted_resource_retention_days` in the GTS type definition. A value of 0 means immediate hard-delete upon soft-delete. A value of null inherits the system default (30 days). After the retention period expires, the system **MUST** permanently purge the resource from storage via a dedicated Jobs Manager job.
+
+**Rationale**: Soft-deleted resources accumulate storage over time. Configurable retention balances data recovery needs with storage efficiency while allowing type authors to define appropriate policies for their data.
+**Actors**: `cpt-cf-srr-actor-consumer-module`
+
+#### Batch Operations
+
+- [ ] `p2` - **ID**: `cpt-cf-srr-fr-batch-operations`
+
+The system **MUST** support batch CRUD operations on resources following the DNA batch conventions (`POST /resources:batch` and `POST /resources:batch-get`):
+- **Batch GET** (`POST /resources:batch-get`): Retrieve multiple resources by a list of IDs in a single request.
+- **Batch Create/Update/Delete** (`POST /resources:batch`): Process multiple create, update, and delete operations in a single request. Each item specifies its action, `type` (for create), and `payload`. The system **MUST** validate each item independently and return per-item results.
+
+All batch operations **MUST** return `207 Multi-Status` for partial success with per-item results (including `index`, HTTP `status`, `data` or RFC 9457 Problem Details `error`), per DNA BATCH.md conventions. Per-item `idempotency_key` **SHOULD** be supported for safe retries. All batch operations **MUST** enforce the same authentication, tenant scoping, GTS type-based access control, and behavioral flag evaluation as their single-resource counterparts. Batch size **MUST** be capped by a configurable limit (default: 100 items per request).
+
+**Rationale**: Consumers that manage related resources (workflow engines, data connectors, agent pipelines) frequently need to operate on multiple resources in a single logical operation. Batch endpoints reduce round-trip overhead and improve throughput for bulk workloads.
+**Actors**: `cpt-cf-srr-actor-consumer-module`, `cpt-cf-srr-actor-platform-user`
+
+
+### 5.2 Events and Audit
+
+#### Notification Events
+
+- [ ] `p2` - **ID**: `cpt-cf-srr-fr-notification-events`
+
+The system **MUST** emit domain events (resource.created, resource.updated, resource.deleted) to the Events Broker when the corresponding behavioral flags are enabled on the resource's GTS type definition. The event schema **MUST** include: `id` (event id), `type` (event type), `subject_type` (resource type), and `subject_id` (resource id). The event payload **MUST NOT** include the full resource payload to keep events lightweight.
+
+**Rationale**: Enables reactive integrations — other modules can respond to resource lifecycle changes without polling. Fixed event schema ensures consistent event handling across all resource types.
+
+#### Audit Events
+
+- [ ] `p2` - **ID**: `cpt-cf-srr-fr-audit-events`
+
+The system **MUST** emit audit events for create, update, and delete operations to the Audit Module when the corresponding audit flags are enabled on the resource's GTS type definition or any of the parent GTS type. The audit event schema **MUST** be fixed and include: `id` (event id), `type` (event type), `subject_type` (resource type), `subject_id` (resource id), previous resource payload (null for create), and new resource payload (null for delete). This enables full audit trail reconstruction.
+
+**Rationale**: Compliance and traceability requirements demand auditable resource operations with complete before/after state for change tracking.
+
+### 5.3 Multi-Backend Storage
+
+#### Multi-Backend Storage
+
+- [ ] `p3` - **ID**: `cpt-cf-srr-fr-multi-backend-storage`
+
+The system **MUST** support multiple interchangeable storage backends beyond the default relational database (e.g., search engines for full-text-searchable resources, vendor-provided stores for existing platform data). New backends **MUST** conform to the storage backend interface and declare their capabilities (e.g., `odata_support`, `search_support`). Platform vendors **MAY** implement custom storage backends to integrate with existing platform components that already persist the appropriate resources (e.g., a vendor-specific CMDB, asset inventory, or configuration store). Multiple backends **MAY** coexist simultaneously, with per-resource-type routing directing operations to the appropriate backend.
+
+**Rationale**: Different resource types have different query and scalability needs; a single storage backend cannot serve all use cases optimally. Backend capabilities enable the API layer to route requests appropriately and return errors when a requested operation is not supported by the target backend. Allowing vendor-provided backends enables the registry to act as a unified API façade over heterogeneous storage systems without requiring data migration.
+**Actors**: `cpt-cf-srr-actor-platform-user`
+
+#### Per-Resource-Type Storage Routing
+
+- [ ] `p3` - **ID**: `cpt-cf-srr-fr-storage-routing`
+
+The system **MUST** support configuration-level routing that maps GTS resource types to specific storage backends. When a resource is created or queried, the system **MUST** route the operation to the configured storage backend for that resource type. Unrouted types **MUST** fall back to the default storage backend.
+
+**Rationale**: Enables heterogeneous storage strategies — relational databases for transactional resources, search engines for search-heavy resources — managed through configuration.
+**Actors**: `cpt-cf-srr-actor-platform-user`
+
+#### Resource Groups
+
+- [ ] `p3` - **ID**: `cpt-cf-srr-fr-resource-groups`
+
+The system **MUST** support logical grouping of resources into resource groups. A resource group is identified by a UUID and associated with a tenant. Resources **MAY** belong to zero, one or many resource groups. Resource groups enable batch operations (e.g., delete all resources in a group), lifecycle management (e.g., auto-delete a group when a parent workflow completes), and organizational queries (e.g., list all resources in a group).
+
+**Rationale**: Many use cases produce multiple related resources (workflow steps, agent execution artifacts) that share a lifecycle. Resource groups provide a first-class mechanism for managing these collections without requiring consumer-side tracking.
+**Actors**: `cpt-cf-srr-actor-consumer-module`
+
+#### Resource Search API
+
+- [ ] `p5` - **ID**: `cpt-cf-srr-fr-search-api`
+
+The system **MUST** provide a dedicated search API endpoint (POST /resources:search) that accepts full-text search queries and filters. The search operation **MUST** rely on the storage backend's `search_support` capability. If the target resource type's storage backend does not support search, the API **MUST** return 501 Not Implemented (RFC 9457 Problem Details). Search queries **MUST** support:
+- Full-text search within resource payloads
+- Filtering by schema fields (type, tenant_id, owner_id, timestamps)
+- Pagination and result ranking
+
+**Rationale**: Full-text search within JSON payloads is not feasible with OData on relational databases. A dedicated search API enables consumers to leverage search-capable plugins (e.g., ElasticSearch) when available, while providing clear error feedback when the feature is unavailable for a given resource type.
+**Actors**: `cpt-cf-srr-actor-platform-user`, `cpt-cf-srr-actor-consumer-module`
+
+## 6. Non-Functional Requirements
+
+### 6.1 Module-Specific NFRs
+
+#### Single-Resource Read Latency
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-nfr-read-latency`
+
+Single-resource GET operations **MUST** respond within 50ms at p95 under normal load (stricter than project default due to registry being a frequently called building block).
+
+**Threshold**: 50ms p95 for single-resource reads
+**Rationale**: The registry serves as a data access primitive for other modules and workflows; high latency compounds across dependent operations.
+**Architecture Allocation**: See DESIGN.md section "NFR Allocation"
+
+#### Payload Size Limit
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-nfr-payload-size`
+
+Individual resource payloads **MUST** not exceed 64 KB.
+
+**Threshold**: 64 KB per resource payload
+**Rationale**: Prevents storage abuse and ensures predictable query performance; large binary data belongs in File Storage.
+**Architecture Allocation**: See DESIGN.md section "NFR Allocation"
+
+#### Scalability
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-nfr-scalability`
+
+The system **MUST** support storing up to 100 million total resources across all resource types. The default storage backend **MUST** sustain at least 100 write operations per second (resource creates/updates) and at least 1000 single-resource fetch-by-ID operations per second under normal load.
+
+**Threshold**: 100M total resources; 100 writes/s; 1000 reads-by-ID/s
+**Rationale**: The registry is a shared building block used across the platform. Scalability targets ensure it can serve as the primary storage layer for lightweight resource types without becoming a bottleneck. These targets are achievable with proper indexing on a modern relational database and do not require partitioning or sharding.
+**Architecture Allocation**: See DESIGN.md section "NFR Allocation"
+
+### 6.2 NFR Exclusions
+
+- **Real-time streaming**: Not applicable because the module does not expose SSE or WebSocket endpoints; consumers use Events Broker for change notifications.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### REST API
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-interface-rest-api`
+
+**Type**: REST API (OpenAPI 3.0)
+**Stability**: stable
+**Description**: HTTP REST API for resource CRUD with OData query support on schema fields
+**Breaking Change Policy**: Major version bump required for endpoint removal or incompatible request/response schema changes
+
+#### SDK Client
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-interface-sdk-client`
+
+**Type**: Rust trait (async)
+**Stability**: stable
+**Description**: `SimpleResourceRegistryClient` trait for in-process resource access via ClientHub
+**Breaking Change Policy**: Major version bump for trait method signature changes
+
+#### Storage Backend Interface
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-interface-storage-backend`
+
+**Type**: Rust trait (async)
+**Stability**: stable
+**Description**: `ResourceStoragePluginClient` trait that storage backends implement. Platform vendors may provide their own implementations to integrate with existing platform storage components
+**Breaking Change Policy**: Major version bump required for trait method signature changes
+
+### 7.2 External Integration Contracts
+
+#### Events Broker Contract
+
+- [ ] `p2` - **ID**: `cpt-cf-srr-contract-events`
+
+**Direction**: provided by library (emits events)
+**Protocol/Format**: Internal event bus (Events Broker SDK)
+**Event Schema**: Fixed schema with `id`, `type` (event type), `subject_type` (resource type), `subject_id` (resource id)
+**Compatibility**: Event schema is stable; backward-compatible additions only
+
+#### Audit Module Contract
+
+- [ ] `p2` - **ID**: `cpt-cf-srr-contract-audit`
+
+**Direction**: provided by library (emits audit events)
+**Protocol/Format**: Internal audit bus (Audit SDK)
+**Event Schema**: Fixed schema with `id`, `type` (event type), `subject_type` (resource type), `subject_id` (resource id), previous_payload (null for create), new_payload (null for delete)
+**Compatibility**: Audit event schema follows platform conventions; backward-compatible additions only
+
+## 8. Use Cases
+
+#### Reflect External Resource Entry
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-usecase-reflect-external`
+
+**Actor**: `cpt-cf-srr-actor-consumer-module`
+
+**Preconditions**:
+- Data connector has fetched metadata about an external resource
+- A derived GTS type exists for this external resource representation
+
+**Main Flow**:
+1. Data connector creates a resource entry representing the external object
+2. System stores the partial representation with appropriate GTS type
+3. Other modules query the registry to discover available external resources
+
+**Postconditions**:
+- External resource representation is queryable within the platform
+
+#### Query Resources with OData Filtering
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-usecase-query-odata`
+
+**Actor**: `cpt-cf-srr-actor-api-client`, `cpt-cf-srr-actor-platform-user`
+
+**Preconditions**:
+- Resources of the target GTS type exist for the caller's tenant
+
+**Main Flow**:
+1. Consumer sends GET /simple-resource-registry/v1/resources?$filter=type eq '{type_id}'&$orderby=created_at desc&limit=20
+2. System validates authentication and tenant context
+3. System queries the storage plugin with OData parameters applied to schema fields
+4. System returns paginated results
+
+**Postconditions**:
+- Consumer receives filtered, ordered, paginated resource list
+
+### Store Workflow-Generated Custom Object
+
+- [ ] `p2` - **ID**: `cpt-cf-srr-usecase-store-workflow-object`
+
+**Actor**: `cpt-cf-srr-actor-consumer-module`
+
+**Preconditions**:
+- Workflow engine has a derived GTS resource type registered for its output objects
+- Workflow execution has produced a result object
+
+**Main Flow**:
+1. Workflow engine calls POST /simple-resource-registry/v1/resources with resource `type` (GTS schema ID) and payload
+2. System validates authentication and tenant context
+3. System assigns resource UUID (if not specified), sets `tenant_id` from `SecurityContext.subject_tenant_id`, sets `owner_id` from `SecurityContext.subject_id`, sets timestamps
+4. System persists resource via configured storage backend
+5. System returns created resource with ID
+
+**Postconditions**:
+- Resource is persisted and retrievable by ID
+- If event/audit flags are enabled, corresponding events are emitted
+
+**Alternative Flows**:
+- **Invalid resource type (GTS schema ID)**: System returns 400 Bad Request with details
+- **Resource `type` not in caller GTS scope**: System returns 403 Forbidden
+- **Per-owner resource type with missing SecurityContext.subject_id**: System returns 422 Unprocessable Entity
+- **Payload validation failure**: System returns 422 Unprocessable Entity
+
+## 9. Acceptance Criteria
+
+- [ ] Authenticated user can create a resource with a valid resource `type` (GTS schema ID), `idempotency_key`, and JSON payload
+- [ ] POST without `idempotency_key` returns HTTP STATUS 400 (required field missing)
+- [ ] Created resource is retrievable by ID within the same tenant
+- [ ] Resources are isolated by tenant and cannot be accessed across tenant boundaries (except when explicitly shared via resource groups)
+- [ ] User-scoped resources (is_per_owner_resource=true) enforce owner_id matching
+- [ ] OData $filter, $orderby work correctly on schema fields with cursor-based pagination (limit, cursor)
+- [ ] Soft-deleted resources are excluded from list results by default
+- [ ] All CRUD operations enforce GTS type-based access control against token permissions
+- [ ] GET list supports GTS wildcard filtering with trailing `*` per GTS spec
+- [ ] System returns HTTP STATUS 400 when a referenced GTS type does not exist in Types Registry
+- [ ] System returns HTTP STATUS 403 when the caller's token lacks permissions for POST target type or when LIST type filter has no intersection with caller scope
+- [ ] System returns HTTP STATUS 404 for GET/PUT/DELETE when the target resource is filtered out by tenant/user/type DB-level security filters
+- [ ] POST with a duplicate `idempotency_key` within the same tenant returns HTTP STATUS 409 with the existing resource `id`; no duplicate resource is created (`cpt-cf-srr-fr-idempotent-create`)
+- [ ] Soft-deleted resources are automatically purged (hard-deleted) after the configured retention period (default 30 days)
+- [ ] Event emission respects the behavioral flags on the resource's GTS type (`cpt-cf-srr-fr-notification-events`)
+- [ ] Audit events are emitted according to audit flags on the resource's GTS type or any of its parent GTS types (`cpt-cf-srr-fr-audit-events`)
+- [ ] Alternative storage backend can be wired without changing API or domain logic (`cpt-cf-srr-fr-multi-backend-storage`)
+- [ ] Default storage backend works on PostgreSQL, MariaDB, and SQLite (`cpt-cf-srr-fr-default-storage-backend`)
+- [ ] System sustains 100M total resources, 100 writes/s, 1000 reads-by-ID/s (`cpt-cf-srr-nfr-scalability`)
+- [ ] Batch operations return 207 Multi-Status with per-item results (`cpt-cf-srr-fr-batch-operations`)
+- [ ] Resource groups allow batch lifecycle management (`cpt-cf-srr-fr-resource-groups`)
+- [ ] Search API returns 501 when target backend lacks search_support capability (`cpt-cf-srr-fr-search-api`)
+
+## 10. Dependencies
+
+| Dependency | Description | Needed By |
+|------------|-------------|-----------|
+| Types Registry | GTS type definitions for resource schemas and behavioral flags | `cpt-cf-srr-fr-gts-type-registration`, `cpt-cf-srr-fr-gts-type-validation` |
+| Events Broker | Domain event emission for resource lifecycle | `cpt-cf-srr-fr-notification-events` |
+| Audit Module | Audit event emission for compliance | `cpt-cf-srr-fr-audit-events` |
+| gts-rust crate | GTS library for schema ID generation, validation, and wildcard matching (`GtsID`, `GtsWildcard`) | `cpt-cf-srr-fr-gts-type-registration`, `cpt-cf-srr-fr-gts-wildcard-filtering` |
+
+## 11. Assumptions
+
+- GTS type definitions for derived resource types are registered in Types Registry before resources of that type are created
+- The relational database storage backend (PostgreSQL, MariaDB, SQLite) is available and configured as part of the standard CyberFabric deployment
+- SecurityContext is always available for authenticated requests (enforced by API Gateway middleware)
+- Payload validation against GTS schemas is performed at the application level, not at the database level
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Default storage backend may not scale beyond 100M resources | Query performance degrades as resource count grows | Per-resource-type routing (`cpt-cf-srr-fr-storage-routing`) enables dedicated storage backends for high-volume types; storage optimization is a per-backend concern |
+| Uncontrolled payload sizes impact database performance | Storage costs and query latency increase | Enforce 64 KB payload limit; guide consumers toward File Storage for large data |
+| GTS type definition changes after resources exist | Existing resources may not validate against updated schema | Schema evolution and validation are enforced by the Types Registry module; the registry relies on Types Registry for schema validation at creation time |
+| Over-reliance on JSON payload queries despite explicit exclusion | Consumers may expect full-text or JSON path queries on payload | Clear documentation; search API (`cpt-cf-srr-fr-search-api`) with search-capable backends for search-heavy use cases |
+| Background purge process misses resources under high churn | Soft-deleted or TTL-expired resources accumulate beyond retention window | Purge process runs periodically with batch-size limits; alerting on purge backlog |
+| GTS type-based access control creates permission management overhead | Administrators must manage per-type permissions for each consumer | Support GTS wildcard patterns in permissions (e.g., `gts.x.srr.resource.v1~acme.*`) to grant access to type families |
+
+## 13. Open Questions
+
+- Expected resource counts per tenant/type (p50/p95/p99) for capacity and sizing?
+- Do we need per-tenant/type quotas (count/size), and should they hard-fail, soft-fail, or be observability-only at launch?
+- Is a caching layer (e.g., Redis) required for hot reads, and with what TTL and consistency model?
+- What baseline and burst rate limits apply per tenant/user/client, and do some resource types need stricter write/batch limits?
+
+
+ ## 14. Traceability
+
+- **Design**: [DESIGN.md](./DESIGN.md)
+- **ADRs**: [ADR/](./ADR/)
+- **Features**: [features/](./features/)

--- a/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/ADR/0001-cpt-cf-srr-rdb-adr-storage-optimization.md
+++ b/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/ADR/0001-cpt-cf-srr-rdb-adr-storage-optimization.md
@@ -114,7 +114,7 @@ This means the default plugin does not need to solve every scalability problem â
 
 - **Plugin PRD**: [../PRD.md](../PRD.md)
 - **Plugin DESIGN**: [../DESIGN.md](../DESIGN.md)
-- **Parent Module PRD**: [../../../../simple-resource-registry/docs/PRD.md](../../../../simple-resource-registry/docs/PRD.md)
+- **Parent Module PRD**: [../../../../docs/PRD.md](../../../../docs/PRD.md)
 
 This decision directly addresses the following requirements or design elements:
 

--- a/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/ADR/0001-cpt-cf-srr-rdb-adr-storage-optimization.md
+++ b/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/ADR/0001-cpt-cf-srr-rdb-adr-storage-optimization.md
@@ -1,0 +1,126 @@
+---
+status: accepted
+date: 2026-02-24
+---
+# ADR-0001: Single Table with B-Tree Indexes for Resource Storage
+
+**ID**: `cpt-cf-srr-rdb-adr-storage-optimization`
+
+## Context and Problem Statement
+
+The SRR Relational Database Plugin must store up to 100M resources across potentially thousands of GTS resource types in a single relational database, while sustaining 100 writes/s and 1000 reads-by-ID/s. The plugin must work on PostgreSQL, MariaDB, and SQLite without database-specific configuration. How should the physical storage be organized to meet these performance targets while maintaining cross-database compatibility and operational simplicity?
+
+## Decision Drivers
+
+* Must sustain 100M total resources with 100 writes/s and 1000 reads-by-ID/s (`cpt-cf-srr-rdb-nfr-scalability`)
+* Must work on PostgreSQL, MariaDB, and SQLite without database-specific features (`cpt-cf-srr-rdb-fr-db-agnostic`)
+* Must not require DDL operations at runtime (no table creation when new resource types are registered)
+* Plugin must remain simple and maintainable — complexity belongs in specialized backends, not in the default plugin
+* Other storage backends (via main module's storage routing) can handle workloads that exceed this plugin's capacity
+
+## Considered Options
+
+* Single table with B-tree indexes
+* Per-resource-type dedicated tables
+* Table partitioning by resource type
+
+## Decision Outcome
+
+Chosen option: "Single table with B-tree indexes", because 100M rows is well within the capacity of B-tree indexes on modern relational databases, the approach is fully portable across PostgreSQL/MariaDB/SQLite, it requires no runtime DDL, and it keeps the plugin implementation simple. Workloads that exceed 100M resources or require specialized storage features are served by alternative backends via the main module's per-resource-type storage routing.
+
+### Consequences
+
+* Good, because fully portable — identical behavior on PostgreSQL, MariaDB, and SQLite
+* Good, because no runtime DDL — all tables and indexes are created during migration
+* Good, because simple implementation — one SeaORM entity, one set of indexes, no type-aware branching
+* Good, because well-understood performance model — B-tree index lookups are O(log n), predictable at 100M rows
+* Good, because the main module's storage routing provides an escape hatch for types that outgrow this plugin
+* Bad, because all resource types share index space — a type with millions of resources affects index size for all types
+* Bad, because no index locality by type — queries for a specific type scan a shared B-tree rather than a type-specific structure
+* Bad, because 100M row ceiling is a hard constraint — beyond this, alternative backends are required
+
+### Confirmation
+
+* Load test with 100M synthetic resources verifies read-by-ID < 50ms p95 and sustained 1000 reads/s
+* Load test verifies 100 writes/s sustained with composite indexes
+* Integration tests pass identically on PostgreSQL, MariaDB, and SQLite
+* No DDL statements executed after initial migration
+
+## Pros and Cons of the Options
+
+### Single table with B-tree indexes
+
+All resource types stored in one `simple_resources` table. Composite B-tree indexes on `(tenant_id, type)`, `(tenant_id, type, created_at)`, etc. provide query performance.
+
+* Good, because fully portable across PostgreSQL, MariaDB, and SQLite — B-tree indexes are universal
+* Good, because no runtime DDL — table and indexes created once during migration
+* Good, because simplest implementation — one entity, one table, standard ORM patterns
+* Good, because 100M rows is well within B-tree capacity — PostgreSQL routinely handles billions of rows with proper indexes
+* Good, because composite indexes `(tenant_id, type)` effectively create a "virtual partition" per tenant+type combination
+* Good, because partial indexes (e.g., `WHERE deleted_at IS NOT NULL`) keep index sizes small for specialized queries
+* Neutral, because index maintenance adds overhead to writes — acceptable at 100 writes/s
+* Bad, because shared index space — a disproportionately large resource type inflates the shared index
+* Bad, because no physical data locality by type — related rows may be scattered across disk pages
+* Bad, because of limited future scalability — this approach does not scale well beyond 100M resources and would require another plugin to be implemented
+
+### Per-resource-type dedicated tables
+
+A new database table is created for each GTS resource type when the type is first used. Each table has its own indexes.
+
+* Good, because physical data isolation per type — indexes are type-specific and smaller
+* Good, because per-type index locality — queries only scan the relevant table
+* Good, because per-type vacuuming and maintenance — no cross-type interference
+* Bad, because requires DDL at runtime — `CREATE TABLE` when a new resource type is first used
+* Bad, because DDL at runtime is risky — schema migrations in production, lock contention, potential failures
+* Bad, because not portable — DDL behavior and syntax varies across PostgreSQL, MariaDB, and SQLite
+* Bad, because operational complexity — thousands of tables to monitor, migrate, and maintain
+* Bad, because SeaORM entity model assumes static table names — dynamic table routing adds significant complexity
+* Bad, because connection pool contention during DDL on some databases (especially SQLite)
+
+### Table partitioning by resource type
+
+PostgreSQL-native `PARTITION BY LIST (type)` or `PARTITION BY HASH (type)` to split the single table into type-specific partitions managed by the database engine.
+
+* Good, because physical data isolation per type without application-level routing
+* Good, because transparent to queries — the database query planner routes to the correct partition
+* Good, because per-partition indexes are smaller and more cache-friendly
+* Good, because partition pruning eliminates irrelevant partitions from query plans
+* Bad, because not portable — SQLite has no partitioning support; MariaDB partitioning has significant limitations (no foreign keys on partitioned tables, limited index support)
+* Bad, because requires runtime DDL to create new partitions when new resource types appear
+* Bad, because partition management complexity — need to handle partition creation, merging, and cleanup
+* Bad, because the number of partitions can grow unbounded (one per resource type) — some databases degrade with thousands of partitions
+* Bad, because SeaORM does not have native partitioning support — would require raw SQL or custom migration logic
+* Bad, because violates the plugin's DB-agnostic constraint (`cpt-cf-srr-rdb-constraint-no-db-specific`)
+
+## More Information
+
+### Why 100M rows is "small" for B-tree indexes
+
+A B-tree index with 100M entries has a depth of approximately 4-5 levels (log base ~500 of 100M ≈ 3-4, plus root). Each level requires one disk I/O in the worst case, but the upper levels are almost always cached in the database buffer pool. In practice, a PK lookup on a 100M-row table completes in 1-3 disk I/Os, well within the 50ms p95 latency target.
+
+The composite index `(tenant_id, type)` effectively creates a "virtual partition" — queries that filter on both fields traverse only the relevant portion of the index, making the effective index size proportional to the number of resources of that type within the tenant, not the total table size.
+
+### Escape hatch: storage routing
+
+The Simple Resource Registry's per-resource-type storage routing (`cpt-cf-srr-fr-storage-routing`) provides a clean migration path for resource types that outgrow this plugin:
+
+1. Deploy an alternative backend (e.g., a partitioned PostgreSQL plugin, an ElasticSearch plugin, or a vendor-provided store)
+2. Update the routing configuration to direct the high-volume type to the new backend
+3. Migrate existing resources (if needed) — the main module's API is unchanged
+
+This means the default plugin does not need to solve every scalability problem — it needs to be good enough for the common case, with a clear path to specialization.
+
+## Traceability
+
+- **Plugin PRD**: [../PRD.md](../PRD.md)
+- **Plugin DESIGN**: [../DESIGN.md](../DESIGN.md)
+- **Parent Module PRD**: [../../../../simple-resource-registry/docs/PRD.md](../../../../simple-resource-registry/docs/PRD.md)
+
+This decision directly addresses the following requirements or design elements:
+
+* `cpt-cf-srr-rdb-nfr-scalability` — 100M resources / 100 writes·s⁻¹ / 1000 reads-by-ID·s⁻¹ achieved through B-tree indexes
+* `cpt-cf-srr-rdb-fr-db-agnostic` — Single table with standard indexes works on PostgreSQL, MariaDB, and SQLite
+* `cpt-cf-srr-rdb-constraint-no-db-specific` — No partitioning or database-specific features used
+* `cpt-cf-srr-rdb-constraint-no-runtime-ddl` — No DDL at runtime; all tables created during migration
+* `cpt-cf-srr-rdb-principle-single-table` — Establishes and justifies the single-table storage model
+* `cpt-cf-srr-rdb-principle-index-performance` — Establishes B-tree indexes as the sole performance mechanism

--- a/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/ADR/0002-cpt-cf-srr-rdb-adr-payload-storage-text.md
+++ b/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/ADR/0002-cpt-cf-srr-rdb-adr-payload-storage-text.md
@@ -1,0 +1,80 @@
+---
+status: accepted
+date: 2026-02-24
+---
+# ADR-0002: Store Payload as TEXT (Not JSONB)
+
+**ID**: `cpt-cf-srr-rdb-adr-payload-storage-text`
+
+## Context and Problem Statement
+
+The SRR Relational Database Plugin stores an opaque JSON payload for each resource. Relational databases differ in how they represent JSON:
+
+- PostgreSQL provides JSONB with rich operators and indexing.
+- MariaDB and SQLite typically store JSON as TEXT and have different (or limited) JSON query capabilities.
+
+The plugin must be portable across PostgreSQL, MariaDB, and SQLite and does not require payload-level querying or indexing (schema fields are queryable; payload is opaque). Should the plugin store payload as PostgreSQL JSONB where available, or store payload uniformly as TEXT?
+
+## Decision Drivers
+
+* Portability across PostgreSQL, MariaDB, and SQLite (`cpt-cf-srr-rdb-fr-db-agnostic`)
+* Payload is opaque by contract — no payload-level query language or indexing is required
+* Avoid backend-specific SQL/operators that would leak into the plugin interface or behavior
+* Keep migration and operational footprint simple
+
+## Considered Options
+
+* Use PostgreSQL JSONB and TEXT elsewhere (mixed behavior)
+* Store payload uniformly as TEXT for all supported databases
+* Introduce a dedicated search/index backend for payload queries (out of scope for this plugin)
+
+## Decision Outcome
+
+Chosen option: "Store payload uniformly as TEXT", because it maximizes portability and simplicity, and the SRR contract does not require payload querying or indexing.
+
+This plugin treats the payload as an opaque blob. If payload-level querying or full-text search is required for a resource type, that type should be routed to a search-capable backend.
+
+### Consequences
+
+* Good, because fully portable across PostgreSQL, MariaDB, and SQLite
+* Good, because avoids relying on JSONB-specific operators and indexes
+* Good, because schema fields remain the primary query surface (OData on schema fields)
+* Bad, because PostgreSQL JSONB indexing advantages are intentionally not used
+* Bad, because any future payload-query feature would require a different backend or a new plugin version
+
+### Confirmation
+
+* Plugin can run unchanged on PostgreSQL, MariaDB, and SQLite
+* Integration tests confirm payload round-trips without modification
+* No payload-level filtering, ordering, or indexing is implemented in this plugin
+
+## Pros and Cons of the Options
+
+### Use PostgreSQL JSONB and TEXT elsewhere (mixed behavior)
+
+* Good, because can leverage JSONB operators and indexes on PostgreSQL
+* Bad, because behavior diverges by database backend
+* Bad, because encourages introducing payload-query features that are not portable
+
+### Store payload uniformly as TEXT for all supported databases
+
+* Good, because consistent behavior across all supported databases
+* Good, because simplest schema and ORM mapping
+* Bad, because does not leverage JSONB indexing on PostgreSQL
+
+### Introduce a dedicated search/index backend for payload queries
+
+* Good, because supports payload-level query/search without coupling to relational DB specifics
+* Bad, because out of scope for this plugin; requires a separate backend and routing
+
+## Traceability
+
+- **Plugin PRD**: [../PRD.md](../PRD.md)
+- **Plugin DESIGN**: [../DESIGN.md](../DESIGN.md)
+- **Parent PRD**: [../../../docs/PRD.md](../../../docs/PRD.md)
+
+This decision directly relates to:
+
+* `cpt-cf-srr-rdb-fr-db-agnostic` — DB-agnostic behavior across PostgreSQL/MariaDB/SQLite
+* `cpt-cf-srr-constraint-no-payload-query` — payload remains opaque; no payload query language required
+* `cpt-cf-srr-fr-search-api` — payload search is handled by search-capable backends

--- a/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/DESIGN.md
+++ b/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/DESIGN.md
@@ -1,0 +1,353 @@
+# Technical Design — SRR Relational Database Plugin
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+The SRR Relational Database Plugin is the default storage backend for the Simple Resource Registry. It implements the `ResourceStoragePluginClient` trait defined in the `simple-resource-registry-sdk` crate, providing relational database persistence via SecureORM (SeaORM + SecurityContext-based tenant scoping).
+
+The plugin uses a **single shared table** (`simple_resources`) for all resource types (see ADR `cpt-cf-srr-rdb-adr-storage-optimization`). Schema envelope fields (id, tenant_id, owner_id, type, timestamps) are stored as dedicated indexed columns; the type-specific payload is stored as serialized JSON in a TEXT column (see ADR `cpt-cf-srr-rdb-adr-payload-storage-text`). This design keeps the storage model simple, avoids per-type table proliferation, and relies on B-tree indexes for query performance — sufficient for the target scale of 100M total resources.
+
+Idempotency deduplication is handled atomically within a single database transaction: the plugin checks the `idempotency_keys` table and inserts both the resource row and the idempotency record in one transaction.
+
+### 1.2 Architecture Drivers
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+| --- | --- |
+| `cpt-cf-srr-rdb-fr-relational-storage` | SeaORM entity with dedicated columns for schema fields + TEXT column for serialized JSON payload; SecureORM for tenant scoping; declares `odata_support` capability |
+| `cpt-cf-srr-rdb-fr-odata-translation` | OData $filter/$orderby translated to SeaORM `Condition` and `Order` on schema columns; cursor-based pagination via `id > cursor_id` predicate |
+| `cpt-cf-srr-rdb-fr-gts-wildcard` | Trailing `*` in type filter → SQL `LIKE '{prefix}%'`; prefix derived by stripping `*` from the GTS pattern |
+| `cpt-cf-srr-rdb-fr-idempotency` | Single-transaction: `INSERT INTO idempotency_keys ... ON CONFLICT DO NOTHING` + conditional resource insert; returns `CreateOutcome::Duplicate` if key exists |
+| `cpt-cf-srr-rdb-fr-soft-delete` | `UPDATE simple_resources SET deleted_at = now() WHERE id = ? AND tenant_id = ?`; list queries include `WHERE deleted_at IS NULL` |
+| `cpt-cf-srr-rdb-fr-retention-purge` | `DELETE FROM simple_resources WHERE type = ? AND deleted_at < ? LIMIT ?` |
+| `cpt-cf-srr-rdb-fr-group-memberships` | Junction table `simple_resource_group_memberships` with `(id, group_id)` PK |
+| `cpt-cf-srr-rdb-fr-db-agnostic` | SeaORM-based implementation behaves consistently across PostgreSQL, MariaDB, and SQLite |
+
+#### NFR Allocation
+
+| NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
+| --- | --- | --- | --- | --- |
+| `cpt-cf-srr-rdb-nfr-scalability` | 100M resources; 100 writes/s; 1000 reads-by-ID/s | Database indexes | Composite B-tree indexes on `(tenant_id, type)`, `(tenant_id, owner_id)`, `(tenant_id, type, created_at)`; PK lookup for reads-by-ID | Load test with sustained throughput |
+| `cpt-cf-srr-rdb-nfr-read-latency` | Single-resource GET < 50ms p95 | Database PK index | Primary key lookup on UUID; no joins; connection pooling via modkit-db | Load test with p95 measurement |
+
+### 1.3 Architecture Layers
+
+```
+┌──────────────────────────────────────────────────────────┐
+│              Plugin Entry Point                          │
+│   ClientHub registration, PluginCapabilities             │
+├──────────────────────────────────────────────────────────┤
+│              Storage Implementation                      │
+│   ResourceStoragePluginClient trait methods               │
+│   OData → SeaORM translation, GTS wildcard → LIKE        │
+├──────────────────────────────────────────────────────────┤
+│              SecureORM / SeaORM                           │
+│   Tenant-scoped queries, connection pooling              │
+├──────────────────────────────────────────────────────────┤
+│              Database                                    │
+│   PostgreSQL │ MariaDB │ SQLite                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+| Layer | Responsibility | Technology |
+| --- | --- | --- |
+| Plugin Entry Point | GTS instance registration, ClientHub scoped client, capability declaration | modkit plugin lifecycle |
+| Storage Implementation | CRUD operations, OData translation, wildcard matching, idempotency, soft-delete/hard-delete | Rust async, `ResourceStoragePluginClient` trait |
+| SecureORM / SeaORM | Tenant-scoped query execution, ORM mapping, connection pooling | modkit-db (SecureORM), SeaORM |
+| Database | Physical storage, indexes, transactions | PostgreSQL, MariaDB, or SQLite |
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Single-Table Storage
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-principle-single-table`
+
+**ADRs**: `cpt-cf-srr-rdb-adr-storage-optimization`
+
+All resource types share a single database table (`simple_resources`). This simplifies migrations, avoids DDL operations at runtime, and keeps the plugin portable across PostgreSQL, MariaDB, and SQLite. Query performance is achieved through B-tree indexes on schema fields, which are sufficient for the target scale of 100M resources.
+
+#### Index-Based Performance
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-principle-index-performance`
+
+**ADRs**: `cpt-cf-srr-rdb-adr-storage-optimization`
+
+The plugin relies exclusively on B-tree indexes for query performance. No database-specific optimizations (partitioning, materialized views, partial indexes beyond soft-delete filtering) are used. This ensures the plugin works identically across all supported databases.
+
+#### Opaque Payload
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-principle-opaque-payload`
+
+The JSON payload column is treated as an opaque blob. The plugin does not index, query, or validate payload contents — that responsibility belongs to the main module's domain layer (schema validation) and to search-capable backends (payload querying).
+
+### 2.2 Constraints
+
+#### No Database-Specific Features
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-constraint-no-db-specific`
+
+**ADRs**: `cpt-cf-srr-rdb-adr-storage-optimization`
+
+The plugin **MUST NOT** use database-specific features such as table partitioning, PostgreSQL-specific JSON operators, or MariaDB-specific syntax.
+
+#### No Runtime DDL
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-constraint-no-runtime-ddl`
+
+**ADRs**: `cpt-cf-srr-rdb-adr-storage-optimization`
+
+The plugin **MUST NOT** execute DDL operations (CREATE TABLE, ALTER TABLE) at runtime. All tables and indexes are created during database migration, before the plugin starts. This rules out per-resource-type dedicated tables, which would require DDL when new resource types are registered.
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Technology**: SeaORM entities, Rust structs
+
+The plugin maps the logical `Resource` entity (defined in the main module's domain layer) to a SeaORM entity backed by the `simple_resources` table.
+
+**SeaORM Entity** (conceptual):
+
+```rust
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "simple_resources")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub r#type: String,
+    pub tenant_id: Uuid,
+    pub owner_id: Option<Uuid>,
+    pub created_at: DateTimeWithTimeZone,
+    pub updated_at: DateTimeWithTimeZone,
+    pub deleted_at: Option<DateTimeWithTimeZone>,
+    pub payload: String,  // serialized JSON payload stored as TEXT
+}
+```
+
+### 3.2 Component Model
+
+```mermaid
+graph TB
+    SRR[Simple Resource Registry Main Module] --> Plugin[SRR RDB Plugin]
+    Plugin --> OData[OData → SeaORM Translator]
+    Plugin --> Idem[Idempotency Handler]
+    Plugin --> SecORM[SecureORM]
+    SecORM --> DB[(Database)]
+```
+
+**Components**:
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-component-plugin`
+
+  - **Plugin Entry Point**: Implements `ResourceStoragePluginClient`. Registers as a scoped client in ClientHub with GTS instance ID `gts.x.core.modkit.plugin.v1~x.cf.simple_resource_registry.plugin.v1~x.core._.relational_db.v1`. Declares `PluginCapabilities { odata_support: true, search_support: false }`.
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-component-odata-translator`
+
+  - **OData → SeaORM Translator**: Converts OData $filter expressions to SeaORM `Condition` trees and $orderby to `Order` clauses. Supports schema fields only (id, tenant_id, owner_id, type, created_at, updated_at, deleted_at). GTS wildcard type filters are translated to SQL `LIKE` prefix matches.
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-component-idempotency-handler`
+
+  - **Idempotency Handler**: Manages the `idempotency_keys` table within create transactions. Performs atomic check-and-insert: queries for existing `(tenant_id, idempotency_key)`, and if not found, inserts both the resource row and the idempotency record in the same transaction.
+
+### 3.3 API Contracts
+
+This plugin has no external API — it implements the `ResourceStoragePluginClient` trait defined in the parent module's SDK crate. See the parent module's [DESIGN.md §3.2](../../../docs/DESIGN.md) for the trait definition.
+
+### 3.4 Interactions & Sequences
+
+#### Create with Idempotency
+
+**ID**: `cpt-cf-srr-rdb-seq-create`
+
+```mermaid
+sequenceDiagram
+    participant SRR as ResourceService (Main Module)
+    participant Plugin as RDB Plugin
+    participant DB as Database
+
+    SRR->>Plugin: create(ctx, resource, idempotency_key)
+    Plugin->>DB: BEGIN TRANSACTION
+    Plugin->>DB: SELECT resource_id FROM idempotency_keys<br/>WHERE tenant_id = ? AND idempotency_key = ?
+    alt Key exists and not expired
+        DB-->>Plugin: resource_id
+        Plugin->>DB: ROLLBACK
+        Plugin-->>SRR: CreateOutcome::Duplicate(resource_id)
+    else Key not found
+        Plugin->>DB: INSERT INTO simple_resources (...)
+        Plugin->>DB: INSERT INTO idempotency_keys (...)
+        Plugin->>DB: COMMIT
+        Plugin-->>SRR: CreateOutcome::Created(resource)
+    end
+```
+
+#### List with OData + GTS Wildcard
+
+**ID**: `cpt-cf-srr-rdb-seq-list`
+
+```mermaid
+sequenceDiagram
+    participant SRR as ResourceService (Main Module)
+    participant Plugin as RDB Plugin
+    participant OData as OData Translator
+    participant DB as Database
+
+    SRR->>Plugin: list(ctx, type, odata_query)
+    Plugin->>OData: translate(odata_query)
+    OData-->>Plugin: SeaORM Condition + Order
+    Note over Plugin: Add tenant_id = ctx.subject_tenant_id<br/>Add type LIKE '{prefix}%' (if wildcard)<br/>Add owner_id = ctx.subject_id (if per-owner)<br/>Add deleted_at IS NULL
+    Plugin->>DB: SELECT ... WHERE conditions ORDER BY ... LIMIT ...
+    DB-->>Plugin: rows
+    Plugin-->>SRR: PagedResult<Resource>
+```
+
+#### Retention Purge
+
+**ID**: `cpt-cf-srr-rdb-seq-purge`
+
+```mermaid
+sequenceDiagram
+    participant Job as Retention Purge Job (Main Module)
+    participant Plugin as RDB Plugin
+    participant DB as Database
+
+    Job->>Plugin: purge_deleted_before(type, cutoff, batch_size)
+    Plugin->>DB: DELETE FROM simple_resources<br/>WHERE type = ? AND deleted_at < ?<br/>LIMIT batch_size
+    DB-->>Plugin: deleted_count
+    Plugin-->>Job: deleted_count
+```
+
+### 3.5 Database Schemas & Tables
+
+#### Table: simple_resources
+
+**ID**: `cpt-cf-srr-rdb-dbtable-simple-resources`
+
+**Schema**:
+
+| Column | Type | Nullable | Description |
+| --- | --- | --- | --- |
+| id | UUID | NOT NULL | Primary key, system-generated |
+| type | VARCHAR(512) | NOT NULL | GTS type identifier for this resource |
+| tenant_id | UUID | NOT NULL | Resource Tenant owner (from `SecurityContext.subject_tenant_id`) |
+| owner_id | UUID | NULL | Resource Subject owner (from `SecurityContext.subject_id`, set when `is_per_owner_resource=true`) |
+| created_at | TIMESTAMP WITH TIME ZONE | NOT NULL | Creation timestamp |
+| updated_at | TIMESTAMP WITH TIME ZONE | NOT NULL | Last update timestamp |
+| deleted_at | TIMESTAMP WITH TIME ZONE | NULL | Soft-delete timestamp (NULL = active) |
+| payload | TEXT | NOT NULL | Type-specific serialized JSON payload |
+
+**PK**: `id`
+
+**Indexes**:
+
+- `idx_simple_resources_tenant` — `(tenant_id)` — Required for tenant-scoped queries
+- `idx_simple_resources_tenant_type` — `(tenant_id, type)` — Primary query pattern: list resources of a type within a tenant
+- `idx_simple_resources_tenant_user` — `(tenant_id, owner_id)` WHERE `owner_id IS NOT NULL` — For user-scoped resource queries
+- `idx_simple_resources_tenant_type_created` — `(tenant_id, type, created_at)` — For OData $orderby on created_at within a type
+- `idx_simple_resources_tenant_deleted` — `(tenant_id, deleted_at)` — For filtering out soft-deleted resources
+- `idx_simple_resources_type_deleted` — `(type, deleted_at)` WHERE `deleted_at IS NOT NULL` — For retention purge job queries
+
+**Constraints**:
+
+- `tenant_id` is NOT NULL (mandatory tenant isolation)
+- `payload` is NOT NULL (empty JSON `{}` is valid but NULL is not)
+- `created_at` and `updated_at` are NOT NULL and system-managed
+
+**Example**:
+
+| id | type | tenant_id | owner_id | created_at | updated_at | deleted_at | payload |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 550e8400-... | gts.x.core.srr.resource.v1~acme.crm.\_.contact.v1~ | a1b2c3d4-... | NULL | 2026-02-16T10:00:00Z | 2026-02-16T10:00:00Z | NULL | {"name": "Jane", "email": "jane@example.com"} |
+| 660f9500-... | gts.x.core.srr.resource.v1~acme.crm.\_.note.v1~ | a1b2c3d4-... | b5c6d7e8-... | 2026-02-16T09:30:00Z | 2026-02-16T11:00:00Z | NULL | {"text": "Follow up on meeting"} |
+
+#### Table: simple_resource_group_memberships (`cpt-cf-srr-rdb-fr-group-memberships`)
+
+**ID**: `cpt-cf-srr-rdb-dbtable-group-memberships`
+
+**Schema**:
+
+| Column | Type | Nullable | Description |
+| --- | --- | --- | --- |
+| id | UUID | NOT NULL | FK → simple_resources.id |
+| group_id | UUID | NOT NULL | Resource group identifier |
+| tenant_id | UUID | NOT NULL | Tenant owner (denormalized for scoping) |
+
+**PK**: `(id, group_id)`
+
+**Indexes**:
+
+- `idx_group_memberships_group_tenant` — `(group_id, tenant_id)` — List all resources in a group within a tenant
+- `idx_group_memberships_resource` — `(id)` — List all groups a resource belongs to
+
+**Constraints**:
+
+- `id` references `simple_resources(id)` ON DELETE CASCADE
+- `tenant_id` is NOT NULL (mandatory tenant isolation)
+
+#### Table: idempotency_keys (`cpt-cf-srr-rdb-fr-idempotency`)
+
+**ID**: `cpt-cf-srr-rdb-dbtable-idempotency-keys`
+
+**Purpose**: Deduplication store for POST create operations. `idempotency_key` is required on every create request; the plugin atomically checks this table and inserts the resource + idempotency record in one transaction. If a matching `(tenant_id, idempotency_key)` row exists and is within the retention window, the plugin returns `CreateOutcome::Duplicate` and the main module returns 409 with the `resource_id` of the previously created resource.
+
+**Schema**:
+
+| Column | Type | Nullable | Description |
+| --- | --- | --- | --- |
+| tenant_id | UUID | NOT NULL | Tenant scope (from `SecurityContext.subject_tenant_id`) |
+| idempotency_key | VARCHAR(255) | NOT NULL | Caller-supplied deduplication key |
+| resource_id | UUID | NOT NULL | ID of the resource created on the first successful request |
+| created_at | TIMESTAMP WITH TIME ZONE | NOT NULL | When the idempotency record was stored |
+| expires_at | TIMESTAMP WITH TIME ZONE | NOT NULL | When this record is eligible for purge (default: created_at + 24 h) |
+
+**PK**: `(tenant_id, idempotency_key)`
+
+**Indexes**:
+
+- `idx_srr_idem_expires` — `(expires_at)` — For periodic purge of expired records
+
+**Constraints**:
+
+- `tenant_id` is NOT NULL (mandatory tenant scoping — same key in different tenants is distinct)
+- `idempotency_key` max length 255 chars
+- `resource_id` references `simple_resources(id)` ON DELETE CASCADE
+- Records **MUST** be purged after `expires_at` by a background job (same Jobs Manager job as retention purge, or a dedicated lightweight task)
+
+### 3.6 Indexing Strategy
+
+The indexing strategy is designed to support the primary query patterns at scale (100M resources) without requiring table partitioning or database-specific features:
+
+| Query Pattern | Index Used | Expected Performance at 100M |
+| --- | --- | --- |
+| Fetch by ID (PK lookup) | `PRIMARY KEY (id)` | O(log n) B-tree lookup; < 10ms |
+| List by type within tenant | `idx_simple_resources_tenant_type` | Composite index narrows to type partition within tenant; efficient for up to ~1M per type |
+| List by type ordered by created_at | `idx_simple_resources_tenant_type_created` | Covers the full query without table lookups |
+| Filter soft-deleted resources | `idx_simple_resources_tenant_deleted` | Partial index on active records (deleted_at IS NULL) |
+| Retention purge by type + deleted_at | `idx_simple_resources_type_deleted` | Partial index on deleted records only — small index size |
+| User-scoped queries | `idx_simple_resources_tenant_user` | Partial index on rows with owner_id; avoids indexing tenant-only resources |
+
+See [ADR-0001: Storage Optimization](./ADR/0001-cpt-cf-srr-rdb-adr-storage-optimization.md) for the rationale behind choosing indexes over partitioning or per-type tables.
+
+## 4. Additional Context
+
+### 4.1 Known Design-Level Limitations
+
+1. **No payload querying**: The payload column is opaque serialized JSON. The plugin cannot filter or index payload content. For payload-level queries, use a search-capable backend.
+
+2. **SQLite concurrency**: SQLite uses file-level locking, which limits concurrent write throughput. The 100 writes/s target may not be achievable on SQLite under high concurrency. SQLite is intended for edge/dev environments with lower concurrency requirements; production deployments should use PostgreSQL.
+
+3. **Single-table contention**: Under extreme write loads, the single `simple_resources` table may experience lock contention. This is mitigated by the row-level locking available in PostgreSQL and MariaDB. If contention becomes an issue, the main module's storage routing can redirect high-write types to a dedicated backend.
+
+4. **Idempotency key expiration**: Expired idempotency records are purged by a background job. Between expiration and purge, the record still occupies space but is no longer enforced (the deduplication check uses `WHERE expires_at > now()`).
+
+## 5. Traceability
+
+- **Parent Module PRD**: [../../../docs/PRD.md](../../../docs/PRD.md)
+- **Parent Module DESIGN**: [../../../docs/DESIGN.md](../../../docs/DESIGN.md)
+- **Plugin PRD**: [PRD.md](./PRD.md)
+- **ADRs**: [ADR/](./ADR/)

--- a/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/DESIGN.md
+++ b/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/DESIGN.md
@@ -34,16 +34,16 @@ Idempotency deduplication is handled atomically within a single database transac
 
 ### 1.3 Architecture Layers
 
-```
+```text
 ┌──────────────────────────────────────────────────────────┐
 │              Plugin Entry Point                          │
 │   ClientHub registration, PluginCapabilities             │
 ├──────────────────────────────────────────────────────────┤
 │              Storage Implementation                      │
-│   ResourceStoragePluginClient trait methods               │
+│   ResourceStoragePluginClient trait methods              │
 │   OData → SeaORM translation, GTS wildcard → LIKE        │
 ├──────────────────────────────────────────────────────────┤
-│              SecureORM / SeaORM                           │
+│              SecureORM / SeaORM                          │
 │   Tenant-scoped queries, connection pooling              │
 ├──────────────────────────────────────────────────────────┤
 │              Database                                    │

--- a/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/PRD.md
+++ b/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/PRD.md
@@ -201,7 +201,7 @@ Single-resource fetch-by-ID **MUST** complete within 50ms at p95 under normal lo
 
 ## 8. Use Cases
 
-#### Standard CRUD via Main Module
+### Standard CRUD via Main Module
 
 - [ ] `p1` - **ID**: `cpt-cf-srr-rdb-usecase-crud`
 

--- a/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/PRD.md
+++ b/modules/simple-resource-registry/plugins/srr-rdb-plugin/docs/PRD.md
@@ -1,0 +1,271 @@
+# PRD — Simple Resource Registry Relational Database Plugin
+
+## 1. Overview
+
+### 1.1 Purpose
+
+The SRR Relational Database Plugin (`srr-rdb-plugin`) is the default storage backend for the Simple Resource Registry module.
+
+This PRD specifies **only plugin-specific requirements** for the relational database backend. All system-level requirements (API semantics, security model, tenant/owner/GTS access control behavior, payload validation behavior, batch semantics, error model, etc.) are defined in the main module PRD and are **inherited** by this plugin:
+
+- **Parent PRD (authoritative)**: [../../../docs/PRD.md](../../../docs/PRD.md)
+
+The plugin implements the `ResourceStoragePluginClient` trait using a relational database (PostgreSQL, MariaDB, or SQLite) via SecureORM (SeaORM with SecurityContext-based tenant scoping). The plugin stores resources in a single shared table with fixed schema columns and a TEXT payload column containing serialized JSON, providing ACID guarantees, OData query support on schema fields, and idempotent resource creation.
+
+### 1.2 Background / Problem Statement
+
+The Simple Resource Registry requires at least one default storage backend. This plugin provides a DB-agnostic relational implementation that can run on edge devices (SQLite) and production deployments (PostgreSQL/MariaDB) without database-specific configuration.
+
+The plugin is intentionally kept simple: it uses a single shared table for all resource types and relies on B-tree indexes for query performance (see ADR `cpt-cf-srr-rdb-adr-storage-optimization`). More specialized storage optimizations (partitioning, per-type tables) are intentionally left to other backends.
+
+### 1.3 Goals (Business Outcomes)
+
+- Provide a zero-configuration default storage backend that works on PostgreSQL, MariaDB, and SQLite
+- Meet the parent module's scalability targets through proper indexing (`cpt-cf-srr-nfr-scalability`)
+- Keep the implementation simple and maintainable — no database-specific features (partitioning, materialized views, etc.)
+
+All other business and product goals are defined by the parent Simple Resource Registry PRD.
+
+### 1.4 Glossary
+
+This PRD uses the parent module glossary as the primary source of truth. The terms below are plugin-specific.
+
+| Term | Definition |
+|------|------------|
+| Schema Fields | The fixed envelope columns (id, tenant_id, owner_id, type, timestamps) stored as dedicated database columns and queryable via OData |
+| Payload Column | A TEXT column storing serialized JSON payload as an opaque blob |
+| Idempotency Record | A `(tenant_id, idempotency_key)` entry that maps a deduplication key to the resource ID created on the first successful request |
+| SecureORM | SeaORM wrapper that injects `SecurityContext`-based tenant scoping into every database query |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+This plugin has no direct human actors. It is consumed exclusively by the Simple Resource Registry main module.
+
+### 2.2 System Actors
+
+#### Simple Resource Registry Main Module
+
+**ID**: `cpt-cf-srr-rdb-actor-srr-main`
+
+**Role**: The main module invokes this plugin via the `ResourceStoragePluginClient` trait for all resource persistence and query operations. The main module handles authentication, authorization, GTS type resolution, event/audit emission, and request routing — the plugin only handles storage.
+
+## 3. Operational Concept & Environment
+
+The plugin operates within the standard CyberFabric modkit lifecycle. It registers itself as a scoped client in ClientHub with a GTS plugin instance ID, enabling the main module's Storage Router to discover and invoke it. The plugin uses the platform's shared database connection pool managed by modkit-db.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Implementation of the full `ResourceStoragePluginClient` trait
+- Single shared table (`simple_resources`) for all resource types with fixed schema columns + TEXT payload column (serialized JSON)
+- B-tree indexes on schema fields for query performance
+- OData $filter/$orderby translation to SeaORM query filters on schema fields
+- GTS wildcard type matching via SQL `LIKE` with prefix matching
+- Atomic idempotency: resource creation + idempotency key recording in a single database transaction
+- Soft-delete via `deleted_at` timestamp
+- Immediate hard-delete for resources with `retention_days == 0`
+- Batch purge of soft-deleted resources past their retention period
+- Resource group memberships via a junction table
+- Cursor-based pagination (limit, cursor) on schema fields
+- Support for PostgreSQL, MariaDB, and SQLite without database-specific branching
+
+### 4.2 Out of Scope
+
+- Table partitioning by resource type (not DB-agnostic; see ADR)
+- Per-resource-type dedicated tables (requires DDL at runtime; see ADR)
+- Full-text search within payload content (use a search-capable backend)
+- Payload-level indexing or querying
+- Caching layers (Redis, in-memory) — caching is a main module concern
+- Database migration management beyond initial schema creation
+
+## 5. Functional Requirements
+
+### 5.1 Storage Operations
+
+#### Relational Storage Implementation
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-fr-relational-storage`
+
+The plugin **MUST** implement the `ResourceStoragePluginClient` trait using SecureORM (SeaORM with SecurityContext-based tenant scoping). Schema fields **MUST** be stored as dedicated database columns. The payload **MUST** be stored as a TEXT column containing serialized JSON. The plugin **MUST** declare `odata_support: true` and `search_support: false` in its `PluginCapabilities`.
+
+**Rationale**: Core plugin functionality — implements the storage contract defined by the main module.
+**Actors**: `cpt-cf-srr-rdb-actor-srr-main`
+
+#### OData Query Translation
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-fr-odata-translation`
+
+The plugin **MUST** translate OData $filter and $orderby parameters to SeaORM query conditions on schema fields (id, tenant_id, owner_id, type, created_at, updated_at, deleted_at). The plugin **MUST** support cursor-based pagination (limit, cursor). Invalid OData expressions **MUST** result in an error returned to the main module.
+
+**Rationale**: Enables the main module's OData query support on schema fields.
+**Actors**: `cpt-cf-srr-rdb-actor-srr-main`
+
+#### GTS Wildcard Type Matching
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-fr-gts-wildcard`
+
+The plugin **MUST** support GTS wildcard filtering on the `type` column. A trailing wildcard (`*`) in the type filter **MUST** be translated to a SQL `LIKE` prefix match (e.g., `type LIKE 'gts.x.core.srr.resource.v1~acme.%'`). The wildcard is greedy and matches through the `~` chain separator.
+
+**Rationale**: Enables the main module's GTS wildcard filtering requirement.
+**Actors**: `cpt-cf-srr-rdb-actor-srr-main`
+
+#### Atomic Idempotent Creation
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-fr-idempotency`
+
+The plugin **MUST** atomically check for an existing `(tenant_id, idempotency_key)` record and persist the resource + idempotency record in a single database transaction. If a matching record exists within the retention window (default 24 h), the plugin **MUST** return `CreateOutcome::Duplicate(existing_resource_id)`. If no match exists, the plugin **MUST** insert both the resource row and the idempotency record atomically and return `CreateOutcome::Created(resource)`.
+
+**Rationale**: Ensures safe retry semantics for resource creation without risk of double-creation.
+**Actors**: `cpt-cf-srr-rdb-actor-srr-main`
+
+#### Soft-Delete and Hard-Delete
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-fr-soft-delete`
+
+The plugin **MUST** implement soft-delete by setting `deleted_at = now()` on the resource row. The plugin **MUST** implement immediate hard-delete via `hard_delete()` by permanently removing the resource row. Soft-deleted resources **MUST** be excluded from list queries by default (WHERE `deleted_at IS NULL`).
+
+**Rationale**: Supports the main module's soft-delete + configurable retention model.
+**Actors**: `cpt-cf-srr-rdb-actor-srr-main`
+
+#### Retention Purge
+
+- [ ] `p3` - **ID**: `cpt-cf-srr-rdb-fr-retention-purge`
+
+The plugin **MUST** implement `purge_deleted_before(type, cutoff, batch_size)` to permanently delete resources where `type` matches and `deleted_at < cutoff`, limited to `batch_size` rows per invocation. This operation is called by the main module's retention purge job.
+
+**Rationale**: Enables automatic cleanup of soft-deleted resources past their retention period.
+**Actors**: `cpt-cf-srr-rdb-actor-srr-main`
+
+#### Resource Group Memberships
+
+- [ ] `p3` - **ID**: `cpt-cf-srr-rdb-fr-group-memberships`
+
+The plugin **MUST** store resource group membership data in a dedicated junction table. The plugin **MUST** support listing all resources in a group within a tenant, and listing all groups a resource belongs to.
+
+**Rationale**: Supports the main module's resource groups feature.
+**Actors**: `cpt-cf-srr-rdb-actor-srr-main`
+
+### 5.2 Database Compatibility
+
+#### Multi-Database Support
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-fr-db-agnostic`
+
+The plugin **MUST** work on PostgreSQL, MariaDB, and SQLite without requiring database-specific configuration or conditional SQL.
+
+**Rationale**: Enables the Simple Resource Registry to run on any CyberFabric deployment target.
+**Actors**: `cpt-cf-srr-rdb-actor-srr-main`
+
+## 6. Non-Functional Requirements
+
+### 6.1 Module-Specific NFRs
+
+#### Scalability
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-nfr-scalability`
+
+The plugin **MUST** meet the parent module's scalability targets: 100 million total resources, 100 write operations per second, and 1000 single-resource fetch-by-ID operations per second. These targets **MUST** be achieved through proper B-tree indexing on schema fields, without requiring table partitioning or database-specific optimizations.
+
+**Threshold**: 100M total resources; 100 writes/s; 1000 reads-by-ID/s
+**Rationale**: The default backend must handle the full scalability envelope defined by the parent module.
+**Architecture Allocation**: See DESIGN.md section "Indexing Strategy"
+
+#### Single-Resource Read Latency
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-nfr-read-latency`
+
+Single-resource fetch-by-ID **MUST** complete within 50ms at p95 under normal load. This is achieved via primary key lookup with no joins.
+
+**Threshold**: 50ms p95 for single-resource reads
+**Rationale**: Inherited from parent module NFR `cpt-cf-srr-nfr-read-latency`.
+
+### 6.2 NFR Exclusions
+
+- **High-volume partitioning**: Not applicable — the plugin intentionally avoids DB-specific partitioning to maintain cross-database compatibility. See ADR for rationale.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### ResourceStoragePluginClient Implementation
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-interface-plugin-impl`
+
+**Type**: Rust trait implementation (async)
+**Stability**: stable
+**Description**: Implements `ResourceStoragePluginClient` from the `simple-resource-registry-sdk` crate. Registered as a scoped client in ClientHub with a GTS plugin instance ID.
+**Breaking Change Policy**: Follows the parent module's plugin interface versioning — trait changes are coordinated via the SDK crate.
+
+## 8. Use Cases
+
+#### Standard CRUD via Main Module
+
+- [ ] `p1` - **ID**: `cpt-cf-srr-rdb-usecase-crud`
+
+**Actor**: `cpt-cf-srr-rdb-actor-srr-main`
+
+**Preconditions**:
+- Plugin is registered in ClientHub with its GTS instance ID
+- Database schema (tables + indexes) is deployed
+
+**Main Flow**:
+1. Main module's Storage Router resolves this plugin for the target resource type
+2. Main module calls plugin's `create`/`get`/`list`/`update`/`delete` method with SecurityContext
+3. Plugin executes the operation against the relational database via SecureORM
+4. Plugin returns the result to the main module
+
+**Postconditions**:
+- Resource state is persisted in the database
+- All operations are tenant-scoped via SecureORM
+
+## 9. Acceptance Criteria
+
+- [ ] Plugin implements all `ResourceStoragePluginClient` trait methods
+- [ ] Plugin declares `odata_support: true`, `search_support: false`
+- [ ] CRUD operations work correctly on PostgreSQL, MariaDB, and SQLite
+- [ ] OData $filter, $orderby translate correctly to SQL WHERE/ORDER BY on schema fields
+- [ ] GTS wildcard type filter translates to SQL LIKE prefix match
+- [ ] Idempotent creation: duplicate `idempotency_key` within same tenant returns `CreateOutcome::Duplicate`
+- [ ] Idempotency check + resource insert are atomic (single transaction)
+- [ ] Soft-delete sets `deleted_at`; soft-deleted resources excluded from list queries
+- [ ] `hard_delete()` permanently removes the resource row
+- [ ] `purge_deleted_before()` deletes matching rows up to `batch_size`
+- [ ] System sustains 100M total resources, 100 writes/s, 1000 reads-by-ID/s with B-tree indexes
+- [ ] Single-resource fetch-by-ID completes within 50ms at p95
+
+## 10. Dependencies
+
+| Dependency | Description | Needed By |
+|------------|-------------|-----------|
+| simple-resource-registry-sdk | Plugin trait definition (`ResourceStoragePluginClient`, `CreateOutcome`, `PluginCapabilities`) | `cpt-cf-srr-rdb-fr-relational-storage` |
+| modkit-db (SecureORM) | Tenant-scoped database access via SeaORM + SecurityContext | `cpt-cf-srr-rdb-fr-relational-storage` |
+| SeaORM | ORM for database operations, query building, and migrations | `cpt-cf-srr-rdb-fr-odata-translation` |
+| modkit (ClientHub) | Scoped client registration for plugin discovery | `cpt-cf-srr-rdb-fr-relational-storage` |
+
+## 11. Assumptions
+
+- The database connection pool is managed by modkit-db and shared with other modules
+- Database migrations for this plugin's tables are deployed before the plugin starts
+- The main module handles all authentication, authorization, and GTS type resolution before calling the plugin
+
+## 12. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Single-table design hits performance ceiling before 100M resources on underpowered hardware | Query latency exceeds NFR thresholds | Proper composite indexes; main module's storage routing can redirect high-volume types to alternative backends |
+| SQLite lacks concurrent write support under load | Write throughput may not reach 100 writes/s on SQLite | SQLite is intended for edge/dev environments with lower concurrency; production deployments use PostgreSQL |
+| TEXT payload storage limits payload-specific DB optimization | Payload extraction/indexing is not available in this plugin | Payload is opaque by design — no payload-level queries are supported; use a search-capable backend when payload querying is required |
+
+## 13. Open Questions
+
+None — this plugin's requirements are fully derived from the parent module's storage backend contract.
+
+## 14. Traceability
+
+- **Parent Module PRD**: [../../../docs/PRD.md](../../../docs/PRD.md)
+- **Parent Module DESIGN**: [../../../docs/DESIGN.md](../../../docs/DESIGN.md)
+- **Design**: [DESIGN.md](./DESIGN.md)
+- **ADRs**: [ADR/](./ADR/)


### PR DESCRIPTION
    - Move `make fmt` into a separate fmt workflow that runs on every pull_request.
    - Remove fmt from ci.yml so formatting failures don't block main lint/test jobs.
    
    This change is needed because AI bots frequently breaks formatting, while we still
    want to run the main linters/tests
    
    Signed-off-by: Artifizer <artifizer@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Simple Resource Registry module, including product requirements, technical design, and architectural decision records covering storage, security, and search strategies.
  * Added design and requirements documentation for the Simple Resource Registry Relational Database Plugin component.

* **Chores**
  * Reorganized formatting checks in the CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->