### PR TITLE
feat(mini-chat): add initial module skeleton with SDK, REST routes, domain stubs, and DB migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-mini-chat"
+version = "0.2.14"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "cf-authz-resolver-sdk",
+ "cf-mini-chat-sdk",
+ "cf-modkit",
+ "cf-modkit-db",
+ "cf-modkit-errors",
+ "cf-modkit-errors-macro",
+ "cf-modkit-macros",
+ "cf-modkit-security",
+ "http",
+ "inventory",
+ "sea-orm",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tracing",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
+name = "cf-mini-chat-sdk"
+version = "0.2.14"
+dependencies = [
+ "async-trait",
+ "cf-modkit-security",
+ "thiserror 2.0.18",
+ "time",
+ "uuid",
+]
+
+[[package]]
 name = "cf-modkit"
 version = "0.2.14"
 dependencies = [
@@ -3536,6 +3576,7 @@ dependencies = [
  "cf-credstore",
  "cf-file-parser",
  "cf-grpc-hub",
+ "cf-mini-chat",
  "cf-modkit",
  "cf-module-orchestrator",
  "cf-nodes-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,8 @@ members = [
     "modules/system/authz-resolver/plugins/static-authz-plugin",
     "modules/system/oagw/oagw",
     "modules/system/oagw/oagw-sdk",
+    "modules/mini-chat/mini-chat-sdk",
+    "modules/mini-chat/mini-chat",
 ]
 exclude = ["fuzz"]
 resolver = "3"

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -18,6 +18,7 @@ static-tenants = ["dep:static-tr-plugin"]
 static-authn = ["dep:static-authn-plugin"]
 static-authz = ["dep:static-authz-plugin"]
 static-credstore = ["dep:static-credstore-plugin"]
+mini-chat = ["dep:mini-chat"]
 otel = ["modkit/otel"]
 
 [dependencies]
@@ -57,6 +58,9 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 clap = { workspace = true }
+
+# Optional mini-chat module
+mini-chat = { package = "cf-mini-chat", path = "../../modules/mini-chat/mini-chat", optional = true }
 
 # Optional example module
 users-info = { path = "../../examples/modkit/users-info/users-info", optional = true }

--- a/apps/hyperspot-server/src/registered_modules.rs
+++ b/apps/hyperspot-server/src/registered_modules.rs
@@ -34,6 +34,11 @@ use static_authz_plugin as _;
 #[cfg(feature = "static-credstore")]
 use static_credstore_plugin as _;
 
+// === Optional Modules ===
+
+#[cfg(feature = "mini-chat")]
+use mini_chat as _;
+
 // === Example Features ===
 
 #[cfg(feature = "users-info-example")]

--- a/config/e2e-features.txt
+++ b/config/e2e-features.txt
@@ -1,1 +1,1 @@
-users-info-example,static-tenants,static-authz,static-credstore
+users-info-example,mini-chat,static-tenants,static-authz,static-credstore

--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -224,6 +224,12 @@ modules:
     config:
       vendor: "hyperspot"
       priority: 100
+  
+  mini-chat:
+    # Module-specific database configuration
+    database:
+      server: "sqlite_users"
+      file: "mini_chat.db"
 
   simple-user-settings:
     # Module-specific database configuration

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -138,6 +138,12 @@ modules:
       vendor: "hyperspot"
       priority: 100
 
+  mini-chat:
+    # Module-specific database configuration
+    database:
+      server: "sqlite_users"
+      file: "mini_chat.db"
+
   simple-user-settings:
     # Module-specific database configuration
     database:

--- a/dylint_lints/Cargo.lock
+++ b/dylint_lints/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db-macros"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-error2",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "axum 0.8.8",
  "http",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "base64",
  "bigdecimal",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-security",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-security"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "postcard",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-utils"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "humantime",
  "serde",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdk-directory"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdks"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "cf-system-sdk-directory",
 ]

--- a/modules/mini-chat/mini-chat-sdk/Cargo.toml
+++ b/modules/mini-chat/mini-chat-sdk/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "cf-mini-chat-sdk"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "SDK for mini-chat module: API traits, types, and error definitions"
+
+[lib]
+name = "mini_chat_sdk"
+
+[lints]
+workspace = true
+
+[dependencies]
+thiserror = { workspace = true }
+uuid = { workspace = true }
+time = { workspace = true }
+async-trait = { workspace = true }
+modkit-security = { workspace = true }

--- a/modules/mini-chat/mini-chat-sdk/src/client.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/client.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+use modkit_security::SecurityContext;
+use uuid::Uuid;
+
+use crate::error::MiniChatError;
+use crate::models::{Chat, ChatPatch, NewChat};
+
+/// Object-safe client for inter-module consumption (`ClientHub` registered) (Version 1).
+///
+/// This trait is registered in `ClientHub`:
+/// ```ignore
+/// let mini_chat = hub.get::<dyn MiniChatClientV1>()?;
+/// ```
+#[async_trait]
+pub trait MiniChatClientV1: Send + Sync {
+    /// Create a new chat.
+    async fn create_chat(
+        &self,
+        ctx: &SecurityContext,
+        new_chat: NewChat,
+    ) -> Result<Chat, MiniChatError>;
+
+    /// Get a chat by ID.
+    async fn get_chat(&self, ctx: &SecurityContext, id: Uuid) -> Result<Chat, MiniChatError>;
+
+    /// Update a chat.
+    async fn update_chat(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        patch: ChatPatch,
+    ) -> Result<Chat, MiniChatError>;
+
+    /// Delete a chat (soft delete).
+    async fn delete_chat(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), MiniChatError>;
+}

--- a/modules/mini-chat/mini-chat-sdk/src/error.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/error.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+/// Errors that can be returned by the `MiniChatClient`.
+#[derive(Error, Debug, Clone)]
+pub enum MiniChatError {
+    /// Chat with the specified ID was not found.
+    #[error("Chat not found: {id}")]
+    ChatNotFound { id: uuid::Uuid },
+
+    /// The requested model is invalid or unavailable.
+    #[error("Invalid model: {name}")]
+    InvalidModel { name: String },
+
+    /// Validation error with the provided data.
+    #[error("Validation error: {message}")]
+    Validation { message: String },
+
+    /// Access denied (authorization failure).
+    #[error("Access denied")]
+    Forbidden,
+
+    /// An internal error occurred.
+    #[error("Internal error")]
+    Internal,
+}

--- a/modules/mini-chat/mini-chat-sdk/src/lib.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/lib.rs
@@ -1,0 +1,10 @@
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+
+pub mod client;
+pub mod error;
+pub mod models;
+
+pub use client::MiniChatClientV1;
+pub use error::MiniChatError;
+pub use models::{Chat, ChatPatch, NewChat};

--- a/modules/mini-chat/mini-chat-sdk/src/models.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/models.rs
@@ -1,0 +1,39 @@
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+// ── Chat ──
+
+/// A chat conversation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Chat {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub user_id: Uuid,
+    pub model: String,
+    pub title: Option<String>,
+    pub is_temporary: bool,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+}
+
+/// Data for creating a new chat.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewChat {
+    pub model: String,
+    pub title: Option<String>,
+    pub is_temporary: bool,
+}
+
+/// Partial update data for a chat.
+///
+/// Uses `Option<Option<String>>` for nullable fields to distinguish
+/// "not provided" (None) from "set to null" (Some(None)).
+///
+/// Note: `model` is immutable for the chat lifetime
+/// (`cpt-cf-mini-chat-constraint-model-locked-per-chat`).
+/// `is_temporary` toggling is a P2 feature (`:temporary` endpoint).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[allow(clippy::option_option)]
+pub struct ChatPatch {
+    pub title: Option<Option<String>>,
+}

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -1,0 +1,66 @@
+[package]
+name = "cf-mini-chat"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Mini-chat module: multi-tenant AI chat with SSE streaming"
+
+[lib]
+name = "mini_chat"
+
+[lints]
+workspace = true
+
+[dependencies]
+# SDK - public API, models, and errors
+mini-chat-sdk = { package = "cf-mini-chat-sdk", path = "../mini-chat-sdk" }
+
+# AuthZ resolver for authorization (PEP flow)
+authz-resolver-sdk = { package = "cf-authz-resolver-sdk", path = "../../system/authz-resolver/authz-resolver-sdk" }
+
+# Core dependencies
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+inventory = { workspace = true }
+
+# Serde and JSON
+serde = { workspace = true }
+serde_json = { workspace = true }
+utoipa = { workspace = true, features = ["time"] }
+
+# HTTP and REST
+axum = { workspace = true, features = ["macros"] }
+http = { workspace = true }
+
+# Time handling
+time = { workspace = true }
+
+# UUID support
+uuid = { workspace = true }
+
+# Database - SeaORM
+sea-orm = { workspace = true, features = [
+    "sqlx-sqlite",
+    "sqlx-postgres",
+    "runtime-tokio-rustls",
+    "macros",
+    "with-time",
+    "with-uuid",
+] }
+sea-orm-migration = { workspace = true, features = ["sqlx-sqlite", "sqlx-postgres"] }
+
+# Error handling
+thiserror = { workspace = true }
+
+# Local dependencies
+modkit = { workspace = true }
+modkit-db = { workspace = true, features = ["sqlite", "pg"] }
+modkit-security = { workspace = true }
+modkit-errors = { workspace = true }
+modkit-errors-macro = { workspace = true }
+modkit-macros = { workspace = true }
+

