### PR TITLE
fix(modkit): log forwarder panics and drain timeouts in wait_forwarder

### DIFF
--- a/libs/modkit/src/backends/local.rs
+++ b/libs/modkit/src/backends/local.rs
@@ -139,15 +139,30 @@ async fn stop_child_with_grace(
 }
 
 /// Wait for a log forwarder task to finish with timeout.
-async fn wait_forwarder(handle: Option<JoinHandle<()>>) {
+async fn wait_forwarder(
+    handle: Option<JoinHandle<()>>,
+    module: &str,
+    instance_id: uuid::Uuid,
+    stream: &str,
+) {
     let Some(h) = handle else { return };
     match tokio::time::timeout(FORWARDER_DRAIN_TIMEOUT, h).await {
         Ok(Ok(())) => {}
         Ok(Err(e)) => {
-            tracing::warn!(error = %e, "log forwarder task panicked");
+            if e.is_panic() {
+                tracing::warn!(module, %instance_id, stream, error = %e, "log forwarder task panicked");
+            } else {
+                tracing::warn!(module, %instance_id, stream, error = %e, "log forwarder task cancelled");
+            }
         }
         Err(_) => {
-            tracing::warn!("log forwarder did not finish within drain timeout");
+            tracing::warn!(
+                module,
+                %instance_id,
+                stream,
+                timeout_ms = FORWARDER_DRAIN_TIMEOUT.as_millis(),
+                "log forwarder did not finish within drain timeout",
+            );
         }
     }
 }
@@ -224,8 +239,20 @@ impl LocalProcessBackend {
 
         // Wait for forwarders to drain
         for inst in all_instances {
-            wait_forwarder(inst.stdout_forwarder).await;
-            wait_forwarder(inst.stderr_forwarder).await;
+            wait_forwarder(
+                inst.stdout_forwarder,
+                &inst.handle.module,
+                inst.handle.instance_id,
+                "stdout",
+            )
+            .await;
+            wait_forwarder(
+                inst.stderr_forwarder,
+                &inst.handle.module,
+                inst.handle.instance_id,
+                "stderr",
+            )
+            .await;
         }
 
         tracing::info!("All OoP module processes stopped");

--- a/libs/modkit/src/backends/local.rs
+++ b/libs/modkit/src/backends/local.rs
@@ -140,8 +140,15 @@ async fn stop_child_with_grace(
 
 /// Wait for a log forwarder task to finish with timeout.
 async fn wait_forwarder(handle: Option<JoinHandle<()>>) {
-    if let Some(h) = handle {
-        _ = tokio::time::timeout(FORWARDER_DRAIN_TIMEOUT, h).await;
+    let Some(h) = handle else { return };
+    match tokio::time::timeout(FORWARDER_DRAIN_TIMEOUT, h).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "log forwarder task panicked");
+        }
+        Err(_) => {
+            tracing::warn!("log forwarder did not finish within drain timeout");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`wait_forwarder` in `libs/modkit/src/backends/local.rs` discarded both the
`JoinError` produced when a log-forwarder task panics and the timeout sentinel,
making failures completely invisible in production logs. This PR matches on all
three arms of the `timeout` result and emits a `warn!` for each failure path.

## Changes

- `libs/modkit/src/backends/local.rs`: replace `_ = tokio::time::timeout(…, h).await` with a full `match` that logs forwarder panics and drain timeouts.
