### PR TITLE
Set `AllowInsecureHttp` by default in modkit-http config

### DIFF
--- a/libs/modkit-auth/docs/modkit-auth-client-impl.md
+++ b/libs/modkit-auth/docs/modkit-auth-client-impl.md
@@ -18,7 +18,7 @@ token source and establishes patterns that must be followed:
 | Background refresh | `run_jwks_refresh_task` + `CancellationToken` | `aliri_tokens` watcher |
 | Backoff | Manual exponential in `calculate_backoff()` | Delegated to `aliri_tokens` |
 | Error mapping | `map_http_error(HttpError) -> ClaimsError` | Extract shared `map_http_error` or create parallel `map_http_error(HttpError) -> TokenError` |
-| Test scaffold | `httpmock` + `allow_insecure_http()` | Same pattern |
+| Test scaffold | `httpmock` | Same pattern |
 
 Key reuse points:
 
@@ -34,8 +34,7 @@ Key reuse points:
    `HttpClientConfig::token_endpoint()` instead (retries are appropriate for
    token acquisition).
 4. **Test pattern** — `jwks.rs:482-499` (`test_provider_with_http`) shows
-   how to build a test `HttpClient` with `allow_insecure_http()` for
-   `httpmock`. Reuse the same approach.
+   how to build a test `HttpClient` for `httpmock`. Reuse the same approach.
 5. **Dependencies already available** — `modkit-auth/Cargo.toml` already has
    `arc-swap`, `modkit-http`, `tokio-util`, `httpmock` (dev). Only
    `aliri_tokens` needs to be added.
@@ -361,7 +360,7 @@ Check every item:
 
 8. COMPILATION: `cargo check -p modkit-auth` succeeds.
 
