### PR TITLE
new: fix sharing mode mentions

### DIFF
--- a/modules/system/oagw/docs/ADR/0009-storage-schema.md
+++ b/modules/system/oagw/docs/ADR/0009-storage-schema.md
@@ -163,19 +163,20 @@ Notes:
 | `alias` | TEXT | No | Unique per tenant |
 | `protocol` | TEXT | No | GTS protocol identifier |
 | `enabled` | BOOL | No | |
-| `auth_sharing` | TEXT | No | `private\|inherit\|enforce` |
-| `rate_limit_sharing` | TEXT | No | `private\|inherit\|enforce` |
-| `plugins_sharing` | TEXT | No | `private\|inherit\|enforce` |
 | `schema_version` | INT | No | JSON schema version for JSON text columns in this table |
 | `server` | JSON text | No | Endpoints + protocol config |
 | `auth_plugin_ref` | TEXT | Yes | Canonical plugin identifier |
 | `auth_plugin_uuid` | UUID | Yes | Parsed UUID when custom |
 | `auth_config` | JSON text | Yes | Config only (no plugin id) |
+| `auth_sharing` | TEXT | No | `private\|inherit\|enforce` |
 | `headers` | JSON text | Yes | |
 | `cors` | JSON text | Yes | |
+| `cors_sharing` | TEXT | No | `private\|inherit\|enforce` |
 | `rate_limit` | JSON text | Yes | |
+| `rate_limit_sharing` | TEXT | No | `private\|inherit\|enforce` |
 | `created_at` | TIMESTAMP | No | |
 | `updated_at` | TIMESTAMP | No | |
+| `plugins_sharing` | TEXT | No | `private\|inherit\|enforce` |
 
 Constraints / indexes:
 

--- a/modules/system/oagw/docs/ADR/0010-resource-identification.md
+++ b/modules/system/oagw/docs/ADR/0010-resource-identification.md
@@ -300,7 +300,7 @@ Tenant: sub-tenant
 2. Find Upstream B in sub-tenant (closest) → use this upstream
 3. Collect enforced configs from ancestors with same alias:
    - Root has Upstream A with alias "api.openai.com" 
-   - Root's rate_limit.sharing = "enforce" → collect
+   - Root's rate_limit_sharing = "enforce" → collect
 4. Merge: effective_rate = min(root.enforced:10000, sub:500) = 500
 5. Find tenant binding, apply merged config
 6. Forward request to Upstream B's server
@@ -324,12 +324,13 @@ Tenant: sub-tenant
 
 ### Configuration Sharing Modes
 
-Each binding field specifies sharing mode (`private`/`inherit`/`enforce`):
+Each binding field (except tags) specifies sharing mode (`private`/`inherit`/`enforce`):
 
 - **Auth**: Each tenant specifies own credentials via `cred_store` secret references
 - **Rate limits**: Merged with `min(parent, child)` — stricter always wins
 - **Plugins**: Concatenated (parent + child); enforced plugins cannot be removed
-- **Tags**: Union (add-only); descendants can add but not remove inherited tags
+
+Tags do not have a sharing mode — they always use add-only union semantics: `effective_tags = union(ancestor_tags, descendant_tags)`. Descendants can add but not remove inherited tags.
 
 ### Schema Changes
 

--- a/modules/system/oagw/docs/DESIGN.md
+++ b/modules/system/oagw/docs/DESIGN.md
@@ -369,8 +369,9 @@ Multi-tenant hierarchy with sharing modes (`private`/`inherit`/`enforce`) per co
 | Auth | Override if `inherit`; forced if `enforce` |
 | Rate Limits | `min(ancestor, descendant)` — stricter always wins |
 | Plugins | Concatenate: `ancestor.plugins + descendant.plugins` |
-| Tags | Union (add-only); descendants cannot remove inherited tags |
 | CORS | Union origins if `inherit`; forced if `enforce` |
+
+Tags do not have a sharing mode — they always use add-only union semantics: `effective_tags = union(ancestor_tags, descendant_tags)`. Descendants cannot remove inherited tags.
 
 Alias resolution walks tenant hierarchy from descendant to root; closest match wins (shadowing). Enforced ancestor constraints are never bypassed by shadowing.
 

--- a/modules/system/oagw/docs/PRD.md
+++ b/modules/system/oagw/docs/PRD.md
@@ -294,9 +294,10 @@ Override rules:
 - **Auth**: With `sharing: inherit`, descendant with permission can use own credentials
 - **Rate limits**: Descendant can only be stricter: `effective = min(ancestor.enforced, descendant)`
 - **Plugins**: Descendant's plugins append; enforced plugins cannot be removed
