### PR TITLE
  feat(mini-chat): add multi-provider LLM abstraction layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,9 +410,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -533,6 +533,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -1128,6 +1129,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "bytes",
  "cf-authz-resolver-sdk",
  "cf-mini-chat-sdk",
  "cf-modkit",
@@ -1136,8 +1138,12 @@ dependencies = [
  "cf-modkit-errors-macro",
  "cf-modkit-macros",
  "cf-modkit-security",
+ "cf-oagw-sdk",
+ "futures",
  "http",
  "inventory",
+ "pin-project-lite",
+ "regex",
  "sea-orm",
  "sea-orm-migration",
  "serde",
@@ -1145,6 +1151,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-util",
  "tracing",
  "utoipa",
  "uuid",
@@ -2291,9 +2298,9 @@ checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
 name = "deflate64"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
 
 [[package]]
 name = "der"
@@ -3021,20 +3028,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -3818,9 +3825,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
@@ -3908,9 +3915,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -4027,13 +4034,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.2",
+ "plain",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -4884,6 +4892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pgvector"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc58e2d255979a31caa7cabfa7aac654af0354220719ab7a68520ae7a91e8c0b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4923,18 +4940,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4943,9 +4960,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -4979,6 +4996,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -5096,9 +5119,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -5332,9 +5355,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -5344,6 +5367,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -5456,9 +5485,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -5981,16 +6010,19 @@ checksum = "6d945f62558fac19e5988680d2fdf747b734c2dbc6ce2cb81ba33ed8dde5b103"
 dependencies = [
  "async-stream",
  "async-trait",
+ "bigdecimal",
  "chrono",
  "derive_more 2.1.1",
  "futures-util",
  "log",
  "ouroboros",
+ "pgvector",
  "rust_decimal",
  "sea-orm-macros",
  "sea-query",
  "sea-query-binder",
  "serde",
+ "serde_json",
  "sqlx",
  "strum",
  "thiserror 2.0.18",
@@ -6056,6 +6088,7 @@ dependencies = [
  "ordered-float",
  "rust_decimal",
  "sea-query-derive",
+ "serde_json",
  "time",
  "uuid",
 ]
@@ -6069,6 +6102,7 @@ dependencies = [
  "chrono",
  "rust_decimal",
  "sea-query",
+ "serde_json",
  "sqlx",
  "time",
  "uuid",
@@ -6875,9 +6909,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efc19935b4b66baa6f654ac7924c192f55b175c00a7ab72410fc24284dacda8"
+checksum = "d03c61d2a49c649a15c407338afe7accafde9dac869995dccb73e5f7ef7d9034"
 dependencies = [
  "libc",
  "memchr",
@@ -6945,7 +6979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7125,9 +7159,9 @@ checksum = "b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -7142,9 +7176,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7153,9 +7187,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-metrics"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c48227f311eaa0b0ae5860089860509d7249e0e5da8f7a5d17f4808a1ad387"
+checksum = "0e0410015c6db7b67b9c9ab2a3af4d74a942d637ff248d0d055073750deac6f9"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -7231,19 +7265,10 @@ dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -7257,12 +7282,12 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "a0a07913e63758bc95142d9863a5a45173b71515e68b690cad70cf99c3255ce1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "winnow",
 ]
@@ -7873,7 +7898,7 @@ version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "sha1_smol",
@@ -7965,9 +7990,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7978,9 +8003,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.63"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -7992,9 +8017,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8002,9 +8027,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8015,9 +8040,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -8071,9 +8096,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8773,18 +8798,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8911,9 +8936,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c745c48e1007337ed136dc99df34128b9faa6ed542d80a1c673cf55a6d7236c8"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,6 +349,7 @@ sea-orm = { version = "1.1", default-features = false, features = [
     "with-uuid",
     "with-chrono",
     "with-time",
+    "with-json",
     "with-rust_decimal",
     "macros",
 ] }

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -20,12 +20,22 @@ mini-chat-sdk = { package = "cf-mini-chat-sdk", path = "../mini-chat-sdk" }
 # AuthZ resolver for authorization (PEP flow)
 authz-resolver-sdk = { package = "cf-authz-resolver-sdk", path = "../../system/authz-resolver/authz-resolver-sdk" }
 
+# OAGW SDK — proxy calls, SSE stream, gateway errors
+oagw-sdk = { package = "cf-oagw-sdk", path = "../../system/oagw/oagw-sdk" }
+
 # Core dependencies
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 inventory = { workspace = true }
+
+# Streaming / async utilities
+tokio-util = { workspace = true }
+pin-project-lite = { workspace = true }
+futures = { workspace = true }
+bytes = { workspace = true }
+regex = { workspace = true }
 
 # Serde and JSON
 serde = { workspace = true }

--- a/modules/mini-chat/mini-chat/src/api/rest/dto.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/dto.rs
@@ -3,15 +3,533 @@
 //! All REST DTOs live here; SDK `models.rs` stays transport-agnostic.
 //! Provide `From` conversions between SDK models and DTOs in this file.
 
-/// Server-sent event envelope for the `messages:stream` endpoint.
+use axum::response::sse::Event;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::infra::llm::{Citation, ToolPhase, Usage};
+
+// ════════════════════════════════════════════════════════════════════════════
+// StreamEvent — the SSE wire type
+// ════════════════════════════════════════════════════════════════════════════
+
+/// SSE event for the `messages:stream` endpoint.
 ///
-/// Placeholder — will be expanded with concrete event variants
-/// (delta, `tool_call`, done, error, etc.) during Phase 1 implementation.
-#[derive(Debug, Clone)]
-#[modkit_macros::api_dto(response)]
-pub struct StreamEvent {
-    /// Event type discriminator (e.g. "delta", "done", "error").
-    pub event: String,
-    /// JSON-encoded event payload.
-    pub data: String,
+/// Each variant maps to a distinct `event:` name and `data:` JSON payload.
+/// Ordering grammar: `ping* delta* tool* citations? (done | error)`.
+#[derive(Debug, Clone, ToSchema)]
+pub enum StreamEvent {
+    Ping,
+    Delta(DeltaData),
+    Tool(ToolData),
+    Citations(CitationsData),
+    Done(Box<DoneData>),
+    Error(ErrorData),
+}
+
+/// Delta text chunk.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct DeltaData {
+    pub r#type: &'static str,
+    pub content: String,
+}
+
+/// Tool lifecycle event.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ToolData {
+    pub phase: ToolPhase,
+    pub name: String,
+    pub details: serde_json::Value,
+}
+
+/// Citations from provider annotations.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct CitationsData {
+    pub items: Vec<Citation>,
+}
+
+/// Successful stream completion.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct DoneData {
+    pub message_id: Option<String>,
+    pub usage: Option<Usage>,
+    pub effective_model: String,
+    pub selected_model: String,
+    pub quota_decision: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub downgrade_from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub downgrade_reason: Option<String>,
+}
+
+/// Stream error (terminal).
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ErrorData {
+    pub code: String,
+    pub message: String,
+}
+
+impl StreamEvent {
+    /// Convert to an Axum SSE [`Event`] with the correct `event:` name
+    /// and `data:` JSON payload.
+    pub fn into_sse_event(self) -> Result<Event, axum::Error> {
+        match self {
+            StreamEvent::Ping => Ok(Event::default().event("ping").data("{}")),
+            StreamEvent::Delta(d) => Event::default().event("delta").json_data(&d),
+            StreamEvent::Tool(t) => Event::default().event("tool").json_data(&t),
+            StreamEvent::Citations(c) => Event::default().event("citations").json_data(&c),
+            StreamEvent::Done(d) => Event::default().event("done").json_data(&*d),
+            StreamEvent::Error(e) => Event::default().event("error").json_data(&e),
+        }
+    }
+
+    /// Classify this event for the [`StreamPhase`] state machine.
+    #[must_use]
+    pub fn event_kind(&self) -> StreamEventKind {
+        match self {
+            StreamEvent::Ping => StreamEventKind::Ping,
+            StreamEvent::Delta(_) => StreamEventKind::Delta,
+            StreamEvent::Tool(_) => StreamEventKind::Tool,
+            StreamEvent::Citations(_) => StreamEventKind::Citations,
+            StreamEvent::Done(_) | StreamEvent::Error(_) => StreamEventKind::Terminal,
+        }
+    }
+
+    /// Whether this is a terminal event (done or error).
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, StreamEvent::Done(_) | StreamEvent::Error(_))
+    }
+}
+
+impl modkit::api::api_dto::ResponseApiDto for StreamEvent {}
+
+// ════════════════════════════════════════════════════════════════════════════
+// StreamEventKind — for phase state machine
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Coarse event classification for ordering enforcement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamEventKind {
+    Ping,
+    Delta,
+    Tool,
+    Citations,
+    Terminal,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// StreamPhase — event ordering state machine
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Enforces the SSE ordering grammar: `ping* delta* tool* citations? (done | error)`.
+///
+/// Only forward transitions are allowed. Out-of-order events produce an
+/// [`OrderingViolation`] error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamPhase {
+    /// Before any events. Accepts ping, delta, tool, citations, terminal.
+    Idle,
+    /// After one or more pings. Accepts ping, delta, tool, citations, terminal.
+    Pinging,
+    /// After first delta. Accepts delta, tool, citations, terminal.
+    Deltas,
+    /// After first tool event. Accepts tool, citations, terminal.
+    Tools,
+    /// After citations. Accepts terminal only.
+    Citations,
+    /// Terminal event emitted. No further events accepted.
+    Terminal,
+}
+
+/// An event that violates the ordering grammar.
+#[derive(Debug)]
+pub struct OrderingViolation {
+    pub phase: StreamPhase,
+    pub event: StreamEventKind,
+}
+
+impl std::fmt::Display for OrderingViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SSE ordering violation: {} event in {} phase",
+            self.event, self.phase
+        )
+    }
+}
+
+impl std::fmt::Display for StreamEventKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Ping => f.write_str("Ping"),
+            Self::Delta => f.write_str("Delta"),
+            Self::Tool => f.write_str("Tool"),
+            Self::Citations => f.write_str("Citations"),
+            Self::Terminal => f.write_str("Terminal"),
+        }
+    }
+}
+
+impl std::fmt::Display for StreamPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Idle => f.write_str("Idle"),
+            Self::Pinging => f.write_str("Pinging"),
+            Self::Deltas => f.write_str("Deltas"),
+            Self::Tools => f.write_str("Tools"),
+            Self::Citations => f.write_str("Citations"),
+            Self::Terminal => f.write_str("Terminal"),
+        }
+    }
+}
+
+impl StreamPhase {
+    /// Whether this phase represents a terminal state.
+    #[must_use]
+    pub fn is_terminal(self) -> bool {
+        matches!(self, StreamPhase::Terminal)
+    }
+
+    /// Attempt to advance the phase based on the incoming event kind.
+    ///
+    /// Returns the new phase on success, or an [`OrderingViolation`] if the
+    /// event would break the grammar.
+    pub fn try_advance(self, kind: StreamEventKind) -> Result<StreamPhase, OrderingViolation> {
+        match (self, kind) {
+            // Terminal phase rejects everything
+            (StreamPhase::Terminal, _) => Err(OrderingViolation {
+                phase: self,
+                event: kind,
+            }),
+
+            // Terminal events are always accepted from non-terminal phases
+            (_, StreamEventKind::Terminal) => Ok(StreamPhase::Terminal),
+
+            // Ping: only from Idle or Pinging
+            (StreamPhase::Idle | StreamPhase::Pinging, StreamEventKind::Ping) => {
+                Ok(StreamPhase::Pinging)
+            }
+
+            // Delta: from Idle, Pinging, or Deltas
+            (
+                StreamPhase::Idle | StreamPhase::Pinging | StreamPhase::Deltas,
+                StreamEventKind::Delta,
+            ) => Ok(StreamPhase::Deltas),
+
+            // Tool: from Idle, Pinging, Deltas, or Tools
+            (
+                StreamPhase::Idle | StreamPhase::Pinging | StreamPhase::Deltas | StreamPhase::Tools,
+                StreamEventKind::Tool,
+            ) => Ok(StreamPhase::Tools),
+
+            // Citations: from Idle, Pinging, Deltas, or Tools (at most once)
+            (
+                StreamPhase::Idle | StreamPhase::Pinging | StreamPhase::Deltas | StreamPhase::Tools,
+                StreamEventKind::Citations,
+            ) => Ok(StreamPhase::Citations),
+
+            // Everything else is a violation
+            _ => Err(OrderingViolation {
+                phase: self,
+                event: kind,
+            }),
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Conversions from provider types
+// ════════════════════════════════════════════════════════════════════════════
+
+use crate::infra::llm::ClientSseEvent;
+
+impl From<ClientSseEvent> for StreamEvent {
+    fn from(event: ClientSseEvent) -> Self {
+        match event {
+            ClientSseEvent::Delta { r#type, content } => {
+                StreamEvent::Delta(DeltaData { r#type, content })
+            }
+            ClientSseEvent::Tool {
+                phase,
+                name,
+                details,
+            } => StreamEvent::Tool(ToolData {
+                phase,
+                name: name.to_owned(),
+                details,
+            }),
+            ClientSseEvent::Citations { items } => StreamEvent::Citations(CitationsData { items }),
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Request DTO
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Request body for `POST /v1/chats/{id}/messages/stream`.
+#[derive(Debug, Clone, serde::Deserialize, ToSchema)]
+pub struct StreamMessageRequest {
+    /// Message content (must be non-empty).
+    pub content: String,
+    /// Client-generated idempotency key (UUID v4). Optional in P1.
+    #[serde(default)]
+    pub request_id: Option<uuid::Uuid>,
+    /// Attachment IDs to include.
+    #[serde(default)]
+    pub attachment_ids: Vec<uuid::Uuid>,
+    /// Web search configuration.
+    #[serde(default)]
+    pub web_search: Option<WebSearchConfig>,
+}
+
+impl modkit::api::api_dto::RequestApiDto for StreamMessageRequest {}
+
+/// Web search toggle.
+#[derive(Debug, Clone, serde::Deserialize, ToSchema)]
+pub struct WebSearchConfig {
+    pub enabled: bool,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Tests
+// ════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ping_converts_to_sse_event() {
+        assert!(StreamEvent::Ping.into_sse_event().is_ok());
+    }
+
+    #[test]
+    fn delta_converts_to_sse_event() {
+        assert!(
+            StreamEvent::Delta(DeltaData {
+                r#type: "text",
+                content: "hello".into(),
+            })
+            .into_sse_event()
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn delta_data_serializes_correctly() {
+        let data = DeltaData {
+            r#type: "text",
+            content: "hello".into(),
+        };
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(json.contains("\"type\":\"text\""));
+        assert!(json.contains("\"content\":\"hello\""));
+    }
+
+    #[test]
+    fn done_serializes_without_optional_fields() {
+        let data = DoneData {
+            message_id: None,
+            usage: None,
+            effective_model: "gpt-4o".into(),
+            selected_model: "gpt-4o".into(),
+            quota_decision: "allow".into(),
+            downgrade_from: None,
+            downgrade_reason: None,
+        };
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(json.contains("\"effective_model\":\"gpt-4o\""));
+        assert!(!json.contains("downgrade_from"));
+        assert!(!json.contains("downgrade_reason"));
+    }
+
+    #[test]
+    fn done_serializes_with_downgrade() {
+        let data = DoneData {
+            message_id: Some("msg-123".into()),
+            usage: Some(Usage {
+                input_tokens: 100,
+                output_tokens: 50,
+            }),
+            effective_model: "gpt-4o-mini".into(),
+            selected_model: "gpt-4o".into(),
+            quota_decision: "downgrade".into(),
+            downgrade_from: Some("gpt-4o".into()),
+            downgrade_reason: Some("premium_quota_exhausted".into()),
+        };
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(json.contains("\"downgrade_reason\":\"premium_quota_exhausted\""));
+        assert!(json.contains("\"downgrade_from\":\"gpt-4o\""));
+    }
+
+    #[test]
+    fn done_converts_to_sse_event() {
+        assert!(
+            StreamEvent::Done(Box::new(DoneData {
+                message_id: None,
+                usage: None,
+                effective_model: "gpt-4o".into(),
+                selected_model: "gpt-4o".into(),
+                quota_decision: "allow".into(),
+                downgrade_from: None,
+                downgrade_reason: None,
+            }))
+            .into_sse_event()
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn error_data_serializes_correctly() {
+        let data = ErrorData {
+            code: "provider_error".into(),
+            message: "Something went wrong".into(),
+        };
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(json.contains("\"code\":\"provider_error\""));
+        assert!(json.contains("\"message\":\"Something went wrong\""));
+    }
+
+    #[test]
+    fn error_converts_to_sse_event() {
+        assert!(
+            StreamEvent::Error(ErrorData {
+                code: "provider_error".into(),
+                message: "Something went wrong".into(),
+            })
+            .into_sse_event()
+            .is_ok()
+        );
+    }
+
+    // ── StreamPhase tests ──
+
+    #[test]
+    fn phase_idle_accepts_all_kinds() {
+        assert_eq!(
+            StreamPhase::Idle
+                .try_advance(StreamEventKind::Ping)
+                .unwrap(),
+            StreamPhase::Pinging
+        );
+        assert_eq!(
+            StreamPhase::Idle
+                .try_advance(StreamEventKind::Delta)
+                .unwrap(),
+            StreamPhase::Deltas
+        );
+        assert_eq!(
+            StreamPhase::Idle
+                .try_advance(StreamEventKind::Tool)
+                .unwrap(),
+            StreamPhase::Tools
+        );
+        assert_eq!(
+            StreamPhase::Idle
+                .try_advance(StreamEventKind::Citations)
+                .unwrap(),
+            StreamPhase::Citations
+        );
+        assert_eq!(
+            StreamPhase::Idle
+                .try_advance(StreamEventKind::Terminal)
+                .unwrap(),
+            StreamPhase::Terminal
+        );
+    }
+
+    #[test]
+    fn phase_deltas_rejects_ping() {
+        assert!(
+            StreamPhase::Deltas
+                .try_advance(StreamEventKind::Ping)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn phase_tools_rejects_delta() {
+        assert!(
+            StreamPhase::Tools
+                .try_advance(StreamEventKind::Delta)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn phase_citations_rejects_non_terminal() {
+        assert!(
+            StreamPhase::Citations
+                .try_advance(StreamEventKind::Ping)
+                .is_err()
+        );
+        assert!(
+            StreamPhase::Citations
+                .try_advance(StreamEventKind::Delta)
+                .is_err()
+        );
+        assert!(
+            StreamPhase::Citations
+                .try_advance(StreamEventKind::Tool)
+                .is_err()
+        );
+        assert!(
+            StreamPhase::Citations
+                .try_advance(StreamEventKind::Citations)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn phase_terminal_rejects_everything() {
+        assert!(
+            StreamPhase::Terminal
+                .try_advance(StreamEventKind::Ping)
+                .is_err()
+        );
+        assert!(
+            StreamPhase::Terminal
+                .try_advance(StreamEventKind::Terminal)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn phase_citations_accepts_terminal() {
+        assert_eq!(
+            StreamPhase::Citations
+                .try_advance(StreamEventKind::Terminal)
+                .unwrap(),
+            StreamPhase::Terminal
+        );
+    }
+
+    #[test]
+    fn normal_stream_sequence() {
+        let mut phase = StreamPhase::Idle;
+        phase = phase.try_advance(StreamEventKind::Ping).unwrap();
+        assert_eq!(phase, StreamPhase::Pinging);
+        phase = phase.try_advance(StreamEventKind::Delta).unwrap();
+        assert_eq!(phase, StreamPhase::Deltas);
+        phase = phase.try_advance(StreamEventKind::Delta).unwrap();
+        assert_eq!(phase, StreamPhase::Deltas);
+        phase = phase.try_advance(StreamEventKind::Terminal).unwrap();
+        assert_eq!(phase, StreamPhase::Terminal);
+    }
+
+    #[test]
+    fn tool_stream_sequence() {
+        let mut phase = StreamPhase::Idle;
+        phase = phase.try_advance(StreamEventKind::Delta).unwrap();
+        phase = phase.try_advance(StreamEventKind::Tool).unwrap();
+        assert_eq!(phase, StreamPhase::Tools);
+        phase = phase.try_advance(StreamEventKind::Tool).unwrap();
+        assert_eq!(phase, StreamPhase::Tools);
+        phase = phase.try_advance(StreamEventKind::Citations).unwrap();
+        assert_eq!(phase, StreamPhase::Citations);
+        phase = phase.try_advance(StreamEventKind::Terminal).unwrap();
+        assert_eq!(phase, StreamPhase::Terminal);
+    }
 }

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
@@ -5,7 +5,7 @@ use axum::extract::Path;
 use modkit::api::prelude::*;
 use modkit_security::SecurityContext;
 
-use crate::domain::service::AppServices;
+use crate::module::AppServices;
 
 use super::not_implemented;
 

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/chats.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/chats.rs
@@ -5,7 +5,7 @@ use axum::extract::Path;
 use modkit::api::prelude::*;
 use modkit_security::SecurityContext;
 
-use crate::domain::service::AppServices;
+use crate::module::AppServices;
 
 use super::not_implemented;
 

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
@@ -1,11 +1,24 @@
+use std::convert::Infallible;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
 
-use axum::Extension;
 use axum::extract::Path;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::{Extension, Json};
+use futures::Stream;
 use modkit::api::prelude::*;
 use modkit_security::SecurityContext;
+use tokio::sync::mpsc;
+use tokio::time::{Interval, interval};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
 
-use crate::domain::service::AppServices;
+use crate::api::rest::dto::{StreamEvent, StreamEventKind, StreamMessageRequest, StreamPhase};
+use crate::domain::service::StreamError;
+use crate::module::AppServices;
 
 use super::not_implemented;
 
@@ -19,10 +32,228 @@ pub(crate) async fn list_messages(
 }
 
 /// POST /mini-chat/v1/chats/{id}/messages/stream
+///
+/// Pre-stream validation returns JSON errors. On success, opens an SSE
+/// connection and relays events from the provider through a bounded channel.
 pub(crate) async fn stream_message(
-    Extension(_ctx): Extension<SecurityContext>,
-    Extension(_svc): Extension<Arc<AppServices>>,
-    Path(_chat_id): Path<uuid::Uuid>,
-) -> ApiResult<StatusCode> {
-    Err(not_implemented())
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<AppServices>>,
+    Path(chat_id): Path<uuid::Uuid>,
+    Json(body): Json<StreamMessageRequest>,
+) -> Response {
+    // ── Pre-stream validation ──────────────────────────────────────────
+    if body.content.trim().is_empty() {
+        return Problem::new(
+            StatusCode::BAD_REQUEST,
+            "Bad Request",
+            "Message content must not be empty",
+        )
+        .into_response();
+    }
+
+    // TODO P1: AuthZ (PolicyEnforcer::evaluate with send_message action)
+    // TODO P1: Chat existence check via AccessScope
+
+    // ── Wire up streaming pipeline ─────────────────────────────────────
+    let capacity = svc.stream.channel_capacity();
+    let ping_secs = svc.stream.ping_interval_secs();
+    let (tx, rx) = mpsc::channel::<StreamEvent>(capacity);
+    let cancel = CancellationToken::new();
+
+    // TODO: model should come from user preferences / quota decision
+    let model = "gpt-4o".to_owned();
+    let request_id = body.request_id.unwrap_or_else(uuid::Uuid::new_v4);
+
+    info!(chat_id = %chat_id, %request_id, model = %model, "starting SSE stream");
+
+    // Pre-stream checks + spawn the provider task
+    let provider_handle = match svc
+        .stream
+        .run_stream(
+            ctx,
+            chat_id,
+            request_id,
+            body.content,
+            model,
+            cancel.clone(),
+            tx,
+        )
+        .await
+    {
+        Ok(handle) => handle,
+        Err(StreamError::Replay { .. }) => {
+            return Problem::new(StatusCode::CONFLICT, "Conflict", "Duplicate request_id")
+                .into_response();
+        }
+        Err(StreamError::Conflict { message, .. }) => {
+            return Problem::new(StatusCode::CONFLICT, "Conflict", &message).into_response();
+        }
+        Err(StreamError::TurnCreationFailed { source }) => {
+            warn!(error = %source, "pre-stream turn creation failed");
+            return Problem::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal Error",
+                "Failed to initialize turn",
+            )
+            .into_response();
+        }
+    };
+
+    // Monitor provider task for panics
+    tokio::spawn(async move {
+        if let Err(e) = provider_handle.await {
+            tracing::error!(error = ?e, "provider task panicked");
+        }
+    });
+
+    // Build the SSE relay stream
+    let relay = SseRelay::new(rx, cancel, ping_secs);
+
+    Sse::new(relay)
+        .keep_alive(KeepAlive::new().interval(Duration::from_secs(30)))
+        .into_response()
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// SseRelay — handler-side relay loop as a Stream
+// ════════════════════════════════════════════════════════════════════════════
+
+/// SSE relay that reads from the provider channel, enforces event ordering,
+/// emits ping keepalives, and respects cancellation.
+///
+/// Implements `Stream<Item = Result<Event, Infallible>>` for Axum SSE.
+struct SseRelay {
+    rx: mpsc::Receiver<StreamEvent>,
+    cancel: CancellationToken,
+    phase: StreamPhase,
+    ping_timer: Interval,
+    done: bool,
+    /// TODO: will be used for disconnect-stage reporting
+    first_delta_emitted: bool,
+}
+
+impl SseRelay {
+    fn new(rx: mpsc::Receiver<StreamEvent>, cancel: CancellationToken, ping_secs: u64) -> Self {
+        Self {
+            rx,
+            cancel,
+            phase: StreamPhase::Idle,
+            ping_timer: interval(Duration::from_secs(ping_secs)),
+            done: false,
+            first_delta_emitted: false,
+        }
+    }
+}
+
+impl Drop for SseRelay {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+impl Stream for SseRelay {
+    type Item = Result<Event, Infallible>;
+
+    #[allow(clippy::cognitive_complexity)]
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        if this.done {
+            return Poll::Ready(None);
+        }
+
+        // Check cancellation
+        if this.cancel.is_cancelled() {
+            this.done = true;
+            return Poll::Ready(None);
+        }
+
+        // Try to receive an event from the channel (non-blocking poll)
+        match this.rx.poll_recv(cx) {
+            Poll::Ready(Some(event)) => {
+                let kind = event.event_kind();
+                let is_terminal = event.is_terminal();
+
+                // Enforce ordering via StreamPhase
+                match this.phase.try_advance(kind) {
+                    Ok(new_phase) => {
+                        this.phase = new_phase;
+                    }
+                    Err(violation) => {
+                        warn!(%violation, "suppressing out-of-order SSE event");
+                        // Wake immediately to try next event
+                        cx.waker().wake_by_ref();
+                        return Poll::Pending;
+                    }
+                }
+
+                // Track first delta for disconnect stage reporting
+                if kind == StreamEventKind::Delta {
+                    this.first_delta_emitted = true;
+                }
+
+                // Convert to SSE Event
+                let sse_event = match event.into_sse_event() {
+                    Ok(e) => e,
+                    Err(e) => {
+                        warn!(error = %e, "failed to serialize SSE event");
+                        cx.waker().wake_by_ref();
+                        return Poll::Pending;
+                    }
+                };
+
+                // Terminal events end the stream
+                if is_terminal {
+                    this.done = true;
+                }
+
+                // Reset ping timer on any event
+                this.ping_timer.reset();
+
+                Poll::Ready(Some(Ok(sse_event)))
+            }
+            Poll::Ready(None) => {
+                // Channel closed — provider task exited
+                debug!("provider channel closed");
+                this.done = true;
+
+                // If no terminal event was received, emit an error to honour
+                // the SSE contract (streams must end with done or error).
+                if !this.phase.is_terminal() {
+                    let error_event = StreamEvent::Error(crate::api::rest::dto::ErrorData {
+                        code: "stream_interrupted".to_owned(),
+                        message: "Provider stream ended unexpectedly".to_owned(),
+                    });
+                    if let Ok(sse) = error_event.into_sse_event() {
+                        return Poll::Ready(Some(Ok(sse)));
+                    }
+                }
+
+                Poll::Ready(None)
+            }
+            Poll::Pending => {
+                // No event ready — check if ping timer fired
+                if this.ping_timer.poll_tick(cx).is_ready() {
+                    // Only emit pings in Idle or Pinging phase
+                    let kind = StreamEventKind::Ping;
+                    match this.phase.try_advance(kind) {
+                        Ok(new_phase) => {
+                            this.phase = new_phase;
+                            #[allow(clippy::expect_used)]
+                            let ping = StreamEvent::Ping
+                                .into_sse_event()
+                                .expect("ping serialization cannot fail");
+                            Poll::Ready(Some(Ok(ping)))
+                        }
+                        Err(_) => {
+                            // Past pinging phase — skip the ping silently
+                            Poll::Pending
+                        }
+                    }
+                } else {
+                    Poll::Pending
+                }
+            }
+        }
+    }
 }

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/models.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/models.rs
@@ -5,7 +5,7 @@ use axum::extract::Path;
 use modkit::api::prelude::*;
 use modkit_security::SecurityContext;
 
-use crate::domain::service::AppServices;
+use crate::module::AppServices;
 
 use super::not_implemented;
 

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/reactions.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/reactions.rs
@@ -5,7 +5,7 @@ use axum::extract::Path;
 use modkit::api::prelude::*;
 use modkit_security::SecurityContext;
 
-use crate::domain::service::AppServices;
+use crate::module::AppServices;
 
 use super::not_implemented;
 

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
@@ -5,7 +5,7 @@ use axum::extract::Path;
 use modkit::api::prelude::*;
 use modkit_security::SecurityContext;
 
-use crate::domain::service::AppServices;
+use crate::module::AppServices;
 
 use super::not_implemented;
 

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/messages.rs
@@ -35,6 +35,7 @@ pub(super) fn register_message_routes(
         .authenticated()
         .require_license_features([&AiChatLicense])
         .path_param("id", "Chat UUID")
+        .json_request::<dto::StreamMessageRequest>(openapi, "Message to send")
         .handler(handlers::messages::stream_message)
         .sse_json::<dto::StreamEvent>(openapi, "SSE stream of chat response events")
         .standard_errors(openapi)

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/mod.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/mod.rs
@@ -11,7 +11,7 @@ use axum::Router;
 use modkit::api::OpenApiRegistry;
 use modkit::api::operation_builder::LicenseFeature;
 
-use crate::domain::service::AppServices;
+use crate::module::AppServices;
 
 /// License feature required by all mini-chat endpoints.
 ///

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -7,16 +7,157 @@ use crate::module::DEFAULT_URL_PREFIX;
 pub struct MiniChatConfig {
     #[serde(default = "default_url_prefix")]
     pub url_prefix: String,
+    #[serde(default)]
+    pub streaming: StreamingConfig,
+}
+
+/// SSE streaming tuning parameters.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StreamingConfig {
+    /// Bounded mpsc channel capacity between provider task and SSE writer.
+    /// Valid range: 16–64 (default 32).
+    #[serde(default = "default_channel_capacity")]
+    pub sse_channel_capacity: u16,
+
+    /// Ping keepalive interval in seconds.
+    /// Valid range: 5–60 (default 15).
+    #[serde(default = "default_ping_interval")]
+    pub sse_ping_interval_seconds: u16,
+}
+
+impl Default for StreamingConfig {
+    fn default() -> Self {
+        Self {
+            sse_channel_capacity: default_channel_capacity(),
+            sse_ping_interval_seconds: default_ping_interval(),
+        }
+    }
+}
+
+impl StreamingConfig {
+    /// Validate configuration values at startup. Returns an error message
+    /// describing the first invalid value found.
+    pub fn validate(self) -> Result<(), String> {
+        if !(16..=64).contains(&self.sse_channel_capacity) {
+            return Err(format!(
+                "sse_channel_capacity must be 16-64, got {}",
+                self.sse_channel_capacity
+            ));
+        }
+        if !(5..=60).contains(&self.sse_ping_interval_seconds) {
+            return Err(format!(
+                "sse_ping_interval_seconds must be 5-60, got {}",
+                self.sse_ping_interval_seconds
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn default_channel_capacity() -> u16 {
+    32
+}
+
+fn default_ping_interval() -> u16 {
+    15
 }
 
 impl Default for MiniChatConfig {
     fn default() -> Self {
         Self {
             url_prefix: default_url_prefix(),
+            streaming: StreamingConfig::default(),
         }
     }
 }
 
 fn default_url_prefix() -> String {
     DEFAULT_URL_PREFIX.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_valid() {
+        StreamingConfig::default().validate().unwrap();
+    }
+
+    #[test]
+    fn channel_capacity_boundaries() {
+        let valid = StreamingConfig::default();
+
+        assert!(
+            (StreamingConfig {
+                sse_channel_capacity: 15,
+                ..valid
+            })
+            .validate()
+            .is_err()
+        );
+        assert!(
+            (StreamingConfig {
+                sse_channel_capacity: 16,
+                ..valid
+            })
+            .validate()
+            .is_ok()
+        );
+        assert!(
+            (StreamingConfig {
+                sse_channel_capacity: 64,
+                ..valid
+            })
+            .validate()
+            .is_ok()
+        );
+        assert!(
+            (StreamingConfig {
+                sse_channel_capacity: 65,
+                ..valid
+            })
+            .validate()
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn ping_interval_boundaries() {
+        let valid = StreamingConfig::default();
+
+        assert!(
+            (StreamingConfig {
+                sse_ping_interval_seconds: 4,
+                ..valid
+            })
+            .validate()
+            .is_err()
+        );
+        assert!(
+            (StreamingConfig {
+                sse_ping_interval_seconds: 5,
+                ..valid
+            })
+            .validate()
+            .is_ok()
+        );
+        assert!(
+            (StreamingConfig {
+                sse_ping_interval_seconds: 60,
+                ..valid
+            })
+            .validate()
+            .is_ok()
+        );
+        assert!(
+            (StreamingConfig {
+                sse_ping_interval_seconds: 61,
+                ..valid
+            })
+            .validate()
+            .is_err()
+        );
+    }
 }

--- a/modules/mini-chat/mini-chat/src/domain/error.rs
+++ b/modules/mini-chat/mini-chat/src/domain/error.rs
@@ -1,0 +1,88 @@
+use modkit_db::DbError;
+use modkit_db::secure::ScopeError;
+use modkit_macros::domain_model;
+use thiserror::Error;
+use uuid::Uuid;
+
+#[domain_model]
+#[derive(Error, Debug)]
+pub enum DomainError {
+    #[error("Database error: {message}")]
+    Database { message: String },
+
+    #[error("Conflict: {code}: {message}")]
+    Conflict { code: String, message: String },
+
+    #[error("{entity} not found: {id}")]
+    NotFound { entity: String, id: Uuid },
+
+    #[error("Access denied")]
+    Forbidden,
+
+    #[error("Internal error")]
+    Internal,
+}
+
+impl DomainError {
+    pub fn database(message: impl Into<String>) -> Self {
+        Self::Database {
+            message: message.into(),
+        }
+    }
+
+    pub fn conflict(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Conflict {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    pub fn not_found(entity: impl Into<String>, id: Uuid) -> Self {
+        Self::NotFound {
+            entity: entity.into(),
+            id,
+        }
+    }
+}
+
+/// Helper to convert any displayable error into `DomainError::Database`.
+pub fn db_err(e: impl std::fmt::Display) -> DomainError {
+    DomainError::database(e.to_string())
+}
+
+impl From<DbError> for DomainError {
+    fn from(e: DbError) -> Self {
+        DomainError::database(e.to_string())
+    }
+}
+
+impl From<ScopeError> for DomainError {
+    #[allow(clippy::cognitive_complexity)]
+    fn from(e: ScopeError) -> Self {
+        match e {
+            ScopeError::Db(ref db_err) => map_db_err(db_err),
+            ScopeError::Denied(msg) => {
+                tracing::warn!("scope denied: {msg}");
+                DomainError::Forbidden
+            }
+            ScopeError::TenantNotInScope { tenant_id } => {
+                tracing::warn!("tenant {tenant_id} not in scope");
+                DomainError::Forbidden
+            }
+            ScopeError::Invalid(msg) => {
+                tracing::error!("invalid scope: {msg}");
+                DomainError::Internal
+            }
+        }
+    }
+}
+
+fn map_db_err(db_err: &sea_orm::DbErr) -> DomainError {
+    if let Some(sea_orm::SqlErr::UniqueConstraintViolation(msg)) = db_err.sql_err() {
+        return DomainError::Conflict {
+            code: "unique_violation".into(),
+            message: msg,
+        };
+    }
+    DomainError::database(db_err.to_string())
+}

--- a/modules/mini-chat/mini-chat/src/domain/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/mod.rs
@@ -3,5 +3,6 @@
 #![allow(unknown_lints)]
 #![allow(de0301_no_infra_in_domain)]
 
+pub mod error;
 pub mod repos;
 pub mod service;

--- a/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
@@ -1,2 +1,63 @@
+use async_trait::async_trait;
+use modkit_db::secure::DBRunner;
+use modkit_macros::domain_model;
+use modkit_security::AccessScope;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::infra::db::entity::message::Model as MessageModel;
+
+/// Parameters for inserting a user message.
+#[domain_model]
+pub struct InsertUserMessageParams {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    pub request_id: Uuid,
+    pub content: String,
+}
+
+/// Parameters for inserting an assistant message.
+#[domain_model]
+pub struct InsertAssistantMessageParams {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    pub request_id: Uuid,
+    pub content: String,
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub model: Option<String>,
+    pub provider_response_id: Option<String>,
+}
+
 /// Repository trait for message persistence operations.
-pub trait MessageRepository: Send + Sync {}
+#[async_trait]
+#[allow(dead_code)]
+pub trait MessageRepository: Send + Sync {
+    /// INSERT a user message linked to a turn's `request_id`.
+    async fn insert_user_message<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: InsertUserMessageParams,
+    ) -> Result<MessageModel, DomainError>;
+
+    /// INSERT an assistant message with usage data. Returns the message model
+    /// (caller uses `model.id` to set `chat_turns.assistant_message_id`).
+    async fn insert_assistant_message<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: InsertAssistantMessageParams,
+    ) -> Result<MessageModel, DomainError>;
+
+    /// SELECT messages for a turn by `(chat_id, request_id)` where not deleted.
+    async fn find_by_chat_and_request_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<Vec<MessageModel>, DomainError>;
+}

--- a/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
@@ -10,10 +10,14 @@ mod vector_store_repo;
 
 pub(crate) use attachment_repo::AttachmentRepository;
 pub(crate) use chat_repo::ChatRepository;
-pub(crate) use message_repo::MessageRepository;
+pub(crate) use message_repo::{
+    InsertAssistantMessageParams, InsertUserMessageParams, MessageRepository,
+};
 pub(crate) use model_pref_repo::ModelPrefRepository;
-pub(crate) use quota_usage_repo::QuotaUsageRepository;
+pub(crate) use quota_usage_repo::{IncrementReserveParams, QuotaUsageRepository, SettleParams};
 pub(crate) use reaction_repo::ReactionRepository;
 pub(crate) use thread_summary_repo::ThreadSummaryRepository;
-pub(crate) use turn_repo::TurnRepository;
+pub(crate) use turn_repo::{
+    CasCompleteParams, CasTerminalParams, CreateTurnParams, TurnRepository,
+};
 pub(crate) use vector_store_repo::VectorStoreRepository;

--- a/modules/mini-chat/mini-chat/src/domain/repos/quota_usage_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/quota_usage_repo.rs
@@ -1,2 +1,66 @@
+use async_trait::async_trait;
+use modkit_db::secure::DBRunner;
+use modkit_macros::domain_model;
+use modkit_security::AccessScope;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::infra::db::entity::quota_usage::{Model as QuotaUsageModel, PeriodType};
+
+/// Parameters for reserving quota credits.
+#[domain_model]
+#[allow(dead_code)]
+pub struct IncrementReserveParams {
+    pub tenant_id: Uuid,
+    pub user_id: Uuid,
+    pub period_type: PeriodType,
+    pub period_start: time::Date,
+    pub bucket: String,
+    pub amount_micro: i64,
+}
+
+/// Parameters for settling quota after turn completion.
+#[domain_model]
+#[allow(dead_code)]
+pub struct SettleParams {
+    pub tenant_id: Uuid,
+    pub user_id: Uuid,
+    pub period_type: PeriodType,
+    pub period_start: time::Date,
+    pub bucket: String,
+    pub reserved_credits_micro: i64,
+    pub actual_credits_micro: i64,
+    /// Token telemetry — only applied on `total` bucket.
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+}
+
 /// Repository trait for quota usage persistence operations.
-pub trait QuotaUsageRepository: Send + Sync {}
+#[async_trait]
+#[allow(dead_code)]
+pub trait QuotaUsageRepository: Send + Sync {
+    /// Atomically increment `reserved_credits_micro` (UPSERT).
+    async fn increment_reserve<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: IncrementReserveParams,
+    ) -> Result<(), DomainError>;
+
+    /// Atomic reserve-release + spend-commit for settlement.
+    async fn settle<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: SettleParams,
+    ) -> Result<(), DomainError>;
+
+    /// SELECT all `quota_usage` rows for a user across periods and buckets.
+    async fn find_bucket_rows<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Vec<QuotaUsageModel>, DomainError>;
+}

--- a/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
@@ -1,2 +1,109 @@
+use async_trait::async_trait;
+use modkit_db::secure::DBRunner;
+use modkit_macros::domain_model;
+use modkit_security::AccessScope;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::infra::db::entity::chat_turn::{Model as TurnModel, TurnState};
+
+/// Parameters for creating a new turn.
+#[domain_model]
+pub struct CreateTurnParams {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    pub request_id: Uuid,
+    pub requester_type: String,
+    pub requester_user_id: Option<Uuid>,
+    /// Preflight fields — NULL in P2, populated by P3 quota service.
+    pub reserve_tokens: Option<i64>,
+    pub max_output_tokens_applied: Option<i32>,
+    pub reserved_credits_micro: Option<i64>,
+    pub policy_version_applied: Option<i64>,
+    pub effective_model: Option<String>,
+    pub minimal_generation_floor_applied: Option<i32>,
+}
+
+/// Parameters for CAS update to completed state.
+#[domain_model]
+#[allow(clippy::struct_field_names)]
+pub struct CasCompleteParams {
+    pub turn_id: Uuid,
+    pub assistant_message_id: Uuid,
+    pub provider_response_id: Option<String>,
+}
+
+/// Parameters for CAS update to a terminal state (failed/cancelled).
+#[domain_model]
+pub struct CasTerminalParams {
+    pub turn_id: Uuid,
+    pub state: TurnState,
+    pub error_code: Option<String>,
+    pub error_detail: Option<String>,
+}
+
 /// Repository trait for turn persistence operations.
-pub trait TurnRepository: Send + Sync {}
+#[async_trait]
+#[allow(dead_code)]
+pub trait TurnRepository: Send + Sync {
+    /// INSERT a new turn with `state = running`.
+    async fn create_turn<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: CreateTurnParams,
+    ) -> Result<TurnModel, DomainError>;
+
+    /// SELECT by `(chat_id, request_id)` for idempotency check.
+    async fn find_by_chat_and_request_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<Option<TurnModel>, DomainError>;
+
+    /// SELECT the running turn for a chat (state=running, `deleted_at` IS NULL).
+    async fn find_running_by_chat_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<TurnModel>, DomainError>;
+
+    /// CAS state transition to a terminal state.
+    /// Returns `rows_affected` (0 = another finalizer won, 1 = success).
+    async fn cas_update_state<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: CasTerminalParams,
+    ) -> Result<u64, DomainError>;
+
+    /// CAS transition to completed, setting `assistant_message_id` and
+    /// `provider_response_id`.
+    async fn cas_update_completed<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: CasCompleteParams,
+    ) -> Result<u64, DomainError>;
+
+    /// Soft-delete a turn, linking to a replacement `request_id`.
+    async fn soft_delete<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        turn_id: Uuid,
+        replaced_by_request_id: Option<Uuid>,
+    ) -> Result<(), DomainError>;
+
+    /// SELECT the most recent non-deleted turn for a chat.
+    async fn find_latest_turn<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<TurnModel>, DomainError>;
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
@@ -9,19 +9,19 @@ use super::DbProvider;
 
 /// Service handling file attachment operations.
 #[domain_model]
-pub struct AttachmentService {
+pub struct AttachmentService<CR: ChatRepository> {
     _db: Arc<DbProvider>,
     _attachment_repo: Arc<dyn AttachmentRepository>,
-    _chat_repo: Arc<dyn ChatRepository>,
+    _chat_repo: Arc<CR>,
     _vector_store_repo: Arc<dyn VectorStoreRepository>,
     _enforcer: PolicyEnforcer,
 }
 
-impl AttachmentService {
+impl<CR: ChatRepository> AttachmentService<CR> {
     pub(crate) fn new(
         db: Arc<DbProvider>,
         attachment_repo: Arc<dyn AttachmentRepository>,
-        chat_repo: Arc<dyn ChatRepository>,
+        chat_repo: Arc<CR>,
         vector_store_repo: Arc<dyn VectorStoreRepository>,
         enforcer: PolicyEnforcer,
     ) -> Self {

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
@@ -9,19 +9,19 @@ use super::DbProvider;
 
 /// Service handling chat CRUD and message listing operations.
 #[domain_model]
-pub struct ChatService {
+pub struct ChatService<MR: MessageRepository, CR: ChatRepository> {
     _db: Arc<DbProvider>,
-    _chat_repo: Arc<dyn ChatRepository>,
-    _message_repo: Arc<dyn MessageRepository>,
+    _chat_repo: Arc<CR>,
+    _message_repo: Arc<MR>,
     _thread_summary_repo: Arc<dyn ThreadSummaryRepository>,
     _enforcer: PolicyEnforcer,
 }
 
-impl ChatService {
+impl<MR: MessageRepository, CR: ChatRepository> ChatService<MR, CR> {
     pub(crate) fn new(
         db: Arc<DbProvider>,
-        chat_repo: Arc<dyn ChatRepository>,
-        message_repo: Arc<dyn MessageRepository>,
+        chat_repo: Arc<CR>,
+        message_repo: Arc<MR>,
         thread_summary_repo: Arc<dyn ThreadSummaryRepository>,
         enforcer: PolicyEnforcer,
     ) -> Self {

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -5,11 +5,13 @@ use authz_resolver_sdk::{AuthZResolverClient, PolicyEnforcer};
 use modkit_db::DBProvider;
 use modkit_macros::domain_model;
 
+use crate::config::StreamingConfig;
 use crate::domain::repos::{
     AttachmentRepository, ChatRepository, MessageRepository, ModelPrefRepository,
     QuotaUsageRepository, ReactionRepository, ThreadSummaryRepository, TurnRepository,
     VectorStoreRepository,
 };
+use crate::infra::llm::LlmProvider;
 
 mod attachment_service;
 mod chat_service;
@@ -23,7 +25,7 @@ pub(crate) use chat_service::ChatService;
 pub(crate) use model_service::ModelService;
 pub(crate) use quota_service::QuotaService;
 pub(crate) use reaction_service::ReactionService;
-pub(crate) use stream_service::StreamService;
+pub(crate) use stream_service::{StreamError, StreamService};
 
 pub(crate) type DbProvider = DBProvider<modkit_db::DbError>;
 
@@ -64,12 +66,17 @@ pub(crate) mod actions {
 
 /// All repository instances passed to `AppServices::new` as a single bundle.
 #[domain_model]
-pub(crate) struct Repositories {
-    pub(crate) chat: Arc<dyn ChatRepository>,
+pub(crate) struct Repositories<
+    TR: TurnRepository,
+    MR: MessageRepository,
+    QR: QuotaUsageRepository,
+    CR: ChatRepository,
+> {
+    pub(crate) chat: Arc<CR>,
     pub(crate) attachment: Arc<dyn AttachmentRepository>,
-    pub(crate) message: Arc<dyn MessageRepository>,
-    pub(crate) quota: Arc<dyn QuotaUsageRepository>,
-    pub(crate) turn: Arc<dyn TurnRepository>,
+    pub(crate) message: Arc<MR>,
+    pub(crate) quota: Arc<QR>,
+    pub(crate) turn: Arc<TR>,
     pub(crate) reaction: Arc<dyn ReactionRepository>,
     pub(crate) model_pref: Arc<dyn ModelPrefRepository>,
     pub(crate) thread_summary: Arc<dyn ThreadSummaryRepository>,
@@ -83,20 +90,33 @@ pub(crate) struct Repositories {
 /// handlers call service methods with business parameters only.
 #[domain_model]
 #[allow(dead_code)]
-pub(crate) struct AppServices {
-    pub(crate) chats: ChatService,
-    pub(crate) stream: StreamService,
-    pub(crate) reactions: ReactionService,
-    pub(crate) attachments: AttachmentService,
+pub(crate) struct AppServices<
+    TR: TurnRepository + 'static,
+    MR: MessageRepository + 'static,
+    QR: QuotaUsageRepository + 'static,
+    CR: ChatRepository + 'static,
+> {
+    pub(crate) chats: ChatService<MR, CR>,
+    pub(crate) stream: StreamService<TR, MR, CR>,
+    pub(crate) reactions: ReactionService<MR, CR>,
+    pub(crate) attachments: AttachmentService<CR>,
     pub(crate) models: ModelService,
-    pub(crate) quota: QuotaService,
+    pub(crate) quota: QuotaService<QR>,
 }
 
-impl AppServices {
+impl<
+    TR: TurnRepository + 'static,
+    MR: MessageRepository + 'static,
+    QR: QuotaUsageRepository + 'static,
+    CR: ChatRepository + 'static,
+> AppServices<TR, MR, QR, CR>
+{
     pub(crate) fn new(
-        repos: &Repositories,
+        repos: &Repositories<TR, MR, QR, CR>,
         db: Arc<DbProvider>,
         authz: Arc<dyn AuthZResolverClient>,
+        llm: Arc<dyn LlmProvider>,
+        streaming_config: StreamingConfig,
     ) -> Self {
         let enforcer = PolicyEnforcer::new(authz);
 
@@ -114,6 +134,8 @@ impl AppServices {
                 Arc::clone(&repos.message),
                 Arc::clone(&repos.chat),
                 enforcer.clone(),
+                llm,
+                streaming_config,
             ),
             reactions: ReactionService::new(
                 Arc::clone(&db),

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
@@ -9,18 +9,14 @@ use super::DbProvider;
 
 /// Service handling quota tracking and enforcement.
 #[domain_model]
-pub struct QuotaService {
+pub struct QuotaService<QR: QuotaUsageRepository> {
     _db: Arc<DbProvider>,
-    _repo: Arc<dyn QuotaUsageRepository>,
+    _repo: Arc<QR>,
     _enforcer: PolicyEnforcer,
 }
 
-impl QuotaService {
-    pub(crate) fn new(
-        db: Arc<DbProvider>,
-        repo: Arc<dyn QuotaUsageRepository>,
-        enforcer: PolicyEnforcer,
-    ) -> Self {
+impl<QR: QuotaUsageRepository> QuotaService<QR> {
+    pub(crate) fn new(db: Arc<DbProvider>, repo: Arc<QR>, enforcer: PolicyEnforcer) -> Self {
         Self {
             _db: db,
             _repo: repo,

--- a/modules/mini-chat/mini-chat/src/domain/service/reaction_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/reaction_service.rs
@@ -9,20 +9,20 @@ use super::DbProvider;
 
 /// Service handling message reaction operations.
 #[domain_model]
-pub struct ReactionService {
+pub struct ReactionService<MR: MessageRepository, CR: ChatRepository> {
     _db: Arc<DbProvider>,
     _reaction_repo: Arc<dyn ReactionRepository>,
-    _message_repo: Arc<dyn MessageRepository>,
-    _chat_repo: Arc<dyn ChatRepository>,
+    _message_repo: Arc<MR>,
+    _chat_repo: Arc<CR>,
     _enforcer: PolicyEnforcer,
 }
 
-impl ReactionService {
+impl<MR: MessageRepository, CR: ChatRepository> ReactionService<MR, CR> {
     pub(crate) fn new(
         db: Arc<DbProvider>,
         reaction_repo: Arc<dyn ReactionRepository>,
-        message_repo: Arc<dyn MessageRepository>,
-        chat_repo: Arc<dyn ChatRepository>,
+        message_repo: Arc<MR>,
+        chat_repo: Arc<CR>,
         enforcer: PolicyEnforcer,
     ) -> Self {
         Self {

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -1,36 +1,1033 @@
 use std::sync::Arc;
 
 use authz_resolver_sdk::PolicyEnforcer;
+use futures::StreamExt;
 use modkit_macros::domain_model;
+use modkit_security::AccessScope;
+use oagw_sdk::SecurityContext;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
 
-use crate::domain::repos::{ChatRepository, MessageRepository, TurnRepository};
+use crate::api::rest::dto::{DoneData, ErrorData, StreamEvent};
+use crate::config::StreamingConfig;
+use crate::domain::error::DomainError;
+use crate::domain::repos::{
+    CasCompleteParams, CasTerminalParams, ChatRepository, CreateTurnParams,
+    InsertAssistantMessageParams, InsertUserMessageParams, MessageRepository, TurnRepository,
+};
+use crate::infra::db::entity::chat_turn::{Model as TurnModel, TurnState};
+use crate::infra::llm::{
+    ClientSseEvent, LlmMessage, LlmProvider, LlmProviderError, LlmRequestBuilder, TerminalOutcome,
+    Usage,
+};
 
 use super::DbProvider;
 
-/// Service handling SSE streaming, turn orchestration, and turn mutations.
+// ════════════════════════════════════════════════════════════════════════════
+// StreamTerminal — service-level terminal classification
+// ════════════════════════════════════════════════════════════════════════════
+
+/// How the stream ended at the service level.
+///
+/// Maps from the provider-level [`TerminalOutcome`] with an additional
+/// `Cancelled` variant for client/server-initiated cancellation.
 #[domain_model]
-pub struct StreamService {
-    _db: Arc<DbProvider>,
-    _turn_repo: Arc<dyn TurnRepository>,
-    _message_repo: Arc<dyn MessageRepository>,
-    _chat_repo: Arc<dyn ChatRepository>,
-    _enforcer: PolicyEnforcer,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamTerminal {
+    /// Provider completed successfully — full response received.
+    Completed,
+    /// Provider stopped early (e.g. `max_output_tokens` hit).
+    Incomplete,
+    /// Provider or stream-level error.
+    Failed,
+    /// Cancelled (client disconnect or server-initiated).
+    Cancelled,
 }
 
-impl StreamService {
+// ════════════════════════════════════════════════════════════════════════════
+// StreamOutcome — returned from run_stream()
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Summary of a finished stream, returned from [`StreamService::run_stream()`].
+///
+/// Used by P1 for logging and metrics, and by P4 for CAS finalization.
+#[domain_model]
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct StreamOutcome {
+    /// How the stream ended.
+    pub terminal: StreamTerminal,
+    /// Accumulated assistant text from delta events.
+    pub accumulated_text: String,
+    /// Token usage from the provider (if available).
+    pub usage: Option<Usage>,
+    /// The model actually used by the provider.
+    pub effective_model: String,
+    /// Normalized error code (e.g. `rate_limited`, `provider_timeout`).
+    pub error_code: Option<String>,
+    /// Provider response ID (e.g. `OpenAI` `response_id`).
+    pub provider_response_id: Option<String>,
+    /// Whether usage was from a partial/incomplete provider response.
+    pub provider_partial_usage: bool,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// StreamError — pre-stream error before SSE connection opens
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Pre-stream error — returned from [`StreamService::run_stream()`] before
+/// the SSE connection opens. The handler maps these to JSON error responses.
+#[domain_model]
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum StreamError {
+    /// Idempotent replay: a turn with this `request_id` already exists.
+    Replay { turn: Box<TurnModel> },
+    /// Conflict: another turn is already running for this chat.
+    Conflict { code: String, message: String },
+    /// Turn creation or pre-stream DB operation failed.
+    TurnCreationFailed { source: DomainError },
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// PersistenceCtx — bundled context for CAS finalization in the spawned task
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Persistence context cloned into the spawned provider task for CAS
+/// finalization after stream completion. `None` in unit tests.
+#[domain_model]
+struct PersistenceCtx<TR: TurnRepository, MR: MessageRepository> {
+    db: Arc<DbProvider>,
+    turn_repo: Arc<TR>,
+    message_repo: Arc<MR>,
+    scope: AccessScope,
+    turn_id: Uuid,
+    tenant_id: Uuid,
+    chat_id: Uuid,
+    request_id: Uuid,
+    /// Pre-generated assistant message ID, also sent in `DoneData`.
+    message_id: Uuid,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Error normalization
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Normalize an [`LlmProviderError`] to a `(code, message)` pair for the SSE
+/// error event. Messages are already sanitized by the infra layer.
+fn normalize_error(err: &LlmProviderError) -> (String, String) {
+    match err {
+        LlmProviderError::RateLimited { .. } => (
+            "rate_limited".to_owned(),
+            "Rate limited by provider".to_owned(),
+        ),
+        LlmProviderError::Timeout => (
+            "provider_timeout".to_owned(),
+            "Provider request timed out".to_owned(),
+        ),
+        LlmProviderError::ProviderError { message, .. } => {
+            ("provider_error".to_owned(), message.clone())
+        }
+        LlmProviderError::InvalidResponse { detail } => (
+            "provider_error".to_owned(),
+            crate::infra::llm::sanitize_provider_message(detail),
+        ),
+        LlmProviderError::ProviderUnavailable => (
+            "provider_error".to_owned(),
+            "Provider is currently unavailable".to_owned(),
+        ),
+        LlmProviderError::StreamError(e) => (
+            "provider_error".to_owned(),
+            crate::infra::llm::sanitize_provider_message(&e.to_string()),
+        ),
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// StreamService
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Service handling SSE streaming and turn orchestration.
+///
+/// In P1 this is a stateless proxy: it builds an LLM request, streams
+/// provider events through a bounded channel, and returns a `StreamOutcome`.
+/// P2 adds turn persistence (pre-stream checks + CAS finalization).
+#[domain_model]
+#[allow(dead_code)]
+pub struct StreamService<TR: TurnRepository, MR: MessageRepository, CR: ChatRepository> {
+    db: Arc<DbProvider>,
+    turn_repo: Arc<TR>,
+    message_repo: Arc<MR>,
+    chat_repo: Arc<CR>,
+    enforcer: PolicyEnforcer,
+    llm: Arc<dyn LlmProvider>,
+    streaming_config: StreamingConfig,
+}
+
+impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepository>
+    StreamService<TR, MR, CR>
+{
     pub(crate) fn new(
         db: Arc<DbProvider>,
-        turn_repo: Arc<dyn TurnRepository>,
-        message_repo: Arc<dyn MessageRepository>,
-        chat_repo: Arc<dyn ChatRepository>,
+        turn_repo: Arc<TR>,
+        message_repo: Arc<MR>,
+        chat_repo: Arc<CR>,
         enforcer: PolicyEnforcer,
+        llm: Arc<dyn LlmProvider>,
+        streaming_config: StreamingConfig,
     ) -> Self {
         Self {
-            _db: db,
-            _turn_repo: turn_repo,
-            _message_repo: message_repo,
-            _chat_repo: chat_repo,
-            _enforcer: enforcer,
+            db,
+            turn_repo,
+            message_repo,
+            chat_repo,
+            enforcer,
+            llm,
+            streaming_config,
         }
+    }
+
+    /// The configured channel capacity for the provider→writer mpsc channel.
+    pub(crate) fn channel_capacity(&self) -> usize {
+        usize::from(self.streaming_config.sse_channel_capacity)
+    }
+
+    /// The configured ping interval in seconds.
+    pub(crate) fn ping_interval_secs(&self) -> u64 {
+        u64::from(self.streaming_config.sse_ping_interval_seconds)
+    }
+
+    /// Perform pre-stream checks (idempotency, parallel guard, message/turn
+    /// creation) then spawn the provider task.
+    ///
+    /// Returns `Err(StreamError)` if pre-stream validation fails (before SSE
+    /// connection opens). The handler maps these to JSON error responses.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn run_stream(
+        &self,
+        ctx: SecurityContext,
+        chat_id: Uuid,
+        request_id: Uuid,
+        content: String,
+        model: String,
+        cancel: CancellationToken,
+        tx: mpsc::Sender<StreamEvent>,
+    ) -> Result<tokio::task::JoinHandle<StreamOutcome>, StreamError> {
+        let tenant_id = ctx.subject_tenant_id();
+        let user_id = ctx.subject_id();
+        let scope = AccessScope::for_tenant(tenant_id);
+
+        // Non-transactional connection for pre-stream checks (D6)
+        let conn = self
+            .db
+            .conn()
+            .map_err(|e| StreamError::TurnCreationFailed {
+                source: DomainError::from(e),
+            })?;
+
+        // ── Idempotency check ──
+        if let Some(existing_turn) = self
+            .turn_repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .map_err(|e| StreamError::TurnCreationFailed { source: e })?
+        {
+            return Err(StreamError::Replay {
+                turn: Box::new(existing_turn),
+            });
+        }
+
+        // ── Parallel turn guard ──
+        if let Some(running) = self
+            .turn_repo
+            .find_running_by_chat_id(&conn, &scope, chat_id)
+            .await
+            .map_err(|e| StreamError::TurnCreationFailed { source: e })?
+        {
+            return Err(StreamError::Conflict {
+                code: "turn_already_running".to_owned(),
+                message: format!("Chat {} already has a running turn {}", chat_id, running.id),
+            });
+        }
+
+        // ── Insert user message + create turn (atomic) ──
+        let user_msg_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let requester_type = ctx.subject_type().unwrap_or("user").to_owned();
+        let effective_model = model.clone();
+
+        let message_repo = Arc::clone(&self.message_repo);
+        let turn_repo = Arc::clone(&self.turn_repo);
+        let content_clone = content.clone();
+        let scope_tx = scope.clone();
+
+        self.db
+            .transaction(|tx| {
+                Box::pin(async move {
+                    message_repo
+                        .insert_user_message(
+                            tx,
+                            &scope_tx,
+                            InsertUserMessageParams {
+                                id: user_msg_id,
+                                tenant_id,
+                                chat_id,
+                                request_id,
+                                content: content_clone,
+                            },
+                        )
+                        .await
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::anyhow!(e)))?;
+
+                    turn_repo
+                        .create_turn(
+                            tx,
+                            &scope_tx,
+                            CreateTurnParams {
+                                id: turn_id,
+                                tenant_id,
+                                chat_id,
+                                request_id,
+                                requester_type,
+                                requester_user_id: Some(user_id),
+                                reserve_tokens: None,
+                                max_output_tokens_applied: None,
+                                reserved_credits_micro: None,
+                                policy_version_applied: None,
+                                effective_model: Some(effective_model),
+                                minimal_generation_floor_applied: None,
+                            },
+                        )
+                        .await
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::anyhow!(e)))?;
+
+                    Ok(())
+                })
+            })
+            .await
+            .map_err(|e| StreamError::TurnCreationFailed {
+                source: DomainError::from(e),
+            })?;
+
+        // Pre-generate assistant message ID (sent in DoneData and used in CAS)
+        let message_id = Uuid::new_v4();
+
+        let persist = PersistenceCtx {
+            db: Arc::clone(&self.db),
+            turn_repo: Arc::clone(&self.turn_repo),
+            message_repo: Arc::clone(&self.message_repo),
+            scope,
+            turn_id,
+            tenant_id,
+            chat_id,
+            request_id,
+            message_id,
+        };
+
+        Ok(spawn_provider_task(
+            Arc::clone(&self.llm),
+            ctx,
+            content,
+            model,
+            cancel,
+            tx,
+            Some(persist),
+        ))
+    }
+}
+
+/// Core provider task: reads from the LLM, translates events, and returns
+/// a [`StreamOutcome`]. After the stream ends, CAS-finalizes the turn if
+/// a persistence context is provided.
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::cognitive_complexity,
+    clippy::let_underscore_must_use,
+    clippy::cast_possible_truncation
+)]
+fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'static>(
+    llm: Arc<dyn LlmProvider>,
+    ctx: SecurityContext,
+    content: String,
+    model: String,
+    cancel: CancellationToken,
+    tx: mpsc::Sender<StreamEvent>,
+    persist: Option<PersistenceCtx<TR, MR>>,
+) -> tokio::task::JoinHandle<StreamOutcome> {
+    tokio::spawn(async move {
+        let stream_start = std::time::Instant::now();
+        let mut first_token_time: Option<std::time::Duration> = None;
+        let msg_id_str = persist.as_ref().map(|p| p.message_id.to_string());
+
+        // Build the LLM request
+        let request = LlmRequestBuilder::new(&model)
+            .message(LlmMessage::user(&content))
+            .build_streaming();
+
+        // Call the provider to start streaming
+        let stream_result = llm.stream(ctx, request, cancel.clone()).await;
+
+        let mut provider_stream = match stream_result {
+            Ok(s) => s,
+            Err(e) => {
+                // Provider failed before any events — send error and return.
+                let (code, message) = normalize_error(&e);
+                let _ = tx
+                    .send(StreamEvent::Error(ErrorData {
+                        code: code.clone(),
+                        message,
+                    }))
+                    .await;
+
+                // CAS finalize: mark turn as failed
+                if let Some(ref p) = persist {
+                    cas_finalize_terminal(p, TurnState::Failed, Some(code.clone()), None).await;
+                }
+
+                return StreamOutcome {
+                    terminal: StreamTerminal::Failed,
+                    accumulated_text: String::new(),
+                    usage: None,
+                    effective_model: model,
+                    error_code: Some(code),
+                    provider_response_id: None,
+                    provider_partial_usage: false,
+                };
+            }
+        };
+
+        // Read events from provider, translate and forward through channel
+        let mut accumulated_text = String::new();
+        let mut cancelled = false;
+
+        loop {
+            tokio::select! {
+                biased;
+
+                () = cancel.cancelled() => {
+                    debug!("stream cancelled, aborting provider");
+                    provider_stream.cancel();
+                    cancelled = true;
+                    break;
+                }
+
+                event = provider_stream.next() => {
+                    match event {
+                        Some(Ok(client_event)) => {
+                            if let ClientSseEvent::Delta { ref content, .. } = client_event {
+                                if first_token_time.is_none() {
+                                    let ttft = stream_start.elapsed();
+                                    first_token_time = Some(ttft);
+                                    debug!(
+                                        time_to_first_token_ms = ttft.as_millis() as u64,
+                                        model = %model,
+                                        "first token received"
+                                    );
+                                }
+                                accumulated_text.push_str(content);
+                            }
+                            let stream_event = StreamEvent::from(client_event);
+                            if tx.send(stream_event).await.is_err() {
+                                // Receiver dropped (client disconnect handled by relay)
+                                debug!("channel closed, exiting provider task");
+                                break;
+                            }
+                        }
+                        Some(Err(e)) => {
+                            warn!(error = %e, "provider stream error");
+                            let (code, message) =
+                                normalize_error(&LlmProviderError::StreamError(e));
+                            let _ = tx
+                                .send(StreamEvent::Error(ErrorData {
+                                    code: code.clone(),
+                                    message,
+                                }))
+                                .await;
+
+                            // CAS finalize: mark turn as failed
+                            if let Some(ref p) = persist {
+                                cas_finalize_terminal(
+                                    p,
+                                    TurnState::Failed,
+                                    Some(code.clone()),
+                                    None,
+                                ).await;
+                            }
+
+                            let has_partial = !accumulated_text.is_empty();
+                            return StreamOutcome {
+                                terminal: StreamTerminal::Failed,
+                                accumulated_text,
+                                usage: None,
+                                effective_model: model,
+                                error_code: Some(code),
+                                provider_response_id: None,
+                                provider_partial_usage: has_partial,
+                            };
+                        }
+                        None => {
+                            // Stream ended — terminal captured by ProviderStream
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if cancelled {
+            let elapsed = stream_start.elapsed();
+            info!(
+                terminal = "cancelled",
+                model = %model,
+                duration_ms = elapsed.as_millis() as u64,
+                "stream cancelled"
+            );
+
+            // CAS finalize: mark turn as cancelled
+            if let Some(ref p) = persist {
+                cas_finalize_terminal(p, TurnState::Cancelled, None, None).await;
+            }
+
+            return StreamOutcome {
+                terminal: StreamTerminal::Cancelled,
+                accumulated_text,
+                usage: None,
+                effective_model: model,
+                error_code: None,
+                provider_response_id: None,
+                provider_partial_usage: false,
+            };
+        }
+
+        // Extract the terminal outcome from the provider stream
+        let terminal = provider_stream.into_outcome().await;
+
+        match terminal {
+            TerminalOutcome::Completed {
+                usage,
+                content: _,
+                citations,
+                response_id,
+                ..
+            } => {
+                // Send citations if present
+                if !citations.is_empty() {
+                    let _ = tx
+                        .send(StreamEvent::Citations(
+                            crate::api::rest::dto::CitationsData { items: citations },
+                        ))
+                        .await;
+                }
+                // Send Done terminal
+                let _ = tx
+                    .send(StreamEvent::Done(Box::new(DoneData {
+                        message_id: msg_id_str,
+                        usage: Some(usage),
+                        effective_model: model.clone(),
+                        selected_model: model.clone(),
+                        quota_decision: "allow".into(), // P3 provides real decision
+                        downgrade_from: None,           // P3 provides
+                        downgrade_reason: None,         // P3 provides
+                    })))
+                    .await;
+                let elapsed = stream_start.elapsed();
+                info!(
+                    terminal = "completed",
+                    model = %model,
+                    input_tokens = usage.input_tokens,
+                    output_tokens = usage.output_tokens,
+                    duration_ms = elapsed.as_millis() as u64,
+                    "stream completed"
+                );
+
+                // CAS finalize: insert assistant message + mark turn completed
+                if let Some(ref p) = persist {
+                    cas_finalize_completed(
+                        p,
+                        &accumulated_text,
+                        Some(usage),
+                        Some(model.clone()),
+                        Some(response_id.clone()),
+                    )
+                    .await;
+                }
+
+                StreamOutcome {
+                    terminal: StreamTerminal::Completed,
+                    accumulated_text,
+                    usage: Some(usage),
+                    effective_model: model,
+                    error_code: None,
+                    provider_response_id: Some(response_id),
+                    provider_partial_usage: false,
+                }
+            }
+            TerminalOutcome::Incomplete { usage, reason, .. } => {
+                let _ = tx
+                    .send(StreamEvent::Done(Box::new(DoneData {
+                        message_id: msg_id_str,
+                        usage: Some(usage),
+                        effective_model: model.clone(),
+                        selected_model: model.clone(),
+                        quota_decision: "allow".into(),
+                        downgrade_from: None,
+                        downgrade_reason: None,
+                    })))
+                    .await;
+                let elapsed = stream_start.elapsed();
+                warn!(
+                    terminal = "incomplete",
+                    model = %model,
+                    reason = %reason,
+                    duration_ms = elapsed.as_millis() as u64,
+                    "stream incomplete"
+                );
+
+                // CAS finalize: insert assistant message + mark turn completed
+                // (incomplete is still a valid response, just truncated)
+                if let Some(ref p) = persist {
+                    cas_finalize_completed(
+                        p,
+                        &accumulated_text,
+                        Some(usage),
+                        Some(model.clone()),
+                        None, // Incomplete has no response_id
+                    )
+                    .await;
+                }
+
+                StreamOutcome {
+                    terminal: StreamTerminal::Incomplete,
+                    accumulated_text,
+                    usage: Some(usage),
+                    effective_model: model,
+                    error_code: Some(format!("incomplete:{reason}")),
+                    provider_response_id: None,
+                    provider_partial_usage: false,
+                }
+            }
+            TerminalOutcome::Failed { error, usage, .. } => {
+                let (code, message) = normalize_error(&error);
+                let _ = tx
+                    .send(StreamEvent::Error(ErrorData {
+                        code: code.clone(),
+                        message,
+                    }))
+                    .await;
+                let elapsed = stream_start.elapsed();
+                warn!(
+                    terminal = "failed",
+                    model = %model,
+                    error_code = %code,
+                    duration_ms = elapsed.as_millis() as u64,
+                    "stream failed"
+                );
+
+                // CAS finalize: mark turn as failed
+                if let Some(ref p) = persist {
+                    cas_finalize_terminal(p, TurnState::Failed, Some(code.clone()), None).await;
+                }
+
+                StreamOutcome {
+                    terminal: StreamTerminal::Failed,
+                    accumulated_text,
+                    usage,
+                    effective_model: model,
+                    error_code: Some(code),
+                    provider_response_id: None,
+                    provider_partial_usage: usage.is_some(),
+                }
+            }
+        }
+    })
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// CAS finalization helpers
+// ════════════════════════════════════════════════════════════════════════════
+
+/// CAS-finalize a completed/incomplete turn: insert assistant message then
+/// update turn to `completed`.
+#[allow(clippy::cognitive_complexity)]
+async fn cas_finalize_completed<TR: TurnRepository, MR: MessageRepository>(
+    p: &PersistenceCtx<TR, MR>,
+    text: &str,
+    usage: Option<Usage>,
+    model: Option<String>,
+    provider_response_id: Option<String>,
+) {
+    let conn = match p.db.conn() {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, turn_id = %p.turn_id, "CAS finalize: failed to get DB connection");
+            return;
+        }
+    };
+
+    // Insert assistant message
+    let msg_result = p
+        .message_repo
+        .insert_assistant_message(
+            &conn,
+            &p.scope,
+            InsertAssistantMessageParams {
+                id: p.message_id,
+                tenant_id: p.tenant_id,
+                chat_id: p.chat_id,
+                request_id: p.request_id,
+                content: text.to_owned(),
+                input_tokens: usage.map(|u| u.input_tokens),
+                output_tokens: usage.map(|u| u.output_tokens),
+                model,
+                provider_response_id: provider_response_id.clone(),
+            },
+        )
+        .await;
+
+    match msg_result {
+        Ok(msg) => {
+            let rows = p
+                .turn_repo
+                .cas_update_completed(
+                    &conn,
+                    &p.scope,
+                    CasCompleteParams {
+                        turn_id: p.turn_id,
+                        assistant_message_id: msg.id,
+                        provider_response_id,
+                    },
+                )
+                .await;
+            match rows {
+                Ok(0) => warn!(turn_id = %p.turn_id, "CAS completed: lost race (0 rows)"),
+                Ok(_) => debug!(turn_id = %p.turn_id, "CAS completed: turn finalized"),
+                Err(e) => warn!(error = %e, turn_id = %p.turn_id, "CAS completed: update failed"),
+            }
+        }
+        Err(e) => {
+            warn!(error = %e, turn_id = %p.turn_id, "CAS finalize: failed to insert assistant message");
+        }
+    }
+}
+
+/// CAS-finalize a terminal (failed/cancelled) turn.
+#[allow(clippy::cognitive_complexity)]
+async fn cas_finalize_terminal<TR: TurnRepository, MR: MessageRepository>(
+    p: &PersistenceCtx<TR, MR>,
+    state: TurnState,
+    error_code: Option<String>,
+    error_detail: Option<String>,
+) {
+    let conn = match p.db.conn() {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, turn_id = %p.turn_id, "CAS finalize: failed to get DB connection");
+            return;
+        }
+    };
+
+    let state_label = format!("{state:?}");
+    let rows = p
+        .turn_repo
+        .cas_update_state(
+            &conn,
+            &p.scope,
+            CasTerminalParams {
+                turn_id: p.turn_id,
+                state,
+                error_code,
+                error_detail,
+            },
+        )
+        .await;
+
+    match rows {
+        Ok(0) => warn!(turn_id = %p.turn_id, "CAS terminal: lost race (0 rows)"),
+        Ok(_) => debug!(turn_id = %p.turn_id, state = %state_label, "CAS terminal: turn finalized"),
+        Err(e) => warn!(error = %e, turn_id = %p.turn_id, "CAS terminal: update failed"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infra::db::repo::message_repo::MessageRepository as MsgRepo;
+    use crate::infra::db::repo::turn_repo::TurnRepository as TurnRepo;
+    use crate::infra::llm::{
+        LlmRequest, NonStreaming, ProviderStream, ResponseResult, Streaming, TranslatedEvent,
+    };
+    use futures::stream;
+    use oagw_sdk::error::StreamingError;
+
+    #[test]
+    fn normalize_rate_limited() {
+        let err = LlmProviderError::RateLimited {
+            retry_after_secs: Some(30),
+        };
+        let (code, _) = normalize_error(&err);
+        assert_eq!(code, "rate_limited");
+    }
+
+    #[test]
+    fn normalize_timeout() {
+        let (code, _) = normalize_error(&LlmProviderError::Timeout);
+        assert_eq!(code, "provider_timeout");
+    }
+
+    #[test]
+    fn normalize_provider_error() {
+        let err = LlmProviderError::ProviderError {
+            code: "bad_request".into(),
+            message: "something went wrong".into(),
+            raw_detail: None,
+        };
+        let (code, msg) = normalize_error(&err);
+        assert_eq!(code, "provider_error");
+        assert_eq!(msg, "something went wrong");
+    }
+
+    #[test]
+    fn normalize_unavailable() {
+        let (code, _) = normalize_error(&LlmProviderError::ProviderUnavailable);
+        assert_eq!(code, "provider_error");
+    }
+
+    #[test]
+    fn normalize_invalid_response() {
+        let err = LlmProviderError::InvalidResponse {
+            detail: "bad json".into(),
+        };
+        let (code, msg) = normalize_error(&err);
+        assert_eq!(code, "provider_error");
+        assert_eq!(msg, "bad json");
+    }
+
+    // ── Mock LlmProvider for integration tests ──
+
+    /// A mock LLM provider that yields predefined events and a terminal outcome.
+    #[allow(de0309_must_have_domain_model)]
+    struct MockProvider {
+        events: std::sync::Mutex<Vec<Result<TranslatedEvent, StreamingError>>>,
+    }
+
+    impl MockProvider {
+        fn completed(deltas: &[&str]) -> Self {
+            let mut events: Vec<Result<TranslatedEvent, StreamingError>> = deltas
+                .iter()
+                .map(|text| {
+                    Ok(TranslatedEvent::Sse(ClientSseEvent::Delta {
+                        r#type: "text",
+                        content: (*text).to_owned(),
+                    }))
+                })
+                .collect();
+
+            let full_text: String = deltas.iter().copied().collect();
+            events.push(Ok(TranslatedEvent::Terminal(TerminalOutcome::Completed {
+                usage: Usage {
+                    input_tokens: 10,
+                    output_tokens: 5,
+                },
+                response_id: "resp-test".to_owned(),
+                content: full_text,
+                citations: vec![],
+                raw_response: serde_json::Value::Null,
+            })));
+
+            Self {
+                events: std::sync::Mutex::new(events),
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                events: std::sync::Mutex::new(vec![Ok(TranslatedEvent::Terminal(
+                    TerminalOutcome::Failed {
+                        error: LlmProviderError::Timeout,
+                        usage: None,
+                        partial_content: String::new(),
+                    },
+                ))]),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for MockProvider {
+        async fn stream(
+            &self,
+            _ctx: SecurityContext,
+            _request: LlmRequest<Streaming>,
+            cancel: CancellationToken,
+        ) -> Result<ProviderStream, LlmProviderError> {
+            let events = self.events.lock().unwrap().drain(..).collect::<Vec<_>>();
+            let inner = stream::iter(events);
+            Ok(ProviderStream::new(inner, cancel))
+        }
+
+        async fn complete(
+            &self,
+            _ctx: SecurityContext,
+            _request: LlmRequest<NonStreaming>,
+        ) -> Result<ResponseResult, LlmProviderError> {
+            unimplemented!("not needed for streaming tests")
+        }
+    }
+
+    fn mock_ctx() -> SecurityContext {
+        SecurityContext::anonymous()
+    }
+
+    // ── Integration tests ──
+
+    /// 6.5: End-to-end stream with mock provider returning deltas + completed.
+    #[tokio::test]
+    async fn end_to_end_completed_stream() {
+        let provider: Arc<dyn LlmProvider> =
+            Arc::new(MockProvider::completed(&["Hello", ", ", "world!"]));
+        let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
+        let cancel = CancellationToken::new();
+
+        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+            provider,
+            mock_ctx(),
+            "hi".into(),
+            "test-model".into(),
+            cancel,
+            tx,
+            None,
+        );
+
+        // Collect all events from the channel
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            let is_term = ev.is_terminal();
+            events.push(ev);
+            if is_term {
+                break;
+            }
+        }
+
+        // Verify event sequence: 3 deltas + 1 done
+        assert_eq!(events.len(), 4);
+        assert!(matches!(events[0], StreamEvent::Delta(_)));
+        assert!(matches!(events[1], StreamEvent::Delta(_)));
+        assert!(matches!(events[2], StreamEvent::Delta(_)));
+        assert!(matches!(events[3], StreamEvent::Done(_)));
+
+        // Verify accumulated text in outcome
+        let outcome = handle.await.expect("task should complete");
+        assert_eq!(outcome.terminal, StreamTerminal::Completed);
+        assert_eq!(outcome.accumulated_text, "Hello, world!");
+        assert!(outcome.usage.is_some());
+        assert_eq!(outcome.error_code, None);
+        assert_eq!(outcome.provider_response_id.as_deref(), Some("resp-test"));
+    }
+
+    /// 6.5 variant: Provider fails before first event.
+    #[tokio::test]
+    async fn provider_error_produces_error_event() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::failing());
+        let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
+        let cancel = CancellationToken::new();
+
+        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+            provider,
+            mock_ctx(),
+            "hi".into(),
+            "test-model".into(),
+            cancel,
+            tx,
+            None,
+        );
+
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            let is_term = ev.is_terminal();
+            events.push(ev);
+            if is_term {
+                break;
+            }
+        }
+
+        // Should get exactly one Error event
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], StreamEvent::Error(_)));
+
+        let outcome = handle.await.expect("task should complete");
+        assert_eq!(outcome.terminal, StreamTerminal::Failed);
+        assert_eq!(outcome.error_code.as_deref(), Some("provider_timeout"));
+    }
+
+    /// 6.6: Cancellation mid-stream.
+    #[tokio::test]
+    async fn cancellation_stops_stream() {
+        // A provider that yields one delta then blocks until cancelled.
+        #[allow(de0309_must_have_domain_model)]
+        struct SlowProvider;
+
+        #[async_trait::async_trait]
+        impl LlmProvider for SlowProvider {
+            async fn stream(
+                &self,
+                _ctx: SecurityContext,
+                _request: LlmRequest<Streaming>,
+                cancel: CancellationToken,
+            ) -> Result<ProviderStream, LlmProviderError> {
+                let inner = stream::unfold(0u8, |state| async move {
+                    if state == 0 {
+                        Some((
+                            Ok(TranslatedEvent::Sse(ClientSseEvent::Delta {
+                                r#type: "text",
+                                content: "partial".to_owned(),
+                            })),
+                            1,
+                        ))
+                    } else {
+                        // Block until cancelled
+                        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                        None
+                    }
+                });
+                Ok(ProviderStream::new(inner, cancel))
+            }
+
+            async fn complete(
+                &self,
+                _ctx: SecurityContext,
+                _request: LlmRequest<NonStreaming>,
+            ) -> Result<ResponseResult, LlmProviderError> {
+                unimplemented!()
+            }
+        }
+
+        let provider: Arc<dyn LlmProvider> = Arc::new(SlowProvider);
+        let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
+        let cancel = CancellationToken::new();
+
+        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+            provider,
+            mock_ctx(),
+            "hi".into(),
+            "test-model".into(),
+            cancel.clone(),
+            tx,
+            None,
+        );
+
+        // Read the first delta
+        let first = rx.recv().await.expect("should get first delta");
+        assert!(matches!(first, StreamEvent::Delta(_)));
+
+        // Cancel the stream
+        cancel.cancel();
+
+        // The provider task should exit
+        let outcome = handle.await.expect("task should complete");
+        assert_eq!(outcome.terminal, StreamTerminal::Cancelled);
+        assert_eq!(outcome.accumulated_text, "partial");
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/chat_turn.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/chat_turn.rs
@@ -1,0 +1,64 @@
+use modkit_db::secure::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "chat_turns")]
+#[secure(tenant_col = "tenant_id", resource_col = "id", no_owner, no_type)]
+#[allow(clippy::struct_field_names)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    pub request_id: Uuid,
+    pub requester_type: String,
+    pub requester_user_id: Option<Uuid>,
+    pub state: TurnState,
+    pub provider_name: Option<String>,
+    pub provider_response_id: Option<String>,
+    pub assistant_message_id: Option<Uuid>,
+    pub error_code: Option<String>,
+    #[sea_orm(column_type = "Text")]
+    pub error_detail: Option<String>,
+    pub reserve_tokens: Option<i64>,
+    pub max_output_tokens_applied: Option<i32>,
+    pub reserved_credits_micro: Option<i64>,
+    pub policy_version_applied: Option<i64>,
+    pub effective_model: Option<String>,
+    pub minimal_generation_floor_applied: Option<i32>,
+    pub deleted_at: Option<OffsetDateTime>,
+    pub replaced_by_request_id: Option<Uuid>,
+    pub started_at: OffsetDateTime,
+    pub completed_at: Option<OffsetDateTime>,
+    pub updated_at: OffsetDateTime,
+}
+
+/// Turn lifecycle states. Only `Running` is non-terminal.
+/// Allowed transitions: Running → Completed | Failed | Cancelled.
+#[derive(Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::N(16))")]
+pub enum TurnState {
+    #[sea_orm(string_value = "running")]
+    Running,
+    #[sea_orm(string_value = "completed")]
+    Completed,
+    #[sea_orm(string_value = "failed")]
+    Failed,
+    #[sea_orm(string_value = "cancelled")]
+    Cancelled,
+}
+
+impl TurnState {
+    /// Returns `true` if the state is terminal (no further transitions).
+    #[must_use]
+    pub fn is_terminal(&self) -> bool {
+        !matches!(self, Self::Running)
+    }
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/message.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/message.rs
@@ -1,0 +1,47 @@
+use modkit_db::secure::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "messages")]
+#[secure(tenant_col = "tenant_id", resource_col = "id", no_owner, no_type)]
+#[allow(clippy::struct_field_names)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    pub request_id: Option<Uuid>,
+    pub role: MessageRole,
+    #[sea_orm(column_type = "Text")]
+    pub content: String,
+    pub content_type: String,
+    pub token_estimate: i32,
+    pub provider_response_id: Option<String>,
+    pub request_kind: Option<String>,
+    #[sea_orm(column_type = "JsonBinary")]
+    pub features_used: serde_json::Value,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub model: Option<String>,
+    pub is_compressed: bool,
+    pub created_at: OffsetDateTime,
+    pub deleted_at: Option<OffsetDateTime>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::N(16))")]
+pub enum MessageRole {
+    #[sea_orm(string_value = "user")]
+    User,
+    #[sea_orm(string_value = "assistant")]
+    Assistant,
+    #[sea_orm(string_value = "system")]
+    System,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/mod.rs
@@ -1,0 +1,3 @@
+pub mod chat_turn;
+pub mod message;
+pub mod quota_usage;

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/quota_usage.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/quota_usage.rs
@@ -1,0 +1,47 @@
+use modkit_db::secure::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "quota_usage")]
+#[secure(
+    tenant_col = "tenant_id",
+    owner_col = "user_id",
+    resource_col = "id",
+    no_type
+)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub user_id: Uuid,
+    pub period_type: PeriodType,
+    pub period_start: time::Date,
+    pub bucket: String,
+    pub spent_credits_micro: i64,
+    pub reserved_credits_micro: i64,
+    pub calls: i32,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub file_search_calls: i32,
+    pub web_search_calls: i32,
+    pub rag_retrieval_calls: i32,
+    pub image_inputs: i32,
+    pub image_upload_bytes: i64,
+    pub updated_at: OffsetDateTime,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::N(16))")]
+pub enum PeriodType {
+    #[sea_orm(string_value = "daily")]
+    Daily,
+    #[sea_orm(string_value = "monthly")]
+    Monthly,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/mini-chat/mini-chat/src/infra/db/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/mod.rs
@@ -1,2 +1,3 @@
+pub mod entity;
 pub mod migrations;
 pub mod repo;

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
@@ -1,4 +1,96 @@
-/// Repository for message persistence operations.
+use async_trait::async_trait;
+use modkit_db::secure::{DBRunner, SecureEntityExt, secure_insert};
+use modkit_security::AccessScope;
+use sea_orm::{ColumnTrait, Condition, EntityTrait, Order, QueryFilter, Set};
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::domain::repos::{InsertAssistantMessageParams, InsertUserMessageParams};
+use crate::infra::db::entity::message::{
+    ActiveModel, Column, Entity as MessageEntity, MessageRole, Model as MessageModel,
+};
+
 pub struct MessageRepository;
 
-impl crate::domain::repos::MessageRepository for MessageRepository {}
+#[async_trait]
+impl crate::domain::repos::MessageRepository for MessageRepository {
+    async fn insert_user_message<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: InsertUserMessageParams,
+    ) -> Result<MessageModel, DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let am = ActiveModel {
+            id: Set(params.id),
+            tenant_id: Set(params.tenant_id),
+            chat_id: Set(params.chat_id),
+            request_id: Set(Some(params.request_id)),
+            role: Set(MessageRole::User),
+            content: Set(params.content),
+            content_type: Set("text".to_owned()),
+            token_estimate: Set(0),
+            provider_response_id: Set(None),
+            request_kind: Set(Some("chat".to_owned())),
+            features_used: Set(serde_json::json!([])),
+            input_tokens: Set(0),
+            output_tokens: Set(0),
+            model: Set(None),
+            is_compressed: Set(false),
+            created_at: Set(now),
+            deleted_at: Set(None),
+        };
+        Ok(secure_insert::<MessageEntity>(am, scope, runner).await?)
+    }
+
+    async fn insert_assistant_message<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: InsertAssistantMessageParams,
+    ) -> Result<MessageModel, DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let am = ActiveModel {
+            id: Set(params.id),
+            tenant_id: Set(params.tenant_id),
+            chat_id: Set(params.chat_id),
+            request_id: Set(Some(params.request_id)),
+            role: Set(MessageRole::Assistant),
+            content: Set(params.content),
+            content_type: Set("text".to_owned()),
+            token_estimate: Set(0),
+            provider_response_id: Set(params.provider_response_id),
+            request_kind: Set(Some("chat".to_owned())),
+            features_used: Set(serde_json::json!([])),
+            input_tokens: Set(params.input_tokens.unwrap_or(0)),
+            output_tokens: Set(params.output_tokens.unwrap_or(0)),
+            model: Set(params.model),
+            is_compressed: Set(false),
+            created_at: Set(now),
+            deleted_at: Set(None),
+        };
+        Ok(secure_insert::<MessageEntity>(am, scope, runner).await?)
+    }
+
+    async fn find_by_chat_and_request_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<Vec<MessageModel>, DomainError> {
+        Ok(MessageEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::RequestId.eq(request_id))
+                    .add(Column::DeletedAt.is_null()),
+            )
+            .secure()
+            .scope_with(scope)
+            .order_by(Column::CreatedAt, Order::Asc)
+            .all(runner)
+            .await?)
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/quota_usage_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/quota_usage_repo.rs
@@ -1,4 +1,150 @@
-/// Repository for quota usage persistence operations.
+use async_trait::async_trait;
+use modkit_db::secure::{
+    DBRunner, SecureEntityExt, SecureInsertExt, SecureOnConflict, SecureUpdateExt,
+};
+use modkit_security::AccessScope;
+use sea_orm::sea_query::Expr;
+use sea_orm::{ActiveEnum, ColumnTrait, Condition, EntityTrait, QueryFilter, Set};
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::domain::repos::{IncrementReserveParams, SettleParams};
+use crate::infra::db::entity::quota_usage::{
+    ActiveModel, Column, Entity as QuotaUsageEntity, Model as QuotaUsageModel,
+};
+
 pub struct QuotaUsageRepository;
 
-impl crate::domain::repos::QuotaUsageRepository for QuotaUsageRepository {}
+#[async_trait]
+impl crate::domain::repos::QuotaUsageRepository for QuotaUsageRepository {
+    async fn increment_reserve<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: IncrementReserveParams,
+    ) -> Result<(), DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let id = Uuid::new_v4();
+
+        let am = ActiveModel {
+            id: Set(id),
+            tenant_id: Set(params.tenant_id),
+            user_id: Set(params.user_id),
+            period_type: Set(params.period_type),
+            period_start: Set(params.period_start),
+            bucket: Set(params.bucket),
+            spent_credits_micro: Set(0),
+            reserved_credits_micro: Set(params.amount_micro),
+            calls: Set(0),
+            input_tokens: Set(0),
+            output_tokens: Set(0),
+            file_search_calls: Set(0),
+            web_search_calls: Set(0),
+            rag_retrieval_calls: Set(0),
+            image_inputs: Set(0),
+            image_upload_bytes: Set(0),
+            updated_at: Set(now),
+        };
+
+        // ON CONFLICT: increment reserved_credits_micro and refresh updated_at.
+        let on_conflict = SecureOnConflict::<QuotaUsageEntity>::columns([
+            Column::TenantId,
+            Column::UserId,
+            Column::PeriodType,
+            Column::PeriodStart,
+            Column::Bucket,
+        ])
+        .value(
+            Column::ReservedCreditsMicro,
+            Expr::col(Column::ReservedCreditsMicro).add(Expr::value(params.amount_micro)),
+        )?
+        .value(Column::UpdatedAt, Expr::value(now))?;
+
+        QuotaUsageEntity::insert(am)
+            .secure()
+            .scope_unchecked(scope)?
+            .on_conflict(on_conflict)
+            .exec(runner)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn settle<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: SettleParams,
+    ) -> Result<(), DomainError> {
+        let now = OffsetDateTime::now_utc();
+
+        // Determine if token telemetry should be updated (only for `total` bucket).
+        let is_total = params.bucket == "total";
+        let (input_delta, output_delta) = if is_total {
+            (
+                params.input_tokens.unwrap_or(0),
+                params.output_tokens.unwrap_or(0),
+            )
+        } else {
+            (0, 0)
+        };
+
+        QuotaUsageEntity::update_many()
+            .col_expr(
+                Column::ReservedCreditsMicro,
+                Expr::col(Column::ReservedCreditsMicro)
+                    .sub(Expr::value(params.reserved_credits_micro)),
+            )
+            .col_expr(
+                Column::SpentCreditsMicro,
+                Expr::col(Column::SpentCreditsMicro).add(Expr::value(params.actual_credits_micro)),
+            )
+            .col_expr(
+                Column::Calls,
+                Expr::col(Column::Calls).add(Expr::value(1i32)),
+            )
+            .col_expr(
+                Column::InputTokens,
+                Expr::col(Column::InputTokens).add(Expr::value(input_delta)),
+            )
+            .col_expr(
+                Column::OutputTokens,
+                Expr::col(Column::OutputTokens).add(Expr::value(output_delta)),
+            )
+            .col_expr(Column::UpdatedAt, Expr::value(now))
+            .filter(
+                Condition::all()
+                    .add(Column::TenantId.eq(params.tenant_id))
+                    .add(Column::UserId.eq(params.user_id))
+                    .add(Column::PeriodType.eq(params.period_type.into_value()))
+                    .add(Column::PeriodStart.eq(params.period_start))
+                    .add(Column::Bucket.eq(params.bucket)),
+            )
+            .secure()
+            .scope_with(scope)
+            .exec(runner)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn find_bucket_rows<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Vec<QuotaUsageModel>, DomainError> {
+        Ok(QuotaUsageEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::TenantId.eq(tenant_id))
+                    .add(Column::UserId.eq(user_id)),
+            )
+            .secure()
+            .scope_with(scope)
+            .all(runner)
+            .await?)
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
@@ -1,4 +1,192 @@
-/// Repository for turn persistence operations.
+use async_trait::async_trait;
+use modkit_db::secure::{DBRunner, SecureEntityExt, SecureUpdateExt, secure_insert};
+use modkit_security::AccessScope;
+use sea_orm::sea_query::Expr;
+use sea_orm::{ActiveEnum, ColumnTrait, Condition, EntityTrait, Order, QueryFilter, Set};
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::domain::repos::{CasCompleteParams, CasTerminalParams, CreateTurnParams};
+use crate::infra::db::entity::chat_turn::{
+    ActiveModel, Column, Entity as TurnEntity, Model as TurnModel, TurnState,
+};
+
 pub struct TurnRepository;
 
-impl crate::domain::repos::TurnRepository for TurnRepository {}
+#[async_trait]
+impl crate::domain::repos::TurnRepository for TurnRepository {
+    async fn create_turn<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: CreateTurnParams,
+    ) -> Result<TurnModel, DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let am = ActiveModel {
+            id: Set(params.id),
+            tenant_id: Set(params.tenant_id),
+            chat_id: Set(params.chat_id),
+            request_id: Set(params.request_id),
+            requester_type: Set(params.requester_type),
+            requester_user_id: Set(params.requester_user_id),
+            state: Set(TurnState::Running),
+            provider_name: Set(None),
+            provider_response_id: Set(None),
+            assistant_message_id: Set(None),
+            error_code: Set(None),
+            error_detail: Set(None),
+            reserve_tokens: Set(params.reserve_tokens),
+            max_output_tokens_applied: Set(params.max_output_tokens_applied),
+            reserved_credits_micro: Set(params.reserved_credits_micro),
+            policy_version_applied: Set(params.policy_version_applied),
+            effective_model: Set(params.effective_model),
+            minimal_generation_floor_applied: Set(params.minimal_generation_floor_applied),
+            deleted_at: Set(None),
+            replaced_by_request_id: Set(None),
+            started_at: Set(now),
+            completed_at: Set(None),
+            updated_at: Set(now),
+        };
+        Ok(secure_insert::<TurnEntity>(am, scope, runner).await?)
+    }
+
+    async fn find_by_chat_and_request_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<Option<TurnModel>, DomainError> {
+        Ok(TurnEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::RequestId.eq(request_id)),
+            )
+            .secure()
+            .scope_with(scope)
+            .one(runner)
+            .await?)
+    }
+
+    async fn find_running_by_chat_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<TurnModel>, DomainError> {
+        Ok(TurnEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::State.eq(TurnState::Running))
+                    .add(Column::DeletedAt.is_null()),
+            )
+            .secure()
+            .scope_with(scope)
+            .one(runner)
+            .await?)
+    }
+
+    async fn cas_update_state<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: CasTerminalParams,
+    ) -> Result<u64, DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let result = TurnEntity::update_many()
+            .col_expr(Column::State, Expr::value(params.state.into_value()))
+            .col_expr(Column::ErrorCode, Expr::value(params.error_code))
+            .col_expr(Column::ErrorDetail, Expr::value(params.error_detail))
+            .col_expr(Column::CompletedAt, Expr::value(now))
+            .col_expr(Column::UpdatedAt, Expr::value(now))
+            .filter(
+                Condition::all()
+                    .add(Column::Id.eq(params.turn_id))
+                    .add(Column::State.eq(TurnState::Running)),
+            )
+            .secure()
+            .scope_with(scope)
+            .exec(runner)
+            .await?;
+        Ok(result.rows_affected)
+    }
+
+    async fn cas_update_completed<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: CasCompleteParams,
+    ) -> Result<u64, DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let result = TurnEntity::update_many()
+            .col_expr(
+                Column::State,
+                Expr::value(TurnState::Completed.into_value()),
+            )
+            .col_expr(
+                Column::AssistantMessageId,
+                Expr::value(Some(params.assistant_message_id)),
+            )
+            .col_expr(
+                Column::ProviderResponseId,
+                Expr::value(params.provider_response_id),
+            )
+            .col_expr(Column::CompletedAt, Expr::value(now))
+            .col_expr(Column::UpdatedAt, Expr::value(now))
+            .filter(
+                Condition::all()
+                    .add(Column::Id.eq(params.turn_id))
+                    .add(Column::State.eq(TurnState::Running)),
+            )
+            .secure()
+            .scope_with(scope)
+            .exec(runner)
+            .await?;
+        Ok(result.rows_affected)
+    }
+
+    async fn soft_delete<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        turn_id: Uuid,
+        replaced_by_request_id: Option<Uuid>,
+    ) -> Result<(), DomainError> {
+        let now = OffsetDateTime::now_utc();
+        TurnEntity::update_many()
+            .col_expr(Column::DeletedAt, Expr::value(Some(now)))
+            .col_expr(
+                Column::ReplacedByRequestId,
+                Expr::value(replaced_by_request_id),
+            )
+            .col_expr(Column::UpdatedAt, Expr::value(now))
+            .filter(Column::Id.eq(turn_id))
+            .secure()
+            .scope_with(scope)
+            .exec(runner)
+            .await?;
+        Ok(())
+    }
+
+    async fn find_latest_turn<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<TurnModel>, DomainError> {
+        Ok(TurnEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::DeletedAt.is_null()),
+            )
+            .secure()
+            .scope_with(scope)
+            .order_by(Column::StartedAt, Order::Desc)
+            .one(runner)
+            .await?)
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/llm/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/mod.rs
@@ -1,0 +1,588 @@
+//! Provider-agnostic LLM integration layer.
+//!
+//! This module defines shared types, the [`LlmProvider`] trait, and
+//! [`ProviderStream`] for communicating with LLM providers via OAGW.
+//! Provider-specific adapters live in [`providers`].
+//!
+//! # Architecture
+//!
+//! ```text
+//! Consumer → LlmProvider::stream() → OAGW (proxy_request) → Provider
+//!                                   ← ProviderStream (ClientSseEvent items)
+//!                                   ← TerminalOutcome (via into_outcome)
+//! ```
+
+pub mod providers;
+pub mod request;
+
+use std::pin::Pin;
+use std::sync::LazyLock;
+use std::task::{Context, Poll};
+
+use futures::Stream;
+use futures::StreamExt;
+use oagw_sdk::SecurityContext;
+use oagw_sdk::error::{ServiceGatewayError, StreamingError};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+use utoipa::ToSchema;
+
+// Re-export commonly used request types.
+pub use request::{
+    Feature, LlmMessage, LlmRequest, LlmRequestBuilder, LlmTool, RequestMetadata, RequestType,
+    Role, UserIdentity,
+};
+
+// Re-export provider factory types.
+pub use providers::{ProviderConfig, ProviderKind, create_provider};
+
+// ════════════════════════════════════════════════════════════════════════════
+// Streaming mode markers
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Marker: request will be sent as streaming SSE.
+pub struct Streaming;
+/// Marker: request will be sent as single JSON response.
+pub struct NonStreaming;
+
+// ════════════════════════════════════════════════════════════════════════════
+// Error types
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Errors from the LLM provider layer.
+///
+/// Variants containing provider-originated text apply sanitization at
+/// construction time — no provider IDs, URLs, or credentials leak.
+#[derive(Debug, thiserror::Error)]
+pub enum LlmProviderError {
+    /// Provider returned 429 (after OAGW retry exhaustion).
+    #[error("rate limited")]
+    RateLimited { retry_after_secs: Option<u64> },
+
+    /// Connection or request timeout from OAGW.
+    #[error("provider timeout")]
+    Timeout,
+
+    /// Provider returned an error response (sanitized).
+    #[error("provider error: {code}: {message}")]
+    ProviderError {
+        code: String,
+        /// Sanitized message safe for client exposure.
+        message: String,
+        /// Raw unsanitized detail for internal logging only.
+        #[source]
+        raw_detail: Option<RawDetail>,
+    },
+
+    /// Upstream disabled or unreachable.
+    #[error("provider unavailable")]
+    ProviderUnavailable,
+
+    /// Unparseable provider response.
+    #[error("invalid response: {detail}")]
+    InvalidResponse { detail: String },
+
+    /// SSE stream-level error from oagw-sdk.
+    #[error("stream error: {0}")]
+    StreamError(#[from] StreamingError),
+}
+
+/// Wrapper for raw error detail (private, only accessible via `raw_detail()`).
+pub struct RawDetail(pub(crate) String);
+
+impl std::fmt::Debug for RawDetail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("RawDetail").field(&self.0).finish()
+    }
+}
+
+impl std::fmt::Display for RawDetail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for RawDetail {}
+
+impl LlmProviderError {
+    /// Raw unsanitized error detail for internal logging/persistence.
+    /// Stored in `chat_turns.error_detail`, never exposed via API.
+    #[must_use]
+    pub fn raw_detail(&self) -> Option<&str> {
+        match self {
+            LlmProviderError::ProviderError {
+                raw_detail: Some(rd),
+                ..
+            } => Some(&rd.0),
+            _ => None,
+        }
+    }
+}
+
+#[allow(clippy::unwrap_used)] // Compile-time-known regex patterns; panics in init are intentional
+static RE_RESP_ID: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(resp_|chatcmpl-|cmpl-|msg_)[A-Za-z0-9]+").unwrap());
+#[allow(clippy::unwrap_used)]
+static RE_URL: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"https?://[^\s,\])}"']+"#).unwrap());
+#[allow(clippy::unwrap_used)]
+static RE_CRED: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(sk-[A-Za-z0-9]{10,}|Bearer\s+[A-Za-z0-9._\-]+)").unwrap());
+
+/// Regex-based scrubbing of provider response IDs, URLs, and credential fragments.
+pub(crate) fn sanitize_provider_message(msg: &str) -> String {
+    let sanitized = RE_RESP_ID.replace_all(msg, "[provider_id]");
+    let sanitized = RE_URL.replace_all(&sanitized, "[url]");
+    RE_CRED.replace_all(&sanitized, "[credential]").into_owned()
+}
+
+impl From<ServiceGatewayError> for LlmProviderError {
+    fn from(err: ServiceGatewayError) -> Self {
+        match err {
+            ServiceGatewayError::RateLimitExceeded {
+                retry_after_secs, ..
+            } => LlmProviderError::RateLimited { retry_after_secs },
+
+            ServiceGatewayError::ConnectionTimeout { .. }
+            | ServiceGatewayError::RequestTimeout { .. } => LlmProviderError::Timeout,
+
+            ServiceGatewayError::UpstreamDisabled { .. } => LlmProviderError::ProviderUnavailable,
+
+            other => {
+                let raw = other.to_string();
+                let sanitized = sanitize_provider_message(&raw);
+                LlmProviderError::ProviderError {
+                    code: "gateway_error".to_owned(),
+                    message: sanitized,
+                    raw_detail: Some(RawDetail(raw)),
+                }
+            }
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Usage, Citation, Response types
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Token usage counters.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+pub struct Usage {
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+}
+
+/// A citation extracted from provider annotations.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct Citation {
+    pub source: CitationSource,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attachment_id: Option<String>,
+    pub snippet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub span: Option<TextSpan>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CitationSource {
+    File,
+    Web,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, ToSchema)]
+pub struct TextSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// Successful LLM response (non-streaming path).
+#[derive(Debug)]
+pub struct ResponseResult {
+    pub content: String,
+    pub usage: Usage,
+    pub response_id: String,
+    pub citations: Vec<Citation>,
+    pub raw_response: serde_json::Value,
+}
+
+/// Terminal outcome when a stream ends.
+#[derive(Debug)]
+pub enum TerminalOutcome {
+    /// Provider completed successfully.
+    Completed {
+        usage: Usage,
+        response_id: String,
+        content: String,
+        citations: Vec<Citation>,
+        raw_response: serde_json::Value,
+    },
+    /// Provider returned an error or stream failed.
+    Failed {
+        error: LlmProviderError,
+        usage: Option<Usage>,
+        partial_content: String,
+    },
+    /// Provider stopped early (e.g., `max_output_tokens` hit).
+    Incomplete {
+        reason: String,
+        usage: Usage,
+        partial_content: String,
+    },
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Translated events (internal)
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Result of translating a provider event.
+///
+/// Produced by adapter streams, consumed by [`ProviderStream`] which
+/// intercepts `Terminal` and `Skip`, only yielding `Sse` to consumers.
+#[derive(Debug)]
+pub(crate) enum TranslatedEvent {
+    /// Forward to client as an SSE event.
+    Sse(ClientSseEvent),
+    /// Terminal outcome — captured by `ProviderStream`, not yielded.
+    Terminal(TerminalOutcome),
+    /// No client-visible action.
+    Skip,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Client SSE events
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A client-facing SSE event payload (before SSE framing).
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "event", content = "data")]
+pub enum ClientSseEvent {
+    /// Incremental text chunk.
+    #[serde(rename = "delta")]
+    Delta {
+        r#type: &'static str,
+        content: String,
+    },
+    /// Tool lifecycle event.
+    #[serde(rename = "tool")]
+    Tool {
+        phase: ToolPhase,
+        name: &'static str,
+        details: serde_json::Value,
+    },
+    /// Citations from provider annotations.
+    #[serde(rename = "citations")]
+    Citations { items: Vec<Citation> },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolPhase {
+    Start,
+    Done,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// ProviderStream
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A streaming response from an LLM provider, yielding [`ClientSseEvent`]s.
+///
+/// Wraps a type-erased inner stream with cancellation and terminal capture.
+/// Implements `Stream<Item = Result<ClientSseEvent, StreamingError>>`.
+///
+/// Terminal events are captured internally — call [`into_outcome`](Self::into_outcome)
+/// after the stream ends to retrieve the final result.
+pub struct ProviderStream {
+    #[allow(clippy::type_complexity)]
+    inner: Pin<Box<dyn Stream<Item = Result<TranslatedEvent, StreamingError>> + Send>>,
+    cancel: CancellationToken,
+    terminal: Option<TerminalOutcome>,
+    accumulated_text: String,
+    finished: bool,
+}
+
+impl std::fmt::Debug for ProviderStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProviderStream")
+            .field("cancelled", &self.cancel.is_cancelled())
+            .field("finished", &self.finished)
+            .field("accumulated_len", &self.accumulated_text.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ProviderStream {
+    /// Create a new provider stream from a translated event stream.
+    pub(crate) fn new(
+        inner: impl Stream<Item = Result<TranslatedEvent, StreamingError>> + Send + 'static,
+        cancel: CancellationToken,
+    ) -> Self {
+        ProviderStream {
+            inner: Box::pin(inner),
+            cancel,
+            terminal: None,
+            accumulated_text: String::new(),
+            finished: false,
+        }
+    }
+
+    /// Cancel the stream. Drops the underlying HTTP connection.
+    pub fn cancel(&self) {
+        self.cancel.cancel();
+    }
+
+    /// Whether the stream has been cancelled.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
+
+    /// Consume the stream, draining all remaining events, and return
+    /// the terminal outcome.
+    pub async fn into_outcome(mut self) -> TerminalOutcome {
+        // Drain remaining events — terminal will be captured in poll_next
+        loop {
+            match self.next().await {
+                Some(Ok(_)) => {} // SSE events accumulated in poll_next
+                Some(Err(e)) => {
+                    return TerminalOutcome::Failed {
+                        error: LlmProviderError::StreamError(e),
+                        usage: None,
+                        partial_content: self.accumulated_text,
+                    };
+                }
+                None => break,
+            }
+        }
+
+        match self.terminal {
+            Some(terminal) => terminal,
+            None if self.cancel.is_cancelled() => TerminalOutcome::Incomplete {
+                reason: "cancelled".to_owned(),
+                usage: Usage {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                },
+                partial_content: self.accumulated_text,
+            },
+            None => TerminalOutcome::Failed {
+                error: LlmProviderError::InvalidResponse {
+                    detail: "stream ended without terminal event".to_owned(),
+                },
+                usage: None,
+                partial_content: self.accumulated_text,
+            },
+        }
+    }
+}
+
+impl Stream for ProviderStream {
+    type Item = Result<ClientSseEvent, StreamingError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        if this.finished {
+            return Poll::Ready(None);
+        }
+
+        if this.cancel.is_cancelled() {
+            this.finished = true;
+            return Poll::Ready(None);
+        }
+
+        loop {
+            match this.inner.as_mut().poll_next(cx) {
+                Poll::Ready(Some(Ok(TranslatedEvent::Sse(event)))) => {
+                    // Accumulate delta text for fallback partial_content
+                    if let ClientSseEvent::Delta { ref content, .. } = event {
+                        this.accumulated_text.push_str(content);
+                    }
+                    return Poll::Ready(Some(Ok(event)));
+                }
+                Poll::Ready(Some(Ok(TranslatedEvent::Terminal(outcome)))) => {
+                    this.finished = true;
+                    this.terminal = Some(outcome);
+                    return Poll::Ready(None);
+                }
+                Poll::Ready(Some(Ok(TranslatedEvent::Skip))) => {}
+                Poll::Ready(Some(Err(e))) => {
+                    return Poll::Ready(Some(Err(e)));
+                }
+                Poll::Ready(None) => {
+                    this.finished = true;
+                    return Poll::Ready(None);
+                }
+                Poll::Pending => {
+                    if this.cancel.is_cancelled() {
+                        this.finished = true;
+                        return Poll::Ready(None);
+                    }
+                    return Poll::Pending;
+                }
+            }
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// LlmProvider trait
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Provider-agnostic LLM trait. Each provider adapter implements this.
+#[async_trait::async_trait]
+pub trait LlmProvider: Send + Sync {
+    /// Send a streaming request. Returns a stream of SSE events.
+    async fn stream(
+        &self,
+        ctx: SecurityContext,
+        request: LlmRequest<Streaming>,
+        cancel: CancellationToken,
+    ) -> Result<ProviderStream, LlmProviderError>;
+
+    /// Send a non-streaming request. Returns the complete response.
+    async fn complete(
+        &self,
+        ctx: SecurityContext,
+        request: LlmRequest<NonStreaming>,
+    ) -> Result<ResponseResult, LlmProviderError>;
+}
+
+/// Start building a provider-agnostic LLM request with the given model.
+#[must_use]
+pub fn llm_request(model: impl Into<String>) -> LlmRequestBuilder {
+    LlmRequestBuilder::new(model)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Tests — shared types
+// ════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+#[allow(clippy::str_to_string)]
+mod tests {
+    use super::*;
+    use oagw_sdk::error::ServiceGatewayError;
+
+    #[test]
+    fn sanitize_removes_provider_response_ids() {
+        let msg = "Error in response resp_abc123xyz: rate limit exceeded";
+        let sanitized = sanitize_provider_message(msg);
+        assert!(!sanitized.contains("resp_abc123xyz"));
+        assert!(sanitized.contains("[provider_id]"));
+    }
+
+    #[test]
+    fn sanitize_removes_urls() {
+        let msg = "Error at https://api.openai.com/v1/responses: bad request";
+        let sanitized = sanitize_provider_message(msg);
+        assert!(!sanitized.contains("https://api.openai.com"));
+        assert!(sanitized.contains("[url]"));
+    }
+
+    #[test]
+    fn sanitize_removes_credentials() {
+        let msg = "Auth failed with sk-proj1234567890abcdef";
+        let sanitized = sanitize_provider_message(msg);
+        assert!(!sanitized.contains("sk-proj1234567890abcdef"));
+        assert!(sanitized.contains("[credential]"));
+    }
+
+    #[test]
+    fn sanitize_mixed_content() {
+        let msg = "resp_abc123 at https://api.openai.com with sk-test1234567890";
+        let sanitized = sanitize_provider_message(msg);
+        assert!(!sanitized.contains("resp_abc123"));
+        assert!(!sanitized.contains("https://api.openai.com"));
+        assert!(!sanitized.contains("sk-test1234567890"));
+    }
+
+    #[test]
+    fn raw_detail_preserves_original() {
+        let err = LlmProviderError::ProviderError {
+            code: "error".to_string(),
+            message: "sanitized".to_string(),
+            raw_detail: Some(RawDetail(
+                "resp_abc123 at https://api.openai.com".to_string(),
+            )),
+        };
+        assert_eq!(
+            err.raw_detail(),
+            Some("resp_abc123 at https://api.openai.com")
+        );
+    }
+
+    #[test]
+    fn gateway_rate_limit_maps_to_rate_limited() {
+        let err = ServiceGatewayError::RateLimitExceeded {
+            detail: "too many requests".into(),
+            instance: "/test".into(),
+            retry_after_secs: Some(60),
+        };
+        let mapped: LlmProviderError = err.into();
+        assert!(matches!(
+            mapped,
+            LlmProviderError::RateLimited {
+                retry_after_secs: Some(60)
+            }
+        ));
+    }
+
+    #[test]
+    fn gateway_connection_timeout_maps_to_timeout() {
+        let err = ServiceGatewayError::ConnectionTimeout {
+            detail: "timed out".into(),
+            instance: "/test".into(),
+        };
+        let mapped: LlmProviderError = err.into();
+        assert!(matches!(mapped, LlmProviderError::Timeout));
+    }
+
+    #[test]
+    fn gateway_request_timeout_maps_to_timeout() {
+        let err = ServiceGatewayError::RequestTimeout {
+            detail: "timed out".into(),
+            instance: "/test".into(),
+        };
+        let mapped: LlmProviderError = err.into();
+        assert!(matches!(mapped, LlmProviderError::Timeout));
+    }
+
+    #[test]
+    fn gateway_upstream_disabled_maps_to_unavailable() {
+        let err = ServiceGatewayError::UpstreamDisabled {
+            detail: "disabled".into(),
+            instance: "/test".into(),
+        };
+        let mapped: LlmProviderError = err.into();
+        assert!(matches!(mapped, LlmProviderError::ProviderUnavailable));
+    }
+
+    #[test]
+    fn gateway_downstream_error_maps_to_provider_error() {
+        let err = ServiceGatewayError::DownstreamError {
+            detail: "resp_xyz789 failed at https://api.example.com".into(),
+            instance: "/test".into(),
+        };
+        let mapped: LlmProviderError = err.into();
+        match mapped {
+            LlmProviderError::ProviderError {
+                code,
+                message,
+                raw_detail,
+            } => {
+                assert_eq!(code, "gateway_error");
+                assert!(!message.contains("resp_xyz789"));
+                assert!(!message.contains("https://api.example.com"));
+                assert!(raw_detail.is_some());
+            }
+            _ => panic!("expected ProviderError"),
+        }
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/mod.rs
@@ -1,0 +1,53 @@
+//! Provider-specific LLM adapters.
+//!
+//! Each adapter implements [`LlmProvider`](super::LlmProvider) by converting
+//! [`LlmRequest`](super::LlmRequest) to the provider's wire format, proxying
+//! through OAGW, and translating SSE events back to `TranslatedEvent`.
+
+pub mod openai_chat;
+pub mod openai_responses;
+
+use std::sync::Arc;
+
+use oagw_sdk::ServiceGatewayClientV1;
+
+pub use openai_chat::OpenAiChatProvider;
+pub use openai_responses::OpenAiResponsesProvider;
+
+// ════════════════════════════════════════════════════════════════════════════
+// Provider selection
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Which provider adapter to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderKind {
+    /// `OpenAI` Responses API (`/v1/responses`).
+    OpenAiResponses,
+    /// `OpenAI` Chat Completions API (`/v1/chat/completions`).
+    OpenAiChatCompletions,
+}
+
+/// Configuration for a provider adapter.
+#[derive(Debug, Clone)]
+pub struct ProviderConfig {
+    /// Which provider adapter to use.
+    pub kind: ProviderKind,
+    /// OAGW upstream alias (e.g., "openai", "azure-openai", "anthropic").
+    pub upstream_alias: String,
+}
+
+/// Create a provider adapter from configuration.
+#[must_use]
+pub fn create_provider(
+    gateway: Arc<dyn ServiceGatewayClientV1>,
+    config: ProviderConfig,
+) -> Arc<dyn super::LlmProvider> {
+    match config.kind {
+        ProviderKind::OpenAiResponses => {
+            Arc::new(OpenAiResponsesProvider::new(gateway, config.upstream_alias))
+        }
+        ProviderKind::OpenAiChatCompletions => {
+            Arc::new(OpenAiChatProvider::new(gateway, config.upstream_alias))
+        }
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_chat.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_chat.rs
@@ -1,0 +1,1250 @@
+//! `OpenAI` Chat Completions API adapter (`/v1/chat/completions`).
+//!
+//! Implements [`LlmProvider`] by converting [`LlmRequest`] to the Chat
+//! Completions API format, proxying through OAGW, parsing SSE events, and
+//! translating them to the shared `TranslatedEvent` contract.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::StreamExt;
+use oagw_sdk::error::StreamingError;
+use oagw_sdk::sse::{FromServerEvent, ServerEvent, ServerEventsResponse, ServerEventsStream};
+use oagw_sdk::{Body, SecurityContext, ServiceGatewayClientV1};
+use serde::Deserialize;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+use crate::infra::llm::request::{ContentPart as MessageContentPart, LlmTool, Role};
+use crate::infra::llm::{
+    ClientSseEvent, LlmProviderError, LlmRequest, NonStreaming, ProviderStream, RawDetail,
+    ResponseResult, Streaming, TerminalOutcome, ToolPhase, TranslatedEvent, Usage,
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// Chat Completions SSE event types
+// ════════════════════════════════════════════════════════════════════════════
+
+#[derive(Debug)]
+enum ChatCompletionEvent {
+    /// Text content delta.
+    Delta {
+        content: String,
+        chunk_id: Option<String>,
+    },
+    /// Tool call delta (streamed incrementally).
+    ToolCallDelta {
+        index: usize,
+        id: Option<String>,
+        name: Option<String>,
+        arguments: Option<String>,
+        /// Additional tool-call deltas from the same chunk.
+        extra: Vec<ToolCallPiece>,
+    },
+    /// Chunk with `finish_reason` set (but usage may arrive in a later chunk).
+    FinishReason { finish_reason: String },
+    /// Final usage-only chunk (empty choices, populated usage).
+    Usage { usage: ChatUsage },
+    /// Combined finish + usage in a single chunk.
+    Done {
+        usage: ChatUsage,
+        finish_reason: String,
+    },
+    /// `data: [DONE]` sentinel.
+    StreamEnd,
+    /// Unrecognized chunk (ignored).
+    Unknown,
+}
+
+/// A single tool-call delta extracted from the chunk.
+#[derive(Debug)]
+struct ToolCallPiece {
+    index: usize,
+    id: Option<String>,
+    name: Option<String>,
+    arguments: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatUsage {
+    prompt_tokens: i64,
+    completion_tokens: i64,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// SSE deserialization helpers
+// ════════════════════════════════════════════════════════════════════════════
+
+#[derive(Deserialize)]
+struct ChatChunk {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    choices: Vec<ChatChoice>,
+    #[serde(default)]
+    usage: Option<ChatUsage>,
+}
+
+#[derive(Deserialize)]
+struct ChatChoice {
+    #[serde(default)]
+    delta: Option<ChatDelta>,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ChatDelta {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<ChatDeltaToolCall>>,
+}
+
+#[derive(Deserialize)]
+struct ChatDeltaToolCall {
+    index: usize,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<ChatDeltaFunction>,
+}
+
+#[derive(Deserialize)]
+struct ChatDeltaFunction {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// FromServerEvent
+// ════════════════════════════════════════════════════════════════════════════
+
+impl FromServerEvent for ChatCompletionEvent {
+    fn from_server_event(event: ServerEvent) -> Result<Self, StreamingError> {
+        let data = event.data.trim();
+
+        // [DONE] sentinel
+        if data == "[DONE]" {
+            return Ok(ChatCompletionEvent::StreamEnd);
+        }
+
+        let chunk: ChatChunk =
+            serde_json::from_str(data).map_err(|e| StreamingError::ServerEventsParse {
+                detail: format!("failed to parse chat completion chunk: {e}"),
+            })?;
+
+        let finish_reason = chunk.choices.first().and_then(|c| c.finish_reason.clone());
+
+        // Usage-only chunk: empty choices with populated usage (final chunk
+        // when stream_options.include_usage = true).
+        if chunk.choices.is_empty() {
+            if let Some(usage) = chunk.usage {
+                return Ok(ChatCompletionEvent::Usage { usage });
+            }
+            return Ok(ChatCompletionEvent::Unknown);
+        }
+
+        // Combined finish + usage in a single chunk.
+        if let (Some(reason), Some(usage)) = (finish_reason.clone(), chunk.usage) {
+            return Ok(ChatCompletionEvent::Done {
+                usage,
+                finish_reason: reason,
+            });
+        }
+
+        // Finish reason without usage — usage arrives in a later chunk.
+        if let Some(reason) = finish_reason {
+            return Ok(ChatCompletionEvent::FinishReason {
+                finish_reason: reason,
+            });
+        }
+
+        // Tool call deltas — a chunk may carry more than one.
+        if let Some(tool_calls) = chunk
+            .choices
+            .first()
+            .and_then(|c| c.delta.as_ref())
+            .and_then(|d| d.tool_calls.as_ref())
+            && let Some(tc) = tool_calls.first()
+        {
+            // Return the first delta as this event; additional deltas in the
+            // same chunk are accumulated in `translate_chat_event`.
+            return Ok(ChatCompletionEvent::ToolCallDelta {
+                index: tc.index,
+                id: tc.id.clone(),
+                name: tc.function.as_ref().and_then(|f| f.name.clone()),
+                arguments: tc.function.as_ref().and_then(|f| f.arguments.clone()),
+                extra: tool_calls
+                    .iter()
+                    .skip(1)
+                    .map(|tc| ToolCallPiece {
+                        index: tc.index,
+                        id: tc.id.clone(),
+                        name: tc.function.as_ref().and_then(|f| f.name.clone()),
+                        arguments: tc.function.as_ref().and_then(|f| f.arguments.clone()),
+                    })
+                    .collect(),
+            });
+        }
+
+        // Delta content.
+        let content = chunk
+            .choices
+            .first()
+            .and_then(|c| c.delta.as_ref())
+            .and_then(|d| d.content.clone())
+            .unwrap_or_default();
+
+        if content.is_empty() {
+            return Ok(ChatCompletionEvent::Unknown);
+        }
+
+        Ok(ChatCompletionEvent::Delta {
+            content,
+            chunk_id: chunk.id,
+        })
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Scan state + translation
+// ════════════════════════════════════════════════════════════════════════════
+
+struct AccumulatedToolCall {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+struct ChatCompletionsState {
+    accumulated_text: String,
+    finish_reason: Option<String>,
+    tool_calls: Vec<AccumulatedToolCall>,
+    response_id: String,
+}
+
+impl ChatCompletionsState {
+    fn new() -> Self {
+        Self {
+            accumulated_text: String::new(),
+            finish_reason: None,
+            tool_calls: Vec::new(),
+            response_id: String::new(),
+        }
+    }
+
+    /// Emit `Tool(Done)` events for all accumulated tool calls.
+    fn tool_call_done_events(&self) -> Vec<TranslatedEvent> {
+        self.tool_calls
+            .iter()
+            .map(|tc| {
+                TranslatedEvent::Sse(ClientSseEvent::Tool {
+                    phase: ToolPhase::Done,
+                    name: "function_call",
+                    details: serde_json::json!({
+                        "call_id": tc.id,
+                        "name": tc.name,
+                        "arguments": tc.arguments,
+                    }),
+                })
+            })
+            .collect()
+    }
+
+    fn make_terminal(&self, usage: &ChatUsage, finish_reason: &str) -> TranslatedEvent {
+        let mapped_usage = Usage {
+            input_tokens: usage.prompt_tokens,
+            output_tokens: usage.completion_tokens,
+        };
+
+        match finish_reason {
+            "length" => TranslatedEvent::Terminal(TerminalOutcome::Incomplete {
+                reason: "max_tokens".to_owned(),
+                usage: mapped_usage,
+                partial_content: self.accumulated_text.clone(),
+            }),
+            _ => TranslatedEvent::Terminal(TerminalOutcome::Completed {
+                usage: mapped_usage,
+                response_id: self.response_id.clone(),
+                content: self.accumulated_text.clone(),
+                citations: vec![],
+                raw_response: serde_json::Value::Null,
+            }),
+        }
+    }
+}
+
+/// Accumulate a single tool-call delta into state, returning a `Start` event
+/// on the first delta for an index or `Skip` for continuations.
+fn accumulate_tool_call(
+    state: &mut ChatCompletionsState,
+    index: usize,
+    id: Option<&String>,
+    name: Option<&String>,
+    arguments: Option<&String>,
+) -> Vec<TranslatedEvent> {
+    while state.tool_calls.len() <= index {
+        state.tool_calls.push(AccumulatedToolCall {
+            id: String::new(),
+            name: String::new(),
+            arguments: String::new(),
+        });
+    }
+    let tc = &mut state.tool_calls[index];
+    if let Some(id) = id {
+        tc.id.clone_from(id);
+    }
+    if let Some(name) = name {
+        tc.name.clone_from(name);
+    }
+    if let Some(args) = arguments {
+        tc.arguments.push_str(args);
+    }
+    if id.is_some() {
+        vec![TranslatedEvent::Sse(ClientSseEvent::Tool {
+            phase: ToolPhase::Start,
+            name: "function_call",
+            details: serde_json::json!({
+                "index": index,
+                "call_id": tc.id,
+                "name": tc.name,
+            }),
+        })]
+    } else {
+        vec![TranslatedEvent::Skip]
+    }
+}
+
+fn translate_chat_event(
+    event: &ChatCompletionEvent,
+    state: &mut ChatCompletionsState,
+) -> Vec<TranslatedEvent> {
+    match event {
+        ChatCompletionEvent::Delta { content, chunk_id } => {
+            if let Some(id) = chunk_id
+                && state.response_id.is_empty()
+            {
+                state.response_id.clone_from(id);
+            }
+            state.accumulated_text.push_str(content);
+            vec![TranslatedEvent::Sse(ClientSseEvent::Delta {
+                r#type: "text",
+                content: content.clone(),
+            })]
+        }
+
+        ChatCompletionEvent::ToolCallDelta {
+            index,
+            id,
+            name,
+            arguments,
+            extra,
+        } => {
+            let mut events = accumulate_tool_call(
+                state,
+                *index,
+                id.as_ref(),
+                name.as_ref(),
+                arguments.as_ref(),
+            );
+            for piece in extra {
+                events.extend(accumulate_tool_call(
+                    state,
+                    piece.index,
+                    piece.id.as_ref(),
+                    piece.name.as_ref(),
+                    piece.arguments.as_ref(),
+                ));
+            }
+            events
+        }
+
+        // finish_reason arrived without usage — stash it for the usage chunk.
+        ChatCompletionEvent::FinishReason { finish_reason } => {
+            state.finish_reason = Some(finish_reason.clone());
+            // Emit Done for accumulated tool calls when finish_reason is "tool_calls".
+            if finish_reason == "tool_calls" {
+                state.tool_call_done_events()
+            } else {
+                vec![TranslatedEvent::Skip]
+            }
+        }
+
+        // Usage-only chunk (after finish_reason chunk).
+        ChatCompletionEvent::Usage { usage } => {
+            let reason = state.finish_reason.as_deref().unwrap_or("stop");
+            vec![state.make_terminal(usage, reason)]
+        }
+
+        // Combined finish + usage in one chunk.
+        ChatCompletionEvent::Done {
+            usage,
+            finish_reason,
+        } => {
+            let mut events = Vec::new();
+            if finish_reason == "tool_calls" {
+                events.extend(state.tool_call_done_events());
+            }
+            events.push(state.make_terminal(usage, finish_reason));
+            events
+        }
+
+        // [DONE] sentinel — if we have a stashed finish_reason but never got
+        // usage, emit terminal with zero usage as fallback.
+        ChatCompletionEvent::StreamEnd => {
+            if let Some(reason) = state.finish_reason.take() {
+                let zero = ChatUsage {
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                };
+                return vec![state.make_terminal(&zero, &reason)];
+            }
+            vec![TranslatedEvent::Skip]
+        }
+
+        ChatCompletionEvent::Unknown => vec![TranslatedEvent::Skip],
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// LlmRequest → Chat Completions conversion
+// ════════════════════════════════════════════════════════════════════════════
+
+fn build_request_body<M>(request: &LlmRequest<M>, stream: bool) -> serde_json::Value {
+    let mut body = serde_json::json!({});
+
+    body["model"] = serde_json::json!(&request.model);
+
+    if stream {
+        body["stream"] = serde_json::json!(true);
+        body["stream_options"] = serde_json::json!({ "include_usage": true });
+    }
+
+    // Build messages array: system instruction as first system message
+    let mut messages: Vec<serde_json::Value> = Vec::new();
+
+    if let Some(ref instructions) = request.system_instructions {
+        messages.push(serde_json::json!({
+            "role": "system",
+            "content": instructions
+        }));
+    }
+
+    for msg in &request.messages {
+        let role = match msg.role {
+            Role::User => "user",
+            Role::Assistant => "assistant",
+            Role::System => "system",
+        };
+
+        // Simple text messages use string content
+        if msg.content.len() == 1
+            && let MessageContentPart::Text { text } = &msg.content[0]
+        {
+            messages.push(serde_json::json!({
+                "role": role,
+                "content": text
+            }));
+            continue;
+        }
+
+        let content: Vec<serde_json::Value> = msg
+            .content
+            .iter()
+            .map(|part| match part {
+                MessageContentPart::Text { text } => serde_json::json!({
+                    "type": "text",
+                    "text": text
+                }),
+                MessageContentPart::Image { file_id } => serde_json::json!({
+                    "type": "image_url",
+                    "image_url": { "url": file_id }
+                }),
+            })
+            .collect();
+
+        messages.push(serde_json::json!({
+            "role": role,
+            "content": content
+        }));
+    }
+    body["messages"] = serde_json::Value::Array(messages);
+
+    if let Some(max_tokens) = request.max_output_tokens {
+        body["max_completion_tokens"] = serde_json::json!(max_tokens);
+    }
+
+    // User field: "{tenant_id}:{user_id}"
+    if let Some(ref identity) = request.user_identity {
+        body["user"] = serde_json::json!(format!("{}:{}", identity.tenant_id, identity.user_id));
+    }
+
+    // Map tools: Function → Chat Completions function format, others dropped
+    let tools: Vec<serde_json::Value> = request
+        .tools
+        .iter()
+        .filter_map(|tool| match tool {
+            LlmTool::Function {
+                name,
+                description,
+                parameters,
+            } => Some(serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description,
+                    "parameters": parameters
+                }
+            })),
+            LlmTool::FileSearch { .. } => {
+                debug!("FileSearch tool not supported by Chat Completions, dropping");
+                None
+            }
+            LlmTool::WebSearch => {
+                debug!("WebSearch tool not supported by Chat Completions, dropping");
+                None
+            }
+        })
+        .collect();
+    if !tools.is_empty() {
+        body["tools"] = serde_json::Value::Array(tools);
+    }
+
+    body
+}
+
+fn body_to_bytes(body: &serde_json::Value) -> Body {
+    #[allow(clippy::expect_used)]
+    let json = serde_json::to_vec(body).expect("serde_json::Value always serializes");
+    Body::Bytes(Bytes::from(json))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// OpenAiChatProvider
+// ════════════════════════════════════════════════════════════════════════════
+
+/// `OpenAI` Chat Completions API adapter. Routes all calls through OAGW.
+#[derive(Clone)]
+pub struct OpenAiChatProvider {
+    gateway: Arc<dyn ServiceGatewayClientV1>,
+    upstream_alias: String,
+}
+
+impl OpenAiChatProvider {
+    #[must_use]
+    pub fn new(gateway: Arc<dyn ServiceGatewayClientV1>, upstream_alias: String) -> Self {
+        Self {
+            gateway,
+            upstream_alias,
+        }
+    }
+}
+
+/// Chat Completions error response payload.
+#[derive(Deserialize)]
+struct ChatErrorPayload {
+    error: ChatErrorDetail,
+}
+
+#[derive(Deserialize)]
+struct ChatErrorDetail {
+    #[serde(default)]
+    code: Option<String>,
+    #[serde(default)]
+    message: String,
+}
+
+/// Chat Completions non-streaming response.
+#[derive(Deserialize)]
+struct ChatResponse {
+    id: String,
+    choices: Vec<ChatResponseChoice>,
+    #[serde(default)]
+    usage: Option<ChatUsage>,
+}
+
+#[derive(Deserialize)]
+struct ChatResponseChoice {
+    #[serde(default)]
+    message: Option<ChatResponseMessage>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ChatResponseMessage {
+    #[serde(default)]
+    content: Option<String>,
+}
+
+#[async_trait::async_trait]
+impl crate::infra::llm::LlmProvider for OpenAiChatProvider {
+    #[tracing::instrument(
+        skip(self, ctx, request, cancel),
+        fields(model = %request.model())
+    )]
+    async fn stream(
+        &self,
+        ctx: SecurityContext,
+        request: LlmRequest<Streaming>,
+        cancel: CancellationToken,
+    ) -> Result<ProviderStream, LlmProviderError> {
+        let body = build_request_body(&request, true);
+        let uri = format!("/{}/v1/chat/completions", self.upstream_alias);
+
+        let http_request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(&uri)
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .header(http::header::ACCEPT, "text/event-stream")
+            .body(body_to_bytes(&body))
+            .map_err(|e| LlmProviderError::InvalidResponse {
+                detail: format!("failed to build HTTP request: {e}"),
+            })?;
+
+        let response = self.gateway.proxy_request(ctx, http_request).await?;
+
+        match ServerEventsStream::from_response::<ChatCompletionEvent>(response) {
+            ServerEventsResponse::Events(event_stream) => {
+                let translated = event_stream
+                    .scan(ChatCompletionsState::new(), |state, result| {
+                        let outputs: Vec<Result<TranslatedEvent, StreamingError>> = match result {
+                            Ok(event) => translate_chat_event(&event, state)
+                                .into_iter()
+                                .map(Ok)
+                                .collect(),
+                            Err(e) => vec![Err(e)],
+                        };
+                        async move { Some(futures::stream::iter(outputs)) }
+                    })
+                    .flatten();
+
+                Ok(ProviderStream::new(translated, cancel))
+            }
+            ServerEventsResponse::Response(resp) => {
+                let (_parts, body) = resp.into_parts();
+                match body.into_bytes().await {
+                    Ok(bytes) => {
+                        if let Ok(error_payload) =
+                            serde_json::from_slice::<ChatErrorPayload>(&bytes)
+                        {
+                            let raw = error_payload.error.message.clone();
+                            Err(LlmProviderError::ProviderError {
+                                code: error_payload.error.code.unwrap_or_default(),
+                                message: crate::infra::llm::sanitize_provider_message(&raw),
+                                raw_detail: Some(RawDetail(raw)),
+                            })
+                        } else {
+                            let body_str = String::from_utf8_lossy(&bytes);
+                            let snippet = crate::infra::llm::sanitize_provider_message(
+                                &body_str.chars().take(200).collect::<String>(),
+                            );
+                            Err(LlmProviderError::InvalidResponse {
+                                detail: format!(
+                                    "non-SSE response with unparseable body: {snippet}"
+                                ),
+                            })
+                        }
+                    }
+                    Err(e) => Err(LlmProviderError::InvalidResponse {
+                        detail: format!("failed to read response body: {e}"),
+                    }),
+                }
+            }
+        }
+    }
+
+    #[tracing::instrument(
+        skip(self, ctx, request),
+        fields(model = %request.model())
+    )]
+    async fn complete(
+        &self,
+        ctx: SecurityContext,
+        request: LlmRequest<NonStreaming>,
+    ) -> Result<ResponseResult, LlmProviderError> {
+        let body = build_request_body(&request, false);
+        let uri = format!("/{}/v1/chat/completions", self.upstream_alias);
+
+        let http_request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(&uri)
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .header(http::header::ACCEPT, "application/json")
+            .body(body_to_bytes(&body))
+            .map_err(|e| LlmProviderError::InvalidResponse {
+                detail: format!("failed to build HTTP request: {e}"),
+            })?;
+
+        let response = self.gateway.proxy_request(ctx, http_request).await?;
+
+        let (parts, resp_body) = response.into_parts();
+        let bytes =
+            resp_body
+                .into_bytes()
+                .await
+                .map_err(|e| LlmProviderError::InvalidResponse {
+                    detail: format!("failed to read response body: {e}"),
+                })?;
+
+        if !parts.status.is_success() {
+            if let Ok(error_payload) = serde_json::from_slice::<ChatErrorPayload>(&bytes) {
+                let raw = error_payload.error.message.clone();
+                return Err(LlmProviderError::ProviderError {
+                    code: error_payload.error.code.unwrap_or_default(),
+                    message: crate::infra::llm::sanitize_provider_message(&raw),
+                    raw_detail: Some(RawDetail(raw)),
+                });
+            }
+            let body_str = String::from_utf8_lossy(&bytes);
+            let snippet = crate::infra::llm::sanitize_provider_message(
+                &body_str.chars().take(200).collect::<String>(),
+            );
+            return Err(LlmProviderError::InvalidResponse {
+                detail: format!("HTTP {}: {snippet}", parts.status),
+            });
+        }
+
+        let resp: ChatResponse =
+            serde_json::from_slice(&bytes).map_err(|e| LlmProviderError::InvalidResponse {
+                detail: format!("failed to parse response: {e}"),
+            })?;
+
+        let content = resp
+            .choices
+            .first()
+            .and_then(|c| c.message.as_ref())
+            .and_then(|m| m.content.clone())
+            .unwrap_or_default();
+
+        let usage = resp.usage.map_or(
+            Usage {
+                input_tokens: 0,
+                output_tokens: 0,
+            },
+            |u| Usage {
+                input_tokens: u.prompt_tokens,
+                output_tokens: u.completion_tokens,
+            },
+        );
+
+        Ok(ResponseResult {
+            content,
+            usage,
+            response_id: resp.id,
+            citations: vec![],
+            raw_response: serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null),
+        })
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Tests
+// ════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infra::llm::{LlmMessage, llm_request};
+    use oagw_sdk::sse::ServerEvent;
+
+    // ── FromServerEvent tests ─────────────────────────────────────────────
+
+    #[test]
+    fn parse_text_delta() {
+        let event = ServerEvent {
+            event: None,
+            data: r#"{"choices":[{"delta":{"content":"Hello"}}]}"#.into(),
+            id: None,
+            retry: None,
+        };
+        let result = ChatCompletionEvent::from_server_event(event).unwrap();
+        assert!(matches!(result, ChatCompletionEvent::Delta { content, .. } if content == "Hello"));
+    }
+
+    #[test]
+    fn parse_done_with_usage() {
+        let event = ServerEvent {
+            event: None,
+            data: r#"{"usage":{"prompt_tokens":500,"completion_tokens":120},"choices":[{"finish_reason":"stop"}]}"#.into(),
+            id: None,
+            retry: None,
+        };
+        let result = ChatCompletionEvent::from_server_event(event).unwrap();
+        match result {
+            ChatCompletionEvent::Done {
+                usage,
+                finish_reason,
+            } => {
+                assert_eq!(usage.prompt_tokens, 500);
+                assert_eq!(usage.completion_tokens, 120);
+                assert_eq!(finish_reason, "stop");
+            }
+            _ => panic!("expected Done"),
+        }
+    }
+
+    #[test]
+    fn parse_finish_reason_without_usage() {
+        let event = ServerEvent {
+            event: None,
+            data: r#"{"choices":[{"delta":{},"finish_reason":"stop"}]}"#.into(),
+            id: None,
+            retry: None,
+        };
+        let result = ChatCompletionEvent::from_server_event(event).unwrap();
+        assert!(matches!(
+            result,
+            ChatCompletionEvent::FinishReason { finish_reason } if finish_reason == "stop"
+        ));
+    }
+
+    #[test]
+    fn parse_usage_only_chunk() {
+        let event = ServerEvent {
+            event: None,
+            data: r#"{"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":50}}"#.into(),
+            id: None,
+            retry: None,
+        };
+        let result = ChatCompletionEvent::from_server_event(event).unwrap();
+        match result {
+            ChatCompletionEvent::Usage { usage } => {
+                assert_eq!(usage.prompt_tokens, 100);
+                assert_eq!(usage.completion_tokens, 50);
+            }
+            _ => panic!("expected Usage"),
+        }
+    }
+
+    #[test]
+    fn parse_done_sentinel() {
+        let event = ServerEvent {
+            event: None,
+            data: "[DONE]".into(),
+            id: None,
+            retry: None,
+        };
+        let result = ChatCompletionEvent::from_server_event(event).unwrap();
+        assert!(matches!(result, ChatCompletionEvent::StreamEnd));
+    }
+
+    #[test]
+    fn parse_malformed_json_returns_error() {
+        let event = ServerEvent {
+            event: None,
+            data: "not json at all".into(),
+            id: None,
+            retry: None,
+        };
+        let result = ChatCompletionEvent::from_server_event(event);
+        assert!(matches!(
+            result.unwrap_err(),
+            StreamingError::ServerEventsParse { .. }
+        ));
+    }
+
+    #[test]
+    fn parse_empty_delta_is_unknown() {
+        let event = ServerEvent {
+            event: None,
+            data: r#"{"choices":[{"delta":{}}]}"#.into(),
+            id: None,
+            retry: None,
+        };
+        let result = ChatCompletionEvent::from_server_event(event).unwrap();
+        assert!(matches!(result, ChatCompletionEvent::Unknown));
+    }
+
+    // ── Translation tests ─────────────────────────────────────────────────
+
+    /// Helper: unwrap a single-event translation result.
+    fn translate_one(
+        event: &ChatCompletionEvent,
+        state: &mut ChatCompletionsState,
+    ) -> TranslatedEvent {
+        let mut events = translate_chat_event(event, state);
+        assert_eq!(events.len(), 1, "expected 1 event, got {}", events.len());
+        events.remove(0)
+    }
+
+    #[test]
+    fn translate_delta_to_sse() {
+        let event = ChatCompletionEvent::Delta {
+            content: "Hi".into(),
+            chunk_id: Some("chatcmpl-abc".into()),
+        };
+        let mut state = ChatCompletionsState::new();
+        let translated = translate_one(&event, &mut state);
+        match translated {
+            TranslatedEvent::Sse(ClientSseEvent::Delta { r#type, content }) => {
+                assert_eq!(r#type, "text");
+                assert_eq!(content, "Hi");
+            }
+            _ => panic!("expected Sse(Delta)"),
+        }
+    }
+
+    #[test]
+    fn translate_delta_captures_response_id() {
+        let mut state = ChatCompletionsState::new();
+        let delta = ChatCompletionEvent::Delta {
+            content: "Hi".into(),
+            chunk_id: Some("chatcmpl-abc123".into()),
+        };
+        translate_one(&delta, &mut state);
+        assert_eq!(state.response_id, "chatcmpl-abc123");
+
+        // Terminal should carry the response_id.
+        let done = ChatCompletionEvent::Done {
+            usage: ChatUsage {
+                prompt_tokens: 10,
+                completion_tokens: 5,
+            },
+            finish_reason: "stop".into(),
+        };
+        let translated = translate_one(&done, &mut state);
+        match translated {
+            TranslatedEvent::Terminal(TerminalOutcome::Completed { response_id, .. }) => {
+                assert_eq!(response_id, "chatcmpl-abc123");
+            }
+            _ => panic!("expected Terminal(Completed)"),
+        }
+    }
+
+    #[test]
+    fn translate_done_stop_to_completed() {
+        let event = ChatCompletionEvent::Done {
+            usage: ChatUsage {
+                prompt_tokens: 500,
+                completion_tokens: 120,
+            },
+            finish_reason: "stop".into(),
+        };
+        let mut state = ChatCompletionsState::new();
+        state.accumulated_text = "Hello world".into();
+        let translated = translate_one(&event, &mut state);
+        match translated {
+            TranslatedEvent::Terminal(TerminalOutcome::Completed { usage, content, .. }) => {
+                assert_eq!(usage.input_tokens, 500);
+                assert_eq!(usage.output_tokens, 120);
+                assert_eq!(content, "Hello world");
+            }
+            _ => panic!("expected Terminal(Completed)"),
+        }
+    }
+
+    #[test]
+    fn translate_done_length_to_incomplete() {
+        let event = ChatCompletionEvent::Done {
+            usage: ChatUsage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+            },
+            finish_reason: "length".into(),
+        };
+        let mut state = ChatCompletionsState::new();
+        state.accumulated_text = "partial".into();
+        let translated = translate_one(&event, &mut state);
+        match translated {
+            TranslatedEvent::Terminal(TerminalOutcome::Incomplete {
+                reason,
+                partial_content,
+                ..
+            }) => {
+                assert_eq!(reason, "max_tokens");
+                assert_eq!(partial_content, "partial");
+            }
+            _ => panic!("expected Terminal(Incomplete)"),
+        }
+    }
+
+    #[test]
+    fn translate_stream_end_without_finish_is_skip() {
+        let event = ChatCompletionEvent::StreamEnd;
+        let mut state = ChatCompletionsState::new();
+        let translated = translate_one(&event, &mut state);
+        assert!(matches!(translated, TranslatedEvent::Skip));
+    }
+
+    #[test]
+    fn translate_finish_then_usage_produces_completed() {
+        let mut state = ChatCompletionsState::new();
+        state.accumulated_text = "Hello".into();
+
+        // Step 1: finish_reason arrives without usage — stashed, skip
+        let finish = ChatCompletionEvent::FinishReason {
+            finish_reason: "stop".into(),
+        };
+        let translated = translate_one(&finish, &mut state);
+        assert!(matches!(translated, TranslatedEvent::Skip));
+        assert_eq!(state.finish_reason.as_deref(), Some("stop"));
+
+        // Step 2: usage-only chunk arrives — terminal with correct usage
+        let usage = ChatCompletionEvent::Usage {
+            usage: ChatUsage {
+                prompt_tokens: 100,
+                completion_tokens: 50,
+            },
+        };
+        let translated = translate_one(&usage, &mut state);
+        match translated {
+            TranslatedEvent::Terminal(TerminalOutcome::Completed { usage, content, .. }) => {
+                assert_eq!(usage.input_tokens, 100);
+                assert_eq!(usage.output_tokens, 50);
+                assert_eq!(content, "Hello");
+            }
+            _ => panic!("expected Terminal(Completed)"),
+        }
+    }
+
+    #[test]
+    fn translate_finish_length_then_usage_produces_incomplete() {
+        let mut state = ChatCompletionsState::new();
+        state.accumulated_text = "partial".into();
+
+        let finish = ChatCompletionEvent::FinishReason {
+            finish_reason: "length".into(),
+        };
+        translate_chat_event(&finish, &mut state);
+
+        let usage = ChatCompletionEvent::Usage {
+            usage: ChatUsage {
+                prompt_tokens: 200,
+                completion_tokens: 100,
+            },
+        };
+        let translated = translate_one(&usage, &mut state);
+        match translated {
+            TranslatedEvent::Terminal(TerminalOutcome::Incomplete {
+                reason,
+                usage,
+                partial_content,
+            }) => {
+                assert_eq!(reason, "max_tokens");
+                assert_eq!(usage.input_tokens, 200);
+                assert_eq!(usage.output_tokens, 100);
+                assert_eq!(partial_content, "partial");
+            }
+            _ => panic!("expected Terminal(Incomplete)"),
+        }
+    }
+
+    #[test]
+    fn translate_stream_end_with_stashed_finish_emits_terminal() {
+        let mut state = ChatCompletionsState::new();
+        state.accumulated_text = "text".into();
+        state.finish_reason = Some("stop".into());
+
+        let translated = translate_one(&ChatCompletionEvent::StreamEnd, &mut state);
+        assert!(matches!(
+            translated,
+            TranslatedEvent::Terminal(TerminalOutcome::Completed { .. })
+        ));
+    }
+
+    // ── Tool call translation tests ──────────────────────────────────────
+
+    #[test]
+    fn parse_tool_call_delta() {
+        let event = ServerEvent {
+            event: None,
+            data: r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abc","function":{"name":"get_weather","arguments":""}}]}}]}"#.into(),
+            id: None,
+            retry: None,
+        };
+        let result = ChatCompletionEvent::from_server_event(event).unwrap();
+        match result {
+            ChatCompletionEvent::ToolCallDelta {
+                index,
+                id,
+                name,
+                arguments,
+                ..
+            } => {
+                assert_eq!(index, 0);
+                assert_eq!(id.as_deref(), Some("call_abc"));
+                assert_eq!(name.as_deref(), Some("get_weather"));
+                assert_eq!(arguments.as_deref(), Some(""));
+            }
+            _ => panic!("expected ToolCallDelta"),
+        }
+    }
+
+    #[test]
+    fn translate_tool_call_start_emitted_on_first_delta() {
+        let event = ChatCompletionEvent::ToolCallDelta {
+            index: 0,
+            id: Some("call_abc".into()),
+            name: Some("get_weather".into()),
+            arguments: Some(String::new()),
+            extra: vec![],
+        };
+        let mut state = ChatCompletionsState::new();
+        let translated = translate_one(&event, &mut state);
+        match translated {
+            TranslatedEvent::Sse(ClientSseEvent::Tool {
+                phase,
+                name,
+                details,
+            }) => {
+                assert!(matches!(phase, ToolPhase::Start));
+                assert_eq!(name, "function_call");
+                assert_eq!(details["name"], "get_weather");
+                assert_eq!(details["call_id"], "call_abc");
+            }
+            _ => panic!("expected Sse(Tool)"),
+        }
+    }
+
+    #[test]
+    fn translate_tool_call_argument_deltas_are_skip() {
+        let mut state = ChatCompletionsState::new();
+
+        // First delta: Start event
+        let first = ChatCompletionEvent::ToolCallDelta {
+            index: 0,
+            id: Some("call_abc".into()),
+            name: Some("get_weather".into()),
+            arguments: Some("{\"lo".into()),
+            extra: vec![],
+        };
+        translate_one(&first, &mut state);
+
+        // Subsequent delta: Skip (arguments accumulated)
+        let cont = ChatCompletionEvent::ToolCallDelta {
+            index: 0,
+            id: None,
+            name: None,
+            arguments: Some("cation\":\"SF\"}".into()),
+            extra: vec![],
+        };
+        let translated = translate_one(&cont, &mut state);
+        assert!(matches!(translated, TranslatedEvent::Skip));
+
+        // Verify arguments were accumulated
+        assert_eq!(state.tool_calls[0].arguments, "{\"location\":\"SF\"}");
+    }
+
+    #[test]
+    fn translate_finish_tool_calls_emits_done_events() {
+        let mut state = ChatCompletionsState::new();
+
+        // Simulate accumulated tool call
+        state.tool_calls.push(AccumulatedToolCall {
+            id: "call_abc".into(),
+            name: "get_weather".into(),
+            arguments: r#"{"location":"SF"}"#.into(),
+        });
+
+        let finish = ChatCompletionEvent::FinishReason {
+            finish_reason: "tool_calls".into(),
+        };
+        let events = translate_chat_event(&finish, &mut state);
+
+        // Should emit 1 Done event for the tool call
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            TranslatedEvent::Sse(ClientSseEvent::Tool {
+                phase,
+                name,
+                details,
+            }) => {
+                assert!(matches!(phase, ToolPhase::Done));
+                assert_eq!(*name, "function_call");
+                assert_eq!(details["name"], "get_weather");
+                assert_eq!(details["arguments"], r#"{"location":"SF"}"#);
+            }
+            _ => panic!("expected Sse(Tool)"),
+        }
+    }
+
+    // ── Request serialization tests ───────────────────────────────────────
+
+    #[test]
+    fn request_basic_text() {
+        let request = llm_request("gpt-4o")
+            .message(LlmMessage::user("Hello"))
+            .system_instructions("Be helpful")
+            .max_output_tokens(4096)
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert_eq!(body["model"], "gpt-4o");
+        assert_eq!(body["max_completion_tokens"], 4096);
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["stream_options"]["include_usage"], true);
+
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "Be helpful");
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(messages[1]["content"], "Hello");
+    }
+
+    #[test]
+    fn request_multi_turn() {
+        let request = llm_request("gpt-4o")
+            .message(LlmMessage::user("Hi"))
+            .message(LlmMessage::assistant("Hello!"))
+            .message(LlmMessage::user("How are you?"))
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[1]["role"], "assistant");
+        assert_eq!(messages[2]["role"], "user");
+    }
+
+    #[test]
+    fn request_user_identity_mapped() {
+        let request = llm_request("gpt-4o")
+            .user_identity("abc", "def")
+            .message(LlmMessage::user("Hi"))
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert_eq!(body["user"], "abc:def");
+    }
+
+    #[test]
+    fn request_function_tool_mapped() {
+        let request = llm_request("gpt-4o")
+            .tool(LlmTool::Function {
+                name: "get_weather".into(),
+                description: "Get weather".into(),
+                parameters: serde_json::json!({"type": "object"}),
+            })
+            .message(LlmMessage::user("Hi"))
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["tools"][0]["function"]["name"], "get_weather");
+        assert_eq!(body["tools"][0]["function"]["description"], "Get weather");
+    }
+
+    #[test]
+    fn request_file_search_dropped() {
+        let request = llm_request("gpt-4o")
+            .tool(LlmTool::FileSearch {
+                vector_store_ids: vec!["vs-1".into()],
+            })
+            .message(LlmMessage::user("Hi"))
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert!(body.get("tools").is_none());
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
@@ -1,0 +1,1856 @@
+//! `OpenAI` Responses API adapter (`/v1/responses`).
+//!
+//! Implements [`LlmProvider`] by converting [`LlmRequest`] to the Responses
+//! API wire format, proxying through OAGW, parsing SSE events, and
+//! translating them to the shared `TranslatedEvent` contract.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::StreamExt;
+use oagw_sdk::error::StreamingError;
+use oagw_sdk::sse::{FromServerEvent, ServerEvent, ServerEventsResponse, ServerEventsStream};
+use oagw_sdk::{Body, SecurityContext, ServiceGatewayClientV1};
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+use crate::infra::llm::request::{ContentPart as MessageContentPart, LlmTool};
+use crate::infra::llm::{
+    Citation, CitationSource, ClientSseEvent, LlmProviderError, LlmRequest, NonStreaming,
+    ProviderStream, RawDetail, ResponseResult, Streaming, TerminalOutcome, TextSpan, ToolPhase,
+    TranslatedEvent, Usage,
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// Provider event types (internal)
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Raw provider SSE event from the Responses API.
+#[derive(Debug, Clone)]
+enum ProviderEvent {
+    ResponseOutputTextDelta {
+        delta: String,
+    },
+    ResponseOutputTextDone {
+        #[allow(dead_code)]
+        text: String,
+    },
+    ResponseFileSearchCallSearching,
+    ResponseFileSearchCallCompleted {
+        results: Vec<FileSearchResult>,
+    },
+    ResponseWebSearchCallSearching,
+    ResponseWebSearchCallCompleted,
+    ResponseCompleted {
+        response: ResponseObject,
+    },
+    ResponseFailed {
+        error: ProviderErrorPayload,
+    },
+    ResponseIncomplete {
+        reason: String,
+    },
+    Unknown {
+        #[allow(dead_code)]
+        event_name: String,
+    },
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Response data types
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Raw provider response object (Responses API schema).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseObject {
+    pub id: String,
+    #[serde(default)]
+    pub output: Vec<OutputItem>,
+    pub usage: RawUsage,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RawUsage {
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+}
+
+/// Provider error payload from `response.failed` event.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct ProviderErrorPayload {
+    #[serde(default)]
+    code: String,
+    #[serde(default)]
+    message: String,
+}
+
+/// `OpenAI` wraps errors in `{"error": {...}}`.
+#[derive(Deserialize)]
+struct ProviderErrorEnvelope {
+    error: ProviderErrorPayload,
+}
+
+/// Parse an error response body, handling both `{"error":{...}}` (`OpenAI`)
+/// and flat `{"code":"...","message":"..."}` shapes.
+fn parse_error_response(bytes: &[u8]) -> LlmProviderError {
+    // Try OpenAI envelope first: {"error": {"message": "...", "code": "..."}}
+    if let Ok(envelope) = serde_json::from_slice::<ProviderErrorEnvelope>(bytes) {
+        let raw = envelope.error.message.clone();
+        return LlmProviderError::ProviderError {
+            code: envelope.error.code,
+            message: crate::infra::llm::sanitize_provider_message(&envelope.error.message),
+            raw_detail: Some(RawDetail(raw)),
+        };
+    }
+
+    // Try flat shape: {"code": "...", "message": "..."}
+    if let Ok(payload) = serde_json::from_slice::<ProviderErrorPayload>(bytes)
+        && (!payload.message.is_empty() || !payload.code.is_empty())
+    {
+        let raw = payload.message.clone();
+        return LlmProviderError::ProviderError {
+            code: payload.code,
+            message: crate::infra::llm::sanitize_provider_message(&payload.message),
+            raw_detail: Some(RawDetail(raw)),
+        };
+    }
+
+    // Fallback: unparseable body
+    let body_str = String::from_utf8_lossy(bytes);
+    let snippet = crate::infra::llm::sanitize_provider_message(
+        &body_str.chars().take(200).collect::<String>(),
+    );
+    LlmProviderError::InvalidResponse {
+        detail: format!("non-SSE response with unparseable body: {snippet}"),
+    }
+}
+
+/// File search result from `response.file_search_call.completed`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileSearchResult {
+    #[serde(default)]
+    pub file_id: String,
+    #[serde(default)]
+    pub filename: String,
+    #[serde(default)]
+    pub score: f64,
+    #[serde(default)]
+    pub text: String,
+}
+
+/// An output item from the provider response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputItem {
+    #[serde(default)]
+    pub r#type: String,
+    #[serde(default)]
+    pub content: Vec<ResponseContentPart>,
+}
+
+/// A content part within an output item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResponseContentPart {
+    #[serde(default)]
+    pub r#type: String,
+    #[serde(default)]
+    pub text: String,
+    #[serde(default)]
+    pub annotations: Vec<Annotation>,
+}
+
+/// An annotation on a content part (citation source).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Annotation {
+    #[serde(default)]
+    pub r#type: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub file_id: Option<String>,
+    #[serde(default)]
+    pub start_index: Option<usize>,
+    #[serde(default)]
+    pub end_index: Option<usize>,
+    #[serde(default)]
+    pub text: Option<String>,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// SSE deserialization helpers
+// ════════════════════════════════════════════════════════════════════════════
+
+#[derive(Deserialize)]
+struct TextDeltaData {
+    delta: String,
+}
+
+#[derive(Deserialize)]
+struct TextDoneData {
+    text: String,
+}
+
+#[derive(Deserialize)]
+struct FileSearchCompletedData {
+    #[serde(default)]
+    results: Vec<FileSearchResult>,
+}
+
+#[derive(Deserialize)]
+struct ResponseCompletedData {
+    response: ResponseObject,
+}
+
+#[derive(Deserialize)]
+struct ResponseFailedData {
+    #[serde(default)]
+    error: ProviderErrorPayload,
+}
+
+#[derive(Deserialize)]
+struct ResponseIncompleteData {
+    #[serde(default)]
+    reason: String,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// FromServerEvent
+// ════════════════════════════════════════════════════════════════════════════
+
+impl FromServerEvent for ProviderEvent {
+    fn from_server_event(event: ServerEvent) -> Result<Self, StreamingError> {
+        let event_name = event.event.as_deref().unwrap_or("message");
+
+        match event_name {
+            "response.output_text.delta" => {
+                let data: TextDeltaData = serde_json::from_str(&event.data).map_err(|e| {
+                    StreamingError::ServerEventsParse {
+                        detail: format!("failed to parse text delta: {e}"),
+                    }
+                })?;
+                Ok(ProviderEvent::ResponseOutputTextDelta { delta: data.delta })
+            }
+
+            "response.output_text.done" => {
+                let data: TextDoneData = serde_json::from_str(&event.data).map_err(|e| {
+                    StreamingError::ServerEventsParse {
+                        detail: format!("failed to parse text done: {e}"),
+                    }
+                })?;
+                Ok(ProviderEvent::ResponseOutputTextDone { text: data.text })
+            }
+
+            "response.file_search_call.searching" => {
+                Ok(ProviderEvent::ResponseFileSearchCallSearching)
+            }
+
+            "response.file_search_call.completed" => {
+                let data: FileSearchCompletedData =
+                    serde_json::from_str(&event.data).map_err(|e| {
+                        StreamingError::ServerEventsParse {
+                            detail: format!("failed to parse file search completed: {e}"),
+                        }
+                    })?;
+                Ok(ProviderEvent::ResponseFileSearchCallCompleted {
+                    results: data.results,
+                })
+            }
+
+            "response.web_search_call.searching" => {
+                Ok(ProviderEvent::ResponseWebSearchCallSearching)
+            }
+
+            "response.web_search_call.completed" => {
+                Ok(ProviderEvent::ResponseWebSearchCallCompleted)
+            }
+
+            "response.completed" => {
+                let data: ResponseCompletedData =
+                    serde_json::from_str(&event.data).map_err(|e| {
+                        StreamingError::ServerEventsParse {
+                            detail: format!("failed to parse response completed: {e}"),
+                        }
+                    })?;
+                Ok(ProviderEvent::ResponseCompleted {
+                    response: data.response,
+                })
+            }
+
+            "response.failed" => {
+                let data: ResponseFailedData = serde_json::from_str(&event.data).map_err(|e| {
+                    StreamingError::ServerEventsParse {
+                        detail: format!("failed to parse response failed: {e}"),
+                    }
+                })?;
+                Ok(ProviderEvent::ResponseFailed { error: data.error })
+            }
+
+            "response.incomplete" => {
+                let data: ResponseIncompleteData =
+                    serde_json::from_str(&event.data).map_err(|e| {
+                        StreamingError::ServerEventsParse {
+                            detail: format!("failed to parse response incomplete: {e}"),
+                        }
+                    })?;
+                Ok(ProviderEvent::ResponseIncomplete {
+                    reason: data.reason,
+                })
+            }
+
+            "error" => {
+                // OpenAI sends `event: error` with the actual error details.
+                // Try nested `{"error": {...}}` shape first, then flat shape.
+                let sanitized_data = crate::infra::llm::sanitize_provider_message(&event.data);
+                tracing::warn!(data = %sanitized_data, "provider error SSE event");
+                let error =
+                    if let Ok(data) = serde_json::from_str::<ResponseFailedData>(&event.data) {
+                        data.error
+                    } else if let Ok(payload) =
+                        serde_json::from_str::<ProviderErrorPayload>(&event.data)
+                    {
+                        payload
+                    } else {
+                        ProviderErrorPayload {
+                            code: String::new(),
+                            message: event.data.clone(),
+                        }
+                    };
+                Ok(ProviderEvent::ResponseFailed { error })
+            }
+
+            other => {
+                debug!(event_name = other, data = %event.data, "unknown provider event, skipping");
+                Ok(ProviderEvent::Unknown {
+                    event_name: other.to_owned(),
+                })
+            }
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Event translation + citation extraction
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Translate a raw Responses API event into the shared contract.
+fn translate_provider_event(event: &ProviderEvent, accumulated_text: &str) -> TranslatedEvent {
+    match event {
+        ProviderEvent::ResponseOutputTextDelta { delta } => {
+            TranslatedEvent::Sse(ClientSseEvent::Delta {
+                r#type: "text",
+                content: delta.clone(),
+            })
+        }
+
+        ProviderEvent::ResponseOutputTextDone { .. } | ProviderEvent::Unknown { .. } => {
+            TranslatedEvent::Skip
+        }
+
+        ProviderEvent::ResponseFileSearchCallSearching => {
+            TranslatedEvent::Sse(ClientSseEvent::Tool {
+                phase: ToolPhase::Start,
+                name: "file_search",
+                details: serde_json::json!({}),
+            })
+        }
+
+        ProviderEvent::ResponseFileSearchCallCompleted { results } => {
+            TranslatedEvent::Sse(ClientSseEvent::Tool {
+                phase: ToolPhase::Done,
+                name: "file_search",
+                details: serde_json::json!({ "files_searched": results.len() }),
+            })
+        }
+
+        ProviderEvent::ResponseWebSearchCallSearching => {
+            TranslatedEvent::Sse(ClientSseEvent::Tool {
+                phase: ToolPhase::Start,
+                name: "web_search",
+                details: serde_json::json!({}),
+            })
+        }
+
+        ProviderEvent::ResponseWebSearchCallCompleted => {
+            TranslatedEvent::Sse(ClientSseEvent::Tool {
+                phase: ToolPhase::Done,
+                name: "web_search",
+                details: serde_json::json!({}),
+            })
+        }
+
+        ProviderEvent::ResponseCompleted { response } => {
+            let citations = extract_citations(response);
+            let usage = Usage {
+                input_tokens: response.usage.input_tokens,
+                output_tokens: response.usage.output_tokens,
+            };
+            let raw = serde_json::to_value(response).unwrap_or_default();
+            TranslatedEvent::Terminal(TerminalOutcome::Completed {
+                usage,
+                response_id: response.id.clone(),
+                content: accumulated_text.to_owned(),
+                citations,
+                raw_response: raw,
+            })
+        }
+
+        ProviderEvent::ResponseFailed { error } => {
+            let sanitized = crate::infra::llm::sanitize_provider_message(&error.message);
+            TranslatedEvent::Terminal(TerminalOutcome::Failed {
+                error: LlmProviderError::ProviderError {
+                    code: error.code.clone(),
+                    message: sanitized,
+                    raw_detail: Some(RawDetail(error.message.clone())),
+                },
+                usage: None,
+                partial_content: accumulated_text.to_owned(),
+            })
+        }
+
+        ProviderEvent::ResponseIncomplete { reason } => {
+            TranslatedEvent::Terminal(TerminalOutcome::Incomplete {
+                reason: reason.clone(),
+                usage: Usage {
+                    input_tokens: 0,
+                    output_tokens: 0,
+                },
+                partial_content: accumulated_text.to_owned(),
+            })
+        }
+    }
+}
+
+/// Extract citations from a `ResponseCompleted`'s output annotations.
+fn extract_citations(response: &ResponseObject) -> Vec<Citation> {
+    let mut citations = Vec::new();
+
+    for output_item in &response.output {
+        for content_part in &output_item.content {
+            for annotation in &content_part.annotations {
+                let citation = match annotation.r#type.as_str() {
+                    "file_citation" => Citation {
+                        source: CitationSource::File,
+                        title: annotation.title.clone(),
+                        url: None,
+                        attachment_id: annotation.file_id.clone(),
+                        snippet: annotation.text.clone().unwrap_or_default(),
+                        score: None,
+                        span: match (annotation.start_index, annotation.end_index) {
+                            (Some(start), Some(end)) => Some(TextSpan { start, end }),
+                            _ => None,
+                        },
+                    },
+                    "url_citation" => Citation {
+                        source: CitationSource::Web,
+                        title: annotation.title.clone(),
+                        url: annotation.url.clone(),
+                        attachment_id: None,
+                        snippet: annotation.text.clone().unwrap_or_default(),
+                        score: None,
+                        span: match (annotation.start_index, annotation.end_index) {
+                            (Some(start), Some(end)) => Some(TextSpan { start, end }),
+                            _ => None,
+                        },
+                    },
+                    _ => continue,
+                };
+                citations.push(citation);
+            }
+        }
+    }
+
+    citations
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// LlmRequest → Responses API conversion
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Build the Responses API JSON body from an `LlmRequest`.
+fn build_request_body<M>(request: &LlmRequest<M>, stream: bool) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "stream": stream,
+        "store": false,
+        "previous_response_id": null,
+    });
+
+    body["model"] = serde_json::json!(&request.model);
+
+    // Build Responses API input array — each LlmMessage becomes a
+    // {"type": "message", "role": "…", "content": [{type: "input_text", …}, …]}
+    let input: Vec<serde_json::Value> = request
+        .messages
+        .iter()
+        .filter(|msg| msg.role != crate::infra::llm::request::Role::System)
+        .map(|msg| {
+            let role = match msg.role {
+                crate::infra::llm::request::Role::User => "user",
+                crate::infra::llm::request::Role::Assistant => "assistant",
+                // System messages are handled via the `instructions` field above.
+                crate::infra::llm::request::Role::System => unreachable!(),
+            };
+            let content: Vec<serde_json::Value> = msg
+                .content
+                .iter()
+                .map(|part| match part {
+                    MessageContentPart::Text { text } => serde_json::json!({
+                        "type": "input_text",
+                        "text": text
+                    }),
+                    MessageContentPart::Image { file_id } => serde_json::json!({
+                        "type": "input_image",
+                        "file_id": file_id
+                    }),
+                })
+                .collect();
+            serde_json::json!({
+                "type": "message",
+                "role": role,
+                "content": content
+            })
+        })
+        .collect();
+    if !input.is_empty() {
+        body["input"] = serde_json::Value::Array(input);
+    }
+
+    if let Some(ref instructions) = request.system_instructions {
+        body["instructions"] = serde_json::json!(instructions);
+    }
+
+    if let Some(max_tokens) = request.max_output_tokens {
+        body["max_output_tokens"] = serde_json::json!(max_tokens);
+    }
+
+    // User field: "{tenant_id}:{user_id}"
+    if let Some(ref identity) = request.user_identity {
+        body["user"] = serde_json::json!(format!("{}:{}", identity.tenant_id, identity.user_id));
+    }
+
+    if let Some(ref metadata) = request.metadata {
+        body["metadata"] = serde_json::to_value(metadata).unwrap_or_default();
+    }
+
+    // Map tools: FileSearch → file_search, WebSearch → web_search_preview, Function → drop
+    let tools: Vec<serde_json::Value> = request
+        .tools
+        .iter()
+        .filter_map(|tool| match tool {
+            LlmTool::FileSearch { vector_store_ids } => Some(serde_json::json!({
+                "type": "file_search",
+                "vector_store_ids": vector_store_ids
+            })),
+            LlmTool::WebSearch => Some(serde_json::json!({
+                "type": "web_search_preview"
+            })),
+            LlmTool::Function { name, .. } => {
+                debug!(tool_name = %name, "Function tool not supported by Responses API, dropping");
+                None
+            }
+        })
+        .collect();
+    if !tools.is_empty() {
+        body["tools"] = serde_json::Value::Array(tools);
+    }
+
+    // Merge additional params
+    if let Some(ref extra) = request.additional_params
+        && let (Some(body_obj), Some(extra_obj)) = (body.as_object_mut(), extra.as_object())
+    {
+        for (k, v) in extra_obj {
+            body_obj.insert(k.clone(), v.clone());
+        }
+    }
+
+    body
+}
+
+/// Serialize a request body to `Body::Bytes`.
+#[allow(clippy::expect_used)] // serde_json::Value always serializes successfully
+fn body_to_bytes(body: &serde_json::Value) -> Body {
+    let json = serde_json::to_vec(body).expect("serde_json::Value always serializes");
+    Body::Bytes(Bytes::from(json))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// OpenAiResponsesProvider
+// ════════════════════════════════════════════════════════════════════════════
+
+/// `OpenAI` Responses API adapter. Routes all calls through OAGW.
+#[derive(Clone)]
+pub struct OpenAiResponsesProvider {
+    gateway: Arc<dyn ServiceGatewayClientV1>,
+    upstream_alias: String,
+}
+
+impl OpenAiResponsesProvider {
+    #[must_use]
+    pub fn new(gateway: Arc<dyn ServiceGatewayClientV1>, upstream_alias: String) -> Self {
+        Self {
+            gateway,
+            upstream_alias,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::infra::llm::LlmProvider for OpenAiResponsesProvider {
+    #[tracing::instrument(
+        skip(self, ctx, request, cancel),
+        fields(model = %request.model())
+    )]
+    async fn stream(
+        &self,
+        ctx: SecurityContext,
+        request: LlmRequest<Streaming>,
+        cancel: CancellationToken,
+    ) -> Result<ProviderStream, LlmProviderError> {
+        let body = build_request_body(&request, true);
+        let uri = format!("/{}/v1/responses", self.upstream_alias);
+
+        let http_request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(&uri)
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .header(http::header::ACCEPT, "text/event-stream")
+            .body(body_to_bytes(&body))
+            .map_err(|e| LlmProviderError::InvalidResponse {
+                detail: format!("failed to build HTTP request: {e}"),
+            })?;
+
+        debug!(uri = %uri, "sending streaming request to provider");
+
+        let response = self.gateway.proxy_request(ctx, http_request).await?;
+
+        match ServerEventsStream::from_response::<ProviderEvent>(response) {
+            ServerEventsResponse::Events(event_stream) => {
+                // Translate events with accumulated text state
+                let translated = event_stream.scan(String::new(), |accumulated, result| {
+                    let output = match result {
+                        Ok(event) => {
+                            if let ProviderEvent::ResponseOutputTextDelta { ref delta } = event {
+                                accumulated.push_str(delta);
+                            }
+                            Ok(translate_provider_event(&event, accumulated))
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "provider SSE stream error");
+                            Err(e)
+                        }
+                    };
+                    async move { Some(output) }
+                });
+
+                Ok(ProviderStream::new(translated, cancel))
+            }
+            ServerEventsResponse::Response(resp) => {
+                // Non-SSE response — parse as JSON error
+                let (parts, body) = resp.into_parts();
+                tracing::warn!(status = %parts.status, "provider returned non-SSE response");
+                match body.into_bytes().await {
+                    Ok(bytes) => {
+                        let body_preview = crate::infra::llm::sanitize_provider_message(
+                            &String::from_utf8_lossy(&bytes)
+                                .chars()
+                                .take(200)
+                                .collect::<String>(),
+                        );
+                        debug!(body = %body_preview, "non-SSE response body");
+                        Err(parse_error_response(&bytes))
+                    }
+                    Err(e) => Err(LlmProviderError::InvalidResponse {
+                        detail: format!("failed to read response body: {e}"),
+                    }),
+                }
+            }
+        }
+    }
+
+    #[tracing::instrument(
+        skip(self, ctx, request),
+        fields(model = %request.model())
+    )]
+    async fn complete(
+        &self,
+        ctx: SecurityContext,
+        request: LlmRequest<NonStreaming>,
+    ) -> Result<ResponseResult, LlmProviderError> {
+        let body = build_request_body(&request, false);
+        let uri = format!("/{}/v1/responses", self.upstream_alias);
+
+        let http_request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(&uri)
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .header(http::header::ACCEPT, "application/json")
+            .body(body_to_bytes(&body))
+            .map_err(|e| LlmProviderError::InvalidResponse {
+                detail: format!("failed to build HTTP request: {e}"),
+            })?;
+
+        let response = self.gateway.proxy_request(ctx, http_request).await?;
+
+        let (parts, resp_body) = response.into_parts();
+        let bytes =
+            resp_body
+                .into_bytes()
+                .await
+                .map_err(|e| LlmProviderError::InvalidResponse {
+                    detail: format!("failed to read response body: {e}"),
+                })?;
+
+        if !parts.status.is_success() {
+            return Err(parse_error_response(&bytes));
+        }
+
+        let response_obj: ResponseObject =
+            serde_json::from_slice(&bytes).map_err(|_| parse_error_response(&bytes))?;
+
+        let citations = extract_citations(&response_obj);
+
+        // Extract text content from output
+        let content = response_obj
+            .output
+            .iter()
+            .flat_map(|item| &item.content)
+            .filter(|part| part.r#type == "output_text")
+            .map(|part| part.text.as_str())
+            .collect::<Vec<_>>()
+            .join("");
+
+        let usage = Usage {
+            input_tokens: response_obj.usage.input_tokens,
+            output_tokens: response_obj.usage.output_tokens,
+        };
+
+        let raw = serde_json::to_value(&response_obj).unwrap_or_default();
+
+        Ok(ResponseResult {
+            content,
+            usage,
+            response_id: response_obj.id,
+            citations,
+            raw_response: raw,
+        })
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Tests
+// ════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+#[allow(clippy::str_to_string)]
+mod tests {
+    use super::*;
+    use crate::infra::llm::request::{Feature, RequestMetadata, RequestType};
+    use crate::infra::llm::{LlmMessage, LlmProvider, LlmTool, llm_request};
+
+    use std::sync::Mutex;
+
+    use futures::StreamExt;
+    use oagw_sdk::error::ServiceGatewayError;
+    use oagw_sdk::models::*;
+
+    // ── MockGateway ───────────────────────────────────────────────────────
+
+    /// What the mock should return from `proxy_request`.
+    enum MockResponse {
+        /// Return an SSE stream from raw byte chunks.
+        Sse(Vec<String>),
+        /// Return a JSON body (non-SSE).
+        Json(serde_json::Value),
+        /// Return a `ServiceGatewayError`.
+        Error(ServiceGatewayError),
+    }
+
+    struct MockGateway {
+        response: Mutex<Option<MockResponse>>,
+        last_request: Mutex<Option<(String, String)>>, // (uri, body)
+    }
+
+    impl MockGateway {
+        fn returning_sse(events: Vec<String>) -> Arc<Self> {
+            Arc::new(MockGateway {
+                response: Mutex::new(Some(MockResponse::Sse(events))),
+                last_request: Mutex::new(None),
+            })
+        }
+
+        fn returning_json(json: serde_json::Value) -> Arc<Self> {
+            Arc::new(MockGateway {
+                response: Mutex::new(Some(MockResponse::Json(json))),
+                last_request: Mutex::new(None),
+            })
+        }
+
+        fn returning_error(err: ServiceGatewayError) -> Arc<Self> {
+            Arc::new(MockGateway {
+                response: Mutex::new(Some(MockResponse::Error(err))),
+                last_request: Mutex::new(None),
+            })
+        }
+
+        fn last_request_uri(&self) -> Option<String> {
+            self.last_request
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|(u, _)| u.clone())
+        }
+
+        fn last_request_body(&self) -> Option<String> {
+            self.last_request
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|(_, b)| b.clone())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ServiceGatewayClientV1 for MockGateway {
+        async fn create_upstream(
+            &self,
+            _: SecurityContext,
+            _: CreateUpstreamRequest,
+        ) -> Result<Upstream, ServiceGatewayError> {
+            unimplemented!()
+        }
+        async fn get_upstream(
+            &self,
+            _: SecurityContext,
+            _: uuid::Uuid,
+        ) -> Result<Upstream, ServiceGatewayError> {
+            unimplemented!()
+        }
+        async fn list_upstreams(
+            &self,
+            _: SecurityContext,
+            _: &ListQuery,
+        ) -> Result<Vec<Upstream>, ServiceGatewayError> {
+            unimplemented!()
+        }
+        async fn update_upstream(
+            &self,
+            _: SecurityContext,
+            _: uuid::Uuid,
+            _: UpdateUpstreamRequest,
+        ) -> Result<Upstream, ServiceGatewayError> {
+            unimplemented!()
+        }
+        async fn delete_upstream(
+            &self,
+            _: SecurityContext,
+            _: uuid::Uuid,
+        ) -> Result<(), ServiceGatewayError> {
+            unimplemented!()
+        }
+        async fn create_route(
+            &self,
+            _: SecurityContext,
+            _: CreateRouteRequest,
+        ) -> Result<Route, ServiceGatewayError> {
+            unimplemented!()
+        }
+        async fn get_route(
+            &self,
+            _: SecurityContext,
+            _: uuid::Uuid,
+        ) -> Result<Route, ServiceGatewayError> {
+            unimplemented!()
+        }
+        async fn list_routes(
+            &self,
+            _: SecurityContext,
+            _: uuid::Uuid,
+            _: &ListQuery,
+        ) -> Result<Vec<Route>, ServiceGatewayError> {
+            unimplemented!()
+        }
+        async fn update_route(
+            &self,
+            _: SecurityContext,
+            _: uuid::Uuid,
+            _: UpdateRouteRequest,
+        ) -> Result<Route, ServiceGatewayError> {
+            unimplemented!()
+        }
+        async fn delete_route(
+            &self,
+            _: SecurityContext,
+            _: uuid::Uuid,
+        ) -> Result<(), ServiceGatewayError> {
+            unimplemented!()
+        }
+        async fn resolve_upstream(
+            &self,
+            _: SecurityContext,
+            _: &str,
+        ) -> Result<Upstream, ServiceGatewayError> {
+            unimplemented!()
+        }
+        async fn resolve_route(
+            &self,
+            _: SecurityContext,
+            _: uuid::Uuid,
+            _: &str,
+            _: &str,
+        ) -> Result<Route, ServiceGatewayError> {
+            unimplemented!()
+        }
+
+        async fn proxy_request(
+            &self,
+            _ctx: SecurityContext,
+            req: http::Request<Body>,
+        ) -> Result<http::Response<Body>, ServiceGatewayError> {
+            let uri = req.uri().to_string();
+            let (_parts, body) = req.into_parts();
+            let body_bytes = body.into_bytes().await.unwrap_or_default();
+            let body_str = String::from_utf8_lossy(&body_bytes).to_string();
+            *self.last_request.lock().unwrap() = Some((uri, body_str));
+
+            let mock_resp = self
+                .response
+                .lock()
+                .unwrap()
+                .take()
+                .expect("MockGateway response already consumed");
+
+            match mock_resp {
+                MockResponse::Sse(events) => {
+                    let mut sse_bytes = String::new();
+                    for event_str in &events {
+                        sse_bytes.push_str(event_str);
+                        sse_bytes.push_str("\n\n");
+                    }
+                    let body = Body::Stream(Box::pin(futures::stream::once(async move {
+                        Ok(Bytes::from(sse_bytes))
+                    })));
+
+                    let response = http::Response::builder()
+                        .status(200)
+                        .header("content-type", "text/event-stream")
+                        .body(body)
+                        .unwrap();
+                    Ok(response)
+                }
+                MockResponse::Json(json) => {
+                    let body = Body::Bytes(Bytes::from(serde_json::to_vec(&json).unwrap()));
+                    let response = http::Response::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(body)
+                        .unwrap();
+                    Ok(response)
+                }
+                MockResponse::Error(err) => Err(err),
+            }
+        }
+    }
+
+    fn test_security_context() -> SecurityContext {
+        SecurityContext::anonymous()
+    }
+
+    fn sse_event(event_type: &str, data: &str) -> String {
+        format!("event: {event_type}\ndata: {data}")
+    }
+
+    // ── Unit tests: request builder ────────────────────────────────────────
+
+    #[test]
+    fn builder_minimal_text_request() {
+        let request = llm_request("gpt-4o")
+            .message(LlmMessage::user("Hello"))
+            .system_instructions("You are helpful")
+            .max_output_tokens(4096)
+            .user_identity("abc", "def")
+            .metadata(RequestMetadata {
+                tenant_id: "abc".into(),
+                user_id: "def".into(),
+                chat_id: "ghi".into(),
+                request_type: RequestType::Chat,
+                feature: Feature::None,
+            })
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert_eq!(body["model"], "gpt-4o");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["store"], false);
+        assert_eq!(body["user"], "abc:def");
+        assert_eq!(body["max_output_tokens"], 4096);
+        assert_eq!(body["instructions"], "You are helpful");
+        assert!(body["previous_response_id"].is_null());
+        assert_eq!(body["metadata"]["tenant_id"], "abc");
+        assert_eq!(body["metadata"]["user_id"], "def");
+        assert_eq!(body["metadata"]["chat_id"], "ghi");
+        assert_eq!(body["metadata"]["request_type"], "chat");
+        assert_eq!(body["metadata"]["feature"], "none");
+    }
+
+    #[test]
+    fn builder_file_search_tool() {
+        let request = llm_request("gpt-4o")
+            .tool(LlmTool::FileSearch {
+                vector_store_ids: vec!["vs-123".into()],
+            })
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert_eq!(body["tools"][0]["type"], "file_search");
+        assert_eq!(body["tools"][0]["vector_store_ids"][0], "vs-123");
+    }
+
+    #[test]
+    fn builder_web_search_tool() {
+        let request = llm_request("gpt-4o")
+            .tool(LlmTool::WebSearch)
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert_eq!(body["tools"][0]["type"], "web_search_preview");
+    }
+
+    #[test]
+    fn builder_both_tools_and_feature() {
+        let request = llm_request("gpt-4o")
+            .tools(vec![
+                LlmTool::FileSearch {
+                    vector_store_ids: vec!["vs-123".into()],
+                },
+                LlmTool::WebSearch,
+            ])
+            .metadata(RequestMetadata {
+                tenant_id: "t1".into(),
+                user_id: "u1".into(),
+                chat_id: "c1".into(),
+                request_type: RequestType::Chat,
+                feature: Feature::FileSearchAndWebSearch,
+            })
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert_eq!(body["tools"].as_array().unwrap().len(), 2);
+        assert_eq!(body["tools"][0]["type"], "file_search");
+        assert_eq!(body["tools"][1]["type"], "web_search_preview");
+        assert_eq!(body["metadata"]["feature"], "file_search+web_search");
+    }
+
+    #[test]
+    fn builder_multimodal_input() {
+        let request = llm_request("gpt-4o")
+            .message(LlmMessage::user_with_image("Describe this", "file-abc"))
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert_eq!(body["input"][0]["type"], "message");
+        assert_eq!(body["input"][0]["role"], "user");
+        assert_eq!(body["input"][0]["content"][0]["type"], "input_text");
+        assert_eq!(body["input"][0]["content"][0]["text"], "Describe this");
+        assert_eq!(body["input"][0]["content"][1]["type"], "input_image");
+        assert_eq!(body["input"][0]["content"][1]["file_id"], "file-abc");
+    }
+
+    #[test]
+    fn builder_non_streaming_mode() {
+        let request = llm_request("gpt-4o").build_non_streaming();
+
+        let body = build_request_body(&request, false);
+
+        assert_eq!(body["stream"], false);
+    }
+
+    #[test]
+    fn builder_streaming_mode() {
+        let request = llm_request("gpt-4o").build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert_eq!(body["stream"], true);
+    }
+
+    #[test]
+    fn builder_user_field_format() {
+        let request = llm_request("gpt-4o")
+            .user_identity("tenant-1", "user-2")
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert_eq!(body["user"], "tenant-1:user-2");
+    }
+
+    #[test]
+    fn builder_function_tool_dropped() {
+        let request = llm_request("gpt-4o")
+            .tool(LlmTool::Function {
+                name: "get_weather".into(),
+                description: "Get weather".into(),
+                parameters: serde_json::json!({}),
+            })
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        // Function tools are dropped for Responses API
+        assert!(body.get("tools").is_none());
+    }
+
+    // ── Unit tests: FromServerEvent ────────────────────────────────────────
+
+    #[test]
+    fn parse_text_delta_event() {
+        let event = ServerEvent {
+            event: Some("response.output_text.delta".to_string()),
+            data: r#"{"delta":"Hello"}"#.to_string(),
+            id: None,
+            retry: None,
+        };
+        let result = ProviderEvent::from_server_event(event).unwrap();
+        assert!(
+            matches!(result, ProviderEvent::ResponseOutputTextDelta { delta } if delta == "Hello")
+        );
+    }
+
+    #[test]
+    fn parse_text_done_event() {
+        let event = ServerEvent {
+            event: Some("response.output_text.done".to_string()),
+            data: r#"{"text":"Hello world"}"#.to_string(),
+            id: None,
+            retry: None,
+        };
+        let result = ProviderEvent::from_server_event(event).unwrap();
+        assert!(
+            matches!(result, ProviderEvent::ResponseOutputTextDone { text } if text == "Hello world")
+        );
+    }
+
+    #[test]
+    fn parse_file_search_searching_event() {
+        let event = ServerEvent {
+            event: Some("response.file_search_call.searching".to_string()),
+            data: "{}".to_string(),
+            id: None,
+            retry: None,
+        };
+        let result = ProviderEvent::from_server_event(event).unwrap();
+        assert!(matches!(
+            result,
+            ProviderEvent::ResponseFileSearchCallSearching
+        ));
+    }
+
+    #[test]
+    fn parse_file_search_completed_event() {
+        let event = ServerEvent {
+            event: Some("response.file_search_call.completed".to_string()),
+            data: r#"{"results":[{"file_id":"f1","filename":"test.pdf","score":0.95,"text":"snippet"}]}"#.to_string(),
+            id: None,
+            retry: None,
+        };
+        let result = ProviderEvent::from_server_event(event).unwrap();
+        match result {
+            ProviderEvent::ResponseFileSearchCallCompleted { results } => {
+                assert_eq!(results.len(), 1);
+                assert_eq!(results[0].file_id, "f1");
+            }
+            _ => panic!("expected ResponseFileSearchCallCompleted"),
+        }
+    }
+
+    #[test]
+    fn parse_web_search_searching_event() {
+        let event = ServerEvent {
+            event: Some("response.web_search_call.searching".to_string()),
+            data: "{}".to_string(),
+            id: None,
+            retry: None,
+        };
+        let result = ProviderEvent::from_server_event(event).unwrap();
+        assert!(matches!(
+            result,
+            ProviderEvent::ResponseWebSearchCallSearching
+        ));
+    }
+
+    #[test]
+    fn parse_web_search_completed_event() {
+        let event = ServerEvent {
+            event: Some("response.web_search_call.completed".to_string()),
+            data: "{}".to_string(),
+            id: None,
+            retry: None,
+        };
+        let result = ProviderEvent::from_server_event(event).unwrap();
+        assert!(matches!(
+            result,
+            ProviderEvent::ResponseWebSearchCallCompleted
+        ));
+    }
+
+    #[test]
+    fn parse_response_completed_event() {
+        let event = ServerEvent {
+            event: Some("response.completed".to_string()),
+            data: r#"{"response":{"id":"resp-abc","output":[{"type":"message","content":[{"type":"output_text","text":"Hello","annotations":[]}]}],"usage":{"input_tokens":100,"output_tokens":50}}}"#.to_string(),
+            id: None,
+            retry: None,
+        };
+        let result = ProviderEvent::from_server_event(event).unwrap();
+        match result {
+            ProviderEvent::ResponseCompleted { response } => {
+                assert_eq!(response.id, "resp-abc");
+                assert_eq!(response.usage.input_tokens, 100);
+                assert_eq!(response.usage.output_tokens, 50);
+            }
+            _ => panic!("expected ResponseCompleted"),
+        }
+    }
+
+    #[test]
+    fn parse_response_failed_event() {
+        let event = ServerEvent {
+            event: Some("response.failed".to_string()),
+            data: r#"{"error":{"code":"server_error","message":"internal failure"}}"#.to_string(),
+            id: None,
+            retry: None,
+        };
+        let result = ProviderEvent::from_server_event(event).unwrap();
+        match result {
+            ProviderEvent::ResponseFailed { error } => {
+                assert_eq!(error.code, "server_error");
+                assert_eq!(error.message, "internal failure");
+            }
+            _ => panic!("expected ResponseFailed"),
+        }
+    }
+
+    #[test]
+    fn parse_response_incomplete_event() {
+        let event = ServerEvent {
+            event: Some("response.incomplete".to_string()),
+            data: r#"{"reason":"max_output_tokens"}"#.to_string(),
+            id: None,
+            retry: None,
+        };
+        let result = ProviderEvent::from_server_event(event).unwrap();
+        assert!(
+            matches!(result, ProviderEvent::ResponseIncomplete { reason } if reason == "max_output_tokens")
+        );
+    }
+
+    #[test]
+    fn parse_unknown_event_returns_unknown() {
+        let event = ServerEvent {
+            event: Some("response.new_feature.delta".to_string()),
+            data: r#"{"something":"new"}"#.to_string(),
+            id: None,
+            retry: None,
+        };
+        let result = ProviderEvent::from_server_event(event).unwrap();
+        assert!(
+            matches!(result, ProviderEvent::Unknown { event_name } if event_name == "response.new_feature.delta")
+        );
+    }
+
+    #[test]
+    fn parse_malformed_json_in_known_event_returns_error() {
+        let event = ServerEvent {
+            event: Some("response.output_text.delta".to_string()),
+            data: "not valid json".to_string(),
+            id: None,
+            retry: None,
+        };
+        let result = ProviderEvent::from_server_event(event);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            StreamingError::ServerEventsParse { .. }
+        ));
+    }
+
+    // ── Unit tests: translate_provider_event ───────────────────────────────
+
+    #[test]
+    fn translate_text_delta() {
+        let event = ProviderEvent::ResponseOutputTextDelta { delta: "Hi".into() };
+        let translated = translate_provider_event(&event, "");
+        match translated {
+            TranslatedEvent::Sse(ClientSseEvent::Delta { r#type, content }) => {
+                assert_eq!(r#type, "text");
+                assert_eq!(content, "Hi");
+            }
+            _ => panic!("expected Sse(Delta)"),
+        }
+    }
+
+    #[test]
+    fn translate_text_done_is_skip() {
+        let event = ProviderEvent::ResponseOutputTextDone {
+            text: "done".into(),
+        };
+        let translated = translate_provider_event(&event, "");
+        assert!(matches!(translated, TranslatedEvent::Skip));
+    }
+
+    #[test]
+    fn translate_file_search_start() {
+        let event = ProviderEvent::ResponseFileSearchCallSearching;
+        let translated = translate_provider_event(&event, "");
+        match translated {
+            TranslatedEvent::Sse(ClientSseEvent::Tool { phase, name, .. }) => {
+                assert!(matches!(phase, ToolPhase::Start));
+                assert_eq!(name, "file_search");
+            }
+            _ => panic!("expected Sse(Tool)"),
+        }
+    }
+
+    #[test]
+    fn translate_file_search_done_with_count() {
+        let event = ProviderEvent::ResponseFileSearchCallCompleted {
+            results: vec![
+                FileSearchResult {
+                    file_id: "f1".into(),
+                    filename: "a.pdf".into(),
+                    score: 0.9,
+                    text: String::new(),
+                },
+                FileSearchResult {
+                    file_id: "f2".into(),
+                    filename: "b.pdf".into(),
+                    score: 0.8,
+                    text: String::new(),
+                },
+            ],
+        };
+        let translated = translate_provider_event(&event, "");
+        match translated {
+            TranslatedEvent::Sse(ClientSseEvent::Tool {
+                phase,
+                name,
+                details,
+            }) => {
+                assert!(matches!(phase, ToolPhase::Done));
+                assert_eq!(name, "file_search");
+                assert_eq!(details["files_searched"], 2);
+            }
+            _ => panic!("expected Sse(Tool)"),
+        }
+    }
+
+    #[test]
+    fn translate_web_search_start() {
+        let event = ProviderEvent::ResponseWebSearchCallSearching;
+        let translated = translate_provider_event(&event, "");
+        match translated {
+            TranslatedEvent::Sse(ClientSseEvent::Tool { phase, name, .. }) => {
+                assert!(matches!(phase, ToolPhase::Start));
+                assert_eq!(name, "web_search");
+            }
+            _ => panic!("expected Sse(Tool)"),
+        }
+    }
+
+    #[test]
+    fn translate_web_search_done() {
+        let event = ProviderEvent::ResponseWebSearchCallCompleted;
+        let translated = translate_provider_event(&event, "");
+        match translated {
+            TranslatedEvent::Sse(ClientSseEvent::Tool { phase, name, .. }) => {
+                assert!(matches!(phase, ToolPhase::Done));
+                assert_eq!(name, "web_search");
+            }
+            _ => panic!("expected Sse(Tool)"),
+        }
+    }
+
+    #[test]
+    fn translate_completed_returns_terminal() {
+        let event = ProviderEvent::ResponseCompleted {
+            response: ResponseObject {
+                id: "resp-abc".into(),
+                output: vec![],
+                usage: RawUsage {
+                    input_tokens: 500,
+                    output_tokens: 120,
+                },
+            },
+        };
+        let translated = translate_provider_event(&event, "Hello");
+        match translated {
+            TranslatedEvent::Terminal(TerminalOutcome::Completed {
+                usage,
+                response_id,
+                content,
+                ..
+            }) => {
+                assert_eq!(usage.input_tokens, 500);
+                assert_eq!(usage.output_tokens, 120);
+                assert_eq!(response_id, "resp-abc");
+                assert_eq!(content, "Hello");
+            }
+            _ => panic!("expected Terminal(Completed)"),
+        }
+    }
+
+    #[test]
+    fn translate_failed_returns_terminal() {
+        let event = ProviderEvent::ResponseFailed {
+            error: ProviderErrorPayload {
+                code: "err".into(),
+                message: "failed".into(),
+            },
+        };
+        let translated = translate_provider_event(&event, "partial");
+        match translated {
+            TranslatedEvent::Terminal(TerminalOutcome::Failed {
+                partial_content, ..
+            }) => {
+                assert_eq!(partial_content, "partial");
+            }
+            _ => panic!("expected Terminal(Failed)"),
+        }
+    }
+
+    #[test]
+    fn translate_incomplete_returns_terminal() {
+        let event = ProviderEvent::ResponseIncomplete {
+            reason: "max_output_tokens".into(),
+        };
+        let translated = translate_provider_event(&event, "partial");
+        match translated {
+            TranslatedEvent::Terminal(TerminalOutcome::Incomplete {
+                reason,
+                partial_content,
+                ..
+            }) => {
+                assert_eq!(reason, "max_output_tokens");
+                assert_eq!(partial_content, "partial");
+            }
+            _ => panic!("expected Terminal(Incomplete)"),
+        }
+    }
+
+    #[test]
+    fn translate_unknown_is_skip() {
+        let event = ProviderEvent::Unknown {
+            event_name: "response.new".into(),
+        };
+        let translated = translate_provider_event(&event, "");
+        assert!(matches!(translated, TranslatedEvent::Skip));
+    }
+
+    #[test]
+    fn extract_citations_file_citation() {
+        let response = ResponseObject {
+            id: "resp-1".into(),
+            output: vec![OutputItem {
+                r#type: "message".into(),
+                content: vec![ResponseContentPart {
+                    r#type: "output_text".into(),
+                    text: "Hello".into(),
+                    annotations: vec![Annotation {
+                        r#type: "file_citation".into(),
+                        title: "Report.pdf".into(),
+                        url: None,
+                        file_id: Some("file-xyz".into()),
+                        start_index: Some(0),
+                        end_index: Some(5),
+                        text: Some("snippet".into()),
+                    }],
+                }],
+            }],
+            usage: RawUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+            },
+        };
+        let citations = extract_citations(&response);
+        assert_eq!(citations.len(), 1);
+        assert!(matches!(citations[0].source, CitationSource::File));
+        assert_eq!(citations[0].title, "Report.pdf");
+        assert_eq!(citations[0].attachment_id.as_deref(), Some("file-xyz"));
+        assert_eq!(citations[0].span.unwrap().start, 0);
+        assert_eq!(citations[0].span.unwrap().end, 5);
+    }
+
+    #[test]
+    fn extract_citations_url_citation() {
+        let response = ResponseObject {
+            id: "resp-1".into(),
+            output: vec![OutputItem {
+                r#type: "message".into(),
+                content: vec![ResponseContentPart {
+                    r#type: "output_text".into(),
+                    text: "Hello".into(),
+                    annotations: vec![Annotation {
+                        r#type: "url_citation".into(),
+                        title: "Example".into(),
+                        url: Some("https://example.com".into()),
+                        file_id: None,
+                        start_index: None,
+                        end_index: None,
+                        text: None,
+                    }],
+                }],
+            }],
+            usage: RawUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+            },
+        };
+        let citations = extract_citations(&response);
+        assert_eq!(citations.len(), 1);
+        assert!(matches!(citations[0].source, CitationSource::Web));
+        assert_eq!(citations[0].url.as_deref(), Some("https://example.com"));
+        assert_eq!(citations[0].title, "Example");
+    }
+
+    #[test]
+    fn extract_citations_empty_annotations() {
+        let response = ResponseObject {
+            id: "resp-1".into(),
+            output: vec![OutputItem {
+                r#type: "message".into(),
+                content: vec![ResponseContentPart {
+                    r#type: "output_text".into(),
+                    text: "Hello".into(),
+                    annotations: vec![],
+                }],
+            }],
+            usage: RawUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+            },
+        };
+        let citations = extract_citations(&response);
+        assert!(citations.is_empty());
+    }
+
+    // ── Integration tests: streaming ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn stream_yields_events_and_outcome() {
+        let events = vec![
+            sse_event("response.output_text.delta", r#"{"delta":"Hel"}"#),
+            sse_event("response.output_text.delta", r#"{"delta":"lo "}"#),
+            sse_event("response.output_text.delta", r#"{"delta":"world"}"#),
+            sse_event(
+                "response.completed",
+                r#"{"response":{"id":"resp-1","output":[],"usage":{"input_tokens":100,"output_tokens":30}}}"#,
+            ),
+        ];
+
+        let gw = MockGateway::returning_sse(events);
+        let provider = OpenAiResponsesProvider::new(gw.clone(), "openai".into());
+
+        let request = llm_request("gpt-4o")
+            .message(LlmMessage::user("Hello"))
+            .build_streaming();
+
+        let cancel = CancellationToken::new();
+        let stream = provider
+            .stream(test_security_context(), request, cancel)
+            .await
+            .unwrap();
+        let outcome = stream.into_outcome().await;
+
+        match outcome {
+            TerminalOutcome::Completed {
+                content,
+                usage,
+                response_id,
+                ..
+            } => {
+                assert_eq!(content, "Hello world");
+                assert_eq!(usage.input_tokens, 100);
+                assert_eq!(usage.output_tokens, 30);
+                assert_eq!(response_id, "resp-1");
+            }
+            _ => panic!("expected Completed, got {outcome:?}"),
+        }
+
+        assert_eq!(gw.last_request_uri().unwrap(), "/openai/v1/responses");
+    }
+
+    #[tokio::test]
+    async fn stream_interleaved_tool_events() {
+        let events = vec![
+            sse_event("response.output_text.delta", r#"{"delta":"A"}"#),
+            sse_event("response.file_search_call.searching", "{}"),
+            sse_event("response.output_text.delta", r#"{"delta":"B"}"#),
+            sse_event("response.file_search_call.completed", r#"{"results":[]}"#),
+            sse_event("response.output_text.delta", r#"{"delta":"C"}"#),
+            sse_event(
+                "response.completed",
+                r#"{"response":{"id":"resp-2","output":[],"usage":{"input_tokens":50,"output_tokens":10}}}"#,
+            ),
+        ];
+
+        let gw = MockGateway::returning_sse(events);
+        let provider = OpenAiResponsesProvider::new(gw, "openai".into());
+
+        let request = llm_request("gpt-4o").build_streaming();
+        let cancel = CancellationToken::new();
+        let stream = provider
+            .stream(test_security_context(), request, cancel)
+            .await
+            .unwrap();
+        let outcome = stream.into_outcome().await;
+
+        match outcome {
+            TerminalOutcome::Completed { content, .. } => {
+                assert_eq!(content, "ABC");
+            }
+            _ => panic!("expected Completed"),
+        }
+    }
+
+    // ── Integration test: cancellation ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn cancellation_terminates_stream() {
+        let events = vec![
+            sse_event("response.output_text.delta", r#"{"delta":"Hello"}"#),
+            sse_event("response.output_text.delta", r#"{"delta":" world"}"#),
+            sse_event(
+                "response.completed",
+                r#"{"response":{"id":"resp-3","output":[],"usage":{"input_tokens":10,"output_tokens":5}}}"#,
+            ),
+        ];
+
+        let gw = MockGateway::returning_sse(events);
+        let provider = OpenAiResponsesProvider::new(gw, "openai".into());
+
+        let request = llm_request("gpt-4o").build_streaming();
+        let cancel = CancellationToken::new();
+        let mut stream = provider
+            .stream(test_security_context(), request, cancel.clone())
+            .await
+            .unwrap();
+
+        // Read first event
+        let first = stream.next().await;
+        assert!(first.is_some());
+
+        // Cancel
+        cancel.cancel();
+        assert!(stream.is_cancelled());
+
+        // Stream should terminate
+        let _remaining: Vec<_> = stream.collect().await;
+    }
+
+    // ── Integration test: OAGW error paths ─────────────────────────────────
+
+    #[tokio::test]
+    async fn oagw_rate_limit_error() {
+        let gw = MockGateway::returning_error(ServiceGatewayError::RateLimitExceeded {
+            detail: "too many requests".into(),
+            instance: "/test".into(),
+            retry_after_secs: Some(30),
+        });
+        let provider = OpenAiResponsesProvider::new(gw, "openai".into());
+
+        let request = llm_request("gpt-4o").build_streaming();
+        let cancel = CancellationToken::new();
+        let result = provider
+            .stream(test_security_context(), request, cancel)
+            .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            LlmProviderError::RateLimited {
+                retry_after_secs: Some(30)
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn oagw_connection_timeout_error() {
+        let gw = MockGateway::returning_error(ServiceGatewayError::ConnectionTimeout {
+            detail: "timed out".into(),
+            instance: "/test".into(),
+        });
+        let provider = OpenAiResponsesProvider::new(gw, "openai".into());
+
+        let request = llm_request("gpt-4o").build_streaming();
+        let cancel = CancellationToken::new();
+        let result = provider
+            .stream(test_security_context(), request, cancel)
+            .await;
+
+        assert!(matches!(result.unwrap_err(), LlmProviderError::Timeout));
+    }
+
+    #[tokio::test]
+    async fn oagw_upstream_disabled_error() {
+        let gw = MockGateway::returning_error(ServiceGatewayError::UpstreamDisabled {
+            detail: "disabled".into(),
+            instance: "/test".into(),
+        });
+        let provider = OpenAiResponsesProvider::new(gw, "openai".into());
+
+        let request = llm_request("gpt-4o").build_streaming();
+        let cancel = CancellationToken::new();
+        let result = provider
+            .stream(test_security_context(), request, cancel)
+            .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            LlmProviderError::ProviderUnavailable
+        ));
+    }
+
+    // ── Integration test: non-SSE response ─────────────────────────────────
+
+    #[tokio::test]
+    async fn non_sse_json_error_response() {
+        let gw = MockGateway::returning_json(serde_json::json!({
+            "code": "invalid_request",
+            "message": "Error in resp_xyz123: invalid model at https://api.openai.com/v1"
+        }));
+        let provider = OpenAiResponsesProvider::new(gw, "openai".into());
+
+        let request = llm_request("bad-model").build_streaming();
+        let cancel = CancellationToken::new();
+        let result = provider
+            .stream(test_security_context(), request, cancel)
+            .await;
+
+        match result.unwrap_err() {
+            LlmProviderError::ProviderError {
+                code,
+                message,
+                raw_detail,
+            } => {
+                assert_eq!(code, "invalid_request");
+                assert!(!message.contains("resp_xyz123"));
+                assert!(!message.contains("https://api.openai.com"));
+                assert!(raw_detail.is_some());
+            }
+            other => panic!("expected ProviderError, got {other:?}"),
+        }
+    }
+
+    // ── Integration test: complete ────────────────────────────────────
+
+    #[tokio::test]
+    async fn complete_response_success() {
+        let gw = MockGateway::returning_json(serde_json::json!({
+            "id": "resp-complete-1",
+            "output": [{
+                "type": "message",
+                "content": [{
+                    "type": "output_text",
+                    "text": "Summary of the conversation.",
+                    "annotations": [{
+                        "type": "file_citation",
+                        "title": "Doc.pdf",
+                        "file_id": "file-1",
+                        "start_index": 0,
+                        "end_index": 10,
+                        "text": "snippet"
+                    }]
+                }]
+            }],
+            "usage": {
+                "input_tokens": 500,
+                "output_tokens": 50
+            }
+        }));
+        let provider = OpenAiResponsesProvider::new(gw.clone(), "azure-openai".into());
+
+        let request = llm_request("gpt-4o")
+            .system_instructions("Summarize.")
+            .message(LlmMessage::user("conversation"))
+            .max_output_tokens(1024)
+            .build_non_streaming();
+
+        let result = provider
+            .complete(test_security_context(), request)
+            .await
+            .unwrap();
+
+        assert_eq!(result.content, "Summary of the conversation.");
+        assert_eq!(result.usage.input_tokens, 500);
+        assert_eq!(result.usage.output_tokens, 50);
+        assert_eq!(result.response_id, "resp-complete-1");
+        assert_eq!(result.citations.len(), 1);
+        assert!(matches!(result.citations[0].source, CitationSource::File));
+
+        assert_eq!(gw.last_request_uri().unwrap(), "/azure-openai/v1/responses");
+    }
+
+    // ── Integration test: fluent builder ───────────────────────────────────
+
+    #[tokio::test]
+    async fn fluent_builder_produces_valid_json() {
+        let events = vec![sse_event(
+            "response.completed",
+            r#"{"response":{"id":"resp-fb","output":[],"usage":{"input_tokens":10,"output_tokens":5}}}"#,
+        )];
+
+        let gw = MockGateway::returning_sse(events);
+        let provider = OpenAiResponsesProvider::new(gw.clone(), "openai".into());
+
+        let request = llm_request("gpt-4o")
+            .system_instructions("You are helpful")
+            .message(LlmMessage::user("Hello"))
+            .max_output_tokens(4096)
+            .tools(vec![
+                LlmTool::FileSearch {
+                    vector_store_ids: vec!["vs-123".into()],
+                },
+                LlmTool::WebSearch,
+            ])
+            .user_identity("t1", "u1")
+            .metadata(RequestMetadata {
+                tenant_id: "t1".into(),
+                user_id: "u1".into(),
+                chat_id: "c1".into(),
+                request_type: RequestType::Chat,
+                feature: Feature::FileSearchAndWebSearch,
+            })
+            .build_streaming();
+
+        let cancel = CancellationToken::new();
+        let _stream = provider
+            .stream(test_security_context(), request, cancel)
+            .await
+            .unwrap();
+
+        let body_str = gw.last_request_body().unwrap();
+        let body: serde_json::Value = serde_json::from_str(&body_str).unwrap();
+
+        assert_eq!(body["model"], "gpt-4o");
+        assert_eq!(body["instructions"], "You are helpful");
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["store"], false);
+        assert_eq!(body["max_output_tokens"], 4096);
+        assert_eq!(body["user"], "t1:u1");
+        assert!(body["previous_response_id"].is_null());
+        assert_eq!(body["input"][0]["type"], "message");
+        assert_eq!(body["input"][0]["role"], "user");
+        assert_eq!(body["input"][0]["content"][0]["type"], "input_text");
+        assert_eq!(body["input"][0]["content"][0]["text"], "Hello");
+        assert_eq!(body["tools"][0]["type"], "file_search");
+        assert_eq!(body["tools"][0]["vector_store_ids"][0], "vs-123");
+        assert_eq!(body["tools"][1]["type"], "web_search_preview");
+        assert_eq!(body["metadata"]["tenant_id"], "t1");
+        assert_eq!(body["metadata"]["feature"], "file_search+web_search");
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/llm/request.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/request.rs
@@ -1,0 +1,301 @@
+//! Provider-agnostic LLM request types.
+//!
+//! [`LlmRequest`] is the common input for all provider adapters. Each adapter
+//! converts it to its provider-specific wire format.
+
+use std::marker::PhantomData;
+
+use serde::Serialize;
+
+use super::{NonStreaming, Streaming};
+
+// ════════════════════════════════════════════════════════════════════════════
+// Message types
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A role in the conversation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    User,
+    Assistant,
+    System,
+}
+
+/// A content part within a message.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum ContentPart {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image")]
+    Image { file_id: String },
+}
+
+/// A single message in the conversation.
+#[derive(Debug, Clone)]
+pub struct LlmMessage {
+    pub role: Role,
+    pub content: Vec<ContentPart>,
+}
+
+impl LlmMessage {
+    /// Create a user message with text content.
+    #[must_use]
+    pub fn user(text: impl Into<String>) -> Self {
+        LlmMessage {
+            role: Role::User,
+            content: vec![ContentPart::Text { text: text.into() }],
+        }
+    }
+
+    /// Create an assistant message with text content.
+    #[must_use]
+    pub fn assistant(text: impl Into<String>) -> Self {
+        LlmMessage {
+            role: Role::Assistant,
+            content: vec![ContentPart::Text { text: text.into() }],
+        }
+    }
+
+    /// Create a user message with text and an image.
+    #[must_use]
+    pub fn user_with_image(text: impl Into<String>, file_id: impl Into<String>) -> Self {
+        LlmMessage {
+            role: Role::User,
+            content: vec![
+                ContentPart::Text { text: text.into() },
+                ContentPart::Image {
+                    file_id: file_id.into(),
+                },
+            ],
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Tool types
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A provider-agnostic tool descriptor.
+///
+/// Each adapter maps supported tools to its wire format and silently drops
+/// unsupported ones with a `debug!` log.
+#[derive(Debug, Clone)]
+pub enum LlmTool {
+    /// Server-side file search (provider manages execution).
+    FileSearch { vector_store_ids: Vec<String> },
+    /// Server-side web search (provider manages execution).
+    WebSearch,
+    /// Generic function tool (for providers supporting function calling).
+    Function {
+        name: String,
+        description: String,
+        parameters: serde_json::Value,
+    },
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// User identity and metadata
+// ════════════════════════════════════════════════════════════════════════════
+
+/// User identity for provider abuse detection and observability.
+#[derive(Debug, Clone)]
+pub struct UserIdentity {
+    pub tenant_id: String,
+    pub user_id: String,
+}
+
+/// Observability metadata attached to provider requests.
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestMetadata {
+    pub tenant_id: String,
+    pub user_id: String,
+    pub chat_id: String,
+    pub request_type: RequestType,
+    pub feature: Feature,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequestType {
+    Chat,
+    Summary,
+    DocSummary,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub enum Feature {
+    #[serde(rename = "file_search")]
+    FileSearch,
+    #[serde(rename = "web_search")]
+    WebSearch,
+    #[serde(rename = "file_search+web_search")]
+    FileSearchAndWebSearch,
+    #[serde(rename = "none")]
+    None,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// LlmRequest
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A provider-agnostic LLM request, parameterized by streaming mode.
+///
+/// Each provider adapter converts this to its wire format.
+pub struct LlmRequest<Mode = Streaming> {
+    pub(crate) model: String,
+    pub(crate) messages: Vec<LlmMessage>,
+    pub(crate) system_instructions: Option<String>,
+    pub(crate) max_output_tokens: Option<u64>,
+    pub(crate) tools: Vec<LlmTool>,
+    pub(crate) user_identity: Option<UserIdentity>,
+    pub(crate) metadata: Option<RequestMetadata>,
+    pub(crate) additional_params: Option<serde_json::Value>,
+    pub(crate) _mode: PhantomData<Mode>,
+}
+
+impl<M> LlmRequest<M> {
+    /// The model identifier set on this request.
+    #[must_use]
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// The messages in this request.
+    #[must_use]
+    pub fn messages(&self) -> &[LlmMessage] {
+        &self.messages
+    }
+
+    /// The tools in this request.
+    #[must_use]
+    pub fn tools(&self) -> &[LlmTool] {
+        &self.tools
+    }
+}
+
+/// Fluent builder for [`LlmRequest`].
+pub struct LlmRequestBuilder {
+    model: String,
+    messages: Vec<LlmMessage>,
+    system_instructions: Option<String>,
+    max_output_tokens: Option<u64>,
+    tools: Vec<LlmTool>,
+    user_identity: Option<UserIdentity>,
+    metadata: Option<RequestMetadata>,
+    additional_params: Option<serde_json::Value>,
+}
+
+impl LlmRequestBuilder {
+    /// Create a new builder with the required model identifier.
+    #[must_use]
+    pub fn new(model: impl Into<String>) -> Self {
+        LlmRequestBuilder {
+            model: model.into(),
+            messages: Vec::new(),
+            system_instructions: None,
+            max_output_tokens: None,
+            tools: Vec::new(),
+            user_identity: None,
+            metadata: None,
+            additional_params: None,
+        }
+    }
+
+    /// Add a single message to the conversation.
+    #[must_use]
+    pub fn message(mut self, message: LlmMessage) -> Self {
+        self.messages.push(message);
+        self
+    }
+
+    /// Set all messages at once.
+    #[must_use]
+    pub fn messages(mut self, messages: Vec<LlmMessage>) -> Self {
+        self.messages = messages;
+        self
+    }
+
+    /// Set system instructions.
+    #[must_use]
+    pub fn system_instructions(mut self, instructions: impl Into<String>) -> Self {
+        self.system_instructions = Some(instructions.into());
+        self
+    }
+
+    /// Set the hard token cap.
+    #[must_use]
+    pub fn max_output_tokens(mut self, max_tokens: u64) -> Self {
+        self.max_output_tokens = Some(max_tokens);
+        self
+    }
+
+    /// Add a single tool.
+    #[must_use]
+    pub fn tool(mut self, tool: LlmTool) -> Self {
+        self.tools.push(tool);
+        self
+    }
+
+    /// Set all tools at once.
+    #[must_use]
+    pub fn tools(mut self, tools: Vec<LlmTool>) -> Self {
+        self.tools = tools;
+        self
+    }
+
+    /// Set user identity for provider abuse detection.
+    #[must_use]
+    pub fn user_identity(
+        mut self,
+        tenant_id: impl Into<String>,
+        user_id: impl Into<String>,
+    ) -> Self {
+        self.user_identity = Some(UserIdentity {
+            tenant_id: tenant_id.into(),
+            user_id: user_id.into(),
+        });
+        self
+    }
+
+    /// Set observability metadata.
+    #[must_use]
+    pub fn metadata(mut self, metadata: RequestMetadata) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+
+    /// Set additional provider-specific parameters (escape hatch).
+    #[must_use]
+    pub fn additional_params(mut self, params: serde_json::Value) -> Self {
+        self.additional_params = Some(params);
+        self
+    }
+
+    fn build_inner<Mode>(self) -> LlmRequest<Mode> {
+        LlmRequest {
+            model: self.model,
+            messages: self.messages,
+            system_instructions: self.system_instructions,
+            max_output_tokens: self.max_output_tokens,
+            tools: self.tools,
+            user_identity: self.user_identity,
+            metadata: self.metadata,
+            additional_params: self.additional_params,
+            _mode: PhantomData,
+        }
+    }
+
+    /// Build a streaming request.
+    #[must_use]
+    pub fn build_streaming(self) -> LlmRequest<Streaming> {
+        self.build_inner()
+    }
+
+    /// Build a non-streaming request.
+    #[must_use]
+    pub fn build_non_streaming(self) -> LlmRequest<NonStreaming> {
+        self.build_inner()
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/mod.rs
@@ -1,1 +1,2 @@
 pub mod db;
+pub mod llm;

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -4,11 +4,15 @@ use async_trait::async_trait;
 use authz_resolver_sdk::AuthZResolverClient;
 use modkit::api::OpenApiRegistry;
 use modkit::{DatabaseCapability, Module, ModuleCtx, RestApiCapability};
+use oagw_sdk::ServiceGatewayClientV1;
 use sea_orm_migration::MigrationTrait;
 use tracing::info;
 
 use crate::api::rest::routes;
-use crate::domain::service::{AppServices, Repositories};
+use crate::domain::service::{AppServices as GenericAppServices, Repositories};
+
+pub(crate) type AppServices =
+    GenericAppServices<TurnRepository, MessageRepository, QuotaUsageRepository, ChatRepository>;
 use crate::infra::db::repo::attachment_repo::AttachmentRepository;
 use crate::infra::db::repo::chat_repo::ChatRepository;
 use crate::infra::db::repo::message_repo::MessageRepository;
@@ -18,6 +22,7 @@ use crate::infra::db::repo::reaction_repo::ReactionRepository;
 use crate::infra::db::repo::thread_summary_repo::ThreadSummaryRepository;
 use crate::infra::db::repo::turn_repo::TurnRepository;
 use crate::infra::db::repo::vector_store_repo::VectorStoreRepository;
+use crate::infra::llm::providers::{ProviderConfig, ProviderKind, create_provider};
 
 /// Default URL prefix for all mini-chat REST routes.
 pub const DEFAULT_URL_PREFIX: &str = "/mini-chat";
@@ -48,6 +53,10 @@ impl Module for MiniChatModule {
         info!("Initializing {} module", Self::MODULE_NAME);
 
         let cfg: crate::config::MiniChatConfig = ctx.config()?;
+        cfg.streaming
+            .validate()
+            .map_err(|e| anyhow::anyhow!("streaming config: {e}"))?;
+
         self.url_prefix
             .set(cfg.url_prefix)
             .map_err(|_| anyhow::anyhow!("{} url_prefix already set", Self::MODULE_NAME))?;
@@ -58,6 +67,21 @@ impl Module for MiniChatModule {
             .client_hub()
             .get::<dyn AuthZResolverClient>()
             .map_err(|e| anyhow::anyhow!("failed to get AuthZ resolver: {e}"))?;
+
+        let gateway = ctx
+            .client_hub()
+            .get::<dyn ServiceGatewayClientV1>()
+            .map_err(|e| anyhow::anyhow!("failed to get OAGW gateway: {e}"))?;
+
+        // TODO: provider kind and upstream alias should come from config in a
+        // follow-up — hardcoded to OpenAI Responses for initial P1 wiring.
+        let llm = create_provider(
+            gateway,
+            ProviderConfig {
+                kind: ProviderKind::OpenAiResponses,
+                upstream_alias: "openai".to_owned(),
+            },
+        );
 
         let repos = Repositories {
             chat: Arc::new(ChatRepository),
@@ -71,7 +95,7 @@ impl Module for MiniChatModule {
             vector_store: Arc::new(VectorStoreRepository),
         };
 
-        let services = Arc::new(AppServices::new(&repos, db, authz));
+        let services = Arc::new(AppServices::new(&repos, db, authz, llm, cfg.streaming));
 
         self.service
             .set(services)

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -320,6 +320,17 @@ impl DataPlaneService for DataPlaneServiceImpl {
 
         // 9. Build streaming response.
         let status = response.status();
+        let content_type = response
+            .headers()
+            .get(http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("<none>");
+        tracing::debug!(
+            %status,
+            content_type,
+            upstream_url = %url,
+            "upstream response received"
+        );
         let mut resp_headers = response.headers().clone();
         headers::sanitize_response_headers(&mut resp_headers);
 


### PR DESCRIPTION
  Introduce a provider-agnostic LLM interface behind an `LlmProvider` trait
  with streaming and non-streaming methods. Refactor the monolithic llm module
  into focused files with adapters for OpenAI Responses, OpenAI Chat
  Completions, and Anthropic Messages APIs.

  - Add `LlmProvider` trait with `stream()` and `complete()` methods
  - Add `LlmRequest` builder with typestate streaming/non-streaming markers
  - Add `ProviderStream` with type-erased inner stream and terminal capture
  - Move existing OpenAI Responses code to providers/openai_responses.rs
  - Add new Anthropic Messages API adapter (providers/anthropic.rs)
  - Add new Chat Completions API adapter (providers/openai_chat.rs)
  - Add `ProviderKind` enum and `create_provider()` factory
  - 84 tests (51 moved+adapted, 33 new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming message responses via SSE for real-time chat.
  * Full streaming lifecycle, keep-alive, and phase-aware event sequencing.
  * Multi-provider LLM support (OpenAI Chat & Responses) with provider-agnostic request/response models.
  * Persistent chat turns and messages with repository-backed storage.
  * Configurable streaming parameters (channel capacity, ping interval).

* **Refactors**
  * Improved database runner compatibility and internal DB operation robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->