--- a/modules/mini-chat/mini-chat/src/api/mod.rs
+++ b/modules/mini-chat/mini-chat/src/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod rest;

--- a/modules/mini-chat/mini-chat/src/api/rest/dto.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/dto.rs
@@ -1,0 +1,17 @@
+//! HTTP DTOs (serde/utoipa) — REST-only request and response types.
+//!
+//! All REST DTOs live here; SDK `models.rs` stays transport-agnostic.
+//! Provide `From` conversions between SDK models and DTOs in this file.
+
+/// Server-sent event envelope for the `messages:stream` endpoint.
+///
+/// Placeholder — will be expanded with concrete event variants
+/// (delta, `tool_call`, done, error, etc.) during Phase 1 implementation.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct StreamEvent {
+    /// Event type discriminator (e.g. "delta", "done", "error").
+    pub event: String,
+    /// JSON-encoded event payload.
+    pub data: String,
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use axum::Extension;
+use axum::extract::Path;
+use modkit::api::prelude::*;
+use modkit_security::SecurityContext;
+
+use crate::domain::service::AppServices;
+
+use super::not_implemented;
+
+/// POST /mini-chat/v1/chats/{id}/attachments
+pub(crate) async fn upload_attachment(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path(_chat_id): Path<uuid::Uuid>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}
+
+/// GET /mini-chat/v1/chats/{id}/attachments/{attachment_id}
+pub(crate) async fn get_attachment(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path((_chat_id, _attachment_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/chats.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/chats.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use axum::Extension;
+use axum::extract::Path;
+use modkit::api::prelude::*;
+use modkit_security::SecurityContext;
+
+use crate::domain::service::AppServices;
+
+use super::not_implemented;
+
+/// POST /mini-chat/v1/chats
+pub(crate) async fn create_chat(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}
+
+/// GET /mini-chat/v1/chats
+pub(crate) async fn list_chats(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}
+
+/// GET /mini-chat/v1/chats/{id}
+pub(crate) async fn get_chat(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path(_id): Path<uuid::Uuid>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}
+
+/// PATCH /mini-chat/v1/chats/{id}
+pub(crate) async fn update_chat(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path(_id): Path<uuid::Uuid>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}
+
+/// DELETE /mini-chat/v1/chats/{id}
+pub(crate) async fn delete_chat(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path(_id): Path<uuid::Uuid>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use axum::Extension;
+use axum::extract::Path;
+use modkit::api::prelude::*;
+use modkit_security::SecurityContext;
+
+use crate::domain::service::AppServices;
+
+use super::not_implemented;
+
+/// GET /mini-chat/v1/chats/{id}/messages
+pub(crate) async fn list_messages(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path(_chat_id): Path<uuid::Uuid>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}
+
+/// POST /mini-chat/v1/chats/{id}/messages/stream
+pub(crate) async fn stream_message(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path(_chat_id): Path<uuid::Uuid>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/mod.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/mod.rs
@@ -1,0 +1,17 @@
+pub mod attachments;
+pub mod chats;
+pub mod messages;
+pub mod models;
+pub mod reactions;
+pub mod turns;
+
+use modkit::api::prelude::*;
+
+/// Helper to create a 501 Not Implemented problem response.
+pub(crate) fn not_implemented() -> Problem {
+    Problem::new(
+        StatusCode::NOT_IMPLEMENTED,
+        "Not Implemented",
+        "This endpoint is not yet implemented",
+    )
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/models.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/models.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use axum::Extension;
+use axum::extract::Path;
+use modkit::api::prelude::*;
+use modkit_security::SecurityContext;
+
+use crate::domain::service::AppServices;
+
+use super::not_implemented;
+
+/// GET /mini-chat/v1/models
+pub(crate) async fn list_models(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}
+
+/// GET /mini-chat/v1/models/{id}
+pub(crate) async fn get_model(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path(_id): Path<String>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/reactions.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/reactions.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use axum::Extension;
+use axum::extract::Path;
+use modkit::api::prelude::*;
+use modkit_security::SecurityContext;
+
+use crate::domain::service::AppServices;
+
+use super::not_implemented;
+
+/// PUT /mini-chat/v1/chats/{id}/messages/{msg_id}/reaction
+pub(crate) async fn put_reaction(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path((_chat_id, _msg_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}
+
+/// DELETE /mini-chat/v1/chats/{id}/messages/{msg_id}/reaction
+pub(crate) async fn delete_reaction(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path((_chat_id, _msg_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use axum::Extension;
+use axum::extract::Path;
+use modkit::api::prelude::*;
+use modkit_security::SecurityContext;
+
+use crate::domain::service::AppServices;
+
+use super::not_implemented;
+
+/// GET /mini-chat/v1/chats/{id}/turns/{request_id}
+pub(crate) async fn get_turn(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path((_chat_id, _request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}
+
+/// POST /mini-chat/v1/chats/{id}/turns/{request_id}/retry
+pub(crate) async fn retry_turn(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path((_chat_id, _request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}
+
+/// PATCH /mini-chat/v1/chats/{id}/turns/{request_id}
+pub(crate) async fn edit_turn(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path((_chat_id, _request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}
+
+/// DELETE /mini-chat/v1/chats/{id}/turns/{request_id}
+pub(crate) async fn delete_turn(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(_svc): Extension<Arc<AppServices>>,
+    Path((_chat_id, _request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> ApiResult<StatusCode> {
+    Err(not_implemented())
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/mod.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/mod.rs
@@ -1,0 +1,3 @@
+pub mod dto;
+pub mod handlers;
+pub mod routes;

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/attachments.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/attachments.rs
@@ -1,0 +1,43 @@
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::api::operation_builder::OperationBuilder;
+
+use super::AiChatLicense;
+use crate::api::rest::handlers;
+
+pub(super) fn register_attachment_routes(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    prefix: &str,
+) -> Router {
+    // POST {prefix}/v1/chats/{id}/attachments
+    router = OperationBuilder::post(format!("{prefix}/v1/chats/{{id}}/attachments"))
+        .operation_id("mini_chat.upload_attachment")
+        .summary("Upload an attachment to a chat")
+        .tag("attachments")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .path_param("id", "Chat UUID")
+        .handler(handlers::attachments::upload_attachment)
+        .json_response(http::StatusCode::CREATED, "Attachment uploaded")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    // GET {prefix}/v1/chats/{id}/attachments/{attachment_id}
+    router = OperationBuilder::get(format!(
+        "{prefix}/v1/chats/{{id}}/attachments/{{attachment_id}}"
+    ))
+    .operation_id("mini_chat.get_attachment")
+    .summary("Get attachment metadata")
+    .tag("attachments")
+    .authenticated()
+    .require_license_features([&AiChatLicense])
+    .path_param("id", "Chat UUID")
+    .path_param("attachment_id", "Attachment UUID")
+    .handler(handlers::attachments::get_attachment)
+    .json_response(http::StatusCode::OK, "Attachment metadata")
+    .standard_errors(openapi)
+    .register(router, openapi);
+
+    router
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/chats.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/chats.rs
@@ -1,0 +1,77 @@
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::api::operation_builder::OperationBuilder;
+
+use super::AiChatLicense;
+use crate::api::rest::handlers;
+
+pub(super) fn register_chat_routes(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    prefix: &str,
+) -> Router {
+    // POST {prefix}/v1/chats
+    router = OperationBuilder::post(format!("{prefix}/v1/chats"))
+        .operation_id("mini_chat.create_chat")
+        .summary("Create a new chat")
+        .tag("chats")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .handler(handlers::chats::create_chat)
+        .json_response(http::StatusCode::CREATED, "Created chat")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    // GET {prefix}/v1/chats
+    router = OperationBuilder::get(format!("{prefix}/v1/chats"))
+        .operation_id("mini_chat.list_chats")
+        .summary("List chats for the current user")
+        .tag("chats")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .handler(handlers::chats::list_chats)
+        .json_response(http::StatusCode::OK, "List of chats")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    // GET {prefix}/v1/chats/{id}
+    router = OperationBuilder::get(format!("{prefix}/v1/chats/{{id}}"))
+        .operation_id("mini_chat.get_chat")
+        .summary("Get a chat by ID")
+        .tag("chats")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .path_param("id", "Chat UUID")
+        .handler(handlers::chats::get_chat)
+        .json_response(http::StatusCode::OK, "Chat found")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    // PATCH {prefix}/v1/chats/{id}
+    router = OperationBuilder::patch(format!("{prefix}/v1/chats/{{id}}"))
+        .operation_id("mini_chat.update_chat")
+        .summary("Update a chat")
+        .tag("chats")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .path_param("id", "Chat UUID")
+        .handler(handlers::chats::update_chat)
+        .json_response(http::StatusCode::OK, "Updated chat")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    // DELETE {prefix}/v1/chats/{id}
+    router = OperationBuilder::delete(format!("{prefix}/v1/chats/{{id}}"))
+        .operation_id("mini_chat.delete_chat")
+        .summary("Delete a chat")
+        .tag("chats")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .path_param("id", "Chat UUID")
+        .handler(handlers::chats::delete_chat)
+        .json_response(http::StatusCode::NO_CONTENT, "Chat deleted")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    router
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/messages.rs
@@ -1,0 +1,44 @@
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::api::operation_builder::OperationBuilder;
+
+use super::AiChatLicense;
+use crate::api::rest::{dto, handlers};
+
+pub(super) fn register_message_routes(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    prefix: &str,
+) -> Router {
+    // GET {prefix}/v1/chats/{id}/messages
+    router = OperationBuilder::get(format!("{prefix}/v1/chats/{{id}}/messages"))
+        .operation_id("mini_chat.list_messages")
+        .summary("List messages in a chat")
+        .tag("messages")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .path_param("id", "Chat UUID")
+        .handler(handlers::messages::list_messages)
+        .json_response(http::StatusCode::OK, "List of messages")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    // TODO: DESIGN.md specifies Google-style custom method `messages:stream`, but Axum's
+    // matchit router doesn't support mixed param+literal segments. Consider adding a
+    // rewrite middleware in api-gateway to map `:verb` → `/verb` so clients can use the
+    // colon syntax externally while Axum routes via `/stream` internally.
+    // POST {prefix}/v1/chats/{id}/messages/stream
+    router = OperationBuilder::post(format!("{prefix}/v1/chats/{{id}}/messages/stream"))
+        .operation_id("mini_chat.stream_message")
+        .summary("Send a message and stream the response via SSE")
+        .tag("messages")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .path_param("id", "Chat UUID")
+        .handler(handlers::messages::stream_message)
+        .sse_json::<dto::StreamEvent>(openapi, "SSE stream of chat response events")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    router
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/mod.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/mod.rs
@@ -1,0 +1,45 @@
+mod attachments;
+mod chats;
+mod messages;
+mod models;
+mod reactions;
+mod turns;
+
+use std::sync::Arc;
+
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::api::operation_builder::LicenseFeature;
+
+use crate::domain::service::AppServices;
+
+/// License feature required by all mini-chat endpoints.
+///
+/// DESIGN constraint `cpt-cf-mini-chat-constraint-license-gate`:
+/// access requires the `ai_chat` feature on the tenant license.
+pub(crate) struct AiChatLicense;
+
+impl AsRef<str> for AiChatLicense {
+    fn as_ref(&self) -> &'static str {
+        "ai_chat"
+    }
+}
+
+impl LicenseFeature for AiChatLicense {}
+
+/// Register all mini-chat REST routes.
+pub(crate) fn register_routes(
+    router: Router,
+    openapi: &dyn OpenApiRegistry,
+    services: Arc<AppServices>,
+    prefix: &str,
+) -> Router {
+    let router = chats::register_chat_routes(router, openapi, prefix);
+    let router = messages::register_message_routes(router, openapi, prefix);
+    let router = attachments::register_attachment_routes(router, openapi, prefix);
+    let router = turns::register_turn_routes(router, openapi, prefix);
+    let router = models::register_model_routes(router, openapi, prefix);
+    let router = reactions::register_reaction_routes(router, openapi, prefix);
+
+    router.layer(axum::Extension(services))
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/models.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/models.rs
@@ -1,0 +1,39 @@
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::api::operation_builder::OperationBuilder;
+
+use super::AiChatLicense;
+use crate::api::rest::handlers;
+
+pub(super) fn register_model_routes(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    prefix: &str,
+) -> Router {
+    // GET {prefix}/v1/models
+    router = OperationBuilder::get(format!("{prefix}/v1/models"))
+        .operation_id("mini_chat.list_models")
+        .summary("List available AI models")
+        .tag("models")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .handler(handlers::models::list_models)
+        .json_response(http::StatusCode::OK, "List of models")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    // GET {prefix}/v1/models/{id}
+    router = OperationBuilder::get(format!("{prefix}/v1/models/{{id}}"))
+        .operation_id("mini_chat.get_model")
+        .summary("Get model details")
+        .tag("models")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .path_param("id", "Model identifier")
+        .handler(handlers::models::get_model)
+        .json_response(http::StatusCode::OK, "Model details")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    router
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/reactions.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/reactions.rs
@@ -1,0 +1,46 @@
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::api::operation_builder::OperationBuilder;
+
+use super::AiChatLicense;
+use crate::api::rest::handlers;
+
+pub(super) fn register_reaction_routes(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    prefix: &str,
+) -> Router {
+    // PUT {prefix}/v1/chats/{id}/messages/{msg_id}/reaction
+    router = OperationBuilder::put(format!(
+        "{prefix}/v1/chats/{{id}}/messages/{{msg_id}}/reaction"
+    ))
+    .operation_id("mini_chat.put_reaction")
+    .summary("Set or update a reaction on a message")
+    .tag("reactions")
+    .authenticated()
+    .require_license_features([&AiChatLicense])
+    .path_param("id", "Chat UUID")
+    .path_param("msg_id", "Message UUID")
+    .handler(handlers::reactions::put_reaction)
+    .json_response(http::StatusCode::OK, "Reaction set")
+    .standard_errors(openapi)
+    .register(router, openapi);
+
+    // DELETE {prefix}/v1/chats/{id}/messages/{msg_id}/reaction
+    router = OperationBuilder::delete(format!(
+        "{prefix}/v1/chats/{{id}}/messages/{{msg_id}}/reaction"
+    ))
+    .operation_id("mini_chat.delete_reaction")
+    .summary("Remove a reaction from a message")
+    .tag("reactions")
+    .authenticated()
+    .require_license_features([&AiChatLicense])
+    .path_param("id", "Chat UUID")
+    .path_param("msg_id", "Message UUID")
+    .handler(handlers::reactions::delete_reaction)
+    .json_response(http::StatusCode::NO_CONTENT, "Reaction removed")
+    .standard_errors(openapi)
+    .register(router, openapi);
+
+    router
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/turns.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/turns.rs
@@ -1,0 +1,76 @@
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::api::operation_builder::OperationBuilder;
+
+use super::AiChatLicense;
+use crate::api::rest::handlers;
+
+pub(super) fn register_turn_routes(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    prefix: &str,
+) -> Router {
+    // GET {prefix}/v1/chats/{id}/turns/{request_id}
+    router = OperationBuilder::get(format!("{prefix}/v1/chats/{{id}}/turns/{{request_id}}"))
+        .operation_id("mini_chat.get_turn")
+        .summary("Get a turn by request ID")
+        .tag("turns")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .path_param("id", "Chat UUID")
+        .path_param("request_id", "Turn request UUID")
+        .handler(handlers::turns::get_turn)
+        .json_response(http::StatusCode::OK, "Turn found")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    // TODO: DESIGN.md specifies Google-style custom method `{request_id}:retry`, but Axum's
+    // matchit router doesn't support mixed param+literal segments. Consider adding a
+    // rewrite middleware in api-gateway to map `:verb` → `/verb` so clients can use the
+    // colon syntax externally while Axum routes via `/retry` internally.
+    // POST {prefix}/v1/chats/{id}/turns/{request_id}/retry
+    router = OperationBuilder::post(format!(
+        "{prefix}/v1/chats/{{id}}/turns/{{request_id}}/retry"
+    ))
+    .operation_id("mini_chat.retry_turn")
+    .summary("Retry a failed turn")
+    .tag("turns")
+    .authenticated()
+    .require_license_features([&AiChatLicense])
+    .path_param("id", "Chat UUID")
+    .path_param("request_id", "Turn request UUID")
+    .handler(handlers::turns::retry_turn)
+    .json_response(http::StatusCode::OK, "Turn retry initiated")
+    .standard_errors(openapi)
+    .register(router, openapi);
+
+    // PATCH {prefix}/v1/chats/{id}/turns/{request_id}
+    router = OperationBuilder::patch(format!("{prefix}/v1/chats/{{id}}/turns/{{request_id}}"))
+        .operation_id("mini_chat.edit_turn")
+        .summary("Edit a turn (user message)")
+        .tag("turns")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .path_param("id", "Chat UUID")
+        .path_param("request_id", "Turn request UUID")
+        .handler(handlers::turns::edit_turn)
+        .json_response(http::StatusCode::OK, "Turn edited")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    // DELETE {prefix}/v1/chats/{id}/turns/{request_id}
+    router = OperationBuilder::delete(format!("{prefix}/v1/chats/{{id}}/turns/{{request_id}}"))
+        .operation_id("mini_chat.delete_turn")
+        .summary("Delete a turn")
+        .tag("turns")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .path_param("id", "Chat UUID")
+        .path_param("request_id", "Turn request UUID")
+        .handler(handlers::turns::delete_turn)
+        .json_response(http::StatusCode::NO_CONTENT, "Turn deleted")
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    router
+}

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+
+use crate::module::DEFAULT_URL_PREFIX;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MiniChatConfig {
+    #[serde(default = "default_url_prefix")]
+    pub url_prefix: String,
+}
+
+impl Default for MiniChatConfig {
+    fn default() -> Self {
+        Self {
+            url_prefix: default_url_prefix(),
+        }
+    }
+}
+
+fn default_url_prefix() -> String {
+    DEFAULT_URL_PREFIX.to_owned()
+}

--- a/modules/mini-chat/mini-chat/src/domain/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/mod.rs
@@ -1,0 +1,7 @@
+// TODO: DE0301 - refactor to remove modkit_db dependency from domain layer
+// This module currently uses modkit_db types which violates DDD
+#![allow(unknown_lints)]
+#![allow(de0301_no_infra_in_domain)]
+
+pub mod repos;
+pub mod service;

--- a/modules/mini-chat/mini-chat/src/domain/repos/attachment_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/attachment_repo.rs
@@ -1,0 +1,2 @@
+/// Repository trait for attachment persistence operations.
+pub trait AttachmentRepository: Send + Sync {}

--- a/modules/mini-chat/mini-chat/src/domain/repos/chat_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/chat_repo.rs
@@ -1,0 +1,2 @@
+/// Repository trait for chat persistence operations.
+pub trait ChatRepository: Send + Sync {}

--- a/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
@@ -1,0 +1,2 @@
+/// Repository trait for message persistence operations.
+pub trait MessageRepository: Send + Sync {}

--- a/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
@@ -1,0 +1,19 @@
+mod attachment_repo;
+mod chat_repo;
+mod message_repo;
+mod model_pref_repo;
+mod quota_usage_repo;
+mod reaction_repo;
+mod thread_summary_repo;
+mod turn_repo;
+mod vector_store_repo;
+
+pub(crate) use attachment_repo::AttachmentRepository;
+pub(crate) use chat_repo::ChatRepository;
+pub(crate) use message_repo::MessageRepository;
+pub(crate) use model_pref_repo::ModelPrefRepository;
+pub(crate) use quota_usage_repo::QuotaUsageRepository;
+pub(crate) use reaction_repo::ReactionRepository;
+pub(crate) use thread_summary_repo::ThreadSummaryRepository;
+pub(crate) use turn_repo::TurnRepository;
+pub(crate) use vector_store_repo::VectorStoreRepository;

--- a/modules/mini-chat/mini-chat/src/domain/repos/model_pref_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/model_pref_repo.rs
@@ -1,0 +1,2 @@
+/// Repository trait for model preference persistence operations.
+pub trait ModelPrefRepository: Send + Sync {}

--- a/modules/mini-chat/mini-chat/src/domain/repos/quota_usage_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/quota_usage_repo.rs
@@ -1,0 +1,2 @@
+/// Repository trait for quota usage persistence operations.
+pub trait QuotaUsageRepository: Send + Sync {}

--- a/modules/mini-chat/mini-chat/src/domain/repos/reaction_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/reaction_repo.rs
@@ -1,0 +1,2 @@
+/// Repository trait for reaction persistence operations.
+pub trait ReactionRepository: Send + Sync {}

--- a/modules/mini-chat/mini-chat/src/domain/repos/thread_summary_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/thread_summary_repo.rs
@@ -1,0 +1,2 @@
+/// Repository trait for thread summary persistence operations.
+pub trait ThreadSummaryRepository: Send + Sync {}

--- a/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
@@ -1,0 +1,2 @@
+/// Repository trait for turn persistence operations.
+pub trait TurnRepository: Send + Sync {}

--- a/modules/mini-chat/mini-chat/src/domain/repos/vector_store_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/vector_store_repo.rs
@@ -1,0 +1,2 @@
+/// Repository trait for vector store persistence operations.
+pub trait VectorStoreRepository: Send + Sync {}

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::PolicyEnforcer;
+use modkit_macros::domain_model;
+
+use crate::domain::repos::{AttachmentRepository, ChatRepository, VectorStoreRepository};
+
+use super::DbProvider;
+
+/// Service handling file attachment operations.
+#[domain_model]
+pub struct AttachmentService {
+    _db: Arc<DbProvider>,
+    _attachment_repo: Arc<dyn AttachmentRepository>,
+    _chat_repo: Arc<dyn ChatRepository>,
+    _vector_store_repo: Arc<dyn VectorStoreRepository>,
+    _enforcer: PolicyEnforcer,
+}
+
+impl AttachmentService {
+    pub(crate) fn new(
+        db: Arc<DbProvider>,
+        attachment_repo: Arc<dyn AttachmentRepository>,
+        chat_repo: Arc<dyn ChatRepository>,
+        vector_store_repo: Arc<dyn VectorStoreRepository>,
+        enforcer: PolicyEnforcer,
+    ) -> Self {
+        Self {
+            _db: db,
+            _attachment_repo: attachment_repo,
+            _chat_repo: chat_repo,
+            _vector_store_repo: vector_store_repo,
+            _enforcer: enforcer,
+        }
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::PolicyEnforcer;
+use modkit_macros::domain_model;
+
+use crate::domain::repos::{ChatRepository, MessageRepository, ThreadSummaryRepository};
+
+use super::DbProvider;
+
+/// Service handling chat CRUD and message listing operations.
+#[domain_model]
+pub struct ChatService {
+    _db: Arc<DbProvider>,
+    _chat_repo: Arc<dyn ChatRepository>,
+    _message_repo: Arc<dyn MessageRepository>,
+    _thread_summary_repo: Arc<dyn ThreadSummaryRepository>,
+    _enforcer: PolicyEnforcer,
+}
+
+impl ChatService {
+    pub(crate) fn new(
+        db: Arc<DbProvider>,
+        chat_repo: Arc<dyn ChatRepository>,
+        message_repo: Arc<dyn MessageRepository>,
+        thread_summary_repo: Arc<dyn ThreadSummaryRepository>,
+        enforcer: PolicyEnforcer,
+    ) -> Self {
+        Self {
+            _db: db,
+            _chat_repo: chat_repo,
+            _message_repo: message_repo,
+            _thread_summary_repo: thread_summary_repo,
+            _enforcer: enforcer,
+        }
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -1,0 +1,140 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::pep::ResourceType;
+use authz_resolver_sdk::{AuthZResolverClient, PolicyEnforcer};
+use modkit_db::DBProvider;
+use modkit_macros::domain_model;
+
+use crate::domain::repos::{
+    AttachmentRepository, ChatRepository, MessageRepository, ModelPrefRepository,
+    QuotaUsageRepository, ReactionRepository, ThreadSummaryRepository, TurnRepository,
+    VectorStoreRepository,
+};
+
+mod attachment_service;
+mod chat_service;
+mod model_service;
+mod quota_service;
+mod reaction_service;
+mod stream_service;
+
+pub(crate) use attachment_service::AttachmentService;
+pub(crate) use chat_service::ChatService;
+pub(crate) use model_service::ModelService;
+pub(crate) use quota_service::QuotaService;
+pub(crate) use reaction_service::ReactionService;
+pub(crate) use stream_service::StreamService;
+
+pub(crate) type DbProvider = DBProvider<modkit_db::DbError>;
+
+/// Authorization resource type for mini-chat.
+///
+/// All sub-resources (message, turn, attachment, reaction) inherit
+/// authorization from the chat level — there is a single GTS resource type.
+/// TODO: discuss with the team about resource type GTS identifier.
+#[allow(dead_code)]
+pub(crate) mod resources {
+    use super::ResourceType;
+    use modkit_security::pep_properties;
+
+    pub const CHAT: ResourceType = ResourceType {
+        name: "gts.cf.core.ai_chat.chat.v1~cf.core.mini_chat.chat.v1",
+        supported_properties: &[pep_properties::OWNER_TENANT_ID, pep_properties::RESOURCE_ID],
+    };
+}
+
+#[allow(dead_code)]
+pub(crate) mod actions {
+    pub const CREATE: &str = "create";
+    pub const READ: &str = "read";
+    pub const LIST: &str = "list";
+    pub const UPDATE: &str = "update";
+    pub const DELETE: &str = "delete";
+    pub const LIST_MESSAGES: &str = "list_messages";
+    pub const SEND_MESSAGE: &str = "send_message";
+    pub const READ_TURN: &str = "read_turn";
+    pub const RETRY_TURN: &str = "retry_turn";
+    pub const EDIT_TURN: &str = "edit_turn";
+    pub const DELETE_TURN: &str = "delete_turn";
+    pub const UPLOAD: &str = "upload";
+    pub const READ_ATTACHMENT: &str = "read_attachment";
+    pub const REACT: &str = "react";
+    pub const DELETE_REACTION: &str = "delete_reaction";
+}
+
+/// All repository instances passed to `AppServices::new` as a single bundle.
+#[domain_model]
+pub(crate) struct Repositories {
+    pub(crate) chat: Arc<dyn ChatRepository>,
+    pub(crate) attachment: Arc<dyn AttachmentRepository>,
+    pub(crate) message: Arc<dyn MessageRepository>,
+    pub(crate) quota: Arc<dyn QuotaUsageRepository>,
+    pub(crate) turn: Arc<dyn TurnRepository>,
+    pub(crate) reaction: Arc<dyn ReactionRepository>,
+    pub(crate) model_pref: Arc<dyn ModelPrefRepository>,
+    pub(crate) thread_summary: Arc<dyn ThreadSummaryRepository>,
+    pub(crate) vector_store: Arc<dyn VectorStoreRepository>,
+}
+
+/// DI container — aggregates all domain services.
+///
+/// Created once during `Module::init` and shared with handlers via `Arc`.
+/// Services acquire database connections internally via `DbProvider`;
+/// handlers call service methods with business parameters only.
+#[domain_model]
+#[allow(dead_code)]
+pub(crate) struct AppServices {
+    pub(crate) chats: ChatService,
+    pub(crate) stream: StreamService,
+    pub(crate) reactions: ReactionService,
+    pub(crate) attachments: AttachmentService,
+    pub(crate) models: ModelService,
+    pub(crate) quota: QuotaService,
+}
+
+impl AppServices {
+    pub(crate) fn new(
+        repos: &Repositories,
+        db: Arc<DbProvider>,
+        authz: Arc<dyn AuthZResolverClient>,
+    ) -> Self {
+        let enforcer = PolicyEnforcer::new(authz);
+
+        Self {
+            chats: ChatService::new(
+                Arc::clone(&db),
+                Arc::clone(&repos.chat),
+                Arc::clone(&repos.message),
+                Arc::clone(&repos.thread_summary),
+                enforcer.clone(),
+            ),
+            stream: StreamService::new(
+                Arc::clone(&db),
+                Arc::clone(&repos.turn),
+                Arc::clone(&repos.message),
+                Arc::clone(&repos.chat),
+                enforcer.clone(),
+            ),
+            reactions: ReactionService::new(
+                Arc::clone(&db),
+                Arc::clone(&repos.reaction),
+                Arc::clone(&repos.message),
+                Arc::clone(&repos.chat),
+                enforcer.clone(),
+            ),
+            attachments: AttachmentService::new(
+                Arc::clone(&db),
+                Arc::clone(&repos.attachment),
+                Arc::clone(&repos.chat),
+                Arc::clone(&repos.vector_store),
+                enforcer.clone(),
+            ),
+            models: ModelService::new(
+                Arc::clone(&db),
+                Arc::clone(&repos.model_pref),
+                enforcer.clone(),
+            ),
+            quota: QuotaService::new(db, Arc::clone(&repos.quota), enforcer),
+        }
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/model_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/model_service.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::PolicyEnforcer;
+use modkit_macros::domain_model;
+
+use crate::domain::repos::ModelPrefRepository;
+
+use super::DbProvider;
+
+/// Service handling model listing and selection.
+#[domain_model]
+pub struct ModelService {
+    _db: Arc<DbProvider>,
+    _model_pref_repo: Arc<dyn ModelPrefRepository>,
+    _enforcer: PolicyEnforcer,
+}
+
+impl ModelService {
+    pub(crate) fn new(
+        db: Arc<DbProvider>,
+        model_pref_repo: Arc<dyn ModelPrefRepository>,
+        enforcer: PolicyEnforcer,
+    ) -> Self {
+        Self {
+            _db: db,
+            _model_pref_repo: model_pref_repo,
+            _enforcer: enforcer,
+        }
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::PolicyEnforcer;
+use modkit_macros::domain_model;
+
+use crate::domain::repos::QuotaUsageRepository;
+
+use super::DbProvider;
+
+/// Service handling quota tracking and enforcement.
+#[domain_model]
+pub struct QuotaService {
+    _db: Arc<DbProvider>,
+    _repo: Arc<dyn QuotaUsageRepository>,
+    _enforcer: PolicyEnforcer,
+}
+
+impl QuotaService {
+    pub(crate) fn new(
+        db: Arc<DbProvider>,
+        repo: Arc<dyn QuotaUsageRepository>,
+        enforcer: PolicyEnforcer,
+    ) -> Self {
+        Self {
+            _db: db,
+            _repo: repo,
+            _enforcer: enforcer,
+        }
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/reaction_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/reaction_service.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::PolicyEnforcer;
+use modkit_macros::domain_model;
+
+use crate::domain::repos::{ChatRepository, MessageRepository, ReactionRepository};
+
+use super::DbProvider;
+
+/// Service handling message reaction operations.
+#[domain_model]
+pub struct ReactionService {
+    _db: Arc<DbProvider>,
+    _reaction_repo: Arc<dyn ReactionRepository>,
+    _message_repo: Arc<dyn MessageRepository>,
+    _chat_repo: Arc<dyn ChatRepository>,
+    _enforcer: PolicyEnforcer,
+}
+
+impl ReactionService {
+    pub(crate) fn new(
+        db: Arc<DbProvider>,
+        reaction_repo: Arc<dyn ReactionRepository>,
+        message_repo: Arc<dyn MessageRepository>,
+        chat_repo: Arc<dyn ChatRepository>,
+        enforcer: PolicyEnforcer,
+    ) -> Self {
+        Self {
+            _db: db,
+            _reaction_repo: reaction_repo,
+            _message_repo: message_repo,
+            _chat_repo: chat_repo,
+            _enforcer: enforcer,
+        }
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::PolicyEnforcer;
+use modkit_macros::domain_model;
+
+use crate::domain::repos::{ChatRepository, MessageRepository, TurnRepository};
+
+use super::DbProvider;
+
+/// Service handling SSE streaming, turn orchestration, and turn mutations.
+#[domain_model]
+pub struct StreamService {
+    _db: Arc<DbProvider>,
+    _turn_repo: Arc<dyn TurnRepository>,
+    _message_repo: Arc<dyn MessageRepository>,
+    _chat_repo: Arc<dyn ChatRepository>,
+    _enforcer: PolicyEnforcer,
+}
+
+impl StreamService {
+    pub(crate) fn new(
+        db: Arc<DbProvider>,
+        turn_repo: Arc<dyn TurnRepository>,
+        message_repo: Arc<dyn MessageRepository>,
+        chat_repo: Arc<dyn ChatRepository>,
+        enforcer: PolicyEnforcer,
+    ) -> Self {
+        Self {
+            _db: db,
+            _turn_repo: turn_repo,
+            _message_repo: message_repo,
+            _chat_repo: chat_repo,
+            _enforcer: enforcer,
+        }
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/db/migrations/m20260302_000001_initial.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/migrations/m20260302_000001_initial.rs
@@ -1,0 +1,416 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::ConnectionTrait;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+        let conn = manager.get_connection();
+
+        let sql = match backend {
+            sea_orm::DatabaseBackend::Postgres => POSTGRES_UP,
+            sea_orm::DatabaseBackend::Sqlite => SQLITE_UP,
+            sea_orm::DatabaseBackend::MySql => {
+                return Err(DbErr::Migration("MySQL not supported for mini-chat".into()));
+            }
+        };
+
+        conn.execute_unprepared(sql).await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.execute_unprepared(DOWN).await?;
+        Ok(())
+    }
+}
+
+const DOWN: &str = r"
+DROP TABLE IF EXISTS message_reactions;
+DROP TABLE IF EXISTS user_model_prefs;
+DROP TABLE IF EXISTS quota_usage;
+DROP TABLE IF EXISTS chat_vector_stores;
+DROP TABLE IF EXISTS thread_summaries;
+DROP TABLE IF EXISTS attachments;
+DROP TABLE IF EXISTS chat_turns;
+DROP TABLE IF EXISTS messages;
+DROP TABLE IF EXISTS chats;
+";
+
+const POSTGRES_UP: &str = r"
+-- 1. chats
+CREATE TABLE IF NOT EXISTS chats (
+    id          UUID PRIMARY KEY NOT NULL,
+    tenant_id   UUID NOT NULL,
+    user_id     UUID NOT NULL,
+    model       VARCHAR(64) NOT NULL,
+    title       VARCHAR(255),
+    is_temporary BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at  TIMESTAMPTZ NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL,
+    deleted_at  TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS idx_chats_tenant_user_updated
+    ON chats (tenant_id, user_id, updated_at DESC)
+    WHERE deleted_at IS NULL;
+
+-- 2. messages
+CREATE TABLE IF NOT EXISTS messages (
+    id                  UUID PRIMARY KEY NOT NULL,
+    tenant_id           UUID NOT NULL,
+    chat_id             UUID NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    request_id          UUID,
+    role                VARCHAR(16) NOT NULL,
+    content             TEXT NOT NULL DEFAULT '',
+    content_type        VARCHAR(32) NOT NULL DEFAULT 'text',
+    token_estimate      INT NOT NULL DEFAULT 0 CHECK (token_estimate >= 0),
+    provider_response_id VARCHAR(128),
+    request_kind        VARCHAR(16),
+    features_used       JSONB NOT NULL DEFAULT '[]',
+    input_tokens        BIGINT NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens       BIGINT NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    model               VARCHAR(64),
+    is_compressed       BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at          TIMESTAMPTZ NOT NULL,
+    deleted_at          TIMESTAMPTZ
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_chat_request_role
+    ON messages (chat_id, request_id, role)
+    WHERE request_id IS NOT NULL AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_messages_chat_created
+    ON messages (chat_id, created_at)
+    WHERE deleted_at IS NULL;
+
+-- 3. chat_turns
+CREATE TABLE IF NOT EXISTS chat_turns (
+    id                          UUID PRIMARY KEY NOT NULL,
+    tenant_id                   UUID NOT NULL,
+    chat_id                     UUID NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    request_id                  UUID NOT NULL,
+    requester_type              VARCHAR(16) NOT NULL,
+    requester_user_id           UUID,
+    state                       VARCHAR(16) NOT NULL,
+    provider_name               VARCHAR(128),
+    provider_response_id        VARCHAR(128),
+    assistant_message_id        UUID REFERENCES messages(id) ON DELETE SET NULL,
+    error_code                  VARCHAR(64),
+    error_detail                TEXT,
+    reserve_tokens              BIGINT,
+    max_output_tokens_applied   INT,
+    reserved_credits_micro      BIGINT,
+    policy_version_applied      BIGINT,
+    effective_model             VARCHAR(64),
+    minimal_generation_floor_applied INT,
+    deleted_at                  TIMESTAMPTZ,
+    replaced_by_request_id      UUID,
+    started_at                  TIMESTAMPTZ NOT NULL,
+    completed_at                TIMESTAMPTZ,
+    updated_at                  TIMESTAMPTZ NOT NULL,
+    UNIQUE (chat_id, request_id),
+    CHECK (requester_type IN ('user', 'system')),
+    CHECK (state IN ('running', 'completed', 'failed', 'cancelled'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_turns_running
+    ON chat_turns (chat_id)
+    WHERE state = 'running' AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_chat_turns_chat_started
+    ON chat_turns (chat_id, started_at DESC)
+    WHERE deleted_at IS NULL;
+
+-- 4. attachments
+CREATE TABLE IF NOT EXISTS attachments (
+    id                      UUID PRIMARY KEY NOT NULL,
+    tenant_id               UUID NOT NULL,
+    chat_id                 UUID NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    uploaded_by_user_id     UUID NOT NULL,
+    filename                VARCHAR(255) NOT NULL,
+    content_type            VARCHAR(128) NOT NULL,
+    size_bytes              BIGINT NOT NULL CHECK (size_bytes >= 0),
+    storage_backend         VARCHAR(32) NOT NULL DEFAULT 'azure',
+    provider_file_id        VARCHAR(128),
+    status                  VARCHAR(16) NOT NULL,
+    attachment_kind         VARCHAR(16) NOT NULL,
+    doc_summary             TEXT,
+    img_thumbnail           BYTEA,
+    img_thumbnail_width     INT CHECK (img_thumbnail_width >= 0),
+    img_thumbnail_height    INT CHECK (img_thumbnail_height >= 0),
+    summary_model           VARCHAR(64),
+    summary_updated_at      TIMESTAMPTZ,
+    cleanup_status          VARCHAR(16),
+    cleanup_attempts        INT NOT NULL DEFAULT 0 CHECK (cleanup_attempts >= 0),
+    last_cleanup_error      TEXT,
+    cleanup_updated_at      TIMESTAMPTZ,
+    created_at              TIMESTAMPTZ NOT NULL,
+    deleted_at              TIMESTAMPTZ,
+    CHECK (attachment_kind IN ('document', 'image'))
+);
+CREATE INDEX IF NOT EXISTS idx_attachments_tenant_chat
+    ON attachments (tenant_id, chat_id)
+    WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_attachments_cleanup
+    ON attachments (cleanup_status)
+    WHERE cleanup_status IS NOT NULL AND deleted_at IS NULL;
+
+-- 5. thread_summaries
+CREATE TABLE IF NOT EXISTS thread_summaries (
+    id                  UUID PRIMARY KEY NOT NULL,
+    tenant_id           UUID NOT NULL,
+    chat_id             UUID NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    summary_text        TEXT NOT NULL,
+    summarized_up_to    UUID NOT NULL,
+    token_estimate      INT NOT NULL DEFAULT 0 CHECK (token_estimate >= 0),
+    created_at          TIMESTAMPTZ NOT NULL,
+    updated_at          TIMESTAMPTZ NOT NULL,
+    UNIQUE (chat_id)
+);
+
+-- 6. chat_vector_stores
+CREATE TABLE IF NOT EXISTS chat_vector_stores (
+    id              UUID PRIMARY KEY NOT NULL,
+    tenant_id       UUID NOT NULL,
+    chat_id         UUID NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    vector_store_id VARCHAR(128),
+    provider        VARCHAR(128) NOT NULL,
+    file_count      INT NOT NULL DEFAULT 0 CHECK (file_count >= 0),
+    created_at      TIMESTAMPTZ NOT NULL,
+    UNIQUE (tenant_id, chat_id)
+);
+
+-- 7. quota_usage
+CREATE TABLE IF NOT EXISTS quota_usage (
+    id                      UUID PRIMARY KEY NOT NULL,
+    tenant_id               UUID NOT NULL,
+    user_id                 UUID NOT NULL,
+    period_type             VARCHAR(16) NOT NULL,
+    period_start            DATE NOT NULL,
+    bucket                  VARCHAR(32) NOT NULL,
+    spent_credits_micro     BIGINT NOT NULL DEFAULT 0 CHECK (spent_credits_micro >= 0),
+    reserved_credits_micro  BIGINT NOT NULL DEFAULT 0 CHECK (reserved_credits_micro >= 0),
+    calls                   INT NOT NULL DEFAULT 0 CHECK (calls >= 0),
+    input_tokens            BIGINT NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens           BIGINT NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    file_search_calls       INT NOT NULL DEFAULT 0 CHECK (file_search_calls >= 0),
+    web_search_calls        INT NOT NULL DEFAULT 0 CHECK (web_search_calls >= 0),
+    rag_retrieval_calls     INT NOT NULL DEFAULT 0 CHECK (rag_retrieval_calls >= 0),
+    image_inputs            INT NOT NULL DEFAULT 0 CHECK (image_inputs >= 0),
+    image_upload_bytes      BIGINT NOT NULL DEFAULT 0 CHECK (image_upload_bytes >= 0),
+    updated_at              TIMESTAMPTZ NOT NULL,
+    UNIQUE (tenant_id, user_id, period_type, period_start, bucket)
+);
+
+-- 8. user_model_prefs
+CREATE TABLE IF NOT EXISTS user_model_prefs (
+    tenant_id   UUID NOT NULL,
+    user_id     UUID NOT NULL,
+    model_id    VARCHAR(64) NOT NULL,
+    is_enabled  BOOLEAN NOT NULL DEFAULT TRUE,
+    overrides   JSONB NOT NULL DEFAULT '{}',
+    updated_at  TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, user_id, model_id)
+);
+CREATE INDEX IF NOT EXISTS idx_user_model_prefs_tenant_user
+    ON user_model_prefs (tenant_id, user_id);
+
+-- 9. message_reactions
+CREATE TABLE IF NOT EXISTS message_reactions (
+    id          UUID PRIMARY KEY NOT NULL,
+    tenant_id   UUID NOT NULL,
+    message_id  UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    user_id     UUID NOT NULL,
+    reaction    VARCHAR(16) NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL,
+    UNIQUE (message_id, user_id),
+    CHECK (reaction IN ('like', 'dislike'))
+);
+";
+
+const SQLITE_UP: &str = r"
+-- 1. chats
+CREATE TABLE IF NOT EXISTS chats (
+    id          TEXT PRIMARY KEY NOT NULL,
+    tenant_id   TEXT NOT NULL,
+    user_id     TEXT NOT NULL,
+    model       TEXT NOT NULL,
+    title       TEXT,
+    is_temporary INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL,
+    deleted_at  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_chats_tenant_user_updated
+    ON chats (tenant_id, user_id, updated_at DESC)
+    WHERE deleted_at IS NULL;
+
+-- 2. messages
+CREATE TABLE IF NOT EXISTS messages (
+    id                  TEXT PRIMARY KEY NOT NULL,
+    tenant_id           TEXT NOT NULL,
+    chat_id             TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    request_id          TEXT,
+    role                TEXT NOT NULL,
+    content             TEXT NOT NULL DEFAULT '',
+    content_type        TEXT NOT NULL DEFAULT 'text',
+    token_estimate      INTEGER NOT NULL DEFAULT 0 CHECK (token_estimate >= 0),
+    provider_response_id TEXT,
+    request_kind        TEXT,
+    features_used       TEXT NOT NULL DEFAULT '[]',
+    input_tokens        INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens       INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    model               TEXT,
+    is_compressed       INTEGER NOT NULL DEFAULT 0,
+    created_at          TEXT NOT NULL,
+    deleted_at          TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_chat_request_role
+    ON messages (chat_id, request_id, role)
+    WHERE request_id IS NOT NULL AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_messages_chat_created
+    ON messages (chat_id, created_at)
+    WHERE deleted_at IS NULL;
+
+-- 3. chat_turns
+CREATE TABLE IF NOT EXISTS chat_turns (
+    id                          TEXT PRIMARY KEY NOT NULL,
+    tenant_id                   TEXT NOT NULL,
+    chat_id                     TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    request_id                  TEXT NOT NULL,
+    requester_type              TEXT NOT NULL,
+    requester_user_id           TEXT,
+    state                       TEXT NOT NULL,
+    provider_name               TEXT,
+    provider_response_id        TEXT,
+    assistant_message_id        TEXT REFERENCES messages(id) ON DELETE SET NULL,
+    error_code                  TEXT,
+    error_detail                TEXT,
+    reserve_tokens              INTEGER,
+    max_output_tokens_applied   INTEGER,
+    reserved_credits_micro      INTEGER,
+    policy_version_applied      INTEGER,
+    effective_model             TEXT,
+    minimal_generation_floor_applied INTEGER,
+    deleted_at                  TEXT,
+    replaced_by_request_id      TEXT,
+    started_at                  TEXT NOT NULL,
+    completed_at                TEXT,
+    updated_at                  TEXT NOT NULL,
+    UNIQUE (chat_id, request_id),
+    CHECK (requester_type IN ('user', 'system')),
+    CHECK (state IN ('running', 'completed', 'failed', 'cancelled'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_chat_turns_running
+    ON chat_turns (chat_id)
+    WHERE state = 'running' AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_chat_turns_chat_started
+    ON chat_turns (chat_id, started_at DESC)
+    WHERE deleted_at IS NULL;
+
+-- 4. attachments
+CREATE TABLE IF NOT EXISTS attachments (
+    id                      TEXT PRIMARY KEY NOT NULL,
+    tenant_id               TEXT NOT NULL,
+    chat_id                 TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    uploaded_by_user_id     TEXT NOT NULL,
+    filename                TEXT NOT NULL,
+    content_type            TEXT NOT NULL,
+    size_bytes              INTEGER NOT NULL CHECK (size_bytes >= 0),
+    storage_backend         TEXT NOT NULL DEFAULT 'azure',
+    provider_file_id        TEXT,
+    status                  TEXT NOT NULL,
+    attachment_kind         TEXT NOT NULL,
+    doc_summary             TEXT,
+    img_thumbnail           BLOB,
+    img_thumbnail_width     INTEGER CHECK (img_thumbnail_width >= 0),
+    img_thumbnail_height    INTEGER CHECK (img_thumbnail_height >= 0),
+    summary_model           TEXT,
+    summary_updated_at      TEXT,
+    cleanup_status          TEXT,
+    cleanup_attempts        INTEGER NOT NULL DEFAULT 0 CHECK (cleanup_attempts >= 0),
+    last_cleanup_error      TEXT,
+    cleanup_updated_at      TEXT,
+    created_at              TEXT NOT NULL,
+    deleted_at              TEXT,
+    CHECK (attachment_kind IN ('document', 'image'))
+);
+CREATE INDEX IF NOT EXISTS idx_attachments_tenant_chat
+    ON attachments (tenant_id, chat_id)
+    WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_attachments_cleanup
+    ON attachments (cleanup_status)
+    WHERE cleanup_status IS NOT NULL AND deleted_at IS NULL;
+
+-- 5. thread_summaries
+CREATE TABLE IF NOT EXISTS thread_summaries (
+    id                  TEXT PRIMARY KEY NOT NULL,
+    tenant_id           TEXT NOT NULL,
+    chat_id             TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    summary_text        TEXT NOT NULL,
+    summarized_up_to    TEXT NOT NULL,
+    token_estimate      INTEGER NOT NULL DEFAULT 0 CHECK (token_estimate >= 0),
+    created_at          TEXT NOT NULL,
+    updated_at          TEXT NOT NULL,
+    UNIQUE (chat_id)
+);
+
+-- 6. chat_vector_stores
+CREATE TABLE IF NOT EXISTS chat_vector_stores (
+    id              TEXT PRIMARY KEY NOT NULL,
+    tenant_id       TEXT NOT NULL,
+    chat_id         TEXT NOT NULL REFERENCES chats(id) ON DELETE CASCADE,
+    vector_store_id TEXT,
+    provider        TEXT NOT NULL,
+    file_count      INTEGER NOT NULL DEFAULT 0 CHECK (file_count >= 0),
+    created_at      TEXT NOT NULL,
+    UNIQUE (tenant_id, chat_id)
+);
+
+-- 7. quota_usage
+CREATE TABLE IF NOT EXISTS quota_usage (
+    id                      TEXT PRIMARY KEY NOT NULL,
+    tenant_id               TEXT NOT NULL,
+    user_id                 TEXT NOT NULL,
+    period_type             TEXT NOT NULL,
+    period_start            TEXT NOT NULL,
+    bucket                  TEXT NOT NULL,
+    spent_credits_micro     INTEGER NOT NULL DEFAULT 0 CHECK (spent_credits_micro >= 0),
+    reserved_credits_micro  INTEGER NOT NULL DEFAULT 0 CHECK (reserved_credits_micro >= 0),
+    calls                   INTEGER NOT NULL DEFAULT 0 CHECK (calls >= 0),
+    input_tokens            INTEGER NOT NULL DEFAULT 0 CHECK (input_tokens >= 0),
+    output_tokens           INTEGER NOT NULL DEFAULT 0 CHECK (output_tokens >= 0),
+    file_search_calls       INTEGER NOT NULL DEFAULT 0 CHECK (file_search_calls >= 0),
+    web_search_calls        INTEGER NOT NULL DEFAULT 0 CHECK (web_search_calls >= 0),
+    rag_retrieval_calls     INTEGER NOT NULL DEFAULT 0 CHECK (rag_retrieval_calls >= 0),
+    image_inputs            INTEGER NOT NULL DEFAULT 0 CHECK (image_inputs >= 0),
+    image_upload_bytes      INTEGER NOT NULL DEFAULT 0 CHECK (image_upload_bytes >= 0),
+    updated_at              TEXT NOT NULL,
+    UNIQUE (tenant_id, user_id, period_type, period_start, bucket)
+);
+
+-- 8. user_model_prefs
+CREATE TABLE IF NOT EXISTS user_model_prefs (
+    tenant_id   TEXT NOT NULL,
+    user_id     TEXT NOT NULL,
+    model_id    TEXT NOT NULL,
+    is_enabled  INTEGER NOT NULL DEFAULT 1,
+    overrides   TEXT NOT NULL DEFAULT '{}',
+    updated_at  TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, user_id, model_id)
+);
+CREATE INDEX IF NOT EXISTS idx_user_model_prefs_tenant_user
+    ON user_model_prefs (tenant_id, user_id);
+
+-- 9. message_reactions
+CREATE TABLE IF NOT EXISTS message_reactions (
+    id          TEXT PRIMARY KEY NOT NULL,
+    tenant_id   TEXT NOT NULL,
+    message_id  TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    user_id     TEXT NOT NULL,
+    reaction    TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    UNIQUE (message_id, user_id),
+    CHECK (reaction IN ('like', 'dislike'))
+);
+";

--- a/modules/mini-chat/mini-chat/src/infra/db/migrations/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/migrations/mod.rs
@@ -1,0 +1,12 @@
+use sea_orm_migration::prelude::*;
+
+mod m20260302_000001_initial;
+
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![Box::new(m20260302_000001_initial::Migration)]
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/db/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/mod.rs
@@ -1,0 +1,2 @@
+pub mod migrations;
+pub mod repo;

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/attachment_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/attachment_repo.rs
@@ -1,0 +1,4 @@
+/// Repository for attachment persistence operations.
+pub struct AttachmentRepository;
+
+impl crate::domain::repos::AttachmentRepository for AttachmentRepository {}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/chat_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/chat_repo.rs
@@ -1,0 +1,4 @@
+/// Repository for chat persistence operations.
+pub struct ChatRepository;
+
+impl crate::domain::repos::ChatRepository for ChatRepository {}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
@@ -1,0 +1,4 @@
+/// Repository for message persistence operations.
+pub struct MessageRepository;
+
+impl crate::domain::repos::MessageRepository for MessageRepository {}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/mod.rs
@@ -1,0 +1,9 @@
+pub mod attachment_repo;
+pub mod chat_repo;
+pub mod message_repo;
+pub mod model_pref_repo;
+pub mod quota_usage_repo;
+pub mod reaction_repo;
+pub mod thread_summary_repo;
+pub mod turn_repo;
+pub mod vector_store_repo;

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/model_pref_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/model_pref_repo.rs
@@ -1,0 +1,4 @@
+/// Repository for model preference persistence operations.
+pub struct ModelPrefRepository;
+
+impl crate::domain::repos::ModelPrefRepository for ModelPrefRepository {}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/quota_usage_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/quota_usage_repo.rs
@@ -1,0 +1,4 @@
+/// Repository for quota usage persistence operations.
+pub struct QuotaUsageRepository;
+
+impl crate::domain::repos::QuotaUsageRepository for QuotaUsageRepository {}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/reaction_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/reaction_repo.rs
@@ -1,0 +1,4 @@
+/// Repository for reaction persistence operations.
+pub struct ReactionRepository;
+
+impl crate::domain::repos::ReactionRepository for ReactionRepository {}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/thread_summary_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/thread_summary_repo.rs
@@ -1,0 +1,4 @@
+/// Repository for thread summary persistence operations.
+pub struct ThreadSummaryRepository;
+
+impl crate::domain::repos::ThreadSummaryRepository for ThreadSummaryRepository {}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
@@ -1,0 +1,4 @@
+/// Repository for turn persistence operations.
+pub struct TurnRepository;
+
+impl crate::domain::repos::TurnRepository for TurnRepository {}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/vector_store_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/vector_store_repo.rs
@@ -1,0 +1,4 @@
+/// Repository for vector store persistence operations.
+pub struct VectorStoreRepository;
+
+impl crate::domain::repos::VectorStoreRepository for VectorStoreRepository {}

--- a/modules/mini-chat/mini-chat/src/infra/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/mod.rs
@@ -1,0 +1,1 @@
+pub mod db;

--- a/modules/mini-chat/mini-chat/src/lib.rs
+++ b/modules/mini-chat/mini-chat/src/lib.rs
@@ -1,0 +1,18 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+// === PUBLIC API (from SDK) ===
+pub use mini_chat_sdk::{Chat, ChatPatch, MiniChatClientV1, MiniChatError, NewChat};
+
+// === MODULE DEFINITION ===
+pub mod module;
+pub use module::MiniChatModule;
+
+// === INTERNAL MODULES ===
+#[doc(hidden)]
+pub mod api;
+#[doc(hidden)]
+pub mod config;
+#[doc(hidden)]
+pub mod domain;
+#[doc(hidden)]
+pub mod infra;

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -1,0 +1,115 @@
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use authz_resolver_sdk::AuthZResolverClient;
+use modkit::api::OpenApiRegistry;
+use modkit::{DatabaseCapability, Module, ModuleCtx, RestApiCapability};
+use sea_orm_migration::MigrationTrait;
+use tracing::info;
+
+use crate::api::rest::routes;
+use crate::domain::service::{AppServices, Repositories};
+use crate::infra::db::repo::attachment_repo::AttachmentRepository;
+use crate::infra::db::repo::chat_repo::ChatRepository;
+use crate::infra::db::repo::message_repo::MessageRepository;
+use crate::infra::db::repo::model_pref_repo::ModelPrefRepository;
+use crate::infra::db::repo::quota_usage_repo::QuotaUsageRepository;
+use crate::infra::db::repo::reaction_repo::ReactionRepository;
+use crate::infra::db::repo::thread_summary_repo::ThreadSummaryRepository;
+use crate::infra::db::repo::turn_repo::TurnRepository;
+use crate::infra::db::repo::vector_store_repo::VectorStoreRepository;
+
+/// Default URL prefix for all mini-chat REST routes.
+pub const DEFAULT_URL_PREFIX: &str = "/mini-chat";
+
+/// The mini-chat module: multi-tenant AI chat with SSE streaming.
+#[modkit::module(
+    name = "mini-chat",
+    deps = ["authz-resolver", "oagw"],
+    capabilities = [db, rest],
+)]
+pub struct MiniChatModule {
+    service: OnceLock<Arc<AppServices>>,
+    url_prefix: OnceLock<String>,
+}
+
+impl Default for MiniChatModule {
+    fn default() -> Self {
+        Self {
+            service: OnceLock::new(),
+            url_prefix: OnceLock::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Module for MiniChatModule {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        info!("Initializing {} module", Self::MODULE_NAME);
+
+        let cfg: crate::config::MiniChatConfig = ctx.config()?;
+        self.url_prefix
+            .set(cfg.url_prefix)
+            .map_err(|_| anyhow::anyhow!("{} url_prefix already set", Self::MODULE_NAME))?;
+
+        let db = Arc::new(ctx.db_required()?);
+
+        let authz = ctx
+            .client_hub()
+            .get::<dyn AuthZResolverClient>()
+            .map_err(|e| anyhow::anyhow!("failed to get AuthZ resolver: {e}"))?;
+
+        let repos = Repositories {
+            chat: Arc::new(ChatRepository),
+            attachment: Arc::new(AttachmentRepository),
+            message: Arc::new(MessageRepository),
+            quota: Arc::new(QuotaUsageRepository),
+            turn: Arc::new(TurnRepository),
+            reaction: Arc::new(ReactionRepository),
+            model_pref: Arc::new(ModelPrefRepository),
+            thread_summary: Arc::new(ThreadSummaryRepository),
+            vector_store: Arc::new(VectorStoreRepository),
+        };
+
+        let services = Arc::new(AppServices::new(&repos, db, authz));
+
+        self.service
+            .set(services)
+            .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
+
+        info!("{} module initialized successfully", Self::MODULE_NAME);
+        Ok(())
+    }
+}
+
+impl DatabaseCapability for MiniChatModule {
+    fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+        use sea_orm_migration::MigratorTrait;
+        info!("Providing mini-chat database migrations");
+        crate::infra::db::migrations::Migrator::migrations()
+    }
+}
+
+impl RestApiCapability for MiniChatModule {
+    fn register_rest(
+        &self,
+        _ctx: &ModuleCtx,
+        router: axum::Router,
+        openapi: &dyn OpenApiRegistry,
+    ) -> anyhow::Result<axum::Router> {
+        let services = self
+            .service
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("{} not initialized", Self::MODULE_NAME))?;
+
+        info!("Registering mini-chat REST routes");
+        let prefix = self
+            .url_prefix
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("{} not initialized (url_prefix)", Self::MODULE_NAME))?;
+
+        let router = routes::register_routes(router, openapi, Arc::clone(services), prefix);
+        info!("Mini-chat REST routes registered successfully");
+        Ok(router)
+    }
+}


### PR DESCRIPTION
- Add cf-mini-chat and cf-mini-chat-sdk crates to workspace
- SDK: client trait, domain models (Chat, Message, Turn, Attachment, Reaction, Quota), error types
- API layer: REST routes and stub handlers for chats, messages, turns, attachments, reactions, models
- Domain layer: stub service files for chat, message, turn, attachment, quota, and stream
- Infra layer: stub repo files and initial SeaORM migration (m20260302_000001_initial)
- Register module in hyperspot-server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a mini-chat module with SDK, public data types & errors, config defaults, DB migrations, and a DI-backed service surface.
  * Exposes REST APIs for chats, messages (including SSE streaming), turns, attachments, reactions, and model listing; endpoints are gated by an AI Chat license and optional server feature.

* **Chores**
  * Workspace updated to include the new mini-chat crates; server can enable mini-chat via an optional feature flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->