### PR TITLE
feat(mini-chat): atomic turn finalization with CAS guard and billing …

### DIFF
--- a/modules/mini-chat/mini-chat-sdk/src/error.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/error.rs
@@ -9,3 +9,27 @@ pub enum MiniChatModelPolicyPluginError {
     #[error("internal policy plugin error: {0}")]
     Internal(String),
 }
+
+/// Errors returned by `publish_usage()`.
+#[derive(Debug, Error)]
+pub enum PublishError {
+    /// Transient failure — safe to retry.
+    #[error("transient publish error: {0}")]
+    Transient(String),
+
+    /// Permanent failure — do not retry.
+    #[error("permanent publish error: {0}")]
+    Permanent(String),
+}
+
+impl PublishError {
+    #[must_use]
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::Transient(_))
+    }
+
+    #[must_use]
+    pub fn is_permanent(&self) -> bool {
+        matches!(self, Self::Permanent(_))
+    }
+}

--- a/modules/mini-chat/mini-chat-sdk/src/lib.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/lib.rs
@@ -3,10 +3,10 @@ pub mod gts;
 pub mod models;
 pub mod plugin_api;
 
-pub use error::MiniChatModelPolicyPluginError;
+pub use error::{MiniChatModelPolicyPluginError, PublishError};
 pub use gts::MiniChatModelPolicyPluginSpecV1;
 pub use models::{
     KillSwitches, ModelCatalogEntry, ModelTier, PolicySnapshot, PolicyVersionInfo, TierLimits,
-    UserLimits,
+    UsageEvent, UsageTokens, UserLimits,
 };
 pub use plugin_api::MiniChatModelPolicyPluginClientV1;

--- a/modules/mini-chat/mini-chat-sdk/src/models.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/models.rs
@@ -78,3 +78,32 @@ pub struct TierLimits {
     pub limit_daily_credits_micro: i64,
     pub limit_monthly_credits_micro: i64,
 }
+
+/// Token usage reported by the provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageTokens {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+/// Canonical usage event payload published via the outbox after finalization.
+///
+/// Single canonical type — both the outbox enqueuer (infra) and the plugin
+/// `publish_usage()` method use this same struct.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageEvent {
+    pub tenant_id: Uuid,
+    pub user_id: Uuid,
+    pub chat_id: Uuid,
+    pub turn_id: Uuid,
+    pub request_id: Uuid,
+    pub effective_model: String,
+    pub selected_model: String,
+    pub terminal_state: String,
+    pub billing_outcome: String,
+    pub usage: Option<UsageTokens>,
+    pub actual_credits_micro: i64,
+    pub settlement_method: String,
+    pub policy_version_applied: i64,
+    pub timestamp: OffsetDateTime,
+}

--- a/modules/mini-chat/mini-chat-sdk/src/plugin_api.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/plugin_api.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use crate::error::MiniChatModelPolicyPluginError;
-use crate::models::{PolicySnapshot, PolicyVersionInfo, UserLimits};
+use crate::error::{MiniChatModelPolicyPluginError, PublishError};
+use crate::models::{PolicySnapshot, PolicyVersionInfo, UsageEvent, UserLimits};
 
 /// Plugin API trait for mini-chat model policy implementations.
 ///
@@ -30,4 +30,10 @@ pub trait MiniChatModelPolicyPluginClientV1: Send + Sync {
         user_id: Uuid,
         policy_version: u64,
     ) -> Result<UserLimits, MiniChatModelPolicyPluginError>;
+
+    /// Publish a usage event after turn finalization.
+    ///
+    /// Called by the outbox processor after the finalization transaction
+    /// commits. Plugins can forward the event to external billing systems.
+    async fn publish_usage(&self, payload: UsageEvent) -> Result<(), PublishError>;
 }

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -15,6 +15,8 @@ pub struct MiniChatConfig {
     pub estimation_budgets: EstimationBudgets,
     #[serde(default)]
     pub quota: QuotaConfig,
+    #[serde(default)]
+    pub outbox: OutboxConfig,
 }
 
 /// SSE streaming tuning parameters.
@@ -77,6 +79,7 @@ impl Default for MiniChatConfig {
             vendor: default_vendor(),
             estimation_budgets: EstimationBudgets::default(),
             quota: QuotaConfig::default(),
+            outbox: OutboxConfig::default(),
         }
     }
 }
@@ -177,6 +180,51 @@ impl QuotaConfig {
     }
 }
 
