### PR TITLE
fix: return 400 Problem on malformed OData query params

### DIFF
--- a/libs/modkit/src/api/odata.rs
+++ b/libs/modkit/src/api/odata.rs
@@ -148,10 +148,9 @@ pub async fn extract_odata_query<S>(
 where
     S: Send + Sync,
 {
-    // Parse query; default if missing
     let Query(params) = Query::<ODataParams>::from_request_parts(parts, state)
         .await
-        .unwrap_or_else(|_| Query(ODataParams::default()));
+        .map_err(|e| crate::api::bad_request(format!("Invalid query parameters: {e}")))?;
 
     let mut query = ODataQuery::new();
 


### PR DESCRIPTION
## Summary

When a client sends a malformed OData query parameter (e.g. `?limit=abc`), Axum's `Query` extractor rejects it. Previously the rejection was silently swallowed with `unwrap_or_else`, causing all params to default to `None` with no error returned to the caller. This change maps the rejection to a 400 Bad Request `Problem` response, consistent with the RFC 9457 pattern used throughout the crate.

## Changes

- `libs/modkit/src/api/odata.rs`: replace `unwrap_or_else(|_| Query(ODataParams::default()))` with `map_err(|e| bad_request(...))?`
