### PR TITLE
fix(modkit): oop reconnect issue  #671

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "utoipa",
 ]
@@ -872,10 +873,13 @@ dependencies = [
  "prost",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
+ "tokio-util",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/docs/modkit_unified_system/09_oop_grpc_sdk_pattern.md
+++ b/docs/modkit_unified_system/09_oop_grpc_sdk_pattern.md
@@ -8,6 +8,7 @@ ModKit supports running modules as separate processes with gRPC-based inter-proc
 - **Rule**: For gRPC: server implementations live in the module itself; the SDK crate provides only the client.
 - **Rule**: For gRPC clients: always use `modkit_transport_grpc::client` utilities (`connect_with_stack`, `connect_with_retry`).
 - **Rule**: Use `CancellationToken` for coordinated shutdown across the entire process tree.
+- **Rule**: Use `wire_and_watch` (or an SDK-specific `wire_and_watch_client`) for reconnection-safe OoP wiring. Never use the deprecated one-shot `wire_client` for production OoP communication.
 
 ## RuntimeKind
 
@@ -255,31 +256,36 @@ impl MyModuleApi for MyModuleGrpcClient {
 
 ```rust
 // my_module-sdk/src/wiring.rs
+use std::sync::Arc;
+use anyhow::Result;
+use modkit::client_hub::ClientHub;
+use modkit::runtime::InstanceEventSource;
+use modkit::DirectoryClient;
+use tokio_util::sync::CancellationToken;
 use crate::{MyModuleApi, MyModuleGrpcClient, SERVICE_NAME};
-use modkit_transport_grpc::client::{connect_with_stack, connect_with_retry};
-use tonic::transport::Channel;
 
-/// Wire a gRPC client with default stack
-pub async fn wire_client(endpoint: &str) -> Result<Box<dyn MyModuleApi>, Box<dyn std::error::Error>> {
-    let channel = connect_with_stack(endpoint).await?;
-    let client = MyModuleGrpcClient::new(channel);
-    Ok(Box::new(client))
-}
-
-/// Wire a gRPC client with retry logic
-pub async fn build_client(
-    endpoint: &str,
-    max_retries: u32,
-    retry_delay: std::time::Duration,
-) -> Result<Box<dyn MyModuleApi>, Box<dyn std::error::Error>> {
-    let channel = connect_with_retry(endpoint, max_retries, retry_delay).await?;
-    let client = MyModuleGrpcClient::new(channel);
-    Ok(Box::new(client))
-}
-
-/// Get service name for discovery
-pub fn service_name() -> &'static str {
-    SERVICE_NAME
+/// Wire the gRPC client into ClientHub and watch for reconnections.
+///
+/// This is the recommended approach for OoP modules. It automatically
+/// re-wires the client when the module reconnects on a new endpoint.
+pub async fn wire_and_watch_client(
+    hub: &Arc<ClientHub>,
+    directory: &Arc<dyn DirectoryClient>,
+    events: &Arc<dyn InstanceEventSource>,
+    cancel: CancellationToken,
+) -> Result<modkit::GrpcWatcher> {
+    modkit::wire_and_watch::<dyn MyModuleApi>(
+        Arc::clone(hub),
+        Arc::clone(directory),
+        Arc::clone(events),
+        SERVICE_NAME,
+        |uri| Box::pin(async move {
+            let client = MyModuleGrpcClient::connect(&uri).await?;
+            Ok(Arc::new(client) as Arc<dyn MyModuleApi>)
+        }),
+        cancel,
+    )
+    .await
 }
 ```
 
@@ -383,25 +389,39 @@ impl MyModule {
 
 > The `client = ...` attribute validates the trait at compile time and exposes MODULE_NAME, but does not auto-register the client into ClientHub. You must still register it explicitly in your `init()` method using `ctx.client_hub().register::<dyn my_module_sdk::MyModuleApi>(client)`. 
 
-## Client Registration (in module)
+## Client Registration (in gateway module)
 
-### Register both local and remote clients
+### Using `wire_and_watch_client` for reconnection-safe wiring
 
 ```rust
-// In module's init()
-async fn register_clients(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-    // Try local client first
-    if let Ok(local_client) = ctx.client_hub().try_get::<dyn my_module_sdk::MyModuleApi>() {
-        ctx.client_hub().register::<dyn my_module_sdk::MyModuleApi>(local_client);
-        return Ok(());
+// In gateway service (lazy wiring on first request)
+pub struct Service {
+    client_hub: Arc<ClientHub>,
+    cancel: CancellationToken,
+    wired: OnceCell<modkit::GrpcWatcher>,
+}
+
+impl Service {
+    pub async fn call_my_module(&self) -> Result<(), ServiceError> {
+        // Ensure wiring + watcher starts exactly once.
+        // If it fails (no healthy instance yet), retries on next request.
+        self.wired
+            .get_or_try_init(|| async {
+                let mgr = self.client_hub.get::<ModuleManager>()?;
+                let directory: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(mgr.clone()));
+                let events: Arc<dyn InstanceEventSource> = mgr;
+                my_module_sdk::wire_and_watch_client(
+                    &self.client_hub, &directory, &events, self.cancel.clone()
+                ).await
+            })
+            .await?;
+
+        let client = self.client_hub.get::<dyn my_module_sdk::MyModuleApi>()?;
+        // Use client — if the OoP module reconnects, the watcher
+        // automatically replaces the client in ClientHub.
+        client.do_something(input).await?;
+        Ok(())
     }
-    
-    // Fall back to remote client
-    let endpoint = "http://127.0.0.1:50051";
-    let remote_client = my_module_sdk::wire_client(endpoint).await?;
-    ctx.client_hub().register::<dyn my_module_sdk::MyModuleApi>(remote_client);
-    
-    Ok(())
 }
 ```
 
@@ -430,12 +450,46 @@ async fn test_grpc_client() {
 }
 ```
 
+## Reconnection
+
+### The problem
+
+When an OoP module disconnects and reconnects (e.g., crash recovery, rolling restart), it binds to a **new ephemeral port**. The `ModuleManager` (directory) correctly registers the new endpoint, but previously the cached gRPC client in `ClientHub` still pointed at the old dead socket.
+
+### The solution: `wire_and_watch`
+
+`modkit::wire_and_watch` is a framework-level utility that:
+
+1. Performs initial wiring: resolves the endpoint from `ModuleManager`, calls the connect factory, registers the client in `ClientHub`.
+2. Subscribes to `ModuleManager`'s `InstanceEvent` broadcast.
+3. On any event for the watched service: re-resolves, reconnects, and atomically replaces the client in `ClientHub`.
+4. On connect failure: removes the stale client so callers get a clear `NotFound` error instead of hitting a dead socket.
+
+Each SDK crate provides a thin `wire_and_watch_client` wrapper that supplies the service-specific connect factory.
+
+### Event types
+
+```rust
+pub enum InstanceEventKind {
+    Registered,    // New instance or re-registration
+    Deregistered,  // Explicit removal
+    Evicted,       // Heartbeat-based eviction
+}
+```
+
+Events are fired **after** `DashMap` locks are released to avoid contention.
+
+### Multi-instance note
+
+In multi-instance topologies the watcher re-resolves on *any* event for the watched service, even if the event doesn't affect the current client's endpoint. This is intentional: the re-wire is cheap, last-writer-wins is safe for single-instance OoP, and comparing URIs would introduce false negatives (same-port reconnect, round-robin rotation). The `Lagged` path already unconditionally re-resolves.
+
 ## Quick checklist
 
 - [ ] Create `*-sdk` crate with API trait, types, gRPC client, and wiring helpers.
 - [ ] Define `.proto` file and generate gRPC stubs in SDK.
 - [ ] Implement gRPC server in module crate.
 - [ ] Use `modkit_transport_grpc::client` utilities for connections.
-- [ ] Register both local and remote clients in module.
+- [ ] Add `wire_and_watch_client` to SDK for reconnection-safe wiring.
+- [ ] Use `wire_and_watch_client` in gateway service (not the deprecated `wire_client`).
 - [ ] Use `CancellationToken` for coordinated shutdown.
-- [ ] Test with mock gRPC servers.
+- [ ] Test with mock gRPC servers, including reconnection scenarios.

--- a/examples/oop-modules/calculator-gateway/calculator-gateway/Cargo.toml
+++ b/examples/oop-modules/calculator-gateway/calculator-gateway/Cargo.toml
@@ -27,6 +27,7 @@ utoipa = { workspace = true }
 # Async & concurrency
 async-trait = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 
 # Error handling
 thiserror = { workspace = true }

--- a/examples/oop-modules/calculator-gateway/calculator-gateway/src/domain/service.rs
+++ b/examples/oop-modules/calculator-gateway/calculator-gateway/src/domain/service.rs
@@ -1,15 +1,17 @@
 //! Domain service for calculator_gateway
 //!
 //! Contains business logic for accumulator operations.
-//! Resolves calculator client from ClientHub at call time.
+//! Uses `wire_and_watch_client` for reconnection-safe OoP wiring.
 
 use std::sync::Arc;
 
 use calculator_sdk::CalculatorClientV1;
 use modkit::client_hub::ClientHub;
+use modkit::runtime::InstanceEventSource;
 use modkit_macros::domain_model;
 use modkit_security::SecurityContext;
 use tokio::sync::OnceCell;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, instrument};
 
 /// Error type for Service operations.
@@ -30,18 +32,21 @@ pub enum ServiceError {
 
 /// Domain service that orchestrates accumulator operations.
 ///
-/// Holds a reference to ClientHub for resolving dependencies at call time.
+/// Uses `wire_and_watch_client` to automatically re-wire the gRPC client
+/// when the calculator OoP module reconnects on a new endpoint.
 #[domain_model]
 pub struct Service {
     client_hub: Arc<ClientHub>,
-    wired: OnceCell<()>,
+    cancel: CancellationToken,
+    wired: OnceCell<modkit::GrpcWatcher>,
 }
 
 impl Service {
     /// Create a new service with ClientHub for dependency resolution.
-    pub fn new(client_hub: Arc<ClientHub>) -> Self {
+    pub fn new(client_hub: Arc<ClientHub>, cancel: CancellationToken) -> Self {
         Self {
             client_hub,
+            cancel,
             wired: OnceCell::new(),
         }
     }
@@ -51,24 +56,38 @@ impl Service {
     pub async fn add(&self, ctx: &SecurityContext, a: i64, b: i64) -> Result<i64, ServiceError> {
         debug!("Resolving calculator client from ClientHub");
 
-        // Ensure wiring happens exactly once, even under concurrent callers.
+        // Ensure wiring + watcher starts exactly once, even under concurrent callers.
         // Why not on init?  CalculatorGateway::init() runs during the init phase,
         // before the OoP child is spawned (which happens after the start phase).
-        // So the LocalDirectoryClient won't have the calculator's endpoint registered yet
-        // when wire_client tries to resolve it.
+        // So the DirectoryClient won't have the calculator's endpoint registered yet
+        // when wire_and_watch_client tries to resolve it.
+        //
+        // If wire_and_watch_client fails (no healthy instance yet), get_or_try_init
+        // retries on the next request.
         self.wired
             .get_or_try_init(|| async {
                 let directory = self
                     .client_hub
                     .get::<dyn modkit::DirectoryClient>()
                     .map_err(|e| {
-                        ServiceError::Internal(format!("DirectoryClient not available: {}", e))
+                        ServiceError::Internal(format!("DirectoryClient not available: {e}"))
                     })?;
-                calculator_sdk::wire_client(&self.client_hub, directory.as_ref())
-                    .await
+                let events = self
+                    .client_hub
+                    .get::<dyn InstanceEventSource>()
                     .map_err(|e| {
-                        ServiceError::Internal(format!("Failed to wire calculator client: {}", e))
-                    })
+                        ServiceError::Internal(format!("InstanceEventSource not available: {e}"))
+                    })?;
+                calculator_sdk::wire_and_watch_client(
+                    &self.client_hub,
+                    &directory,
+                    &events,
+                    self.cancel.clone(),
+                )
+                .await
+                .map_err(|e| {
+                    ServiceError::Internal(format!("Failed to wire calculator client: {e}"))
+                })
             })
             .await?;
 
@@ -76,7 +95,7 @@ impl Service {
             .client_hub
             .get::<dyn CalculatorClientV1>()
             .map_err(|e| {
-                ServiceError::Internal(format!("CalculatorClientV1 not available: {}", e))
+                ServiceError::Internal(format!("CalculatorClientV1 not available: {e}"))
             })?;
 
         debug!("Delegating addition to calculator service");

--- a/examples/oop-modules/calculator-gateway/calculator-gateway/src/module.rs
+++ b/examples/oop-modules/calculator-gateway/calculator-gateway/src/module.rs
@@ -38,10 +38,14 @@ impl modkit::Module for CalculatorGateway {
     async fn init(&self, ctx: &ModuleCtx) -> Result<()> {
         tracing::info!("Initializing {} module", Self::MODULE_NAME);
 
-        // Create domain service with ClientHub for dependency resolution
-        let service = Arc::new(Service::new(ctx.client_hub()));
+        // Create domain service with ClientHub and CancellationToken for
+        // reconnection-safe OoP wiring via wire_and_watch_client.
+        let service = Arc::new(Service::new(
+            ctx.client_hub(),
+            ctx.cancellation_token().clone(),
+        ));
 
-        // Register Service in ClientHub for SDK's wire_client() to access
+        // Register Service in ClientHub for route handlers to access
         ctx.client_hub().register::<Service>(service);
 
         tracing::info!("{} module initialized successfully", Self::MODULE_NAME);

--- a/examples/oop-modules/calculator/calculator-sdk/Cargo.toml
+++ b/examples/oop-modules/calculator/calculator-sdk/Cargo.toml
@@ -23,9 +23,13 @@ tonic-prost = { workspace = true }
 prost = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
+tokio-util = { workspace = true }
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
+uuid = { workspace = true }

--- a/examples/oop-modules/calculator/calculator-sdk/src/lib.rs
+++ b/examples/oop-modules/calculator/calculator-sdk/src/lib.rs
@@ -3,16 +3,16 @@
 //! This crate provides everything needed to consume the calculator service:
 //! - API trait (`CalculatorClientV1`)
 //! - Error types (`CalculatorError`)
-//! - Wiring function (`wire_client`)
+//! - Wiring function (`wire_and_watch_client`)
 //! - Proto stubs for server implementation
 //!
 //! ## Usage
 //!
 //! ```ignore
-//! use calculator_sdk::{CalculatorClientV1, wire_client};
+//! use calculator_sdk::{CalculatorClientV1, wire_and_watch_client};
 //!
-//! // Wire the client into ClientHub
-//! wire_client(&hub, &directory).await?;
+//! // Wire the client into ClientHub with automatic reconnection
+//! let _watcher = wire_and_watch_client(&hub, &directory, &events, cancel).await?;
 //!
 //! // Get the client from ClientHub
 //! let client = hub.get::<dyn CalculatorClientV1>()?;
@@ -29,7 +29,7 @@ pub use api::{CalculatorClientV1, CalculatorError};
 // === WIRING ===
 mod client;
 mod wiring;
-pub use wiring::wire_client;
+pub use wiring::wire_and_watch_client;
 
 // === GRPC PROTO STUBS (for server implementation) ===
 /// Generated protobuf types for CalculatorService

--- a/examples/oop-modules/calculator/calculator-sdk/src/wiring.rs
+++ b/examples/oop-modules/calculator/calculator-sdk/src/wiring.rs
@@ -1,35 +1,46 @@
 //! Wiring for Calculator SDK
 //!
-//! Provides `wire_client` to register the gRPC client into ClientHub.
+//! Provides `wire_and_watch_client` (reconnection-safe) to register the
+//! gRPC client into ClientHub.
 
 use std::sync::Arc;
 
 use anyhow::Result;
 use cf_system_sdks::directory::DirectoryClient;
 use modkit::client_hub::ClientHub;
+use modkit::runtime::InstanceEventSource;
+use tokio_util::sync::CancellationToken;
 
 use crate::SERVICE_NAME;
 use crate::api::CalculatorClientV1;
 use crate::client::CalculatorGrpcClient;
 
-/// Wire the Calculator gRPC client into the ClientHub.
+/// Wire the Calculator gRPC client into the ClientHub and watch for reconnections.
 ///
 /// This function:
-/// 1. Resolves the CalculatorService endpoint from the DirectoryClient
-/// 2. Creates a gRPC client
-/// 3. Registers it in the ClientHub as `dyn CalculatorClientV1`
+/// 1. Resolves the CalculatorService endpoint via `DirectoryClient`
+/// 2. Creates a gRPC client and registers it in the ClientHub
+/// 3. Spawns a background task that re-wires the client when instances change
 ///
-/// # Example
-/// ```ignore
-/// use calculator_sdk::{wire_client, CalculatorClientV1};
-///
-/// wire_client(&hub, &directory_api).await?;
-/// let client = hub.get::<dyn CalculatorClientV1>()?;
-/// ```
-pub async fn wire_client(hub: &ClientHub, resolver: &dyn DirectoryClient) -> Result<()> {
-    let endpoint = resolver.resolve_grpc_service(SERVICE_NAME).await?;
-    let client = CalculatorGrpcClient::connect(&endpoint.uri).await?;
-    hub.register::<dyn CalculatorClientV1>(Arc::new(client));
-    tracing::info!(service = SERVICE_NAME, "CalculatorClientV1 client wired");
-    Ok(())
+/// Returns a [`modkit::GrpcWatcher`] for monitoring re-wire events.
+pub async fn wire_and_watch_client(
+    hub: &Arc<ClientHub>,
+    directory: &Arc<dyn DirectoryClient>,
+    events: &Arc<dyn InstanceEventSource>,
+    cancel: CancellationToken,
+) -> Result<modkit::GrpcWatcher> {
+    modkit::wire_and_watch::<dyn CalculatorClientV1>(
+        Arc::clone(hub),
+        Arc::clone(directory),
+        Arc::clone(events),
+        SERVICE_NAME,
+        |uri| {
+            Box::pin(async move {
+                let client = CalculatorGrpcClient::connect(&uri).await?;
+                Ok(Arc::new(client) as Arc<dyn CalculatorClientV1>)
+            })
+        },
+        cancel,
+    )
+    .await
 }

--- a/examples/oop-modules/calculator/calculator-sdk/tests/reconnect_test.rs
+++ b/examples/oop-modules/calculator/calculator-sdk/tests/reconnect_test.rs
@@ -1,0 +1,336 @@
+//! Integration test reproducing OoP reconnect bug (cyberfabric-core#671).
+//!
+//! **Bug**: When an OoP follower disconnects and reconnects on a new ephemeral
+//! port, the master's gateway still sends gRPC requests to the old dead socket
+//! because `wire_client()` is guarded by `OnceCell` and the cached tonic
+//! `Channel` in `ClientHub` is never refreshed.
+//!
+//! **Fix**: `wire_and_watch_client` subscribes to instance events and
+//! automatically re-wires the client when instances change.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::TcpListenerStream;
+use tokio_util::sync::CancellationToken;
+use tonic::{Request, Response, Status, transport::Server};
+use uuid::Uuid;
+
+use calculator_sdk::{
+    AddRequest, AddResponse, CalculatorClientV1, CalculatorService, CalculatorServiceServer,
+    SERVICE_NAME, wire_and_watch_client,
+};
+use modkit::runtime::InstanceEventSource;
+use modkit::{
+    ClientHub, DirectoryClient, Endpoint, LocalDirectoryClient, ModuleInstance, ModuleManager,
+};
+use modkit_security::SecurityContext;
+
+// ---------------------------------------------------------------------------
+// Test server: minimal CalculatorService that returns a + b
+// ---------------------------------------------------------------------------
+
+struct TestCalculatorService;
+
+#[tonic::async_trait]
+impl CalculatorService for TestCalculatorService {
+    async fn add(&self, request: Request<AddRequest>) -> Result<Response<AddResponse>, Status> {
+        let req = request.into_inner();
+        Ok(Response::new(AddResponse { sum: req.a + req.b }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test server lifecycle helpers
+// ---------------------------------------------------------------------------
+
+struct TestServer {
+    port: u16,
+    cancel: CancellationToken,
+    handle: JoinHandle<()>,
+}
+
+/// Spawn a tonic gRPC server on an ephemeral port (`127.0.0.1:0`).
+///
+/// The `TcpListener` is bound *before* the server task is spawned, so the
+/// port is ready for connections as soon as this function returns — no sleeps
+/// needed.
+async fn spawn_test_server() -> TestServer {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+
+    let incoming = TcpListenerStream::new(listener);
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(CalculatorServiceServer::new(TestCalculatorService))
+            .serve_with_incoming_shutdown(incoming, async move {
+                cancel_clone.cancelled().await;
+            })
+            .await
+            .unwrap();
+    });
+
+    TestServer {
+        port,
+        cancel,
+        handle,
+    }
+}
+
+impl TestServer {
+    /// Signal shutdown and wait for the server task to fully exit.
+    ///
+    /// After this returns the TCP listener is dropped and the port is free.
+    /// Any existing HTTP/2 connections are torn down.
+    async fn shutdown(self) {
+        self.cancel.cancel();
+        self.handle.await.unwrap();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: register a healthy instance in ModuleManager
+// ---------------------------------------------------------------------------
+
+/// Creates a `ModuleInstance` for "calculator" with the given port and registers
+/// it in `ModuleManager`, but does NOT send a heartbeat. The instance stays in
+/// `Registered` state (not yet discoverable by `pick_service_round_robin`).
+fn register_instance_only(mgr: &ModuleManager, port: u16) -> Uuid {
+    let instance_id = Uuid::new_v4();
+    let instance = Arc::new(
+        ModuleInstance::new("calculator", instance_id)
+            .with_grpc_service(SERVICE_NAME, Endpoint::http("127.0.0.1", port)),
+    );
+    mgr.register_instance(instance);
+    instance_id
+}
+
+/// Creates a `ModuleInstance` for "calculator" with the given port, registers
+/// it in `ModuleManager`, and sends a heartbeat to transition it to `Healthy`
+/// so that `pick_service_round_robin` can discover it.
+fn register_healthy_instance(mgr: &ModuleManager, port: u16) -> Uuid {
+    let instance_id = Uuid::new_v4();
+    let instance = Arc::new(
+        ModuleInstance::new("calculator", instance_id)
+            .with_grpc_service(SERVICE_NAME, Endpoint::http("127.0.0.1", port)),
+    );
+    mgr.register_instance(instance);
+    mgr.update_heartbeat("calculator", instance_id, Instant::now());
+    instance_id
+}
+
+// ---------------------------------------------------------------------------
+// The tests
+// ---------------------------------------------------------------------------
+
+/// Tests that `wire_and_watch_client` re-wires the gRPC client when an OoP
+/// module reconnects on a different port.
+///
+/// After server1 shuts down and server2 starts on a new port, the watcher
+/// receives the `InstanceEvent::Registered` event, re-resolves the endpoint,
+/// and atomically replaces the client in `ClientHub`.
+#[tokio::test]
+async fn test_client_reaches_new_server_after_oop_reconnect() {
+    // === Phase 1: Start server1, wire the client, verify it works =========
+
+    let server1 = spawn_test_server().await;
+    let port_a = server1.port;
+
+    let mgr = Arc::new(ModuleManager::new());
+    let directory: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(mgr.clone()));
+    let events: Arc<dyn InstanceEventSource> = mgr.clone();
+    let hub = Arc::new(ClientHub::new());
+    let cancel = CancellationToken::new();
+
+    let instance_id_1 = register_healthy_instance(&mgr, port_a);
+
+    // wire_and_watch_client resolves the endpoint, creates a gRPC client,
+    // registers it in the hub, and starts a background watcher.
+    let _watcher = wire_and_watch_client(&hub, &directory, &events, cancel.clone())
+        .await
+        .unwrap();
+
+    let client = hub.get::<dyn CalculatorClientV1>().unwrap();
+    let ctx = SecurityContext::anonymous();
+
+    let result = client.add(&ctx, 2, 3).await;
+    assert_eq!(result.unwrap(), 5, "Phase 1: add(2, 3) should return 5");
+
+    // === Phase 2: Simulate OoP disconnect + reconnect =====================
+
+    // Shutdown server1 and wait for the task to fully exit.
+    server1.shutdown().await;
+    mgr.deregister("calculator", instance_id_1);
+
+    // Start server2 on a *different* ephemeral port.
+    let server2 = spawn_test_server().await;
+    let port_b = server2.port;
+    assert_ne!(port_a, port_b, "server2 must bind to a different port");
+
+    // Register server2 as a new healthy instance in the directory.
+    let _instance_id_2 = register_healthy_instance(&mgr, port_b);
+
+    // === Phase 3: Verify the watcher re-wired the client ==================
+    //
+    // The watcher received the Registered event (from register_healthy_instance)
+    // and re-resolved + reconnected. Use a retry loop to allow the async
+    // re-wire to complete.
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        // Re-fetch client from hub each iteration (don't cache the Arc)
+        let Ok(client) = hub.get::<dyn CalculatorClientV1>() else {
+            if tokio::time::Instant::now() < deadline {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                continue;
+            }
+            panic!("client still absent from hub after reconnect");
+        };
+        match client.add(&ctx, 10, 20).await {
+            Ok(sum) => {
+                assert_eq!(sum, 30, "add(10,20) should return 30");
+                break;
+            }
+            Err(_) if tokio::time::Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            Err(e) => panic!("add(10,20) still failing after reconnect: {e}"),
+        }
+    }
+
+    // Cleanup
+    cancel.cancel();
+    server2.shutdown().await;
+}
+
+/// Deterministic test using `GrpcWatcher::rewired()` to synchronize on
+/// the re-wire event instead of a retry loop.
+#[tokio::test]
+async fn test_grpc_watcher_signals_rewire() {
+    let server1 = spawn_test_server().await;
+    let port_a = server1.port;
+
+    let mgr = Arc::new(ModuleManager::new());
+    let directory: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(mgr.clone()));
+    let events: Arc<dyn InstanceEventSource> = mgr.clone();
+    let hub = Arc::new(ClientHub::new());
+    let cancel = CancellationToken::new();
+
+    let instance_id_1 = register_healthy_instance(&mgr, port_a);
+
+    let mut watcher = wire_and_watch_client(&hub, &directory, &events, cancel.clone())
+        .await
+        .unwrap();
+
+    // Verify initial wiring works
+    let ctx = SecurityContext::anonymous();
+    let client = hub.get::<dyn CalculatorClientV1>().unwrap();
+    assert_eq!(client.add(&ctx, 1, 1).await.unwrap(), 2);
+
+    // Simulate reconnect
+    server1.shutdown().await;
+    mgr.deregister("calculator", instance_id_1);
+
+    let server2 = spawn_test_server().await;
+    let port_b = server2.port;
+    assert_ne!(port_a, port_b);
+
+    let _instance_id_2 = register_healthy_instance(&mgr, port_b);
+
+    // Wait for the watcher to signal a re-wire (deterministic, no retry loop)
+    let count = watcher.rewired().await.unwrap();
+    assert!(count >= 1, "expected at least 1 re-wire, got {count}");
+
+    // Verify new client reaches server2
+    let client = hub.get::<dyn CalculatorClientV1>().unwrap();
+    assert_eq!(
+        client.add(&ctx, 100, 200).await.unwrap(),
+        300,
+        "after re-wire, add(100, 200) should return 300"
+    );
+
+    // Cleanup
+    cancel.cancel();
+    server2.shutdown().await;
+}
+
+/// Reproduces the race between registration and first heartbeat.
+///
+/// When an OoP module registers but hasn't sent its first heartbeat yet,
+/// the instance is in `Registered` state. The watcher receives the
+/// `Registered` event but `pick_service_round_robin` can't find the
+/// instance (it filters on `Healthy | Ready`). Without the fix, this
+/// would remove the existing client from `ClientHub` permanently.
+///
+/// The fix has two parts:
+/// 1. `update_heartbeat` fires a `BecameHealthy` event on Registered→Healthy
+/// 2. The watcher doesn't remove the client on resolve failure for additive events
+#[tokio::test]
+async fn test_watcher_survives_registration_before_healthy() {
+    // === Phase 1: Start server1, wire the client, verify it works =========
+
+    let server1 = spawn_test_server().await;
+    let port_a = server1.port;
+
+    let mgr = Arc::new(ModuleManager::new());
+    let directory: Arc<dyn DirectoryClient> = Arc::new(LocalDirectoryClient::new(mgr.clone()));
+    let events: Arc<dyn InstanceEventSource> = mgr.clone();
+    let hub = Arc::new(ClientHub::new());
+    let cancel = CancellationToken::new();
+
+    let instance_id_1 = register_healthy_instance(&mgr, port_a);
+
+    let mut watcher = wire_and_watch_client(&hub, &directory, &events, cancel.clone())
+        .await
+        .unwrap();
+
+    let ctx = SecurityContext::anonymous();
+    let client = hub.get::<dyn CalculatorClientV1>().unwrap();
+    assert_eq!(client.add(&ctx, 2, 3).await.unwrap(), 5);
+
+    // === Phase 2: Simulate disconnect =====================================
+
+    server1.shutdown().await;
+    mgr.deregister("calculator", instance_id_1);
+
+    // === Phase 3: Register server2 WITHOUT heartbeat (stays Registered) ===
+
+    let server2 = spawn_test_server().await;
+    let port_b = server2.port;
+    assert_ne!(port_a, port_b, "server2 must bind to a different port");
+
+    let instance_id_2 = register_instance_only(&mgr, port_b);
+
+    // Yield to let the watcher process the Registered event. The resolve
+    // will fail (instance is Registered, not Healthy), but the fix ensures
+    // the watcher does NOT remove the existing client.
+    tokio::task::yield_now().await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // === Phase 4: Send heartbeat → BecameHealthy event fires ==============
+
+    mgr.update_heartbeat("calculator", instance_id_2, Instant::now());
+
+    // Wait for the watcher to re-wire via the BecameHealthy event
+    let count = tokio::time::timeout(Duration::from_secs(5), watcher.rewired())
+        .await
+        .expect("timed out waiting for rewire")
+        .expect("watcher gone");
+    assert!(count >= 1, "expected at least 1 re-wire, got {count}");
+
+    // Verify the new client reaches server2
+    let client = hub.get::<dyn CalculatorClientV1>().unwrap();
+    assert_eq!(
+        client.add(&ctx, 100, 200).await.unwrap(),
+        300,
+        "after BecameHealthy re-wire, add(100, 200) should return 300"
+    );
+
+    // Cleanup
+    cancel.cancel();
+    server2.shutdown().await;
+}

--- a/libs/modkit/src/lib.rs
+++ b/libs/modkit/src/lib.rs
@@ -139,6 +139,10 @@ pub use directory::{
     ServiceInstanceInfo,
 };
 
+// OoP reconnection-safe wiring
+pub mod wiring;
+pub use wiring::{GrpcWatcher, WatcherGoneError, wire_and_watch};
+
 // GTS schema support
 pub mod gts;
 
@@ -152,8 +156,8 @@ pub use backends::{
 pub use lifecycle::{Lifecycle, Runnable, Status, StopReason, WithLifecycle};
 pub use plugins::GtsPluginSelector;
 pub use runtime::{
-    DbOptions, Endpoint, ModuleInstance, ModuleManager, OopModuleSpawnConfig, OopSpawnOptions,
-    RunOptions, ShutdownOptions, run,
+    DbOptions, Endpoint, InstanceEvent, InstanceEventKind, InstanceEventSource, ModuleInstance,
+    ModuleManager, OopModuleSpawnConfig, OopSpawnOptions, RunOptions, ShutdownOptions, run,
 };
 
 #[cfg(feature = "bootstrap")]

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -100,6 +100,12 @@ impl HostRuntime {
             DbOptions::None => None,
         };
 
+        // Register the event subscription interface so gateway modules can
+        // subscribe to instance lifecycle events via wire_and_watch, without
+        // exposing the full ModuleManager API.
+        client_hub
+            .register::<dyn crate::runtime::InstanceEventSource>(Arc::clone(&module_manager) as _);
+
         let ctx_builder = ModuleContextBuilder::new(
             instance_id,
             modules_cfg,

--- a/libs/modkit/src/runtime/mod.rs
+++ b/libs/modkit/src/runtime/mod.rs
@@ -14,7 +14,10 @@ pub use grpc_installers::{GrpcInstallerData, GrpcInstallerStore, ModuleInstaller
 pub use host_runtime::{
     DbOptions, HostRuntime, MODKIT_DIRECTORY_ENDPOINT_ENV, MODKIT_MODULE_CONFIG_ENV,
 };
-pub use module_manager::{Endpoint, InstanceState, ModuleInstance, ModuleManager};
+pub use module_manager::{
+    Endpoint, InstanceEvent, InstanceEventKind, InstanceEventSource, InstanceState, ModuleInstance,
+    ModuleManager,
+};
 pub use runner::{
     ClientRegistration, OopModuleSpawnConfig, OopSpawnOptions, RunOptions, ShutdownOptions, run,
 };

--- a/libs/modkit/src/runtime/module_manager.rs
+++ b/libs/modkit/src/runtime/module_manager.rs
@@ -4,7 +4,43 @@ use dashmap::DashMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::broadcast;
 use uuid::Uuid;
+
+/// Event emitted by `ModuleManager` when an instance is registered, deregistered, or evicted.
+#[derive(Clone, Debug)]
+pub struct InstanceEvent {
+    pub module: String,
+    pub instance_id: Uuid,
+    pub kind: InstanceEventKind,
+    /// gRPC service names from the instance's `grpc_services` keys.
+    pub services: Vec<String>,
+}
+
+/// The kind of lifecycle event for a module instance.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum InstanceEventKind {
+    Registered,
+    BecameHealthy,
+    Deregistered,
+    Evicted,
+}
+
+/// Narrow trait for subscribing to instance lifecycle events.
+///
+/// Registered in `ClientHub` as `dyn InstanceEventSource` so that consumers
+/// (e.g. `wire_and_watch`) can observe directory changes without access to
+/// the full `ModuleManager` API.
+pub trait InstanceEventSource: Send + Sync {
+    /// Subscribe to instance lifecycle events.
+    fn subscribe(&self) -> broadcast::Receiver<InstanceEvent>;
+}
+
+impl InstanceEventSource for ModuleManager {
+    fn subscribe(&self) -> broadcast::Receiver<InstanceEvent> {
+        self.events_tx.subscribe()
+    }
+}
 
 /// Represents an endpoint where a module instance can be reached
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -154,13 +190,16 @@ impl ModuleInstance {
 
 /// Central registry that tracks all running module instances in the system.
 /// Provides discovery, health tracking, and round-robin load balancing.
-#[derive(Clone)]
+// NOTE: ModuleManager is intentionally not Clone. DashMap deep-clones its data
+// but broadcast::Sender shares the channel, so a clone would have independent
+// instance state emitting events on the same channel. Always use Arc<ModuleManager>.
 #[must_use]
 pub struct ModuleManager {
     inner: DashMap<String, Vec<Arc<ModuleInstance>>>,
     rr_counters: DashMap<String, usize>,
     hb_ttl: Duration,
     hb_grace: Duration,
+    events_tx: broadcast::Sender<InstanceEvent>,
 }
 
 impl std::fmt::Debug for ModuleManager {
@@ -177,11 +216,16 @@ impl std::fmt::Debug for ModuleManager {
 
 impl ModuleManager {
     pub fn new() -> Self {
+        // Capacity 16: a performance knob, not a correctness concern. The watcher's
+        // Lagged handler already re-resolves unconditionally, so a smaller channel
+        // just means slightly more Lagged fallbacks under burst registrations.
+        let (events_tx, _) = broadcast::channel(16);
         Self {
             inner: DashMap::new(),
             rr_counters: DashMap::new(),
             hb_ttl: Duration::from_secs(15),
             hb_grace: Duration::from_secs(30),
+            events_tx,
         }
     }
 
@@ -191,19 +235,41 @@ impl ModuleManager {
         self
     }
 
+    /// Override the default broadcast channel capacity (default: 16).
+    ///
+    /// Larger values reduce `Lagged` fallbacks under burst registrations;
+    /// the watcher handles `Lagged` correctly, so this is a performance knob.
+    pub fn with_event_channel_capacity(mut self, capacity: usize) -> Self {
+        let (events_tx, _) = broadcast::channel(capacity);
+        self.events_tx = events_tx;
+        self
+    }
+
     /// Register or update a module instance
     pub fn register_instance(&self, instance: Arc<ModuleInstance>) {
         let module = instance.module.clone();
-        let mut vec = self.inner.entry(module).or_default();
-        // replace by instance_id if it already exists
-        if let Some(pos) = vec
-            .iter()
-            .position(|i| i.instance_id == instance.instance_id)
+        let instance_id = instance.instance_id;
+        let services: Vec<String> = instance.grpc_services.keys().cloned().collect();
+
         {
-            vec[pos] = instance;
-        } else {
-            vec.push(instance);
+            let mut vec = self.inner.entry(module.clone()).or_default();
+            // replace by instance_id if it already exists
+            if let Some(pos) = vec
+                .iter()
+                .position(|i| i.instance_id == instance.instance_id)
+            {
+                vec[pos] = instance;
+            } else {
+                vec.push(instance);
+            }
         }
+        // Fire event AFTER releasing DashMap guard
+        drop(self.events_tx.send(InstanceEvent {
+            module,
+            instance_id,
+            kind: InstanceEventKind::Registered,
+            services,
+        }));
     }
 
     /// Mark an instance as ready
@@ -218,15 +284,37 @@ impl ModuleManager {
 
     /// Update the heartbeat timestamp for an instance
     pub fn update_heartbeat(&self, module: &str, instance_id: Uuid, at: Instant) {
+        let mut became_healthy: Option<(String, Vec<String>)> = None;
+
         if let Some(mut vec) = self.inner.get_mut(module)
             && let Some(inst) = vec.iter_mut().find(|i| i.instance_id == instance_id)
         {
-            let mut state = inst.inner.write();
-            state.last_heartbeat = at;
-            // Transition Registered -> Healthy on first heartbeat
-            if state.state == InstanceState::Registered {
-                state.state = InstanceState::Healthy;
+            let was_registered = {
+                let mut state = inst.inner.write();
+                state.last_heartbeat = at;
+                if state.state == InstanceState::Registered {
+                    state.state = InstanceState::Healthy;
+                    true
+                } else {
+                    false
+                }
+            };
+            if was_registered {
+                became_healthy = Some((
+                    module.to_owned(),
+                    inst.grpc_services.keys().cloned().collect(),
+                ));
             }
+        }
+
+        // Fire event AFTER releasing DashMap guard
+        if let Some((module_name, services)) = became_healthy {
+            drop(self.events_tx.send(InstanceEvent {
+                module: module_name,
+                instance_id,
+                kind: InstanceEventKind::BecameHealthy,
+                services,
+            }));
         }
     }
 
@@ -251,9 +339,14 @@ impl ModuleManager {
     /// Remove an instance from the directory
     pub fn deregister(&self, module: &str, instance_id: Uuid) {
         let mut remove_module = false;
+        let mut services = Vec::new();
         {
             if let Some(mut vec) = self.inner.get_mut(module) {
                 let list = vec.value_mut();
+                // Collect service names before removal
+                if let Some(inst) = list.iter().find(|i| i.instance_id == instance_id) {
+                    services = inst.grpc_services.keys().cloned().collect();
+                }
                 list.retain(|inst| inst.instance_id != instance_id);
                 if list.is_empty() {
                     remove_module = true;
@@ -265,6 +358,16 @@ impl ModuleManager {
             self.inner.remove(module);
             self.rr_counters.remove(module);
         }
+
+        // Fire event AFTER releasing DashMap guard — always fire, even for
+        // instances with no gRPC services. The watcher filters by service name,
+        // so empty-services events are harmless and this is more predictable.
+        drop(self.events_tx.send(InstanceEvent {
+            module: module.to_owned(),
+            instance_id,
+            kind: InstanceEventKind::Deregistered,
+            services,
+        }));
     }
 
     /// Get all instances of a specific module
@@ -289,6 +392,7 @@ impl ModuleManager {
     pub fn evict_stale(&self, now: Instant) {
         use InstanceState::{Draining, Quarantined};
         let mut empty_modules = Vec::new();
+        let mut evicted = Vec::new();
 
         for mut entry in self.inner.iter_mut() {
             let module = entry.key().clone();
@@ -306,6 +410,12 @@ impl ModuleManager {
 
                 // Evict quarantined instances that exceed grace period
                 if state.state == Quarantined && age >= self.hb_ttl + self.hb_grace {
+                    evicted.push(InstanceEvent {
+                        module: module.clone(),
+                        instance_id: inst.instance_id,
+                        kind: InstanceEventKind::Evicted,
+                        services: inst.grpc_services.keys().cloned().collect(),
+                    });
                     return false; // Remove from directory
                 }
 
@@ -320,6 +430,11 @@ impl ModuleManager {
         for module in empty_modules {
             self.inner.remove(&module);
             self.rr_counters.remove(&module);
+        }
+
+        // Fire eviction events AFTER releasing DashMap locks
+        for event in evicted {
+            drop(self.events_tx.send(event));
         }
     }
 
@@ -730,5 +845,39 @@ mod tests {
         assert_ne!(inst1.instance_id, inst2.instance_id);
         // Endpoints should differ
         assert_ne!(ep1, ep2);
+    }
+
+    #[test]
+    fn test_became_healthy_event() {
+        let dir = ModuleManager::new();
+        let mut rx = dir.events_tx.subscribe();
+
+        let instance_id = Uuid::new_v4();
+        let instance = Arc::new(
+            ModuleInstance::new("test_module", instance_id)
+                .with_grpc_service("test.Service", Endpoint::http("127.0.0.1", 8001)),
+        );
+
+        dir.register_instance(instance);
+
+        // Drain the Registered event
+        let ev = rx.try_recv().unwrap();
+        assert_eq!(ev.kind, InstanceEventKind::Registered);
+
+        // First heartbeat: Registered → Healthy should fire BecameHealthy
+        dir.update_heartbeat("test_module", instance_id, Instant::now());
+
+        let ev = rx.try_recv().unwrap();
+        assert_eq!(ev.kind, InstanceEventKind::BecameHealthy);
+        assert_eq!(ev.instance_id, instance_id);
+        assert_eq!(ev.module, "test_module");
+        assert!(ev.services.contains(&"test.Service".to_owned()));
+
+        // Second heartbeat: Healthy → Healthy should NOT fire another event
+        dir.update_heartbeat("test_module", instance_id, Instant::now());
+        assert!(
+            rx.try_recv().is_err(),
+            "no event should fire on subsequent heartbeats"
+        );
     }
 }

--- a/libs/modkit/src/wiring.rs
+++ b/libs/modkit/src/wiring.rs
@@ -1,0 +1,160 @@
+//! Framework-level `wire_and_watch` utility for reconnection-safe
+//! out-of-process gRPC wiring.
+//!
+//! Bridges `InstanceEventSource`, `ClientHub`, and `DirectoryClient` so that
+//! gRPC clients are automatically re-wired when an `OoP` module reconnects on
+//! a new endpoint.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::sync::{broadcast, watch};
+use tokio_util::sync::CancellationToken;
+
+use crate::DirectoryClient;
+use crate::client_hub::ClientHub;
+use crate::runtime::{InstanceEventKind, InstanceEventSource};
+
+/// The watcher background task has exited (cancelled or event source closed).
+#[derive(Debug, thiserror::Error)]
+#[error("wire_and_watch background task has exited")]
+pub struct WatcherGoneError;
+
+/// Handle returned by [`wire_and_watch`] for monitoring re-wire activity.
+pub struct GrpcWatcher {
+    rewire_rx: watch::Receiver<u64>,
+}
+
+impl GrpcWatcher {
+    /// Wait for the next re-wire to complete. Returns the total re-wire count.
+    ///
+    /// Useful for deterministic test synchronization and monitoring.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WatcherGoneError`] if the background watcher task has exited
+    /// (e.g. cancelled or event source closed).
+    pub async fn rewired(&mut self) -> std::result::Result<u64, WatcherGoneError> {
+        self.rewire_rx
+            .changed()
+            .await
+            .map_err(|_| WatcherGoneError)?;
+        Ok(*self.rewire_rx.borrow())
+    }
+}
+
+/// Wire a gRPC client into `ClientHub` and watch for instance events
+/// to automatically re-wire when endpoints change.
+///
+/// # Arguments
+///
+/// * `hub` — the `ClientHub` where the client will be registered
+/// * `directory` — resolves service endpoints (e.g. `LocalDirectoryClient`)
+/// * `events` — source of instance lifecycle events (e.g. `ModuleManager`)
+/// * `service_name` — the gRPC service name to watch
+///   (e.g. `"calculator.v1.CalculatorService"`)
+/// * `connect` — factory that creates a new `Arc<T>` client from an endpoint URI
+/// * `cancel` — token to stop the background watcher task
+///
+/// # Errors
+///
+/// Returns an error if the initial endpoint resolution or connection fails.
+pub async fn wire_and_watch<T: ?Sized + Send + Sync + 'static>(
+    hub: Arc<ClientHub>,
+    directory: Arc<dyn DirectoryClient>,
+    events: Arc<dyn InstanceEventSource>,
+    service_name: impl Into<String>,
+    connect: impl Fn(String) -> Pin<Box<dyn Future<Output = Result<Arc<T>>> + Send>>
+    + Send
+    + Sync
+    + 'static,
+    cancel: CancellationToken,
+) -> Result<GrpcWatcher> {
+    let service_name = service_name.into();
+
+    // Subscribe before initial wiring so events that fire during
+    // resolve/connect are queued and processed by the watcher task.
+    let (rewire_tx, rewire_rx) = watch::channel(0u64);
+    let mut events_rx = events.subscribe();
+
+    // Initial wiring: resolve → connect → register
+    let endpoint = directory.resolve_grpc_service(&service_name).await?;
+    let client = connect(endpoint.uri).await?;
+    hub.register::<T>(client);
+
+    let svc = service_name.clone();
+    tokio::spawn(async move {
+        let mut rewire_count: u64 = 0;
+
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => break,
+                event = events_rx.recv() => {
+                    // In multi-instance topologies this re-resolves on *any*
+                    // event for the watched service, even if the event doesn't
+                    // affect the current client's endpoint. This is intentional:
+                    // the re-wire is cheap (resolve + connect), last-writer-wins
+                    // is safe for single-instance OoP, and comparing URIs would
+                    // introduce false negatives (same-port reconnect, round-robin
+                    // rotation). The Lagged path already unconditionally re-resolves.
+                    // Determine whether to rewire, and whether failure should
+                    // remove the existing client. Additive events (Registered,
+                    // BecameHealthy) mean "not ready yet" on failure — keeping
+                    // the existing client is strictly better than removing it.
+                    let (should_rewire, remove_on_failure) = match &event {
+                        Ok(ev) => {
+                            let dominated = ev.services.contains(&svc);
+                            let destructive = matches!(
+                                ev.kind,
+                                InstanceEventKind::Deregistered | InstanceEventKind::Evicted
+                            );
+                            (dominated, destructive)
+                        }
+                        Err(broadcast::error::RecvError::Lagged(_)) => (true, true),
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    };
+
+                    if !should_rewire {
+                        continue;
+                    }
+
+                    match directory.resolve_grpc_service(&svc).await {
+                        Ok(ep) => match connect(ep.uri).await {
+                            Ok(new_client) => {
+                                hub.register::<T>(new_client);
+                                rewire_count += 1;
+                                rewire_tx.send(rewire_count).ok();
+                            }
+                            Err(e) => {
+                                if remove_on_failure {
+                                    hub.remove::<T>();
+                                }
+                                tracing::warn!(
+                                    service = %svc,
+                                    error = %e,
+                                    "wire_and_watch: connect failed{}",
+                                    if remove_on_failure { ", removed stale client" } else { ", kept existing client" }
+                                );
+                            }
+                        },
+                        Err(e) => {
+                            if remove_on_failure {
+                                hub.remove::<T>();
+                            }
+                            tracing::warn!(
+                                service = %svc,
+                                error = %e,
+                                "wire_and_watch: resolve failed{}",
+                                if remove_on_failure { ", removed stale client" } else { ", kept existing client" }
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(GrpcWatcher { rewire_rx })
+}


### PR DESCRIPTION
## Summary

  Fixes #671 — when an OoP follower disconnects and reconnects on a new
  ephemeral port, the master keeps sending gRPC requests to the old dead
  socket (500 errors). Root cause: `wire_client` + `OnceCell` create a
  one-shot connection that never refreshes when the Directory updates.

  ## Solution

  - Add `InstanceEvent` broadcast to `ModuleManager` (fires on
    register/deregister/evict)
  - Add `wire_and_watch` framework utility in `modkit::wiring` that
    performs initial wiring then spawns a background task to re-wire
    on relevant events
  - Add `wire_and_watch_client` SDK wrapper in `calculator-sdk`
  - Replace `OnceCell<()>` with `OnceCell<GrpcWatcher>` in the gateway
    service — wiring still lazy (OoP child not yet spawned during init),
    but now auto-refreshes
  - `ClientHub` unchanged — `register()` already supports atomic overwrite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateways gain reconnection-safe gRPC wiring that automatically replaces clients when service instances change.
  * Added instance lifecycle events so gateways can subscribe to registration and health changes.

* **Public API**
  * Introduced watcher-backed wiring primitives with cancellation and long-lived rewire signaling for robust OoP clients.

* **Tests**
  * Added integration tests validating reconnection, watcher signaling, and race conditions around late registrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->