### PR TITLE
docs: fix GTS id in docs/arch/errors

### DIFF
--- a/docs/arch/errors/ADR/0002-cpt-cf-adr-gts-error-identification.md
+++ b/docs/arch/errors/ADR/0002-cpt-cf-adr-gts-error-identification.md
@@ -84,7 +84,7 @@ gts.cf.core.errors.err.v1~cf.core.err.{category}.v1~
 └────── base type ──────┘ └───── instance type ────┘
 ```
 
-The base type `gts.cf.core.errors.err.v1` identifies "canonical error." The instance type `cf.core.err.{category}.v1` identifies the specific category. The `~` separator is part of GTS compound type syntax.
+The base type `gts.cf.core.errors.err.v1~` identifies "canonical error." The instance type `cf.core.err.{category}.v1~` identifies the specific category.
 
 All 16 identifiers are defined as `const` values in the `CanonicalError` implementation. See [DESIGN.md](../DESIGN.md) § Category Reference.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GTS identifier format examples in architecture documentation to reflect standardized conventions using trailing tilde suffixes on both base type and instance type identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->