### PR TITLE
Log warning on DTO serialization failure in apply_select

### DIFF
--- a/libs/modkit/src/api/select.rs
+++ b/libs/modkit/src/api/select.rs
@@ -96,10 +96,16 @@ pub fn apply_select<T: serde::Serialize>(value: T, selected_fields: Option<&[Str
             let fields_set: HashSet<String> = fields.iter().map(|f| f.to_lowercase()).collect();
             match serde_json::to_value(value) {
                 Ok(v) => project_json(&v, &fields_set),
-                Err(_) => json!({}),
+                Err(e) => {
+                    tracing::warn!(error = %e, "DTO serialization failed in apply_select; returning empty object");
+                    json!({})
+                }
             }
         }
-        _ => serde_json::to_value(value).unwrap_or_else(|_| json!({})),
+        _ => serde_json::to_value(value).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "DTO serialization failed in apply_select; returning empty object");
+            json!({})
+        }),
     }
 }
 


### PR DESCRIPTION
## Summary

`apply_select` in `libs/modkit/src/api/select.rs` was silently returning an
empty `{}` JSON object (with HTTP 200) whenever `serde_json::to_value` failed
on the response DTO. This was indistinguishable from a valid empty response,
causing silent data loss at the API boundary.

Both error arms now emit a `tracing::warn!` with the serialization error before
returning the empty fallback.

## Changes

- `libs/modkit/src/api/select.rs` — log warning on DTO serialization failure in `apply_select`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics and observability in data selection operations. When serialization failures occur during processing, the system now logs runtime warning messages with diagnostic details. This provides better visibility into operational issues and significantly improves the ability to identify and troubleshoot problems encountered. Existing functionality is fully preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->