### PR TITLE
Fix swallowed errors in SSE broadcaster and ReadySignal

### DIFF
--- a/libs/modkit/src/http/sse.rs
+++ b/libs/modkit/src/http/sse.rs
@@ -26,7 +26,9 @@ impl<T: Clone + Send + 'static> SseBroadcaster<T> {
     /// Broadcast a single message to current subscribers.
     /// Errors are ignored to keep the hot path cheap (e.g., no active subscribers).
     pub fn send(&self, value: T) {
-        _ = self.tx.send(value);
+        if self.tx.send(value).is_err() {
+            tracing::trace!("SSE broadcast: no active receivers");
+        }
     }
 
     /// Subscribe to a typed stream of messages; lag/drop errors are filtered out.

--- a/libs/modkit/src/lifecycle.rs
+++ b/libs/modkit/src/lifecycle.rs
@@ -76,7 +76,9 @@ pub struct ReadySignal(oneshot::Sender<()>);
 impl ReadySignal {
     #[inline]
     pub fn notify(self) {
-        _ = self.0.send(());
+        if self.0.send(()).is_err() {
+            tracing::debug!("ReadySignal::notify: receiver already dropped");
+        }
     }
     /// Construct a `ReadySignal` from a oneshot sender (used by macro-generated shims).
     #[inline]


### PR DESCRIPTION
## Summary

Two sites in the modkit library silently discarded `Err` variants from channel sends,
making it impossible to observe unexpected subscriber loss or early receiver drops.
This PR adds low-level log statements at each site without altering happy-path behaviour.

## Changes

- `libs/modkit/src/http/sse.rs` — emit `tracing::trace!("SSE broadcast: no active receivers")` when `broadcast::Sender::send` returns `Err` (i.e. no subscribers are listening)
- `libs/modkit/src/lifecycle.rs` — emit `tracing::debug!("ReadySignal::notify: receiver already dropped")` when the oneshot receiver in `ReadySignal::notify` is gone before the signal fires


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for broadcast operations and signal notifications to enhance system observability and reliability when handling edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->