+/// Outbox configuration for usage event publishing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OutboxConfig {
+    /// Queue name for usage events.
+    #[serde(default = "default_outbox_queue_name")]
+    pub queue_name: String,
+
+    /// Number of outbox partitions. Must be 1–64.
+    #[serde(default = "default_outbox_num_partitions")]
+    pub num_partitions: u32,
+}
+
+impl Default for OutboxConfig {
+    fn default() -> Self {
+        Self {
+            queue_name: default_outbox_queue_name(),
+            num_partitions: default_outbox_num_partitions(),
+        }
+    }
+}
+
+impl OutboxConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.queue_name.trim().is_empty() {
+            return Err("outbox queue_name must not be empty".to_owned());
+        }
+        if !(1..=64).contains(&self.num_partitions) {
+            return Err(format!(
+                "outbox num_partitions must be 1-64, got {}",
+                self.num_partitions
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn default_outbox_queue_name() -> String {
+    "mini-chat.usage_snapshot".to_owned()
+}
+
+fn default_outbox_num_partitions() -> u32 {
+    4
+}
+
 fn default_overshoot_tolerance() -> f64 {
     1.10
 }
@@ -198,6 +246,7 @@ mod tests {
         StreamingConfig::default().validate().unwrap();
         EstimationBudgets::default().validate().unwrap();
         QuotaConfig::default().validate().unwrap();
+        OutboxConfig::default().validate().unwrap();
     }
 
     #[test]

--- a/modules/mini-chat/mini-chat/src/domain/model/billing_outcome.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/billing_outcome.rs
@@ -1,0 +1,264 @@
+use modkit_macros::domain_model;
+
+use crate::domain::model::quota::SettlementMethod;
+use crate::infra::db::entity::chat_turn::TurnState;
+
+/// Billing outcome classification for a finalized turn.
+///
+/// Maps from `TurnState` but is NOT a 1:1 mapping — see
+/// DESIGN.md §5.8 "Critical Distinction: Internal State vs Billing Outcome".
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BillingOutcome {
+    Completed,
+    Failed,
+    Aborted,
+}
+
+impl BillingOutcome {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Aborted => "aborted",
+        }
+    }
+}
+
+/// Result of billing outcome derivation.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BillingDerivation {
+    pub outcome: BillingOutcome,
+    pub settlement_method: SettlementMethod,
+    /// When `true`, the caller MUST log a critical error and increment
+    /// `mini_chat_unknown_error_code_total` after the transaction commits.
+    /// Kept out of the pure function to preserve testability.
+    pub unknown_error_code: bool,
+}
+
+/// Input to `derive_billing_outcome()`.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct BillingDerivationInput {
+    pub terminal_state: TurnState,
+    pub error_code: Option<String>,
+    /// `true` when the provider reported a `Usage` object with at least one
+    /// non-zero field (`input_tokens > 0 || output_tokens > 0`).
+    /// A zero-valued or missing usage object is "usage unknown".
+    pub has_usage: bool,
+}
+
+/// Derive billing outcome from terminal condition.
+///
+/// Pure function — no I/O, no logging, no metrics. The `unknown_error_code`
+/// flag on the result signals the caller to emit side effects after the
+/// transaction commits.
+///
+/// Implements the normative mapping from DESIGN.md §5.8.
+#[must_use]
+pub fn derive_billing_outcome(input: &BillingDerivationInput) -> BillingDerivation {
+    match input.terminal_state {
+        TurnState::Completed => BillingDerivation {
+            outcome: BillingOutcome::Completed,
+            settlement_method: SettlementMethod::Actual,
+            unknown_error_code: false,
+        },
+
+        TurnState::Cancelled => {
+            // Client disconnect — billing ABORTED.
+            // Settlement depends on whether the provider reported usage.
+            if input.has_usage {
+                BillingDerivation {
+                    outcome: BillingOutcome::Aborted,
+                    settlement_method: SettlementMethod::Actual,
+                    unknown_error_code: false,
+                }
+            } else {
+                BillingDerivation {
+                    outcome: BillingOutcome::Aborted,
+                    settlement_method: SettlementMethod::Estimated,
+                    unknown_error_code: false,
+                }
+            }
+        }
+
+        TurnState::Failed => match input.error_code.as_deref() {
+            // Orphan timeout — always ABORTED/Estimated (no provider terminal event).
+            Some("orphan_timeout") => BillingDerivation {
+                outcome: BillingOutcome::Aborted,
+                settlement_method: SettlementMethod::Estimated,
+                unknown_error_code: false,
+            },
+
+            // Pre-provider errors — reserve released, charge = 0.
+            Some("context_length_exceeded" | "validation_error") => BillingDerivation {
+                outcome: BillingOutcome::Failed,
+                settlement_method: SettlementMethod::Released,
+                unknown_error_code: false,
+            },
+
+            // Post-provider errors — depends on usage availability.
+            Some(
+                "provider_error"
+                | "provider_timeout"
+                | "rate_limited"
+                | "web_search_calls_exceeded",
+            ) => {
+                if input.has_usage {
+                    BillingDerivation {
+                        outcome: BillingOutcome::Failed,
+                        settlement_method: SettlementMethod::Actual,
+                        unknown_error_code: false,
+                    }
+                } else {
+                    BillingDerivation {
+                        outcome: BillingOutcome::Failed,
+                        settlement_method: SettlementMethod::Estimated,
+                        unknown_error_code: false,
+                    }
+                }
+            }
+
+            // Unknown error code — conservative: Failed/Estimated.
+            // Signal caller to log + metric via unknown_error_code flag.
+            _ => BillingDerivation {
+                outcome: BillingOutcome::Failed,
+                settlement_method: SettlementMethod::Estimated,
+                unknown_error_code: true,
+            },
+        },
+
+        // Running should never reach finalization — defensive.
+        TurnState::Running => unreachable!("finalization called with Running state"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(
+        state: TurnState,
+        error_code: Option<&str>,
+        has_usage: bool,
+    ) -> BillingDerivationInput {
+        BillingDerivationInput {
+            terminal_state: state,
+            error_code: error_code.map(String::from),
+            has_usage,
+        }
+    }
+
+    // ── Completed ──
+
+    #[test]
+    fn completed_derives_completed_actual() {
+        let r = derive_billing_outcome(&input(TurnState::Completed, None, true));
+        assert_eq!(r.outcome, BillingOutcome::Completed);
+        assert_eq!(r.settlement_method, SettlementMethod::Actual);
+        assert!(!r.unknown_error_code);
+    }
+
+    // ── Cancelled ──
+
+    #[test]
+    fn cancelled_with_usage_derives_aborted_actual() {
+        let r = derive_billing_outcome(&input(TurnState::Cancelled, None, true));
+        assert_eq!(r.outcome, BillingOutcome::Aborted);
+        assert_eq!(r.settlement_method, SettlementMethod::Actual);
+    }
+
+    #[test]
+    fn cancelled_without_usage_derives_aborted_estimated() {
+        let r = derive_billing_outcome(&input(TurnState::Cancelled, None, false));
+        assert_eq!(r.outcome, BillingOutcome::Aborted);
+        assert_eq!(r.settlement_method, SettlementMethod::Estimated);
+    }
+
+    // ── Failed: orphan_timeout ──
+
+    #[test]
+    fn orphan_timeout_derives_aborted_estimated() {
+        let r = derive_billing_outcome(&input(TurnState::Failed, Some("orphan_timeout"), true));
+        assert_eq!(r.outcome, BillingOutcome::Aborted);
+        assert_eq!(r.settlement_method, SettlementMethod::Estimated);
+        // Usage is ignored for orphan_timeout — always estimated.
+    }
+
+    // ── Failed: pre-provider errors ──
+
+    #[test]
+    fn context_length_exceeded_derives_failed_released() {
+        let r = derive_billing_outcome(&input(
+            TurnState::Failed,
+            Some("context_length_exceeded"),
+            false,
+        ));
+        assert_eq!(r.outcome, BillingOutcome::Failed);
+        assert_eq!(r.settlement_method, SettlementMethod::Released);
+    }
+
+    #[test]
+    fn validation_error_derives_failed_released() {
+        let r = derive_billing_outcome(&input(TurnState::Failed, Some("validation_error"), false));
+        assert_eq!(r.outcome, BillingOutcome::Failed);
+        assert_eq!(r.settlement_method, SettlementMethod::Released);
+    }
+
+    // ── Failed: post-provider errors ──
+
+    #[test]
+    fn provider_error_with_usage_derives_failed_actual() {
+        let r = derive_billing_outcome(&input(TurnState::Failed, Some("provider_error"), true));
+        assert_eq!(r.outcome, BillingOutcome::Failed);
+        assert_eq!(r.settlement_method, SettlementMethod::Actual);
+    }
+
+    #[test]
+    fn provider_error_without_usage_derives_failed_estimated() {
+        let r = derive_billing_outcome(&input(TurnState::Failed, Some("provider_error"), false));
+        assert_eq!(r.outcome, BillingOutcome::Failed);
+        assert_eq!(r.settlement_method, SettlementMethod::Estimated);
+    }
+
+    #[test]
+    fn rate_limited_with_usage_derives_failed_actual() {
+        let r = derive_billing_outcome(&input(TurnState::Failed, Some("rate_limited"), true));
+        assert_eq!(r.outcome, BillingOutcome::Failed);
+        assert_eq!(r.settlement_method, SettlementMethod::Actual);
+    }
+
+    // ── Failed: unknown error code ──
+
+    #[test]
+    fn unknown_error_code_derives_failed_estimated_with_flag() {
+        let r = derive_billing_outcome(&input(TurnState::Failed, Some("some_new_code"), true));
+        assert_eq!(r.outcome, BillingOutcome::Failed);
+        assert_eq!(r.settlement_method, SettlementMethod::Estimated);
+        assert!(r.unknown_error_code);
+    }
+
+    #[test]
+    fn failed_with_no_error_code_derives_failed_estimated_with_flag() {
+        let r = derive_billing_outcome(&input(TurnState::Failed, None, false));
+        assert_eq!(r.outcome, BillingOutcome::Failed);
+        assert_eq!(r.settlement_method, SettlementMethod::Estimated);
+        assert!(r.unknown_error_code);
+    }
+
+    // ── Edge case: Running state ──
+
+    #[test]
+    #[should_panic(expected = "finalization called with Running state")]
+    #[allow(clippy::let_underscore_must_use, dropping_copy_types)]
+    fn running_state_panics() {
+        // The function panics before returning, so the result is never used.
+        drop(derive_billing_outcome(&input(
+            TurnState::Running,
+            None,
+            false,
+        )));
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/model/finalization.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/finalization.rs
@@ -1,0 +1,86 @@
+use modkit_macros::domain_model;
+use modkit_security::AccessScope;
+use uuid::Uuid;
+
+use crate::domain::model::billing_outcome::BillingDerivation;
+use crate::domain::model::quota::{SettlementMethod, SettlementOutcome, SettlementPath};
+use crate::infra::db::entity::chat_turn::TurnState;
+use crate::infra::db::entity::quota_usage::PeriodType;
+use crate::infra::llm::Usage;
+
+/// All fields needed by `finalize_turn_cas()`.
+///
+/// Assembled by the spawned task from `FinalizationCtx` (preflight fields)
+/// and `StreamOutcome` (stream result).
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct FinalizationInput {
+    // ── Identity ──
+    pub turn_id: Uuid,
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    pub request_id: Uuid,
+    pub user_id: Uuid,
+    pub scope: AccessScope,
+    pub message_id: Uuid,
+
+    // ── Terminal state (from StreamOutcome) ──
+    pub terminal_state: TurnState,
+    pub error_code: Option<String>,
+    pub error_detail: Option<String>,
+    pub accumulated_text: String,
+    /// Provider-reported usage; `None` if not available.
+    pub usage: Option<Usage>,
+    pub provider_response_id: Option<String>,
+
+    // ── Quota fields (from preflight, carried via FinalizationCtx) ──
+    pub effective_model: String,
+    pub selected_model: String,
+    pub reserve_tokens: i64,
+    pub max_output_tokens_applied: i32,
+    pub reserved_credits_micro: i64,
+    pub policy_version_applied: i64,
+    pub minimal_generation_floor_applied: i32,
+    pub quota_decision: String,
+    pub downgrade_from: Option<String>,
+    pub downgrade_reason: Option<String>,
+    pub period_starts: Vec<(PeriodType, time::Date)>,
+}
+
+/// Result of `finalize_turn_cas()`.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct FinalizationOutcome {
+    pub won_cas: bool,
+    pub billing_outcome: Option<BillingDerivation>,
+    pub settlement_outcome: Option<SettlementOutcome>,
+}
+
+/// Determine whether provider-reported usage is "known" for billing purposes.
+///
+/// "Usage known" = at least one non-zero token field. A zero-valued or
+/// missing usage object is treated as unknown (follows estimated path).
+#[must_use]
+pub fn has_known_usage(usage: Option<Usage>) -> bool {
+    usage.is_some_and(|u| u.input_tokens > 0 || u.output_tokens > 0)
+}
+
+/// Build `SettlementPath` from the billing derivation and provider usage.
+#[must_use]
+pub fn settlement_path_from_billing(
+    method: SettlementMethod,
+    usage: Option<Usage>,
+) -> SettlementPath {
+    match method {
+        SettlementMethod::Actual => {
+            // SAFETY: billing derivation guarantees `usage.is_some()` when method is Actual.
+            let u = usage.unwrap_or_else(|| unreachable!("Actual settlement requires usage"));
+            SettlementPath::Actual {
+                input_tokens: u.input_tokens,
+                output_tokens: u.output_tokens,
+            }
+        }
+        SettlementMethod::Estimated => SettlementPath::Estimated,
+        SettlementMethod::Released => SettlementPath::Released,
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/model/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/mod.rs
@@ -1,1 +1,3 @@
+pub mod billing_outcome;
+pub mod finalization;
 pub mod quota;

--- a/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
@@ -3,6 +3,7 @@ mod chat_repo;
 mod message_repo;
 mod model_pref_repo;
 mod model_resolver;
+mod outbox_enqueuer;
 mod policy_snapshot_provider;
 mod quota_usage_repo;
 mod reaction_repo;
@@ -18,6 +19,7 @@ pub(crate) use message_repo::{
 };
 pub(crate) use model_pref_repo::ModelPrefRepository;
 pub(crate) use model_resolver::ModelResolver;
+pub(crate) use outbox_enqueuer::OutboxEnqueuer;
 pub(crate) use policy_snapshot_provider::PolicySnapshotProvider;
 pub(crate) use quota_usage_repo::{IncrementReserveParams, QuotaUsageRepository, SettleParams};
 pub(crate) use reaction_repo::{ReactionRepository, UpsertReactionParams};

--- a/modules/mini-chat/mini-chat/src/domain/repos/outbox_enqueuer.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/outbox_enqueuer.rs
@@ -1,0 +1,55 @@
+use mini_chat_sdk::UsageEvent;
+use modkit_db::secure::DBRunner;
+
+use crate::domain::error::DomainError;
+
+/// Domain-layer abstraction for enqueuing outbox events within a transaction.
+///
+/// The finalization service calls this trait to insert outbox rows atomically
+/// alongside the CAS state transition and quota settlement. The infra layer
+/// implements it by delegating to `modkit_db::outbox::Outbox::enqueue()`.
+///
+/// # Why a trait?
+///
+/// The `modkit_db::outbox::Outbox` API is partition-based and accepts raw
+/// `Vec<u8>` payloads. Mini-Chat needs a domain-oriented interface that:
+/// - Accepts a typed `UsageEvent` (from `mini-chat-sdk`; serialized by the implementation)
+/// - Resolves the queue name and partition from tenant context
+/// - Participates in the caller's transaction via `&impl DBRunner`
+/// - Returns domain errors, not infra-level `OutboxError`
+///
+/// # Payload type
+///
+/// Uses `UsageEvent` from `mini-chat-sdk` directly — the single canonical
+/// representation of the usage outbox payload. No separate domain payload type
+/// exists. The SDK crate is already a dependency of the domain layer.
+///
+/// # Implementation note
+///
+/// The infra implementation (`InfraOutboxEnqueuer`) will hold an
+/// `Arc<modkit_db::outbox::Outbox>` and call `outbox.enqueue(runner, ...)`
+/// within the finalization transaction. The `Outbox::flush()` notification
+/// is sent after the transaction commits (by the finalization service).
+// TODO(P4): implement InfraOutboxEnqueuer backed by modkit_db::outbox::Outbox
+// TODO(P4): Wire into FinalizationService once modkit_db::outbox is merged.
+#[async_trait::async_trait]
+#[allow(dead_code)]
+pub trait OutboxEnqueuer: Send + Sync {
+    /// Enqueue a usage event within the caller's transaction.
+    ///
+    /// The implementation MUST:
+    /// - Serialize `event` to `Vec<u8>` (JSON wire format)
+    /// - Insert into the outbox table using the provided `runner` (transaction)
+    /// - Use `queue = "mini-chat.usage_snapshot"` (or equivalent registered name)
+    /// - Derive the partition from `event.tenant_id`
+    ///
+    /// Duplicate prevention is handled by the CAS guard in the finalization
+    /// transaction — the outbox enqueue is only reached by the CAS winner.
+    ///
+    /// Returns `Ok(())` on success. Returns `Err` on database error.
+    async fn enqueue_usage_event<C: DBRunner>(
+        &self,
+        runner: &C,
+        event: UsageEvent,
+    ) -> Result<(), DomainError>;
+}

--- a/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
@@ -27,20 +27,29 @@ pub struct CreateTurnParams {
 
 /// Parameters for CAS update to completed state.
 #[domain_model]
-#[allow(clippy::struct_field_names)]
+// Fields are read in infra::db::repo::turn_repo — #[domain_model] hides access from clippy.
+#[allow(clippy::struct_field_names, dead_code)]
 pub struct CasCompleteParams {
     pub turn_id: Uuid,
     pub assistant_message_id: Uuid,
     pub provider_response_id: Option<String>,
 }
 
-/// Parameters for CAS update to a terminal state (failed/cancelled).
+/// Parameters for CAS update to a terminal state (completed/failed/cancelled).
+///
+/// Unified CAS method: handles all terminal transitions. For completed turns,
+/// `assistant_message_id` and `provider_response_id` are set; for failed/cancelled
+/// they are `None` (content durability invariant — DESIGN.md §5.7).
 #[domain_model]
 pub struct CasTerminalParams {
     pub turn_id: Uuid,
     pub state: TurnState,
     pub error_code: Option<String>,
     pub error_detail: Option<String>,
+    /// Set only for completed turns — links to the persisted assistant message.
+    pub assistant_message_id: Option<Uuid>,
+    /// Provider response ID (e.g. `OpenAI` `response_id`); set for completed turns.
+    pub provider_response_id: Option<String>,
 }
 
 /// Repository trait for turn persistence operations.
@@ -89,6 +98,19 @@ pub trait TurnRepository: Send + Sync {
         scope: &AccessScope,
         params: CasCompleteParams,
     ) -> Result<u64, DomainError>;
+
+    /// Set `assistant_message_id` on a turn after the message has been persisted.
+    ///
+    /// Called within the finalization transaction, AFTER the assistant message
+    /// INSERT and CAS guard. Separate from the CAS step because
+    /// `assistant_message_id` has a FK to `messages(id)`.
+    async fn set_assistant_message_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        turn_id: Uuid,
+        assistant_message_id: Uuid,
+    ) -> Result<(), DomainError>;
 
     /// Soft-delete a turn, linking to a replacement `request_id`.
     async fn soft_delete<C: DBRunner>(

--- a/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
@@ -1,0 +1,609 @@
+use std::sync::Arc;
+
+use modkit_macros::domain_model;
+use tracing::{debug, error, warn};
+
+use crate::domain::error::DomainError;
+use crate::domain::model::billing_outcome::{
+    BillingDerivation, BillingDerivationInput, BillingOutcome, derive_billing_outcome,
+};
+use crate::domain::model::finalization::{
+    FinalizationInput, FinalizationOutcome, has_known_usage, settlement_path_from_billing,
+};
+use crate::domain::model::quota::SettlementInput;
+use crate::domain::repos::{
+    CasTerminalParams, InsertAssistantMessageParams, MessageRepository, TurnRepository,
+};
+use crate::domain::service::quota_settler::QuotaSettler;
+use crate::infra::db::entity::chat_turn::TurnState;
+
+use super::DbProvider;
+
+fn to_db(e: DomainError) -> modkit_db::DbError {
+    modkit_db::DbError::Other(anyhow::anyhow!(e))
+}
+
+/// Service encapsulating the atomic finalization transaction.
+///
+/// Generic over `TR` and `MR` (repository traits are not dyn-compatible
+/// due to `&impl DBRunner` methods). The `QuotaService<QR>` generic is
+/// erased via the `QuotaSettler` trait (see D2).
+///
+/// Created once in `AppServices::new()` and shared with spawned tasks
+/// via `Arc<FinalizationService<TR, MR>>`.
+#[domain_model]
+pub struct FinalizationService<TR: TurnRepository + 'static, MR: MessageRepository + 'static> {
+    db: Arc<DbProvider>,
+    turn_repo: Arc<TR>,
+    message_repo: Arc<MR>,
+    quota_settler: Arc<dyn QuotaSettler>,
+    // TODO(P4): add Arc<dyn OutboxEnqueuer> once UsageEvent type is real (task 6.1)
+}
+
+impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> FinalizationService<TR, MR> {
+    pub(crate) fn new(
+        db: Arc<DbProvider>,
+        turn_repo: Arc<TR>,
+        message_repo: Arc<MR>,
+        quota_settler: Arc<dyn QuotaSettler>,
+    ) -> Self {
+        Self {
+            db,
+            turn_repo,
+            message_repo,
+            quota_settler,
+        }
+    }
+
+    /// Single universal finalization function for all terminal paths.
+    ///
+    /// Executes CAS guard + billing derivation + quota settlement +
+    /// message persistence + outbox enqueue in one atomic DB transaction.
+    ///
+    /// Returns `FinalizationOutcome { won_cas: false, .. }` if another
+    /// finalizer already committed (CAS loser — no-op).
+    ///
+    /// If message persistence fails on a completed turn, rolls back and
+    /// retries as `Failed` with `error_code = "message_persistence_failed"`
+    /// (content durability invariant, DESIGN.md §5.7).
+    pub(crate) async fn finalize_turn_cas(
+        &self,
+        input: FinalizationInput,
+    ) -> Result<FinalizationOutcome, DomainError> {
+        let result = self.try_finalize(&input).await;
+
+        match result {
+            Ok(outcome) => {
+                // Emit side effects after transaction commit.
+                if let Some(billing) = outcome.billing_outcome {
+                    Self::emit_post_commit_side_effects(&input, billing);
+                }
+                Ok(outcome)
+            }
+            Err(FinalizationError::MessagePersistenceFailed(e)) => {
+                // Content durability invariant: downgrade completed → failed.
+                // The transaction rolled back, so the turn is still 'running'.
+                // Retry with Failed state.
+                error!(
+                    error = %e,
+                    turn_id = %input.turn_id,
+                    "message persistence failed, downgrading completed to failed"
+                );
+                let mut retry_input = input;
+                retry_input.terminal_state = TurnState::Failed;
+                retry_input.error_code = Some("message_persistence_failed".to_owned());
+                let retry_outcome =
+                    self.try_finalize(&retry_input)
+                        .await
+                        .map_err(|fe| match fe {
+                            FinalizationError::Domain(de) => de,
+                            FinalizationError::MessagePersistenceFailed(e2) => {
+                                // Should not happen on Failed path (no message INSERT).
+                                DomainError::internal(format!("unexpected retry failure: {e2}"))
+                            }
+                        })?;
+                if let Some(billing) = retry_outcome.billing_outcome {
+                    Self::emit_post_commit_side_effects(&retry_input, billing);
+                }
+                Ok(retry_outcome)
+            }
+            Err(FinalizationError::Domain(e)) => Err(e),
+        }
+    }
+
+    /// Core finalization logic inside a transaction.
+    async fn try_finalize(
+        &self,
+        input: &FinalizationInput,
+    ) -> Result<FinalizationOutcome, FinalizationError> {
+        let turn_repo = Arc::clone(&self.turn_repo);
+        let message_repo = Arc::clone(&self.message_repo);
+        let quota_settler = Arc::clone(&self.quota_settler);
+        let input = input.clone();
+
+        let tx_result = self
+            .db
+            .transaction(|tx| {
+                Box::pin(async move {
+                    let scope = input.scope.clone();
+
+                    // 1. CAS guard — state transition only.
+                    //    assistant_message_id and provider_response_id are set
+                    //    AFTER the message INSERT (step 4) to avoid FK violation
+                    //    (assistant_message_id REFERENCES messages(id)).
+                    let rows = turn_repo
+                        .cas_update_state(
+                            tx,
+                            &scope,
+                            CasTerminalParams {
+                                turn_id: input.turn_id,
+                                state: input.terminal_state.clone(),
+                                error_code: input.error_code.clone(),
+                                error_detail: input.error_detail.clone(),
+                                assistant_message_id: None,
+                                provider_response_id: input.provider_response_id.clone(),
+                            },
+                        )
+                        .await
+                        .map_err(to_db)?;
+
+                    if rows == 0 {
+                        debug!(turn_id = %input.turn_id, "CAS loser: another finalizer won");
+                        return Ok(FinalizationOutcome {
+                            won_cas: false,
+                            billing_outcome: None,
+                            settlement_outcome: None,
+                        });
+                    }
+
+                    // 2. Derive billing outcome (pure function, no DB)
+                    let billing = derive_billing_outcome(&BillingDerivationInput {
+                        terminal_state: input.terminal_state.clone(),
+                        error_code: input.error_code.clone(),
+                        has_usage: has_known_usage(input.usage),
+                    });
+
+                    // 3. Build SettlementInput and settle quota
+                    let settlement_path =
+                        settlement_path_from_billing(billing.settlement_method, input.usage);
+                    let settlement_input = SettlementInput {
+                        tenant_id: input.tenant_id,
+                        user_id: input.user_id,
+                        effective_model: input.effective_model.clone(),
+                        policy_version_applied: input.policy_version_applied,
+                        reserve_tokens: input.reserve_tokens,
+                        max_output_tokens_applied: input.max_output_tokens_applied,
+                        reserved_credits_micro: input.reserved_credits_micro,
+                        minimal_generation_floor_applied: input.minimal_generation_floor_applied,
+                        settlement_path,
+                        period_starts: input.period_starts.clone(),
+                    };
+                    let settlement_outcome = quota_settler
+                        .settle_in_tx(tx, &scope, settlement_input)
+                        .await
+                        .map_err(to_db)?;
+
+                    // 4. Persist assistant message (completed turns only)
+                    //    Content durability invariant (DESIGN.md §5.7):
+                    //    "completed ⟹ full assistant content is durably persisted"
+                    if input.terminal_state == TurnState::Completed {
+                        message_repo
+                            .insert_assistant_message(
+                                tx,
+                                &scope,
+                                InsertAssistantMessageParams {
+                                    id: input.message_id,
+                                    tenant_id: input.tenant_id,
+                                    chat_id: input.chat_id,
+                                    request_id: input.request_id,
+                                    content: input.accumulated_text.clone(),
+                                    input_tokens: input.usage.map(|u| u.input_tokens),
+                                    output_tokens: input.usage.map(|u| u.output_tokens),
+                                    model: Some(input.effective_model.clone()),
+                                    provider_response_id: input.provider_response_id.clone(),
+                                },
+                            )
+                            .await
+                            .map_err(|e| {
+                                // Signal message persistence failure for retry logic.
+                                modkit_db::DbError::Other(anyhow::anyhow!("MSG_PERSIST_FAILED:{e}"))
+                            })?;
+
+                        // 4b. Link assistant_message_id on the turn row.
+                        //     Done as a separate UPDATE (not in the CAS step) because
+                        //     assistant_message_id has a FK to messages(id), so the
+                        //     message row must exist first.
+                        turn_repo
+                            .set_assistant_message_id(tx, &scope, input.turn_id, input.message_id)
+                            .await
+                            .map_err(to_db)?;
+                    }
+
+                    // 5. Enqueue outbox event via domain trait
+                    // TODO(P4): enqueue UsageEvent once real type exists (task 6.1)
+                    // let event = build_usage_event(&input, &billing, &settlement_outcome);
+                    // outbox_enqueuer.enqueue_usage_event(tx, event).await.map_err(to_db)?;
+
+                    // 6. Return outcome
+                    Ok(FinalizationOutcome {
+                        won_cas: true,
+                        billing_outcome: Some(billing),
+                        settlement_outcome: Some(settlement_outcome),
+                    })
+                })
+            })
+            .await;
+
+        match tx_result {
+            Ok(outcome) => Ok(outcome),
+            Err(e) => {
+                // Check if this was a message persistence failure (sentinel).
+                let err_str = e.to_string();
+                if err_str.contains("MSG_PERSIST_FAILED:") {
+                    let inner = err_str
+                        .strip_prefix("MSG_PERSIST_FAILED:")
+                        .unwrap_or(&err_str);
+                    Err(FinalizationError::MessagePersistenceFailed(
+                        inner.to_owned(),
+                    ))
+                } else {
+                    Err(FinalizationError::Domain(DomainError::from(e)))
+                }
+            }
+        }
+    }
+
+    /// Emit metrics and logs after the transaction commits.
+    /// These MUST NOT run inside the transaction.
+    fn emit_post_commit_side_effects(input: &FinalizationInput, billing: BillingDerivation) {
+        // Unknown error code → critical log + metric
+        if billing.unknown_error_code {
+            error!(
+                error_code = ?input.error_code,
+                turn_id = %input.turn_id,
+                "CRITICAL: unknown error code in billing derivation"
+            );
+            // TODO(P4): increment mini_chat_unknown_error_code_total{code} (task 8.4)
+        }
+
+        // Aborted billing outcome → streams_aborted metric
+        if billing.outcome == BillingOutcome::Aborted {
+            let trigger = match input.error_code.as_deref() {
+                Some("orphan_timeout") => "orphan_timeout",
+                _ if input.terminal_state == TurnState::Cancelled => "client_disconnect",
+                _ => "internal_abort",
+            };
+            warn!(
+                turn_id = %input.turn_id,
+                trigger = trigger,
+                "stream aborted"
+            );
+            // TODO(P4): increment mini_chat_streams_aborted_total{trigger} (task 8.3)
+        }
+    }
+}
+
+/// Internal error type to distinguish message persistence failure
+/// from other domain errors, enabling the retry-as-failed logic.
+#[domain_model]
+enum FinalizationError {
+    Domain(DomainError),
+    MessagePersistenceFailed(String),
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::domain::model::finalization::FinalizationInput;
+    use crate::domain::model::quota::{SettlementMethod, SettlementOutcome};
+    use crate::domain::repos::{CreateTurnParams, TurnRepository as TurnRepoTrait};
+    use crate::domain::service::test_helpers::{inmem_db, mock_db_provider};
+    use crate::infra::db::entity::chat_turn::TurnState;
+    use crate::infra::db::entity::quota_usage::PeriodType;
+    use crate::infra::db::repo::message_repo::MessageRepository as MsgRepo;
+    use crate::infra::db::repo::turn_repo::TurnRepository as TurnRepo;
+    use crate::infra::llm::Usage;
+    use modkit_security::AccessScope;
+    use uuid::Uuid;
+
+    // ── Mock QuotaSettler ──
+
+    #[domain_model]
+    struct MockQuotaSettler;
+
+    #[async_trait::async_trait]
+    impl QuotaSettler for MockQuotaSettler {
+        async fn settle_in_tx(
+            &self,
+            _tx: &modkit_db::secure::DbTx<'_>,
+            _scope: &AccessScope,
+            _input: crate::domain::model::quota::SettlementInput,
+        ) -> Result<SettlementOutcome, DomainError> {
+            Ok(SettlementOutcome {
+                settlement_method: SettlementMethod::Actual,
+                actual_credits_micro: 500,
+                charged_tokens: 15,
+                overshoot_capped: false,
+            })
+        }
+    }
+
+    fn build_finalization_service(db: Arc<DbProvider>) -> FinalizationService<TurnRepo, MsgRepo> {
+        FinalizationService::new(
+            db,
+            Arc::new(TurnRepo),
+            Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
+                default: 20,
+                max: 100,
+            })),
+            Arc::new(MockQuotaSettler),
+        )
+    }
+
+    /// Insert a parent chat row (FK constraint).
+    async fn insert_test_chat(db: &Arc<DbProvider>, tenant_id: Uuid, chat_id: Uuid, user_id: Uuid) {
+        use crate::infra::db::entity::chat::{ActiveModel, Entity as ChatEntity};
+        use modkit_db::secure::secure_insert;
+        use sea_orm::Set;
+        use time::OffsetDateTime;
+
+        let now = OffsetDateTime::now_utc();
+        let am = ActiveModel {
+            id: Set(chat_id),
+            tenant_id: Set(tenant_id),
+            user_id: Set(user_id),
+            model: Set("gpt-5.2".to_owned()),
+            title: Set(Some("test".to_owned())),
+            is_temporary: Set(false),
+            created_at: Set(now),
+            updated_at: Set(now),
+            deleted_at: Set(None),
+        };
+        let conn = db.conn().unwrap();
+        secure_insert::<ChatEntity>(am, &AccessScope::allow_all(), &conn)
+            .await
+            .expect("insert chat");
+    }
+
+    /// Insert a turn in `running` state.
+    async fn insert_running_turn(
+        db: &Arc<DbProvider>,
+        tenant_id: Uuid,
+        chat_id: Uuid,
+        turn_id: Uuid,
+        request_id: Uuid,
+    ) {
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let turn_repo = TurnRepo;
+        turn_repo
+            .create_turn(
+                &conn,
+                &scope,
+                CreateTurnParams {
+                    id: turn_id,
+                    tenant_id,
+                    chat_id,
+                    request_id,
+                    requester_type: "user".to_owned(),
+                    requester_user_id: None,
+                    reserve_tokens: Some(100),
+                    max_output_tokens_applied: Some(4096),
+                    reserved_credits_micro: Some(1000),
+                    policy_version_applied: Some(1),
+                    effective_model: Some("gpt-5.2".to_owned()),
+                    minimal_generation_floor_applied: Some(10),
+                },
+            )
+            .await
+            .expect("create turn");
+    }
+
+    fn make_input(
+        tenant_id: Uuid,
+        chat_id: Uuid,
+        turn_id: Uuid,
+        request_id: Uuid,
+        user_id: Uuid,
+        terminal_state: TurnState,
+    ) -> FinalizationInput {
+        let today = time::OffsetDateTime::now_utc().date();
+        let month_start = today.replace_day(1).unwrap();
+        FinalizationInput {
+            turn_id,
+            tenant_id,
+            chat_id,
+            request_id,
+            user_id,
+            scope: AccessScope::allow_all(),
+            message_id: Uuid::new_v4(),
+            terminal_state,
+            error_code: None,
+            error_detail: None,
+            accumulated_text: "Hello, world!".to_owned(),
+            usage: Some(Usage {
+                input_tokens: 10,
+                output_tokens: 5,
+            }),
+            provider_response_id: Some("resp-123".to_owned()),
+            effective_model: "gpt-5.2".to_owned(),
+            selected_model: "gpt-5.2".to_owned(),
+            reserve_tokens: 100,
+            max_output_tokens_applied: 4096,
+            reserved_credits_micro: 1000,
+            policy_version_applied: 1,
+            minimal_generation_floor_applied: 10,
+            quota_decision: "allow".to_owned(),
+            downgrade_from: None,
+            downgrade_reason: None,
+            period_starts: vec![
+                (PeriodType::Daily, today),
+                (PeriodType::Monthly, month_start),
+            ],
+        }
+    }
+
+    // ── 3.6: CAS winner executes full atomic finalization ──
+
+    #[tokio::test]
+    async fn cas_winner_completes_finalization() {
+        let db = mock_db_provider(inmem_db().await);
+        let svc = build_finalization_service(Arc::clone(&db));
+
+        let tenant_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        insert_test_chat(&db, tenant_id, chat_id, user_id).await;
+        insert_running_turn(&db, tenant_id, chat_id, turn_id, request_id).await;
+
+        let input = make_input(
+            tenant_id,
+            chat_id,
+            turn_id,
+            request_id,
+            user_id,
+            TurnState::Completed,
+        );
+        let outcome = svc
+            .finalize_turn_cas(input)
+            .await
+            .expect("finalization should succeed");
+
+        assert!(outcome.won_cas, "should be CAS winner");
+        assert!(outcome.billing_outcome.is_some());
+        assert!(outcome.settlement_outcome.is_some());
+
+        // Verify turn is now in completed state
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let turn_repo = TurnRepo;
+        let turn = turn_repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .expect("find turn")
+            .expect("turn should exist");
+        assert_eq!(turn.state, TurnState::Completed);
+    }
+
+    // ── 3.7: CAS loser returns won_cas = false ──
+
+    #[tokio::test]
+    async fn cas_loser_returns_no_side_effects() {
+        let db = mock_db_provider(inmem_db().await);
+        let svc = build_finalization_service(Arc::clone(&db));
+
+        let tenant_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        insert_test_chat(&db, tenant_id, chat_id, user_id).await;
+        insert_running_turn(&db, tenant_id, chat_id, turn_id, request_id).await;
+
+        // First finalization — wins CAS
+        let input = make_input(
+            tenant_id,
+            chat_id,
+            turn_id,
+            request_id,
+            user_id,
+            TurnState::Completed,
+        );
+        let outcome1 = svc
+            .finalize_turn_cas(input)
+            .await
+            .expect("first finalization");
+        assert!(outcome1.won_cas);
+
+        // Second finalization — loses CAS (turn already completed)
+        let input2 = make_input(
+            tenant_id,
+            chat_id,
+            turn_id,
+            request_id,
+            user_id,
+            TurnState::Failed,
+        );
+        let outcome2 = svc
+            .finalize_turn_cas(input2)
+            .await
+            .expect("second finalization");
+        assert!(!outcome2.won_cas, "second finalizer should lose CAS");
+        assert!(outcome2.billing_outcome.is_none());
+        assert!(outcome2.settlement_outcome.is_none());
+    }
+
+    // ── 3.8: Transaction rollback on failure leaves turn in running state ──
+
+    #[tokio::test]
+    async fn failed_settlement_leaves_turn_running() {
+        // Use a QuotaSettler that always fails
+        #[domain_model]
+        struct FailingQuotaSettler;
+
+        #[async_trait::async_trait]
+        impl QuotaSettler for FailingQuotaSettler {
+            async fn settle_in_tx(
+                &self,
+                _tx: &modkit_db::secure::DbTx<'_>,
+                _scope: &AccessScope,
+                _input: crate::domain::model::quota::SettlementInput,
+            ) -> Result<SettlementOutcome, DomainError> {
+                Err(DomainError::internal("settlement exploded"))
+            }
+        }
+
+        let db = mock_db_provider(inmem_db().await);
+        let svc = FinalizationService::new(
+            Arc::clone(&db),
+            Arc::new(TurnRepo),
+            Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
+                default: 20,
+                max: 100,
+            })),
+            Arc::new(FailingQuotaSettler),
+        );
+
+        let tenant_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        insert_test_chat(&db, tenant_id, chat_id, user_id).await;
+        insert_running_turn(&db, tenant_id, chat_id, turn_id, request_id).await;
+
+        let input = make_input(
+            tenant_id,
+            chat_id,
+            turn_id,
+            request_id,
+            user_id,
+            TurnState::Completed,
+        );
+        let result = svc.finalize_turn_cas(input).await;
+
+        // Should fail due to settlement error
+        assert!(
+            result.is_err(),
+            "finalization should fail when settlement fails"
+        );
+
+        // Verify turn is still running (transaction rolled back)
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let turn_repo = TurnRepo;
+        let running = turn_repo
+            .find_running_by_chat_id(&conn, &scope, chat_id)
+            .await
+            .expect("find running turn")
+            .expect("turn should still be running");
+        assert_eq!(running.id, turn_id);
+        assert_eq!(running.state, TurnState::Running);
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -11,14 +11,17 @@ use crate::domain::repos::{
     PolicySnapshotProvider, QuotaUsageRepository, ReactionRepository, ThreadSummaryRepository,
     TurnRepository, UserLimitsProvider, VectorStoreRepository,
 };
+use crate::domain::service::quota_settler::QuotaSettler;
 use crate::infra::llm::LlmProvider;
 
 mod attachment_service;
 mod chat_service;
 pub(crate) mod credit_arithmetic;
+pub(crate) mod finalization_service;
 mod message_service;
 mod model_service;
 mod quota_service;
+pub(crate) mod quota_settler;
 mod reaction_service;
 mod stream_service;
 #[cfg(test)]
@@ -27,6 +30,7 @@ pub(crate) mod token_estimator;
 
 pub(crate) use attachment_service::AttachmentService;
 pub(crate) use chat_service::ChatService;
+pub(crate) use finalization_service::FinalizationService;
 pub(crate) use message_service::MessageService;
 pub(crate) use model_service::ModelService;
 pub(crate) use quota_service::QuotaService;
@@ -115,6 +119,7 @@ pub(crate) struct AppServices<
     pub(crate) attachments: AttachmentService<CR>,
     pub(crate) models: ModelService,
     pub(crate) quota: QuotaService<QR>,
+    pub(crate) finalization: Arc<FinalizationService<TR, MR>>,
 }
 
 impl<
@@ -140,6 +145,25 @@ impl<
     ) -> Self {
         let enforcer = PolicyEnforcer::new(authz);
 
+        // Type-erase QuotaService<QR> → Arc<dyn QuotaSettler> for FinalizationService (D2).
+        // QuotaService is stateless (holds only Arc refs and Copy configs), so a second
+        // instance is functionally identical to sharing via Arc.
+        let quota_settler: Arc<dyn QuotaSettler> = Arc::new(QuotaService::new(
+            Arc::clone(&db),
+            Arc::clone(&repos.quota),
+            Arc::clone(&policy_provider),
+            Arc::clone(&limits_provider),
+            estimation_budgets,
+            quota_config,
+        ));
+
+        let finalization = Arc::new(FinalizationService::new(
+            Arc::clone(&db),
+            Arc::clone(&repos.turn),
+            Arc::clone(&repos.message),
+            quota_settler,
+        ));
+
         Self {
             chats: ChatService::new(
                 Arc::clone(&db),
@@ -162,6 +186,7 @@ impl<
                 enforcer.clone(),
                 llm,
                 streaming_config,
+                Arc::clone(&finalization),
             ),
             reactions: ReactionService::new(
                 Arc::clone(&db),
@@ -186,6 +211,7 @@ impl<
                 estimation_budgets,
                 quota_config,
             ),
+            finalization,
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_settler.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_settler.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+use modkit_db::secure::DbTx;
+use modkit_security::AccessScope;
+
+use crate::domain::error::DomainError;
+use crate::domain::model::quota::{SettlementInput, SettlementOutcome};
+use crate::domain::repos::QuotaUsageRepository;
+use crate::domain::service::QuotaService;
+
+/// Type-erased settlement interface for `FinalizationService`.
+///
+/// Erases the `QuotaService<QR>` generic so that `FinalizationService` is
+/// non-generic and can be shared via `Arc` into spawned task closures
+/// without propagating repository type parameters.
+///
+/// Takes `&DbTx` (transaction) rather than generic `&impl DBRunner` because
+/// finalization always runs within a transaction. This avoids the `Sized`
+/// constraint issue with `&dyn DBRunner`.
+///
+/// See design D2: "Generic erasure via `QuotaSettler` trait".
+#[async_trait]
+pub trait QuotaSettler: Send + Sync {
+    async fn settle_in_tx(
+        &self,
+        tx: &DbTx<'_>,
+        scope: &AccessScope,
+        input: SettlementInput,
+    ) -> Result<SettlementOutcome, DomainError>;
+}
+
+#[async_trait]
+impl<QR: QuotaUsageRepository + 'static> QuotaSettler for QuotaService<QR> {
+    async fn settle_in_tx(
+        &self,
+        tx: &DbTx<'_>,
+        scope: &AccessScope,
+        input: SettlementInput,
+    ) -> Result<SettlementOutcome, DomainError> {
+        // DbTx implements DBRunner, so we can pass it to the generic settle().
+        self.settle(tx, scope, input).await
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -13,8 +13,7 @@ use uuid::Uuid;
 use crate::config::StreamingConfig;
 use crate::domain::error::DomainError;
 use crate::domain::repos::{
-    CasCompleteParams, CasTerminalParams, ChatRepository, CreateTurnParams,
-    InsertAssistantMessageParams, InsertUserMessageParams, MessageRepository, TurnRepository,
+    ChatRepository, CreateTurnParams, InsertUserMessageParams, MessageRepository, TurnRepository,
 };
 use crate::domain::stream_events::{DoneData, ErrorData, StreamEvent};
 use crate::infra::db::entity::chat_turn::{Model as TurnModel, TurnState};
@@ -92,23 +91,81 @@ pub enum StreamError {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
-// PersistenceCtx — bundled context for CAS finalization in the spawned task
+// FinalizationCtx — bundled context for atomic finalization in the spawned task
 // ════════════════════════════════════════════════════════════════════════════
 
-/// Persistence context cloned into the spawned provider task for CAS
-/// finalization after stream completion. `None` in unit tests.
+/// All context needed to call `FinalizationService::finalize_turn_cas()`
+/// from the spawned provider task. Replaces the old `PersistenceCtx`.
+///
+/// Assembled in `run_stream()` after preflight commits, from `PreflightDecision`
+/// fields + request context. `None` in unit tests (no DB).
 #[domain_model]
-struct PersistenceCtx<TR: TurnRepository, MR: MessageRepository> {
-    db: Arc<DbProvider>,
-    turn_repo: Arc<TR>,
-    message_repo: Arc<MR>,
+struct FinalizationCtx<TR: TurnRepository + 'static, MR: MessageRepository + 'static> {
+    finalization_svc:
+        Arc<crate::domain::service::finalization_service::FinalizationService<TR, MR>>,
     scope: AccessScope,
     turn_id: Uuid,
     tenant_id: Uuid,
     chat_id: Uuid,
     request_id: Uuid,
+    user_id: Uuid,
     /// Pre-generated assistant message ID, also sent in `DoneData`.
     message_id: Uuid,
+    // ── Quota/preflight fields (from PreflightDecision) ──
+    effective_model: String,
+    selected_model: String,
+    reserve_tokens: i64,
+    max_output_tokens_applied: i32,
+    reserved_credits_micro: i64,
+    policy_version_applied: i64,
+    minimal_generation_floor_applied: i32,
+    quota_decision: String,
+    downgrade_from: Option<String>,
+    downgrade_reason: Option<String>,
+    period_starts: Vec<(
+        crate::infra::db::entity::quota_usage::PeriodType,
+        time::Date,
+    )>,
+}
+
+impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> FinalizationCtx<TR, MR> {
+    /// Build a [`FinalizationInput`] from this context and stream outcome data.
+    fn to_finalization_input(
+        &self,
+        terminal_state: TurnState,
+        accumulated_text: &str,
+        usage: Option<Usage>,
+        error_code: Option<String>,
+        error_detail: Option<String>,
+        provider_response_id: Option<String>,
+    ) -> crate::domain::model::finalization::FinalizationInput {
+        crate::domain::model::finalization::FinalizationInput {
+            turn_id: self.turn_id,
+            tenant_id: self.tenant_id,
+            chat_id: self.chat_id,
+            request_id: self.request_id,
+            user_id: self.user_id,
+            scope: self.scope.clone(),
+            message_id: self.message_id,
+            terminal_state,
+            error_code,
+            error_detail,
+            accumulated_text: accumulated_text.to_owned(),
+            usage,
+            provider_response_id,
+            effective_model: self.effective_model.clone(),
+            selected_model: self.selected_model.clone(),
+            reserve_tokens: self.reserve_tokens,
+            max_output_tokens_applied: self.max_output_tokens_applied,
+            reserved_credits_micro: self.reserved_credits_micro,
+            policy_version_applied: self.policy_version_applied,
+            minimal_generation_floor_applied: self.minimal_generation_floor_applied,
+            quota_decision: self.quota_decision.clone(),
+            downgrade_from: self.downgrade_from.clone(),
+            downgrade_reason: self.downgrade_reason.clone(),
+            period_starts: self.period_starts.clone(),
+        }
+    }
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -156,7 +213,11 @@ fn normalize_error(err: &LlmProviderError) -> (String, String) {
 /// P2 adds turn persistence (pre-stream checks + CAS finalization).
 #[domain_model]
 #[allow(dead_code)]
-pub struct StreamService<TR: TurnRepository, MR: MessageRepository, CR: ChatRepository> {
+pub struct StreamService<
+    TR: TurnRepository + 'static,
+    MR: MessageRepository + 'static,
+    CR: ChatRepository,
+> {
     db: Arc<DbProvider>,
     turn_repo: Arc<TR>,
     message_repo: Arc<MR>,
@@ -164,11 +225,13 @@ pub struct StreamService<TR: TurnRepository, MR: MessageRepository, CR: ChatRepo
     enforcer: PolicyEnforcer,
     llm: Arc<dyn LlmProvider>,
     streaming_config: StreamingConfig,
+    finalization: Arc<crate::domain::service::finalization_service::FinalizationService<TR, MR>>,
 }
 
 impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepository>
     StreamService<TR, MR, CR>
 {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         db: Arc<DbProvider>,
         turn_repo: Arc<TR>,
@@ -177,6 +240,9 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
         enforcer: PolicyEnforcer,
         llm: Arc<dyn LlmProvider>,
         streaming_config: StreamingConfig,
+        finalization: Arc<
+            crate::domain::service::finalization_service::FinalizationService<TR, MR>,
+        >,
     ) -> Self {
         Self {
             db,
@@ -186,6 +252,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
             enforcer,
             llm,
             streaming_config,
+            finalization,
         }
     }
 
@@ -262,6 +329,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
         let turn_repo = Arc::clone(&self.turn_repo);
         let content_clone = content.clone();
         let scope_tx = scope.clone();
+        let effective_model_tx = effective_model.clone();
 
         self.db
             .transaction(|tx| {
@@ -296,7 +364,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
                                 max_output_tokens_applied: None,
                                 reserved_credits_micro: None,
                                 policy_version_applied: None,
-                                effective_model: Some(effective_model),
+                                effective_model: Some(effective_model_tx),
                                 minimal_generation_floor_applied: None,
                             },
                         )
@@ -320,16 +388,29 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
         // Pre-generate assistant message ID (sent in DoneData and used in CAS)
         let message_id = Uuid::new_v4();
 
-        let persist = PersistenceCtx {
-            db: Arc::clone(&self.db),
-            turn_repo: Arc::clone(&self.turn_repo),
-            message_repo: Arc::clone(&self.message_repo),
+        // TODO(P3→P4): populate quota fields from PreflightDecision once preflight
+        // is wired in. For now, use zero/placeholder values — finalization still
+        // runs (settlement will be Released/Estimated with zero reserves).
+        let finalization_ctx = FinalizationCtx {
+            finalization_svc: Arc::clone(&self.finalization),
             scope,
             turn_id,
             tenant_id,
             chat_id,
             request_id,
+            user_id,
             message_id,
+            effective_model: effective_model.clone(),
+            selected_model: model.clone(),
+            reserve_tokens: 0,
+            max_output_tokens_applied: 0,
+            reserved_credits_micro: 0,
+            policy_version_applied: 0,
+            minimal_generation_floor_applied: 0,
+            quota_decision: "allow".to_owned(),
+            downgrade_from: None,
+            downgrade_reason: None,
+            period_starts: Vec::new(),
         };
 
         Ok(spawn_provider_task(
@@ -339,14 +420,19 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
             model,
             cancel,
             tx,
-            Some(persist),
+            Some(finalization_ctx),
         ))
     }
 }
 
 /// Core provider task: reads from the LLM, translates events, and returns
-/// a [`StreamOutcome`]. After the stream ends, CAS-finalizes the turn if
-/// a persistence context is provided.
+/// a [`StreamOutcome`]. After the stream ends, atomically finalizes the turn
+/// via `FinalizationService::finalize_turn_cas()` if a context is provided.
+///
+/// All five terminal paths (provider done, incomplete, provider error,
+/// client disconnect, pre-stream error) route through `finalize_turn_cas()`.
+/// SSE terminal events (Done/Error) are emitted only after the CAS winner
+/// commits the transaction (D3).
 #[allow(
     clippy::too_many_arguments,
     clippy::too_many_lines,
@@ -361,12 +447,12 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
     model: String,
     cancel: CancellationToken,
     tx: mpsc::Sender<StreamEvent>,
-    persist: Option<PersistenceCtx<TR, MR>>,
+    fin_ctx: Option<FinalizationCtx<TR, MR>>,
 ) -> tokio::task::JoinHandle<StreamOutcome> {
     tokio::spawn(async move {
         let stream_start = std::time::Instant::now();
         let mut first_token_time: Option<std::time::Duration> = None;
-        let msg_id_str = persist.as_ref().map(|p| p.message_id.to_string());
+        let msg_id_str = fin_ctx.as_ref().map(|p| p.message_id.to_string());
 
         // Build the LLM request
         let request = LlmRequestBuilder::new(&model)
@@ -379,18 +465,46 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
         let mut provider_stream = match stream_result {
             Ok(s) => s,
             Err(e) => {
-                // Provider failed before any events — send error and return.
+                // Provider failed before any events — finalize first, then emit error.
                 let (code, message) = normalize_error(&e);
-                let _ = tx
-                    .send(StreamEvent::Error(ErrorData {
-                        code: code.clone(),
-                        message,
-                    }))
-                    .await;
 
-                // CAS finalize: mark turn as failed
-                if let Some(ref p) = persist {
-                    cas_finalize_terminal(p, TurnState::Failed, Some(code.clone()), None).await;
+                if let Some(ref fctx) = fin_ctx {
+                    let input = fctx.to_finalization_input(
+                        TurnState::Failed,
+                        "",
+                        None,
+                        Some(code.clone()),
+                        None,
+                        None,
+                    );
+                    match fctx.finalization_svc.finalize_turn_cas(input).await {
+                        Ok(outcome) if outcome.won_cas => {
+                            let _ = tx
+                                .send(StreamEvent::Error(ErrorData {
+                                    code: code.clone(),
+                                    message,
+                                }))
+                                .await;
+                        }
+                        Ok(_) => { /* CAS loser — no SSE emission */ }
+                        Err(fe) => {
+                            warn!(error = %fe, "finalization failed on pre-stream error");
+                            // Still emit error so client isn't left hanging
+                            let _ = tx
+                                .send(StreamEvent::Error(ErrorData {
+                                    code: code.clone(),
+                                    message,
+                                }))
+                                .await;
+                        }
+                    }
+                } else {
+                    let _ = tx
+                        .send(StreamEvent::Error(ErrorData {
+                            code: code.clone(),
+                            message,
+                        }))
+                        .await;
                 }
 
                 return StreamOutcome {
@@ -446,21 +560,44 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                             warn!(error = %e, "provider stream error");
                             let (code, message) =
                                 normalize_error(&LlmProviderError::StreamError(e));
-                            let _ = tx
-                                .send(StreamEvent::Error(ErrorData {
-                                    code: code.clone(),
-                                    message,
-                                }))
-                                .await;
 
-                            // CAS finalize: mark turn as failed
-                            if let Some(ref p) = persist {
-                                cas_finalize_terminal(
-                                    p,
+                            // Finalize first, emit error only if CAS winner (D3)
+                            if let Some(ref fctx) = fin_ctx {
+                                let input = fctx.to_finalization_input(
                                     TurnState::Failed,
+                                    &accumulated_text,
+                                    None,
                                     Some(code.clone()),
                                     None,
-                                ).await;
+                                    None,
+                                );
+                                match fctx.finalization_svc.finalize_turn_cas(input).await {
+                                    Ok(outcome) if outcome.won_cas => {
+                                        let _ = tx
+                                            .send(StreamEvent::Error(ErrorData {
+                                                code: code.clone(),
+                                                message,
+                                            }))
+                                            .await;
+                                    }
+                                    Ok(_) => {}
+                                    Err(fe) => {
+                                        warn!(error = %fe, "finalization failed on stream error");
+                                        let _ = tx
+                                            .send(StreamEvent::Error(ErrorData {
+                                                code: code.clone(),
+                                                message,
+                                            }))
+                                            .await;
+                                    }
+                                }
+                            } else {
+                                let _ = tx
+                                    .send(StreamEvent::Error(ErrorData {
+                                        code: code.clone(),
+                                        message,
+                                    }))
+                                    .await;
                             }
 
                             let has_partial = !accumulated_text.is_empty();
@@ -492,9 +629,19 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                 "stream cancelled"
             );
 
-            // CAS finalize: mark turn as cancelled
-            if let Some(ref p) = persist {
-                cas_finalize_terminal(p, TurnState::Cancelled, None, None).await;
+            // Finalize cancelled turn — no SSE emission (stream already disconnected) (D3)
+            if let Some(ref fctx) = fin_ctx {
+                let input = fctx.to_finalization_input(
+                    TurnState::Cancelled,
+                    &accumulated_text,
+                    None,
+                    None,
+                    None,
+                    None,
+                );
+                if let Err(e) = fctx.finalization_svc.finalize_turn_cas(input).await {
+                    warn!(error = %e, "finalization failed on cancelled stream");
+                }
             }
 
             return StreamOutcome {
@@ -519,26 +666,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                 response_id,
                 ..
             } => {
-                // Send citations if present
-                if !citations.is_empty() {
-                    let _ = tx
-                        .send(StreamEvent::Citations(
-                            crate::domain::stream_events::CitationsData { items: citations },
-                        ))
-                        .await;
-                }
-                // Send Done terminal
-                let _ = tx
-                    .send(StreamEvent::Done(Box::new(DoneData {
-                        message_id: msg_id_str,
-                        usage: Some(usage),
-                        effective_model: model.clone(),
-                        selected_model: model.clone(),
-                        quota_decision: "allow".into(), // P3 provides real decision
-                        downgrade_from: None,           // P3 provides
-                        downgrade_reason: None,         // P3 provides
-                    })))
-                    .await;
                 let elapsed = stream_start.elapsed();
                 info!(
                     terminal = "completed",
@@ -549,16 +676,76 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                     "stream completed"
                 );
 
-                // CAS finalize: insert assistant message + mark turn completed
-                if let Some(ref p) = persist {
-                    cas_finalize_completed(
-                        p,
+                // Finalize first, then emit Done only if CAS winner (D3)
+                if let Some(ref fctx) = fin_ctx {
+                    let input = fctx.to_finalization_input(
+                        TurnState::Completed,
                         &accumulated_text,
                         Some(usage),
-                        Some(model.clone()),
+                        None,
+                        None,
                         Some(response_id.clone()),
-                    )
-                    .await;
+                    );
+                    match fctx.finalization_svc.finalize_turn_cas(input).await {
+                        Ok(outcome) if outcome.won_cas => {
+                            if !citations.is_empty() {
+                                let _ = tx
+                                    .send(StreamEvent::Citations(
+                                        crate::domain::stream_events::CitationsData {
+                                            items: citations,
+                                        },
+                                    ))
+                                    .await;
+                            }
+                            let _ = tx
+                                .send(StreamEvent::Done(Box::new(DoneData {
+                                    message_id: msg_id_str.clone(),
+                                    usage: Some(usage),
+                                    effective_model: model.clone(),
+                                    selected_model: model.clone(),
+                                    quota_decision: fctx.quota_decision.clone(),
+                                    downgrade_from: fctx.downgrade_from.clone(),
+                                    downgrade_reason: fctx.downgrade_reason.clone(),
+                                })))
+                                .await;
+                        }
+                        Ok(_) => { /* CAS loser — no SSE emission */ }
+                        Err(fe) => {
+                            warn!(error = %fe, "finalization failed on completed stream");
+                            // Emit Done anyway so client isn't left hanging
+                            let _ = tx
+                                .send(StreamEvent::Done(Box::new(DoneData {
+                                    message_id: msg_id_str.clone(),
+                                    usage: Some(usage),
+                                    effective_model: model.clone(),
+                                    selected_model: model.clone(),
+                                    quota_decision: "allow".into(),
+                                    downgrade_from: None,
+                                    downgrade_reason: None,
+                                })))
+                                .await;
+                        }
+                    }
+                } else {
+                    // No finalization context (unit tests) — emit directly
+                    if !citations.is_empty() {
+                        let _ = tx
+                            .send(StreamEvent::Citations(
+                                crate::domain::stream_events::CitationsData { items: citations },
+                            ))
+                            .await;
+                    }
+                    let _ = tx
+                        .send(StreamEvent::Done(Box::new(DoneData {
+                            message_id: msg_id_str.clone(),
+                            usage: Some(usage),
+                            effective_model: model.clone(),
+                            selected_model: model.clone(),
+                            quota_decision: "allow".into(),
+                            downgrade_from: None,
+                            downgrade_reason: None,
+                        })))
+                        .await;
                 }
 
                 StreamOutcome {
@@ -572,17 +759,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                 }
             }
             TerminalOutcome::Incomplete { usage, reason, .. } => {
-                let _ = tx
-                    .send(StreamEvent::Done(Box::new(DoneData {
-                        message_id: msg_id_str,
-                        usage: Some(usage),
-                        effective_model: model.clone(),
-                        selected_model: model.clone(),
-                        quota_decision: "allow".into(),
-                        downgrade_from: None,
-                        downgrade_reason: None,
-                    })))
-                    .await;
                 let elapsed = stream_start.elapsed();
                 warn!(
                     terminal = "incomplete",
@@ -592,17 +768,60 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                     "stream incomplete"
                 );
 
-                // CAS finalize: insert assistant message + mark turn completed
-                // (incomplete is still a valid response, just truncated)
-                if let Some(ref p) = persist {
-                    cas_finalize_completed(
-                        p,
+                // Incomplete maps to Completed in DB — provider finished but hit
+                // max_output_tokens. From billing/persistence perspective this is
+                // a completed turn with truncated content (see design D10).
+                if let Some(ref fctx) = fin_ctx {
+                    let input = fctx.to_finalization_input(
+                        TurnState::Completed,
                         &accumulated_text,
                         Some(usage),
-                        Some(model.clone()),
-                        None, // Incomplete has no response_id
-                    )
-                    .await;
+                        None,
+                        None,
+                        None,
+                    );
+                    match fctx.finalization_svc.finalize_turn_cas(input).await {
+                        Ok(outcome) if outcome.won_cas => {
+                            let _ = tx
+                                .send(StreamEvent::Done(Box::new(DoneData {
+                                    message_id: msg_id_str.clone(),
+                                    usage: Some(usage),
+                                    effective_model: model.clone(),
+                                    selected_model: model.clone(),
+                                    quota_decision: fctx.quota_decision.clone(),
+                                    downgrade_from: fctx.downgrade_from.clone(),
+                                    downgrade_reason: fctx.downgrade_reason.clone(),
+                                })))
+                                .await;
+                        }
+                        Ok(_) => {}
+                        Err(fe) => {
+                            warn!(error = %fe, "finalization failed on incomplete stream");
+                            let _ = tx
+                                .send(StreamEvent::Done(Box::new(DoneData {
+                                    message_id: msg_id_str.clone(),
+                                    usage: Some(usage),
+                                    effective_model: model.clone(),
+                                    selected_model: model.clone(),
+                                    quota_decision: "allow".into(),
+                                    downgrade_from: None,
+                                    downgrade_reason: None,
+                                })))
+                                .await;
+                        }
+                    }
+                } else {
+                    let _ = tx
+                        .send(StreamEvent::Done(Box::new(DoneData {
+                            message_id: msg_id_str.clone(),
+                            usage: Some(usage),
+                            effective_model: model.clone(),
+                            selected_model: model.clone(),
+                            quota_decision: "allow".into(),
+                            downgrade_from: None,
+                            downgrade_reason: None,
+                        })))
+                        .await;
                 }
 
                 StreamOutcome {
@@ -617,12 +836,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
             }
             TerminalOutcome::Failed { error, usage, .. } => {
                 let (code, message) = normalize_error(&error);
-                let _ = tx
-                    .send(StreamEvent::Error(ErrorData {
-                        code: code.clone(),
-                        message,
-                    }))
-                    .await;
                 let elapsed = stream_start.elapsed();
                 warn!(
                     terminal = "failed",
@@ -632,9 +845,43 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                     "stream failed"
                 );
 
-                // CAS finalize: mark turn as failed
-                if let Some(ref p) = persist {
-                    cas_finalize_terminal(p, TurnState::Failed, Some(code.clone()), None).await;
+                // Finalize first, emit error only if CAS winner (D3)
+                if let Some(ref fctx) = fin_ctx {
+                    let input = fctx.to_finalization_input(
+                        TurnState::Failed,
+                        &accumulated_text,
+                        usage,
+                        Some(code.clone()),
+                        None,
+                        None,
+                    );
+                    match fctx.finalization_svc.finalize_turn_cas(input).await {
+                        Ok(outcome) if outcome.won_cas => {
+                            let _ = tx
+                                .send(StreamEvent::Error(ErrorData {
+                                    code: code.clone(),
+                                    message,
+                                }))
+                                .await;
+                        }
+                        Ok(_) => {}
+                        Err(fe) => {
+                            warn!(error = %fe, "finalization failed on failed stream");
+                            let _ = tx
+                                .send(StreamEvent::Error(ErrorData {
+                                    code: code.clone(),
+                                    message,
+                                }))
+                                .await;
+                        }
+                    }
+                } else {
+                    let _ = tx
+                        .send(StreamEvent::Error(ErrorData {
+                            code: code.clone(),
+                            message,
+                        }))
+                        .await;
                 }
 
                 StreamOutcome {
@@ -651,116 +898,11 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
     })
 }
 
-// ════════════════════════════════════════════════════════════════════════════
-// CAS finalization helpers
-// ════════════════════════════════════════════════════════════════════════════
-
-/// CAS-finalize a completed/incomplete turn: insert assistant message then
-/// update turn to `completed`.
-#[allow(clippy::cognitive_complexity)]
-async fn cas_finalize_completed<TR: TurnRepository, MR: MessageRepository>(
-    p: &PersistenceCtx<TR, MR>,
-    text: &str,
-    usage: Option<Usage>,
-    model: Option<String>,
-    provider_response_id: Option<String>,
-) {
-    let conn = match p.db.conn() {
-        Ok(c) => c,
-        Err(e) => {
-            warn!(error = %e, turn_id = %p.turn_id, "CAS finalize: failed to get DB connection");
-            return;
-        }
-    };
-
-    // Insert assistant message
-    let msg_result = p
-        .message_repo
-        .insert_assistant_message(
-            &conn,
-            &p.scope,
-            InsertAssistantMessageParams {
-                id: p.message_id,
-                tenant_id: p.tenant_id,
-                chat_id: p.chat_id,
-                request_id: p.request_id,
-                content: text.to_owned(),
-                input_tokens: usage.map(|u| u.input_tokens),
-                output_tokens: usage.map(|u| u.output_tokens),
-                model,
-                provider_response_id: provider_response_id.clone(),
-            },
-        )
-        .await;
-
-    match msg_result {
-        Ok(msg) => {
-            let rows = p
-                .turn_repo
-                .cas_update_completed(
-                    &conn,
-                    &p.scope,
-                    CasCompleteParams {
-                        turn_id: p.turn_id,
-                        assistant_message_id: msg.id,
-                        provider_response_id,
-                    },
-                )
-                .await;
-            match rows {
-                Ok(0) => warn!(turn_id = %p.turn_id, "CAS completed: lost race (0 rows)"),
-                Ok(_) => debug!(turn_id = %p.turn_id, "CAS completed: turn finalized"),
-                Err(e) => warn!(error = %e, turn_id = %p.turn_id, "CAS completed: update failed"),
-            }
-        }
-        Err(e) => {
-            warn!(error = %e, turn_id = %p.turn_id, "CAS finalize: failed to insert assistant message");
-        }
-    }
-}
-
-/// CAS-finalize a terminal (failed/cancelled) turn.
-#[allow(clippy::cognitive_complexity)]
-async fn cas_finalize_terminal<TR: TurnRepository, MR: MessageRepository>(
-    p: &PersistenceCtx<TR, MR>,
-    state: TurnState,
-    error_code: Option<String>,
-    error_detail: Option<String>,
-) {
-    let conn = match p.db.conn() {
-        Ok(c) => c,
-        Err(e) => {
-            warn!(error = %e, turn_id = %p.turn_id, "CAS finalize: failed to get DB connection");
-            return;
-        }
-    };
-
-    let state_label = format!("{state:?}");
-    let rows = p
-        .turn_repo
-        .cas_update_state(
-            &conn,
-            &p.scope,
-            CasTerminalParams {
-                turn_id: p.turn_id,
-                state,
-                error_code,
-                error_detail,
-            },
-        )
-        .await;
-
-    match rows {
-        Ok(0) => warn!(turn_id = %p.turn_id, "CAS terminal: lost race (0 rows)"),
-        Ok(_) => debug!(turn_id = %p.turn_id, state = %state_label, "CAS terminal: turn finalized"),
-        Err(e) => warn!(error = %e, turn_id = %p.turn_id, "CAS terminal: update failed"),
-    }
-}
-
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    use crate::domain::repos::CasTerminalParams;
     use crate::infra::db::repo::chat_repo::ChatRepository as OrmChatRepo;
     use crate::infra::db::repo::message_repo::MessageRepository as MsgRepo;
     use crate::infra::db::repo::turn_repo::TurnRepository as TurnRepo;
@@ -1050,13 +1192,48 @@ mod tests {
         db: Arc<DbProvider>,
         provider: Arc<dyn LlmProvider>,
     ) -> StreamService<TurnRepo, MsgRepo, OrmChatRepo> {
+        use crate::domain::service::finalization_service::FinalizationService;
+        use crate::domain::service::quota_settler::QuotaSettler;
+
+        // Mock QuotaSettler for stream service tests
+        #[domain_model]
+        struct MockQuotaSettler;
+        #[async_trait::async_trait]
+        impl QuotaSettler for MockQuotaSettler {
+            async fn settle_in_tx(
+                &self,
+                _tx: &modkit_db::secure::DbTx<'_>,
+                _scope: &AccessScope,
+                _input: crate::domain::model::quota::SettlementInput,
+            ) -> Result<
+                crate::domain::model::quota::SettlementOutcome,
+                crate::domain::error::DomainError,
+            > {
+                Ok(crate::domain::model::quota::SettlementOutcome {
+                    settlement_method: crate::domain::model::quota::SettlementMethod::Released,
+                    actual_credits_micro: 0,
+                    charged_tokens: 0,
+                    overshoot_capped: false,
+                })
+            }
+        }
+
+        let turn_repo = Arc::new(TurnRepo);
+        let message_repo = Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
+            default: 20,
+            max: 100,
+        }));
+        let finalization = Arc::new(FinalizationService::new(
+            Arc::clone(&db),
+            Arc::clone(&turn_repo),
+            Arc::clone(&message_repo),
+            Arc::new(MockQuotaSettler) as Arc<dyn QuotaSettler>,
+        ));
+
         StreamService::new(
             db,
-            Arc::new(TurnRepo),
-            Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
-                default: 20,
-                max: 100,
-            })),
+            turn_repo,
+            message_repo,
             Arc::new(OrmChatRepo::new(modkit_db::odata::LimitCfg {
                 default: 20,
                 max: 100,
@@ -1064,6 +1241,7 @@ mod tests {
             mock_enforcer(),
             provider,
             crate::config::StreamingConfig::default(),
+            finalization,
         )
     }
 
@@ -1139,6 +1317,8 @@ mod tests {
                     state: TurnState::Completed,
                     error_code: None,
                     error_detail: None,
+                    assistant_message_id: None,
+                    provider_response_id: None,
                 },
             )
             .await

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/repo_test.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/repo_test.rs
@@ -301,6 +301,8 @@ async fn find_running_returns_none_after_completion() {
                 state: TurnState::Completed,
                 error_code: None,
                 error_detail: None,
+                assistant_message_id: None,
+                provider_response_id: None,
             },
         )
         .await
@@ -343,6 +345,8 @@ async fn cas_update_state_on_running_succeeds() {
                 state: TurnState::Failed,
                 error_code: Some("provider_error".to_owned()),
                 error_detail: Some("timeout".to_owned()),
+                assistant_message_id: None,
+                provider_response_id: None,
             },
         )
         .await
@@ -374,6 +378,8 @@ async fn cas_update_state_on_terminal_returns_zero() {
             state: TurnState::Completed,
             error_code: None,
             error_detail: None,
+            assistant_message_id: None,
+            provider_response_id: None,
         },
     )
     .await
@@ -389,6 +395,8 @@ async fn cas_update_state_on_terminal_returns_zero() {
                 state: TurnState::Cancelled,
                 error_code: None,
                 error_detail: None,
+                assistant_message_id: None,
+                provider_response_id: None,
             },
         )
         .await
@@ -488,6 +496,8 @@ async fn soft_delete_hides_from_find_latest() {
             state: TurnState::Completed,
             error_code: None,
             error_detail: None,
+            assistant_message_id: None,
+            provider_response_id: None,
         },
     )
     .await
@@ -530,6 +540,8 @@ async fn find_latest_turn_returns_most_recent() {
             state: TurnState::Completed,
             error_code: None,
             error_detail: None,
+            assistant_message_id: None,
+            provider_response_id: None,
         },
     )
     .await
@@ -999,6 +1011,8 @@ async fn cas_mutual_exclusion_exactly_one_winner() {
                 state: TurnState::Completed,
                 error_code: None,
                 error_detail: None,
+                assistant_message_id: None,
+                provider_response_id: None,
             },
         ),
         repo.cas_update_state(
@@ -1009,6 +1023,8 @@ async fn cas_mutual_exclusion_exactly_one_winner() {
                 state: TurnState::Failed,
                 error_code: Some("timeout".to_owned()),
                 error_detail: None,
+                assistant_message_id: None,
+                provider_response_id: None,
             },
         ),
     );

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
@@ -96,12 +96,26 @@ impl crate::domain::repos::TurnRepository for TurnRepository {
         params: CasTerminalParams,
     ) -> Result<u64, DomainError> {
         let now = OffsetDateTime::now_utc();
-        let result = TurnEntity::update_many()
+        let mut update = TurnEntity::update_many()
             .col_expr(Column::State, Expr::value(params.state.into_value()))
             .col_expr(Column::ErrorCode, Expr::value(params.error_code))
             .col_expr(Column::ErrorDetail, Expr::value(params.error_detail))
             .col_expr(Column::CompletedAt, Expr::value(now))
-            .col_expr(Column::UpdatedAt, Expr::value(now))
+            .col_expr(Column::UpdatedAt, Expr::value(now));
+
+        // For completed turns, set assistant_message_id and provider_response_id
+        // within the same CAS UPDATE (content durability invariant).
+        if let Some(msg_id) = params.assistant_message_id {
+            update = update.col_expr(Column::AssistantMessageId, Expr::value(Some(msg_id)));
+        }
+        if params.provider_response_id.is_some() {
+            update = update.col_expr(
+                Column::ProviderResponseId,
+                Expr::value(params.provider_response_id),
+            );
+        }
+
+        let result = update
             .filter(
                 Condition::all()
                     .add(Column::Id.eq(params.turn_id))
@@ -146,6 +160,33 @@ impl crate::domain::repos::TurnRepository for TurnRepository {
             .exec(runner)
             .await?;
         Ok(result.rows_affected)
+    }
+
+    async fn set_assistant_message_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        turn_id: Uuid,
+        assistant_message_id: Uuid,
+    ) -> Result<(), DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let result = TurnEntity::update_many()
+            .col_expr(
+                Column::AssistantMessageId,
+                Expr::value(Some(assistant_message_id)),
+            )
+            .col_expr(Column::UpdatedAt, Expr::value(now))
+            .filter(Column::Id.eq(turn_id))
+            .secure()
+            .scope_with(scope)
+            .exec(runner)
+            .await?;
+        if result.rows_affected == 0 {
+            return Err(DomainError::internal(format!(
+                "set_assistant_message_id: turn {turn_id} not found"
+            )));
+        }
+        Ok(())
     }
 
     async fn soft_delete<C: DBRunner>(

--- a/modules/mini-chat/mini-chat/src/infra/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/mod.rs
@@ -1,3 +1,4 @@
 pub mod db;
 pub mod llm;
 pub(crate) mod model_policy;
+pub(crate) mod outbox;

--- a/modules/mini-chat/mini-chat/src/infra/outbox.rs
+++ b/modules/mini-chat/mini-chat/src/infra/outbox.rs
@@ -1,0 +1,69 @@
+#![allow(dead_code)]
+
+use async_trait::async_trait;
+use mini_chat_sdk::UsageEvent;
+use modkit_db::secure::DBRunner;
+use tracing::debug;
+
+use crate::domain::error::DomainError;
+use crate::domain::repos::OutboxEnqueuer;
+
+/// Infrastructure implementation of [`OutboxEnqueuer`].
+///
+/// Serializes `UsageEvent` to JSON and inserts into the outbox table
+/// within the caller's transaction via `modkit_db::outbox::Outbox::enqueue()`.
+///
+/// TODO(P4): replace stub with real implementation once `modkit_db::outbox`
+/// is merged from the `transactional-outbox` branch. The implementation should:
+/// - Hold `Arc<modkit_db::outbox::Outbox>`
+/// - Serialize `event` to `serde_json::to_vec(&event)?`
+/// - Derive partition from `event.tenant_id` (e.g., hash % `num_partitions`)
+/// - Call `outbox.enqueue(runner, queue_name, partition, payload).await`
+pub struct InfraOutboxEnqueuer {
+    queue_name: String,
+    num_partitions: u32,
+}
+
+impl InfraOutboxEnqueuer {
+    pub(crate) fn new(queue_name: String, num_partitions: u32) -> Self {
+        Self {
+            queue_name,
+            num_partitions,
+        }
+    }
+
+    fn partition_for(&self, tenant_id: uuid::Uuid) -> u32 {
+        // Simple hash-based partition assignment
+        let hash = tenant_id.as_u128();
+        #[allow(clippy::cast_possible_truncation)] // result is bounded by num_partitions (u32)
+        {
+            (hash % u128::from(self.num_partitions)) as u32
+        }
+    }
+}
+
+#[async_trait]
+impl OutboxEnqueuer for InfraOutboxEnqueuer {
+    async fn enqueue_usage_event<C: DBRunner>(
+        &self,
+        _runner: &C,
+        event: UsageEvent,
+    ) -> Result<(), DomainError> {
+        let _partition = self.partition_for(event.tenant_id);
+        let _payload = serde_json::to_vec(&event)
+            .map_err(|e| DomainError::internal(format!("failed to serialize UsageEvent: {e}")))?;
+
+        debug!(
+            turn_id = %event.turn_id,
+            queue = %self.queue_name,
+            partition = _partition,
+            "outbox enqueue stub (modkit_db::outbox not yet available)"
+        );
+
+        // TODO(P4): replace with real outbox.enqueue() call:
+        // self.outbox.enqueue(runner, &self.queue_name, partition, payload).await
+        //     .map_err(|e| DomainError::internal(format!("outbox enqueue failed: {e}")))?;
+
+        Ok(())
+    }
+}

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -70,6 +70,9 @@ impl Module for MiniChatModule {
         cfg.quota
             .validate()
             .map_err(|e| anyhow::anyhow!("quota config: {e}"))?;
+        cfg.outbox
+            .validate()
+            .map_err(|e| anyhow::anyhow!("outbox config: {e}"))?;
 
         let vendor = cfg.vendor.trim().to_owned();
         if vendor.is_empty() {

--- a/modules/mini-chat/plugins/static-model-policy-plugin/src/domain/client.rs
+++ b/modules/mini-chat/plugins/static-model-policy-plugin/src/domain/client.rs
@@ -1,9 +1,10 @@
 use async_trait::async_trait;
 use mini_chat_sdk::{
     MiniChatModelPolicyPluginClientV1, MiniChatModelPolicyPluginError, PolicySnapshot,
-    PolicyVersionInfo, UserLimits,
+    PolicyVersionInfo, PublishError, UsageEvent, UserLimits,
 };
 use time::OffsetDateTime;
+use tracing::debug;
 use uuid::Uuid;
 
 use super::service::Service;
@@ -51,5 +52,15 @@ impl MiniChatModelPolicyPluginClientV1 for Service {
             standard: self.default_standard_limits.clone(),
             premium: self.default_premium_limits.clone(),
         })
+    }
+
+    async fn publish_usage(&self, payload: UsageEvent) -> Result<(), PublishError> {
+        debug!(
+            turn_id = %payload.turn_id,
+            tenant_id = %payload.tenant_id,
+            billing_outcome = %payload.billing_outcome,
+            "static plugin: publish_usage no-op"
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
feat(mini-chat): atomic turn finalization with CAS guard and billing derivation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage-event publishing API to report tokens and settlement outcomes.
  * Atomic finalization workflow for reliably completing chat turns (reduces duplicate/incorrect emissions).
  * Automatic billing outcome derivation and settlement-path calculation.
  * Outbox enqueuer and infra stub to queue usage events.

* **Configuration**
  * New outbox settings for queue name and partition count.

* **Other**
  * Plugin adapter includes a no-op publisher implementation for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->