### PR TITLE
fix(grpc): correct backoff to exponential and add jitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,7 @@ version = "0.2.14"
 dependencies = [
  "anyhow",
  "cf-modkit-security",
+ "rand 0.9.2",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/libs/modkit-transport-grpc/Cargo.toml
+++ b/libs/modkit-transport-grpc/Cargo.toml
@@ -25,3 +25,4 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tokio-stream = { workspace = true }
+rand = { workspace = true }

--- a/libs/modkit-transport-grpc/src/backoff.rs
+++ b/libs/modkit-transport-grpc/src/backoff.rs
@@ -1,0 +1,102 @@
+//! Shared exponential-backoff helper used by both [`crate::client`] and [`crate::rpc_retry`].
+
+use std::time::Duration;
+
+/// Compute exponential backoff with jitter, clamped to `max_backoff`.
+///
+/// Formula: `base * 2^(attempt-1)`, capped at `max_backoff`, then `jitter_factor * raw` is
+/// added and the result is clamped to `max_backoff` again so that `max_backoff` is always a
+/// strict upper bound even after jitter.
+///
+/// The `jitter_factor` parameter (typically in `[0.0, 0.25]`) is passed in so the function
+/// is pure and can be tested deterministically without touching an RNG.
+pub fn compute_backoff(
+    base: Duration,
+    max_backoff: Duration,
+    attempt: u32,
+    jitter_factor: f64,
+) -> Duration {
+    let exp = i32::try_from(attempt.saturating_sub(1)).unwrap_or(i32::MAX);
+    let factor = 2_f64.powi(exp);
+    let raw = if factor.is_finite() {
+        base.mul_f64(factor).min(max_backoff)
+    } else {
+        max_backoff
+    };
+    (raw + raw.mul_f64(jitter_factor)).min(max_backoff)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_backoff_first_attempt_no_jitter() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // attempt=1: base * 2^0 = 100ms
+        assert_eq!(
+            compute_backoff(base, max, 1, 0.0),
+            Duration::from_millis(100)
+        );
+    }
+
+    #[test]
+    fn test_compute_backoff_exponential_growth() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // attempt=2: 100ms * 2^1 = 200ms
+        assert_eq!(
+            compute_backoff(base, max, 2, 0.0),
+            Duration::from_millis(200)
+        );
+        // attempt=3: 100ms * 2^2 = 400ms
+        assert_eq!(
+            compute_backoff(base, max, 3, 0.0),
+            Duration::from_millis(400)
+        );
+    }
+
+    #[test]
+    fn test_compute_backoff_capped_at_max() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_millis(150);
+        // attempt=2 gives 200ms without cap; expect 150ms
+        assert_eq!(
+            compute_backoff(base, max, 2, 0.0),
+            Duration::from_millis(150)
+        );
+    }
+
+    #[test]
+    fn test_compute_backoff_jitter_does_not_exceed_max() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_millis(100);
+        // With max jitter (25%), raw = 100ms; 100ms + 25ms would be 125ms but must be capped
+        assert_eq!(
+            compute_backoff(base, max, 1, 0.25),
+            Duration::from_millis(100)
+        );
+    }
+
+    #[test]
+    fn test_compute_backoff_jitter_applied() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // With 10% jitter: 100ms + 10ms = 110ms
+        assert_eq!(
+            compute_backoff(base, max, 1, 0.10),
+            Duration::from_millis(110)
+        );
+    }
+
+    #[test]
+    fn test_compute_backoff_huge_attempt_does_not_overflow() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // Large attempt → exp clamped to i32::MAX, exponential saturates to f64::INFINITY,
+        // then .min(max_backoff) clamps the result
+        assert_eq!(compute_backoff(base, max, u32::MAX, 0.0), max);
+    }
+}

--- a/libs/modkit-transport-grpc/src/client.rs
+++ b/libs/modkit-transport-grpc/src/client.rs
@@ -6,9 +6,11 @@
 //! - Tracing spans around connection establishment
 //!
 //! **Note:** This module is responsible only for transport-level configuration.
-//! For RPC-level retry logic with exponential backoff, see the [`crate::rpc_retry`] module.
+//! For RPC-level retry logic with exponential backoff and jitter, see the [`crate::rpc_retry`] module.
 
 use std::time::Duration;
+
+use rand::Rng as _;
 use tonic::transport::{Channel, Endpoint};
 use tracing::Instrument;
 
@@ -212,13 +214,15 @@ where
     .await
 }
 
