### PR TITLE
fix(modkit-utils): add Deserialize impl for SecretString behind serde feature

### DIFF
--- a/libs/modkit-utils/Cargo.toml
+++ b/libs/modkit-utils/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 
 [features]
 serde = ["dep:serde"]
-humantime-serde = ["dep:humantime", "dep:serde"]
+humantime-serde = ["serde", "dep:humantime"]
 
 [dependencies]
 serde = { workspace = true, optional = true }

--- a/libs/modkit-utils/Cargo.toml
+++ b/libs/modkit-utils/Cargo.toml
@@ -18,6 +18,7 @@ name = "modkit_utils"
 workspace = true
 
 [features]
+serde = ["dep:serde"]
 humantime-serde = ["dep:humantime", "dep:serde"]
 
 [dependencies]

--- a/libs/modkit-utils/src/secret_string.rs
+++ b/libs/modkit-utils/src/secret_string.rs
@@ -33,7 +33,7 @@ impl<'de> serde::Deserialize<'de> for SecretString {
     where
         D: serde::Deserializer<'de>,
     {
-        String::deserialize(deserializer).map(SecretString::new)
+        <String as serde::Deserialize>::deserialize(deserializer).map(SecretString::new)
     }
 }
 

--- a/libs/modkit-utils/src/secret_string.rs
+++ b/libs/modkit-utils/src/secret_string.rs
@@ -27,6 +27,16 @@ impl SecretString {
     }
 }
 
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for SecretString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(SecretString::new)
+    }
+}
+
 impl Clone for SecretString {
     fn clone(&self) -> Self {
         Self(self.0.clone())
@@ -83,6 +93,13 @@ mod tests {
         #[allow(clippy::redundant_clone)]
         let c = s.clone();
         assert_eq!(c.expose(), "value");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deserialize_from_json_string() {
+        let s: SecretString = serde_json::from_str("\"hunter2\"").unwrap();
+        assert_eq!(s.expose(), "hunter2");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`SecretString` had no `Deserialize` impl, forcing callers to deserialize a plain `String` first and then wrap it — leaving a short-lived but unprotected `String` on the heap that `zeroize` never sees. This PR adds a `Deserialize` impl gated behind a new `serde` feature flag so the conversion happens in one step with no intermediate allocation.

## Changes

- `libs/modkit-utils/Cargo.toml`: expose a standalone `serde` feature (`dep:serde`); the `humantime-serde` feature now implies the crate-level `serde` feature (rather than only `dep:serde`) so the `SecretString` `Deserialize` impl is reachable when `humantime-serde` is enabled.
- `libs/modkit-utils/src/secret_string.rs`: implement `serde::Deserialize` for `SecretString` under `#[cfg(feature = "serde")]` using fully-qualified syntax (`<String as serde::Deserialize>::deserialize`) to avoid requiring the trait to be in scope; add a unit test exercising JSON deserialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional serialization/deserialization support added for library types; enabling the option allows sensitive string values to be serialized/deserialized safely.

* **Tests**
  * Added a unit test to validate deserialization of the sensitive string type when serialization support is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->