-- **Tags (discovery metadata)**: Merged top-to-bottom with add-only semantics:
-  `effective_tags = union(ancestor_tags..., descendant_tags)`. Descendants can add tags but cannot remove inherited tags.
-  If upstream creation resolves to an existing upstream definition (binding-style flow), request tags are treated as tenant-local additions for effective discovery; they do not mutate ancestor tags.
+
+Tags do not have a sharing mode — they always use add-only union semantics:
+`effective_tags = union(ancestor_tags..., descendant_tags)`. Descendants can add tags but cannot remove inherited tags.
+If upstream creation resolves to an existing upstream definition (binding-style flow), request tags are treated as tenant-local additions for effective discovery; they do not mutate ancestor tags.
 
 **Example — Hierarchical Override**:
 

--- a/modules/system/oagw/docs/features/0005-cpt-cf-oagw-feature-tenant-hierarchy.md
+++ b/modules/system/oagw/docs/features/0005-cpt-cf-oagw-feature-tenant-hierarchy.md
@@ -63,7 +63,7 @@ Enables partner/customer hierarchies where partners share upstream access with c
 4. [ ] - `p2` - **IF** any sharing mode is invalid - `inst-share-4`
    1. [ ] - `p2` - **RETURN** 400 ValidationError with invalid field details - `inst-share-4a`
 5. [ ] - `p2` - Validate upstream fields per `cpt-cf-oagw-algo-domain-entity-validation` - `inst-share-5`
-6. [ ] - `p2` - DB: INSERT oagw_upstream with sharing mode columns (auth_sharing, rate_limit_sharing, plugins_sharing, tags_sharing, cors_sharing) - `inst-share-6`
+6. [ ] - `p2` - DB: INSERT oagw_upstream with sharing mode columns (auth_sharing, rate_limit_sharing, plugins_sharing, cors_sharing) - `inst-share-6`
 7. [ ] - `p2` - **IF** `(tenant_id, alias)` uniqueness constraint fails - `inst-share-7`
    1. [ ] - `p2` - **RETURN** 409 Conflict with alias collision details - `inst-share-7a`
 8. [ ] - `p2` - **RETURN** created upstream with sharing configuration - `inst-share-8`
@@ -188,7 +188,7 @@ Enables partner/customer hierarchies where partners share upstream access with c
       1. [ ] - `p2` - Merge auth: **IF** `auth_sharing == private`, skip; **IF** field is absent on current level, inherit from previous level; **IF** `auth_sharing: inherit` and descendant has override, use descendant auth; **IF** `auth_sharing: enforce`, use ancestor auth - `inst-merge-3a1`
       2. [ ] - `p2` - Merge rate_limit: **IF** `rate_limit_sharing == private`, skip; **IF** field is absent, inherit from previous level (no limit = unbounded); **IF** present, `effective = min(ancestor_enforced, current_effective)` — stricter always wins - `inst-merge-3a2`
       3. [ ] - `p2` - Merge plugins: **IF** `plugins_sharing == private`, skip; **IF** field is absent, inherit ancestor plugins; **IF** present, concatenate `ancestor.plugins + descendant.plugins`; enforced plugins cannot be removed - `inst-merge-3a3`
-      4. [ ] - `p2` - Merge tags: **IF** `tags_sharing == private`, skip; `effective_tags = union(ancestor_tags, descendant_tags)` — add-only semantics; absent tags treated as empty set - `inst-merge-3a4`
+      4. [ ] - `p2` - Merge tags: `effective_tags = union(ancestor_tags, descendant_tags)` — always add-only semantics; absent tags treated as empty set - `inst-merge-3a4`
       5. [ ] - `p2` - Merge CORS: **IF** `cors_sharing == private`, skip; **IF** field is absent, inherit from previous level; **IF** `cors_sharing: inherit`, union origins; **IF** `cors_sharing: enforce`, use ancestor CORS - `inst-merge-3a5`
 4. [ ] - `p2` - **RETURN** effective configuration with all three layers merged - `inst-merge-4`
 
@@ -206,7 +206,7 @@ Enables partner/customer hierarchies where partners share upstream access with c
 1. [ ] - `p2` - Obtain ancestor chain for requesting tenant (ordered: self → parent → ... → root) - `inst-shadow-1`
 2. [ ] - `p2` - **FOR EACH** tenant_id in chain (self first) - `inst-shadow-2`
    1. [ ] - `p2` - DB: SELECT from oagw_upstream WHERE tenant_id = :current AND alias = :alias - `inst-shadow-2a`
-   2. [ ] - `p2` - **IF** upstream found AND (tenant_id == requesting_tenant OR any per-field sharing flag — `auth.sharing`, `rate_limit.sharing`, `plugins.sharing`, `tags.sharing`, `cors.sharing` — is != `private`) - `inst-shadow-2b`
+   2. [ ] - `p2` - **IF** upstream found AND (tenant_id == requesting_tenant OR any per-field sharing flag — `auth_sharing`, `rate_limit_sharing`, `plugins_sharing`, `cors_sharing` — is != `private`) - `inst-shadow-2b`
       1. [ ] - `p2` - **IF** upstream is enabled - `inst-shadow-2b1`
          1. [ ] - `p2` - **RETURN** found upstream as selected match - `inst-shadow-2b1a`
       2. [ ] - `p2` - **ELSE** (upstream disabled) - `inst-shadow-2b2`