-/// Connect to a gRPC service with retry logic using exponential backoff.
+/// Connect to a gRPC service with retry logic using exponential backoff and jitter.
 ///
 /// This function attempts to establish a connection and retries on failure
 /// using the retry parameters from [`GrpcClientConfig`]:
 /// - `max_retries`: Maximum number of retry attempts
-/// - `base_backoff`: Initial backoff duration (multiplied by attempt number)
-/// - `max_backoff`: Maximum backoff duration cap
+/// - `base_backoff`: Initial backoff duration; doubled each attempt (`base * 2^(attempt-1)`)
+/// - `max_backoff`: Maximum backoff duration cap (applied before jitter)
+///
+/// A random jitter of 0–25 % is added after capping to spread out concurrent retries.
 ///
 /// # Example
 ///
@@ -263,7 +267,12 @@ where
                 return Ok(client);
             }
             Err(e) if attempt <= cfg.max_retries => {
-                let backoff = (cfg.base_backoff * attempt).min(cfg.max_backoff);
+                let base = cfg
+                    .base_backoff
+                    .mul_f64(2_f64.powi((attempt - 1) as i32))
+                    .min(cfg.max_backoff);
+                let jitter_factor = rand::rng().random_range(0.0..=0.25);
+                let backoff = base + base.mul_f64(jitter_factor);
                 tracing::warn!(
                     service = cfg.service_name,
                     attempt,

--- a/libs/modkit-transport-grpc/src/client.rs
+++ b/libs/modkit-transport-grpc/src/client.rs
@@ -5,8 +5,8 @@
 //! - HTTP/2 keepalive settings for connection health
 //! - Tracing spans around connection establishment
 //!
-//! **Note:** This module is responsible only for transport-level configuration.
-//! For RPC-level retry logic with exponential backoff and jitter, see the [`crate::rpc_retry`] module.
+//! **Note:** This module handles both transport-level configuration and connection retries
+//! ([`connect_with_retry`]). For RPC-level retry logic, see the [`crate::rpc_retry`] module.
 
 use std::time::Duration;
 
@@ -36,19 +36,20 @@ pub struct GrpcClientConfig {
     /// Timeout for individual RPC calls (applied at transport level).
     pub rpc_timeout: Duration,
 
-    /// Maximum number of retry attempts for RPC calls.
+    /// Maximum number of retry attempts.
     ///
-    /// Used by [`crate::rpc_retry::call_with_retry`], not by the transport layer.
+    /// Used by both [`connect_with_retry`] (connection retries) and
+    /// [`crate::rpc_retry::call_with_retry`] (RPC-call retries).
     pub max_retries: u32,
 
-    /// Base duration for exponential backoff between retries.
+    /// Initial backoff duration; doubled each attempt (`base * 2^(attempt-1)`).
     ///
-    /// Used by [`crate::rpc_retry::call_with_retry`], not by the transport layer.
+    /// Used by both [`connect_with_retry`] and [`crate::rpc_retry::call_with_retry`].
     pub base_backoff: Duration,
 
-    /// Maximum duration for exponential backoff.
+    /// Strict upper bound on backoff duration, enforced both before and after jitter.
     ///
-    /// Used by [`crate::rpc_retry::call_with_retry`], not by the transport layer.
+    /// Used by both [`connect_with_retry`] and [`crate::rpc_retry::call_with_retry`].
     pub max_backoff: Duration,
 
     /// Service name for metrics and tracing.
@@ -214,13 +215,32 @@ where
     .await
 }
 
+/// Compute exponential backoff with jitter, clamped to `max_backoff`.
+///
+/// Formula: `base * 2^(attempt-1)`, capped at `max_backoff`, then `jitter_factor * base` is
+/// added and the result is clamped to `max_backoff` again so that `max_backoff` is always a
+/// strict upper bound even after jitter.
+///
+/// The `jitter_factor` parameter (typically in `[0.0, 0.25]`) is passed in so the function
+/// is pure and can be tested deterministically without touching an RNG.
+fn compute_backoff(
+    base: Duration,
+    max_backoff: Duration,
+    attempt: u32,
+    jitter_factor: f64,
+) -> Duration {
+    let exp = i32::try_from(attempt.saturating_sub(1)).unwrap_or(i32::MAX);
+    let raw = base.mul_f64(2_f64.powi(exp)).min(max_backoff);
+    (raw + raw.mul_f64(jitter_factor)).min(max_backoff)
+}
+
 /// Connect to a gRPC service with retry logic using exponential backoff and jitter.
 ///
 /// This function attempts to establish a connection and retries on failure
 /// using the retry parameters from [`GrpcClientConfig`]:
 /// - `max_retries`: Maximum number of retry attempts
 /// - `base_backoff`: Initial backoff duration; doubled each attempt (`base * 2^(attempt-1)`)
-/// - `max_backoff`: Maximum backoff duration cap (applied before jitter)
+/// - `max_backoff`: Strict upper bound on backoff duration (enforced both before and after jitter)
 ///
 /// A random jitter of 0–25 % is added after capping to spread out concurrent retries.
 ///
@@ -267,12 +287,9 @@ where
                 return Ok(client);
             }
             Err(e) if attempt <= cfg.max_retries => {
-                let base = cfg
-                    .base_backoff
-                    .mul_f64(2_f64.powi((attempt - 1) as i32))
-                    .min(cfg.max_backoff);
                 let jitter_factor = rand::rng().random_range(0.0..=0.25);
-                let backoff = base + base.mul_f64(jitter_factor);
+                let backoff =
+                    compute_backoff(cfg.base_backoff, cfg.max_backoff, attempt, jitter_factor);
                 tracing::warn!(
                     service = cfg.service_name,
                     attempt,
@@ -365,5 +382,56 @@ mod tests {
         let cfg = GrpcClientConfig::default();
         let result = build_endpoint(String::new(), &cfg);
         assert!(result.is_err(), "build_endpoint should fail with empty URI");
+    }
+
+    #[test]
+    fn test_compute_backoff_first_attempt_no_jitter() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // attempt=1: base * 2^0 = 100ms
+        assert_eq!(compute_backoff(base, max, 1, 0.0), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_compute_backoff_exponential_growth() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // attempt=2: 100ms * 2^1 = 200ms
+        assert_eq!(compute_backoff(base, max, 2, 0.0), Duration::from_millis(200));
+        // attempt=3: 100ms * 2^2 = 400ms
+        assert_eq!(compute_backoff(base, max, 3, 0.0), Duration::from_millis(400));
+    }
+
+    #[test]
+    fn test_compute_backoff_capped_at_max() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_millis(150);
+        // attempt=2 gives 200ms without cap; expect 150ms
+        assert_eq!(compute_backoff(base, max, 2, 0.0), Duration::from_millis(150));
+    }
+
+    #[test]
+    fn test_compute_backoff_jitter_does_not_exceed_max() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_millis(100);
+        // With max jitter (25%), raw = 100ms; 100ms + 25ms would be 125ms but must be capped
+        assert_eq!(compute_backoff(base, max, 1, 0.25), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_compute_backoff_jitter_applied() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // With 10% jitter: 100ms + 10ms = 110ms
+        assert_eq!(compute_backoff(base, max, 1, 0.10), Duration::from_millis(110));
+    }
+
+    #[test]
+    fn test_compute_backoff_huge_attempt_does_not_overflow() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // Large attempt → exp clamped to i32::MAX, exponential saturates to f64::INFINITY,
+        // then .min(max_backoff) clamps the result
+        assert_eq!(compute_backoff(base, max, u32::MAX, 0.0), max);
     }
 }