-9. TESTS (use httpmock + allow_insecure_http, same pattern as
+9. TESTS (use httpmock, same pattern as
    jwks.rs test_provider_with_http at line 482):
    - Mock server returns valid token response → assert access_token + lifetime.
    - Mock returns response without expires_in → assert default_ttl used.
@@ -784,7 +783,7 @@ Check every item:
 
 7. COMPILATION: `cargo check -p modkit-auth` succeeds.
 
-8. TESTS (httpmock + allow_insecure_http, same pattern as JWKS tests):
+8. TESTS (httpmock, same pattern as JWKS tests):
    - Integration: mock OIDC discovery + mock token endpoint → Token::get()
      returns expected token.
    - Unit: discover_token_endpoint with valid response.

--- a/libs/modkit-auth/src/oauth2/builder_ext.rs
+++ b/libs/modkit-auth/src/oauth2/builder_ext.rs
@@ -103,7 +103,6 @@ mod tests {
         let token = Token::new(token_config(&oauth_server)).await.unwrap();
 
         let client = modkit_http::HttpClientBuilder::new()
-            .allow_insecure_http()
             .with_bearer_auth(token)
             .build()
             .unwrap();
@@ -141,7 +140,6 @@ mod tests {
         let custom = HeaderName::from_static("x-api-key");
 
         let client = modkit_http::HttpClientBuilder::new()
-            .allow_insecure_http()
             .with_bearer_auth_header(token, custom)
             .build()
             .unwrap();
@@ -173,10 +171,7 @@ mod tests {
             then.status(200).body("no-auth");
         });
 
-        let client = modkit_http::HttpClientBuilder::new()
-            .allow_insecure_http()
-            .build()
-            .unwrap();
+        let client = modkit_http::HttpClientBuilder::new().build().unwrap();
 
         let _resp = client
             .get(&format!("http://localhost:{}/api/data", api_server.port()))

--- a/libs/modkit-auth/src/providers/jwks.rs
+++ b/libs/modkit-auth/src/providers/jwks.rs
@@ -506,7 +506,6 @@ mod tests {
         let client = modkit_http::HttpClient::builder()
             .timeout(Duration::from_secs(5))
             .retry(None)
-            .allow_insecure_http()
             .build()
             .expect("failed to create test HTTP client");
 

--- a/libs/modkit-auth/tests/oauth2_integration.rs
+++ b/libs/modkit-auth/tests/oauth2_integration.rs
@@ -55,7 +55,6 @@ async fn full_oauth2_bearer_flow() {
     let token = Token::new(config).await.unwrap();
 
     let client = modkit_http::HttpClientBuilder::new()
-        .allow_insecure_http()
         .with_bearer_auth(token)
         .build()
         .unwrap();
@@ -128,7 +127,6 @@ async fn full_oauth2_with_oidc_discovery() {
     let token = Token::new(config).await.unwrap();
 
     let client = modkit_http::HttpClientBuilder::new()
-        .allow_insecure_http()
         .with_bearer_auth(token)
         .build()
         .unwrap();

--- a/libs/modkit-http/Cargo.toml
+++ b/libs/modkit-http/Cargo.toml
@@ -21,9 +21,6 @@ workspace = true
 default = []
 # OpenTelemetry integration for distributed tracing
 otel = ["dep:opentelemetry", "dep:tracing-opentelemetry"]
-# Allow insecure HTTP in release builds (for integration testing only)
-# By default, allow_insecure_http() is only available in debug builds
-allow-insecure-http = []
 
 [dependencies]
 # Core dependencies

--- a/libs/modkit-http/src/builder.rs
+++ b/libs/modkit-http/src/builder.rs
@@ -95,38 +95,25 @@ impl HttpClientBuilder {
 
     /// Set transport security mode
     ///
-    /// Use `TransportSecurity::AllowInsecureHttp` only for testing with mock servers.
+    /// Use `TransportSecurity::TlsOnly` to enforce HTTPS for all connections.
     #[must_use]
     pub fn transport(mut self, transport: TransportSecurity) -> Self {
         self.config.transport = transport;
         self
     }
 
-    /// Allow insecure HTTP connections (for testing only)
+    /// Deny insecure HTTP connections, enforcing TLS for all traffic
     ///
-    /// Equivalent to `.transport(TransportSecurity::AllowInsecureHttp)`.
+    /// Equivalent to `.transport(TransportSecurity::TlsOnly)`.
     ///
-    /// **WARNING**: This should only be used for local testing with mock servers.
-    /// Never use in production as it exposes traffic to interception.
-    ///
-    /// # Compile-time Safety
-    ///
-    /// This method is only available in debug builds or when the `allow-insecure-http`
-    /// feature is explicitly enabled. This prevents accidental use in production.
-    ///
-    /// To use in release builds (e.g., for integration tests), add:
-    /// ```toml
-    /// [features]
-    /// allow-insecure-http = []
-    /// ```
+    /// Use this when TLS enforcement is required (e.g., production environments).
     #[must_use]
-    #[cfg(any(debug_assertions, feature = "allow-insecure-http"))]
-    pub fn allow_insecure_http(mut self) -> Self {
-        tracing::warn!(
+    pub fn deny_insecure_http(mut self) -> Self {
+        tracing::debug!(
             target: "modkit_http::security",
-            "allow_insecure_http() called - HTTP traffic will NOT be encrypted"
+            "deny_insecure_http() called - enforcing TLS for all connections"
         );
-        self.config.transport = TransportSecurity::AllowInsecureHttp;
+        self.config.transport = TransportSecurity::TlsOnly;
         self
     }
 
@@ -241,14 +228,6 @@ impl HttpClientBuilder {
     /// # Errors
     /// Returns an error if TLS initialization fails or configuration is invalid
     pub fn build(self) -> Result<crate::HttpClient, HttpError> {
-        // Warn if insecure HTTP is enabled (should only be used for testing)
-        if self.config.transport == TransportSecurity::AllowInsecureHttp {
-            tracing::warn!(
-                "insecure HTTP enabled (TransportSecurity::AllowInsecureHttp); \
-                 use only for testing with mock servers"
-            );
-        }
-
         let timeout = self.config.request_timeout;
         let total_timeout = self.config.total_timeout;
 
@@ -546,20 +525,17 @@ mod tests {
 
     #[test]
     fn test_builder_transport_security() {
-        let builder = HttpClientBuilder::new().transport(TransportSecurity::AllowInsecureHttp);
-        assert_eq!(
-            builder.config.transport,
-            TransportSecurity::AllowInsecureHttp
-        );
+        let builder = HttpClientBuilder::new().transport(TransportSecurity::TlsOnly);
+        assert_eq!(builder.config.transport, TransportSecurity::TlsOnly);
 
-        let builder = HttpClientBuilder::new().allow_insecure_http();
-        assert_eq!(
-            builder.config.transport,
-            TransportSecurity::AllowInsecureHttp
-        );
+        let builder = HttpClientBuilder::new().deny_insecure_http();
+        assert_eq!(builder.config.transport, TransportSecurity::TlsOnly);
 
         let builder = HttpClientBuilder::new();
-        assert_eq!(builder.config.transport, TransportSecurity::TlsOnly);
+        assert_eq!(
+            builder.config.transport,
+            TransportSecurity::AllowInsecureHttp
+        );
     }
 
     #[test]
@@ -610,7 +586,6 @@ mod tests {
     #[tokio::test]
     async fn test_builder_with_auth_layer() {
         let client = HttpClientBuilder::new()
-            .allow_insecure_http()
             .with_auth_layer(|svc| svc) // identity transform
             .build();
         assert!(client.is_ok());
@@ -623,8 +598,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_builder_build_with_insecure_http() {
-        let client = HttpClientBuilder::new().allow_insecure_http().build();
+    async fn test_builder_build_with_deny_insecure_http() {
+        let client = HttpClientBuilder::new().deny_insecure_http().build();
         assert!(client.is_ok());
     }
 
@@ -700,8 +675,8 @@ mod tests {
     /// The hyper client uses `http2_only(false)` to allow both protocols.
     #[tokio::test]
     async fn test_http2_enabled_for_all_configurations() {
-        // Test WebPki with AllowInsecureHttp
-        let client = HttpClientBuilder::new().allow_insecure_http().build();
+        // Test WebPki with AllowInsecureHttp (default)
+        let client = HttpClientBuilder::new().build();
         assert!(
             client.is_ok(),
             "WebPki + AllowInsecureHttp should build with HTTP/2 enabled"
@@ -834,123 +809,6 @@ mod tests {
         assert!(
             matches!(err, HttpError::Overloaded),
             "Expected Overloaded error, got: {err:?}"
-        );
-    }
-
-    /// Test that `AllowInsecureHttp` emits a warning during `build()`
-    #[tokio::test]
-    async fn test_insecure_http_warning_emitted() {
-        use std::sync::{Arc, Mutex};
-        use tracing_subscriber::layer::SubscriberExt;
-
-        // Custom layer to capture warning events
-        #[derive(Clone, Default)]
-        struct WarningCapture {
-            warnings: Arc<Mutex<Vec<String>>>,
-        }
-
-        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for WarningCapture {
-            fn on_event(
-                &self,
-                event: &tracing::Event<'_>,
-                _ctx: tracing_subscriber::layer::Context<'_, S>,
-            ) {
-                if *event.metadata().level() == tracing::Level::WARN {
-                    let mut visitor = MessageVisitor(String::new());
-                    event.record(&mut visitor);
-                    self.warnings.lock().unwrap().push(visitor.0);
-                }
-            }
-        }
-
-        struct MessageVisitor(String);
-        impl tracing::field::Visit for MessageVisitor {
-            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-                if field.name() == "message" {
-                    self.0 = format!("{value:?}");
-                }
-            }
-        }
-
-        let capture = WarningCapture::default();
-        let warnings = capture.warnings.clone();
-
-        let subscriber = tracing_subscriber::registry().with(capture);
-
-        // Build with `AllowInsecureHttp` under the capturing subscriber
-        tracing::subscriber::with_default(subscriber, || {
-            _ = HttpClientBuilder::new().allow_insecure_http().build();
-        });
-
-        let captured = warnings.lock().unwrap();
-        // Two warnings: one from allow_insecure_http() and one from build()
-        assert!(
-            !captured.is_empty(),
-            "expected at least one warning, got: {:?}",
-            *captured
-        );
-        assert!(
-            captured
-                .iter()
-                .any(|w| w.contains("insecure HTTP") || w.contains("HTTP traffic")),
-            "warning should mention insecure HTTP: {:?}",
-            *captured
-        );
-    }
-
-    /// Test that `TlsOnly` does NOT emit an insecure HTTP warning
-    #[tokio::test]
-    async fn test_tls_only_no_warning() {
-        use std::sync::{Arc, Mutex};
-        use tracing_subscriber::layer::SubscriberExt;
-
-        #[derive(Clone, Default)]
-        struct WarningCapture {
-            warnings: Arc<Mutex<Vec<String>>>,
-        }
-
-        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for WarningCapture {
-            fn on_event(
-                &self,
-                event: &tracing::Event<'_>,
-                _ctx: tracing_subscriber::layer::Context<'_, S>,
-            ) {
-                if *event.metadata().level() == tracing::Level::WARN {
-                    let mut visitor = MessageVisitor(String::new());
-                    event.record(&mut visitor);
-                    if visitor.0.contains("insecure HTTP") {
-                        self.warnings.lock().unwrap().push(visitor.0);
-                    }
-                }
-            }
-        }
-
-        struct MessageVisitor(String);
-        impl tracing::field::Visit for MessageVisitor {
-            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-                if field.name() == "message" {
-                    self.0 = format!("{value:?}");
-                }
-            }
-        }
-
-        let capture = WarningCapture::default();
-        let warnings = capture.warnings.clone();
-
-        let subscriber = tracing_subscriber::registry().with(capture);
-
-        // Build with `TlsOnly`
-        tracing::subscriber::with_default(subscriber, || {
-            _ = HttpClientBuilder::new()
-                .transport(TransportSecurity::TlsOnly)
-                .build();
-        });
-
-        let captured = warnings.lock().unwrap();
-        assert!(
-            captured.is_empty(),
-            "no insecure HTTP warning expected, got: {:?}",
-            *captured
         );
     }
 

--- a/libs/modkit-http/src/client.rs
+++ b/libs/modkit-http/src/client.rs
@@ -283,11 +283,7 @@ mod tests {
     use serde_json::json;
 
     fn test_client() -> HttpClient {
-        HttpClientBuilder::new()
-            .allow_insecure_http()
-            .retry(None)
-            .build()
-            .unwrap()
+        HttpClientBuilder::new().retry(None).build().unwrap()
     }
 
     #[tokio::test]
@@ -377,7 +373,6 @@ mod tests {
         });
 
         let client = HttpClientBuilder::new()
-            .allow_insecure_http()
             .retry(None)
             .max_body_size(1024) // 1KB limit
             .build()
@@ -400,7 +395,6 @@ mod tests {
         });
 
         let client = HttpClientBuilder::new()
-            .allow_insecure_http()
             .retry(None)
             .user_agent("custom/1.0")
             .build()
@@ -656,7 +650,6 @@ mod tests {
         });
 
         let client = HttpClientBuilder::new()
-            .allow_insecure_http()
             .retry(None)
             .max_body_size(1024 * 1024) // 1MB limit
             .build()
@@ -1282,7 +1275,6 @@ mod tests {
 
         // Create client with 10KB body limit - smaller than decompressed size
         let client = HttpClientBuilder::new()
-            .allow_insecure_http()
             .retry(None)
             .max_body_size(10 * 1024) // 10KB limit
             .build()
@@ -1890,20 +1882,14 @@ mod tests {
     // URL Scheme Validation Tests
     // ==========================================================================
 
-    /// Test: http:// URL rejected when transport security is `TlsOnly` (default)
+    /// Test: http:// URL rejected when transport security is `TlsOnly`
     #[tokio::test]
     async fn test_url_scheme_http_rejected_with_tls_only() {
-        use crate::config::HttpClientConfig;
-
-        // Default config has TlsOnly transport security
-        let config = HttpClientConfig {
-            retry: None,
-            rate_limit: None,
-            ..Default::default()
-        };
-        assert_eq!(config.transport, crate::config::TransportSecurity::TlsOnly);
-
-        let client = HttpClientBuilder::with_config(config).build().unwrap();
+        let client = HttpClientBuilder::new()
+            .transport(crate::config::TransportSecurity::TlsOnly)
+            .retry(None)
+            .build()
+            .unwrap();
 
         // Try to send a request to http:// URL
         let result = client.get("http://example.com/test").send().await;
@@ -1932,7 +1918,7 @@ mod tests {
         });
 
         let client = HttpClientBuilder::new()
-            .allow_insecure_http()
+            .transport(crate::config::TransportSecurity::AllowInsecureHttp)
             .retry(None)
             .build()
             .unwrap();
@@ -1948,7 +1934,11 @@ mod tests {
     async fn test_url_scheme_https_always_allowed() {
         // Note: We can't actually test HTTPS without a real server,
         // but we can verify the validation passes and fails later on connection
-        let client = HttpClientBuilder::new().retry(None).build().unwrap();
+        let client = HttpClientBuilder::new()
+            .transport(crate::config::TransportSecurity::TlsOnly)
+            .retry(None)
+            .build()
+            .unwrap();
 
         // The scheme validation should pass (not InvalidScheme)
         // but the actual connection will fail because example.com won't respond
@@ -1965,7 +1955,7 @@ mod tests {
     #[tokio::test]
     async fn test_url_scheme_invalid_rejected() {
         let client = HttpClientBuilder::new()
-            .allow_insecure_http() // Even with insecure allowed
+            .transport(crate::config::TransportSecurity::AllowInsecureHttp)
             .retry(None)
             .build()
             .unwrap();
@@ -1989,7 +1979,7 @@ mod tests {
     #[tokio::test]
     async fn test_url_scheme_missing_rejected() {
         let client = HttpClientBuilder::new()
-            .allow_insecure_http()
+            .transport(crate::config::TransportSecurity::AllowInsecureHttp)
             .retry(None)
             .build()
             .unwrap();

--- a/libs/modkit-http/src/config.rs
+++ b/libs/modkit-http/src/config.rs
@@ -476,13 +476,13 @@ pub enum TlsRootConfig {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum TransportSecurity {
-    /// Require TLS for all connections (HTTPS only) - default and recommended
-    #[default]
+    /// Require TLS for all connections (HTTPS only)
     TlsOnly,
-    /// Allow insecure HTTP connections (for testing with mock servers only)
+    /// Allow insecure HTTP connections (default)
     ///
-    /// **WARNING**: This should only be used for local testing with mock servers.
-    /// Never use in production as it exposes traffic to interception.
+    /// Use [`HttpClientBuilder::deny_insecure_http`] to switch to `TlsOnly`
+    /// when TLS enforcement is required.
+    #[default]
     AllowInsecureHttp,
 }
 
@@ -517,9 +517,9 @@ pub struct HttpClientConfig {
     /// Rate limiting / concurrency configuration
     pub rate_limit: Option<RateLimitConfig>,
 
-    /// Transport security mode (default: `TlsOnly`)
+    /// Transport security mode (default: `AllowInsecureHttp`)
     ///
-    /// Use `AllowInsecureHttp` only for testing with local mock servers.
+    /// Use [`HttpClientBuilder::deny_insecure_http`] to enforce TLS for all connections.
     pub transport: TransportSecurity,
 
     /// TLS root certificate strategy (default: `WebPki`)
@@ -578,7 +578,7 @@ impl Default for HttpClientConfig {
             user_agent: DEFAULT_USER_AGENT.to_owned(),
             retry: Some(RetryConfig::default()),
             rate_limit: Some(RateLimitConfig::default()),
-            transport: TransportSecurity::TlsOnly,
+            transport: TransportSecurity::AllowInsecureHttp,
             tls_roots: TlsRootConfig::default(),
             otel: false,
             buffer_capacity: 1024,
@@ -600,7 +600,7 @@ impl HttpClientConfig {
             user_agent: DEFAULT_USER_AGENT.to_owned(),
             retry: None,
             rate_limit: None,
-            transport: TransportSecurity::TlsOnly,
+            transport: TransportSecurity::AllowInsecureHttp,
             tls_roots: TlsRootConfig::default(),
             otel: false,
             buffer_capacity: 256,
@@ -620,7 +620,7 @@ impl HttpClientConfig {
             user_agent: DEFAULT_USER_AGENT.to_owned(),
             retry: Some(RetryConfig::aggressive()),
             rate_limit: Some(RateLimitConfig::default()),
-            transport: TransportSecurity::TlsOnly,
+            transport: TransportSecurity::AllowInsecureHttp,
             tls_roots: TlsRootConfig::default(),
             otel: false,
             buffer_capacity: 1024,
@@ -661,7 +661,7 @@ impl HttpClientConfig {
                 ..RetryConfig::default()
             }),
             rate_limit: Some(RateLimitConfig::conservative()),
-            transport: TransportSecurity::TlsOnly,
+            transport: TransportSecurity::AllowInsecureHttp,
             tls_roots: TlsRootConfig::default(),
             otel: false,
             buffer_capacity: 256,
@@ -672,9 +672,6 @@ impl HttpClientConfig {
     }
 
     /// Create configuration for testing with mock servers (allows insecure HTTP)
-    ///
-    /// **WARNING**: This configuration allows plain HTTP connections.
-    /// Use only for local testing with mock servers, never in production.
     #[must_use]
     pub fn for_testing() -> Self {
         Self {
@@ -743,7 +740,7 @@ impl HttpClientConfig {
             user_agent: DEFAULT_USER_AGENT.to_owned(),
             retry: None, // SSE reconnection is protocol-level (Last-Event-ID)
             rate_limit: None,
-            transport: TransportSecurity::TlsOnly,
+            transport: TransportSecurity::AllowInsecureHttp,
             tls_roots: TlsRootConfig::default(),
             otel: false,
             buffer_capacity: 64,
@@ -979,7 +976,7 @@ mod tests {
         assert_eq!(config.user_agent, DEFAULT_USER_AGENT);
         assert!(config.retry.is_some());
         assert!(config.rate_limit.is_some());
-        assert_eq!(config.transport, TransportSecurity::TlsOnly);
+        assert_eq!(config.transport, TransportSecurity::AllowInsecureHttp);
         assert!(!config.otel);
         assert_eq!(config.buffer_capacity, 1024);
     }


### PR DESCRIPTION
Set `AllowInsecureHttp` by default in `modkit-http` config, add `deny_insecure_http` method for TLS enforcement.

Dev task: https://github.com/cyberfabric/cyberfabric-core/issues/861 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added an explicit TLS-enforcement option for the HTTP client; legacy per-call insecure toggle removed.
  * Client configuration defaults now allow insecure HTTP by default; TLS must be explicitly enforced.

* **Chores**
  * Build-time feature exposing insecure-HTTP was removed.

* **Tests**
  * Test setups updated to match the new default transport behavior and TLS-enforcement option.

* **Documentation**
  * Client docs and test guidance updated to reflect the new transport defaults and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->