### PR TITLE
ci(workflows): run fmt in dedicated workflow and remove from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,6 @@ jobs:
             echo "sccache failed, falling back to plain rustc"
           fi
 
-      - name: cargo fmt (check)
-        run: make fmt
-
       - name: cargo clippy
         run: make clippy
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,37 @@
+name: Fmt
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - '**/*.rs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  fmt:
+    name: cargo fmt (check)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
+
+      - name: Cache Cargo/target
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+        with:
+          cache-bin: false
+          cache-targets: false
+          shared-key: pr-fmt-stable-1.92
+
+      - name: cargo fmt (check)
+        run: make fmt

--- a/libs/modkit/src/bootstrap/config/dump.rs
+++ b/libs/modkit/src/bootstrap/config/dump.rs
@@ -55,7 +55,10 @@ pub fn render_effective_modules_config(app: &AppConfig) -> Result<serde_json::Va
 
     let home_dir = PathBuf::from(&app.server.home_dir);
     // Prevent path traversal attacks by rejecting paths containing '..'
-    if home_dir.components().any(|c| c == std::path::Component::ParentDir) {
+    if home_dir
+        .components()
+        .any(|c| c == std::path::Component::ParentDir)
+    {
         return Err(anyhow::anyhow!("Invalid input: {}", home_dir.display()));
     }
     let mut modules_config = serde_json::Map::new();

--- a/scripts/ci.py
+++ b/scripts/ci.py
@@ -243,6 +243,8 @@ def _print_log_file(path, label):
         return
     print(f"\n--- {label}: {path} ---")
     try:
+        if "../" in path or "..\\" in path:
+            raise Exception("Invalid file path")
         with open(path) as f:
             content = f.read()
             if content:

--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -751,15 +751,16 @@ def start_instrumented_server(config_file, output_dir, port=None):
     target_real = os.path.realpath(log_file)
     if os.path.commonpath([base_real, target_real]) != base_real:
         raise Exception("Invalid file path")
+    log_fp = open(target_real, "w")
     server_process = popen_new_group(
         cmd,
         env=env2,
         cwd=PROJECT_ROOT,
-        stdout=open(target_real, "w"),
+        stdout=log_fp,
         stderr=subprocess.STDOUT,
     )
 
-    return server_process, log_file, port
+    return server_process, log_file, port, log_fp
 
 
 def run_e2e_tests(base_url, test_filter=None):

--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -276,7 +276,11 @@ def enumerate_project_rs_files(project_root):
 def count_non_empty_lines(abs_path):
     """Approximate LOC by counting non-empty lines for a file."""
     try:
-        with open(abs_path, "r", encoding="utf-8", errors="ignore") as f:
+        base_real = os.path.realpath(PROJECT_ROOT)
+        target_real = os.path.realpath(abs_path)
+        if os.path.commonpath([base_real, target_real]) != base_real:
+            raise Exception("Invalid file path")
+        with open(target_real, "r", encoding="utf-8", errors="ignore") as f:
             return sum(1 for ln in f if ln.strip())
     except FileNotFoundError:
         return 0
@@ -598,7 +602,11 @@ def parse_bind_addr_port(config_file):
         int: Port number from api_gateway.bind_addr
     """
     config_path = PROJECT_ROOT / config_file
-    with open(config_path, 'r') as f:
+    base_real = os.path.realpath(PROJECT_ROOT)
+    target_real = os.path.realpath(config_path)
+    if os.path.commonpath([base_real, target_real]) != base_real:
+        raise Exception('Invalid file path')
+    with open(target_real, 'r') as f:
         config = yaml.safe_load(f)
 
     bind_addr = config.get('modules', {}).get('api-gateway', {}).get(
@@ -739,11 +747,15 @@ def start_instrumented_server(config_file, output_dir, port=None):
     )
 
     # Start server
+    base_real = os.path.realpath(COVERAGE_DIR)
+    target_real = os.path.realpath(log_file)
+    if os.path.commonpath([base_real, target_real]) != base_real:
+        raise Exception("Invalid file path")
     server_process = popen_new_group(
         cmd,
         env=env2,
         cwd=PROJECT_ROOT,
-        stdout=open(log_file, "w"),
+        stdout=open(target_real, "w"),
         stderr=subprocess.STDOUT,
     )
 
@@ -962,6 +974,10 @@ def generate_reports(output_dir, mode, threshold=COVERAGE_THRESHOLD, use_color=F
     )
 
     json_file = output_dir / "coverage.json"
+    base_real = os.path.realpath(COVERAGE_DIR)
+    target_real = os.path.realpath(json_file)
+    if os.path.commonpath([base_real, target_real]) != base_real:
+        raise Exception("Invalid file path")
     json_file.write_text(json_result.stdout)
     print(f"[OK] JSON report: {json_file}")
 
@@ -978,6 +994,10 @@ def generate_reports(output_dir, mode, threshold=COVERAGE_THRESHOLD, use_color=F
 
     # Save custom report (without color codes)
     custom_file = output_dir / "coverage_report.txt"
+    base_real = os.path.realpath(COVERAGE_DIR)
+    target_real = os.path.realpath(custom_file)
+    if os.path.commonpath([base_real, target_real]) != base_real:
+        raise Exception("Invalid file path")
     custom_file.write_text(
         format_custom_coverage_report(
             json_data,

--- a/testing/docker/http-mock.Dockerfile
+++ b/testing/docker/http-mock.Dockerfile
@@ -11,5 +11,7 @@ COPY ../e2e/helpers/run_mock_server.py /app/run_mock_server.py
 EXPOSE 8080
 
 # Run the mock server
+RUN useradd -U -u 1000 appuser && \
+    chown -R 1000:1000 /app
+USER 1000
 CMD ["python", "-u", "/app/run_mock_server.py"]
-

--- a/testing/docker/hyperspot.Dockerfile
+++ b/testing/docker/hyperspot.Dockerfile
@@ -52,5 +52,7 @@ COPY --from=builder /build/config /app/config
 EXPOSE 8086
 
 # Run with shared e2e-local config (same config path as local E2E).
+RUN useradd -U -u 1000 appuser && \
+    chown -R 1000:1000 /app
+USER 1000
 CMD ["/app/hyperspot-server", "--config", "/app/config/e2e-local.yaml"]
-


### PR DESCRIPTION
- Move `make fmt` into a separate fmt workflow that runs on every pull_request.
- Remove fmt from ci.yml so formatting failures don't block main lint/test jobs.

This change is needed because AI bots frequently breaks formatting, while we still want to run the main linters/tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized code formatting checks in the continuous integration pipeline by introducing a dedicated workflow step, improving CI workflow organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->