--- a/libs/modkit-transport-grpc/src/client.rs
+++ b/libs/modkit-transport-grpc/src/client.rs
@@ -217,7 +217,7 @@ where
 
 /// Compute exponential backoff with jitter, clamped to `max_backoff`.
 ///
-/// Formula: `base * 2^(attempt-1)`, capped at `max_backoff`, then `jitter_factor * base` is
+/// Formula: `base * 2^(attempt-1)`, capped at `max_backoff`, then `jitter_factor * raw` is
 /// added and the result is clamped to `max_backoff` again so that `max_backoff` is always a
 /// strict upper bound even after jitter.
 ///
@@ -230,7 +230,12 @@ fn compute_backoff(
     jitter_factor: f64,
 ) -> Duration {
     let exp = i32::try_from(attempt.saturating_sub(1)).unwrap_or(i32::MAX);
-    let raw = base.mul_f64(2_f64.powi(exp)).min(max_backoff);
+    let factor = 2_f64.powi(exp);
+    let raw = if factor.is_finite() {
+        base.mul_f64(factor).min(max_backoff)
+    } else {
+        max_backoff
+    };
     (raw + raw.mul_f64(jitter_factor)).min(max_backoff)
 }
 
@@ -389,7 +394,10 @@ mod tests {
         let base = Duration::from_millis(100);
         let max = Duration::from_secs(5);
         // attempt=1: base * 2^0 = 100ms
-        assert_eq!(compute_backoff(base, max, 1, 0.0), Duration::from_millis(100));
+        assert_eq!(
+            compute_backoff(base, max, 1, 0.0),
+            Duration::from_millis(100)
+        );
     }
 
     #[test]