@@ -231,7 +231,7 @@ Enables partner/customer hierarchies where partners share upstream access with c
 3. [ ] - `p2` - **IF** required permission is `oagw:upstream:override_auth` - `inst-perm-3`
    1. [ ] - `p2` - Check token has `oagw:upstream:override_auth` AND ancestor auth sharing is `inherit` - `inst-perm-3a`
 4. [ ] - `p2` - **IF** required permission is `oagw:upstream:override_rate` - `inst-perm-4`
-   1. [ ] - `p2` - Check token has `oagw:upstream:override_rate` AND ancestor rate_limit sharing is `inherit` - `inst-perm-4a`
+   1. [ ] - `p2` - Check token has `oagw:upstream:override_rate` AND ancestor rate_limit_sharing is `inherit` - `inst-perm-4a`
 5. [ ] - `p2` - **IF** required permission is `oagw:upstream:add_plugins` - `inst-perm-5`
    1. [ ] - `p2` - Check token has `oagw:upstream:add_plugins` AND ancestor plugins sharing is `inherit` - `inst-perm-5a`
 6. [ ] - `p2` - **IF** permission check fails - `inst-perm-6`
@@ -248,7 +248,7 @@ Enables partner/customer hierarchies where partners share upstream access with c
 
 **Steps**:
 1. [ ] - `p2` - **IF** descendant has configured rate_limit, start with descendant's rate as candidate; **ELSE** set candidate to unbounded (no limit) - `inst-rate-1`
-2. [ ] - `p2` - **FOR EACH** ancestor with `rate_limit.sharing: enforce` - `inst-rate-2`
+2. [ ] - `p2` - **FOR EACH** ancestor with `rate_limit_sharing: enforce` - `inst-rate-2`
    1. [ ] - `p2` - `candidate = min(candidate, ancestor.rate_limit.rate)` — enforced ancestor always constrains, even if descendant is unbounded - `inst-rate-2a`
 3. [ ] - `p2` - **IF** route-level rate_limit is defined - `inst-rate-3`
    1. [ ] - `p2` - `candidate = min(candidate, route.rate_limit.rate)` - `inst-rate-3a`
@@ -264,7 +264,7 @@ Not applicable — sharing modes (`private`, `inherit`, `enforce`) are static co
 
 - [ ] `p2` - **ID**: `cpt-cf-oagw-dod-tenant-sharing-modes`
 
-The system **MUST** support `private`, `inherit`, and `enforce` sharing modes on upstream and route configuration fields (auth, rate_limit, plugins, tags, CORS). The default sharing mode **MUST** be `private`. Sharing modes **MUST** be stored as columns on `oagw_upstream` and `oagw_route` and validated during create/update operations. Route-level sharing follows the same semantics as upstream-level sharing and participates in the 3-layer merge per `cpt-cf-oagw-fr-config-layering`.
+The system **MUST** support `private`, `inherit`, and `enforce` sharing modes on upstream and route configuration fields (auth, rate_limit, plugins, CORS). Tags do not have a sharing mode — they always use add-only union semantics across the hierarchy. The default sharing mode **MUST** be `private`. Sharing modes **MUST** be stored as columns on `oagw_upstream` and `oagw_route` and validated during create/update operations. Route-level sharing follows the same semantics as upstream-level sharing and participates in the 3-layer merge per `cpt-cf-oagw-fr-config-layering`.
 
 **Implements**:
 - `cpt-cf-oagw-flow-tenant-share-upstream`

--- a/modules/system/oagw/docs/features/0006-cpt-cf-oagw-feature-rate-limiting.md
+++ b/modules/system/oagw/docs/features/0006-cpt-cf-oagw-feature-rate-limiting.md
@@ -323,7 +323,7 @@ The system **MUST** compute effective rate limits by walking the tenant hierarch
 - `cpt-cf-oagw-flow-configure-rate-limits`
 
 **Touches**:
-- Entities: `Upstream` (rate_limit.sharing, rate_limit.budget)
+- Entities: `Upstream` (rate_limit_sharing, rate_limit.budget)
 
 ### Implement Circuit Breaker State Machine
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized sharing field names to snake_case across docs and resolution flows.
  * Updated examples and schema docs to reflect reordered/added sharing entries.
  * Clarified that tags no longer have a separate sharing flag and always use add-only union semantics.
  * Documented public rename of the rate-limit sharing field to the snake_case form and aligned examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->