### PR TITLE
feat(mini-chat): implement endpoints for list messages and set/delete reactions

### DIFF
--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -112,16 +112,40 @@ modules:
           tier: Premium
           global_enabled: true
           is_default: true
+          input_tokens_credit_multiplier_micro: 3000000
+          output_tokens_credit_multiplier_micro: 15000000
+          multimodal_capabilities: ["VISION_INPUT"]
+          context_window: 128000
+          max_output_tokens: 8192
+          description: "Most capable model"
+          provider_display_name: "OpenAI"
+          multiplier_display: "3x"
         - model_id: "gpt-5-mini"
           display_name: "GPT-5 Mini"
           tier: Standard
           global_enabled: true
           is_default: false
+          input_tokens_credit_multiplier_micro: 1000000
+          output_tokens_credit_multiplier_micro: 3000000
+          multimodal_capabilities: []
+          context_window: 128000
+          max_output_tokens: 4096
+          description: "Fast and efficient model"
+          provider_display_name: "OpenAI"
+          multiplier_display: "1x"
         - model_id: "gpt-5-nano"
           display_name: "GPT-5 Nano"
           tier: Standard
           global_enabled: true
           is_default: false
+          input_tokens_credit_multiplier_micro: 500000
+          output_tokens_credit_multiplier_micro: 1500000
+          multimodal_capabilities: []
+          context_window: 64000
+          max_output_tokens: 4096
+          description: "Lightweight and fast model"
+          provider_display_name: "OpenAI"
+          multiplier_display: "0.5x"
 
 tracing:
   enabled: false

--- a/libs/modkit-security/src/access_scope.rs
+++ b/libs/modkit-security/src/access_scope.rs
@@ -538,6 +538,62 @@ impl AccessScope {
             .iter()
             .any(|c| c.filters().iter().any(|f| f.property() == property))
     }
+
+    /// Create a new scope retaining only `owner_tenant_id` filters.
+    ///
+    /// Useful for entities declared with `no_owner` (e.g., messages, reactions),
+    /// where `owner_id` constraints cannot be resolved and would cause fail-closed
+    /// deny-all behaviour.
+    ///
+    /// - Unconstrained scopes are returned as-is.
+    /// - Constraints that contain no `owner_tenant_id` filter are dropped entirely.
+    /// - If all constraints are dropped, the result is deny-all.
+    #[must_use]
+    pub fn tenant_only(&self) -> Self {
+        self.retain_properties(&[pep_properties::OWNER_TENANT_ID])
+    }
+
+    /// Create a new scope retaining only `owner_tenant_id` and `owner_id` filters.
+    ///
+    /// Useful for entities that have both tenant and owner columns but no
+    /// resource-level constraints (e.g., reactions scoped to the acting user).
+    ///
+    /// - Unconstrained scopes are returned as-is.
+    /// - Constraints that contain none of the retained properties are dropped.
+    /// - If all constraints are dropped, the result is deny-all.
+    #[must_use]
+    pub fn tenant_and_owner(&self) -> Self {
+        self.retain_properties(&[pep_properties::OWNER_TENANT_ID, pep_properties::OWNER_ID])
+    }
+
+    /// Internal helper: build a new scope keeping only filters whose property
+    /// is in the given whitelist.
+    fn retain_properties(&self, properties: &[&str]) -> Self {
+        if self.unconstrained {
+            return self.clone();
+        }
+
+        let constraints = self
+            .constraints
+            .iter()
+            .filter_map(|c| {
+                let kept: Vec<ScopeFilter> = c
+                    .filters()
+                    .iter()
+                    .filter(|f| properties.contains(&f.property()))
+                    .cloned()
+                    .collect();
+
+                if kept.is_empty() {
+                    None
+                } else {
+                    Some(ScopeConstraint::new(kept))
+                }
+            })
+            .collect();
+
+        Self::from_constraints(constraints)
+    }
 }
 
 #[cfg(test)]
@@ -599,5 +655,75 @@ mod tests {
         )]));
         assert!(scope.contains_uuid(pep_properties::OWNER_TENANT_ID, uid(T1)));
         assert!(!scope.contains_uuid(pep_properties::OWNER_TENANT_ID, uid(T2)));
+    }
+
+    // --- tenant_only ---
+
+    #[test]
+    fn tenant_only_strips_owner_id() {
+        let scope = AccessScope::single(ScopeConstraint::new(vec![
+            ScopeFilter::eq(pep_properties::OWNER_TENANT_ID, uid(T1)),
+            ScopeFilter::eq(pep_properties::OWNER_ID, uid(T2)),
+        ]));
+
+        let tenant_scope = scope.tenant_only();
+        assert!(tenant_scope.contains_uuid(pep_properties::OWNER_TENANT_ID, uid(T1)));
+        assert!(!tenant_scope.has_property(pep_properties::OWNER_ID));
+    }
+
+    #[test]
+    fn tenant_only_preserves_unconstrained() {
+        let scope = AccessScope::allow_all();
+        let tenant_scope = scope.tenant_only();
+        assert!(tenant_scope.is_unconstrained());
+    }
+
+    #[test]
+    fn tenant_only_deny_all_when_no_tenant_filters() {
+        let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::eq(
+            pep_properties::OWNER_ID,
+            uid(T1),
+        )]));
+
+        let tenant_scope = scope.tenant_only();
+        assert!(tenant_scope.is_deny_all());
+    }
+
+    #[test]
+    fn tenant_only_on_deny_all_stays_deny_all() {
+        let scope = AccessScope::deny_all();
+        let tenant_scope = scope.tenant_only();
+        assert!(tenant_scope.is_deny_all());
+    }
+
+    // --- tenant_and_owner ---
+
+    #[test]
+    fn tenant_and_owner_keeps_both_properties() {
+        let scope = AccessScope::single(ScopeConstraint::new(vec![
+            ScopeFilter::eq(pep_properties::OWNER_TENANT_ID, uid(T1)),
+            ScopeFilter::eq(pep_properties::OWNER_ID, uid(T2)),
+            ScopeFilter::eq(pep_properties::RESOURCE_ID, uid(T1)),
+        ]));
+
+        let narrowed = scope.tenant_and_owner();
+        assert!(narrowed.contains_uuid(pep_properties::OWNER_TENANT_ID, uid(T1)));
+        assert!(narrowed.contains_uuid(pep_properties::OWNER_ID, uid(T2)));
+        assert!(!narrowed.has_property(pep_properties::RESOURCE_ID));
+    }
+
+    #[test]
+    fn tenant_and_owner_preserves_unconstrained() {
+        let scope = AccessScope::allow_all();
+        assert!(scope.tenant_and_owner().is_unconstrained());
+    }
+
+    #[test]
+    fn tenant_and_owner_deny_all_when_no_matching_filters() {
+        let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::eq(
+            pep_properties::RESOURCE_ID,
+            uid(T1),
+        )]));
+        assert!(scope.tenant_and_owner().is_deny_all());
     }
 }

--- a/modules/mini-chat/docs/DESIGN.md
+++ b/modules/mini-chat/docs/DESIGN.md
@@ -1174,15 +1174,9 @@ The domain service computes model visibility for `(tenant_id, user_id)` as follo
 
 **Request body**: none
 
-**Response** (success): `200 OK` with:
-```json
-{
-  "message_id": "uuid",
-  "deleted": true
-}
-```
+**Response** (success): `204 No Content` (no body).
 
-If no reaction exists, return `200 OK` with `"deleted": true` (idempotent delete).
+Idempotent: returns `204` whether or not a reaction existed.
 
 **Errors**: same as Set Reaction (excluding `invalid_reaction_target`).
 
@@ -2038,17 +2032,17 @@ The authorized resource is **Chat**. Sub-resources (Message, Attachment, ThreadS
 | `POST /v1/chats/{id}:temporary` (P2) | `update` | present | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `GET /v1/chats/{id}/messages` | `list_messages` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `POST /v1/chats/{id}/messages:stream` | `send_message` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
-| `POST /v1/chats/{id}/attachments` | `upload` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
+| `POST /v1/chats/{id}/attachments` | `upload_attachment` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `GET /v1/chats/{id}/attachments/{attachment_id}` | `read_attachment` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `GET /v1/chats/{id}/turns/{request_id}` | `read_turn` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `POST /v1/chats/{id}/turns/{request_id}:retry` | `retry_turn` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `PATCH /v1/chats/{id}/turns/{request_id}` | `edit_turn` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `DELETE /v1/chats/{id}/turns/{request_id}` | `delete_turn` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
-| `PUT /v1/chats/{id}/messages/{msg_id}/reaction` | `react` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
+| `PUT /v1/chats/{id}/messages/{msg_id}/reaction` | `set_reaction` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `DELETE /v1/chats/{id}/messages/{msg_id}/reaction` | `delete_reaction` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 
 **Notes**:
-- `list_messages`, `send_message`, `upload`, `read_attachment`, `retry_turn`, `edit_turn`, `delete_turn`, `react`, and `delete_reaction` are actions on the Chat resource, not on Message or Turn sub-resources. The `resource.id` is the chat's ID.
+- `list_messages`, `send_message`, `upload_attachment`, `read_attachment`, `retry_turn`, `edit_turn`, `delete_turn`, `set_reaction`, and `delete_reaction` are actions on the Chat resource, not on Message or Turn sub-resources. The `resource.id` is the chat's ID.
 - For streaming (`send_message`, `retry_turn`, `edit_turn`), authorization is evaluated once at SSE connection establishment. The entire streaming session operates under the initial authorization decision. No per-message re-authorization.
 - For `create`, the PEP passes `resource.properties.owner_tenant_id` and `resource.properties.user_id` from the SecurityContext. The PDP validates permission without returning constraints.
 - Turn mutation endpoints (`retry_turn`, `edit_turn`, `delete_turn`) additionally enforce latest-turn and terminal-state checks in the domain service after authorization succeeds (see section 3.9).
@@ -2242,7 +2236,7 @@ Mini Chat recognizes the following token scopes for third-party application narr
 |-------|---------|
 | `ai:mini_chat` | All mini-chat operations (umbrella scope) |
 | `ai:mini_chat:read` | `list`, `read`, `list_messages`, `read_attachment`, `read_turn` actions only |
-| `ai:mini_chat:write` | `create`, `update`, `delete`, `send_message`, `upload`, `retry_turn`, `edit_turn`, `delete_turn`, `react`, `delete_reaction` actions |
+| `ai:mini_chat:write` | `create`, `update`, `delete`, `send_message`, `upload_attachment`, `retry_turn`, `edit_turn`, `delete_turn`, `set_reaction`, `delete_reaction` actions |
 
 First-party applications (UI) use `token_scopes: ["*"]`. Third-party integrations receive narrowed scopes. Scope enforcement is handled by the PDP - the PEP includes `token_scopes` in the evaluation request context.
 

--- a/modules/mini-chat/docs/openapi.json
+++ b/modules/mini-chat/docs/openapi.json
@@ -974,17 +974,10 @@
         "operationId": "removeReaction",
         "tags": ["reactions"],
         "summary": "Remove reaction from an assistant message",
-        "description": "Removes the current user's reaction from an assistant message. Idempotent: returns 200 even if no reaction exists.",
+        "description": "Removes the current user's reaction from an assistant message. Idempotent: returns 204 whether or not a reaction existed.",
         "responses": {
-          "200": {
-            "description": "Reaction removed (or was already absent).",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ReactionDeleteResponse"
-                }
-              }
-            }
+          "204": {
+            "description": "Reaction removed (or was already absent)."
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -1492,20 +1485,6 @@
           "created_at": {
             "type": "string",
             "format": "date-time"
-          }
-        }
-      },
-      "ReactionDeleteResponse": {
-        "type": "object",
-        "required": ["message_id", "deleted"],
-        "properties": {
-          "message_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "deleted": {
-            "type": "boolean",
-            "const": true
           }
         }
       },