@@ -397,9 +405,15 @@ mod tests {
         let base = Duration::from_millis(100);
         let max = Duration::from_secs(5);
         // attempt=2: 100ms * 2^1 = 200ms
-        assert_eq!(compute_backoff(base, max, 2, 0.0), Duration::from_millis(200));
+        assert_eq!(
+            compute_backoff(base, max, 2, 0.0),
+            Duration::from_millis(200)
+        );
         // attempt=3: 100ms * 2^2 = 400ms
-        assert_eq!(compute_backoff(base, max, 3, 0.0), Duration::from_millis(400));
+        assert_eq!(
+            compute_backoff(base, max, 3, 0.0),
+            Duration::from_millis(400)
+        );
     }
 
     #[test]
@@ -407,7 +421,10 @@ mod tests {
         let base = Duration::from_millis(100);
         let max = Duration::from_millis(150);
         // attempt=2 gives 200ms without cap; expect 150ms
-        assert_eq!(compute_backoff(base, max, 2, 0.0), Duration::from_millis(150));
+        assert_eq!(
+            compute_backoff(base, max, 2, 0.0),
+            Duration::from_millis(150)
+        );
     }
 
     #[test]
@@ -415,7 +432,10 @@ mod tests {
         let base = Duration::from_millis(100);
         let max = Duration::from_millis(100);
         // With max jitter (25%), raw = 100ms; 100ms + 25ms would be 125ms but must be capped
-        assert_eq!(compute_backoff(base, max, 1, 0.25), Duration::from_millis(100));
+        assert_eq!(
+            compute_backoff(base, max, 1, 0.25),
+            Duration::from_millis(100)
+        );
     }
 
     #[test]
@@ -423,7 +443,10 @@ mod tests {
         let base = Duration::from_millis(100);
         let max = Duration::from_secs(5);
         // With 10% jitter: 100ms + 10ms = 110ms
-        assert_eq!(compute_backoff(base, max, 1, 0.10), Duration::from_millis(110));
+        assert_eq!(
+            compute_backoff(base, max, 1, 0.10),
+            Duration::from_millis(110)
+        );
     }
 
     #[test]

--- a/libs/modkit-transport-grpc/src/client.rs
+++ b/libs/modkit-transport-grpc/src/client.rs
@@ -215,30 +215,6 @@ where
     .await
 }
 
-/// Compute exponential backoff with jitter, clamped to `max_backoff`.
-///
-/// Formula: `base * 2^(attempt-1)`, capped at `max_backoff`, then `jitter_factor * raw` is
-/// added and the result is clamped to `max_backoff` again so that `max_backoff` is always a
-/// strict upper bound even after jitter.
-///
-/// The `jitter_factor` parameter (typically in `[0.0, 0.25]`) is passed in so the function
-/// is pure and can be tested deterministically without touching an RNG.
-fn compute_backoff(
-    base: Duration,
-    max_backoff: Duration,
-    attempt: u32,
-    jitter_factor: f64,
-) -> Duration {
-    let exp = i32::try_from(attempt.saturating_sub(1)).unwrap_or(i32::MAX);
-    let factor = 2_f64.powi(exp);
-    let raw = if factor.is_finite() {
-        base.mul_f64(factor).min(max_backoff)
-    } else {
-        max_backoff
-    };
-    (raw + raw.mul_f64(jitter_factor)).min(max_backoff)
-}
-
 /// Connect to a gRPC service with retry logic using exponential backoff and jitter.
 ///
 /// This function attempts to establish a connection and retries on failure
