### PR TITLE
fix(mini-chat): wrap update_chat in transaction and fix credstore test

### DIFF
--- a/dylint_lints/Cargo.lock
+++ b/dylint_lints/Cargo.lock
@@ -3452,20 +3452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3572,40 +3558,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
 ]
 
 [[package]]
@@ -4153,7 +4105,6 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "rust_decimal",
- "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -4165,7 +4116,6 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4926,12 +4876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5192,24 +5136,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/dylint_lints/Cargo.toml
+++ b/dylint_lints/Cargo.toml
@@ -54,8 +54,8 @@ tokio = { version = "1.44", features = ["macros", "rt"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 utoipa = "5.2"
-modkit-macros = { package = "cf-modkit-macros", version = "0.2.0", path = "../libs/modkit-macros" }
-modkit = { package = "cf-modkit", version = "0.2.0", path = "../libs/modkit" }
+modkit-macros = { package = "cf-modkit-macros", path = "../libs/modkit-macros" }
+modkit = { package = "cf-modkit", path = "../libs/modkit" }
 gts-id = "0.8.1"
 gts = "0.8.1"
 gts-macros = "0.8.1"

--- a/modules/credstore/credstore/src/domain/error.rs
+++ b/modules/credstore/credstore/src/domain/error.rs
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn from_choose_plugin_error_not_found_becomes_plugin_not_found() {
         let src = ChoosePluginError::PluginNotFound {
-            schema_id: "gts.x.core.test.v1~".into(),
+            schema_id: "gts.x.core.test.plugin.v1~".into(),
             vendor: "acme".into(),
         };
         let dst = DomainError::from(src);

--- a/modules/credstore/credstore/src/domain/error.rs
+++ b/modules/credstore/credstore/src/domain/error.rs
@@ -138,6 +138,7 @@ mod tests {
     #[test]
     fn from_choose_plugin_error_not_found_becomes_plugin_not_found() {
         let src = ChoosePluginError::PluginNotFound {
+            schema_id: "gts.x.core.test.v1~".into(),
             vendor: "acme".into(),
         };
         let dst = DomainError::from(src);

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/chats.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/chats.rs
@@ -20,7 +20,7 @@ pub(crate) async fn create_chat(
     Json(req_body): Json<CreateChatReq>,
 ) -> ApiResult<impl IntoResponse> {
     let new = NewChat {
-        model: req_body.model.unwrap_or_default(),
+        model: req_body.model,
         title: req_body.title,
         is_temporary: false,
     };

--- a/modules/mini-chat/mini-chat/src/domain/models.rs
+++ b/modules/mini-chat/mini-chat/src/domain/models.rs
@@ -35,7 +35,7 @@ pub struct ChatDetail {
 #[domain_model]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewChat {
-    pub model: String,
+    pub model: Option<String>,
     pub title: Option<String>,
     pub is_temporary: bool,
 }

--- a/modules/mini-chat/mini-chat/src/domain/repos/model_resolver.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/model_resolver.rs
@@ -5,9 +5,13 @@ use crate::domain::error::DomainError;
 
 /// Resolves and validates model IDs against the tenant's policy catalog.
 ///
-/// If `model` is empty, returns the default model for the tenant.
-/// If `model` is non-empty, validates it exists and is enabled in the catalog.
+/// If `model` is `None`, returns the default model for the tenant.
+/// If `model` is `Some`, validates it is non-empty and exists in the catalog.
 #[async_trait]
 pub trait ModelResolver: Send + Sync {
-    async fn resolve_model(&self, tenant_id: Uuid, model: &str) -> Result<String, DomainError>;
+    async fn resolve_model(
+        &self,
+        tenant_id: Uuid,
+        model: Option<String>,
+    ) -> Result<String, DomainError>;
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
@@ -72,7 +72,7 @@ impl<CR: ChatRepository + 'static> ChatService<CR> {
 
         let model = self
             .model_resolver
-            .resolve_model(tenant_id, &new.model)
+            .resolve_model(tenant_id, new.model)
             .await?;
 
         let now = OffsetDateTime::now_utc();
@@ -201,7 +201,7 @@ impl<CR: ChatRepository + 'static> ChatService<CR> {
             .transaction(|tx| {
                 let scope = scope.clone();
                 Box::pin(async move {
-                    let map = |e: DomainError| modkit_db::DbError::Other(anyhow::anyhow!(e));
+                    let map = |e: DomainError| modkit_db::DbError::Other(anyhow::Error::new(e));
 
                     let mut chat = chat_repo
                         .get(tx, &scope, id)
@@ -225,7 +225,13 @@ impl<CR: ChatRepository + 'static> ChatService<CR> {
                 })
             })
             .await
-            .map_err(DomainError::from)?;
+            .map_err(|e| match e {
+                modkit_db::DbError::Other(err) => match err.downcast::<DomainError>() {
+                    Ok(domain_err) => domain_err,
+                    Err(err) => DomainError::from(modkit_db::DbError::Other(err)),
+                },
+                other => DomainError::from(other),
+            })?;
 
         tracing::debug!("Successfully updated chat title");
         Ok(Self::to_detail(updated, message_count))

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
@@ -26,7 +26,7 @@ pub struct ChatService<CR: ChatRepository> {
     model_resolver: Arc<dyn ModelResolver>,
 }
 
-impl<CR: ChatRepository> ChatService<CR> {
+impl<CR: ChatRepository + 'static> ChatService<CR> {
     pub(crate) fn new(
         db: Arc<DbProvider>,
         chat_repo: Arc<CR>,
@@ -190,27 +190,42 @@ impl<CR: ChatRepository> ChatService<CR> {
             validate_title(Some(title.as_str()))?;
         }
 
-        let conn = self.db.conn().map_err(DomainError::from)?;
-
         let scope = self
             .enforcer
             .access_scope(ctx, &resources::CHAT, actions::UPDATE, Some(id))
             .await?;
 
-        let mut chat = self
-            .chat_repo
-            .get(&conn, &scope, id)
-            .await?
-            .ok_or_else(|| DomainError::chat_not_found(id))?;
+        let chat_repo = Arc::clone(&self.chat_repo);
+        let (updated, message_count) = self
+            .db
+            .transaction(|tx| {
+                let scope = scope.clone();
+                Box::pin(async move {
+                    let map = |e: DomainError| modkit_db::DbError::Other(anyhow::anyhow!(e));
 
-        // Apply patch
-        if let Some(title_opt) = patch.title {
-            chat.title = title_opt.map(|t| t.trim().to_owned());
-        }
-        chat.updated_at = OffsetDateTime::now_utc();
+                    let mut chat = chat_repo
+                        .get(tx, &scope, id)
+                        .await
+                        .map_err(map)?
+                        .ok_or_else(|| map(DomainError::chat_not_found(id)))?;
 
-        let updated = self.chat_repo.update(&conn, &scope, chat).await?;
-        let message_count = self.chat_repo.count_messages(&conn, &scope, id).await?;
+                    // Apply patch
+                    if let Some(title_opt) = patch.title {
+                        chat.title = title_opt.map(|t| t.trim().to_owned());
+                    }
+                    chat.updated_at = OffsetDateTime::now_utc();
+
+                    let updated = chat_repo.update(tx, &scope, chat).await.map_err(map)?;
+                    let message_count = chat_repo
+                        .count_messages(tx, &scope, id)
+                        .await
+                        .map_err(map)?;
+
+                    Ok((updated, message_count))
+                })
+            })
+            .await
+            .map_err(DomainError::from)?;
 
         tracing::debug!("Successfully updated chat title");
         Ok(Self::to_detail(updated, message_count))

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
@@ -44,7 +44,7 @@ async fn create_chat_default_model() {
         .create_chat(
             &ctx,
             NewChat {
-                model: String::new(), // empty → default
+                model: None, // empty → default
                 title: Some("Hello".to_owned()),
                 is_temporary: false,
             },
@@ -68,7 +68,7 @@ async fn create_chat_explicit_valid_model() {
         .create_chat(
             &ctx,
             NewChat {
-                model: "gpt-5.2".to_owned(),
+                model: Some("gpt-5.2".to_owned()),
                 title: None,
                 is_temporary: false,
             },
@@ -89,7 +89,7 @@ async fn create_chat_disabled_model_rejected() {
         .create_chat(
             &ctx,
             NewChat {
-                model: "gpt-5-mini".to_owned(),
+                model: Some("gpt-5-mini".to_owned()),
                 title: None,
                 is_temporary: false,
             },
@@ -114,7 +114,7 @@ async fn create_chat_empty_title_rejected() {
         .create_chat(
             &ctx,
             NewChat {
-                model: "gpt-5.2".to_owned(),
+                model: Some("gpt-5.2".to_owned()),
                 title: Some(String::new()),
                 is_temporary: false,
             },
@@ -138,7 +138,7 @@ async fn create_chat_title_trimmed() {
         .create_chat(
             &ctx,
             NewChat {
-                model: "gpt-5.2".to_owned(),
+                model: Some("gpt-5.2".to_owned()),
                 title: Some("  padded  ".to_owned()),
                 is_temporary: false,
             },
@@ -159,7 +159,7 @@ async fn create_chat_invalid_model() {
         .create_chat(
             &ctx,
             NewChat {
-                model: "nonexistent-model".to_owned(),
+                model: Some("nonexistent-model".to_owned()),
                 title: None,
                 is_temporary: false,
             },
@@ -185,7 +185,7 @@ async fn get_chat_happy_path() {
         .create_chat(
             &ctx,
             NewChat {
-                model: "gpt-5.2".to_owned(),
+                model: Some("gpt-5.2".to_owned()),
                 title: Some("Test".to_owned()),
                 is_temporary: false,
             },
@@ -224,7 +224,7 @@ async fn update_chat_title_happy_path() {
         .create_chat(
             &ctx,
             NewChat {
-                model: "gpt-5.2".to_owned(),
+                model: Some("gpt-5.2".to_owned()),
                 title: Some("Old Title".to_owned()),
                 is_temporary: false,
             },
@@ -256,7 +256,7 @@ async fn update_chat_title_empty_rejected() {
         .create_chat(
             &ctx,
             NewChat {
-                model: "gpt-5.2".to_owned(),
+                model: Some("gpt-5.2".to_owned()),
                 title: Some("Title".to_owned()),
                 is_temporary: false,
             },
@@ -291,7 +291,7 @@ async fn update_chat_title_whitespace_only_rejected() {
         .create_chat(
             &ctx,
             NewChat {
-                model: "gpt-5.2".to_owned(),
+                model: Some("gpt-5.2".to_owned()),
                 title: Some("Title".to_owned()),
                 is_temporary: false,
             },
@@ -326,7 +326,7 @@ async fn update_chat_title_too_long_rejected() {
         .create_chat(
             &ctx,
             NewChat {
-                model: "gpt-5.2".to_owned(),
+                model: Some("gpt-5.2".to_owned()),
                 title: Some("Title".to_owned()),
                 is_temporary: false,
             },
@@ -362,7 +362,7 @@ async fn delete_chat_happy_path() {
         .create_chat(
             &ctx,
             NewChat {
-                model: "gpt-5.2".to_owned(),
+                model: Some("gpt-5.2".to_owned()),
                 title: Some("To Delete".to_owned()),
                 is_temporary: false,
             },
@@ -391,7 +391,7 @@ async fn list_chats_returns_page() {
     svc.create_chat(
         &ctx,
         NewChat {
-            model: "gpt-5.2".to_owned(),
+            model: Some("gpt-5.2".to_owned()),
             title: Some("First".to_owned()),
             is_temporary: false,
         },
@@ -402,7 +402,7 @@ async fn list_chats_returns_page() {
     svc.create_chat(
         &ctx,
         NewChat {
-            model: "gpt-5.2".to_owned(),
+            model: Some("gpt-5.2".to_owned()),
             title: Some("Second".to_owned()),
             is_temporary: false,
         },
@@ -439,7 +439,7 @@ async fn list_chats_cross_tenant_returns_empty() {
     svc.create_chat(
         &ctx_a,
         NewChat {
-            model: "gpt-5.2".to_owned(),
+            model: Some("gpt-5.2".to_owned()),
             title: Some("Tenant A chat".to_owned()),
             is_temporary: false,
         },
@@ -470,7 +470,7 @@ async fn list_chats_cross_owner_returns_empty() {
     svc.create_chat(
         &ctx_a,
         NewChat {
-            model: "gpt-5.2".to_owned(),
+            model: Some("gpt-5.2".to_owned()),
             title: Some("User A chat".to_owned()),
             is_temporary: false,
         },
@@ -500,7 +500,7 @@ async fn get_chat_cross_tenant_not_found() {
         .create_chat(
             &ctx_a,
             NewChat {
-                model: "gpt-5.2".to_owned(),
+                model: Some("gpt-5.2".to_owned()),
                 title: Some("Tenant A chat".to_owned()),
                 is_temporary: false,
             },
@@ -532,7 +532,7 @@ async fn delete_chat_cross_owner_not_found() {
         .create_chat(
             &ctx_a,
             NewChat {
-                model: "gpt-5.2".to_owned(),
+                model: Some("gpt-5.2".to_owned()),
                 title: Some("User A chat".to_owned()),
                 is_temporary: false,
             },

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -279,7 +279,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
                             },
                         )
                         .await
-                        .map_err(|e| modkit_db::DbError::Other(anyhow::anyhow!(e)))?;
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
 
                     turn_repo
                         .create_turn(
@@ -301,14 +301,20 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
                             },
                         )
                         .await
-                        .map_err(|e| modkit_db::DbError::Other(anyhow::anyhow!(e)))?;
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
 
                     Ok(())
                 })
             })
             .await
             .map_err(|e| StreamError::TurnCreationFailed {
-                source: DomainError::from(e),
+                source: match e {
+                    modkit_db::DbError::Other(err) => match err.downcast::<DomainError>() {
+                        Ok(domain_err) => domain_err,
+                        Err(err) => DomainError::from(modkit_db::DbError::Other(err)),
+                    },
+                    other => DomainError::from(other),
+                },
             })?;
 
         // Pre-generate assistant message ID (sent in DoneData and used in CAS)

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -117,16 +117,23 @@ pub struct MockModelResolver;
 
 #[async_trait]
 impl ModelResolver for MockModelResolver {
-    async fn resolve_model(&self, _tenant_id: Uuid, model: &str) -> Result<String, DomainError> {
+    async fn resolve_model(
+        &self,
+        _tenant_id: Uuid,
+        model: Option<String>,
+    ) -> Result<String, DomainError> {
         let catalog = [("gpt-5.2", true), ("gpt-5-mini", false)];
 
-        if model.is_empty() {
-            // Return default model
-            Ok("gpt-5.2".to_owned())
-        } else if catalog.iter().any(|(id, enabled)| *id == model && *enabled) {
-            Ok(model.to_owned())
-        } else {
-            Err(DomainError::invalid_model(model))
+        match model {
+            None => Ok("gpt-5.2".to_owned()),
+            Some(m) if m.is_empty() => Err(DomainError::invalid_model("model must not be empty")),
+            Some(m) => {
+                if catalog.iter().any(|(id, enabled)| *id == m && *enabled) {
+                    Ok(m)
+                } else {
+                    Err(DomainError::invalid_model(&m))
+                }
+            }
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
@@ -69,7 +69,11 @@ impl ModelPolicyGateway {
 
 #[async_trait]
 impl ModelResolver for ModelPolicyGateway {
-    async fn resolve_model(&self, tenant_id: Uuid, model: &str) -> Result<String, DomainError> {
+    async fn resolve_model(
+        &self,
+        tenant_id: Uuid,
+        model: Option<String>,
+    ) -> Result<String, DomainError> {
         let plugin = self.get_policy_plugin().await?;
         let version_info = plugin
             .get_current_policy_version(tenant_id)
@@ -80,29 +84,35 @@ impl ModelResolver for ModelPolicyGateway {
             .await
             .map_err(|e| DomainError::internal(e.to_string()))?;
 
-        if model.is_empty() {
-            // Find default model (prefer is_default + enabled, else first enabled)
-            let default = snapshot
-                .model_catalog
-                .iter()
-                .find(|m| m.is_default && m.global_enabled)
-                .or_else(|| snapshot.model_catalog.iter().find(|m| m.global_enabled));
+        match model {
+            None => {
+                // Find default model (prefer is_default + enabled, else first enabled)
+                let default = snapshot
+                    .model_catalog
+                    .iter()
+                    .find(|m| m.is_default && m.global_enabled)
+                    .or_else(|| snapshot.model_catalog.iter().find(|m| m.global_enabled));
 
-            match default {
-                Some(entry) => Ok(entry.model_id.clone()),
-                None => Err(DomainError::invalid_model("no models available in catalog")),
+                match default {
+                    Some(entry) => Ok(entry.model_id.clone()),
+                    None => Err(DomainError::invalid_model("no models available in catalog")),
+                }
             }
-        } else {
-            // Validate provided model exists in catalog
-            let found = snapshot
-                .model_catalog
-                .iter()
-                .any(|m| m.model_id == model && m.global_enabled);
+            Some(model) if model.is_empty() => {
+                Err(DomainError::invalid_model("model must not be empty"))
+            }
+            Some(model) => {
+                // Validate provided model exists in catalog
+                let found = snapshot
+                    .model_catalog
+                    .iter()
+                    .any(|m| m.model_id == model && m.global_enabled);
 
-            if found {
-                Ok(model.to_owned())
-            } else {
-                Err(DomainError::invalid_model(model))
+                if found {
+                    Ok(model)
+                } else {
+                    Err(DomainError::invalid_model(&model))
+                }
             }
         }
     }


### PR DESCRIPTION
- Wrap chat update (get → update) in a db transaction for atomicity
- Fix credstore test to include new schema_id field in PluginNotFound

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test setup for plugin-not-found to include additional schema information.

* **Refactor**
  * Added stricter lifetime constraints for repository types.
  * Switched chat updates to transaction-backed operations for atomicity and consistent error mapping.

* **Bug Fixes / Behavior**
  * Made chat model optional during creation and removed defaulting; request-provided model is now used as-is.
  * Model resolution now distinguishes None vs Some(model) and rejects empty model strings; test mocks and resolver policy updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->