### PR TITLE
fix(modkit-db): warn on malformed database config

### DIFF
--- a/libs/modkit-db/src/manager.rs
+++ b/libs/modkit-db/src/manager.rs
@@ -96,31 +96,25 @@ impl DbManager {
             .extract()
             .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()));
 
-        let module_cfg: Option<DbConnConfig> = match module_data
+        let Some(db_value) = module_data
             .get("modules")
             .and_then(|modules| modules.get(module))
             .and_then(|m| m.get("database"))
-        {
-            None => None,
-            Some(db) => match serde_json::from_value(db.clone()) {
-                Ok(cfg) => Some(cfg),
-                Err(e) => {
-                    tracing::warn!(
-                        module = %module,
-                        error = %e,
-                        "Module 'database' key is present but failed to deserialize; ignoring"
-                    );
-                    None
-                }
-            },
+        else {
+            tracing::debug!(module = %module, "Module has no database configuration; skipping");
+            return Ok(None);
         };
 
-        let Some(mut cfg) = module_cfg else {
-            tracing::debug!(
-                module = %module,
-                "Module has no database configuration; skipping"
-            );
-            return Ok(None);
+        let mut cfg: DbConnConfig = match serde_json::from_value(db_value.clone()) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                tracing::warn!(
+                    module = %module,
+                    error = %e,
+                    "Module 'database' key is present but failed to deserialize; ignoring"
+                );
+                return Ok(None);
+            }
         };
 
         // If module references a global server, merge configurations

--- a/libs/modkit-db/src/manager.rs
+++ b/libs/modkit-db/src/manager.rs
@@ -35,9 +35,19 @@ impl DbManager {
             .extract()
             .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()));
 
-        let global: Option<GlobalDatabaseConfig> = all_data
-            .get("database")
-            .and_then(|db| serde_json::from_value(db.clone()).ok());
+        let global: Option<GlobalDatabaseConfig> = match all_data.get("database") {
+            None => None,
+            Some(db) => match serde_json::from_value(db.clone()) {
+                Ok(cfg) => Some(cfg),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Global 'database' key is present but failed to deserialize; ignoring"
+                    );
+                    None
+                }
+            },
+        };
 
         Ok(Self {
             global,
@@ -86,11 +96,24 @@ impl DbManager {
             .extract()
             .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()));
 
-        let module_cfg: Option<DbConnConfig> = module_data
+        let module_cfg: Option<DbConnConfig> = match module_data
             .get("modules")
             .and_then(|modules| modules.get(module))
             .and_then(|m| m.get("database"))
-            .and_then(|db| serde_json::from_value(db.clone()).ok());
+        {
+            None => None,
+            Some(db) => match serde_json::from_value(db.clone()) {
+                Ok(cfg) => Some(cfg),
+                Err(e) => {
+                    tracing::warn!(
+                        module = %module,
+                        error = %e,
+                        "Module 'database' key is present but failed to deserialize; ignoring"
+                    );
+                    None
+                }
+            },
+        };
 
         let Some(mut cfg) = module_cfg else {
             tracing::debug!(


### PR DESCRIPTION
## Summary

`DbManager` silently discarded `serde_json` deserialization errors via `.ok()`,
turning a config typo (e.g. `server` instead of `servers` under
`#[serde(deny_unknown_fields)]`) into a confusing downstream error
("Referenced server 'main' not found") with no indication of the real cause.
Additionally, `build_for_module` collapsed both "key absent" and "key present
but malformed" into `None`, causing the misleading `debug!("Module has no
database configuration; skipping")` message to fire even after a deserialization
failure had already been handled.

This PR fixes both issues by replacing `.ok()` call sites with explicit match
arms that emit `tracing::warn!` on failure, and restructuring `build_for_module`
into two distinct early-return paths so each diagnostic log fires only for its
own case.

## Changes

- `libs/modkit-db/src/manager.rs`: warn on malformed global `database` config in `from_figment()`
- `libs/modkit-db/src/manager.rs`: warn on malformed module `database` config in `build_for_module()`, including the module name in the log field
- `libs/modkit-db/src/manager.rs`: restructure `build_for_module` so `debug!` fires only when the key is genuinely absent, and `warn!` + early return fires only on deserialization failure