@@ -293,8 +269,12 @@ where
             }
             Err(e) if attempt <= cfg.max_retries => {
                 let jitter_factor = rand::rng().random_range(0.0..=0.25);
-                let backoff =
-                    compute_backoff(cfg.base_backoff, cfg.max_backoff, attempt, jitter_factor);
+                let backoff = crate::backoff::compute_backoff(
+                    cfg.base_backoff,
+                    cfg.max_backoff,
+                    attempt,
+                    jitter_factor,
+                );
                 tracing::warn!(
                     service = cfg.service_name,
                     attempt,
@@ -387,74 +367,5 @@ mod tests {
         let cfg = GrpcClientConfig::default();
         let result = build_endpoint(String::new(), &cfg);
         assert!(result.is_err(), "build_endpoint should fail with empty URI");
-    }
-
-    #[test]
-    fn test_compute_backoff_first_attempt_no_jitter() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_secs(5);
-        // attempt=1: base * 2^0 = 100ms
-        assert_eq!(
-            compute_backoff(base, max, 1, 0.0),
-            Duration::from_millis(100)
-        );
-    }
-
-    #[test]
-    fn test_compute_backoff_exponential_growth() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_secs(5);
-        // attempt=2: 100ms * 2^1 = 200ms
-        assert_eq!(
-            compute_backoff(base, max, 2, 0.0),
-            Duration::from_millis(200)
-        );
-        // attempt=3: 100ms * 2^2 = 400ms
-        assert_eq!(
-            compute_backoff(base, max, 3, 0.0),
-            Duration::from_millis(400)
-        );
-    }
-
-    #[test]
-    fn test_compute_backoff_capped_at_max() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_millis(150);
-        // attempt=2 gives 200ms without cap; expect 150ms
-        assert_eq!(
-            compute_backoff(base, max, 2, 0.0),
-            Duration::from_millis(150)
-        );
-    }
-
-    #[test]
-    fn test_compute_backoff_jitter_does_not_exceed_max() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_millis(100);
-        // With max jitter (25%), raw = 100ms; 100ms + 25ms would be 125ms but must be capped
-        assert_eq!(
-            compute_backoff(base, max, 1, 0.25),
-            Duration::from_millis(100)
-        );
-    }
-
-    #[test]
-    fn test_compute_backoff_jitter_applied() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_secs(5);
-        // With 10% jitter: 100ms + 10ms = 110ms
-        assert_eq!(
-            compute_backoff(base, max, 1, 0.10),
-            Duration::from_millis(110)
-        );
-    }
-
-    #[test]
-    fn test_compute_backoff_huge_attempt_does_not_overflow() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_secs(5);
-        // Large attempt → exp clamped to i32::MAX, exponential saturates to f64::INFINITY,
-        // then .min(max_backoff) clamps the result
-        assert_eq!(compute_backoff(base, max, u32::MAX, 0.0), max);
     }
 }

--- a/libs/modkit-transport-grpc/src/lib.rs
+++ b/libs/modkit-transport-grpc/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+mod backoff;
 pub mod client;
 pub mod rpc_retry;
 

--- a/libs/modkit-transport-grpc/src/rpc_retry.rs
+++ b/libs/modkit-transport-grpc/src/rpc_retry.rs
@@ -1,7 +1,7 @@
 //! RPC-level retry helper for unary gRPC calls.
 //!
 //! This module provides a generic retry helper [`call_with_retry`] that implements
-//! safe retries with exponential backoff for unary gRPC calls.
+//! safe retries with exponential backoff and jitter for unary gRPC calls.
 //!
 //! ## Retry Policy
 //!
@@ -44,6 +44,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use rand::Rng as _;
 use tokio::time::sleep;
 use tonic::{Code, Status};
 use tracing::Instrument;