--- a/modules/mini-chat/mini-chat/src/api/rest/dto.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/dto.rs
@@ -63,6 +63,76 @@ impl From<ChatDetail> for ChatDetailDto {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
+// Message DTOs
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Response DTO for a message in the list endpoint.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct MessageDto {
+    pub id: Uuid,
+    pub request_id: Uuid,
+    pub role: String,
+    pub content: String,
+    pub attachment_ids: Vec<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_tokens: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<i64>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+}
+
+impl From<crate::domain::models::Message> for MessageDto {
+    fn from(m: crate::domain::models::Message) -> Self {
+        Self {
+            id: m.id,
+            request_id: m.request_id,
+            role: m.role,
+            content: m.content,
+            attachment_ids: m.attachment_ids,
+            model: m.model,
+            input_tokens: m.input_tokens,
+            output_tokens: m.output_tokens,
+            created_at: m.created_at,
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Reaction DTOs
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Request DTO for setting a reaction.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request)]
+pub struct SetReactionReq {
+    pub reaction: String,
+}
+
+/// Response DTO for a reaction.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct ReactionDto {
+    pub message_id: Uuid,
+    pub reaction: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
+}
+
+impl From<crate::domain::models::Reaction> for ReactionDto {
+    fn from(r: crate::domain::models::Reaction) -> Self {
+        Self {
+            message_id: r.message_id,
+            reaction: r.kind.as_str().to_owned(),
+            created_at: r.created_at,
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 // Streaming request DTOs
 // ════════════════════════════════════════════════════════════════════════════
 

--- a/modules/mini-chat/mini-chat/src/api/rest/error.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/error.rs
@@ -47,6 +47,20 @@ impl From<DomainError> for Problem {
             )
             .with_trace_id(trace_id.unwrap_or_default()),
 
+            DomainError::MessageNotFound { id } => Problem::new(
+                StatusCode::NOT_FOUND,
+                "Message Not Found",
+                format!("Message with id {id} was not found"),
+            )
+            .with_trace_id(trace_id.unwrap_or_default()),
+
+            DomainError::InvalidReactionTarget { id } => Problem::new(
+                StatusCode::BAD_REQUEST,
+                "Invalid Reaction Target",
+                format!("Message {id} is not an assistant message"),
+            )
+            .with_trace_id(trace_id.unwrap_or_default()),
+
             DomainError::Database { .. } | DomainError::InternalError { .. } => {
                 tracing::error!(error = ?e, "Internal error occurred");
                 Problem::new(

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
@@ -9,6 +9,7 @@ use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::{Extension, Json};
 use futures::Stream;
+use modkit::api::odata::OData;
 use modkit::api::prelude::*;
 use modkit_security::SecurityContext;
 use tokio::sync::mpsc;
@@ -16,21 +17,23 @@ use tokio::time::{Interval, interval};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
-use crate::api::rest::dto::StreamMessageRequest;
+use crate::api::rest::dto::{MessageDto, StreamMessageRequest};
 use crate::api::rest::sse::{StreamEventKind, StreamPhase};
 use crate::domain::service::StreamError;
 use crate::domain::stream_events::StreamEvent;
 use crate::module::AppServices;
 
-use super::not_implemented;
-
 /// GET /mini-chat/v1/chats/{id}/messages
+#[tracing::instrument(skip(svc, ctx, query))]
 pub(crate) async fn list_messages(
-    Extension(_ctx): Extension<SecurityContext>,
-    Extension(_svc): Extension<Arc<AppServices>>,
-    Path(_chat_id): Path<uuid::Uuid>,
-) -> ApiResult<StatusCode> {
-    Err(not_implemented())
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<AppServices>>,
+    Path(chat_id): Path<uuid::Uuid>,
+    OData(query): OData,
+) -> ApiResult<JsonPage<MessageDto>> {
+    let page = svc.messages.list_messages(&ctx, chat_id, &query).await?;
+    let page = page.map_items(MessageDto::from);
+    Ok(Json(page))
 }
 
 /// POST /mini-chat/v1/chats/{id}/messages/stream

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/reactions.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/reactions.rs
@@ -5,24 +5,31 @@ use axum::extract::Path;
 use modkit::api::prelude::*;
 use modkit_security::SecurityContext;
 
+use crate::api::rest::dto::{ReactionDto, SetReactionReq};
 use crate::module::AppServices;
 
-use super::not_implemented;
-
 /// PUT /mini-chat/v1/chats/{id}/messages/{msg_id}/reaction
+#[tracing::instrument(skip(svc, ctx, req_body))]
 pub(crate) async fn put_reaction(
-    Extension(_ctx): Extension<SecurityContext>,
-    Extension(_svc): Extension<Arc<AppServices>>,
-    Path((_chat_id, _msg_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> ApiResult<StatusCode> {
-    Err(not_implemented())
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<AppServices>>,
+    Path((chat_id, msg_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+    Json(req_body): Json<SetReactionReq>,
+) -> ApiResult<JsonBody<ReactionDto>> {
+    let result = svc
+        .reactions
+        .set_reaction(&ctx, chat_id, msg_id, &req_body.reaction)
+        .await?;
+    Ok(Json(ReactionDto::from(result)))
 }
 
 /// DELETE /mini-chat/v1/chats/{id}/messages/{msg_id}/reaction
+#[tracing::instrument(skip(svc, ctx))]
 pub(crate) async fn delete_reaction(
-    Extension(_ctx): Extension<SecurityContext>,
-    Extension(_svc): Extension<Arc<AppServices>>,
-    Path((_chat_id, _msg_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> ApiResult<StatusCode> {
-    Err(not_implemented())
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<AppServices>>,
+    Path((chat_id, msg_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> ApiResult<impl IntoResponse> {
+    svc.reactions.delete_reaction(&ctx, chat_id, msg_id).await?;
+    Ok(no_content().into_response())
 }

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/messages.rs
@@ -1,5 +1,6 @@
 use axum::Router;
 use modkit::api::OpenApiRegistry;
+use modkit::api::ensure_schema;
 use modkit::api::operation_builder::OperationBuilder;
 
 use super::AiChatLicense;
@@ -10,6 +11,14 @@ pub(super) fn register_message_routes(
     openapi: &dyn OpenApiRegistry,
     prefix: &str,
 ) -> Router {
+    // TODO(modkit): `ensure_schema` should resolve dangling `$ref` targets
+    //  automatically. utoipa's derived `Page<T>::schemas()` omits `T` from
+    //  its dependency list, so `Page<MessageDto>` creates a `$ref` to
+    //  `MessageDto` without registering it.  Remove this workaround once
+    //  `ensure_schema_raw` learns to walk `$ref` pointers and pull missing
+    //  schemas into the registry.
+    ensure_schema::<dto::MessageDto>(openapi);
+
     // GET {prefix}/v1/chats/{id}/messages
     router = OperationBuilder::get(format!("{prefix}/v1/chats/{{id}}/messages"))
         .operation_id("mini_chat.list_messages")
@@ -18,8 +27,19 @@ pub(super) fn register_message_routes(
         .authenticated()
         .require_license_features([&AiChatLicense])
         .path_param("id", "Chat UUID")
+        .query_param_typed(
+            "limit",
+            false,
+            "Maximum number of messages to return",
+            "integer",
+        )
+        .query_param("cursor", false, "Cursor for pagination")
         .handler(handlers::messages::list_messages)
-        .json_response(http::StatusCode::OK, "List of messages")
+        .json_response_with_schema::<modkit_odata::Page<dto::MessageDto>>(
+            openapi,
+            http::StatusCode::OK,
+            "Paginated list of messages",
+        )
         .standard_errors(openapi)
         .register(router, openapi);
 

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/reactions.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/reactions.rs
@@ -3,7 +3,7 @@ use modkit::api::OpenApiRegistry;
 use modkit::api::operation_builder::OperationBuilder;
 
 use super::AiChatLicense;
-use crate::api::rest::handlers;
+use crate::api::rest::{dto, handlers};
 
 pub(super) fn register_reaction_routes(
     mut router: Router,
@@ -21,8 +21,9 @@ pub(super) fn register_reaction_routes(
     .require_license_features([&AiChatLicense])
     .path_param("id", "Chat UUID")
     .path_param("msg_id", "Message UUID")
+    .json_request::<dto::SetReactionReq>(openapi, "Reaction data")
     .handler(handlers::reactions::put_reaction)
-    .json_response(http::StatusCode::OK, "Reaction set")
+    .json_response_with_schema::<dto::ReactionDto>(openapi, http::StatusCode::OK, "Reaction set")
     .standard_errors(openapi)
     .register(router, openapi);
 

--- a/modules/mini-chat/mini-chat/src/domain/error.rs
+++ b/modules/mini-chat/mini-chat/src/domain/error.rs
@@ -30,6 +30,12 @@ pub enum DomainError {
     #[error("Access denied")]
     Forbidden,
 
+    #[error("Message not found: {id}")]
+    MessageNotFound { id: Uuid },
+
+    #[error("Invalid reaction target: message {id} is not an assistant message")]
+    InvalidReactionTarget { id: Uuid },
+
     #[error("Internal error: {message}")]
     InternalError { message: String },
 }
@@ -77,6 +83,16 @@ impl DomainError {
         Self::InternalError {
             message: message.into(),
         }
+    }
+
+    #[must_use]
+    pub fn message_not_found(id: Uuid) -> Self {
+        Self::MessageNotFound { id }
+    }
+
+    #[must_use]
+    pub fn invalid_reaction_target(id: Uuid) -> Self {
+        Self::InvalidReactionTarget { id }
     }
 
     #[must_use]

--- a/modules/mini-chat/mini-chat/src/domain/models.rs
+++ b/modules/mini-chat/mini-chat/src/domain/models.rs
@@ -54,3 +54,66 @@ pub struct NewChat {
 pub struct ChatPatch {
     pub title: Option<Option<String>>,
 }
+
+// ── Message ──
+
+/// A chat message as returned by the list endpoint.
+#[domain_model]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Message {
+    pub id: Uuid,
+    pub request_id: Uuid,
+    pub role: String,
+    pub content: String,
+    pub attachment_ids: Vec<Uuid>,
+    pub model: Option<String>,
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub created_at: OffsetDateTime,
+}
+
+// ── Reaction ──
+
+/// Binary like/dislike reaction value.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReactionKind {
+    Like,
+    Dislike,
+}
+
+impl ReactionKind {
+    /// Parse from a string value ("like" / "dislike").
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "like" => Some(Self::Like),
+            "dislike" => Some(Self::Dislike),
+            _ => None,
+        }
+    }
+
+    /// Wire representation used in DB and REST.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Like => "like",
+            Self::Dislike => "dislike",
+        }
+    }
+}
+
+impl std::fmt::Display for ReactionKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A reaction on an assistant message.
+#[domain_model]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Reaction {
+    pub message_id: Uuid,
+    pub kind: ReactionKind,
+    pub created_at: OffsetDateTime,
+}

--- a/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
@@ -60,4 +60,23 @@ pub trait MessageRepository: Send + Sync {
         chat_id: Uuid,
         request_id: Uuid,
     ) -> Result<Vec<MessageModel>, DomainError>;
+
+    /// SELECT a single message by `(id, chat_id)` where not deleted.
+    async fn get_by_chat<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        msg_id: Uuid,
+        chat_id: Uuid,
+    ) -> Result<Option<MessageModel>, DomainError>;
+
+    /// List messages for a chat with cursor pagination + `OData` filter/sort.
+    /// Only returns messages with `request_id` IS NOT NULL and `deleted_at` IS NULL.
+    async fn list_by_chat<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        query: &modkit_odata::ODataQuery,
+    ) -> Result<modkit_odata::Page<MessageModel>, DomainError>;
 }

--- a/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use model_pref_repo::ModelPrefRepository;
 pub(crate) use model_resolver::ModelResolver;
 pub(crate) use policy_snapshot_provider::PolicySnapshotProvider;
 pub(crate) use quota_usage_repo::{IncrementReserveParams, QuotaUsageRepository, SettleParams};
-pub(crate) use reaction_repo::ReactionRepository;
+pub(crate) use reaction_repo::{ReactionRepository, UpsertReactionParams};
 pub(crate) use thread_summary_repo::ThreadSummaryRepository;
 pub(crate) use turn_repo::{
     CasCompleteParams, CasTerminalParams, CreateTurnParams, TurnRepository,

--- a/modules/mini-chat/mini-chat/src/domain/repos/reaction_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/reaction_repo.rs
@@ -1,2 +1,44 @@
+use async_trait::async_trait;
+use modkit_db::secure::DBRunner;
+use modkit_macros::domain_model;
+use modkit_security::AccessScope;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::domain::models::ReactionKind;
+use crate::infra::db::entity::message_reaction::Model as ReactionModel;
+
+/// Parameters for upserting a reaction.
+#[domain_model]
+pub struct UpsertReactionParams {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub message_id: Uuid,
+    pub user_id: Uuid,
+    pub reaction: ReactionKind,
+}
+
 /// Repository trait for reaction persistence operations.
-pub trait ReactionRepository: Send + Sync {}
+///
+/// All methods accept:
+/// - `conn: &C` where `C: DBRunner` - database runner (connection or transaction)
+/// - `scope: &AccessScope` - security scope prepared by the service layer
+#[async_trait]
+pub trait ReactionRepository: Send + Sync {
+    /// Upsert a reaction for (`message_id`, `user_id`). Returns the model.
+    async fn upsert<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: UpsertReactionParams,
+    ) -> Result<ReactionModel, DomainError>;
+
+    /// Delete reaction for (`message_id`, `user_id`). Returns true if deleted.
+    async fn delete_by_message_and_user<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        message_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<bool, DomainError>;
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
@@ -125,7 +125,8 @@ impl<CR: ChatRepository + 'static> ChatService<CR> {
             .await?
             .ok_or_else(|| DomainError::chat_not_found(id))?;
 
-        let message_count = self.chat_repo.count_messages(&conn, &scope, id).await?;
+        let msg_scope = scope.tenant_only();
+        let message_count = self.chat_repo.count_messages(&conn, &msg_scope, id).await?;
 
         tracing::debug!("Successfully retrieved chat");
         Ok(Self::to_detail(chat, message_count))
@@ -149,13 +150,14 @@ impl<CR: ChatRepository + 'static> ChatService<CR> {
 
         let page = self.chat_repo.list_page(&conn, &scope, query).await?;
 
-        // Batch count: single GROUP BY query for all chat IDs
+        // Batch count: single GROUP BY query for all chat IDs.
+        let msg_scope = scope.tenant_only();
         let chat_ids: Vec<Uuid> = page.items.iter().map(|c| c.id).collect();
         let counts = if chat_ids.is_empty() {
             std::collections::HashMap::new()
         } else {
             self.chat_repo
-                .count_messages_batch(&conn, &scope, &chat_ids)
+                .count_messages_batch(&conn, &msg_scope, &chat_ids)
                 .await?
         };
 
@@ -216,8 +218,9 @@ impl<CR: ChatRepository + 'static> ChatService<CR> {
                     chat.updated_at = OffsetDateTime::now_utc();
 
                     let updated = chat_repo.update(tx, &scope, chat).await.map_err(map)?;
+                    let msg_scope = scope.tenant_only();
                     let message_count = chat_repo
-                        .count_messages(tx, &scope, id)
+                        .count_messages(tx, &msg_scope, id)
                         .await
                         .map_err(map)?;
 

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
@@ -548,3 +548,291 @@ async fn delete_chat_cross_owner_not_found() {
         "Expected ChatNotFound for cross-owner delete"
     );
 }
+
+// ── Message Count Tests ──
+
+#[tokio::test]
+async fn get_chat_message_count_reflects_inserted_messages() {
+    use crate::domain::repos::{
+        InsertAssistantMessageParams, InsertUserMessageParams,
+        MessageRepository as MessageRepoTrait,
+    };
+    use crate::infra::db::repo::message_repo::MessageRepository as OrmMessageRepository;
+    use modkit_security::AccessScope;
+
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(modkit_db::odata::LimitCfg {
+        default: 20,
+        max: 100,
+    }));
+
+    let svc = ChatService::new(
+        Arc::clone(&db_provider),
+        Arc::clone(&chat_repo),
+        mock_thread_summary_repo(),
+        mock_enforcer(),
+        mock_model_resolver(),
+    );
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let created = svc
+        .create_chat(
+            &ctx,
+            NewChat {
+                model: Some("gpt-5.2".to_owned()),
+                title: Some("Chat with messages".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+
+    // Insert messages via repo directly
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = db_provider.conn().expect("conn failed");
+    let message_repo = OrmMessageRepository::new(modkit_db::odata::LimitCfg {
+        default: 20,
+        max: 100,
+    });
+    let request_id = Uuid::new_v4();
+
+    message_repo
+        .insert_user_message(
+            &conn,
+            &scope,
+            InsertUserMessageParams {
+                id: Uuid::now_v7(),
+                tenant_id,
+                chat_id: created.id,
+                request_id,
+                content: "Hello".to_owned(),
+            },
+        )
+        .await
+        .expect("insert_user_message failed");
+
+    message_repo
+        .insert_assistant_message(
+            &conn,
+            &scope,
+            InsertAssistantMessageParams {
+                id: Uuid::now_v7(),
+                tenant_id,
+                chat_id: created.id,
+                request_id,
+                content: "Hi there!".to_owned(),
+                input_tokens: Some(10),
+                output_tokens: Some(20),
+                model: Some("gpt-5.2".to_owned()),
+                provider_response_id: None,
+            },
+        )
+        .await
+        .expect("insert_assistant_message failed");
+
+    // get_chat should report message_count = 2
+    let detail = svc
+        .get_chat(&ctx, created.id)
+        .await
+        .expect("get_chat failed");
+    assert_eq!(detail.message_count, 2, "get_chat should report 2 messages");
+
+    // list_chats should also report message_count = 2
+    let page = svc
+        .list_chats(&ctx, &ODataQuery::default())
+        .await
+        .expect("list_chats failed");
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(
+        page.items[0].message_count, 2,
+        "list_chats should report 2 messages"
+    );
+}
+
+// ── Pagination Tests ──
+
+#[tokio::test]
+async fn list_chats_pagination_forward_cursor() {
+    let db = inmem_db().await;
+    let svc = build_service(db);
+    let ctx = test_security_ctx(Uuid::new_v4());
+
+    // Create 5 chats
+    for i in 0..5 {
+        svc.create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some(format!("Chat {i}")),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+    }
+
+    // Page 1: request 2 items
+    let query = ODataQuery::new().with_limit(2);
+    let page1 = svc
+        .list_chats(&ctx, &query)
+        .await
+        .expect("list_chats page 1 failed");
+
+    assert_eq!(page1.items.len(), 2, "Page 1 should have 2 items");
+    assert!(
+        page1.page_info.next_cursor.is_some(),
+        "Page 1 must have next_cursor (3 more items remain)"
+    );
+    assert!(
+        page1.page_info.prev_cursor.is_none(),
+        "Page 1 must not have prev_cursor (first page)"
+    );
+
+    // Page 2: use next_cursor
+    let cursor = modkit_odata::CursorV1::decode(page1.page_info.next_cursor.as_ref().unwrap())
+        .expect("decode cursor failed");
+    let query2 = ODataQuery::new().with_limit(2).with_cursor(cursor);
+    let page2 = svc
+        .list_chats(&ctx, &query2)
+        .await
+        .expect("list_chats page 2 failed");
+
+    assert_eq!(page2.items.len(), 2, "Page 2 should have 2 items");
+    assert!(
+        page2.page_info.next_cursor.is_some(),
+        "Page 2 must have next_cursor (1 more item remains)"
+    );
+    assert!(
+        page2.page_info.prev_cursor.is_some(),
+        "Page 2 must have prev_cursor"
+    );
+
+    // Page 3: use next_cursor — should return the last item
+    let cursor = modkit_odata::CursorV1::decode(page2.page_info.next_cursor.as_ref().unwrap())
+        .expect("decode cursor failed");
+    let query3 = ODataQuery::new().with_limit(2).with_cursor(cursor);
+    let page3 = svc
+        .list_chats(&ctx, &query3)
+        .await
+        .expect("list_chats page 3 failed");
+
+    assert_eq!(page3.items.len(), 1, "Page 3 should have 1 item");
+    assert!(
+        page3.page_info.next_cursor.is_none(),
+        "Page 3 must not have next_cursor (no more items)"
+    );
+
+    // All IDs across pages must be unique and cover all 5 chats
+    let mut all_ids: Vec<Uuid> = page1
+        .items
+        .iter()
+        .chain(page2.items.iter())
+        .chain(page3.items.iter())
+        .map(|c| c.id)
+        .collect();
+    assert_eq!(all_ids.len(), 5, "Total items across pages should be 5");
+    all_ids.sort();
+    all_ids.dedup();
+    assert_eq!(all_ids.len(), 5, "All IDs must be unique");
+}
+
+#[tokio::test]
+async fn list_chats_pagination_no_cursor_when_all_fit() {
+    let db = inmem_db().await;
+    let svc = build_service(db);
+    let ctx = test_security_ctx(Uuid::new_v4());
+
+    // Create 3 chats, request page of 10
+    for i in 0..3 {
+        svc.create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some(format!("Chat {i}")),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+    }
+
+    let query = ODataQuery::new().with_limit(10);
+    let page = svc
+        .list_chats(&ctx, &query)
+        .await
+        .expect("list_chats failed");
+
+    assert_eq!(page.items.len(), 3);
+    assert!(
+        page.page_info.next_cursor.is_none(),
+        "No next_cursor when all items fit in a single page"
+    );
+    assert!(
+        page.page_info.prev_cursor.is_none(),
+        "No prev_cursor on the first (and only) page"
+    );
+}
+
+#[tokio::test]
+async fn list_chats_pagination_backward_cursor() {
+    let db = inmem_db().await;
+    let svc = build_service(db);
+    let ctx = test_security_ctx(Uuid::new_v4());
+
+    // Create 5 chats
+    for i in 0..5 {
+        svc.create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some(format!("Chat {i}")),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+    }
+
+    // Page 1 forward (2 items)
+    let query = ODataQuery::new().with_limit(2);
+    let page1 = svc
+        .list_chats(&ctx, &query)
+        .await
+        .expect("list_chats page 1 failed");
+    assert_eq!(page1.items.len(), 2);
+
+    // Page 2 forward
+    let cursor = modkit_odata::CursorV1::decode(page1.page_info.next_cursor.as_ref().unwrap())
+        .expect("decode cursor failed");
+    let query2 = ODataQuery::new().with_limit(2).with_cursor(cursor);
+    let page2 = svc
+        .list_chats(&ctx, &query2)
+        .await
+        .expect("list_chats page 2 failed");
+    assert_eq!(page2.items.len(), 2);
+
+    // Now go backward from page 2 using prev_cursor
+    let prev = modkit_odata::CursorV1::decode(page2.page_info.prev_cursor.as_ref().unwrap())
+        .expect("decode prev cursor failed");
+    let query_back = ODataQuery::new().with_limit(2).with_cursor(prev);
+    let page_back = svc
+        .list_chats(&ctx, &query_back)
+        .await
+        .expect("list_chats backward failed");
+
+    assert_eq!(
+        page_back.items.len(),
+        page1.items.len(),
+        "Backward page should have same count as page 1"
+    );
+    // Items should match page 1 (same IDs, same order)
+    let back_ids: Vec<Uuid> = page_back.items.iter().map(|c| c.id).collect();
+    let page1_ids: Vec<Uuid> = page1.items.iter().map(|c| c.id).collect();
+    assert_eq!(
+        back_ids, page1_ids,
+        "Backward navigation must return to page 1 items"
+    );
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/message_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/message_service.rs
@@ -1,0 +1,114 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::PolicyEnforcer;
+use modkit_macros::domain_model;
+use modkit_odata::{ODataQuery, Page};
+use modkit_security::SecurityContext;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::domain::models::Message;
+use crate::domain::repos::{ChatRepository, MessageRepository};
+use crate::infra::db::entity::message::MessageRole;
+
+use super::{DbProvider, actions, resources};
+
+/// Service handling message query operations.
+#[domain_model]
+pub struct MessageService<MR: MessageRepository, CR: ChatRepository> {
+    db: Arc<DbProvider>,
+    message_repo: Arc<MR>,
+    chat_repo: Arc<CR>,
+    enforcer: PolicyEnforcer,
+}
+
+impl<MR: MessageRepository, CR: ChatRepository> MessageService<MR, CR> {
+    pub(crate) fn new(
+        db: Arc<DbProvider>,
+        message_repo: Arc<MR>,
+        chat_repo: Arc<CR>,
+        enforcer: PolicyEnforcer,
+    ) -> Self {
+        Self {
+            db,
+            message_repo,
+            chat_repo,
+            enforcer,
+        }
+    }
+
+    /// List messages in a chat with cursor-based pagination.
+    #[instrument(skip(self, ctx, query), fields(chat_id = %chat_id))]
+    pub async fn list_messages(
+        &self,
+        ctx: &SecurityContext,
+        chat_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<Message>, DomainError> {
+        tracing::debug!("Listing messages for chat");
+
+        let conn = self.db.conn().map_err(DomainError::from)?;
+
+        let scope = self
+            .enforcer
+            .access_scope(ctx, &resources::CHAT, actions::LIST_MESSAGES, Some(chat_id))
+            .await?;
+
+        // Verify chat exists (scoped)
+        self.chat_repo
+            .get(&conn, &scope, chat_id)
+            .await?
+            .ok_or_else(|| DomainError::chat_not_found(chat_id))?;
+
+        let msg_scope = scope.tenant_only();
+        let page = self
+            .message_repo
+            .list_by_chat(&conn, &msg_scope, chat_id, query)
+            .await?;
+
+        let items: Vec<Message> = page
+            .items
+            .into_iter()
+            .map(|m| {
+                // list_by_chat SQL already filters `request_id IS NOT NULL`
+                let request_id = m.request_id.ok_or_else(|| {
+                    DomainError::internal("list_by_chat returned message with null request_id")
+                })?;
+                Ok(Message {
+                    id: m.id,
+                    request_id,
+                    role: match m.role {
+                        MessageRole::User => "user".to_owned(),
+                        MessageRole::Assistant => "assistant".to_owned(),
+                        MessageRole::System => "system".to_owned(),
+                    },
+                    content: m.content,
+                    attachment_ids: Vec::new(), // TODO: fetch attachment IDs and metadata in the future
+                    model: m.model,
+                    input_tokens: if m.input_tokens == 0 {
+                        None
+                    } else {
+                        Some(m.input_tokens)
+                    },
+                    output_tokens: if m.output_tokens == 0 {
+                        None
+                    } else {
+                        Some(m.output_tokens)
+                    },
+                    created_at: m.created_at,
+                })
+            })
+            .collect::<Result<_, DomainError>>()?;
+
+        tracing::debug!("Successfully listed {} messages", items.len());
+        Ok(Page {
+            items,
+            page_info: page.page_info,
+        })
+    }
+}
+
+#[cfg(test)]
+#[path = "message_service_test.rs"]
+mod tests;

--- a/modules/mini-chat/mini-chat/src/domain/service/message_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/message_service_test.rs
@@ -1,0 +1,487 @@
+use std::sync::Arc;
+
+use modkit_odata::ODataQuery;
+use modkit_security::AccessScope;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::domain::models::NewChat;
+
+use crate::domain::repos::{
+    InsertAssistantMessageParams, InsertUserMessageParams, MessageRepository as MessageRepoTrait,
+};
+use crate::domain::service::test_helpers::{
+    inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver, mock_thread_summary_repo,
+    test_security_ctx,
+};
+use crate::infra::db::repo::chat_repo::ChatRepository as OrmChatRepository;
+use crate::infra::db::repo::message_repo::MessageRepository as OrmMessageRepository;
+
+use super::MessageService;
+use crate::domain::service::ChatService;
+
+// ── Test Helpers ──
+
+fn limit_cfg() -> modkit_db::odata::LimitCfg {
+    modkit_db::odata::LimitCfg {
+        default: 20,
+        max: 100,
+    }
+}
+
+fn build_chat_service(
+    db_provider: Arc<crate::domain::service::DbProvider>,
+    chat_repo: Arc<OrmChatRepository>,
+) -> ChatService<OrmChatRepository> {
+    ChatService::new(
+        db_provider,
+        chat_repo,
+        mock_thread_summary_repo(),
+        mock_enforcer(),
+        mock_model_resolver(),
+    )
+}
+
+fn build_message_service(
+    db_provider: Arc<crate::domain::service::DbProvider>,
+    chat_repo: Arc<OrmChatRepository>,
+) -> MessageService<OrmMessageRepository, OrmChatRepository> {
+    let message_repo = Arc::new(OrmMessageRepository::new(limit_cfg()));
+    MessageService::new(db_provider, message_repo, chat_repo, mock_enforcer())
+}
+
+// ── Tests ──
+
+#[tokio::test]
+async fn list_messages_empty_chat() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let chat_svc = build_chat_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let msg_svc = build_message_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let chat = chat_svc
+        .create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some("Empty chat".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+
+    let page = msg_svc
+        .list_messages(&ctx, chat.id, &ODataQuery::default())
+        .await
+        .expect("list_messages failed");
+
+    assert!(page.items.is_empty(), "Expected no messages in new chat");
+}
+
+#[tokio::test]
+async fn list_messages_returns_messages_chronologically() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let chat_svc = build_chat_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let msg_svc = build_message_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let chat = chat_svc
+        .create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some("With messages".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+
+    // Insert messages via the repo directly using tenant-scoped access
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = db_provider.conn().expect("conn failed");
+    let message_repo = OrmMessageRepository::new(limit_cfg());
+
+    let request_id = Uuid::new_v4();
+
+    message_repo
+        .insert_user_message(
+            &conn,
+            &scope,
+            InsertUserMessageParams {
+                id: Uuid::now_v7(),
+                tenant_id,
+                chat_id: chat.id,
+                request_id,
+                content: "Hello".to_owned(),
+            },
+        )
+        .await
+        .expect("insert_user_message failed");
+
+    message_repo
+        .insert_assistant_message(
+            &conn,
+            &scope,
+            InsertAssistantMessageParams {
+                id: Uuid::now_v7(),
+                tenant_id,
+                chat_id: chat.id,
+                request_id,
+                content: "Hi there!".to_owned(),
+                input_tokens: Some(10),
+                output_tokens: Some(20),
+                model: Some("gpt-5.2".to_owned()),
+                provider_response_id: None,
+            },
+        )
+        .await
+        .expect("insert_assistant_message failed");
+
+    let page = msg_svc
+        .list_messages(&ctx, chat.id, &ODataQuery::default())
+        .await
+        .expect("list_messages failed");
+
+    assert_eq!(page.items.len(), 2, "Expected 2 messages");
+    assert_eq!(page.items[0].role, "user", "First message should be user");
+    assert_eq!(
+        page.items[1].role, "assistant",
+        "Second message should be assistant"
+    );
+    assert!(
+        page.items[0].created_at <= page.items[1].created_at,
+        "Messages should be in chronological order"
+    );
+}
+
+#[tokio::test]
+async fn list_messages_chat_not_found() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let msg_svc = build_message_service(db_provider, chat_repo);
+
+    let ctx = test_security_ctx(Uuid::new_v4());
+    let random_chat_id = Uuid::new_v4();
+
+    let result = msg_svc
+        .list_messages(&ctx, random_chat_id, &ODataQuery::default())
+        .await;
+
+    assert!(result.is_err(), "Expected error for non-existent chat");
+    assert!(
+        matches!(result.unwrap_err(), DomainError::ChatNotFound { .. }),
+        "Expected ChatNotFound"
+    );
+}
+
+#[tokio::test]
+async fn list_messages_cross_tenant_returns_not_found() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let chat_svc = build_chat_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let msg_svc = build_message_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let ctx_a = test_security_ctx(tenant_a);
+    let ctx_b = test_security_ctx(tenant_b);
+
+    // Tenant A creates a chat
+    let chat = chat_svc
+        .create_chat(
+            &ctx_a,
+            NewChat {
+                model: None,
+                title: Some("Tenant A chat".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+
+    // Tenant B tries to list messages in Tenant A's chat
+    let result = msg_svc
+        .list_messages(&ctx_b, chat.id, &ODataQuery::default())
+        .await;
+
+    assert!(result.is_err(), "Cross-tenant list must fail");
+    assert!(
+        matches!(result.unwrap_err(), DomainError::ChatNotFound { .. }),
+        "Expected ChatNotFound for cross-tenant access"
+    );
+}
+
+// ── Pagination Tests ──
+
+/// Insert N user+assistant message pairs into a chat via the repo directly.
+async fn insert_message_pairs(
+    db_provider: &Arc<crate::domain::service::DbProvider>,
+    tenant_id: Uuid,
+    chat_id: Uuid,
+    count: usize,
+) {
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = db_provider.conn().expect("conn failed");
+    let message_repo = OrmMessageRepository::new(limit_cfg());
+
+    for _ in 0..count {
+        let request_id = Uuid::new_v4();
+
+        message_repo
+            .insert_user_message(
+                &conn,
+                &scope,
+                InsertUserMessageParams {
+                    id: Uuid::now_v7(),
+                    tenant_id,
+                    chat_id,
+                    request_id,
+                    content: "Hello".to_owned(),
+                },
+            )
+            .await
+            .expect("insert_user_message failed");
+
+        message_repo
+            .insert_assistant_message(
+                &conn,
+                &scope,
+                InsertAssistantMessageParams {
+                    id: Uuid::now_v7(),
+                    tenant_id,
+                    chat_id,
+                    request_id,
+                    content: "Hi there!".to_owned(),
+                    input_tokens: Some(10),
+                    output_tokens: Some(20),
+                    model: Some("gpt-5.2".to_owned()),
+                    provider_response_id: None,
+                },
+            )
+            .await
+            .expect("insert_assistant_message failed");
+    }
+}
+
+#[tokio::test]
+async fn list_messages_pagination_forward_cursor() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let chat_svc = build_chat_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let msg_svc = build_message_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let chat = chat_svc
+        .create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some("Pagination chat".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+
+    // Insert 5 pairs = 10 messages
+    insert_message_pairs(&db_provider, tenant_id, chat.id, 5).await;
+
+    // Page 1: request 3 items
+    let query = ODataQuery::new().with_limit(3);
+    let page1 = msg_svc
+        .list_messages(&ctx, chat.id, &query)
+        .await
+        .expect("list_messages page 1 failed");
+
+    assert_eq!(page1.items.len(), 3, "Page 1 should have 3 items");
+    assert!(
+        page1.page_info.next_cursor.is_some(),
+        "Page 1 must have next_cursor (7 more messages remain)"
+    );
+    assert!(
+        page1.page_info.prev_cursor.is_none(),
+        "Page 1 must not have prev_cursor (first page)"
+    );
+
+    // Page 2: use next_cursor
+    let cursor = modkit_odata::CursorV1::decode(page1.page_info.next_cursor.as_ref().unwrap())
+        .expect("decode cursor failed");
+    let query2 = ODataQuery::new().with_limit(3).with_cursor(cursor);
+    let page2 = msg_svc
+        .list_messages(&ctx, chat.id, &query2)
+        .await
+        .expect("list_messages page 2 failed");
+
+    assert_eq!(page2.items.len(), 3, "Page 2 should have 3 items");
+    assert!(
+        page2.page_info.next_cursor.is_some(),
+        "Page 2 must have next_cursor (4 more messages remain)"
+    );
+
+    // Continue until exhausted, collecting all IDs
+    let mut all_ids: Vec<Uuid> = page1
+        .items
+        .iter()
+        .chain(page2.items.iter())
+        .map(|m| m.id)
+        .collect();
+
+    let mut current_page = page2;
+    while let Some(ref next) = current_page.page_info.next_cursor {
+        let cursor = modkit_odata::CursorV1::decode(next).expect("decode cursor failed");
+        let q = ODataQuery::new().with_limit(3).with_cursor(cursor);
+        current_page = msg_svc
+            .list_messages(&ctx, chat.id, &q)
+            .await
+            .expect("list_messages next page failed");
+        all_ids.extend(current_page.items.iter().map(|m| m.id));
+    }
+
+    assert_eq!(
+        all_ids.len(),
+        10,
+        "Total messages across all pages should be 10"
+    );
+    let unique_count = {
+        let mut sorted = all_ids.clone();
+        sorted.sort();
+        sorted.dedup();
+        sorted.len()
+    };
+    assert_eq!(unique_count, 10, "All message IDs must be unique");
+}
+
+#[tokio::test]
+async fn list_messages_pagination_no_cursor_when_all_fit() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let chat_svc = build_chat_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let msg_svc = build_message_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let chat = chat_svc
+        .create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some("Small chat".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+
+    // Insert 2 pairs = 4 messages, request page of 20
+    insert_message_pairs(&db_provider, tenant_id, chat.id, 2).await;
+
+    let query = ODataQuery::new().with_limit(20);
+    let page = msg_svc
+        .list_messages(&ctx, chat.id, &query)
+        .await
+        .expect("list_messages failed");
+
+    assert_eq!(page.items.len(), 4);
+    assert!(
+        page.page_info.next_cursor.is_none(),
+        "No next_cursor when all messages fit in a single page"
+    );
+    assert!(
+        page.page_info.prev_cursor.is_none(),
+        "No prev_cursor on the first (and only) page"
+    );
+}
+
+#[tokio::test]
+async fn list_messages_pagination_backward_cursor() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let chat_svc = build_chat_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let msg_svc = build_message_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let chat = chat_svc
+        .create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some("Backward pagination chat".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+
+    // Insert 5 pairs = 10 messages
+    insert_message_pairs(&db_provider, tenant_id, chat.id, 5).await;
+
+    // Page 1 forward (3 items)
+    let query = ODataQuery::new().with_limit(3);
+    let page1 = msg_svc
+        .list_messages(&ctx, chat.id, &query)
+        .await
+        .expect("list_messages page 1 failed");
+    assert_eq!(page1.items.len(), 3);
+
+    // Page 2 forward
+    let cursor = modkit_odata::CursorV1::decode(page1.page_info.next_cursor.as_ref().unwrap())
+        .expect("decode cursor failed");
+    let query2 = ODataQuery::new().with_limit(3).with_cursor(cursor);
+    let page2 = msg_svc
+        .list_messages(&ctx, chat.id, &query2)
+        .await
+        .expect("list_messages page 2 failed");
+    assert_eq!(page2.items.len(), 3);
+    assert!(
+        page2.page_info.prev_cursor.is_some(),
+        "Page 2 must have prev_cursor"
+    );
+
+    // Navigate backward from page 2
+    let prev = modkit_odata::CursorV1::decode(page2.page_info.prev_cursor.as_ref().unwrap())
+        .expect("decode prev cursor failed");
+    let query_back = ODataQuery::new().with_limit(3).with_cursor(prev);
+    let page_back = msg_svc
+        .list_messages(&ctx, chat.id, &query_back)
+        .await
+        .expect("list_messages backward failed");
+
+    assert_eq!(
+        page_back.items.len(),
+        page1.items.len(),
+        "Backward page should have same count as page 1"
+    );
+    let back_ids: Vec<Uuid> = page_back.items.iter().map(|m| m.id).collect();
+    let page1_ids: Vec<Uuid> = page1.items.iter().map(|m| m.id).collect();
+    assert_eq!(
+        back_ids, page1_ids,
+        "Backward navigation must return to page 1 items"
+    );
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -16,6 +16,7 @@ use crate::infra::llm::LlmProvider;
 mod attachment_service;
 mod chat_service;
 pub(crate) mod credit_arithmetic;
+mod message_service;
 mod model_service;
 mod quota_service;
 mod reaction_service;
@@ -26,6 +27,7 @@ pub(crate) mod token_estimator;
 
 pub(crate) use attachment_service::AttachmentService;
 pub(crate) use chat_service::ChatService;
+pub(crate) use message_service::MessageService;
 pub(crate) use model_service::ModelService;
 pub(crate) use quota_service::QuotaService;
 pub(crate) use reaction_service::ReactionService;
@@ -66,9 +68,9 @@ pub(crate) mod actions {
     pub const RETRY_TURN: &str = "retry_turn";
     pub const EDIT_TURN: &str = "edit_turn";
     pub const DELETE_TURN: &str = "delete_turn";
-    pub const UPLOAD: &str = "upload";
+    pub const UPLOAD_ATTACHMENT: &str = "upload_attachment";
     pub const READ_ATTACHMENT: &str = "read_attachment";
-    pub const REACT: &str = "react";
+    pub const SET_REACTION: &str = "set_reaction";
     pub const DELETE_REACTION: &str = "delete_reaction";
 }
 
@@ -78,6 +80,7 @@ pub(crate) struct Repositories<
     TR: TurnRepository,
     MR: MessageRepository,
     QR: QuotaUsageRepository,
+    RR: ReactionRepository,
     CR: ChatRepository,
 > {
     pub(crate) chat: Arc<CR>,
@@ -85,7 +88,7 @@ pub(crate) struct Repositories<
     pub(crate) message: Arc<MR>,
     pub(crate) quota: Arc<QR>,
     pub(crate) turn: Arc<TR>,
-    pub(crate) reaction: Arc<dyn ReactionRepository>,
+    pub(crate) reaction: Arc<RR>,
     pub(crate) model_pref: Arc<dyn ModelPrefRepository>,
     pub(crate) thread_summary: Arc<dyn ThreadSummaryRepository>,
     pub(crate) vector_store: Arc<dyn VectorStoreRepository>,
@@ -102,11 +105,13 @@ pub(crate) struct AppServices<
     TR: TurnRepository + 'static,
     MR: MessageRepository + 'static,
     QR: QuotaUsageRepository + 'static,
+    RR: ReactionRepository + 'static,
     CR: ChatRepository + 'static,
 > {
     pub(crate) chats: ChatService<CR>,
+    pub(crate) messages: MessageService<MR, CR>,
     pub(crate) stream: StreamService<TR, MR, CR>,
-    pub(crate) reactions: ReactionService<CR>,
+    pub(crate) reactions: ReactionService<RR, MR, CR>,
     pub(crate) attachments: AttachmentService<CR>,
     pub(crate) models: ModelService,
     pub(crate) quota: QuotaService<QR>,
@@ -116,12 +121,13 @@ impl<
     TR: TurnRepository + 'static,
     MR: MessageRepository + 'static,
     QR: QuotaUsageRepository + 'static,
+    RR: ReactionRepository + 'static,
     CR: ChatRepository + 'static,
-> AppServices<TR, MR, QR, CR>
+> AppServices<TR, MR, QR, RR, CR>
 {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        repos: &Repositories<TR, MR, QR, CR>,
+        repos: &Repositories<TR, MR, QR, RR, CR>,
         db: Arc<DbProvider>,
         authz: Arc<dyn AuthZResolverClient>,
         model_resolver: Arc<dyn ModelResolver>,
@@ -142,6 +148,12 @@ impl<
                 enforcer.clone(),
                 model_resolver,
             ),
+            messages: MessageService::new(
+                Arc::clone(&db),
+                Arc::clone(&repos.message),
+                Arc::clone(&repos.chat),
+                enforcer.clone(),
+            ),
             stream: StreamService::new(
                 Arc::clone(&db),
                 Arc::clone(&repos.turn),
@@ -154,6 +166,7 @@ impl<
             reactions: ReactionService::new(
                 Arc::clone(&db),
                 Arc::clone(&repos.reaction),
+                Arc::clone(&repos.message),
                 Arc::clone(&repos.chat),
                 enforcer.clone(),
             ),

--- a/modules/mini-chat/mini-chat/src/domain/service/reaction_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/reaction_service.rs
@@ -2,32 +2,165 @@ use std::sync::Arc;
 
 use authz_resolver_sdk::PolicyEnforcer;
 use modkit_macros::domain_model;
+use modkit_security::SecurityContext;
+use tracing::instrument;
+use uuid::Uuid;
 
-use crate::domain::repos::{ChatRepository, ReactionRepository};
+use crate::domain::error::DomainError;
+use crate::domain::models::{Reaction, ReactionKind};
+use crate::domain::repos::{
+    ChatRepository, MessageRepository, ReactionRepository, UpsertReactionParams,
+};
+use crate::infra::db::entity::message::MessageRole;
 
-use super::DbProvider;
+use super::{DbProvider, actions, resources};
 
 /// Service handling message reaction operations.
 #[domain_model]
-pub struct ReactionService<CR: ChatRepository> {
-    _db: Arc<DbProvider>,
-    _reaction_repo: Arc<dyn ReactionRepository>,
-    _chat_repo: Arc<CR>,
-    _enforcer: PolicyEnforcer,
+pub struct ReactionService<RR: ReactionRepository, MR: MessageRepository, CR: ChatRepository> {
+    db: Arc<DbProvider>,
+    reaction_repo: Arc<RR>,
+    message_repo: Arc<MR>,
+    chat_repo: Arc<CR>,
+    enforcer: PolicyEnforcer,
 }
 
-impl<CR: ChatRepository> ReactionService<CR> {
+impl<RR: ReactionRepository, MR: MessageRepository, CR: ChatRepository>
+    ReactionService<RR, MR, CR>
+{
     pub(crate) fn new(
         db: Arc<DbProvider>,
-        reaction_repo: Arc<dyn ReactionRepository>,
+        reaction_repo: Arc<RR>,
+        message_repo: Arc<MR>,
         chat_repo: Arc<CR>,
         enforcer: PolicyEnforcer,
     ) -> Self {
         Self {
-            _db: db,
-            _reaction_repo: reaction_repo,
-            _chat_repo: chat_repo,
-            _enforcer: enforcer,
+            db,
+            reaction_repo,
+            message_repo,
+            chat_repo,
+            enforcer,
         }
     }
+
+    /// Set or update a reaction on an assistant message.
+    #[instrument(skip(self, ctx, reaction), fields(chat_id = %chat_id, msg_id = %msg_id))]
+    pub async fn set_reaction(
+        &self,
+        ctx: &SecurityContext,
+        chat_id: Uuid,
+        msg_id: Uuid,
+        reaction: &str,
+    ) -> Result<Reaction, DomainError> {
+        tracing::debug!("Setting reaction on message");
+
+        // Validate reaction value
+        let kind = ReactionKind::parse(reaction)
+            .ok_or_else(|| DomainError::validation("Reaction must be 'like' or 'dislike'"))?;
+
+        let conn = self.db.conn().map_err(DomainError::from)?;
+
+        let scope = self
+            .enforcer
+            .access_scope(ctx, &resources::CHAT, actions::SET_REACTION, Some(chat_id))
+            .await?;
+
+        // Verify chat exists (scoped)
+        self.chat_repo
+            .get(&conn, &scope, chat_id)
+            .await?
+            .ok_or_else(|| DomainError::chat_not_found(chat_id))?;
+
+        let msg_scope = scope.tenant_only();
+        let reaction_scope = scope.tenant_and_owner();
+
+        // Verify message exists in this chat and is an assistant message
+        let message = self
+            .message_repo
+            .get_by_chat(&conn, &msg_scope, msg_id, chat_id)
+            .await?
+            .ok_or_else(|| DomainError::message_not_found(msg_id))?;
+
+        if message.role != MessageRole::Assistant {
+            return Err(DomainError::invalid_reaction_target(msg_id));
+        }
+
+        let params = UpsertReactionParams {
+            id: Uuid::now_v7(),
+            tenant_id: ctx.subject_tenant_id(),
+            message_id: msg_id,
+            user_id: ctx.subject_id(),
+            reaction: kind,
+        };
+
+        let model = self
+            .reaction_repo
+            .upsert(&conn, &reaction_scope, params)
+            .await?;
+
+        let stored_kind = ReactionKind::parse(&model.reaction).ok_or_else(|| {
+            DomainError::database("invalid reaction value returned from repository".to_owned())
+        })?;
+
+        tracing::debug!("Successfully set reaction");
+        Ok(Reaction {
+            message_id: model.message_id,
+            kind: stored_kind,
+            created_at: model.created_at,
+        })
+    }
+
+    /// Delete a reaction from a message (idempotent).
+    #[instrument(skip(self, ctx), fields(chat_id = %chat_id, msg_id = %msg_id))]
+    pub async fn delete_reaction(
+        &self,
+        ctx: &SecurityContext,
+        chat_id: Uuid,
+        msg_id: Uuid,
+    ) -> Result<(), DomainError> {
+        tracing::debug!("Deleting reaction from message");
+
+        let conn = self.db.conn().map_err(DomainError::from)?;
+
+        let scope = self
+            .enforcer
+            .access_scope(
+                ctx,
+                &resources::CHAT,
+                actions::DELETE_REACTION,
+                Some(chat_id),
+            )
+            .await?;
+
+        // Verify chat exists (scoped)
+        self.chat_repo
+            .get(&conn, &scope, chat_id)
+            .await?
+            .ok_or_else(|| DomainError::chat_not_found(chat_id))?;
+
+        // Messages use `no_owner` — strip owner_id constraints to avoid
+        // deny-all when the PDP returns owner-scoped predicates.
+        let msg_scope = scope.tenant_only();
+        let reaction_scope = scope.tenant_and_owner();
+
+        // Verify message exists in this chat
+        self.message_repo
+            .get_by_chat(&conn, &msg_scope, msg_id, chat_id)
+            .await?
+            .ok_or_else(|| DomainError::message_not_found(msg_id))?;
+
+        let user_id = ctx.subject_id();
+
+        self.reaction_repo
+            .delete_by_message_and_user(&conn, &reaction_scope, msg_id, user_id)
+            .await?;
+
+        tracing::debug!("Finished deleting reaction");
+        Ok(())
+    }
 }
+
+#[cfg(test)]
+#[path = "reaction_service_test.rs"]
+mod tests;

--- a/modules/mini-chat/mini-chat/src/domain/service/reaction_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/reaction_service_test.rs
@@ -1,0 +1,366 @@
+use std::sync::Arc;
+
+use modkit_security::AccessScope;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::domain::models::{NewChat, ReactionKind};
+
+use crate::domain::repos::{
+    InsertAssistantMessageParams, InsertUserMessageParams, MessageRepository as MessageRepoTrait,
+};
+use crate::domain::service::test_helpers::{
+    inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver, mock_thread_summary_repo,
+    test_security_ctx,
+};
+use crate::infra::db::repo::chat_repo::ChatRepository as OrmChatRepository;
+use crate::infra::db::repo::message_repo::MessageRepository as OrmMessageRepository;
+use crate::infra::db::repo::reaction_repo::ReactionRepository as OrmReactionRepository;
+
+use super::ReactionService;
+use crate::domain::service::ChatService;
+
+// ── Test Helpers ──
+
+fn limit_cfg() -> modkit_db::odata::LimitCfg {
+    modkit_db::odata::LimitCfg {
+        default: 20,
+        max: 100,
+    }
+}
+
+fn build_chat_service(
+    db_provider: Arc<crate::domain::service::DbProvider>,
+    chat_repo: Arc<OrmChatRepository>,
+) -> ChatService<OrmChatRepository> {
+    ChatService::new(
+        db_provider,
+        chat_repo,
+        mock_thread_summary_repo(),
+        mock_enforcer(),
+        mock_model_resolver(),
+    )
+}
+
+fn build_reaction_service(
+    db_provider: Arc<crate::domain::service::DbProvider>,
+    chat_repo: Arc<OrmChatRepository>,
+) -> ReactionService<OrmReactionRepository, OrmMessageRepository, OrmChatRepository> {
+    let reaction_repo = Arc::new(OrmReactionRepository);
+    let message_repo = Arc::new(OrmMessageRepository::new(limit_cfg()));
+    ReactionService::new(
+        db_provider,
+        reaction_repo,
+        message_repo,
+        chat_repo,
+        mock_enforcer(),
+    )
+}
+
+/// Create a chat and insert a user + assistant message pair.
+/// Returns `(chat_id, user_msg_id, assistant_msg_id)`.
+async fn setup_chat_with_messages(
+    db_provider: &Arc<crate::domain::service::DbProvider>,
+    chat_repo: &Arc<OrmChatRepository>,
+    ctx: &modkit_security::SecurityContext,
+    tenant_id: Uuid,
+) -> (Uuid, Uuid, Uuid) {
+    let chat_svc = build_chat_service(Arc::clone(db_provider), Arc::clone(chat_repo));
+
+    let chat = chat_svc
+        .create_chat(
+            ctx,
+            NewChat {
+                model: None,
+                title: Some("Test chat".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = db_provider.conn().expect("conn failed");
+    let message_repo = OrmMessageRepository::new(limit_cfg());
+    let request_id = Uuid::new_v4();
+
+    let user_msg_id = Uuid::now_v7();
+    message_repo
+        .insert_user_message(
+            &conn,
+            &scope,
+            InsertUserMessageParams {
+                id: user_msg_id,
+                tenant_id,
+                chat_id: chat.id,
+                request_id,
+                content: "Hello".to_owned(),
+            },
+        )
+        .await
+        .expect("insert_user_message failed");
+
+    let assistant_msg_id = Uuid::now_v7();
+    message_repo
+        .insert_assistant_message(
+            &conn,
+            &scope,
+            InsertAssistantMessageParams {
+                id: assistant_msg_id,
+                tenant_id,
+                chat_id: chat.id,
+                request_id,
+                content: "Hi there!".to_owned(),
+                input_tokens: Some(10),
+                output_tokens: Some(20),
+                model: Some("gpt-5.2".to_owned()),
+                provider_response_id: None,
+            },
+        )
+        .await
+        .expect("insert_assistant_message failed");
+
+    (chat.id, user_msg_id, assistant_msg_id)
+}
+
+// ── Tests ──
+
+#[tokio::test]
+async fn set_reaction_on_assistant_message() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let (chat_id, _user_msg_id, assistant_msg_id) =
+        setup_chat_with_messages(&db_provider, &chat_repo, &ctx, tenant_id).await;
+
+    let reaction_svc = build_reaction_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let reaction = reaction_svc
+        .set_reaction(&ctx, chat_id, assistant_msg_id, "like")
+        .await
+        .expect("set_reaction failed");
+
+    assert_eq!(reaction.message_id, assistant_msg_id);
+    assert_eq!(reaction.kind, ReactionKind::Like);
+}
+
+#[tokio::test]
+async fn set_reaction_on_user_message_rejected() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let (chat_id, user_msg_id, _assistant_msg_id) =
+        setup_chat_with_messages(&db_provider, &chat_repo, &ctx, tenant_id).await;
+
+    let reaction_svc = build_reaction_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let result = reaction_svc
+        .set_reaction(&ctx, chat_id, user_msg_id, "like")
+        .await;
+
+    assert!(result.is_err(), "Should reject reaction on user message");
+    assert!(
+        matches!(
+            result.unwrap_err(),
+            DomainError::InvalidReactionTarget { .. }
+        ),
+        "Expected InvalidReactionTarget"
+    );
+}
+
+#[tokio::test]
+async fn set_reaction_upsert_replaces() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let (chat_id, _user_msg_id, assistant_msg_id) =
+        setup_chat_with_messages(&db_provider, &chat_repo, &ctx, tenant_id).await;
+
+    let reaction_svc = build_reaction_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    // First: set "like"
+    let r1 = reaction_svc
+        .set_reaction(&ctx, chat_id, assistant_msg_id, "like")
+        .await
+        .expect("set_reaction like failed");
+    assert_eq!(r1.kind, ReactionKind::Like);
+
+    // Second: set "dislike" — should replace
+    let r2 = reaction_svc
+        .set_reaction(&ctx, chat_id, assistant_msg_id, "dislike")
+        .await
+        .expect("set_reaction dislike failed");
+    assert_eq!(r2.kind, ReactionKind::Dislike);
+}
+
+#[tokio::test]
+async fn set_reaction_invalid_value_rejected() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let (chat_id, _user_msg_id, assistant_msg_id) =
+        setup_chat_with_messages(&db_provider, &chat_repo, &ctx, tenant_id).await;
+
+    let reaction_svc = build_reaction_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let result = reaction_svc
+        .set_reaction(&ctx, chat_id, assistant_msg_id, "love")
+        .await;
+
+    assert!(result.is_err(), "Should reject invalid reaction value");
+    assert!(
+        matches!(result.unwrap_err(), DomainError::Validation { .. }),
+        "Expected Validation error"
+    );
+}
+
+#[tokio::test]
+async fn delete_reaction_happy_path() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let (chat_id, _user_msg_id, assistant_msg_id) =
+        setup_chat_with_messages(&db_provider, &chat_repo, &ctx, tenant_id).await;
+
+    let reaction_svc = build_reaction_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    // Set reaction first
+    reaction_svc
+        .set_reaction(&ctx, chat_id, assistant_msg_id, "like")
+        .await
+        .expect("set_reaction failed");
+
+    // Delete reaction
+    reaction_svc
+        .delete_reaction(&ctx, chat_id, assistant_msg_id)
+        .await
+        .expect("delete_reaction failed");
+}
+
+#[tokio::test]
+async fn delete_reaction_idempotent() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let (chat_id, _user_msg_id, assistant_msg_id) =
+        setup_chat_with_messages(&db_provider, &chat_repo, &ctx, tenant_id).await;
+
+    let reaction_svc = build_reaction_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    // Delete without prior reaction — should still succeed
+    reaction_svc
+        .delete_reaction(&ctx, chat_id, assistant_msg_id)
+        .await
+        .expect("delete_reaction should be idempotent");
+}
+
+#[tokio::test]
+async fn set_reaction_chat_not_found() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let reaction_svc = build_reaction_service(db_provider, chat_repo);
+
+    let ctx = test_security_ctx(Uuid::new_v4());
+    let random_chat_id = Uuid::new_v4();
+    let random_msg_id = Uuid::new_v4();
+
+    let result = reaction_svc
+        .set_reaction(&ctx, random_chat_id, random_msg_id, "like")
+        .await;
+
+    assert!(result.is_err(), "Expected error for non-existent chat");
+    assert!(
+        matches!(result.unwrap_err(), DomainError::ChatNotFound { .. }),
+        "Expected ChatNotFound"
+    );
+}
+
+#[tokio::test]
+async fn set_reaction_message_not_found() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let chat_svc = build_chat_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let chat = chat_svc
+        .create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some("Test chat".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+
+    let reaction_svc = build_reaction_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let random_msg_id = Uuid::new_v4();
+    let result = reaction_svc
+        .set_reaction(&ctx, chat.id, random_msg_id, "like")
+        .await;
+
+    assert!(result.is_err(), "Expected error for non-existent message");
+    assert!(
+        matches!(result.unwrap_err(), DomainError::MessageNotFound { .. }),
+        "Expected MessageNotFound"
+    );
+}
+
+#[tokio::test]
+async fn set_reaction_cross_tenant_rejected() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let ctx_a = test_security_ctx(tenant_a);
+    let ctx_b = test_security_ctx(tenant_b);
+
+    let (chat_id, _user_msg_id, assistant_msg_id) =
+        setup_chat_with_messages(&db_provider, &chat_repo, &ctx_a, tenant_a).await;
+
+    let reaction_svc = build_reaction_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    // Tenant B tries to react to Tenant A's chat message
+    let result = reaction_svc
+        .set_reaction(&ctx_b, chat_id, assistant_msg_id, "like")
+        .await;
+
+    assert!(result.is_err(), "Cross-tenant reaction must fail");
+    assert!(
+        matches!(result.unwrap_err(), DomainError::ChatNotFound { .. }),
+        "Expected ChatNotFound for cross-tenant access"
+    );
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -1053,7 +1053,10 @@ mod tests {
         StreamService::new(
             db,
             Arc::new(TurnRepo),
-            Arc::new(MsgRepo),
+            Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
+                default: 20,
+                max: 100,
+            })),
             Arc::new(OrmChatRepo::new(modkit_db::odata::LimitCfg {
                 default: 20,
                 max: 100,

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/message_reaction.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/message_reaction.rs
@@ -1,0 +1,27 @@
+use modkit_db::secure::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "message_reactions")]
+#[secure(
+    tenant_col = "tenant_id",
+    owner_col = "user_id",
+    resource_col = "id",
+    no_type
+)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub message_id: Uuid,
+    pub user_id: Uuid,
+    pub reaction: String,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/mod.rs
@@ -1,4 +1,5 @@
 pub mod chat;
 pub mod chat_turn;
 pub mod message;
+pub mod message_reaction;
 pub mod quota_usage;

--- a/modules/mini-chat/mini-chat/src/infra/db/odata_mapper.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/odata_mapper.rs
@@ -2,6 +2,9 @@ use modkit_db::odata::sea_orm_filter::{FieldToColumn, ODataFieldMapping};
 use modkit_odata::filter::{FieldKind, FilterField};
 
 use crate::infra::db::entity::chat::{Column, Entity, Model};
+use crate::infra::db::entity::message::{
+    Column as MsgColumn, Entity as MsgEntity, Model as MsgModel,
+};
 
 /// Cursor/sort field enum for chat pagination.
 ///
@@ -53,6 +56,69 @@ impl ODataFieldMapping<ChatCursorField> for ChatODataMapper {
                 sea_orm::Value::TimeDateTimeWithTimeZone(Some(Box::new(model.updated_at)))
             }
             ChatCursorField::Id => sea_orm::Value::Uuid(Some(Box::new(model.id))),
+        }
+    }
+}
+
+/// Cursor/sort field enum for message pagination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MessageField {
+    CreatedAt,
+    Id,
+    Role,
+}
+
+impl FilterField for MessageField {
+    const FIELDS: &'static [Self] = &[Self::CreatedAt, Self::Id, Self::Role];
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::CreatedAt => "created_at",
+            Self::Id => "id",
+            Self::Role => "role",
+        }
+    }
+
+    fn kind(&self) -> FieldKind {
+        match self {
+            Self::CreatedAt => FieldKind::DateTimeUtc,
+            Self::Id => FieldKind::Uuid,
+            Self::Role => FieldKind::String,
+        }
+    }
+}
+
+pub struct MessageODataMapper;
+
+impl FieldToColumn<MessageField> for MessageODataMapper {
+    type Column = MsgColumn;
+
+    fn map_field(field: MessageField) -> MsgColumn {
+        match field {
+            MessageField::CreatedAt => MsgColumn::CreatedAt,
+            MessageField::Id => MsgColumn::Id,
+            MessageField::Role => MsgColumn::Role,
+        }
+    }
+}
+
+impl ODataFieldMapping<MessageField> for MessageODataMapper {
+    type Entity = MsgEntity;
+
+    fn extract_cursor_value(model: &MsgModel, field: MessageField) -> sea_orm::Value {
+        match field {
+            MessageField::CreatedAt => {
+                sea_orm::Value::TimeDateTimeWithTimeZone(Some(Box::new(model.created_at)))
+            }
+            MessageField::Id => sea_orm::Value::Uuid(Some(Box::new(model.id))),
+            MessageField::Role => {
+                let s = match model.role {
+                    crate::infra::db::entity::message::MessageRole::User => "user",
+                    crate::infra::db::entity::message::MessageRole::Assistant => "assistant",
+                    crate::infra::db::entity::message::MessageRole::System => "system",
+                };
+                sea_orm::Value::String(Some(Box::new(s.to_owned())))
+            }
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
+use modkit_db::odata::{LimitCfg, paginate_odata};
 use modkit_db::secure::{DBRunner, SecureEntityExt, secure_insert};
+use modkit_odata::{ODataQuery, Page, SortDir};
 use modkit_security::AccessScope;
 use sea_orm::{ColumnTrait, Condition, EntityTrait, Order, QueryFilter, Set};
 use time::OffsetDateTime;
@@ -10,8 +12,18 @@ use crate::domain::repos::{InsertAssistantMessageParams, InsertUserMessageParams
 use crate::infra::db::entity::message::{
     ActiveModel, Column, Entity as MessageEntity, MessageRole, Model as MessageModel,
 };
+use crate::infra::db::odata_mapper::{MessageField, MessageODataMapper};
 
-pub struct MessageRepository;
+pub struct MessageRepository {
+    limit_cfg: LimitCfg,
+}
+
+impl MessageRepository {
+    #[must_use]
+    pub fn new(limit_cfg: LimitCfg) -> Self {
+        Self { limit_cfg }
+    }
+}
 
 #[async_trait]
 impl crate::domain::repos::MessageRepository for MessageRepository {
@@ -92,5 +104,56 @@ impl crate::domain::repos::MessageRepository for MessageRepository {
             .order_by(Column::CreatedAt, Order::Asc)
             .all(runner)
             .await?)
+    }
+
+    async fn get_by_chat<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        msg_id: Uuid,
+        chat_id: Uuid,
+    ) -> Result<Option<MessageModel>, DomainError> {
+        Ok(MessageEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::Id.eq(msg_id))
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::DeletedAt.is_null()),
+            )
+            .secure()
+            .scope_with(scope)
+            .one(runner)
+            .await?)
+    }
+
+    async fn list_by_chat<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<MessageModel>, DomainError> {
+        let base_query = MessageEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::RequestId.is_not_null())
+                    .add(Column::DeletedAt.is_null()),
+            )
+            .secure()
+            .scope_with(scope);
+
+        let page = paginate_odata::<MessageField, MessageODataMapper, _, _, _, _>(
+            base_query,
+            runner,
+            query,
+            ("created_at", SortDir::Asc),
+            self.limit_cfg,
+            std::convert::identity,
+        )
+        .await
+        .map_err(|e| DomainError::database(e.to_string()))?;
+
+        Ok(page)
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/reaction_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/reaction_repo.rs
@@ -1,4 +1,89 @@
-/// Repository for reaction persistence operations.
+use async_trait::async_trait;
+use modkit_db::secure::{
+    DBRunner, SecureDeleteExt, SecureEntityExt, SecureInsertExt, SecureOnConflict,
+};
+use modkit_security::AccessScope;
+use sea_orm::{ColumnTrait, Condition, EntityTrait, QueryFilter, Set};
+use time::OffsetDateTime;
+
+use crate::domain::error::DomainError;
+use crate::domain::repos::UpsertReactionParams;
+use crate::infra::db::entity::message_reaction::{
+    ActiveModel, Column, Entity as ReactionEntity, Model as ReactionModel,
+};
+
 pub struct ReactionRepository;
 
-impl crate::domain::repos::ReactionRepository for ReactionRepository {}
+#[async_trait]
+impl crate::domain::repos::ReactionRepository for ReactionRepository {
+    async fn upsert<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: UpsertReactionParams,
+    ) -> Result<ReactionModel, DomainError> {
+        let now = OffsetDateTime::now_utc();
+
+        let am = ActiveModel {
+            id: Set(params.id),
+            tenant_id: Set(params.tenant_id),
+            message_id: Set(params.message_id),
+            user_id: Set(params.user_id),
+            reaction: Set(params.reaction.as_str().to_owned()),
+            created_at: Set(now),
+        };
+
+        let on_conflict =
+            SecureOnConflict::<ReactionEntity>::columns([Column::MessageId, Column::UserId])
+                .update_columns([Column::Reaction, Column::CreatedAt])?;
+
+        ReactionEntity::insert(am.clone())
+            .secure()
+            .scope_with_model(scope, &am)?
+            .on_conflict(on_conflict)
+            .exec(runner)
+            .await?;
+
+        // SELECT back by natural key — works on both Postgres and SQLite
+        // (`exec_with_returning` fails on the ON CONFLICT path in SQLite
+        // because it looks up by the *new* PK which doesn't exist when
+        // the row was updated rather than inserted).
+        ReactionEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::MessageId.eq(params.message_id))
+                    .add(Column::UserId.eq(params.user_id)),
+            )
+            .secure()
+            .scope_with(scope)
+            .one(runner)
+            .await?
+            .ok_or_else(|| DomainError::database("reaction row missing after upsert".to_owned()))
+    }
+
+    async fn delete_by_message_and_user<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        message_id: uuid::Uuid,
+        user_id: uuid::Uuid,
+    ) -> Result<bool, DomainError> {
+        let result = ReactionEntity::delete_many()
+            .filter(
+                Condition::all()
+                    .add(Column::MessageId.eq(message_id))
+                    .add(Column::UserId.eq(user_id)),
+            )
+            .secure()
+            .scope_with(scope)
+            .exec(runner)
+            .await
+            .map_err(|e| DomainError::database(e.to_string()))?;
+
+        Ok(result.rows_affected > 0)
+    }
+}
+
+#[cfg(test)]
+#[path = "reaction_repo_test.rs"]
+mod tests;

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/reaction_repo_test.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/reaction_repo_test.rs
@@ -1,0 +1,354 @@
+use std::sync::Arc;
+
+use modkit_db::DBProvider;
+use modkit_db::odata::LimitCfg;
+use modkit_db::secure::secure_insert;
+use modkit_security::AccessScope;
+use sea_orm::Set;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::domain::models::ReactionKind;
+use crate::domain::repos::{
+    InsertAssistantMessageParams, MessageRepository as _, ReactionRepository as _,
+    UpsertReactionParams,
+};
+use crate::domain::service::test_helpers::{inmem_db, mock_db_provider};
+use crate::infra::db::repo::message_repo::MessageRepository;
+use crate::infra::db::repo::reaction_repo::ReactionRepository;
+
+type Db = Arc<DBProvider<modkit_db::DbError>>;
+
+// ── Helpers ──
+
+fn scope() -> AccessScope {
+    AccessScope::allow_all()
+}
+
+fn limit_cfg() -> LimitCfg {
+    LimitCfg {
+        default: 20,
+        max: 100,
+    }
+}
+
+async fn test_db() -> Db {
+    mock_db_provider(inmem_db().await)
+}
+
+/// Insert a parent chat row (required by FK constraints).
+async fn insert_chat(db: &Db, tenant_id: Uuid, chat_id: Uuid) {
+    use crate::infra::db::entity::chat::{ActiveModel, Entity as ChatEntity};
+
+    let now = OffsetDateTime::now_utc();
+    let am = ActiveModel {
+        id: Set(chat_id),
+        tenant_id: Set(tenant_id),
+        user_id: Set(Uuid::new_v4()),
+        model: Set("gpt-5.2".to_owned()),
+        title: Set(Some("test".to_owned())),
+        is_temporary: Set(false),
+        created_at: Set(now),
+        updated_at: Set(now),
+        deleted_at: Set(None),
+    };
+    let conn = db.conn().unwrap();
+    secure_insert::<ChatEntity>(am, &scope(), &conn)
+        .await
+        .expect("insert chat");
+}
+
+/// Insert an assistant message row (required by FK constraints on `message_reactions`).
+/// Returns the message ID.
+async fn insert_assistant_message(db: &Db, tenant_id: Uuid, chat_id: Uuid) -> Uuid {
+    let repo = MessageRepository::new(limit_cfg());
+    let conn = db.conn().unwrap();
+    let msg_id = Uuid::now_v7();
+    repo.insert_assistant_message(
+        &conn,
+        &scope(),
+        InsertAssistantMessageParams {
+            id: msg_id,
+            tenant_id,
+            chat_id,
+            request_id: Uuid::new_v4(),
+            content: "test response".to_owned(),
+            input_tokens: None,
+            output_tokens: None,
+            model: None,
+            provider_response_id: None,
+        },
+    )
+    .await
+    .expect("insert assistant message");
+    msg_id
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Upsert tests
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn upsert_inserts_on_first_call() {
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    insert_chat(&db, tenant_id, chat_id).await;
+    let msg_id = insert_assistant_message(&db, tenant_id, chat_id).await;
+
+    let repo = ReactionRepository;
+    let conn = db.conn().unwrap();
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    let model = repo
+        .upsert(
+            &conn,
+            &scope,
+            UpsertReactionParams {
+                id: Uuid::now_v7(),
+                tenant_id,
+                message_id: msg_id,
+                user_id,
+                reaction: ReactionKind::Like,
+            },
+        )
+        .await
+        .expect("upsert");
+
+    assert_eq!(model.message_id, msg_id);
+    assert_eq!(model.user_id, user_id);
+    assert_eq!(model.reaction, "like");
+    assert_eq!(model.tenant_id, tenant_id);
+}
+
+#[tokio::test]
+async fn upsert_updates_on_conflict() {
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    insert_chat(&db, tenant_id, chat_id).await;
+    let msg_id = insert_assistant_message(&db, tenant_id, chat_id).await;
+
+    let repo = ReactionRepository;
+    let conn = db.conn().unwrap();
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    // First: insert "like"
+    let first = repo
+        .upsert(
+            &conn,
+            &scope,
+            UpsertReactionParams {
+                id: Uuid::now_v7(),
+                tenant_id,
+                message_id: msg_id,
+                user_id,
+                reaction: ReactionKind::Like,
+            },
+        )
+        .await
+        .expect("first upsert");
+    assert_eq!(first.reaction, "like");
+
+    // Second: upsert "dislike" — same (message_id, user_id), should update
+    let second = repo
+        .upsert(
+            &conn,
+            &scope,
+            UpsertReactionParams {
+                id: Uuid::now_v7(),
+                tenant_id,
+                message_id: msg_id,
+                user_id,
+                reaction: ReactionKind::Dislike,
+            },
+        )
+        .await
+        .expect("second upsert");
+
+    assert_eq!(second.reaction, "dislike");
+    assert_eq!(second.message_id, msg_id);
+    assert_eq!(second.user_id, user_id);
+    // created_at should be updated (newer)
+    assert!(second.created_at >= first.created_at);
+}
+
+#[tokio::test]
+async fn upsert_different_users_coexist() {
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    insert_chat(&db, tenant_id, chat_id).await;
+    let msg_id = insert_assistant_message(&db, tenant_id, chat_id).await;
+
+    let repo = ReactionRepository;
+    let conn = db.conn().unwrap();
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    let r_a = repo
+        .upsert(
+            &conn,
+            &scope,
+            UpsertReactionParams {
+                id: Uuid::now_v7(),
+                tenant_id,
+                message_id: msg_id,
+                user_id: user_a,
+                reaction: ReactionKind::Like,
+            },
+        )
+        .await
+        .expect("upsert A");
+
+    let r_b = repo
+        .upsert(
+            &conn,
+            &scope,
+            UpsertReactionParams {
+                id: Uuid::now_v7(),
+                tenant_id,
+                message_id: msg_id,
+                user_id: user_b,
+                reaction: ReactionKind::Dislike,
+            },
+        )
+        .await
+        .expect("upsert B");
+
+    // Both reactions exist independently
+    assert_eq!(r_a.reaction, "like");
+    assert_eq!(r_b.reaction, "dislike");
+    assert_ne!(r_a.id, r_b.id);
+}
+
+#[tokio::test]
+async fn delete_returns_true_when_exists() {
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    insert_chat(&db, tenant_id, chat_id).await;
+    let msg_id = insert_assistant_message(&db, tenant_id, chat_id).await;
+
+    let repo = ReactionRepository;
+    let conn = db.conn().unwrap();
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    repo.upsert(
+        &conn,
+        &scope,
+        UpsertReactionParams {
+            id: Uuid::now_v7(),
+            tenant_id,
+            message_id: msg_id,
+            user_id,
+            reaction: ReactionKind::Like,
+        },
+    )
+    .await
+    .expect("upsert");
+
+    let deleted = repo
+        .delete_by_message_and_user(&conn, &scope, msg_id, user_id)
+        .await
+        .expect("delete");
+    assert!(deleted, "should report deletion");
+
+    // Second delete should return false (nothing to delete)
+    let deleted_again = repo
+        .delete_by_message_and_user(&conn, &scope, msg_id, user_id)
+        .await
+        .expect("delete again");
+    assert!(!deleted_again, "idempotent: nothing left to delete");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Tenant scope isolation
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn upsert_cross_tenant_denied() {
+    let db = test_db().await;
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    insert_chat(&db, tenant_a, chat_id).await;
+    let msg_id = insert_assistant_message(&db, tenant_a, chat_id).await;
+
+    let repo = ReactionRepository;
+    let conn = db.conn().unwrap();
+
+    // Attempt to upsert with tenant_a data but tenant_b scope → denied
+    let scope_b = AccessScope::for_tenant(tenant_b);
+    let result = repo
+        .upsert(
+            &conn,
+            &scope_b,
+            UpsertReactionParams {
+                id: Uuid::now_v7(),
+                tenant_id: tenant_a,
+                message_id: msg_id,
+                user_id,
+                reaction: ReactionKind::Like,
+            },
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "upsert with mismatched tenant scope must fail"
+    );
+}
+
+#[tokio::test]
+async fn delete_cross_tenant_no_effect() {
+    let db = test_db().await;
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    insert_chat(&db, tenant_a, chat_id).await;
+    let msg_id = insert_assistant_message(&db, tenant_a, chat_id).await;
+
+    let repo = ReactionRepository;
+    let conn = db.conn().unwrap();
+
+    // Insert reaction under tenant_a
+    let scope_a = AccessScope::for_tenant(tenant_a);
+    repo.upsert(
+        &conn,
+        &scope_a,
+        UpsertReactionParams {
+            id: Uuid::now_v7(),
+            tenant_id: tenant_a,
+            message_id: msg_id,
+            user_id,
+            reaction: ReactionKind::Like,
+        },
+    )
+    .await
+    .expect("upsert");
+
+    // Attempt delete with tenant_b scope — should not affect tenant_a's data
+    let scope_b = AccessScope::for_tenant(tenant_b);
+    let deleted = repo
+        .delete_by_message_and_user(&conn, &scope_b, msg_id, user_id)
+        .await
+        .expect("delete cross-tenant");
+    assert!(
+        !deleted,
+        "cross-tenant delete must not affect other tenant's reaction"
+    );
+
+    // Verify reaction still exists under tenant_a
+    let deleted_a = repo
+        .delete_by_message_and_user(&conn, &scope_a, msg_id, user_id)
+        .await
+        .expect("delete own tenant");
+    assert!(deleted_a, "reaction must still exist under original tenant");
+}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/repo_test.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/repo_test.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use modkit_db::DBProvider;
+use modkit_db::odata::LimitCfg;
 use modkit_security::AccessScope;
 use sea_orm::ActiveEnum;
 use uuid::Uuid;
@@ -24,6 +25,13 @@ type Db = Arc<DBProvider<modkit_db::DbError>>;
 
 fn scope() -> AccessScope {
     AccessScope::allow_all()
+}
+
+fn limit_cfg() -> LimitCfg {
+    LimitCfg {
+        default: 20,
+        max: 100,
+    }
 }
 
 async fn test_db() -> Db {
@@ -405,7 +413,7 @@ async fn cas_update_completed_sets_assistant_message_id() {
         .expect("create_turn");
 
     // Insert an assistant message (required by FK on assistant_message_id)
-    let msg_repo = MessageRepository;
+    let msg_repo = MessageRepository::new(limit_cfg());
     let msg_id = Uuid::new_v4();
     msg_repo
         .insert_assistant_message(
@@ -554,7 +562,7 @@ async fn insert_user_message_round_trip() {
     let chat_id = Uuid::new_v4();
     insert_chat(&db, tenant_id, chat_id).await;
 
-    let repo = MessageRepository;
+    let repo = MessageRepository::new(limit_cfg());
     let conn = db.conn().unwrap();
     let request_id = Uuid::new_v4();
 
@@ -586,7 +594,7 @@ async fn insert_assistant_message_with_usage() {
     let chat_id = Uuid::new_v4();
     insert_chat(&db, tenant_id, chat_id).await;
 
-    let repo = MessageRepository;
+    let repo = MessageRepository::new(limit_cfg());
     let conn = db.conn().unwrap();
     let request_id = Uuid::new_v4();
 
@@ -622,7 +630,7 @@ async fn find_messages_by_chat_and_request_id() {
     let chat_id = Uuid::new_v4();
     insert_chat(&db, tenant_id, chat_id).await;
 
-    let repo = MessageRepository;
+    let repo = MessageRepository::new(limit_cfg());
     let conn = db.conn().unwrap();
     let request_id = Uuid::new_v4();
 
@@ -676,7 +684,7 @@ async fn duplicate_user_message_rejected() {
     let chat_id = Uuid::new_v4();
     insert_chat(&db, tenant_id, chat_id).await;
 
-    let repo = MessageRepository;
+    let repo = MessageRepository::new(limit_cfg());
     let conn = db.conn().unwrap();
     let request_id = Uuid::new_v4();
 

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -13,8 +13,13 @@ use types_registry_sdk::{RegisterResult, TypesRegistryClient};
 use crate::api::rest::routes;
 use crate::domain::service::{AppServices as GenericAppServices, Repositories};
 
-pub(crate) type AppServices =
-    GenericAppServices<TurnRepository, MessageRepository, QuotaUsageRepository, ChatRepository>;
+pub(crate) type AppServices = GenericAppServices<
+    TurnRepository,
+    MessageRepository,
+    QuotaUsageRepository,
+    ReactionRepository,
+    ChatRepository,
+>;
 use crate::infra::db::repo::attachment_repo::AttachmentRepository;
 use crate::infra::db::repo::chat_repo::ChatRepository;
 use crate::infra::db::repo::message_repo::MessageRepository;
@@ -123,7 +128,10 @@ impl Module for MiniChatModule {
                 max: 100,
             })),
             attachment: Arc::new(AttachmentRepository),
-            message: Arc::new(MessageRepository),
+            message: Arc::new(MessageRepository::new(modkit_db::odata::LimitCfg {
+                default: 20,
+                max: 100,
+            })),
             quota: Arc::new(QuotaUsageRepository),
             turn: Arc::new(TurnRepository),
             reaction: Arc::new(ReactionRepository),


### PR DESCRIPTION
- Add REST endpoints for list messages and set/delete reactions
- Add domain services with unit tests for message and reaction business logic
- Add AccessScope::tenant_only() helper for entities without owner_id scoping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paginated message listing with richer message payloads (attachments, model, token counts).
  * Full reaction management: set and delete reactions; reactions persisted and returned.

* **Improvements**
  * API action names renamed and DELETE reaction now returns 204 No Content (idempotent).
  * Access control tightened to tenant-only filtering for message counts and queries.
  * Public error responses for missing/invalid message targets added.

* **Tests**
  * Extensive tests covering messaging, pagination, and reaction flows.

* **Documentation**
  * API docs updated to reflect new action names and response shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->