### PR TITLE
chore(cargo): unify TLS stack and clean up SeaORM/sqlx feature wiring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,14 +319,22 @@ utoipa = { version = "5.4", features = [
 # HTTP stack dependencies
 hyper = "1.5"
 hyper-util = "0.1"
-hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs"] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "aws-lc-rs",
+    "http1",
+    "http2",
+    "tls12",
+    "native-tokio",
+    "webpki-tokio",
+] }
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std", "tls12"] }
 rustls-native-certs = "0.8"
 rustls-pki-types = "1"
 http-body-util = "0.1"
 http-body = "1"
 
-# HTTP client helpers
+# HTTP client (default-tls = rustls + aws-lc-rs in 0.13)
+reqwest = { version = "0.13", features = ["stream"] }
 rand = "0.9"
 
 # Synchronous locks for better performance
@@ -340,13 +348,15 @@ sea-orm = { version = "1.1", default-features = false, features = [
     "runtime-tokio-rustls",
     "with-uuid",
     "with-chrono",
+    "with-time",
     "with-rust_decimal",
     "macros",
 ] }
 sea-orm-migration = { version = "1.1", default-features = false, features = [
-    "runtime-tokio",
+    "runtime-tokio-rustls",
 ] }
-# sqlx TLS: use aws-lc-rs provider only (not ring) to avoid crypto provider conflicts
+# sqlx: aws-lc-rs is the intended provider; runtime-tokio-rustls from sea-orm
+# also activates tls-rustls-ring via feature unification (unavoidable, harmless)
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "tls-rustls-aws-lc-rs"] }
 
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/examples/modkit/users-info/users-info/Cargo.toml
+++ b/examples/modkit/users-info/users-info/Cargo.toml
@@ -49,15 +49,9 @@ url = { workspace = true }
 uuid = { workspace = true }
 
 
-# Database - SeaORM
-sea-orm = { workspace = true, features = [
-    "sqlx-sqlite",
-    "runtime-tokio-rustls",
-    "macros",
-    "with-time",
-    "with-uuid",
-] }
-sea-orm-migration = { workspace = true, features = ["sqlx-sqlite"] }
+# Database - SeaORM (driver features come from modkit-db)
+sea-orm = { workspace = true }
+sea-orm-migration = { workspace = true }
 
 # Error handling
 thiserror = { workspace = true }

--- a/libs/modkit-db/Cargo.toml
+++ b/libs/modkit-db/Cargo.toml
@@ -18,11 +18,32 @@ name = "modkit_db"
 workspace = true
 
 [features]
-# You can use: sqlite + sea-orm for local development
 default = []
-pg = ["sea-orm/sqlx-postgres", "sqlx/postgres"]
-mysql = ["sea-orm/sqlx-mysql", "sqlx/mysql"]
-sqlite = ["sea-orm/sqlx-sqlite", "sqlx/sqlite"]
+
+# DB driver selection -- the single entry point for backend choice.
+# sea-orm and sea-orm-migration remain non-optional: modkit-db unconditionally
+# re-exports sea_orm_migration and uses sea_orm::{DatabaseConnection, DbErr, …}
+# in non-cfg-gated code.  sqlx is optional because every source-level use is
+# already behind #[cfg(feature = "pg"|"mysql"|"sqlite")].
+sqlite = [
+    "dep:sqlx",
+    "sqlx/sqlite",
+    "sea-orm/sqlx-sqlite",
+    "sea-orm-migration/sqlx-sqlite",
+]
+pg = [
+    "dep:sqlx",
+    "sqlx/postgres",
+    "sea-orm/sqlx-postgres",
+    "sea-orm-migration/sqlx-postgres",
+]
+mysql = [
+    "dep:sqlx",
+    "sqlx/mysql",
+    "sea-orm/sqlx-mysql",
+    "sea-orm-migration/sqlx-mysql",
+]
+
 integration = []
 
 [dependencies]
@@ -33,7 +54,7 @@ xxhash-rust = { workspace = true }
 dirs = { workspace = true }
 chrono = { workspace = true, features = ["serde", "clock"] }
 time = { workspace = true }