@@ -64,8 +65,8 @@ pub struct RpcRetryConfig {
 
     /// Base duration for exponential backoff.
     ///
-    /// The actual backoff duration is `base_backoff * attempt_number`,
-    /// capped at `max_backoff`.
+    /// The actual backoff duration is `base_backoff * 2^(attempt - 1)`,
+    /// capped at `max_backoff`, plus up to 25 % random jitter.
     pub base_backoff: Duration,
 
     /// Maximum duration for exponential backoff.
@@ -117,7 +118,7 @@ impl RpcRetryConfig {
 /// Generic helper for unary gRPC calls with retries.
 ///
 /// Executes a gRPC call and retries on transient errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`)
-/// with exponential backoff.
+/// with exponential backoff and jitter.
 ///
 /// # Arguments
 ///
@@ -212,11 +213,12 @@ where
                     return Err(status);
                 }
 
-                // Exponential backoff with upper bound
-                let mut backoff = cfg.base_backoff * attempt;
-                if backoff > cfg.max_backoff {
-                    backoff = cfg.max_backoff;
-                }
+                let base = cfg
+                    .base_backoff
+                    .mul_f64(2_f64.powi((attempt - 1) as i32))
+                    .min(cfg.max_backoff);
+                let jitter_factor = rand::rng().random_range(0.0..=0.25);
+                let backoff = base + base.mul_f64(jitter_factor);
 
                 tracing::debug!(
                     op = op_name,

--- a/libs/modkit-transport-grpc/src/rpc_retry.rs
+++ b/libs/modkit-transport-grpc/src/rpc_retry.rs
@@ -115,6 +115,25 @@ impl RpcRetryConfig {
     }
 }
 
+/// Compute exponential backoff with jitter, clamped to `max_backoff`.
+///
+/// Formula: `base * 2^(attempt-1)`, capped at `max_backoff`, then `jitter_factor * base` is
+/// added and the result is clamped to `max_backoff` again so that `max_backoff` is always a
+/// strict upper bound even after jitter.
+///
+/// The `jitter_factor` parameter (typically in `[0.0, 0.25]`) is passed in so the function
+/// is pure and can be tested deterministically without touching an RNG.
+fn compute_backoff(
+    base: Duration,
+    max_backoff: Duration,
+    attempt: u32,
+    jitter_factor: f64,
+) -> Duration {
+    let exp = i32::try_from(attempt.saturating_sub(1)).unwrap_or(i32::MAX);
+    let raw = base.mul_f64(2_f64.powi(exp)).min(max_backoff);
+    (raw + raw.mul_f64(jitter_factor)).min(max_backoff)
+}
+
 /// Generic helper for unary gRPC calls with retries.
 ///
 /// Executes a gRPC call and retries on transient errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`)
@@ -213,12 +232,9 @@ where
                     return Err(status);
                 }
 
-                let base = cfg
-                    .base_backoff
-                    .mul_f64(2_f64.powi((attempt - 1) as i32))
-                    .min(cfg.max_backoff);
                 let jitter_factor = rand::rng().random_range(0.0..=0.25);
-                let backoff = base + base.mul_f64(jitter_factor);
+                let backoff =
+                    compute_backoff(cfg.base_backoff, cfg.max_backoff, attempt, jitter_factor);
 
                 tracing::debug!(
                     op = op_name,
@@ -237,6 +253,57 @@ where
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_compute_backoff_first_attempt_no_jitter() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // attempt=1: base * 2^0 = 100ms
+        assert_eq!(compute_backoff(base, max, 1, 0.0), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_compute_backoff_exponential_growth() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // attempt=2: 100ms * 2^1 = 200ms
+        assert_eq!(compute_backoff(base, max, 2, 0.0), Duration::from_millis(200));
+        // attempt=3: 100ms * 2^2 = 400ms
+        assert_eq!(compute_backoff(base, max, 3, 0.0), Duration::from_millis(400));
+    }
+
+    #[test]
+    fn test_compute_backoff_capped_at_max() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_millis(150);
+        // attempt=2 gives 200ms without cap; expect 150ms
+        assert_eq!(compute_backoff(base, max, 2, 0.0), Duration::from_millis(150));
+    }
+
+    #[test]
+    fn test_compute_backoff_jitter_does_not_exceed_max() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_millis(100);
+        // With max jitter (25%), raw = 100ms; 100ms + 25ms would be 125ms but must be capped
+        assert_eq!(compute_backoff(base, max, 1, 0.25), Duration::from_millis(100));
+    }
+
+    #[test]
+    fn test_compute_backoff_jitter_applied() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // With 10% jitter: 100ms + 10ms = 110ms
+        assert_eq!(compute_backoff(base, max, 1, 0.10), Duration::from_millis(110));
+    }
+
+    #[test]
+    fn test_compute_backoff_huge_attempt_does_not_overflow() {
+        let base = Duration::from_millis(100);
+        let max = Duration::from_secs(5);
+        // Large attempt → exp clamped to i32::MAX, exponential saturates to f64::INFINITY,
+        // then .min(max_backoff) clamps the result
+        assert_eq!(compute_backoff(base, max, u32::MAX, 0.0), max);
+    }
 
     #[test]
     fn test_default_retry_config() {

--- a/libs/modkit-transport-grpc/src/rpc_retry.rs
+++ b/libs/modkit-transport-grpc/src/rpc_retry.rs
@@ -115,30 +115,6 @@ impl RpcRetryConfig {
     }
 }
 
-/// Compute exponential backoff with jitter, clamped to `max_backoff`.
-///
-/// Formula: `base * 2^(attempt-1)`, capped at `max_backoff`, then `jitter_factor * raw` is
-/// added and the result is clamped to `max_backoff` again so that `max_backoff` is always a
-/// strict upper bound even after jitter.
-///
-/// The `jitter_factor` parameter (typically in `[0.0, 0.25]`) is passed in so the function
-/// is pure and can be tested deterministically without touching an RNG.
-fn compute_backoff(
-    base: Duration,
-    max_backoff: Duration,
-    attempt: u32,
-    jitter_factor: f64,
-) -> Duration {
-    let exp = i32::try_from(attempt.saturating_sub(1)).unwrap_or(i32::MAX);
-    let factor = 2_f64.powi(exp);
-    let raw = if factor.is_finite() {
-        base.mul_f64(factor).min(max_backoff)
-    } else {
-        max_backoff
-    };
-    (raw + raw.mul_f64(jitter_factor)).min(max_backoff)
-}
-
 /// Generic helper for unary gRPC calls with retries.
 ///
 /// Executes a gRPC call and retries on transient errors (`UNAVAILABLE`, `DEADLINE_EXCEEDED`)
@@ -238,8 +214,12 @@ where
                 }
 
                 let jitter_factor = rand::rng().random_range(0.0..=0.25);