-sea-orm = { workspace = true, features = ["with-time"] }
+sea-orm = { workspace = true }
 sea-orm-migration = { workspace = true }
 modkit-db-macros = { workspace = true }
 thiserror = { workspace = true }
@@ -51,7 +72,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 dashmap = { workspace = true }
 figment = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio"] }
+sqlx = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/libs/modkit-http/Cargo.toml
+++ b/libs/modkit-http/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = { workspace = true }
 # HTTP stack
 hyper = { workspace = true, features = ["client", "http1", "http2"] }
 hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2", "tokio"] }
-hyper-rustls = { workspace = true, features = ["http1", "http2", "tls12", "native-tokio", "webpki-tokio"] }
+hyper-rustls = { workspace = true }
 rustls = { workspace = true }
 rustls-native-certs = { workspace = true }
 rustls-pki-types = { workspace = true }

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -42,16 +42,9 @@ time = { workspace = true }
 # UUID support
 uuid = { workspace = true }
 
-# Database - SeaORM
-sea-orm = { workspace = true, features = [
-    "sqlx-sqlite",
-    "sqlx-postgres",
-    "runtime-tokio-rustls",
-    "macros",
-    "with-time",
-    "with-uuid",
-] }
-sea-orm-migration = { workspace = true, features = ["sqlx-sqlite", "sqlx-postgres"] }
+# Database - SeaORM (driver features come from modkit-db)
+sea-orm = { workspace = true }
+sea-orm-migration = { workspace = true }
 
 # Error handling
 thiserror = { workspace = true }

--- a/modules/simple-user-settings/simple-user-settings/Cargo.toml
+++ b/modules/simple-user-settings/simple-user-settings/Cargo.toml
@@ -33,18 +33,13 @@ serde_json = { workspace = true }
 utoipa = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
 uuid = { workspace = true }
-sea-orm = { workspace = true, features = [
-    "sqlx-sqlite",
-    "runtime-tokio-rustls",
-    "macros",
-    "with-time",
-    "with-uuid",
-] }
+# Database - SeaORM (driver features come from modkit-db)
+sea-orm = { workspace = true }
 sea-orm-migration = { workspace = true }
 thiserror = { workspace = true }
 
 modkit = { workspace = true }
-modkit-db = { workspace = true }
+modkit-db = { workspace = true, features = ["sqlite"] }
 modkit-db-macros = { workspace = true }
 modkit-errors = { workspace = true }
 modkit-errors-macro = { workspace = true }
@@ -53,4 +48,3 @@ modkit-macros = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }
-modkit-db = { workspace = true, features = ["sqlite"] }

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -44,7 +44,7 @@ dashmap = { workspace = true }
 thiserror = { workspace = true }
 # DP deps
 form_urlencoded = "1"
-reqwest = { version = "0.13", features = ["stream"] }
+reqwest = { workspace = true }
 futures-util = { workspace = true, features = ["sink"] }
 tokio = { workspace = true, features = ["time"] }
 # test-utils optional deps


### PR DESCRIPTION
Centralize TLS configuration in workspace Cargo.toml and standardize on
rustls + aws-lc-rs across the project.

Changes:
- move hyper-rustls feature configuration to workspace
- remove per-crate TLS feature configuration (hyper-rustls, rustls)
- ensure SeaORM and sea-orm-migration use runtime-tokio-rustls
- keep sqlx TLS provider set to tls-rustls-aws-lc-rs
- normalize database driver features (sqlite/postgres/mysql)
- propagate driver features to sea-orm-migration
- make libs/* crates usable outside the workspace by keeping their
  feature API for database drivers

Result:
- single TLS stack across the workspace
- no accidental native-tls/OpenSSL through feature unification
- consistent SeaORM/sqlx configuration
- library crates remain usable independently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated and standardized workspace dependency and feature configuration across modules
  * Added an HTTP client dependency and a locking library to improve network and concurrency behavior
  * Expanded TLS/HTTP transport support and harmonized database driver feature handling
  * Updated module manifests to defer driver selection to the shared database configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->