-                let backoff =
-                    compute_backoff(cfg.base_backoff, cfg.max_backoff, attempt, jitter_factor);
+                let backoff = crate::backoff::compute_backoff(
+                    cfg.base_backoff,
+                    cfg.max_backoff,
+                    attempt,
+                    jitter_factor,
+                );
 
                 tracing::debug!(
                     op = op_name,
@@ -258,75 +238,6 @@ where
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_compute_backoff_first_attempt_no_jitter() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_secs(5);
-        // attempt=1: base * 2^0 = 100ms
-        assert_eq!(
-            compute_backoff(base, max, 1, 0.0),
-            Duration::from_millis(100)
-        );
-    }
-
-    #[test]
-    fn test_compute_backoff_exponential_growth() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_secs(5);
-        // attempt=2: 100ms * 2^1 = 200ms
-        assert_eq!(
-            compute_backoff(base, max, 2, 0.0),
-            Duration::from_millis(200)
-        );
-        // attempt=3: 100ms * 2^2 = 400ms
-        assert_eq!(
-            compute_backoff(base, max, 3, 0.0),
-            Duration::from_millis(400)
-        );
-    }
-
-    #[test]
-    fn test_compute_backoff_capped_at_max() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_millis(150);
-        // attempt=2 gives 200ms without cap; expect 150ms
-        assert_eq!(
-            compute_backoff(base, max, 2, 0.0),
-            Duration::from_millis(150)
-        );
-    }
-
-    #[test]
-    fn test_compute_backoff_jitter_does_not_exceed_max() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_millis(100);
-        // With max jitter (25%), raw = 100ms; 100ms + 25ms would be 125ms but must be capped
-        assert_eq!(
-            compute_backoff(base, max, 1, 0.25),
-            Duration::from_millis(100)
-        );
-    }
-
-    #[test]
-    fn test_compute_backoff_jitter_applied() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_secs(5);
-        // With 10% jitter: 100ms + 10ms = 110ms
-        assert_eq!(
-            compute_backoff(base, max, 1, 0.10),
-            Duration::from_millis(110)
-        );
-    }
-
-    #[test]
-    fn test_compute_backoff_huge_attempt_does_not_overflow() {
-        let base = Duration::from_millis(100);
-        let max = Duration::from_secs(5);
-        // Large attempt → exp clamped to i32::MAX, exponential saturates to f64::INFINITY,
-        // then .min(max_backoff) clamps the result
-        assert_eq!(compute_backoff(base, max, u32::MAX, 0.0), max);
-    }
 
     #[test]
     fn test_default_retry_config() {

--- a/libs/modkit-transport-grpc/src/rpc_retry.rs
+++ b/libs/modkit-transport-grpc/src/rpc_retry.rs
@@ -117,7 +117,7 @@ impl RpcRetryConfig {
 
 /// Compute exponential backoff with jitter, clamped to `max_backoff`.
 ///
-/// Formula: `base * 2^(attempt-1)`, capped at `max_backoff`, then `jitter_factor * base` is
+/// Formula: `base * 2^(attempt-1)`, capped at `max_backoff`, then `jitter_factor * raw` is
 /// added and the result is clamped to `max_backoff` again so that `max_backoff` is always a
 /// strict upper bound even after jitter.
 ///
@@ -130,7 +130,12 @@ fn compute_backoff(
     jitter_factor: f64,
 ) -> Duration {
     let exp = i32::try_from(attempt.saturating_sub(1)).unwrap_or(i32::MAX);
-    let raw = base.mul_f64(2_f64.powi(exp)).min(max_backoff);
+    let factor = 2_f64.powi(exp);
+    let raw = if factor.is_finite() {
+        base.mul_f64(factor).min(max_backoff)
+    } else {
+        max_backoff
+    };
     (raw + raw.mul_f64(jitter_factor)).min(max_backoff)
 }
 
@@ -259,7 +264,10 @@ mod tests {
         let base = Duration::from_millis(100);
         let max = Duration::from_secs(5);
         // attempt=1: base * 2^0 = 100ms
-        assert_eq!(compute_backoff(base, max, 1, 0.0), Duration::from_millis(100));
+        assert_eq!(
+            compute_backoff(base, max, 1, 0.0),
+            Duration::from_millis(100)
+        );
     }
 
     #[test]
@@ -267,9 +275,15 @@ mod tests {
         let base = Duration::from_millis(100);
         let max = Duration::from_secs(5);
         // attempt=2: 100ms * 2^1 = 200ms
-        assert_eq!(compute_backoff(base, max, 2, 0.0), Duration::from_millis(200));
+        assert_eq!(
+            compute_backoff(base, max, 2, 0.0),
+            Duration::from_millis(200)
+        );
         // attempt=3: 100ms * 2^2 = 400ms
-        assert_eq!(compute_backoff(base, max, 3, 0.0), Duration::from_millis(400));
+        assert_eq!(
+            compute_backoff(base, max, 3, 0.0),
+            Duration::from_millis(400)
+        );
     }
 
     #[test]
@@ -277,7 +291,10 @@ mod tests {
         let base = Duration::from_millis(100);
         let max = Duration::from_millis(150);
         // attempt=2 gives 200ms without cap; expect 150ms
-        assert_eq!(compute_backoff(base, max, 2, 0.0), Duration::from_millis(150));
+        assert_eq!(
+            compute_backoff(base, max, 2, 0.0),
+            Duration::from_millis(150)
+        );
     }
 
     #[test]
@@ -285,7 +302,10 @@ mod tests {
         let base = Duration::from_millis(100);
         let max = Duration::from_millis(100);
         // With max jitter (25%), raw = 100ms; 100ms + 25ms would be 125ms but must be capped
-        assert_eq!(compute_backoff(base, max, 1, 0.25), Duration::from_millis(100));
+        assert_eq!(
+            compute_backoff(base, max, 1, 0.25),
+            Duration::from_millis(100)
+        );
     }
 
     #[test]
@@ -293,7 +313,10 @@ mod tests {
         let base = Duration::from_millis(100);
         let max = Duration::from_secs(5);
         // With 10% jitter: 100ms + 10ms = 110ms
-        assert_eq!(compute_backoff(base, max, 1, 0.10), Duration::from_millis(110));
+        assert_eq!(
+            compute_backoff(base, max, 1, 0.10),
+            Duration::from_millis(110)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`connect_with_retry` and `call_with_retry` in `modkit-transport-grpc` computed backoff as
`base * attempt` (linear growth), despite docs and comments advertising exponential backoff.
Neither function added jitter, creating a thundering-herd risk when many clients retry
simultaneously. This PR fixes both issues to match the behaviour already present in
`modkit-http`.

## Changes

- `libs/modkit-transport-grpc/Cargo.toml` — add `rand` workspace dependency
- `libs/modkit-transport-grpc/src/client.rs` — `connect_with_retry`: change backoff formula
  from `base * attempt` to `base * 2^(attempt-1)`, capped at `max_backoff`, then add 0–25 %
  random jitter; update doc comment to match
- `libs/modkit-transport-grpc/src/rpc_retry.rs` — `call_with_retry`: same formula change and
  jitter; update module doc, `base_backoff` field doc, and inline comment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry behavior for connections and RPCs: switched to jittered exponential backoff with strict max cap to reduce repeated failures and avoid unbounded delays.
* **Documentation**
  * Clarified configuration docs for retry-related settings (max retries, base and max backoff) to reflect shared usage across connection and RPC retries.
* **Tests**
  * Added unit tests validating backoff growth, capping, jitter, and robustness for large attempt counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->