### PR TITLE
feat(transactional-outbox)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,6 +1405,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-util",
  "tracing",
  "trybuild",
  "url",

--- a/Makefile
+++ b/Makefile
@@ -296,15 +296,16 @@ test-macros:
 
 ## Run SQLite integration tests
 test-sqlite:
-	cargo test -p cf-modkit-db --features sqlite,integration
+	cargo test -p cf-modkit-db --features sqlite,integration,preview-outbox
+	cargo build -p cf-modkit-db --examples --features sqlite,preview-outbox
 
 ## Run PostgreSQL integration tests
 test-pg:
-	cargo test -p cf-modkit-db --features pg,integration
+	cargo test -p cf-modkit-db --features pg,integration,preview-outbox
 
 ## Run MySQL integration tests
 test-mysql:
-	cargo test -p cf-modkit-db --features mysql,integration
+	cargo test -p cf-modkit-db --features mysql,integration,preview-outbox
 
 # Run all database integration tests
 test-db: test-sqlite test-pg test-mysql

--- a/libs/modkit-db/Cargo.toml
+++ b/libs/modkit-db/Cargo.toml
@@ -46,6 +46,9 @@ mysql = [
 
 integration = []
 
+# Transactional outbox pipeline (preview — API may change)
+preview-outbox = ["dep:tokio-util"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -73,6 +76,23 @@ serde_json = { workspace = true }
 dashmap = { workspace = true }
 figment = { workspace = true }
 sqlx = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true }
+
+[[example]]
+name = "outbox_transactional"
+required-features = ["sqlite", "preview-outbox"]
+
+[[example]]
+name = "outbox_retry_reject"
+required-features = ["sqlite", "preview-outbox"]
+
+[[example]]
+name = "outbox_dead_letters"
+required-features = ["sqlite", "preview-outbox"]
+
+[[example]]
+name = "outbox_batch_multi_queue"
+required-features = ["sqlite", "preview-outbox"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/libs/modkit-db/examples/outbox_batch_multi_queue.rs
+++ b/libs/modkit-db/examples/outbox_batch_multi_queue.rs
@@ -1,0 +1,136 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::use_debug)]
+
+//! Batch processing with multiple queues in a single pipeline.
+//!
+//! "orders" uses `batch_decoupled` (handler receives up to 5 messages at once).
+//! "notifications" uses decoupled (single-message handler).
+//! Both queues process independently within the same `OutboxBuilder`.
+//!
+//! Run:
+//!   cargo run -p cf-modkit-db --example `outbox_batch_multi_queue` --features sqlite,preview-outbox
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use modkit_db::outbox::{
+    Handler, HandlerResult, MessageHandler, Outbox, OutboxMessage, Partitions, outbox_migrations,
+};
+use modkit_db::{ConnectOpts, connect_db, migration_runner::run_migrations_for_testing};
+
+struct OrderBatchHandler {
+    count: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl Handler for OrderBatchHandler {
+    async fn handle(
+        &self,
+        msgs: &[OutboxMessage],
+        _cancel: tokio_util::sync::CancellationToken,
+    ) -> HandlerResult {
+        // batch handler receives multiple messages per call
+        println!("  orders: batch of {} messages", msgs.len());
+        self.count.fetch_add(msgs.len(), Ordering::Relaxed);
+        HandlerResult::Success
+    }
+}
+
+struct NotificationHandler {
+    count: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl MessageHandler for NotificationHandler {
+    async fn handle(
+        &self,
+        msg: &OutboxMessage,
+        _cancel: tokio_util::sync::CancellationToken,
+    ) -> HandlerResult {
+        let payload = String::from_utf8_lossy(&msg.payload);
+        println!("  notifs: seq={} payload={payload}", msg.seq);
+        self.count.fetch_add(1, Ordering::Relaxed);
+        HandlerResult::Success
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let db = connect_db(
+        "sqlite:file:outbox_batch?mode=memory&cache=shared",
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await?;
+    run_migrations_for_testing(&db, outbox_migrations()).await?;
+
+    let order_count = Arc::new(AtomicUsize::new(0));
+    let notif_count = Arc::new(AtomicUsize::new(0));
+
+    let handle = Outbox::builder(db.clone())
+        .poll_interval(Duration::from_millis(50))
+        // orders: 2 partitions for parallelism, batch handler processes up to 5 at once
+        .queue("orders", Partitions::of(2))
+        .msg_batch_size(5)
+        .batch_decoupled(OrderBatchHandler {
+            count: order_count.clone(),
+        })
+        // notifications: single partition, single-message handler
+        .queue("notifications", Partitions::of(1))
+        .decoupled(NotificationHandler {
+            count: notif_count.clone(),
+        })
+        .start()
+        .await?;
+
+    let conn = db.conn()?;
+    for i in 0..8u32 {
+        let payload = format!(r#"{{"order_id": {i}}}"#);
+        handle
+            .outbox()
+            .enqueue(
+                &conn,
+                "orders",
+                i % 2,
+                payload.into_bytes(),
+                "application/json;orders.placed.v1",
+            )
+            .await?;
+    }
+    for i in 0..3u32 {
+        let payload = format!("user_{i}_welcome");
+        handle
+            .outbox()
+            .enqueue(
+                &conn,
+                "notifications",
+                0,
+                payload.into_bytes(),
+                "text/plain;notifications.welcome.v1",
+            )
+            .await?;
+    }
+    handle.outbox().flush();
+    println!("Enqueued 8 orders + 3 notifications");
+
+    for _ in 0..100 {
+        let done = order_count.load(Ordering::Relaxed) + notif_count.load(Ordering::Relaxed);
+        if done >= 11 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let orders = order_count.load(Ordering::Relaxed);
+    let notifs = notif_count.load(Ordering::Relaxed);
+    println!("Orders processed: {orders}/8");
+    println!("Notifications processed: {notifs}/3");
+    assert_eq!(orders, 8);
+    assert_eq!(notifs, 3);
+
+    handle.stop().await;
+    println!("Done.");
+    Ok(())
+}

--- a/libs/modkit-db/examples/outbox_dead_letters.rs
+++ b/libs/modkit-db/examples/outbox_dead_letters.rs
@@ -1,0 +1,131 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::use_debug)]
+
+//! Dead letter lifecycle: reject -> list -> replay -> process -> purge.
+//!
+//! Run:
+//!   cargo run -p cf-modkit-db --example `outbox_dead_letters` --features sqlite,preview-outbox
+
+use std::time::Duration;
+
+use modkit_db::outbox::{
+    DeadLetterFilter, HandlerResult, MessageHandler, Outbox, OutboxMessage, Partitions,
+    outbox_migrations,
+};
+use modkit_db::{ConnectOpts, connect_db, migration_runner::run_migrations_for_testing};
+
+struct RejectAll;
+
+#[async_trait::async_trait]
+impl MessageHandler for RejectAll {
+    async fn handle(
+        &self,
+        _msg: &OutboxMessage,
+        _cancel: tokio_util::sync::CancellationToken,
+    ) -> HandlerResult {
+        HandlerResult::Reject {
+            reason: "bad format".into(),
+        }
+    }
+}
+
+struct SucceedAll;
+
+#[async_trait::async_trait]
+impl MessageHandler for SucceedAll {
+    async fn handle(
+        &self,
+        msg: &OutboxMessage,
+        _cancel: tokio_util::sync::CancellationToken,
+    ) -> HandlerResult {
+        println!("  replayed seq={} processed OK", msg.seq);
+        HandlerResult::Success
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let db = connect_db(
+        "sqlite:file:outbox_dl?mode=memory&cache=shared",
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await?;
+    run_migrations_for_testing(&db, outbox_migrations()).await?;
+
+    // Reject 3 messages to populate dead letters
+    let h1 = Outbox::builder(db.clone())
+        .poll_interval(Duration::from_millis(50))
+        .queue("events", Partitions::of(1))
+        .decoupled(RejectAll)
+        .start()
+        .await?;
+    let conn = db.conn()?;
+    for i in 0..3 {
+        h1.outbox()
+            .enqueue(
+                &conn,
+                "events",
+                0,
+                format!("evt-{i}").into_bytes(),
+                "text/plain;events.logged.v1",
+            )
+            .await?;
+    }
+    h1.outbox().flush();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let outbox = std::sync::Arc::clone(h1.outbox());
+    h1.stop().await;
+
+    // List
+    let items = outbox
+        .dead_letter_list(&db, &DeadLetterFilter::default())
+        .await?;
+    println!("Dead letters: {}", items.len());
+    for dl in &items {
+        println!(
+            "  seq={} error={}",
+            dl.seq,
+            dl.last_error.as_deref().unwrap_or("?")
+        );
+    }
+
+    // Replay 1 entry back into the pipeline
+    let replayed = outbox
+        .dead_letter_replay(
+            &db,
+            &DeadLetterFilter {
+                limit: Some(1),
+                ..Default::default()
+            },
+        )
+        .await?;
+    println!("Replayed: {replayed}");
+
+    // Process the replayed message with a success handler
+    let h2 = Outbox::builder(db.clone())
+        .poll_interval(Duration::from_millis(50))
+        .queue("events", Partitions::of(1))
+        .decoupled(SucceedAll)
+        .start()
+        .await?;
+    h2.outbox().flush();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    h2.stop().await;
+
+    // Purge all (force=true deletes even non-replayed entries)
+    let purged = outbox
+        .dead_letter_purge(&db, &DeadLetterFilter::default(), true)
+        .await?;
+    println!("Purged: {purged}");
+
+    let remaining = outbox
+        .dead_letter_count(&db, &DeadLetterFilter::default())
+        .await?;
+    println!("Remaining: {remaining}");
+    assert_eq!(remaining, 0);
+
+    println!("Done.");
+    Ok(())
+}

--- a/libs/modkit-db/examples/outbox_retry_reject.rs
+++ b/libs/modkit-db/examples/outbox_retry_reject.rs
@@ -1,0 +1,106 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::use_debug)]
+
+//! Retry with exponential backoff, then dead-letter on permanent failure.
+//!
+//! The handler retries twice (transient failure), then rejects on the 3rd attempt.
+//! Backoff is configured fast (100ms base) so the demo completes quickly.
+//!
+//! Run:
+//!   cargo run -p cf-modkit-db --example `outbox_retry_reject` --features sqlite,preview-outbox
+
+use std::time::{Duration, Instant};
+
+use modkit_db::outbox::{
+    DeadLetterFilter, HandlerResult, MessageHandler, Outbox, OutboxMessage, Partitions,
+    outbox_migrations,
+};
+use modkit_db::{ConnectOpts, connect_db, migration_runner::run_migrations_for_testing};
+
+struct RetryThenReject {
+    start: Instant,
+}
+
+#[async_trait::async_trait]
+impl MessageHandler for RetryThenReject {
+    async fn handle(
+        &self,
+        msg: &OutboxMessage,
+        _cancel: tokio_util::sync::CancellationToken,
+    ) -> HandlerResult {
+        let elapsed = self.start.elapsed();
+        if msg.attempts < 2 {
+            println!("  attempt={} at {elapsed:.0?} -> Retry", msg.attempts);
+            HandlerResult::Retry {
+                reason: format!("transient failure #{}", msg.attempts),
+            }
+        } else {
+            println!(
+                "  attempt={} at {elapsed:.0?} -> Reject (giving up)",
+                msg.attempts
+            );
+            HandlerResult::Reject {
+                reason: format!("permanent failure after {} attempts", msg.attempts + 1),
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let db = connect_db(
+        "sqlite:file:outbox_retry?mode=memory&cache=shared",
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await?;
+    run_migrations_for_testing(&db, outbox_migrations()).await?;
+
+    let handle = Outbox::builder(db.clone())
+        .poll_interval(Duration::from_millis(50))
+        .queue("events", Partitions::of(1))
+        // fast backoff for demo — production would use default 1s base / 60s max
+        .backoff_base(Duration::from_millis(100))
+        .backoff_max(Duration::from_millis(500))
+        .decoupled(RetryThenReject {
+            start: Instant::now(),
+        })
+        .start()
+        .await?;
+
+    let conn = db.conn()?;
+    handle
+        .outbox()
+        .enqueue(
+            &conn,
+            "events",
+            0,
+            b"webhook-payload".to_vec(),
+            "application/octet-stream;webhooks.delivery.v1",
+        )
+        .await?;
+    handle.outbox().flush();
+    println!("Enqueued 1 message, watching retries:");
+
+    // wait for retries + final reject
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let items = handle
+        .outbox()
+        .dead_letter_list(&db, &DeadLetterFilter::default())
+        .await?;
+    for dl in &items {
+        println!(
+            "Dead letter: seq={} attempts={} reason={}",
+            dl.seq,
+            dl.attempts,
+            dl.last_error.as_deref().unwrap_or("?")
+        );
+    }
+    assert_eq!(items.len(), 1);
+
+    handle.stop().await;
+    println!("Done.");
+    Ok(())
+}

--- a/libs/modkit-db/examples/outbox_transactional.rs
+++ b/libs/modkit-db/examples/outbox_transactional.rs
@@ -1,0 +1,111 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::use_debug)]
+
+//! Exactly-once message processing with a transactional handler.
+//!
+//! The handler runs inside the DB transaction that holds the partition lock,
+//! so handler side-effects and cursor advance commit atomically.
+//!
+//! Run:
+//!   cargo run -p cf-modkit-db --example `outbox_transactional` --features sqlite,preview-outbox
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use modkit_db::outbox::{
+    HandlerResult, Outbox, OutboxMessage, Partitions, TransactionalMessageHandler,
+    outbox_migrations,
+};
+use modkit_db::{ConnectOpts, connect_db, migration_runner::run_migrations_for_testing};
+use sea_orm::ConnectionTrait;
+
+struct Processor {
+    count: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl TransactionalMessageHandler for Processor {
+    async fn handle(
+        &self,
+        _txn: &dyn ConnectionTrait,
+        msg: &OutboxMessage,
+        _cancel: tokio_util::sync::CancellationToken,
+    ) -> HandlerResult {
+        let payload = String::from_utf8_lossy(&msg.payload);
+        println!("  processed seq={} payload={payload}", msg.seq);
+        self.count.fetch_add(1, Ordering::Relaxed);
+        HandlerResult::Success
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // shared-cache so all pool connections see the same in-memory database;
+    // max_conns=1 avoids SQLite locking contention in examples
+    let db = connect_db(
+        "sqlite:file:outbox_tx?mode=memory&cache=shared",
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await?;
+    run_migrations_for_testing(&db, outbox_migrations()).await?;
+
+    let count = Arc::new(AtomicUsize::new(0));
+
+    let handle = Outbox::builder(db.clone())
+        .poll_interval(Duration::from_millis(50))
+        // 2 partitions — messages are spread across them for parallelism
+        .queue("orders", Partitions::of(2))
+        .transactional(Processor {
+            count: count.clone(),
+        })
+        .start()
+        .await?;
+
+    // transaction() auto-flushes the sequencer on commit — no manual flush() needed
+    let outbox = Arc::clone(handle.outbox());
+    let (db, result) = outbox
+        .transaction(db, |tx| {
+            let outbox = Arc::clone(&outbox);
+            Box::pin(async move {
+                for i in 0..5u32 {
+                    let payload = format!(r#"{{"order_id": {i}}}"#);
+                    outbox
+                        // payload_type is user-defined — convention: mime base + vendor domain type
+                        .enqueue(
+                            tx,
+                            "orders",
+                            i % 2,
+                            payload.into_bytes(),
+                            "application/json;orders.created.v1",
+                        )
+                        .await
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                }
+                Ok(())
+            })
+        })
+        .await;
+    result?;
+    println!("Enqueued 5 messages across 2 partitions");
+
+    // Poll until all messages are processed (processor runs in background)
+    for _ in 0..100 {
+        if count.load(Ordering::Relaxed) >= 5 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let processed = count.load(Ordering::Relaxed);
+    println!("Processed: {processed}/5");
+    assert_eq!(processed, 5);
+
+    handle.stop().await;
+    println!("Done.");
+
+    drop(db);
+    Ok(())
+}

--- a/libs/modkit-db/src/lib.rs
+++ b/libs/modkit-db/src/lib.rs
@@ -9,6 +9,7 @@
 //! # Features
 //! - `pg`, `mysql`, `sqlite`: enable `SQLx` backends
 //! - `sea-orm`: add `SeaORM` integration for type-safe operations
+//! - `preview-outbox`: enable the transactional outbox pipeline (experimental — API may change)
 //!
 //! # New Architecture
 //! The crate now supports:
@@ -80,6 +81,8 @@ pub mod migration_runner;
 pub mod odata;
 pub mod options;
 
+#[cfg(feature = "preview-outbox")]
+pub mod outbox;
 pub mod secure;
 
 mod db_provider;

--- a/libs/modkit-db/src/outbox/builder.rs
+++ b/libs/modkit-db/src/outbox/builder.rs
@@ -1,0 +1,236 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{Notify, Semaphore};
+use tokio_util::sync::CancellationToken;
+
+use super::handler::{
+    Handler, MessageHandler, PerMessageAdapter, TransactionalHandler, TransactionalMessageHandler,
+};
+use super::manager::{DeferredSpawnFactory, OutboxBuilder, QueueDeclaration};
+use super::processor::PartitionProcessor;
+use super::strategy::{DecoupledStrategy, TransactionalStrategy, generate_worker_id};
+use super::types::{Partitions, QueueConfig};
+use crate::Db;
+
+/// Builder for registering a queue with per-queue configuration.
+///
+/// Obtained via [`OutboxBuilder::queue`]. Terminal methods (`transactional`,
+/// `decoupled`, `batch_transactional`, `batch_decoupled`) register the queue
+/// and return the parent [`OutboxBuilder`] for chaining.
+pub struct QueueBuilder {
+    builder: OutboxBuilder,
+    name: String,
+    partitions: Partitions,
+    config: QueueConfig,
+}
+
+impl QueueBuilder {
+    pub(crate) fn new(builder: OutboxBuilder, name: String, partitions: Partitions) -> Self {
+        Self {
+            builder,
+            name,
+            partitions,
+            config: QueueConfig::default(),
+        }
+    }
+
+    /// Lease duration for decoupled mode partition locks. Ignored for
+    /// transactional mode.
+    #[must_use]
+    pub fn lease_duration(mut self, d: Duration) -> Self {
+        self.config.lease_duration = d;
+        self
+    }
+
+    /// Max partitions processed concurrently within this queue.
+    #[must_use]
+    pub fn max_concurrent_partitions(mut self, n: usize) -> Self {
+        self.config.max_concurrent_partitions = n;
+        self
+    }
+
+    /// Messages per handler call per partition.
+    #[must_use]
+    pub fn msg_batch_size(mut self, n: u32) -> Self {
+        self.config.msg_batch_size = n;
+        self
+    }
+
+    /// Base delay for exponential backoff on retry.
+    #[must_use]
+    pub fn backoff_base(mut self, d: Duration) -> Self {
+        self.config.backoff_base = d;
+        self
+    }
+
+    /// Maximum delay for exponential backoff on retry.
+    #[must_use]
+    pub fn backoff_max(mut self, d: Duration) -> Self {
+        self.config.backoff_max = d;
+        self
+    }
+
+    /// Register a single-message transactional handler (common case).
+    ///
+    /// Forces `msg_batch_size = 1` — the `PerMessageAdapter` adapter processes
+    /// one message at a time, so fetching larger batches would be wasteful.
+    #[must_use]
+    pub fn transactional(
+        mut self,
+        handler: impl TransactionalMessageHandler + 'static,
+    ) -> OutboxBuilder {
+        self.config.msg_batch_size = 1;
+        self.batch_transactional(PerMessageAdapter::new(handler))
+    }
+
+    /// Register a single-message decoupled handler (common case).
+    ///
+    /// Forces `msg_batch_size = 1` — the `PerMessageAdapter` adapter processes
+    /// one message at a time, so fetching larger batches would be wasteful.
+    #[must_use]
+    pub fn decoupled(mut self, handler: impl MessageHandler + 'static) -> OutboxBuilder {
+        self.config.msg_batch_size = 1;
+        self.batch_decoupled(PerMessageAdapter::new(handler))
+    }
+
+    /// Register a batch transactional handler (advanced).
+    #[must_use]
+    pub fn batch_transactional(
+        self,
+        handler: impl TransactionalHandler + 'static,
+    ) -> OutboxBuilder {
+        let handler = Arc::new(handler);
+        let config = self.config.clone();
+
+        let make_spawn_fn: DeferredSpawnFactory = Box::new(move |pid, _outbox| {
+            let strategy =
+                TransactionalStrategy::new(Box::new(ArcTransactionalHandler(Arc::clone(&handler))));
+            let config = config.clone();
+
+            Box::new(
+                move |db: Db,
+                      cancel: CancellationToken,
+                      notify: Arc<Notify>,
+                      sem: Arc<Semaphore>| {
+                    let processor = PartitionProcessor::new(strategy, pid, config, notify, sem);
+                    tokio::spawn(async move {
+                        if let Err(e) = processor.run(&db, cancel).await {
+                            tracing::error!(error = %e, partition_id = pid, "partition processor exited with error");
+                        }
+                    })
+                },
+            )
+        });
+
+        let mut builder = self.builder;
+        builder.queue_declarations.push(QueueDeclaration {
+            name: self.name,
+            partitions: self.partitions,
+            config: self.config,
+            make_spawn_fn,
+        });
+        builder
+    }
+
+    /// Register a batch decoupled handler (advanced).
+    #[must_use]
+    pub fn batch_decoupled(self, handler: impl Handler + 'static) -> OutboxBuilder {
+        let handler = Arc::new(handler);
+        let config = self.config.clone();
+        let queue_name = self.name.clone();
+
+        let make_spawn_fn: DeferredSpawnFactory = Box::new(move |pid, _outbox| {
+            let worker_id = generate_worker_id(&queue_name);
+            let strategy =
+                DecoupledStrategy::new(Box::new(ArcHandler(Arc::clone(&handler))), worker_id);
+            let config = config.clone();
+
+            Box::new(
+                move |db: Db,
+                      cancel: CancellationToken,
+                      notify: Arc<Notify>,
+                      sem: Arc<Semaphore>| {
+                    let processor = PartitionProcessor::new(strategy, pid, config, notify, sem);
+                    tokio::spawn(async move {
+                        if let Err(e) = processor.run(&db, cancel).await {
+                            tracing::error!(error = %e, partition_id = pid, "partition processor exited with error");
+                        }
+                    })
+                },
+            )
+        });
+
+        let mut builder = self.builder;
+        builder.queue_declarations.push(QueueDeclaration {
+            name: self.name,
+            partitions: self.partitions,
+            config: self.config,
+            make_spawn_fn,
+        });
+        builder
+    }
+}
+
+// Arc wrappers to share handler across partitions
+
+struct ArcTransactionalHandler<H: TransactionalHandler>(Arc<H>);
+
+#[async_trait::async_trait]
+impl<H: TransactionalHandler> TransactionalHandler for ArcTransactionalHandler<H> {
+    async fn handle(
+        &self,
+        txn: &dyn sea_orm::ConnectionTrait,
+        msgs: &[super::handler::OutboxMessage],
+        cancel: CancellationToken,
+    ) -> super::handler::HandlerResult {
+        self.0.handle(txn, msgs, cancel).await
+    }
+
+    fn processed_count(&self) -> Option<usize> {
+        self.0.processed_count()
+    }
+}
+
+struct ArcHandler<H: Handler>(Arc<H>);
+
+#[async_trait::async_trait]
+impl<H: Handler> Handler for ArcHandler<H> {
+    async fn handle(
+        &self,
+        msgs: &[super::handler::OutboxMessage],
+        cancel: CancellationToken,
+    ) -> super::handler::HandlerResult {
+        self.0.handle(msgs, cancel).await
+    }
+
+    fn processed_count(&self) -> Option<usize> {
+        self.0.processed_count()
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::outbox::types::DEFAULT_LEASE_DURATION;
+
+    #[test]
+    fn queue_config_defaults() {
+        let config = QueueConfig::default();
+        assert_eq!(config.lease_duration, DEFAULT_LEASE_DURATION);
+        assert_eq!(config.max_concurrent_partitions, usize::MAX);
+        assert_eq!(config.msg_batch_size, 1);
+    }
+
+    #[test]
+    fn partitions_count() {
+        assert_eq!(Partitions::of(1).count(), 1);
+        assert_eq!(Partitions::of(2).count(), 2);
+        assert_eq!(Partitions::of(4).count(), 4);
+        assert_eq!(Partitions::of(8).count(), 8);
+        assert_eq!(Partitions::of(16).count(), 16);
+        assert_eq!(Partitions::of(32).count(), 32);
+        assert_eq!(Partitions::of(64).count(), 64);
+    }
+}

--- a/libs/modkit-db/src/outbox/core.rs
+++ b/libs/modkit-db/src/outbox/core.rs
@@ -1,0 +1,564 @@
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement};
+use tokio::sync::{Notify, RwLock};
+
+use super::dialect::Dialect;
+use super::manager::OutboxBuilder;
+use super::types::{EnqueueMessage, OutboxConfig, OutboxError, OutboxMessageId};
+use crate::Db;
+use crate::secure::SeaOrmRunner;
+
+/// Maximum payload size in bytes (64 KiB).
+const MAX_PAYLOAD_SIZE: usize = 64 * 1024;
+
+/// Max rows per multi-row INSERT statement to avoid parameter limits.
+const BATCH_CHUNK_SIZE: usize = 100;
+
+/// Core outbox handle. Holds partition cache and notification channels.
+pub struct Outbox {
+    config: OutboxConfig,
+    /// Cached partition lookup: `partitions[queue_name][partition_number] = partitions.id` (PK).
+    partitions: DashMap<String, Vec<i64>>,
+    /// Reverse map: `partition_id → queue_name`. Populated during `register_queue`.
+    partition_to_queue: DashMap<i64, String>,
+    /// Flattened, sorted, deduplicated snapshot of all partition IDs.
+    /// Rebuilt on each `register_queue` call.
+    all_partition_ids: RwLock<Vec<i64>>,
+    sequencer_notify: Arc<Notify>,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct PartitionRow {
+    id: i64,
+}
+
+impl Outbox {
+    /// Create a fluent builder for the outbox pipeline.
+    ///
+    /// This is the main entry point. See [`OutboxBuilder`] for usage.
+    #[must_use]
+    pub fn builder(db: Db) -> OutboxBuilder {
+        OutboxBuilder::new(db)
+    }
+
+    /// Create a new outbox. Construction goes through [`OutboxBuilder::start()`].
+    #[must_use]
+    pub(crate) fn new(config: OutboxConfig, sequencer_notify: Arc<Notify>) -> Self {
+        Self {
+            config,
+            partitions: DashMap::new(),
+            partition_to_queue: DashMap::new(),
+            all_partition_ids: RwLock::new(Vec::new()),
+            sequencer_notify,
+        }
+    }
+
+    /// Register a queue with `num_partitions` partitions `[0, num_partitions)`.
+    ///
+    /// Idempotent when the partition count matches. Returns
+    /// [`OutboxError::PartitionCountMismatch`] if the count differs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database operation fails or if the partition
+    /// count does not match an existing registration.
+    ///
+    /// # Concurrency note
+    ///
+    /// There is a TOCTOU window between the partition-count check and the
+    /// INSERT. During hot upgrades, multiple instances may call
+    /// `register_queue` concurrently for the same queue. The INSERT uses
+    /// `ON CONFLICT DO NOTHING`, so concurrent inserts are safe — the
+    /// second caller will see the already-inserted rows on its read-back.
+    pub async fn register_queue(
+        &self,
+        db: &Db,
+        queue: &str,
+        num_partitions: u16,
+    ) -> Result<(), OutboxError> {
+        let ids = self
+            .ensure_partition_rows(db, queue, num_partitions)
+            .await?;
+        self.ensure_processor_rows(db, &ids).await?;
+        self.populate_caches(queue, &ids).await;
+        Ok(())
+    }
+
+    /// Check existing partition rows; insert new ones if absent.
+    ///
+    /// Returns the partition IDs (PKs) for the queue — whether they were
+    /// already present or freshly inserted.
+    async fn ensure_partition_rows(
+        &self,
+        db: &Db,
+        queue: &str,
+        num_partitions: u16,
+    ) -> Result<Vec<i64>, OutboxError> {
+        let conn = db.sea_internal();
+        let backend = conn.get_database_backend();
+        let dialect = Dialect::from(backend);
+
+        let existing = PartitionRow::find_by_statement(Statement::from_sql_and_values(
+            backend,
+            dialect.register_queue_select(),
+            [queue.into()],
+        ))
+        .all(&conn)
+        .await?;
+
+        if !existing.is_empty() {
+            if existing.len() != usize::from(num_partitions) {
+                return Err(OutboxError::PartitionCountMismatch {
+                    queue: queue.to_owned(),
+                    expected: num_partitions,
+                    found: existing.len(),
+                });
+            }
+            return Ok(existing.into_iter().map(|r| r.id).collect());
+        }
+
+        // First registration — insert partition rows
+        for p in 0..num_partitions {
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                dialect.register_queue_insert(),
+                #[allow(clippy::cast_possible_wrap)]
+                [queue.into(), (p as i16).into()],
+            ))
+            .await?;
+        }
+
+        // Read back inserted rows to get their PKs
+        let rows = PartitionRow::find_by_statement(Statement::from_sql_and_values(
+            backend,
+            dialect.register_queue_select(),
+            [queue.into()],
+        ))
+        .all(&conn)
+        .await?;
+
+        Ok(rows.into_iter().map(|r| r.id).collect())
+    }
+
+    /// Insert a processor row for each partition ID (idempotent via
+    /// `ON CONFLICT DO NOTHING`).
+    async fn ensure_processor_rows(&self, db: &Db, ids: &[i64]) -> Result<(), OutboxError> {
+        let conn = db.sea_internal();
+        let backend = conn.get_database_backend();
+        let dialect = Dialect::from(backend);
+
+        for &id in ids {
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                dialect.insert_processor_row(),
+                [id.into()],
+            ))
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// Update in-memory caches with the partition IDs for a queue.
+    async fn populate_caches(&self, queue: &str, ids: &[i64]) {
+        for &id in ids {
+            self.partition_to_queue.insert(id, queue.to_owned());
+        }
+        self.partitions.insert(queue.to_owned(), ids.to_vec());
+        self.rebuild_partition_id_cache().await;
+    }
+
+    /// Resolve the `partition_id` (PK) for a `(queue, partition)` pair from cache.
+    fn resolve_partition(&self, queue: &str, partition: u32) -> Result<i64, OutboxError> {
+        let entry = self
+            .partitions
+            .get(queue)
+            .ok_or_else(|| OutboxError::QueueNotRegistered(queue.to_owned()))?;
+        let ids = entry.value();
+        ids.get(partition as usize)
+            .copied()
+            .ok_or_else(|| OutboxError::PartitionOutOfRange {
+                queue: queue.to_owned(),
+                partition,
+                #[allow(clippy::cast_possible_truncation)]
+                max: ids.len() as u32,
+            })
+    }
+
+    /// Validate payload size.
+    fn validate_payload(payload: &[u8]) -> Result<(), OutboxError> {
+        if payload.len() > MAX_PAYLOAD_SIZE {
+            return Err(OutboxError::PayloadTooLarge {
+                size: payload.len(),
+                max: MAX_PAYLOAD_SIZE,
+            });
+        }
+        Ok(())
+    }
+
+    /// Enqueue a single message. Accepts `&impl DBRunner` — use within a transaction
+    /// for atomicity with business data, or with a standalone connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on validation failure or database error.
+    pub async fn enqueue(
+        &self,
+        db: &(impl crate::secure::DBRunner + Sync),
+        queue: &str,
+        partition: u32,
+        payload: Vec<u8>,
+        payload_type: &str,
+    ) -> Result<OutboxMessageId, OutboxError> {
+        Self::validate_payload(&payload)?;
+        let partition_id = self.resolve_partition(queue, partition)?;
+
+        let runner = db.as_seaorm();
+        let incoming_id =
+            Self::insert_body_and_incoming(&runner, partition_id, payload, payload_type).await?;
+
+        Ok(OutboxMessageId(incoming_id))
+    }
+
+    /// Enqueue a batch of items for a single queue.
+    /// All validation happens before any DB writes — a single invalid message
+    /// rejects the entire batch.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on validation failure or database error.
+    pub async fn enqueue_batch(
+        &self,
+        db: &(impl crate::secure::DBRunner + Sync),
+        queue: &str,
+        items: &[EnqueueMessage<'_>],
+    ) -> Result<Vec<OutboxMessageId>, OutboxError> {
+        // Validate ALL items first
+        let mut resolved = Vec::with_capacity(items.len());
+        for item in items {
+            Self::validate_payload(&item.payload)?;
+            let partition_id = self.resolve_partition(queue, item.partition)?;
+            resolved.push(partition_id);
+        }
+
+        let runner = db.as_seaorm();
+        let ids = Self::insert_batch(&runner, &resolved, items).await?;
+
+        Ok(ids)
+    }
+
+    /// Insert a batch of body + incoming rows using multi-row INSERTs.
+    async fn insert_batch(
+        runner: &SeaOrmRunner<'_>,
+        partition_ids: &[i64],
+        items: &[EnqueueMessage<'_>],
+    ) -> Result<Vec<OutboxMessageId>, OutboxError> {
+        let (conn, backend): (&dyn ConnectionTrait, DbBackend) = match runner {
+            SeaOrmRunner::Conn(c) => (*c, c.get_database_backend()),
+            SeaOrmRunner::Tx(t) => (*t, t.get_database_backend()),
+        };
+        let dialect = Dialect::from(backend);
+
+        if items.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut all_body_ids: Vec<i64> = Vec::with_capacity(items.len());
+
+        // Insert body rows in chunks
+        for chunk in items.chunks(BATCH_CHUNK_SIZE) {
+            let payloads: Vec<(&[u8], &str)> = chunk
+                .iter()
+                .map(|item| (item.payload.as_slice(), item.payload_type))
+                .collect();
+            let chunk_ids = dialect
+                .exec_insert_body_batch(conn, backend, &payloads)
+                .await?;
+            all_body_ids.extend(chunk_ids);
+        }
+
+        let mut all_incoming_ids: Vec<OutboxMessageId> = Vec::with_capacity(items.len());
+
+        // Insert incoming rows in chunks
+        for chunk_start in (0..items.len()).step_by(BATCH_CHUNK_SIZE) {
+            let chunk_end = (chunk_start + BATCH_CHUNK_SIZE).min(items.len());
+            let entries: Vec<(i64, i64)> = (chunk_start..chunk_end)
+                .map(|i| (partition_ids[i], all_body_ids[i]))
+                .collect();
+            let chunk_ids = dialect
+                .exec_insert_incoming_batch(conn, backend, &entries)
+                .await?;
+            all_incoming_ids.extend(chunk_ids.into_iter().map(OutboxMessageId));
+        }
+
+        Ok(all_incoming_ids)
+    }
+
+    /// Insert body + incoming rows, returning the `incoming_id`.
+    async fn insert_body_and_incoming(
+        runner: &SeaOrmRunner<'_>,
+        partition_id: i64,
+        payload: Vec<u8>,
+        payload_type: &str,
+    ) -> Result<i64, OutboxError> {
+        let (conn, backend): (&dyn ConnectionTrait, DbBackend) = match runner {
+            SeaOrmRunner::Conn(c) => (*c, c.get_database_backend()),
+            SeaOrmRunner::Tx(t) => (*t, t.get_database_backend()),
+        };
+        let dialect = Dialect::from(backend);
+
+        let body_id = dialect
+            .exec_insert_body(conn, backend, payload, payload_type)
+            .await?;
+        let incoming_id = dialect
+            .exec_insert_incoming(conn, backend, partition_id, body_id)
+            .await?;
+
+        Ok(incoming_id)
+    }
+
+    // -- Dead letter operations --
+
+    /// List dead-lettered messages with optional filtering.
+    ///
+    /// # Errors
+    /// Returns error if the database operation fails.
+    pub async fn dead_letter_list(
+        &self,
+        db: &Db,
+        filter: &super::dead_letter::DeadLetterFilter,
+    ) -> Result<Vec<super::dead_letter::DeadLetterMessage>, OutboxError> {
+        super::dead_letter::dead_letter_list(db, filter).await
+    }
+
+    /// Count dead-lettered messages matching the filter.
+    ///
+    /// # Errors
+    /// Returns error if the database operation fails.
+    pub async fn dead_letter_count(
+        &self,
+        db: &Db,
+        filter: &super::dead_letter::DeadLetterFilter,
+    ) -> Result<u64, OutboxError> {
+        super::dead_letter::dead_letter_count(db, filter).await
+    }
+
+    /// Replay dead-lettered messages: re-insert into incoming, set `replayed_at`.
+    ///
+    /// # Errors
+    /// Returns error if the database operation fails.
+    pub async fn dead_letter_replay(
+        &self,
+        db: &Db,
+        filter: &super::dead_letter::DeadLetterFilter,
+    ) -> Result<u64, OutboxError> {
+        super::dead_letter::dead_letter_replay(db, filter).await
+    }
+
+    /// Permanently delete dead-lettered messages.
+    /// Only purges already-replayed messages unless `force = true`.
+    ///
+    /// # Errors
+    /// Returns error if the database operation fails.
+    pub async fn dead_letter_purge(
+        &self,
+        db: &Db,
+        filter: &super::dead_letter::DeadLetterFilter,
+        force: bool,
+    ) -> Result<u64, OutboxError> {
+        super::dead_letter::dead_letter_purge(db, filter, force).await
+    }
+
+    /// Notify the sequencer that new items are available.
+    /// Multiple flushes coalesce into a single wakeup.
+    pub fn flush(&self) {
+        self.sequencer_notify.notify_one();
+    }
+
+    /// Execute a closure inside a database transaction, then auto-flush
+    /// the sequencer notification channel on success.
+    pub async fn transaction<F, T>(&self, db: Db, f: F) -> (Db, anyhow::Result<T>)
+    where
+        F: for<'a> FnOnce(
+                &'a crate::DbTx<'a>,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = anyhow::Result<T>> + Send + 'a>,
+            > + Send,
+        T: Send + 'static,
+    {
+        let (db, result) = db.transaction(f).await;
+        if result.is_ok() {
+            self.flush();
+        }
+        (db, result)
+    }
+
+    /// Returns all registered partition IDs in deterministic order (sorted by PK).
+    /// Reads from a pre-computed cache that is rebuilt on each `register_queue` call.
+    pub(crate) fn all_partition_ids(&self) -> Vec<i64> {
+        // try_read is non-blocking and always succeeds when no writer is active.
+        // Writers only hold the lock briefly during register_queue (startup).
+        self.all_partition_ids
+            .try_read()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
+    }
+
+    /// Rebuild the flattened partition ID cache from the `DashMap`.
+    async fn rebuild_partition_id_cache(&self) {
+        let mut ids: Vec<i64> = self
+            .partitions
+            .iter()
+            .flat_map(|entry| entry.value().clone())
+            .collect();
+        ids.sort_unstable();
+        ids.dedup();
+        *self.all_partition_ids.write().await = ids;
+    }
+
+    /// Access the outbox config.
+    #[must_use]
+    pub fn config(&self) -> &OutboxConfig {
+        &self.config
+    }
+
+    /// Returns the partition IDs for a specific queue, in order.
+    #[must_use]
+    pub(crate) fn partition_ids_for_queue(&self, queue: &str) -> Vec<i64> {
+        self.partitions
+            .get(queue)
+            .map(|v| v.value().clone())
+            .unwrap_or_default()
+    }
+
+    /// Look up the queue name for a partition ID.
+    #[must_use]
+    pub fn partition_to_queue(&self, partition_id: i64) -> Option<String> {
+        self.partition_to_queue
+            .get(&partition_id)
+            .map(|v| v.clone())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::outbox::types::*;
+
+    fn make_outbox(config: OutboxConfig) -> Arc<Outbox> {
+        let notify = Arc::new(Notify::new());
+        Arc::new(Outbox::new(config, notify))
+    }
+
+    fn make_default_outbox() -> Arc<Outbox> {
+        make_outbox(OutboxConfig::default())
+    }
+
+    // -- resolve_partition tests --
+
+    #[test]
+    fn resolve_partition_cache_hit() {
+        let outbox = make_default_outbox();
+        outbox
+            .partitions
+            .insert("orders".to_owned(), vec![10, 20, 30]);
+
+        assert_eq!(outbox.resolve_partition("orders", 0).unwrap(), 10);
+        assert_eq!(outbox.resolve_partition("orders", 1).unwrap(), 20);
+        assert_eq!(outbox.resolve_partition("orders", 2).unwrap(), 30);
+    }
+
+    #[test]
+    fn resolve_partition_unregistered_queue() {
+        let outbox = make_default_outbox();
+
+        let err = outbox.resolve_partition("nonexistent", 0).unwrap_err();
+        assert!(matches!(err, OutboxError::QueueNotRegistered(q) if q == "nonexistent"));
+    }
+
+    #[test]
+    fn resolve_partition_out_of_range() {
+        let outbox = make_default_outbox();
+        outbox
+            .partitions
+            .insert("orders".to_owned(), vec![10, 20, 30]);
+
+        let err = outbox.resolve_partition("orders", 3).unwrap_err();
+        assert!(matches!(
+            err,
+            OutboxError::PartitionOutOfRange { queue, partition: 3, max: 3 } if queue == "orders"
+        ));
+    }
+
+    // -- validate_payload tests --
+
+    #[test]
+    fn validate_payload_oversized() {
+        let oversized = vec![0u8; MAX_PAYLOAD_SIZE + 1];
+        let err = Outbox::validate_payload(&oversized).unwrap_err();
+        assert!(matches!(err, OutboxError::PayloadTooLarge { .. }));
+    }
+
+    #[test]
+    fn validate_payload_at_exact_limit() {
+        let exact = vec![0u8; MAX_PAYLOAD_SIZE];
+        assert!(Outbox::validate_payload(&exact).is_ok());
+    }
+
+    #[test]
+    fn validate_payload_empty() {
+        assert!(Outbox::validate_payload(&[]).is_ok());
+    }
+
+    // -- enqueue_batch validation tests (no DB needed) --
+
+    #[tokio::test]
+    async fn enqueue_batch_rejects_out_of_range_partition() {
+        let outbox = make_default_outbox();
+        outbox.partitions.insert("q".to_owned(), vec![10, 20]);
+
+        let err = outbox.resolve_partition("q", 5).unwrap_err();
+        assert!(matches!(err, OutboxError::PartitionOutOfRange { .. }));
+    }
+
+    #[tokio::test]
+    async fn enqueue_batch_rejects_oversized_payload() {
+        let oversized = vec![0u8; MAX_PAYLOAD_SIZE + 1];
+        let err = Outbox::validate_payload(&oversized).unwrap_err();
+        assert!(matches!(err, OutboxError::PayloadTooLarge { .. }));
+    }
+
+    // -- flush tests --
+
+    #[tokio::test]
+    async fn flush_triggers_notify() {
+        let notify = Arc::new(Notify::new());
+        let outbox = Arc::new(Outbox::new(OutboxConfig::default(), Arc::clone(&notify)));
+
+        outbox.flush();
+        // Notify was signaled — notified() resolves immediately
+        tokio::time::timeout(std::time::Duration::from_millis(50), notify.notified())
+            .await
+            .expect("notify should fire");
+    }
+
+    #[test]
+    fn flush_does_not_block() {
+        let outbox = make_default_outbox();
+        // Multiple flushes should not block or panic
+        outbox.flush();
+        outbox.flush();
+        outbox.flush();
+    }
+
+    // -- config defaults test --
+
+    #[test]
+    fn config_defaults_match_constants() {
+        let config = OutboxConfig::default();
+        assert_eq!(config.sequencer.batch_size, DEFAULT_SEQUENCER_BATCH_SIZE);
+        assert_eq!(config.sequencer.poll_interval, DEFAULT_POLL_INTERVAL);
+    }
+}

--- a/libs/modkit-db/src/outbox/dead_letter.rs
+++ b/libs/modkit-db/src/outbox/dead_letter.rs
@@ -1,0 +1,398 @@
+use std::fmt::Write as _;
+
+use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
+
+use super::dialect::Dialect;
+use super::types::OutboxError;
+use crate::Db;
+
+/// A dead-lettered message with self-contained payload.
+#[derive(Debug, FromQueryResult)]
+pub struct DeadLetterMessage {
+    pub id: i64,
+    pub partition_id: i64,
+    pub seq: i64,
+    pub payload: Vec<u8>,
+    pub payload_type: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub failed_at: chrono::DateTime<chrono::Utc>,
+    pub last_error: Option<String>,
+    pub attempts: i16,
+    pub replayed_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Filter for dead letter queries.
+pub struct DeadLetterFilter {
+    pub partition_id: Option<i64>,
+    pub queue: Option<String>,
+    pub failed_after: Option<chrono::DateTime<chrono::Utc>>,
+    pub failed_before: Option<chrono::DateTime<chrono::Utc>>,
+    /// Filter to entries where `replayed_at IS NULL` (default: true).
+    pub only_pending: bool,
+    pub limit: Option<u32>,
+}
+
+impl Default for DeadLetterFilter {
+    fn default() -> Self {
+        Self {
+            partition_id: None,
+            queue: None,
+            failed_after: None,
+            failed_before: None,
+            only_pending: true,
+            limit: None,
+        }
+    }
+}
+
+/// List dead-lettered messages with optional filtering.
+pub async fn dead_letter_list(
+    db: &Db,
+    filter: &DeadLetterFilter,
+) -> Result<Vec<DeadLetterMessage>, OutboxError> {
+    let conn = db.sea_internal();
+    let backend = conn.get_database_backend();
+    let (sql, values) = build_select_query(backend, filter);
+
+    let rows =
+        DeadLetterMessage::find_by_statement(Statement::from_sql_and_values(backend, &sql, values))
+            .all(&conn)
+            .await?;
+    Ok(rows)
+}
+
+/// Count dead-lettered messages matching the filter.
+pub async fn dead_letter_count(db: &Db, filter: &DeadLetterFilter) -> Result<u64, OutboxError> {
+    #[derive(Debug, FromQueryResult)]
+    struct Count {
+        cnt: i64,
+    }
+
+    let conn = db.sea_internal();
+    let backend = conn.get_database_backend();
+    let (sql, values) = build_count_query(backend, filter);
+
+    let row = Count::find_by_statement(Statement::from_sql_and_values(backend, &sql, values))
+        .one(&conn)
+        .await?;
+
+    #[allow(clippy::cast_sign_loss)]
+    Ok(row.map_or(0, |r| r.cnt as u64))
+}
+
+/// Replay dead-lettered messages: re-insert into incoming, set `replayed_at`.
+pub async fn dead_letter_replay(db: &Db, filter: &DeadLetterFilter) -> Result<u64, OutboxError> {
+    let conn = db.sea_internal();
+    let backend = conn.get_database_backend();
+    let dialect = Dialect::from(backend);
+    let txn = conn.begin().await?;
+
+    let (sql, values) = build_select_query(backend, filter);
+    let rows =
+        DeadLetterMessage::find_by_statement(Statement::from_sql_and_values(backend, &sql, values))
+            .all(&txn)
+            .await?;
+
+    let count = rows.len();
+    if count == 0 {
+        txn.commit().await?;
+        return Ok(0);
+    }
+
+    // Re-insert body rows and incoming rows via dialect helpers
+    let payloads: Vec<(&[u8], &str)> = rows
+        .iter()
+        .map(|r| (r.payload.as_slice(), r.payload_type.as_str()))
+        .collect();
+    let body_ids = dialect
+        .exec_insert_body_batch(&txn, backend, &payloads)
+        .await?;
+
+    let entries: Vec<(i64, i64)> = rows
+        .iter()
+        .zip(&body_ids)
+        .map(|(r, &bid)| (r.partition_id, bid))
+        .collect();
+    dialect
+        .exec_insert_incoming_batch(&txn, backend, &entries)
+        .await?;
+
+    // Batch replayed_at update
+    let now: sea_orm::Value = chrono::Utc::now().into();
+    let dl_ids: Vec<i64> = rows.iter().map(|r| r.id).collect();
+    let update_sql = build_batch_replayed_at_update(backend, dl_ids.len());
+    let mut update_values: Vec<sea_orm::Value> = Vec::with_capacity(1 + dl_ids.len());
+    update_values.push(now);
+    for &id in &dl_ids {
+        update_values.push(id.into());
+    }
+    txn.execute(Statement::from_sql_and_values(
+        backend,
+        &update_sql,
+        update_values,
+    ))
+    .await?;
+
+    txn.commit().await?;
+
+    #[allow(clippy::cast_possible_truncation)]
+    Ok(count as u64)
+}
+
+/// Permanently delete dead-lettered messages.
+/// Only purges messages where `replayed_at IS NOT NULL` (already replayed)
+/// unless `force = true`.
+pub async fn dead_letter_purge(
+    db: &Db,
+    filter: &DeadLetterFilter,
+    force: bool,
+) -> Result<u64, OutboxError> {
+    let conn = db.sea_internal();
+    let backend = conn.get_database_backend();
+
+    let effective_filter = DeadLetterFilter {
+        partition_id: filter.partition_id,
+        queue: filter.queue.clone(),
+        failed_after: filter.failed_after,
+        failed_before: filter.failed_before,
+        only_pending: false,
+        limit: filter.limit,
+    };
+
+    let (sql, values) = if force {
+        build_delete_query(backend, &effective_filter, false)
+    } else {
+        build_delete_query(backend, &effective_filter, true)
+    };
+
+    let result = conn
+        .execute(Statement::from_sql_and_values(backend, &sql, values))
+        .await?;
+
+    Ok(result.rows_affected())
+}
+
+struct QueryBuilder {
+    sql: String,
+    values: Vec<sea_orm::Value>,
+    param_idx: usize,
+    has_where: bool,
+    is_mysql: bool,
+}
+
+impl QueryBuilder {
+    fn new(base: &str, backend: DbBackend) -> Self {
+        Self {
+            sql: base.to_owned(),
+            values: Vec::new(),
+            param_idx: 1,
+            has_where: false,
+            is_mysql: backend == DbBackend::MySql,
+        }
+    }
+
+    fn add_condition(&mut self, clause: &str, value: sea_orm::Value) {
+        if self.has_where {
+            self.sql.push_str(" AND ");
+        } else {
+            self.sql.push_str(" WHERE ");
+            self.has_where = true;
+        }
+        if self.is_mysql {
+            self.sql
+                .push_str(&clause.replace(&format!("${}", self.param_idx), "?"));
+        } else {
+            self.sql.push_str(clause);
+        }
+        self.values.push(value);
+        self.param_idx += 1;
+    }
+
+    fn add_raw_condition(&mut self, clause: &str) {
+        if self.has_where {
+            self.sql.push_str(" AND ");
+        } else {
+            self.sql.push_str(" WHERE ");
+            self.has_where = true;
+        }
+        self.sql.push_str(clause);
+    }
+
+    fn finish(mut self, limit: Option<u32>) -> (String, Vec<sea_orm::Value>) {
+        self.sql.push_str(" ORDER BY failed_at DESC");
+        if let Some(n) = limit {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = write!(self.sql, " LIMIT {n}");
+        }
+        (self.sql, self.values)
+    }
+}
+
+fn apply_filters(qb: &mut QueryBuilder, filter: &DeadLetterFilter) {
+    if let Some(pid) = filter.partition_id {
+        let idx = qb.param_idx;
+        qb.add_condition(&format!("d.partition_id = ${idx}"), pid.into());
+    }
+    if let Some(ref queue) = filter.queue {
+        let idx = qb.param_idx;
+        qb.add_condition(
+            &format!(
+                "d.partition_id IN (SELECT id FROM modkit_outbox_partitions WHERE queue = ${idx})"
+            ),
+            queue.clone().into(),
+        );
+    }
+    if let Some(after) = filter.failed_after {
+        let idx = qb.param_idx;
+        qb.add_condition(&format!("d.failed_at >= ${idx}"), after.into());
+    }
+    if let Some(before) = filter.failed_before {
+        let idx = qb.param_idx;
+        qb.add_condition(&format!("d.failed_at < ${idx}"), before.into());
+    }
+    if filter.only_pending {
+        qb.add_raw_condition("d.replayed_at IS NULL");
+    }
+}
+
+fn build_select_query(
+    backend: DbBackend,
+    filter: &DeadLetterFilter,
+) -> (String, Vec<sea_orm::Value>) {
+    let mut qb = QueryBuilder::new(
+        "SELECT d.id, d.partition_id, d.seq, d.payload, d.payload_type, d.created_at, \
+         d.failed_at, d.last_error, d.attempts, d.replayed_at \
+         FROM modkit_outbox_dead_letters d",
+        backend,
+    );
+    apply_filters(&mut qb, filter);
+    qb.finish(filter.limit)
+}
+
+fn build_count_query(
+    backend: DbBackend,
+    filter: &DeadLetterFilter,
+) -> (String, Vec<sea_orm::Value>) {
+    let mut qb = QueryBuilder::new(
+        "SELECT COUNT(*) AS cnt FROM modkit_outbox_dead_letters d",
+        backend,
+    );
+    apply_filters(&mut qb, filter);
+    // Count doesn't need ORDER BY or LIMIT but we strip them
+    let (mut sql, values) = qb.finish(None);
+    // Remove the ORDER BY clause for count queries
+    if let Some(pos) = sql.find(" ORDER BY") {
+        sql.truncate(pos);
+    }
+    (sql, values)
+}
+
+/// Build a direct DELETE query with the same filter conditions as SELECT.
+/// Uses `DELETE FROM ... WHERE id IN (SELECT id FROM ... )` subquery approach
+/// for all backends — this avoids alias issues (`SQLite`/`MySQL` don't support
+/// aliases on DELETE targets) and handles LIMIT correctly (`SQLite` doesn't
+/// support `DELETE ... LIMIT`).
+fn build_delete_query(
+    backend: DbBackend,
+    filter: &DeadLetterFilter,
+    only_replayed: bool,
+) -> (String, Vec<sea_orm::Value>) {
+    let mut inner_qb = QueryBuilder::new("SELECT d.id FROM modkit_outbox_dead_letters d", backend);
+    apply_filters(&mut inner_qb, filter);
+    if only_replayed {
+        inner_qb.add_raw_condition("d.replayed_at IS NOT NULL");
+    }
+    let (inner_sql, values) = inner_qb.finish(filter.limit);
+    let sql = format!("DELETE FROM modkit_outbox_dead_letters WHERE id IN ({inner_sql})");
+    (sql, values)
+}
+
+/// Build `UPDATE modkit_outbox_dead_letters SET replayed_at = ? WHERE id IN (?, ?, ...)`.
+fn build_batch_replayed_at_update(backend: DbBackend, count: usize) -> String {
+    let is_mysql = backend == DbBackend::MySql;
+    let mut sql = String::from("UPDATE modkit_outbox_dead_letters SET replayed_at = ");
+    if is_mysql {
+        sql.push('?');
+    } else {
+        sql.push_str("$1");
+    }
+    sql.push_str(" WHERE id IN (");
+    for i in 0..count {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        if is_mysql {
+            sql.push('?');
+        } else {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = write!(sql, "${}", i + 2); // $2, $3, ...
+        }
+    }
+    sql.push(')');
+    sql
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_query_empty_filter_pg() {
+        let filter = DeadLetterFilter::default();
+        let (sql, values) = build_select_query(DbBackend::Postgres, &filter);
+        assert!(sql.contains("replayed_at IS NULL"));
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn build_query_partition_filter_pg() {
+        let filter = DeadLetterFilter {
+            partition_id: Some(42),
+            ..Default::default()
+        };
+        let (sql, values) = build_select_query(DbBackend::Postgres, &filter);
+        assert!(sql.contains("partition_id = $1"));
+        assert_eq!(values.len(), 1);
+    }
+
+    #[test]
+    fn build_query_all_fields_pg() {
+        let filter = DeadLetterFilter {
+            partition_id: Some(1),
+            queue: Some("orders".into()),
+            failed_after: Some(chrono::Utc::now()),
+            failed_before: Some(chrono::Utc::now()),
+            only_pending: true,
+            limit: Some(10),
+        };
+        let (sql, values) = build_select_query(DbBackend::Postgres, &filter);
+        assert!(sql.contains("$1"));
+        assert!(sql.contains("$2"));
+        assert!(sql.contains("$3"));
+        assert!(sql.contains("$4"));
+        assert!(sql.contains("LIMIT 10"));
+        assert_eq!(values.len(), 4);
+    }
+
+    #[test]
+    fn build_query_mysql_uses_question_marks() {
+        let filter = DeadLetterFilter {
+            partition_id: Some(1),
+            queue: Some("q".into()),
+            ..Default::default()
+        };
+        let (sql, values) = build_select_query(DbBackend::MySql, &filter);
+        assert!(sql.contains('?'));
+        assert!(!sql.contains('$'));
+        assert_eq!(values.len(), 2);
+    }
+
+    #[test]
+    fn count_query_has_no_order_by() {
+        let filter = DeadLetterFilter::default();
+        let (sql, _) = build_count_query(DbBackend::Postgres, &filter);
+        assert!(sql.contains("COUNT(*)"));
+        assert!(!sql.contains("ORDER BY"));
+    }
+}

--- a/libs/modkit-db/src/outbox/dialect.rs
+++ b/libs/modkit-db/src/outbox/dialect.rs
@@ -1,0 +1,1031 @@
+use std::fmt::Write as _;
+
+use sea_orm::{ConnectionTrait, DbBackend, DbErr, Statement};
+
+/// Backend-specific SQL dialect for the outbox module.
+///
+/// Centralizes all DML differences between `Postgres`, `SQLite`, and `MySQL`
+/// so that `core.rs` and `sequencer.rs` contain zero `match backend` blocks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dialect {
+    Postgres,
+    /// `SQLite`: single-process only. No row-level locking — `lock_partition()`
+    /// and `lock_processor()` return `None`. Do not run multiple outbox
+    /// instances against the same `SQLite` database.
+    Sqlite,
+    /// `MySQL` 8.0+ required. Uses `FOR UPDATE SKIP LOCKED` for partition
+    /// locking and sequencer claims, which is not available in `MySQL` 5.7
+    /// or earlier.
+    MySql,
+}
+
+impl From<DbBackend> for Dialect {
+    fn from(backend: DbBackend) -> Self {
+        match backend {
+            DbBackend::Postgres => Self::Postgres,
+            DbBackend::Sqlite => Self::Sqlite,
+            DbBackend::MySql => Self::MySql,
+        }
+    }
+}
+
+/// SQL for the Reaper's bulk cleanup operation.
+pub enum ReaperSql {
+    /// Postgres: single CTE statement that deletes outgoing and body rows atomically.
+    Cte(&'static str),
+    /// SQLite/MySQL: two-step — select `body_ids`, then delete outgoing, then delete bodies.
+    TwoStep {
+        select_body_ids: &'static str,
+        delete_outgoing: &'static str,
+    },
+}
+
+/// SQL for the sequencer's claim-incoming operation.
+///
+/// All backends use SELECT-then-DELETE to guarantee FIFO ordering:
+/// the SELECT returns rows ordered by `id`, and the sequencer assigns
+/// sequences in that order before deleting.
+pub struct ClaimSql {
+    /// SELECT query that returns `id, body_id, created_at` ordered by `id`.
+    /// Pg/MySQL append `FOR UPDATE`; `SQLite` omits it (no row locking).
+    pub select: String,
+}
+
+/// SQL for the sequencer's sequence-allocation operation.
+pub enum AllocSql {
+    /// `Pg`/`SQLite`: single `UPDATE ... RETURNING` statement.
+    UpdateReturning(&'static str),
+    /// `MySQL`: `UPDATE` then `SELECT` as two separate statements.
+    UpdateThenSelect {
+        update: &'static str,
+        select: &'static str,
+    },
+}
+
+// -- Registration queries --
+
+impl Dialect {
+    pub fn register_queue_select(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "SELECT id FROM modkit_outbox_partitions \
+                 WHERE queue = $1 ORDER BY partition ASC"
+            }
+            Self::MySql => {
+                "SELECT id FROM modkit_outbox_partitions \
+                 WHERE queue = ? ORDER BY `partition` ASC"
+            }
+        }
+    }
+
+    pub fn register_queue_insert(self) -> &'static str {
+        match self {
+            Self::Postgres => {
+                "INSERT INTO modkit_outbox_partitions (queue, partition) \
+                 VALUES ($1, $2) ON CONFLICT (queue, partition) DO NOTHING"
+            }
+            Self::Sqlite => {
+                "INSERT OR IGNORE INTO modkit_outbox_partitions (queue, partition) \
+                 VALUES ($1, $2)"
+            }
+            Self::MySql => {
+                "INSERT IGNORE INTO modkit_outbox_partitions (queue, `partition`) \
+                 VALUES (?, ?)"
+            }
+        }
+    }
+}
+
+// -- Single-row insert queries --
+
+impl Dialect {
+    pub fn insert_body(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "INSERT INTO modkit_outbox_body (payload, payload_type) \
+                 VALUES ($1, $2) RETURNING id"
+            }
+            Self::MySql => {
+                "INSERT INTO modkit_outbox_body (payload, payload_type) \
+                 VALUES (?, ?)"
+            }
+        }
+    }
+
+    pub fn insert_incoming(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "INSERT INTO modkit_outbox_incoming (partition_id, body_id) \
+                 VALUES ($1, $2) RETURNING id"
+            }
+            Self::MySql => {
+                "INSERT INTO modkit_outbox_incoming (partition_id, body_id) \
+                 VALUES (?, ?)"
+            }
+        }
+    }
+
+    fn supports_returning(self) -> bool {
+        match self {
+            Self::Postgres | Self::Sqlite => true,
+            Self::MySql => false,
+        }
+    }
+
+    /// Returns the `MySQL` query to retrieve the last auto-generated ID.
+    fn last_insert_id() -> &'static str {
+        "SELECT LAST_INSERT_ID() AS id"
+    }
+}
+
+// -- Batch insert builders --
+
+impl Dialect {
+    /// Build a multi-row INSERT for body rows.
+    ///
+    /// `MySQL` note: consecutive auto-increment IDs are guaranteed by `InnoDB`
+    /// for a single multi-row INSERT when `innodb_autoinc_lock_mode` is 0 or 1.
+    pub fn build_insert_body_batch(self, count: usize) -> String {
+        let mut sql =
+            String::from("INSERT INTO modkit_outbox_body (payload, payload_type) VALUES ");
+        self.append_value_tuples(&mut sql, count, 2);
+        if self.supports_returning() {
+            sql.push_str(" RETURNING id");
+        }
+        sql
+    }
+
+    pub fn build_insert_incoming_batch(self, count: usize) -> String {
+        let mut sql =
+            String::from("INSERT INTO modkit_outbox_incoming (partition_id, body_id) VALUES ");
+        self.append_value_tuples(&mut sql, count, 2);
+        if self.supports_returning() {
+            sql.push_str(" RETURNING id");
+        }
+        sql
+    }
+
+    /// Build `SELECT id, payload, payload_type FROM modkit_outbox_body WHERE id IN (...)`.
+    pub fn build_read_body_batch(self, count: usize) -> String {
+        let mut sql =
+            String::from("SELECT id, payload, payload_type FROM modkit_outbox_body WHERE id IN (");
+        self.append_in_placeholders(&mut sql, count);
+        sql.push(')');
+        sql
+    }
+
+    /// Build `DELETE FROM modkit_outbox_body WHERE id IN (...)`.
+    pub fn build_delete_body_batch(self, count: usize) -> String {
+        let mut sql = String::from("DELETE FROM modkit_outbox_body WHERE id IN (");
+        self.append_in_placeholders(&mut sql, count);
+        sql.push(')');
+        sql
+    }
+
+    /// Append `$1, $2, ...` or `?, ?, ...` placeholders for an IN clause.
+    fn append_in_placeholders(self, sql: &mut String, count: usize) {
+        for i in 0..count {
+            if i > 0 {
+                sql.push_str(", ");
+            }
+            match self {
+                Self::Postgres | Self::Sqlite => {
+                    #[allow(clippy::let_underscore_must_use)]
+                    let _ = write!(sql, "${}", i + 1);
+                }
+                Self::MySql => {
+                    sql.push('?');
+                }
+            }
+        }
+    }
+
+    /// Append `(p1, p2), (p3, p4), ...` with correct placeholder style.
+    fn append_value_tuples(self, sql: &mut String, row_count: usize, cols: usize) {
+        for i in 0..row_count {
+            if i > 0 {
+                sql.push_str(", ");
+            }
+            sql.push('(');
+            for c in 0..cols {
+                if c > 0 {
+                    sql.push_str(", ");
+                }
+                match self {
+                    Self::Postgres | Self::Sqlite => {
+                        let idx = i * cols + c + 1;
+                        // Writing to a String is infallible.
+                        #[allow(clippy::let_underscore_must_use)]
+                        let _ = write!(sql, "${idx}");
+                    }
+                    Self::MySql => {
+                        sql.push('?');
+                    }
+                }
+            }
+            sql.push(')');
+        }
+    }
+}
+
+// -- Insert execution helpers --
+//
+// Encapsulate the RETURNING vs LAST_INSERT_ID branching so callers
+// never need to check `supports_returning()`.
+
+impl Dialect {
+    /// Execute a multi-row body INSERT and return generated IDs.
+    pub async fn exec_insert_body_batch(
+        self,
+        conn: &dyn ConnectionTrait,
+        backend: DbBackend,
+        payloads: &[(&[u8], &str)],
+    ) -> Result<Vec<i64>, DbErr> {
+        if payloads.is_empty() {
+            return Ok(Vec::new());
+        }
+        let sql = self.build_insert_body_batch(payloads.len());
+        let mut values: Vec<sea_orm::Value> = Vec::with_capacity(payloads.len() * 2);
+        for &(payload, payload_type) in payloads {
+            values.push(payload.to_vec().into());
+            values.push(payload_type.into());
+        }
+
+        if self.supports_returning() {
+            let rows = conn
+                .query_all(Statement::from_sql_and_values(backend, &sql, values))
+                .await?;
+            rows.iter()
+                .map(|r| {
+                    r.try_get_by_index(0)
+                        .map_err(|e| DbErr::Custom(format!("body id column: {e}")))
+                })
+                .collect()
+        } else {
+            conn.execute(Statement::from_sql_and_values(backend, &sql, values))
+                .await?;
+            let row = conn
+                .query_one(Statement::from_string(backend, Self::last_insert_id()))
+                .await?
+                .ok_or_else(|| {
+                    DbErr::Custom("LAST_INSERT_ID() returned no row for body batch".to_owned())
+                })?;
+            let first_id: i64 = row
+                .try_get_by_index(0)
+                .map_err(|e| DbErr::Custom(format!("body first_id column: {e}")))?;
+            #[allow(clippy::cast_possible_wrap)]
+            Ok((0..payloads.len() as i64).map(|i| first_id + i).collect())
+        }
+    }
+
+    /// Execute a multi-row incoming INSERT and return generated IDs.
+    pub async fn exec_insert_incoming_batch(
+        self,
+        conn: &dyn ConnectionTrait,
+        backend: DbBackend,
+        entries: &[(i64, i64)],
+    ) -> Result<Vec<i64>, DbErr> {
+        if entries.is_empty() {
+            return Ok(Vec::new());
+        }
+        let sql = self.build_insert_incoming_batch(entries.len());
+        let mut values: Vec<sea_orm::Value> = Vec::with_capacity(entries.len() * 2);
+        for &(partition_id, body_id) in entries {
+            values.push(partition_id.into());
+            values.push(body_id.into());
+        }
+
+        if self.supports_returning() {
+            let rows = conn
+                .query_all(Statement::from_sql_and_values(backend, &sql, values))
+                .await?;
+            rows.iter()
+                .map(|r| {
+                    r.try_get_by_index(0)
+                        .map_err(|e| DbErr::Custom(format!("incoming id column: {e}")))
+                })
+                .collect()
+        } else {
+            conn.execute(Statement::from_sql_and_values(backend, &sql, values))
+                .await?;
+            let row = conn
+                .query_one(Statement::from_string(backend, Self::last_insert_id()))
+                .await?
+                .ok_or_else(|| {
+                    DbErr::Custom("LAST_INSERT_ID() returned no row for incoming batch".to_owned())
+                })?;
+            let first_id: i64 = row
+                .try_get_by_index(0)
+                .map_err(|e| DbErr::Custom(format!("incoming first_id column: {e}")))?;
+            #[allow(clippy::cast_possible_wrap)]
+            Ok((0..entries.len() as i64).map(|i| first_id + i).collect())
+        }
+    }
+
+    /// Execute a single body INSERT and return the generated ID.
+    pub async fn exec_insert_body(
+        self,
+        conn: &dyn ConnectionTrait,
+        backend: DbBackend,
+        payload: Vec<u8>,
+        payload_type: &str,
+    ) -> Result<i64, DbErr> {
+        if self.supports_returning() {
+            let row = conn
+                .query_one(Statement::from_sql_and_values(
+                    backend,
+                    self.insert_body(),
+                    [payload.into(), payload_type.into()],
+                ))
+                .await?
+                .ok_or_else(|| {
+                    DbErr::Custom("INSERT RETURNING returned no row for body".to_owned())
+                })?;
+            row.try_get_by_index(0)
+                .map_err(|e| DbErr::Custom(format!("body id column: {e}")))
+        } else {
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                self.insert_body(),
+                [payload.into(), payload_type.into()],
+            ))
+            .await?;
+            let row = conn
+                .query_one(Statement::from_string(backend, Self::last_insert_id()))
+                .await?
+                .ok_or_else(|| {
+                    DbErr::Custom("LAST_INSERT_ID() returned no row for body".to_owned())
+                })?;
+            row.try_get_by_index(0)
+                .map_err(|e| DbErr::Custom(format!("body id column: {e}")))
+        }
+    }
+
+    /// Execute a single incoming INSERT and return the generated ID.
+    pub async fn exec_insert_incoming(
+        self,
+        conn: &dyn ConnectionTrait,
+        backend: DbBackend,
+        partition_id: i64,
+        body_id: i64,
+    ) -> Result<i64, DbErr> {
+        if self.supports_returning() {
+            let row = conn
+                .query_one(Statement::from_sql_and_values(
+                    backend,
+                    self.insert_incoming(),
+                    [partition_id.into(), body_id.into()],
+                ))
+                .await?
+                .ok_or_else(|| {
+                    DbErr::Custom("INSERT RETURNING returned no row for incoming".to_owned())
+                })?;
+            row.try_get_by_index(0)
+                .map_err(|e| DbErr::Custom(format!("incoming id column: {e}")))
+        } else {
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                self.insert_incoming(),
+                [partition_id.into(), body_id.into()],
+            ))
+            .await?;
+            let row = conn
+                .query_one(Statement::from_string(backend, Self::last_insert_id()))
+                .await?
+                .ok_or_else(|| {
+                    DbErr::Custom("LAST_INSERT_ID() returned no row for incoming".to_owned())
+                })?;
+            row.try_get_by_index(0)
+                .map_err(|e| DbErr::Custom(format!("incoming id column: {e}")))
+        }
+    }
+
+    /// Execute the lease-acquire UPDATE and return `(processed_seq, attempts)` if
+    /// the lease was obtained.
+    ///
+    /// Encapsulates the `RETURNING` vs UPDATE-then-SELECT branching for `MySQL`.
+    pub async fn exec_lease_acquire(
+        self,
+        conn: &dyn ConnectionTrait,
+        backend: DbBackend,
+        lease_id: &str,
+        lease_secs: i64,
+        partition_id: i64,
+    ) -> Result<Option<(i64, i16)>, DbErr> {
+        if self.supports_returning() {
+            let row = conn
+                .query_one(Statement::from_sql_and_values(
+                    backend,
+                    self.lease_acquire(),
+                    [lease_id.into(), lease_secs.into(), partition_id.into()],
+                ))
+                .await?;
+            match row {
+                Some(r) => {
+                    let processed_seq: i64 = r
+                        .try_get_by_index(0)
+                        .map_err(|e| DbErr::Custom(format!("processed_seq column: {e}")))?;
+                    let attempts: i16 = r
+                        .try_get_by_index(1)
+                        .map_err(|e| DbErr::Custom(format!("attempts column: {e}")))?;
+                    Ok(Some((processed_seq, attempts)))
+                }
+                None => Ok(None),
+            }
+        } else {
+            let result = conn
+                .execute(Statement::from_sql_and_values(
+                    backend,
+                    self.lease_acquire(),
+                    [lease_id.into(), lease_secs.into(), partition_id.into()],
+                ))
+                .await?;
+            if result.rows_affected() == 0 {
+                return Ok(None);
+            }
+            let row = conn
+                .query_one(Statement::from_sql_and_values(
+                    backend,
+                    self.read_processor(),
+                    [partition_id.into()],
+                ))
+                .await?;
+            match row {
+                Some(r) => {
+                    let processed_seq: i64 = r
+                        .try_get_by_index(0)
+                        .map_err(|e| DbErr::Custom(format!("processed_seq column: {e}")))?;
+                    let attempts: i16 = r
+                        .try_get_by_index(1)
+                        .map_err(|e| DbErr::Custom(format!("attempts column: {e}")))?;
+                    Ok(Some((processed_seq, attempts)))
+                }
+                None => Ok(None),
+            }
+        }
+    }
+}
+
+// -- Sequencer queries --
+
+impl Dialect {
+    pub fn claim_incoming(self, batch_size: u32) -> ClaimSql {
+        match self {
+            Self::Postgres => ClaimSql {
+                select: format!(
+                    "SELECT id, body_id, created_at \
+                     FROM modkit_outbox_incoming \
+                     WHERE partition_id = $1 \
+                     ORDER BY id \
+                     LIMIT {batch_size} \
+                     FOR UPDATE"
+                ),
+            },
+            Self::Sqlite => ClaimSql {
+                select: format!(
+                    "SELECT id, body_id, created_at \
+                     FROM modkit_outbox_incoming \
+                     WHERE partition_id = $1 \
+                     ORDER BY id \
+                     LIMIT {batch_size}"
+                ),
+            },
+            Self::MySql => ClaimSql {
+                select: format!(
+                    "SELECT id, body_id, created_at \
+                     FROM modkit_outbox_incoming \
+                     WHERE partition_id = ? \
+                     ORDER BY id \
+                     LIMIT {batch_size} \
+                     FOR UPDATE"
+                ),
+            },
+        }
+    }
+
+    /// Build `DELETE FROM modkit_outbox_incoming WHERE id IN ($1, $2, ...)`.
+    pub fn delete_incoming_batch(self, count: usize) -> String {
+        let mut sql = String::from("DELETE FROM modkit_outbox_incoming WHERE id IN (");
+        for i in 0..count {
+            if i > 0 {
+                sql.push_str(", ");
+            }
+            match self {
+                Self::Postgres | Self::Sqlite => {
+                    // Writing to a String is infallible.
+                    #[allow(clippy::let_underscore_must_use)]
+                    let _ = write!(sql, "${}", i + 1);
+                }
+                Self::MySql => {
+                    sql.push('?');
+                }
+            }
+        }
+        sql.push(')');
+        sql
+    }
+
+    pub fn allocate_sequences(self) -> AllocSql {
+        match self {
+            Self::Postgres | Self::Sqlite => AllocSql::UpdateReturning(
+                "UPDATE modkit_outbox_partitions \
+                 SET sequence = sequence + $2 \
+                 WHERE id = $1 \
+                 RETURNING sequence - $2 AS start_seq",
+            ),
+            Self::MySql => AllocSql::UpdateThenSelect {
+                update: "UPDATE modkit_outbox_partitions \
+                         SET sequence = sequence + ? WHERE id = ?",
+                select: "SELECT sequence - ? AS start_seq \
+                         FROM modkit_outbox_partitions WHERE id = ?",
+            },
+        }
+    }
+
+    pub fn build_insert_outgoing_batch(self, count: usize) -> String {
+        let mut sql = String::from(
+            "INSERT INTO modkit_outbox_outgoing (partition_id, body_id, seq, created_at) VALUES ",
+        );
+        self.append_value_tuples(&mut sql, count, 4);
+        sql
+    }
+
+    pub fn lock_partition(self) -> Option<&'static str> {
+        match self {
+            Self::Postgres => Some(
+                "SELECT id FROM modkit_outbox_partitions \
+                 WHERE id = $1 FOR UPDATE SKIP LOCKED",
+            ),
+            Self::MySql => Some(
+                "SELECT id FROM modkit_outbox_partitions \
+                 WHERE id = ? FOR UPDATE SKIP LOCKED",
+            ),
+            Self::Sqlite => None,
+        }
+    }
+}
+
+// -- Processor queries --
+
+impl Dialect {
+    pub fn insert_processor_row(self) -> &'static str {
+        match self {
+            Self::Postgres => {
+                "INSERT INTO modkit_outbox_processor (partition_id) \
+                 VALUES ($1) ON CONFLICT (partition_id) DO NOTHING"
+            }
+            Self::Sqlite => {
+                "INSERT OR IGNORE INTO modkit_outbox_processor (partition_id) \
+                 VALUES ($1)"
+            }
+            Self::MySql => {
+                "INSERT IGNORE INTO modkit_outbox_processor (partition_id) \
+                 VALUES (?)"
+            }
+        }
+    }
+
+    pub fn lock_processor(self) -> Option<&'static str> {
+        match self {
+            Self::Postgres => Some(
+                "SELECT partition_id, processed_seq, attempts \
+                 FROM modkit_outbox_processor \
+                 WHERE partition_id = $1 FOR UPDATE SKIP LOCKED",
+            ),
+            Self::MySql => Some(
+                "SELECT partition_id, processed_seq, attempts \
+                 FROM modkit_outbox_processor \
+                 WHERE partition_id = ? FOR UPDATE SKIP LOCKED",
+            ),
+            Self::Sqlite => None,
+        }
+    }
+
+    pub fn read_outgoing_batch(self, batch_size: u32) -> String {
+        match self {
+            Self::Postgres | Self::Sqlite => format!(
+                "SELECT id, body_id, seq, created_at \
+                 FROM modkit_outbox_outgoing \
+                 WHERE partition_id = $1 AND seq > $2 \
+                 ORDER BY seq \
+                 LIMIT {batch_size}"
+            ),
+            Self::MySql => format!(
+                "SELECT id, body_id, seq, created_at \
+                 FROM modkit_outbox_outgoing \
+                 WHERE partition_id = ? AND seq > ? \
+                 ORDER BY seq \
+                 LIMIT {batch_size}"
+            ),
+        }
+    }
+
+    pub fn advance_processed_seq(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "UPDATE modkit_outbox_processor \
+                 SET processed_seq = $1, attempts = 0, last_error = NULL \
+                 WHERE partition_id = $2"
+            }
+            Self::MySql => {
+                "UPDATE modkit_outbox_processor \
+                 SET processed_seq = ?, attempts = 0, last_error = NULL \
+                 WHERE partition_id = ?"
+            }
+        }
+    }
+
+    pub fn record_retry(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "UPDATE modkit_outbox_processor \
+                 SET attempts = attempts + 1, last_error = $1 \
+                 WHERE partition_id = $2"
+            }
+            Self::MySql => {
+                "UPDATE modkit_outbox_processor \
+                 SET attempts = attempts + 1, last_error = ? \
+                 WHERE partition_id = ?"
+            }
+        }
+    }
+
+    pub fn insert_dead_letter(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "INSERT INTO modkit_outbox_dead_letters \
+                 (partition_id, seq, payload, payload_type, created_at, last_error, attempts) \
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)"
+            }
+            Self::MySql => {
+                "INSERT INTO modkit_outbox_dead_letters \
+                 (partition_id, seq, payload, payload_type, created_at, last_error, attempts) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?)"
+            }
+        }
+    }
+
+    /// Acquire a lease on the processor row for decoupled mode.
+    ///
+    /// Atomically increments `attempts` so that a pod crash leaves a trace —
+    /// the next pod will see a non-zero attempt count even though the previous
+    /// processing cycle never reached the ack phase.
+    ///
+    /// Returns `processed_seq` and `attempts` (post-increment).
+    /// Callers subtract 1 to recover the pre-increment value for the handler.
+    pub fn lease_acquire(self) -> &'static str {
+        match self {
+            Self::Postgres => {
+                "UPDATE modkit_outbox_processor \
+                 SET locked_by = $1, locked_until = NOW() + $2 * INTERVAL '1 second', \
+                     attempts = attempts + 1 \
+                 WHERE partition_id = $3 \
+                   AND (locked_by IS NULL OR locked_until < NOW()) \
+                 RETURNING processed_seq, attempts"
+            }
+            Self::Sqlite => {
+                "UPDATE modkit_outbox_processor \
+                 SET locked_by = $1, locked_until = datetime('now', '+' || $2 || ' seconds'), \
+                     attempts = attempts + 1 \
+                 WHERE partition_id = $3 \
+                   AND (locked_by IS NULL OR locked_until < datetime('now')) \
+                 RETURNING processed_seq, attempts"
+            }
+            Self::MySql => {
+                "UPDATE modkit_outbox_processor \
+                 SET locked_by = ?, locked_until = DATE_ADD(NOW(6), INTERVAL ? SECOND), \
+                     attempts = attempts + 1 \
+                 WHERE partition_id = ? \
+                   AND (locked_by IS NULL OR locked_until < NOW(6))"
+            }
+        }
+    }
+
+    /// Ack with lease guard: advance `processed_seq` only if we still own the lease.
+    pub fn lease_ack_advance(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "UPDATE modkit_outbox_processor \
+                 SET processed_seq = $1, attempts = 0, last_error = NULL, \
+                     locked_by = NULL, locked_until = NULL \
+                 WHERE partition_id = $2 AND locked_by = $3"
+            }
+            Self::MySql => {
+                "UPDATE modkit_outbox_processor \
+                 SET processed_seq = ?, attempts = 0, last_error = NULL, \
+                     locked_by = NULL, locked_until = NULL \
+                 WHERE partition_id = ? AND locked_by = ?"
+            }
+        }
+    }
+
+    /// Record retry with lease guard.
+    ///
+    /// Does NOT increment `attempts` — already incremented during
+    /// [`lease_acquire`](Self::lease_acquire). Just records the error
+    /// and releases the lease.
+    pub fn lease_record_retry(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "UPDATE modkit_outbox_processor \
+                 SET last_error = $1, \
+                     locked_by = NULL, locked_until = NULL \
+                 WHERE partition_id = $2 AND locked_by = $3"
+            }
+            Self::MySql => {
+                "UPDATE modkit_outbox_processor \
+                 SET last_error = ?, \
+                     locked_by = NULL, locked_until = NULL \
+                 WHERE partition_id = ? AND locked_by = ?"
+            }
+        }
+    }
+
+    /// Release a lease without changing state (e.g. on empty partition).
+    pub fn lease_release(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "UPDATE modkit_outbox_processor \
+                 SET locked_by = NULL, locked_until = NULL \
+                 WHERE partition_id = $1 AND locked_by = $2"
+            }
+            Self::MySql => {
+                "UPDATE modkit_outbox_processor \
+                 SET locked_by = NULL, locked_until = NULL \
+                 WHERE partition_id = ? AND locked_by = ?"
+            }
+        }
+    }
+
+    /// Reaper: delete processed outgoing rows and their body rows atomically.
+    pub fn reaper_cleanup(self) -> ReaperSql {
+        match self {
+            Self::Postgres => ReaperSql::Cte(
+                "WITH deleted_outgoing AS ( \
+                    DELETE FROM modkit_outbox_outgoing \
+                    WHERE partition_id = $1 AND seq <= $2 \
+                    RETURNING body_id \
+                 ) \
+                 DELETE FROM modkit_outbox_body \
+                 WHERE id IN (SELECT body_id FROM deleted_outgoing)",
+            ),
+            Self::Sqlite | Self::MySql => ReaperSql::TwoStep {
+                select_body_ids: match self {
+                    Self::Sqlite => {
+                        "SELECT body_id FROM modkit_outbox_outgoing \
+                         WHERE partition_id = $1 AND seq <= $2"
+                    }
+                    _ => {
+                        "SELECT body_id FROM modkit_outbox_outgoing \
+                         WHERE partition_id = ? AND seq <= ?"
+                    }
+                },
+                delete_outgoing: match self {
+                    Self::Sqlite => {
+                        "DELETE FROM modkit_outbox_outgoing \
+                         WHERE partition_id = $1 AND seq <= $2"
+                    }
+                    _ => {
+                        "DELETE FROM modkit_outbox_outgoing \
+                         WHERE partition_id = ? AND seq <= ?"
+                    }
+                },
+            },
+        }
+    }
+
+    pub fn read_processor(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "SELECT processed_seq, attempts \
+                 FROM modkit_outbox_processor WHERE partition_id = $1"
+            }
+            Self::MySql => {
+                "SELECT processed_seq, attempts \
+                 FROM modkit_outbox_processor WHERE partition_id = ?"
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dialect_from_dbbackend() {
+        assert_eq!(Dialect::from(DbBackend::Postgres), Dialect::Postgres);
+        assert_eq!(Dialect::from(DbBackend::Sqlite), Dialect::Sqlite);
+        assert_eq!(Dialect::from(DbBackend::MySql), Dialect::MySql);
+    }
+
+    #[test]
+    fn postgres_uses_dollar_placeholders() {
+        let d = Dialect::Postgres;
+        assert!(d.insert_body().contains("$1"));
+        assert!(d.insert_body().contains("$2"));
+        assert!(d.insert_body().contains("RETURNING"));
+    }
+
+    #[test]
+    fn mysql_uses_question_placeholders() {
+        let d = Dialect::MySql;
+        assert!(d.insert_body().contains('?'));
+        assert!(!d.insert_body().contains('$'));
+        assert!(!d.insert_body().contains("RETURNING"));
+    }
+
+    #[test]
+    fn supports_returning_correct() {
+        assert!(Dialect::Postgres.supports_returning());
+        assert!(Dialect::Sqlite.supports_returning());
+        assert!(!Dialect::MySql.supports_returning());
+    }
+
+    #[test]
+    fn lock_partition_correct() {
+        assert!(Dialect::Postgres.lock_partition().is_some());
+        assert!(Dialect::MySql.lock_partition().is_some());
+        assert!(Dialect::Sqlite.lock_partition().is_none());
+    }
+
+    #[test]
+    fn batch_body_pg_placeholder_format() {
+        let sql = Dialect::Postgres.build_insert_body_batch(3);
+        assert!(sql.contains("($1, $2), ($3, $4), ($5, $6)"));
+        assert!(sql.ends_with("RETURNING id"));
+    }
+
+    #[test]
+    fn batch_body_mysql_placeholder_format() {
+        let sql = Dialect::MySql.build_insert_body_batch(3);
+        assert!(sql.contains("(?, ?), (?, ?), (?, ?)"));
+        assert!(!sql.contains("RETURNING"));
+    }
+
+    #[test]
+    fn claim_pg_select_ordered_with_for_update() {
+        let claim = Dialect::Postgres.claim_incoming(100);
+        assert!(claim.select.contains("ORDER BY id"));
+        assert!(claim.select.contains("FOR UPDATE"));
+        assert!(claim.select.contains("$1"));
+    }
+
+    #[test]
+    fn claim_sqlite_select_ordered_no_lock() {
+        let claim = Dialect::Sqlite.claim_incoming(100);
+        assert!(claim.select.contains("ORDER BY id"));
+        assert!(!claim.select.contains("FOR UPDATE"));
+    }
+
+    #[test]
+    fn claim_mysql_select_ordered_with_for_update() {
+        let claim = Dialect::MySql.claim_incoming(100);
+        assert!(claim.select.contains("ORDER BY id"));
+        assert!(claim.select.contains("FOR UPDATE"));
+        assert!(claim.select.contains('?'));
+    }
+
+    #[test]
+    fn delete_incoming_batch_placeholders() {
+        let pg = Dialect::Postgres.delete_incoming_batch(3);
+        assert!(pg.contains("$1, $2, $3"));
+        assert!(pg.contains("DELETE FROM modkit_outbox_incoming"));
+
+        let mysql = Dialect::MySql.delete_incoming_batch(3);
+        assert!(mysql.contains("?, ?, ?"));
+    }
+
+    #[test]
+    fn alloc_pg_is_update_returning() {
+        let alloc = Dialect::Postgres.allocate_sequences();
+        assert!(matches!(alloc, AllocSql::UpdateReturning(_)));
+    }
+
+    #[test]
+    fn alloc_mysql_is_update_then_select() {
+        let alloc = Dialect::MySql.allocate_sequences();
+        assert!(matches!(alloc, AllocSql::UpdateThenSelect { .. }));
+    }
+
+    #[test]
+    fn mysql_register_queue_backtick_partition() {
+        let d = Dialect::MySql;
+        assert!(d.register_queue_select().contains("`partition`"));
+        assert!(d.register_queue_insert().contains("`partition`"));
+    }
+
+    // -- Processor dialect tests --
+
+    #[test]
+    fn insert_processor_row_pg_uses_on_conflict() {
+        let sql = Dialect::Postgres.insert_processor_row();
+        assert!(sql.contains("$1"));
+        assert!(sql.contains("ON CONFLICT"));
+    }
+
+    #[test]
+    fn insert_processor_row_sqlite_uses_or_ignore() {
+        let sql = Dialect::Sqlite.insert_processor_row();
+        assert!(sql.contains("INSERT OR IGNORE"));
+        assert!(sql.contains("$1"));
+    }
+
+    #[test]
+    fn insert_processor_row_mysql_uses_insert_ignore() {
+        let sql = Dialect::MySql.insert_processor_row();
+        assert!(sql.contains("INSERT IGNORE"));
+        assert!(sql.contains('?'));
+        assert!(!sql.contains('$'));
+    }
+
+    #[test]
+    fn lock_processor_correct() {
+        assert!(Dialect::Postgres.lock_processor().is_some());
+        assert!(Dialect::MySql.lock_processor().is_some());
+        assert!(Dialect::Sqlite.lock_processor().is_none());
+
+        let pg = Dialect::Postgres.lock_processor().unwrap();
+        assert!(pg.contains("FOR UPDATE SKIP LOCKED"));
+        assert!(pg.contains("$1"));
+
+        let mysql = Dialect::MySql.lock_processor().unwrap();
+        assert!(mysql.contains("FOR UPDATE SKIP LOCKED"));
+        assert!(mysql.contains('?'));
+    }
+
+    #[test]
+    fn read_outgoing_batch_uses_limit() {
+        let pg = Dialect::Postgres.read_outgoing_batch(50);
+        assert!(pg.contains("$1"));
+        assert!(pg.contains("$2"));
+        assert!(!pg.contains("$3"));
+        assert!(pg.contains("seq > $2"));
+        assert!(pg.contains("ORDER BY seq"));
+        assert!(pg.contains("LIMIT 50"));
+
+        let mysql = Dialect::MySql.read_outgoing_batch(50);
+        assert!(mysql.contains('?'));
+        assert!(!mysql.contains('$'));
+        assert!(mysql.contains("seq > ?"));
+        assert!(mysql.contains("LIMIT 50"));
+    }
+
+    #[test]
+    fn build_read_body_batch_placeholders() {
+        let pg = Dialect::Postgres.build_read_body_batch(3);
+        assert!(pg.contains("$1, $2, $3"));
+        assert!(pg.contains("SELECT id, payload, payload_type"));
+
+        let mysql = Dialect::MySql.build_read_body_batch(3);
+        assert!(mysql.contains("?, ?, ?"));
+        assert!(!mysql.contains('$'));
+    }
+
+    #[test]
+    fn build_delete_body_batch_placeholders() {
+        let pg = Dialect::Postgres.build_delete_body_batch(3);
+        assert!(pg.contains("$1, $2, $3"));
+        assert!(pg.contains("DELETE FROM modkit_outbox_body"));
+
+        let mysql = Dialect::MySql.build_delete_body_batch(3);
+        assert!(mysql.contains("?, ?, ?"));
+    }
+
+    #[test]
+    fn advance_processed_seq_placeholders() {
+        let pg = Dialect::Postgres.advance_processed_seq();
+        assert!(pg.contains("$1"));
+        assert!(pg.contains("$2"));
+        assert!(pg.contains("attempts = 0"));
+
+        let mysql = Dialect::MySql.advance_processed_seq();
+        assert!(mysql.contains('?'));
+        assert!(!mysql.contains('$'));
+    }
+
+    #[test]
+    fn record_retry_placeholders() {
+        let pg = Dialect::Postgres.record_retry();
+        assert!(pg.contains("attempts + 1"));
+        assert!(pg.contains("$1"));
+        assert!(pg.contains("$2"));
+
+        let mysql = Dialect::MySql.record_retry();
+        assert!(mysql.contains('?'));
+    }
+
+    #[test]
+    fn insert_dead_letter_placeholders() {
+        let pg = Dialect::Postgres.insert_dead_letter();
+        assert!(pg.contains("$1"));
+        assert!(pg.contains("$7"));
+        assert!(pg.contains("payload"));
+        assert!(pg.contains("payload_type"));
+
+        let mysql = Dialect::MySql.insert_dead_letter();
+        assert!(mysql.contains('?'));
+        assert!(!mysql.contains('$'));
+    }
+}

--- a/libs/modkit-db/src/outbox/handler.rs
+++ b/libs/modkit-db/src/outbox/handler.rs
@@ -1,0 +1,360 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use sea_orm::ConnectionTrait;
+use tokio_util::sync::CancellationToken;
+
+/// A message read from the outbox for handler processing.
+///
+/// All messages in a single handler invocation belong to exactly one partition.
+/// This is a documented invariant — the processor owns one partition and never
+/// mixes messages across partitions in a single call.
+pub struct OutboxMessage {
+    pub partition_id: i64,
+    pub seq: i64,
+    pub payload: Vec<u8>,
+    pub payload_type: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// How many times this message has been retried (0 on first attempt).
+    /// The handler uses this to decide when to give up and return Reject.
+    pub attempts: i16,
+}
+
+/// The result of a handler invocation.
+pub enum HandlerResult {
+    /// All messages processed successfully. The processor advances the cursor
+    /// past the last message. Processed outgoing and body rows are cleaned up
+    /// asynchronously by the reaper.
+    Success,
+    /// Transient failure. The cursor is not advanced; the same batch will be
+    /// retried with exponential backoff. The `attempts` counter is incremented.
+    Retry { reason: String },
+    /// Permanent failure. All messages in the batch are moved to the dead-letter
+    /// table with inline payload copies. The cursor is advanced past the batch.
+    Reject { reason: String },
+}
+
+/// Batch handler that runs **decoupled** from any DB transaction.
+///
+/// **Delivery guarantee:** at-least-once. The processor acquires a lease, reads
+/// messages, releases the lock, calls the handler, then opens a new transaction
+/// with a lease guard to ack. If the lease expires before ack, another processor
+/// may take over and re-deliver the same messages. Handlers must be idempotent.
+///
+/// **Per-partition invariant:** all messages in a single `handle()` call belong
+/// to exactly one partition. The processor owns one partition and never mixes
+/// messages across partitions.
+///
+/// **`cancel` token:** a child token that fires when either (a) the processor
+/// is shutting down, or (b) the partition lease is approaching expiry (at 80%
+/// of `lease_duration`). Handlers should cooperate by returning `Retry` when
+/// cancelled to allow graceful re-processing.
+#[async_trait::async_trait]
+pub trait Handler: Send + Sync {
+    async fn handle(&self, msgs: &[OutboxMessage], cancel: CancellationToken) -> HandlerResult;
+
+    /// Number of messages successfully processed before the batch completed.
+    /// Returns `None` for batch handlers (default), `Some(n)` for `PerMessageAdapter`.
+    /// The processor uses this for partial-failure semantics.
+    fn processed_count(&self) -> Option<usize> {
+        None
+    }
+}
+
+/// Batch handler that runs **inside** the DB transaction holding the partition lock.
+///
+/// **Delivery guarantee:** exactly-once within the database transaction. The
+/// handler can perform DB writes atomically with the ack — both commit or both
+/// roll back together.
+///
+/// **Per-partition invariant:** all messages in a single `handle()` call belong
+/// to exactly one partition.
+///
+/// **`cancel` token:** a child of the overall shutdown signal. Unlike decoupled
+/// mode, this token is not lease-aware (transactional mode uses row-level locks,
+/// not time-based leases).
+#[async_trait::async_trait]
+pub trait TransactionalHandler: Send + Sync {
+    async fn handle(
+        &self,
+        txn: &dyn ConnectionTrait,
+        msgs: &[OutboxMessage],
+        cancel: CancellationToken,
+    ) -> HandlerResult;
+
+    /// Number of messages successfully processed before the batch completed.
+    /// Returns `None` for batch handlers (default), `Some(n)` for `PerMessageAdapter`.
+    /// The processor uses this for partial-failure semantics.
+    fn processed_count(&self) -> Option<usize> {
+        None
+    }
+}
+
+/// Single-message handler (decoupled mode).
+///
+/// Convenience trait for the common case of processing one message at a time.
+/// Use via `QueueBuilder::decoupled()`. Internally wrapped with [`PerMessageAdapter`].
+///
+/// Same delivery guarantees and `cancel` semantics as [`Handler`].
+#[async_trait::async_trait]
+pub trait MessageHandler: Send + Sync {
+    async fn handle(&self, msg: &OutboxMessage, cancel: CancellationToken) -> HandlerResult;
+}
+
+/// Single-message handler (transactional mode).
+///
+/// Convenience trait for the common case of processing one message at a time.
+/// Use via `QueueBuilder::transactional()`. Internally wrapped with [`PerMessageAdapter`].
+///
+/// Same delivery guarantees and `cancel` semantics as [`TransactionalHandler`].
+#[async_trait::async_trait]
+pub trait TransactionalMessageHandler: Send + Sync {
+    async fn handle(
+        &self,
+        txn: &dyn ConnectionTrait,
+        msg: &OutboxMessage,
+        cancel: CancellationToken,
+    ) -> HandlerResult;
+}
+
+/// Adapter: single-message handler → batch handler.
+/// Processes messages one at a time, stops on first non-Success.
+/// Propagates the `CancellationToken` to each call via `clone()`.
+///
+/// Tracks a `processed_count` — the number of messages successfully handled
+/// before the batch completed (or failed). The processor reads this via
+/// `Handler::processed_count()` / `TransactionalHandler::processed_count()`
+/// to support partial-failure semantics (e.g. dead-letter only the remaining
+/// messages on Reject in decoupled mode).
+pub struct PerMessageAdapter<H> {
+    pub handler: H,
+    processed: AtomicUsize,
+}
+
+impl<H> PerMessageAdapter<H> {
+    pub fn new(handler: H) -> Self {
+        Self {
+            handler,
+            processed: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<H: MessageHandler> Handler for PerMessageAdapter<H> {
+    async fn handle(&self, msgs: &[OutboxMessage], cancel: CancellationToken) -> HandlerResult {
+        self.processed.store(0, Ordering::Release);
+        for msg in msgs {
+            let result = self.handler.handle(msg, cancel.clone()).await;
+            if !matches!(result, HandlerResult::Success) {
+                return result;
+            }
+            self.processed.fetch_add(1, Ordering::Release);
+        }
+        HandlerResult::Success
+    }
+
+    fn processed_count(&self) -> Option<usize> {
+        Some(self.processed.load(Ordering::Acquire))
+    }
+}
+
+#[async_trait::async_trait]
+impl<H: TransactionalMessageHandler> TransactionalHandler for PerMessageAdapter<H> {
+    async fn handle(
+        &self,
+        txn: &dyn ConnectionTrait,
+        msgs: &[OutboxMessage],
+        cancel: CancellationToken,
+    ) -> HandlerResult {
+        self.processed.store(0, Ordering::Release);
+        for msg in msgs {
+            let result = self.handler.handle(txn, msg, cancel.clone()).await;
+            if !matches!(result, HandlerResult::Success) {
+                return result;
+            }
+            self.processed.fetch_add(1, Ordering::Release);
+        }
+        HandlerResult::Success
+    }
+
+    fn processed_count(&self) -> Option<usize> {
+        Some(self.processed.load(Ordering::Acquire))
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    struct CountingHandler {
+        count: AtomicU32,
+    }
+
+    impl CountingHandler {
+        fn new() -> Self {
+            Self {
+                count: AtomicU32::new(0),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MessageHandler for CountingHandler {
+        async fn handle(&self, _msg: &OutboxMessage, _cancel: CancellationToken) -> HandlerResult {
+            self.count.fetch_add(1, Ordering::Relaxed);
+            HandlerResult::Success
+        }
+    }
+
+    struct FailAtHandler {
+        fail_at: u32,
+        count: AtomicU32,
+        reject: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl MessageHandler for FailAtHandler {
+        async fn handle(&self, _msg: &OutboxMessage, _cancel: CancellationToken) -> HandlerResult {
+            let n = self.count.fetch_add(1, Ordering::Relaxed);
+            if n == self.fail_at {
+                if self.reject {
+                    return HandlerResult::Reject {
+                        reason: "bad".into(),
+                    };
+                }
+                return HandlerResult::Retry {
+                    reason: "transient".into(),
+                };
+            }
+            HandlerResult::Success
+        }
+    }
+
+    fn make_msg(seq: i64) -> OutboxMessage {
+        OutboxMessage {
+            partition_id: 1,
+            seq,
+            payload: vec![],
+            payload_type: "test".into(),
+            created_at: chrono::Utc::now(),
+            attempts: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn each_message_all_success() {
+        let handler = PerMessageAdapter::new(CountingHandler::new());
+        let msgs: Vec<OutboxMessage> = (1..=5).map(make_msg).collect();
+        let cancel = CancellationToken::new();
+        let result = Handler::handle(&handler, &msgs, cancel).await;
+        assert!(matches!(result, HandlerResult::Success));
+        assert_eq!(handler.handler.count.load(Ordering::Relaxed), 5);
+    }
+
+    #[tokio::test]
+    async fn each_message_stops_on_retry() {
+        let handler = PerMessageAdapter::new(FailAtHandler {
+            fail_at: 2,
+            count: AtomicU32::new(0),
+            reject: false,
+        });
+        let msgs: Vec<OutboxMessage> = (1..=5).map(make_msg).collect();
+        let cancel = CancellationToken::new();
+        let result = Handler::handle(&handler, &msgs, cancel).await;
+        assert!(matches!(result, HandlerResult::Retry { .. }));
+        // Processed 0, 1, 2 (failed at index 2) = 3 calls
+        assert_eq!(handler.handler.count.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn each_message_stops_on_reject() {
+        let handler = PerMessageAdapter::new(FailAtHandler {
+            fail_at: 1,
+            count: AtomicU32::new(0),
+            reject: true,
+        });
+        let msgs: Vec<OutboxMessage> = (1..=5).map(make_msg).collect();
+        let cancel = CancellationToken::new();
+        let result = Handler::handle(&handler, &msgs, cancel).await;
+        assert!(matches!(result, HandlerResult::Reject { .. }));
+        assert_eq!(handler.handler.count.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn each_message_empty_batch() {
+        let handler = PerMessageAdapter::new(CountingHandler::new());
+        let cancel = CancellationToken::new();
+        let result = Handler::handle(&handler, &[], cancel).await;
+        assert!(matches!(result, HandlerResult::Success));
+        assert_eq!(handler.handler.count.load(Ordering::Relaxed), 0);
+    }
+
+    // ---- processed_count tests ----
+
+    #[tokio::test]
+    async fn each_message_reject_at_third_reports_processed_count_2() {
+        let handler = PerMessageAdapter::new(FailAtHandler {
+            fail_at: 2,
+            count: AtomicU32::new(0),
+            reject: true,
+        });
+        let msgs: Vec<OutboxMessage> = (1..=5).map(make_msg).collect();
+        let cancel = CancellationToken::new();
+        let result = Handler::handle(&handler, &msgs, cancel).await;
+        assert!(matches!(result, HandlerResult::Reject { .. }));
+        // Messages 0 and 1 succeeded, poison at index 2
+        assert_eq!(Handler::processed_count(&handler), Some(2));
+    }
+
+    #[tokio::test]
+    async fn each_message_retry_at_first_reports_processed_count_0() {
+        let handler = PerMessageAdapter::new(FailAtHandler {
+            fail_at: 0,
+            count: AtomicU32::new(0),
+            reject: false,
+        });
+        let msgs: Vec<OutboxMessage> = (1..=3).map(make_msg).collect();
+        let cancel = CancellationToken::new();
+        let result = Handler::handle(&handler, &msgs, cancel).await;
+        assert!(matches!(result, HandlerResult::Retry { .. }));
+        assert_eq!(Handler::processed_count(&handler), Some(0));
+    }
+
+    #[tokio::test]
+    async fn each_message_all_success_reports_full_count() {
+        let handler = PerMessageAdapter::new(CountingHandler::new());
+        let msgs: Vec<OutboxMessage> = (1..=5).map(make_msg).collect();
+        let cancel = CancellationToken::new();
+        let result = Handler::handle(&handler, &msgs, cancel).await;
+        assert!(matches!(result, HandlerResult::Success));
+        assert_eq!(Handler::processed_count(&handler), Some(5));
+    }
+
+    #[tokio::test]
+    async fn each_message_empty_batch_reports_zero() {
+        let handler = PerMessageAdapter::new(CountingHandler::new());
+        let cancel = CancellationToken::new();
+        let _result = Handler::handle(&handler, &[], cancel).await;
+        assert_eq!(Handler::processed_count(&handler), Some(0));
+    }
+
+    #[tokio::test]
+    async fn batch_handler_returns_none_processed_count() {
+        // A raw batch handler (not PerMessageAdapter) returns None
+        struct BatchHandler;
+        #[async_trait::async_trait]
+        impl Handler for BatchHandler {
+            async fn handle(
+                &self,
+                _msgs: &[OutboxMessage],
+                _cancel: CancellationToken,
+            ) -> HandlerResult {
+                HandlerResult::Success
+            }
+        }
+        let handler = BatchHandler;
+        assert_eq!(Handler::processed_count(&handler), None);
+    }
+}

--- a/libs/modkit-db/src/outbox/integration_tests.rs
+++ b/libs/modkit-db/src/outbox/integration_tests.rs
@@ -1,0 +1,2630 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Integration tests for the transactional outbox subsystem.
+//!
+//! Organized as narrative chapters that trace complete lifecycle paths.
+//! Uses `SQLite` in-memory databases for fast, hermetic testing.
+//!
+//! Chapter ordering mirrors the pipeline:
+//!   1. Registration  →  2. Enqueue  →  3. Sequencer
+//!   4. Transactional Processing  →  5. Decoupled Processing
+//!   6. Crash Detection & Recovery  →  7. Backoff & Adaptive Batching
+//!   8. Reaper  →  9. Dead Letters  →  10. Builder API
+//!   11. End-to-End Lifecycle
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
+use tokio_util::sync::CancellationToken;
+
+use super::dead_letter::DeadLetterFilter;
+use super::dialect::Dialect;
+use super::handler::{
+    Handler, HandlerResult, MessageHandler, OutboxMessage, PerMessageAdapter, TransactionalHandler,
+    TransactionalMessageHandler,
+};
+use super::sequencer::Sequencer;
+use super::strategy::{
+    DecoupledStrategy, ProcessContext, ProcessingStrategy, TransactionalStrategy,
+};
+use super::types::{EnqueueMessage, OutboxConfig, QueueConfig, SequencerConfig};
+use super::{Outbox, OutboxError, Partitions};
+use crate::migration_runner::run_migrations_for_testing;
+use crate::outbox::OutboxMessageId;
+use crate::{ConnectOpts, Db, connect_db};
+
+// ======================================================================
+// Snapshot structs
+// ======================================================================
+
+struct TestOutbox {
+    outbox: Arc<Outbox>,
+    sequencer_notify: Arc<tokio::sync::Notify>,
+}
+
+#[derive(Debug)]
+struct ProcessorSnapshot {
+    processed_seq: i64,
+    attempts: i16,
+    last_error: Option<String>,
+    locked_by: Option<String>,
+    locked_until: Option<String>,
+}
+
+#[derive(Debug)]
+struct OutgoingSnapshot {
+    id: i64,
+    partition_id: i64,
+    body_id: i64,
+    seq: i64,
+}
+
+#[derive(Debug)]
+struct DeadLetterSnapshot {
+    id: i64,
+    partition_id: i64,
+    seq: i64,
+    payload: Vec<u8>,
+    payload_type: String,
+    last_error: Option<String>,
+    attempts: i16,
+    replayed_at: Option<String>,
+}
+
+// ======================================================================
+// Layer A — Infrastructure (create resources)
+// ======================================================================
+
+async fn setup_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let opts = ConnectOpts {
+        max_conns: Some(1),
+        ..Default::default()
+    };
+    let db = connect_db(&url, opts).await.expect("connect");
+    run_migrations_for_testing(&db, super::outbox_migrations())
+        .await
+        .expect("migrations");
+    db
+}
+
+fn make_test_outbox(config: OutboxConfig) -> TestOutbox {
+    let notify = Arc::new(tokio::sync::Notify::new());
+    TestOutbox {
+        outbox: Arc::new(Outbox::new(config, notify.clone())),
+        sequencer_notify: notify,
+    }
+}
+
+fn make_default_test_outbox() -> TestOutbox {
+    make_test_outbox(OutboxConfig::default())
+}
+
+fn make_sequencer(t: &TestOutbox, config: SequencerConfig) -> Sequencer {
+    Sequencer::new(
+        config,
+        Arc::clone(&t.outbox),
+        Arc::clone(&t.sequencer_notify),
+    )
+}
+
+// ======================================================================
+// Layer B — Actions (do things)
+// ======================================================================
+
+async fn enqueue_msgs(
+    outbox: &Outbox,
+    db: &Db,
+    queue: &str,
+    partition: u32,
+    payloads: &[&str],
+) -> Vec<OutboxMessageId> {
+    let conn = db.conn().expect("conn");
+    let mut ids = Vec::with_capacity(payloads.len());
+    for payload in payloads {
+        let id = outbox
+            .enqueue(
+                &conn,
+                queue,
+                partition,
+                payload.as_bytes().to_vec(),
+                "text/plain",
+            )
+            .await
+            .expect("enqueue");
+        ids.push(id);
+    }
+    ids
+}
+
+async fn run_sequencer_once(t: &TestOutbox, db: &Db) {
+    let seq = make_sequencer(t, SequencerConfig::default());
+    seq.sequence_batch(db).await.expect("sequence_batch");
+}
+
+async fn enqueue_and_sequence(
+    t: &TestOutbox,
+    db: &Db,
+    queue: &str,
+    partition: u32,
+    payloads: &[&str],
+) -> Vec<OutboxMessageId> {
+    let ids = enqueue_msgs(&t.outbox, db, queue, partition, payloads).await;
+    run_sequencer_once(t, db).await;
+    ids
+}
+
+async fn simulate_crash(db: &Db, partition_id: i64, lease_secs: i64) {
+    let conn = db.sea_internal();
+    conn.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "UPDATE modkit_outbox_processor \
+         SET locked_by = $1, \
+             locked_until = datetime('now', '+' || $2 || ' seconds'), \
+             attempts = attempts + 1 \
+         WHERE partition_id = $3",
+        ["crashed-pod".into(), lease_secs.into(), partition_id.into()],
+    ))
+    .await
+    .expect("simulate_crash");
+}
+
+async fn expire_lease(db: &Db, partition_id: i64) {
+    let conn = db.sea_internal();
+    conn.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "UPDATE modkit_outbox_processor \
+         SET locked_until = datetime('now', '-1 seconds') \
+         WHERE partition_id = $1",
+        [partition_id.into()],
+    ))
+    .await
+    .expect("expire_lease");
+}
+
+// ======================================================================
+// Layer C — Observations (read state only)
+// ======================================================================
+
+async fn count_rows(db: &Db, table: &str) -> i64 {
+    #[derive(Debug, FromQueryResult)]
+    struct Count {
+        cnt: i64,
+    }
+    let conn = db.sea_internal();
+    Count::find_by_statement(Statement::from_string(
+        DbBackend::Sqlite,
+        format!("SELECT COUNT(*) AS cnt FROM {table}"),
+    ))
+    .one(&conn)
+    .await
+    .expect("count query")
+    .expect("count row")
+    .cnt
+}
+
+async fn read_processor_state(db: &Db, partition_id: i64) -> ProcessorSnapshot {
+    #[derive(Debug, FromQueryResult)]
+    struct Row {
+        processed_seq: i64,
+        attempts: i16,
+        last_error: Option<String>,
+        locked_by: Option<String>,
+        locked_until: Option<String>,
+    }
+    let conn = db.sea_internal();
+    let row = Row::find_by_statement(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "SELECT processed_seq, attempts, last_error, locked_by, \
+         CAST(locked_until AS TEXT) AS locked_until \
+         FROM modkit_outbox_processor WHERE partition_id = $1",
+        [partition_id.into()],
+    ))
+    .one(&conn)
+    .await
+    .expect("query")
+    .expect("processor row");
+    ProcessorSnapshot {
+        processed_seq: row.processed_seq,
+        attempts: row.attempts,
+        last_error: row.last_error,
+        locked_by: row.locked_by,
+        locked_until: row.locked_until,
+    }
+}
+
+async fn read_outgoing(db: &Db, partition_id: i64) -> Vec<OutgoingSnapshot> {
+    #[derive(Debug, FromQueryResult)]
+    struct Row {
+        id: i64,
+        partition_id: i64,
+        body_id: i64,
+        seq: i64,
+    }
+    let conn = db.sea_internal();
+    Row::find_by_statement(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "SELECT id, partition_id, body_id, seq \
+         FROM modkit_outbox_outgoing WHERE partition_id = $1 ORDER BY seq",
+        [partition_id.into()],
+    ))
+    .all(&conn)
+    .await
+    .expect("query")
+    .into_iter()
+    .map(|r| OutgoingSnapshot {
+        id: r.id,
+        partition_id: r.partition_id,
+        body_id: r.body_id,
+        seq: r.seq,
+    })
+    .collect()
+}
+
+async fn read_dead_letters(db: &Db) -> Vec<DeadLetterSnapshot> {
+    #[derive(Debug, FromQueryResult)]
+    struct Row {
+        id: i64,
+        partition_id: i64,
+        seq: i64,
+        payload: Vec<u8>,
+        payload_type: String,
+        last_error: Option<String>,
+        attempts: i16,
+        replayed_at: Option<String>,
+    }
+    let conn = db.sea_internal();
+    Row::find_by_statement(Statement::from_string(
+        DbBackend::Sqlite,
+        "SELECT id, partition_id, seq, payload, payload_type, last_error, \
+         attempts, CAST(replayed_at AS TEXT) AS replayed_at \
+         FROM modkit_outbox_dead_letters ORDER BY seq",
+    ))
+    .all(&conn)
+    .await
+    .expect("query")
+    .into_iter()
+    .map(|r| DeadLetterSnapshot {
+        id: r.id,
+        partition_id: r.partition_id,
+        seq: r.seq,
+        payload: r.payload,
+        payload_type: r.payload_type,
+        last_error: r.last_error,
+        attempts: r.attempts,
+        replayed_at: r.replayed_at,
+    })
+    .collect()
+}
+
+async fn read_partition_sequence(db: &Db, partition_id: i64) -> i64 {
+    #[derive(Debug, FromQueryResult)]
+    struct Row {
+        sequence: i64,
+    }
+    let conn = db.sea_internal();
+    Row::find_by_statement(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "SELECT sequence FROM modkit_outbox_partitions WHERE id = $1",
+        [partition_id.into()],
+    ))
+    .one(&conn)
+    .await
+    .expect("query")
+    .expect("partition row")
+    .sequence
+}
+
+async fn poll_until<F, Fut>(f: F, timeout_ms: u64)
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms);
+    loop {
+        if f().await {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "poll_until timed out after {timeout_ms}ms"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+// ======================================================================
+// Test handlers
+// ======================================================================
+
+struct CountingSuccessHandler {
+    count: Arc<AtomicU32>,
+}
+
+#[async_trait::async_trait]
+impl Handler for CountingSuccessHandler {
+    async fn handle(&self, msgs: &[OutboxMessage], _cancel: CancellationToken) -> HandlerResult {
+        #[allow(clippy::cast_possible_truncation)]
+        self.count.fetch_add(msgs.len() as u32, Ordering::Relaxed);
+        HandlerResult::Success
+    }
+}
+
+struct CountingMessageHandler {
+    count: Arc<AtomicU32>,
+}
+
+#[async_trait::async_trait]
+impl MessageHandler for CountingMessageHandler {
+    async fn handle(&self, _msg: &OutboxMessage, _cancel: CancellationToken) -> HandlerResult {
+        self.count.fetch_add(1, Ordering::Relaxed);
+        HandlerResult::Success
+    }
+}
+
+struct AlwaysRetryHandler;
+
+#[async_trait::async_trait]
+impl MessageHandler for AlwaysRetryHandler {
+    async fn handle(&self, _msg: &OutboxMessage, _cancel: CancellationToken) -> HandlerResult {
+        HandlerResult::Retry {
+            reason: "transient failure".into(),
+        }
+    }
+}
+
+struct AlwaysRejectHandler;
+
+#[async_trait::async_trait]
+impl MessageHandler for AlwaysRejectHandler {
+    async fn handle(&self, _msg: &OutboxMessage, _cancel: CancellationToken) -> HandlerResult {
+        HandlerResult::Reject {
+            reason: "permanently bad".into(),
+        }
+    }
+}
+
+struct AttemptsRecorder {
+    seen_attempts: Arc<Mutex<Vec<i16>>>,
+}
+
+#[async_trait::async_trait]
+impl MessageHandler for AttemptsRecorder {
+    async fn handle(&self, msg: &OutboxMessage, _cancel: CancellationToken) -> HandlerResult {
+        self.seen_attempts.lock().unwrap().push(msg.attempts);
+        HandlerResult::Success
+    }
+}
+
+struct CountingTxHandler {
+    count: Arc<AtomicU32>,
+}
+
+#[async_trait::async_trait]
+impl TransactionalHandler for CountingTxHandler {
+    async fn handle(
+        &self,
+        _txn: &dyn ConnectionTrait,
+        msgs: &[OutboxMessage],
+        _cancel: CancellationToken,
+    ) -> HandlerResult {
+        #[allow(clippy::cast_possible_truncation)]
+        self.count.fetch_add(msgs.len() as u32, Ordering::Relaxed);
+        HandlerResult::Success
+    }
+}
+
+struct AlwaysRetryTxHandler;
+
+#[async_trait::async_trait]
+impl TransactionalHandler for AlwaysRetryTxHandler {
+    async fn handle(
+        &self,
+        _txn: &dyn ConnectionTrait,
+        _msgs: &[OutboxMessage],
+        _cancel: CancellationToken,
+    ) -> HandlerResult {
+        HandlerResult::Retry {
+            reason: "transient tx failure".into(),
+        }
+    }
+}
+
+struct AlwaysRejectTxHandler;
+
+#[async_trait::async_trait]
+impl TransactionalHandler for AlwaysRejectTxHandler {
+    async fn handle(
+        &self,
+        _txn: &dyn ConnectionTrait,
+        _msgs: &[OutboxMessage],
+        _cancel: CancellationToken,
+    ) -> HandlerResult {
+        HandlerResult::Reject {
+            reason: "permanently bad tx".into(),
+        }
+    }
+}
+
+/// Rejects a specific message (by seq number), succeeds on others.
+struct PoisonMessageHandler {
+    poison_seqs: Vec<i64>,
+}
+
+#[async_trait::async_trait]
+impl MessageHandler for PoisonMessageHandler {
+    async fn handle(&self, msg: &OutboxMessage, _cancel: CancellationToken) -> HandlerResult {
+        if self.poison_seqs.contains(&msg.seq) {
+            HandlerResult::Reject {
+                reason: format!("poison seq={}", msg.seq),
+            }
+        } else {
+            HandlerResult::Success
+        }
+    }
+}
+
+// ======================================================================
+// Chapter 1: Registration
+// ======================================================================
+
+#[tokio::test]
+async fn registration_creates_partition_and_processor_rows() {
+    let db = setup_db("ch1_creates_rows").await;
+    let t = make_default_test_outbox();
+
+    t.outbox.register_queue(&db, "orders", 4).await.unwrap();
+
+    let part_count = count_rows(&db, "modkit_outbox_partitions").await;
+    assert_eq!(part_count, 4, "4 partition rows");
+
+    let proc_count = count_rows(&db, "modkit_outbox_processor").await;
+    assert_eq!(proc_count, 4, "4 processor rows");
+
+    // Each processor row starts at processed_seq=0, attempts=0
+    let ids = t.outbox.all_partition_ids();
+    for id in &ids {
+        let snap = read_processor_state(&db, *id).await;
+        assert_eq!(snap.processed_seq, 0);
+        assert_eq!(snap.attempts, 0);
+    }
+}
+
+#[tokio::test]
+async fn registration_is_idempotent() {
+    let db = setup_db("ch1_idempotent").await;
+    let t = make_default_test_outbox();
+
+    t.outbox.register_queue(&db, "orders", 4).await.unwrap();
+    t.outbox.register_queue(&db, "orders", 4).await.unwrap();
+
+    let part_count = count_rows(&db, "modkit_outbox_partitions").await;
+    assert_eq!(part_count, 4, "still exactly 4 - no duplicates");
+}
+
+#[tokio::test]
+async fn registration_rejects_mismatched_partition_count() {
+    let db = setup_db("ch1_mismatch").await;
+    let t = make_default_test_outbox();
+
+    t.outbox.register_queue(&db, "orders", 4).await.unwrap();
+    let err = t.outbox.register_queue(&db, "orders", 2).await.unwrap_err();
+
+    assert!(matches!(
+        err,
+        OutboxError::PartitionCountMismatch {
+            expected: 2,
+            found: 4,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn registration_multiple_queues_distinct_ids() {
+    let db = setup_db("ch1_multi_queue").await;
+    let t = make_default_test_outbox();
+
+    t.outbox.register_queue(&db, "a", 2).await.unwrap();
+    t.outbox.register_queue(&db, "b", 2).await.unwrap();
+
+    let all_ids = t.outbox.all_partition_ids();
+    assert_eq!(all_ids.len(), 4);
+    // All distinct (sorted + deduped by all_partition_ids)
+    let mut deduped = all_ids;
+    deduped.dedup();
+    assert_eq!(deduped.len(), 4);
+}
+
+#[tokio::test]
+async fn registration_partition_to_queue_reverse_lookup() {
+    let db = setup_db("ch1_reverse_lookup").await;
+    let t = make_default_test_outbox();
+
+    t.outbox.register_queue(&db, "orders", 2).await.unwrap();
+
+    let ids = t.outbox.all_partition_ids();
+    assert_eq!(ids.len(), 2);
+    for id in &ids {
+        assert_eq!(t.outbox.partition_to_queue(*id).as_deref(), Some("orders"));
+    }
+}
+
+// ======================================================================
+// Chapter 2: Enqueue
+// ======================================================================
+
+#[tokio::test]
+async fn enqueue_single_creates_body_and_incoming() {
+    let db = setup_db("ch2_single").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    enqueue_msgs(&t.outbox, &db, "q", 0, &["hello"]).await;
+
+    assert_eq!(count_rows(&db, "modkit_outbox_body").await, 1);
+    assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 1);
+}
+
+#[tokio::test]
+async fn enqueue_returns_correct_id() {
+    let db = setup_db("ch2_correct_id").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    let ids = enqueue_msgs(&t.outbox, &db, "q", 0, &["msg"]).await;
+    assert_eq!(ids.len(), 1);
+    // The returned ID should be the incoming row ID (positive integer)
+    assert!(ids[0].0 > 0);
+}
+
+#[tokio::test]
+async fn enqueue_tx_rollback_leaves_no_rows() {
+    let db = setup_db("ch2_rollback").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    // Use sea_orm transaction directly to simulate rollback
+    let conn = db.sea_internal();
+    let txn = sea_orm::TransactionTrait::begin(&conn).await.unwrap();
+    // Insert body + incoming manually through the transaction
+    txn.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "INSERT INTO modkit_outbox_body (payload, payload_type) VALUES ($1, $2)",
+        [b"data".to_vec().into(), "text/plain".into()],
+    ))
+    .await
+    .unwrap();
+    // Rollback
+    txn.rollback().await.unwrap();
+
+    assert_eq!(count_rows(&db, "modkit_outbox_body").await, 0);
+    assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 0);
+}
+
+#[tokio::test]
+async fn enqueue_with_standalone_connection() {
+    let db = setup_db("ch2_standalone").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    // enqueue_msgs already uses db.conn() (standalone connection)
+    enqueue_msgs(&t.outbox, &db, "q", 0, &["standalone"]).await;
+
+    assert_eq!(count_rows(&db, "modkit_outbox_body").await, 1);
+    assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 1);
+}
+
+#[tokio::test]
+async fn enqueue_batch_creates_n_items() {
+    let db = setup_db("ch2_batch_n").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    let items: Vec<EnqueueMessage<'_>> = (0..50)
+        .map(|i| EnqueueMessage {
+            partition: 0,
+            payload: format!("msg-{i}").into_bytes(),
+            payload_type: "text/plain",
+        })
+        .collect();
+    let conn = db.conn().unwrap();
+    let ids = t.outbox.enqueue_batch(&conn, "q", &items).await.unwrap();
+
+    assert_eq!(ids.len(), 50);
+    assert_eq!(count_rows(&db, "modkit_outbox_body").await, 50);
+    assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 50);
+}
+
+#[tokio::test]
+async fn enqueue_batch_mixed_partitions() {
+    let db = setup_db("ch2_batch_mixed").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 2).await.unwrap();
+
+    let items: Vec<EnqueueMessage<'_>> = vec![
+        EnqueueMessage {
+            partition: 0,
+            payload: b"a".to_vec(),
+            payload_type: "text/plain",
+        },
+        EnqueueMessage {
+            partition: 1,
+            payload: b"b".to_vec(),
+            payload_type: "text/plain",
+        },
+        EnqueueMessage {
+            partition: 0,
+            payload: b"c".to_vec(),
+            payload_type: "text/plain",
+        },
+        EnqueueMessage {
+            partition: 1,
+            payload: b"d".to_vec(),
+            payload_type: "text/plain",
+        },
+    ];
+    let conn = db.conn().unwrap();
+    let ids = t.outbox.enqueue_batch(&conn, "q", &items).await.unwrap();
+    assert_eq!(ids.len(), 4);
+    assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 4);
+}
+
+#[tokio::test]
+async fn enqueue_batch_one_invalid_rejects_entire_batch() {
+    let db = setup_db("ch2_batch_invalid").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    let oversized = vec![0u8; 64 * 1024 + 1];
+    let items: Vec<EnqueueMessage<'_>> = vec![
+        EnqueueMessage {
+            partition: 0,
+            payload: b"ok".to_vec(),
+            payload_type: "text/plain",
+        },
+        EnqueueMessage {
+            partition: 0,
+            payload: oversized,
+            payload_type: "text/plain",
+        },
+    ];
+    let conn = db.conn().unwrap();
+    let err = t
+        .outbox
+        .enqueue_batch(&conn, "q", &items)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, OutboxError::PayloadTooLarge { .. }));
+    assert_eq!(count_rows(&db, "modkit_outbox_body").await, 0);
+}
+
+#[tokio::test]
+async fn enqueue_empty_batch_returns_empty_vec() {
+    let db = setup_db("ch2_batch_empty").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    let conn = db.conn().unwrap();
+    let ids = t.outbox.enqueue_batch(&conn, "q", &[]).await.unwrap();
+    assert!(ids.is_empty());
+}
+
+#[tokio::test]
+async fn enqueue_batch_over_chunk_size_works() {
+    let db = setup_db("ch2_batch_chunk").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    let items: Vec<EnqueueMessage<'_>> = (0..150)
+        .map(|i| EnqueueMessage {
+            partition: 0,
+            payload: format!("msg-{i}").into_bytes(),
+            payload_type: "text/plain",
+        })
+        .collect();
+    let conn = db.conn().unwrap();
+    let ids = t.outbox.enqueue_batch(&conn, "q", &items).await.unwrap();
+
+    assert_eq!(ids.len(), 150);
+    assert_eq!(count_rows(&db, "modkit_outbox_body").await, 150);
+    assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 150);
+}
+
+#[tokio::test]
+async fn enqueue_oversized_payload_rejected() {
+    let db = setup_db("ch2_oversized").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    let oversized = vec![0u8; 64 * 1024 + 1];
+    let conn = db.conn().unwrap();
+    let err = t
+        .outbox
+        .enqueue(&conn, "q", 0, oversized, "bin")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, OutboxError::PayloadTooLarge { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_unregistered_queue_rejected() {
+    let db = setup_db("ch2_unreg").await;
+    let t = make_default_test_outbox();
+    // Don't register any queue
+
+    let conn = db.conn().unwrap();
+    let err = t
+        .outbox
+        .enqueue(&conn, "nonexistent", 0, b"x".to_vec(), "text/plain")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, OutboxError::QueueNotRegistered(_)));
+}
+
+#[tokio::test]
+async fn enqueue_out_of_range_partition_rejected() {
+    let db = setup_db("ch2_oor").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 4).await.unwrap();
+
+    let conn = db.conn().unwrap();
+    let err = t
+        .outbox
+        .enqueue(&conn, "q", 5, b"x".to_vec(), "text/plain")
+        .await
+        .unwrap_err();
+    assert!(matches!(err, OutboxError::PartitionOutOfRange { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_transaction_helper_auto_flushes() {
+    let db = setup_db("ch2_tx_flush").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    // Set up a notified() listener before the transaction
+    let notified = t.sequencer_notify.notified();
+
+    let (_db, result) = t
+        .outbox
+        .transaction(db, |tx| {
+            let outbox = Arc::clone(&t.outbox);
+            Box::pin(async move {
+                outbox
+                    .enqueue(tx, "q", 0, b"hello".to_vec(), "text/plain")
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                Ok(())
+            })
+        })
+        .await;
+    result.unwrap();
+
+    // Notify should fire within a short timeout
+    tokio::time::timeout(Duration::from_millis(100), notified)
+        .await
+        .expect("sequencer should be notified on successful transaction");
+}
+
+#[tokio::test]
+async fn enqueue_transaction_helper_no_flush_on_rollback() {
+    let db = setup_db("ch2_tx_no_flush").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    let (_db, result) = t
+        .outbox
+        .transaction(db, |_tx| {
+            Box::pin(async move { Err::<(), _>(anyhow::anyhow!("rollback")) })
+        })
+        .await;
+    assert!(result.is_err());
+
+    // Give a brief window — notify should NOT fire
+    let notified = t.sequencer_notify.notified();
+    let timed_out = tokio::time::timeout(Duration::from_millis(50), notified)
+        .await
+        .is_err();
+    assert!(timed_out, "sequencer should NOT be notified on rollback");
+}
+
+// ======================================================================
+// Chapter 3: Sequencer
+// ======================================================================
+
+#[tokio::test]
+async fn sequencer_moves_incoming_to_outgoing() {
+    let db = setup_db("ch3_moves").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    enqueue_msgs(&t.outbox, &db, "q", 0, &["a", "b", "c"]).await;
+    assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 3);
+
+    run_sequencer_once(&t, &db).await;
+
+    assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 0);
+    assert_eq!(count_rows(&db, "modkit_outbox_outgoing").await, 3);
+
+    let pid = t.outbox.all_partition_ids()[0];
+    let outgoing = read_outgoing(&db, pid).await;
+    let seqs: Vec<i64> = outgoing.iter().map(|r| r.seq).collect();
+    assert_eq!(seqs, vec![1, 2, 3]);
+
+    // Verify structural fields: each row belongs to the queried partition,
+    // has a positive id, and references a valid body row.
+    for row in &outgoing {
+        assert_eq!(row.partition_id, pid);
+        assert!(row.id > 0);
+        assert!(row.body_id > 0);
+    }
+    // IDs should be unique
+    let ids: Vec<i64> = outgoing.iter().map(|r| r.id).collect();
+    assert_eq!(ids.len(), 3);
+    assert!(ids[0] != ids[1] && ids[1] != ids[2]);
+}
+
+/// Enqueue many messages to one partition, sequence them, and verify the
+/// outgoing sequence order matches the original enqueue (insertion) order.
+/// This guards against non-deterministic row ordering in the claim step.
+#[tokio::test]
+async fn sequencer_preserves_enqueue_order_in_sequences() {
+    let db = setup_db("ch3_fifo").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    // Enqueue 8 messages — enough to surface ordering issues
+    let payloads: Vec<String> = (0..8).map(|i| format!("msg-{i}")).collect();
+    let payload_refs: Vec<&str> = payloads.iter().map(String::as_str).collect();
+    let enqueue_ids = enqueue_msgs(&t.outbox, &db, "q", 0, &payload_refs).await;
+
+    run_sequencer_once(&t, &db).await;
+
+    let pid = t.outbox.all_partition_ids()[0];
+    let outgoing = read_outgoing(&db, pid).await;
+
+    // Sequences must be strictly monotonically increasing
+    let seqs: Vec<i64> = outgoing.iter().map(|r| r.seq).collect();
+    assert_eq!(seqs, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+
+    // body_ids must follow the same order as enqueue_ids (insertion order)
+    let body_ids: Vec<i64> = outgoing.iter().map(|r| r.body_id).collect();
+    for i in 1..body_ids.len() {
+        assert!(
+            body_ids[i] > body_ids[i - 1],
+            "body_id[{i}]={} should be > body_id[{}]={}",
+            body_ids[i],
+            i - 1,
+            body_ids[i - 1]
+        );
+    }
+
+    // Verify count matches
+    assert_eq!(enqueue_ids.len(), 8);
+    assert_eq!(outgoing.len(), 8);
+}
+
+#[tokio::test]
+async fn sequencer_updates_partition_sequence_counter() {
+    let db = setup_db("ch3_seq_counter").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    enqueue_msgs(&t.outbox, &db, "q", 0, &["a", "b", "c"]).await;
+    run_sequencer_once(&t, &db).await;
+
+    let pid = t.outbox.all_partition_ids()[0];
+    let seq = read_partition_sequence(&db, pid).await;
+    assert_eq!(seq, 3);
+}
+
+#[tokio::test]
+async fn sequencer_multi_partition_independent_sequences() {
+    let db = setup_db("ch3_multi_part").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 2).await.unwrap();
+
+    enqueue_msgs(&t.outbox, &db, "q", 0, &["a0", "b0"]).await;
+    enqueue_msgs(&t.outbox, &db, "q", 1, &["a1", "b1", "c1"]).await;
+    run_sequencer_once(&t, &db).await;
+
+    let ids = t.outbox.all_partition_ids();
+    let out0 = read_outgoing(&db, ids[0]).await;
+    let out1 = read_outgoing(&db, ids[1]).await;
+
+    let seqs0: Vec<i64> = out0.iter().map(|r| r.seq).collect();
+    let seqs1: Vec<i64> = out1.iter().map(|r| r.seq).collect();
+    assert_eq!(seqs0, vec![1, 2]);
+    assert_eq!(seqs1, vec![1, 2, 3]);
+}
+
+#[tokio::test]
+async fn sequencer_empty_incoming_returns_zero() {
+    let db = setup_db("ch3_empty").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    let seq = make_sequencer(&t, SequencerConfig::default());
+    let result = seq.sequence_batch(&db).await.unwrap();
+    assert!(!result.any_partition_saturated);
+}
+
+#[tokio::test]
+async fn sequencer_consecutive_batches_contiguous_sequences() {
+    let db = setup_db("ch3_contiguous").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    enqueue_msgs(&t.outbox, &db, "q", 0, &["a", "b"]).await;
+    run_sequencer_once(&t, &db).await;
+
+    enqueue_msgs(&t.outbox, &db, "q", 0, &["c", "d"]).await;
+    run_sequencer_once(&t, &db).await;
+
+    let pid = t.outbox.all_partition_ids()[0];
+    let outgoing = read_outgoing(&db, pid).await;
+    let seqs: Vec<i64> = outgoing.iter().map(|r| r.seq).collect();
+    assert_eq!(seqs, vec![1, 2, 3, 4]);
+}
+
+#[tokio::test]
+async fn sequencer_batch_size_limit_enforced() {
+    let db = setup_db("ch3_batch_limit").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    enqueue_msgs(&t.outbox, &db, "q", 0, &["a", "b", "c", "d", "e"]).await;
+
+    let seq = make_sequencer(
+        &t,
+        SequencerConfig {
+            batch_size: 2,
+            ..Default::default()
+        },
+    );
+    let result = seq.sequence_batch(&db).await.unwrap();
+    assert!(result.any_partition_saturated);
+}
+
+#[tokio::test]
+async fn sequencer_saturated_partition_sets_has_more() {
+    let db = setup_db("ch3_saturated").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    enqueue_msgs(&t.outbox, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let seq = make_sequencer(
+        &t,
+        SequencerConfig {
+            batch_size: 2,
+            ..Default::default()
+        },
+    );
+    let result = seq.sequence_batch(&db).await.unwrap();
+    assert!(result.any_partition_saturated);
+}
+
+#[tokio::test]
+async fn sequencer_unsaturated_partitions_clear_has_more() {
+    let db = setup_db("ch3_unsaturated").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    enqueue_msgs(&t.outbox, &db, "q", 0, &["a"]).await;
+
+    let seq = make_sequencer(
+        &t,
+        SequencerConfig {
+            batch_size: 100,
+            ..Default::default()
+        },
+    );
+    let result = seq.sequence_batch(&db).await.unwrap();
+    assert!(!result.any_partition_saturated);
+}
+
+#[tokio::test]
+async fn sequencer_skips_empty_partitions() {
+    let db = setup_db("ch3_skip_empty").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 2).await.unwrap();
+
+    // Only enqueue to partition 1, not partition 0
+    enqueue_msgs(&t.outbox, &db, "q", 1, &["only-p1"]).await;
+    run_sequencer_once(&t, &db).await;
+
+    let ids = t.outbox.all_partition_ids();
+    let out0 = read_outgoing(&db, ids[0]).await;
+    let out1 = read_outgoing(&db, ids[1]).await;
+
+    assert!(out0.is_empty(), "partition 0 should have no outgoing");
+    assert_eq!(out1.len(), 1, "partition 1 should have 1 outgoing");
+}
+
+// ======================================================================
+// Chapter 4: Transactional Processing
+// ======================================================================
+
+async fn run_transactional(
+    db: &Db,
+    partition_id: i64,
+    handler: impl TransactionalHandler + 'static,
+    config: &QueueConfig,
+) -> Option<super::strategy::ProcessResult> {
+    let conn = db.sea_internal();
+    let backend = conn.get_database_backend();
+    let dialect = Dialect::from(backend);
+    drop(conn);
+
+    let strategy = TransactionalStrategy::new(Box::new(handler));
+    let ctx = ProcessContext {
+        db,
+        backend,
+        dialect,
+        partition_id,
+    };
+    strategy
+        .process(&ctx, config, CancellationToken::new())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn transactional_success_advances_cursor() {
+    let db = setup_db("ch4_tx_success").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    run_transactional(
+        &db,
+        pid,
+        CountingTxHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    assert_eq!(count.load(Ordering::Relaxed), 3);
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 3);
+    assert_eq!(snap.attempts, 0);
+}
+
+#[tokio::test]
+async fn transactional_retry_increments_attempts() {
+    let db = setup_db("ch4_tx_retry").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["msg"]).await;
+
+    let config = QueueConfig::default();
+    run_transactional(&db, pid, AlwaysRetryTxHandler, &config).await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 0, "cursor not advanced");
+    assert_eq!(snap.attempts, 1);
+    assert_eq!(snap.last_error.as_deref(), Some("transient tx failure"));
+}
+
+#[tokio::test]
+async fn transactional_reject_creates_dead_letter_and_advances() {
+    let db = setup_db("ch4_tx_reject").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["poison"]).await;
+
+    let config = QueueConfig::default();
+    run_transactional(&db, pid, AlwaysRejectTxHandler, &config).await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 1, "cursor advanced past rejected msg");
+
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 1);
+    assert!(dls[0].id > 0);
+    assert_eq!(dls[0].partition_id, pid);
+    assert_eq!(dls[0].seq, 1);
+    assert_eq!(dls[0].last_error.as_deref(), Some("permanently bad tx"));
+    assert_eq!(dls[0].payload, b"poison");
+    assert_eq!(dls[0].payload_type, "text/plain");
+    assert_eq!(dls[0].attempts, 0);
+    assert!(dls[0].replayed_at.is_none());
+}
+
+#[tokio::test]
+async fn transactional_batch_processes_multiple_in_single_tx() {
+    let db = setup_db("ch4_tx_batch").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    // CountingTxHandler counts the number of messages per call
+    run_transactional(
+        &db,
+        pid,
+        CountingTxHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    // Handler called once with all 3 messages
+    assert_eq!(count.load(Ordering::Relaxed), 3);
+}
+
+// ======================================================================
+// Chapter 5: Decoupled Processing
+// ======================================================================
+
+async fn run_decoupled(
+    db: &Db,
+    partition_id: i64,
+    handler: impl Handler + 'static,
+    config: &QueueConfig,
+) -> Option<super::strategy::ProcessResult> {
+    let conn = db.sea_internal();
+    let backend = conn.get_database_backend();
+    let dialect = Dialect::from(backend);
+    drop(conn);
+
+    let strategy = DecoupledStrategy::new(Box::new(handler), "test-AAAAAA".to_owned());
+    let ctx = ProcessContext {
+        db,
+        backend,
+        dialect,
+        partition_id,
+    };
+    strategy
+        .process(&ctx, config, CancellationToken::new())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn decoupled_success_advances_cursor_and_releases_lease() {
+    let db = setup_db("ch5_dc_success").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b"]).await;
+
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig {
+        msg_batch_size: 2,
+        ..Default::default()
+    };
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    assert_eq!(count.load(Ordering::Relaxed), 2);
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 2);
+    assert_eq!(snap.attempts, 0);
+    assert!(snap.locked_by.is_none(), "lease released");
+    assert!(snap.locked_until.is_none(), "lease released");
+}
+
+#[tokio::test]
+async fn decoupled_retry_preserves_cursor_and_releases_lease() {
+    let db = setup_db("ch5_dc_retry").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["msg"]).await;
+
+    let config = QueueConfig::default();
+    run_decoupled(
+        &db,
+        pid,
+        PerMessageAdapter::new(AlwaysRetryHandler),
+        &config,
+    )
+    .await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 0, "cursor unchanged");
+    assert_eq!(snap.attempts, 1, "attempts incremented by lease_acquire");
+    assert_eq!(snap.last_error.as_deref(), Some("transient failure"));
+    assert!(snap.locked_by.is_none(), "lease released");
+}
+
+#[tokio::test]
+async fn decoupled_reject_creates_dead_letter_and_releases_lease() {
+    let db = setup_db("ch5_dc_reject").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["bad"]).await;
+
+    let config = QueueConfig::default();
+    run_decoupled(
+        &db,
+        pid,
+        PerMessageAdapter::new(AlwaysRejectHandler),
+        &config,
+    )
+    .await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 1, "cursor advanced past rejected");
+    assert!(snap.locked_by.is_none(), "lease released");
+
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 1);
+    assert_eq!(dls[0].last_error.as_deref(), Some("permanently bad"));
+}
+
+#[tokio::test]
+async fn decoupled_empty_partition_releases_lease() {
+    let db = setup_db("ch5_dc_empty").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    // No messages enqueued
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig::default();
+    let result = run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    assert!(result.is_none(), "no work done");
+    assert_eq!(count.load(Ordering::Relaxed), 0);
+    let snap = read_processor_state(&db, pid).await;
+    assert!(snap.locked_by.is_none(), "lease released after empty");
+}
+
+#[tokio::test]
+async fn decoupled_each_message_adapter_processes_individually() {
+    let db = setup_db("ch5_dc_each").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let count = Arc::new(AtomicU32::new(0));
+    let handler = PerMessageAdapter::new(CountingMessageHandler {
+        count: count.clone(),
+    });
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    run_decoupled(&db, pid, handler, &config).await;
+
+    // PerMessageAdapter calls MessageHandler once per message
+    assert_eq!(count.load(Ordering::Relaxed), 3);
+}
+
+// ======================================================================
+// Chapter 6: Crash Detection & Recovery
+// ======================================================================
+
+#[tokio::test]
+async fn crash_leaves_incremented_attempts_in_db() {
+    let db = setup_db("ch6_crash_trace").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["msg"]).await;
+
+    // Simulate: lease acquired (attempts incremented in DB), then pod dies
+    simulate_crash(&db, pid, 300).await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.attempts, 1, "crash left incremented attempts");
+    assert_eq!(snap.processed_seq, 0, "cursor unchanged");
+    assert!(snap.locked_by.is_some(), "lease still held by crashed pod");
+}
+
+#[tokio::test]
+async fn recovery_after_crash_sees_nonzero_attempts() {
+    let db = setup_db("ch6_recovery").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["msg"]).await;
+
+    // Crash + expire lease so a new processor can acquire it
+    simulate_crash(&db, pid, 300).await;
+    expire_lease(&db, pid).await;
+
+    // Recovery processor should see attempts=1 (from the crash)
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = AttemptsRecorder {
+        seen_attempts: seen.clone(),
+    };
+    let config = QueueConfig::default();
+    run_decoupled(&db, pid, PerMessageAdapter::new(handler), &config).await;
+
+    {
+        let recorded = seen.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0], 1, "handler sees attempts=1 from the crash");
+    }
+
+    // After success, attempts reset to 0
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.attempts, 0);
+}
+
+#[tokio::test]
+async fn multiple_crashes_accumulate_attempts() {
+    let db = setup_db("ch6_multi_crash").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["msg"]).await;
+
+    // Two crashes
+    simulate_crash(&db, pid, 300).await;
+    expire_lease(&db, pid).await;
+    simulate_crash(&db, pid, 300).await;
+    expire_lease(&db, pid).await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.attempts, 2, "two crashes accumulated");
+}
+
+#[tokio::test]
+async fn retry_does_not_double_increment_attempts() {
+    let db = setup_db("ch6_no_double").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["msg"]).await;
+
+    // lease_acquire increments attempts 0→1 in DB;
+    // handler returns Retry; lease_record_retry does NOT increment again
+    let config = QueueConfig::default();
+    run_decoupled(
+        &db,
+        pid,
+        PerMessageAdapter::new(AlwaysRetryHandler),
+        &config,
+    )
+    .await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.attempts, 1, "not 2 - retry doesn't double-increment");
+}
+
+#[tokio::test]
+async fn success_after_crash_resets_attempts() {
+    let db = setup_db("ch6_reset").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["msg"]).await;
+
+    // Crash
+    simulate_crash(&db, pid, 300).await;
+    expire_lease(&db, pid).await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.attempts, 1);
+
+    // Recovery succeeds
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig::default();
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.attempts, 0, "success resets attempts to 0");
+    assert_eq!(snap.processed_seq, 1);
+}
+
+// ======================================================================
+// Chapter 7: Backoff & Adaptive Batching
+// ======================================================================
+
+#[tokio::test]
+async fn adaptive_batch_isolates_poison_message() {
+    let db = setup_db("ch7_poison").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    // Enqueue 4 messages; message at seq=2 is the poison pill
+    enqueue_and_sequence(&t, &db, "q", 0, &["ok1", "poison", "ok3", "ok4"]).await;
+
+    // Demonstrate the adaptive batch isolation mechanism step by step
+    // with batch_size=1 (the degraded size):
+
+    let config = QueueConfig {
+        msg_batch_size: 1,
+        ..Default::default()
+    };
+
+    // Process msg 1 (ok1) — success
+    let r = run_decoupled(
+        &db,
+        pid,
+        PerMessageAdapter::new(PoisonMessageHandler {
+            poison_seqs: vec![2],
+        }),
+        &config,
+    )
+    .await;
+    assert!(matches!(r.unwrap().handler_result, HandlerResult::Success));
+
+    // Process msg 2 (poison) — reject, dead-lettered
+    let r = run_decoupled(
+        &db,
+        pid,
+        PerMessageAdapter::new(PoisonMessageHandler {
+            poison_seqs: vec![2],
+        }),
+        &config,
+    )
+    .await;
+    assert!(matches!(
+        r.unwrap().handler_result,
+        HandlerResult::Reject { .. }
+    ));
+
+    // Process msg 3 (ok3) — success
+    let r = run_decoupled(
+        &db,
+        pid,
+        PerMessageAdapter::new(PoisonMessageHandler {
+            poison_seqs: vec![2],
+        }),
+        &config,
+    )
+    .await;
+    assert!(matches!(r.unwrap().handler_result, HandlerResult::Success));
+
+    // Process msg 4 (ok4) — success
+    let r = run_decoupled(
+        &db,
+        pid,
+        PerMessageAdapter::new(PoisonMessageHandler {
+            poison_seqs: vec![2],
+        }),
+        &config,
+    )
+    .await;
+    assert!(matches!(r.unwrap().handler_result, HandlerResult::Success));
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 4, "all 4 messages processed");
+
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 1, "only the poison message was dead-lettered");
+    assert_eq!(dls[0].seq, 2);
+}
+
+// ======================================================================
+// Chapter 8: Reaper
+// ======================================================================
+
+/// Run the reaper by processing an empty partition (reaper triggers on idle).
+async fn run_reaper(db: &Db, partition_id: i64) {
+    #[derive(Debug, FromQueryResult)]
+    struct ProcRow {
+        processed_seq: i64,
+    }
+
+    let conn = db.sea_internal();
+    let backend = conn.get_database_backend();
+    let dialect = Dialect::from(backend);
+
+    let proc_row = ProcRow::find_by_statement(Statement::from_sql_and_values(
+        backend,
+        "SELECT processed_seq FROM modkit_outbox_processor WHERE partition_id = $1",
+        [partition_id.into()],
+    ))
+    .one(&conn)
+    .await
+    .unwrap()
+    .unwrap();
+
+    if proc_row.processed_seq == 0 {
+        return;
+    }
+
+    let txn = conn.begin().await.unwrap();
+    match dialect.reaper_cleanup() {
+        super::dialect::ReaperSql::Cte(sql) => {
+            txn.execute(Statement::from_sql_and_values(
+                backend,
+                sql,
+                [partition_id.into(), proc_row.processed_seq.into()],
+            ))
+            .await
+            .unwrap();
+        }
+        super::dialect::ReaperSql::TwoStep {
+            select_body_ids,
+            delete_outgoing,
+        } => {
+            let rows = txn
+                .query_all(Statement::from_sql_and_values(
+                    backend,
+                    select_body_ids,
+                    [partition_id.into(), proc_row.processed_seq.into()],
+                ))
+                .await
+                .unwrap();
+            let body_ids: Vec<i64> = rows
+                .iter()
+                .filter_map(|r| r.try_get_by_index::<i64>(0).ok())
+                .collect();
+            txn.execute(Statement::from_sql_and_values(
+                backend,
+                delete_outgoing,
+                [partition_id.into(), proc_row.processed_seq.into()],
+            ))
+            .await
+            .unwrap();
+            if !body_ids.is_empty() {
+                let sql = dialect.build_delete_body_batch(body_ids.len());
+                let values: Vec<sea_orm::Value> = body_ids.iter().map(|&id| id.into()).collect();
+                txn.execute(Statement::from_sql_and_values(backend, &sql, values))
+                    .await
+                    .unwrap();
+            }
+        }
+    }
+    txn.commit().await.unwrap();
+}
+
+#[tokio::test]
+async fn reaper_deletes_processed_outgoing_and_body_rows() {
+    let db = setup_db("ch8_reaper_deletes").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    // Process all 3
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    // Reap
+    run_reaper(&db, pid).await;
+
+    assert_eq!(count_rows(&db, "modkit_outbox_outgoing").await, 0);
+    assert_eq!(count_rows(&db, "modkit_outbox_body").await, 0);
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 3, "cursor preserved");
+}
+
+#[tokio::test]
+async fn reaper_skips_when_processed_seq_is_zero() {
+    let db = setup_db("ch8_reaper_skip").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a"]).await;
+
+    // Don't process — cursor at 0
+    run_reaper(&db, pid).await;
+
+    assert_eq!(
+        count_rows(&db, "modkit_outbox_outgoing").await,
+        1,
+        "rows preserved"
+    );
+}
+
+#[tokio::test]
+async fn reaper_preserves_unprocessed_rows() {
+    let db = setup_db("ch8_reaper_preserves").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c", "d", "e"]).await;
+
+    // Process only 3 of 5 (msg_batch_size=3)
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 3);
+
+    // Reap — should only delete seqs 1-3
+    run_reaper(&db, pid).await;
+
+    let remaining = read_outgoing(&db, pid).await;
+    assert_eq!(remaining.len(), 2);
+    let seqs: Vec<i64> = remaining.iter().map(|r| r.seq).collect();
+    assert_eq!(seqs, vec![4, 5]);
+    for row in &remaining {
+        assert_eq!(row.partition_id, pid);
+        assert!(row.id > 0);
+        assert!(row.body_id > 0);
+    }
+}
+
+// ======================================================================
+// Chapter 9: Dead Letters
+// ======================================================================
+
+/// Helper: enqueue, sequence, and reject N messages to create dead letters.
+async fn create_dead_letters(
+    t: &TestOutbox,
+    db: &Db,
+    queue: &str,
+    partition: u32,
+    payloads: &[&str],
+) {
+    enqueue_and_sequence(t, db, queue, partition, payloads).await;
+    let ids = t.outbox.all_partition_ids();
+    let pid = ids[partition as usize];
+    let config = QueueConfig {
+        msg_batch_size: u32::try_from(payloads.len()).unwrap(),
+        ..Default::default()
+    };
+    run_decoupled(
+        db,
+        pid,
+        PerMessageAdapter::new(AlwaysRejectHandler),
+        &config,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn dead_letter_list_returns_correct_fields() {
+    let db = setup_db("ch9_dl_list").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    create_dead_letters(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let items = t
+        .outbox
+        .dead_letter_list(&db, &DeadLetterFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(items.len(), 3);
+    for item in &items {
+        assert_eq!(item.partition_id, pid);
+        assert_eq!(item.last_error.as_deref(), Some("permanently bad"));
+        assert!(item.replayed_at.is_none());
+    }
+}
+
+#[tokio::test]
+async fn dead_letter_count_matches_list() {
+    let db = setup_db("ch9_dl_count").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    create_dead_letters(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let count = t
+        .outbox
+        .dead_letter_count(&db, &DeadLetterFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(count, 3);
+}
+
+#[tokio::test]
+async fn dead_letter_replay_reinserts_and_sets_replayed_at() {
+    let db = setup_db("ch9_dl_replay").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    create_dead_letters(&t, &db, "q", 0, &["msg"]).await;
+
+    let replayed = t
+        .outbox
+        .dead_letter_replay(&db, &DeadLetterFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(replayed, 1);
+
+    // New incoming row created
+    assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 1);
+
+    // Dead letter now has replayed_at set
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 1);
+    assert!(dls[0].replayed_at.is_some());
+}
+
+#[tokio::test]
+async fn dead_letter_full_replay_roundtrip() {
+    let db = setup_db("ch9_dl_roundtrip").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    // Reject
+    create_dead_letters(&t, &db, "q", 0, &["msg"]).await;
+
+    // Replay → re-sequence → process with success handler
+    t.outbox
+        .dead_letter_replay(&db, &DeadLetterFilter::default())
+        .await
+        .unwrap();
+    run_sequencer_once(&t, &db).await;
+
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig::default();
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    assert_eq!(count.load(Ordering::Relaxed), 1);
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 2); // seq 1 was rejected, seq 2 is the replay
+}
+
+#[tokio::test]
+async fn dead_letter_purge_non_force_only_replayed() {
+    let db = setup_db("ch9_dl_purge_soft").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    // Create 2 dead letters
+    create_dead_letters(&t, &db, "q", 0, &["a", "b"]).await;
+
+    // Replay only 1 (by limit)
+    let filter_one = DeadLetterFilter {
+        limit: Some(1),
+        ..Default::default()
+    };
+    t.outbox.dead_letter_replay(&db, &filter_one).await.unwrap();
+
+    // Purge non-force — should only delete the replayed one
+    let deleted = t
+        .outbox
+        .dead_letter_purge(
+            &db,
+            &DeadLetterFilter {
+                only_pending: false,
+                ..Default::default()
+            },
+            false,
+        )
+        .await
+        .unwrap();
+    assert_eq!(deleted, 1);
+
+    // 1 pending dead letter remains
+    let remaining = t
+        .outbox
+        .dead_letter_count(&db, &DeadLetterFilter::default())
+        .await
+        .unwrap();
+    assert_eq!(remaining, 1);
+}
+
+#[tokio::test]
+async fn dead_letter_purge_force_deletes_all() {
+    let db = setup_db("ch9_dl_purge_force").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    create_dead_letters(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let deleted = t
+        .outbox
+        .dead_letter_purge(
+            &db,
+            &DeadLetterFilter {
+                only_pending: false,
+                ..Default::default()
+            },
+            true,
+        )
+        .await
+        .unwrap();
+    assert_eq!(deleted, 3);
+
+    let remaining = t
+        .outbox
+        .dead_letter_count(
+            &db,
+            &DeadLetterFilter {
+                only_pending: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(remaining, 0);
+}
+
+#[tokio::test]
+async fn dead_letter_filter_by_partition() {
+    let db = setup_db("ch9_dl_filter_part").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 2).await.unwrap();
+    let ids = t.outbox.all_partition_ids();
+
+    // Dead-letter messages on both partitions
+    create_dead_letters(&t, &db, "q", 0, &["a0"]).await;
+    create_dead_letters(&t, &db, "q", 1, &["b1", "b2"]).await;
+
+    let filter_p0 = DeadLetterFilter {
+        partition_id: Some(ids[0]),
+        ..Default::default()
+    };
+    let items = t.outbox.dead_letter_list(&db, &filter_p0).await.unwrap();
+    assert_eq!(items.len(), 1);
+
+    let filter_p1 = DeadLetterFilter {
+        partition_id: Some(ids[1]),
+        ..Default::default()
+    };
+    let items = t.outbox.dead_letter_list(&db, &filter_p1).await.unwrap();
+    assert_eq!(items.len(), 2);
+}
+
+#[tokio::test]
+async fn dead_letter_filter_with_limit() {
+    let db = setup_db("ch9_dl_filter_limit").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+
+    create_dead_letters(&t, &db, "q", 0, &["a", "b", "c", "d", "e"]).await;
+
+    let filter = DeadLetterFilter {
+        limit: Some(2),
+        ..Default::default()
+    };
+    let items = t.outbox.dead_letter_list(&db, &filter).await.unwrap();
+    assert_eq!(items.len(), 2);
+}
+
+// ======================================================================
+// Chapter 10: Builder API
+// ======================================================================
+
+#[tokio::test]
+async fn builder_start_stop_clean() {
+    let db = setup_db("ch10_start_stop").await;
+
+    let count = Arc::new(AtomicU32::new(0));
+    let handler = CountingMessageHandler {
+        count: count.clone(),
+    };
+    let handle = Outbox::builder(db)
+        .poll_interval(Duration::from_millis(50))
+        .queue("orders", Partitions::of(1))
+        .decoupled(handler)
+        .start()
+        .await
+        .unwrap();
+
+    // Just verify it started and can stop cleanly
+    handle.stop().await;
+}
+
+#[tokio::test]
+async fn builder_partitions_of_all_valid_values() {
+    for n in [1, 2, 4, 8, 16, 32, 64] {
+        let p = Partitions::of(n);
+        assert_eq!(p.count(), n);
+    }
+}
+
+#[tokio::test]
+async fn builder_multiple_queues() {
+    let db = setup_db("ch10_multi_queue").await;
+
+    let count_a = Arc::new(AtomicU32::new(0));
+    let count_b = Arc::new(AtomicU32::new(0));
+
+    let handle = Outbox::builder(db)
+        .poll_interval(Duration::from_millis(50))
+        .queue("a", Partitions::of(1))
+        .decoupled(CountingMessageHandler {
+            count: count_a.clone(),
+        })
+        .queue("b", Partitions::of(2))
+        .decoupled(CountingMessageHandler {
+            count: count_b.clone(),
+        })
+        .start()
+        .await
+        .unwrap();
+
+    let outbox = handle.outbox();
+
+    // Enqueue to both queues via a shared-cache connection
+    let db2 = setup_db("ch10_multi_queue").await;
+    let conn = db2.conn().unwrap();
+    outbox
+        .enqueue(&conn, "a", 0, b"hello-a".to_vec(), "text/plain")
+        .await
+        .unwrap();
+    outbox
+        .enqueue(&conn, "b", 0, b"hello-b".to_vec(), "text/plain")
+        .await
+        .unwrap();
+    outbox.flush();
+
+    // Wait for processing
+    poll_until(
+        || {
+            let ca = count_a.load(Ordering::Relaxed);
+            let cb = count_b.load(Ordering::Relaxed);
+            async move { ca >= 1 && cb >= 1 }
+        },
+        5000,
+    )
+    .await;
+
+    assert!(count_a.load(Ordering::Relaxed) >= 1);
+    assert!(count_b.load(Ordering::Relaxed) >= 1);
+
+    handle.stop().await;
+}
+
+// ======================================================================
+// Chapter 11: End-to-End Lifecycle
+// ======================================================================
+
+#[tokio::test]
+async fn e2e_happy_path_enqueue_through_reap() {
+    let db = setup_db("ch11_happy").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    // Enqueue → Sequence → Process (decoupled, success) → Reap
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+    run_reaper(&db, pid).await;
+
+    assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 0);
+    assert_eq!(count_rows(&db, "modkit_outbox_outgoing").await, 0);
+    assert_eq!(count_rows(&db, "modkit_outbox_body").await, 0);
+    assert_eq!(count_rows(&db, "modkit_outbox_dead_letters").await, 0);
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 3);
+    assert_eq!(snap.attempts, 0);
+}
+
+#[tokio::test]
+async fn e2e_retry_then_recovery() {
+    let db = setup_db("ch11_retry").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["msg"]).await;
+
+    let config = QueueConfig::default();
+
+    // Retry twice
+    run_decoupled(
+        &db,
+        pid,
+        PerMessageAdapter::new(AlwaysRetryHandler),
+        &config,
+    )
+    .await;
+    expire_lease(&db, pid).await;
+    run_decoupled(
+        &db,
+        pid,
+        PerMessageAdapter::new(AlwaysRetryHandler),
+        &config,
+    )
+    .await;
+    expire_lease(&db, pid).await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 0);
+    assert_eq!(snap.attempts, 2);
+
+    // Then succeed
+    let count = Arc::new(AtomicU32::new(0));
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 1);
+    assert_eq!(snap.attempts, 0, "attempts reset on success");
+}
+
+#[tokio::test]
+async fn e2e_reject_replay_success() {
+    let db = setup_db("ch11_reject_replay").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    // Reject
+    create_dead_letters(&t, &db, "q", 0, &["msg"]).await;
+
+    // Replay → re-sequence → process with success
+    t.outbox
+        .dead_letter_replay(&db, &DeadLetterFilter::default())
+        .await
+        .unwrap();
+    run_sequencer_once(&t, &db).await;
+
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig::default();
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    // Reap
+    run_reaper(&db, pid).await;
+
+    assert_eq!(count.load(Ordering::Relaxed), 1);
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 2);
+
+    // Dead letter has replayed_at set
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 1);
+    assert!(dls[0].replayed_at.is_some());
+
+    // Body and outgoing cleaned up
+    assert_eq!(count_rows(&db, "modkit_outbox_outgoing").await, 0);
+    assert_eq!(count_rows(&db, "modkit_outbox_body").await, 0);
+}
+
+#[tokio::test]
+async fn e2e_crash_then_recovery() {
+    let db = setup_db("ch11_crash").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["msg"]).await;
+
+    // Simulate crash
+    simulate_crash(&db, pid, 300).await;
+    expire_lease(&db, pid).await;
+
+    // Recovery processor succeeds
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = AttemptsRecorder {
+        seen_attempts: seen.clone(),
+    };
+    let config = QueueConfig::default();
+    run_decoupled(&db, pid, PerMessageAdapter::new(handler), &config).await;
+
+    {
+        let recorded = seen.lock().unwrap();
+        assert_eq!(recorded[0], 1, "handler saw attempts=1 from crash");
+    }
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 1);
+    assert_eq!(snap.attempts, 0, "attempts reset after successful recovery");
+}
+
+// ======================================================================
+// Chapter 12: PerMessageAdapter partial failure
+// ======================================================================
+
+/// Test helper: records which seqs the handler was called with,
+/// rejects or retries at a configurable poison seq.
+struct PartialFailureHandler {
+    seen_seqs: Arc<Mutex<Vec<i64>>>,
+    poison_seq: i64,
+    reject: bool, // true = Reject, false = Retry
+}
+
+#[async_trait::async_trait]
+impl MessageHandler for PartialFailureHandler {
+    async fn handle(&self, msg: &OutboxMessage, _cancel: CancellationToken) -> HandlerResult {
+        self.seen_seqs.lock().unwrap().push(msg.seq);
+        if msg.seq == self.poison_seq {
+            if self.reject {
+                return HandlerResult::Reject {
+                    reason: format!("poison seq={}", msg.seq),
+                };
+            }
+            return HandlerResult::Retry {
+                reason: format!("transient seq={}", msg.seq),
+            };
+        }
+        HandlerResult::Success
+    }
+}
+
+/// Transactional version of `PartialFailureHandler`.
+struct TxPartialFailureHandler {
+    seen_seqs: Arc<Mutex<Vec<i64>>>,
+    poison_seq: i64,
+    reject: bool,
+}
+
+#[async_trait::async_trait]
+impl TransactionalMessageHandler for TxPartialFailureHandler {
+    async fn handle(
+        &self,
+        _txn: &dyn ConnectionTrait,
+        msg: &OutboxMessage,
+        _cancel: CancellationToken,
+    ) -> HandlerResult {
+        self.seen_seqs.lock().unwrap().push(msg.seq);
+        if msg.seq == self.poison_seq {
+            if self.reject {
+                return HandlerResult::Reject {
+                    reason: format!("poison seq={}", msg.seq),
+                };
+            }
+            return HandlerResult::Retry {
+                reason: format!("transient seq={}", msg.seq),
+            };
+        }
+        HandlerResult::Success
+    }
+}
+
+/// Batch handler that always rejects — no `processed_count` side-channel.
+struct BatchRejectHandler;
+
+#[async_trait::async_trait]
+impl Handler for BatchRejectHandler {
+    async fn handle(&self, _msgs: &[OutboxMessage], _cancel: CancellationToken) -> HandlerResult {
+        HandlerResult::Reject {
+            reason: "batch reject".into(),
+        }
+    }
+}
+
+// ---- 14.3 Transactional strategy tests ----
+
+#[tokio::test]
+async fn tx_partial_reject_processed_count_in_result() {
+    let db = setup_db("ch12_tx_partial_reject_pc").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c", "d", "e"]).await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = PerMessageAdapter::new(TxPartialFailureHandler {
+        seen_seqs: seen.clone(),
+        poison_seq: 3, // seqs are 1-based; poison at seq=3
+        reject: true,
+    });
+    let config = QueueConfig {
+        msg_batch_size: 5,
+        ..Default::default()
+    };
+    let result = run_transactional(&db, pid, handler, &config).await;
+
+    let pr = result.expect("should have a result");
+    assert!(matches!(pr.handler_result, HandlerResult::Reject { .. }));
+    // PerMessageAdapter processed seqs 1, 2 successfully before poison at seq 3
+    assert_eq!(pr.processed_count, Some(2));
+
+    // Transactional mode: all messages dead-lettered (tx is atomic)
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 5, "all 5 messages dead-lettered in tx mode");
+
+    // Cursor advances past all messages
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 5);
+}
+
+#[tokio::test]
+async fn tx_partial_retry_rolls_back_all() {
+    let db = setup_db("ch12_tx_partial_retry").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = PerMessageAdapter::new(TxPartialFailureHandler {
+        seen_seqs: seen.clone(),
+        poison_seq: 2,
+        reject: false, // retry
+    });
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    let result = run_transactional(&db, pid, handler, &config).await;
+
+    let pr = result.expect("should have a result");
+    assert!(matches!(pr.handler_result, HandlerResult::Retry { .. }));
+    assert_eq!(pr.processed_count, Some(1)); // seq 1 succeeded before retry at seq 2
+
+    // Cursor not advanced on retry
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 0, "cursor unchanged on retry");
+
+    // No dead letters on retry
+    let dls = read_dead_letters(&db).await;
+    assert!(dls.is_empty(), "no dead letters on retry");
+}
+
+#[tokio::test]
+async fn tx_reject_at_first_msg_processed_count_zero() {
+    let db = setup_db("ch12_tx_reject_first").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b"]).await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = PerMessageAdapter::new(TxPartialFailureHandler {
+        seen_seqs: seen.clone(),
+        poison_seq: 1, // first message
+        reject: true,
+    });
+    let config = QueueConfig {
+        msg_batch_size: 2,
+        ..Default::default()
+    };
+    let result = run_transactional(&db, pid, handler, &config).await;
+
+    let pr = result.expect("should have a result");
+    assert_eq!(pr.processed_count, Some(0));
+}
+
+#[tokio::test]
+async fn tx_batch_handler_reject_deadletters_all() {
+    let db = setup_db("ch12_tx_batch_reject").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    let result = run_transactional(&db, pid, AlwaysRejectTxHandler, &config).await;
+
+    let pr = result.expect("should have a result");
+    assert_eq!(pr.processed_count, None, "batch handler returns None");
+
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 3, "all dead-lettered");
+}
+
+// ---- 14.4 Decoupled strategy tests ----
+
+#[tokio::test]
+async fn decoupled_partial_reject_deadletters_only_remaining() {
+    let db = setup_db("ch12_dc_partial_reject").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c", "d", "e"]).await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = PerMessageAdapter::new(PartialFailureHandler {
+        seen_seqs: seen.clone(),
+        poison_seq: 3,
+        reject: true,
+    });
+    let config = QueueConfig {
+        msg_batch_size: 5,
+        ..Default::default()
+    };
+    let result = run_decoupled(&db, pid, handler, &config).await;
+
+    let pr = result.expect("should have a result");
+    assert!(matches!(pr.handler_result, HandlerResult::Reject { .. }));
+    assert_eq!(pr.processed_count, Some(2));
+
+    // Decoupled partial reject: only msgs[2..] (seqs 3,4,5) dead-lettered
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 3, "only 3 remaining messages dead-lettered");
+    let dl_seqs: Vec<i64> = dls.iter().map(|d| d.seq).collect();
+    assert_eq!(dl_seqs, vec![3, 4, 5]);
+
+    // Cursor advances past all messages
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 5);
+}
+
+#[tokio::test]
+async fn decoupled_reject_at_first_deadletters_all() {
+    let db = setup_db("ch12_dc_reject_first").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = PerMessageAdapter::new(PartialFailureHandler {
+        seen_seqs: seen.clone(),
+        poison_seq: 1, // first message
+        reject: true,
+    });
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    let result = run_decoupled(&db, pid, handler, &config).await;
+
+    let pr = result.expect("should have a result");
+    assert_eq!(pr.processed_count, Some(0));
+
+    // processed_count=0, so all messages dead-lettered
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 3, "all dead-lettered when poison is first");
+}
+
+#[tokio::test]
+async fn decoupled_retry_does_not_advance_cursor() {
+    let db = setup_db("ch12_dc_retry_no_advance").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = PerMessageAdapter::new(PartialFailureHandler {
+        seen_seqs: seen.clone(),
+        poison_seq: 2,
+        reject: false,
+    });
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    let result = run_decoupled(&db, pid, handler, &config).await;
+
+    let pr = result.expect("should have a result");
+    assert!(matches!(pr.handler_result, HandlerResult::Retry { .. }));
+    assert_eq!(pr.processed_count, Some(1));
+
+    let snap = read_processor_state(&db, pid).await;
+    assert_eq!(snap.processed_seq, 0, "cursor not advanced on retry");
+
+    let dls = read_dead_letters(&db).await;
+    assert!(dls.is_empty(), "no dead letters on retry");
+}
+
+#[tokio::test]
+async fn decoupled_batch_handler_reject_deadletters_all() {
+    let db = setup_db("ch12_dc_batch_reject").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    let result = run_decoupled(&db, pid, BatchRejectHandler, &config).await;
+
+    let pr = result.expect("should have a result");
+    assert_eq!(pr.processed_count, None, "batch handler returns None");
+
+    // None → all messages dead-lettered
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 3, "all dead-lettered for batch handler");
+}
+
+// ---- 14.5 Multi-cycle degradation tests ----
+
+#[tokio::test]
+async fn degradation_with_processed_count() {
+    use super::processor::PartitionMode;
+
+    // Simulate: batch_size=8, poison at position 3 (0-indexed)
+    // → processed_count = 3, degrade to max(3, 1) = 3
+    let mut mode = PartitionMode::Normal;
+    mode.transition(
+        &HandlerResult::Reject {
+            reason: "poison".into(),
+        },
+        8,
+        Some(3),
+    );
+    assert_eq!(mode.effective_batch_size(8), 3);
+
+    // Next success: 3 → 6
+    mode.transition(&HandlerResult::Success, 8, None);
+    assert_eq!(mode.effective_batch_size(8), 6);
+
+    // Next success: 6 → Normal(8)
+    mode.transition(&HandlerResult::Success, 8, None);
+    assert!(matches!(mode, PartitionMode::Normal));
+}
+
+#[tokio::test]
+async fn degradation_batch_handler_falls_back_to_one() {
+    use super::processor::PartitionMode;
+
+    let mut mode = PartitionMode::Normal;
+    // Batch handler: None processed_count → degrade to 1
+    mode.transition(
+        &HandlerResult::Reject {
+            reason: "bad".into(),
+        },
+        8,
+        None,
+    );
+    assert_eq!(mode.effective_batch_size(8), 1);
+}
+
+#[tokio::test]
+async fn degradation_processed_count_zero_degrades_to_one() {
+    use super::processor::PartitionMode;
+
+    let mut mode = PartitionMode::Normal;
+    // processed_count=0 → max(0, 1) = 1
+    mode.transition(
+        &HandlerResult::Retry {
+            reason: "fail".into(),
+        },
+        8,
+        Some(0),
+    );
+    assert_eq!(mode.effective_batch_size(8), 1);
+}
+
+// ---- 14.6 Edge case tests ----
+
+#[tokio::test]
+async fn batch_size_one_partial_failure_is_noop() {
+    // With batch_size=1, PerMessageAdapter processes exactly 1 message.
+    // If it rejects, processed_count=0, skip=0 → all (1) dead-lettered.
+    // This is the same as full rejection — no partial behavior.
+    let db = setup_db("ch12_batch_one_noop").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a"]).await;
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let handler = PerMessageAdapter::new(PartialFailureHandler {
+        seen_seqs: seen.clone(),
+        poison_seq: 1,
+        reject: true,
+    });
+    let config = QueueConfig::default(); // batch_size=1
+    let result = run_decoupled(&db, pid, handler, &config).await;
+
+    let pr = result.expect("should have a result");
+    assert_eq!(pr.processed_count, Some(0));
+
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 1, "single message dead-lettered");
+}
+
+#[tokio::test]
+async fn processed_count_exceeds_batch_is_clamped() {
+    use super::processor::PartitionMode;
+
+    // Even if processed_count somehow exceeds batch count, clamping prevents
+    // invalid state. The processor clamps pc to count before passing to transition.
+    let mut mode = PartitionMode::Normal;
+    // Simulated: count=3, processed_count=5 → clamped to 3 by processor
+    let clamped = Some(3u32);
+    mode.transition(&HandlerResult::Reject { reason: "x".into() }, 8, clamped);
+    assert_eq!(mode.effective_batch_size(8), 3);
+}

--- a/libs/modkit-db/src/outbox/manager.rs
+++ b/libs/modkit-db/src/outbox/manager.rs
@@ -1,0 +1,195 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use tokio::sync::{Notify, Semaphore};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use super::builder::QueueBuilder;
+use super::core::Outbox;
+use super::sequencer::Sequencer;
+use super::types::{OutboxConfig, OutboxError, Partitions, QueueConfig, SequencerConfig};
+use crate::Db;
+
+/// Type-erased spawn function captured by the builder.
+/// Called once at `start()` to spawn a per-partition processor task.
+pub type SpawnFn =
+    Box<dyn FnOnce(Db, CancellationToken, Arc<Notify>, Arc<Semaphore>) -> JoinHandle<()> + Send>;
+
+/// Deferred spawn factory — creates `SpawnFn`s at `start()` time when
+/// `Arc<Outbox>` is available.
+pub type DeferredSpawnFactory = Box<dyn FnMut(i64, Arc<Outbox>) -> SpawnFn + Send>;
+
+/// Deferred queue declaration — config + spawn factory, resolved at `start()`.
+pub struct QueueDeclaration {
+    pub(crate) name: String,
+    pub(crate) partitions: Partitions,
+    pub(crate) config: QueueConfig,
+    pub(crate) make_spawn_fn: DeferredSpawnFactory,
+}
+
+/// Fluent builder for the outbox pipeline.
+///
+/// Entry point: [`Outbox::builder(db)`](Outbox::builder). Configure global
+/// settings and register queues with handlers, then call
+/// [`start()`](Self::start) to spawn background tasks.
+///
+/// ```ignore
+/// let handle = Outbox::builder(db)
+///     .poll_interval(Duration::from_millis(100))
+///     .queue("orders", Partitions::of(4))
+///         .decoupled(my_handler)
+///     .start().await?;
+/// // enqueue via handle.outbox()
+/// handle.stop().await;
+/// ```
+pub struct OutboxBuilder {
+    db: Db,
+    sequencer_batch_size: u32,
+    poll_interval: Duration,
+    pub(crate) queue_declarations: Vec<QueueDeclaration>,
+}
+
+impl OutboxBuilder {
+    pub(crate) fn new(db: Db) -> Self {
+        Self {
+            db,
+            sequencer_batch_size: super::types::DEFAULT_SEQUENCER_BATCH_SIZE,
+            poll_interval: super::types::DEFAULT_POLL_INTERVAL,
+            queue_declarations: Vec::new(),
+        }
+    }
+
+    /// Sequencer batch size (rows per cycle). Default: 100.
+    #[must_use]
+    pub fn sequencer_batch_size(mut self, n: u32) -> Self {
+        self.sequencer_batch_size = n;
+        self
+    }
+
+    /// Safety net fallback poll interval for both the sequencer and
+    /// per-partition processors. Default: 1s.
+    #[must_use]
+    pub fn poll_interval(mut self, d: Duration) -> Self {
+        self.poll_interval = d;
+        self
+    }
+
+    /// Begin building a queue registration.
+    #[must_use]
+    pub fn queue(self, name: &str, partitions: Partitions) -> QueueBuilder {
+        QueueBuilder::new(self, name.to_owned(), partitions)
+    }
+
+    /// Spawn background tasks and return a handle to the running pipeline.
+    ///
+    /// Registers all queues in the database, creates the sequencer and
+    /// per-partition processors, then starts them as background tasks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if queue registration fails (DB operation).
+    pub async fn start(mut self) -> Result<OutboxHandle, OutboxError> {
+        let sequencer_notify = Arc::new(Notify::new());
+        let config = OutboxConfig {
+            sequencer: SequencerConfig {
+                batch_size: self.sequencer_batch_size,
+                poll_interval: self.poll_interval,
+            },
+        };
+        let outbox = Arc::new(Outbox::new(config, Arc::clone(&sequencer_notify)));
+
+        let cancel = CancellationToken::new();
+        let mut handles = Vec::new();
+        let partition_notify: DashMap<i64, Arc<Notify>> = DashMap::new();
+
+        // Register queues and create spawn closures
+        for decl in &mut self.queue_declarations {
+            // Apply global poll_interval to each queue
+            decl.config.poll_interval = self.poll_interval;
+
+            outbox
+                .register_queue(&self.db, &decl.name, decl.partitions.count())
+                .await?;
+
+            let partition_ids = outbox.partition_ids_for_queue(&decl.name);
+            let sem = Arc::new(Semaphore::new(
+                decl.config
+                    .max_concurrent_partitions
+                    .min(Semaphore::MAX_PERMITS),
+            ));
+
+            for &pid in &partition_ids {
+                let notify = Arc::new(Notify::new());
+                partition_notify.insert(pid, Arc::clone(&notify));
+                let spawn_fn = (decl.make_spawn_fn)(pid, Arc::clone(&outbox));
+                let handle = spawn_fn(self.db.clone(), cancel.clone(), notify, Arc::clone(&sem));
+                handles.push(handle);
+            }
+        }
+
+        // Collect per-partition notify map for the sequencer
+        let mut notify_map: HashMap<i64, Arc<Notify>> = HashMap::new();
+        for entry in &partition_notify {
+            notify_map.insert(*entry.key(), Arc::clone(entry.value()));
+        }
+        let notify_map = Arc::new(notify_map);
+
+        // Spawn sequencer
+        let sequencer = Sequencer::new(
+            outbox.config().sequencer.clone(),
+            Arc::clone(&outbox),
+            Arc::clone(&sequencer_notify),
+        );
+        sequencer.set_partition_notify(Arc::clone(&notify_map));
+        let seq_cancel = cancel.clone();
+        let seq_db = self.db.clone();
+
+        let seq_handle = tokio::spawn(async move {
+            if let Err(e) = sequencer.run(&seq_db, seq_cancel).await {
+                tracing::error!(error = %e, "sequencer exited with error");
+            }
+        });
+        handles.push(seq_handle);
+
+        Ok(OutboxHandle {
+            outbox,
+            cancel,
+            handles,
+        })
+    }
+}
+
+/// A running outbox pipeline. Obtained by calling [`OutboxBuilder::start()`].
+///
+/// Provides access to the [`Outbox`] for enqueue operations and a
+/// [`stop()`](Self::stop) method for graceful shutdown.
+pub struct OutboxHandle {
+    outbox: Arc<Outbox>,
+    cancel: CancellationToken,
+    handles: Vec<JoinHandle<()>>,
+}
+
+impl OutboxHandle {
+    /// Returns the outbox for enqueue operations.
+    #[must_use]
+    pub fn outbox(&self) -> &Arc<Outbox> {
+        &self.outbox
+    }
+
+    /// Cancel background tasks and join all handles. Consumes self.
+    pub async fn stop(self) {
+        self.cancel.cancel();
+        for handle in self.handles {
+            drop(handle.await);
+        }
+    }
+
+    /// Access the cancellation token (for composing with external shutdown).
+    #[must_use]
+    pub fn cancel_token(&self) -> &CancellationToken {
+        &self.cancel
+    }
+}

--- a/libs/modkit-db/src/outbox/migrations.rs
+++ b/libs/modkit-db/src/outbox/migrations.rs
@@ -1,0 +1,362 @@
+use sea_orm::{ConnectionTrait, DatabaseBackend, DbErr, Statement};
+use sea_orm_migration::prelude::*;
+
+/// Single migration that creates the entire outbox schema.
+///
+/// Tables are created in FK dependency order:
+/// body → partitions → incoming → outgoing → dead-letters → processor
+struct CreateOutboxSchema;
+
+impl MigrationName for CreateOutboxSchema {
+    fn name(&self) -> &'static str {
+        "m001_create_modkit_outbox_schema"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for CreateOutboxSchema {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        let backend = conn.get_database_backend();
+
+        create_body(conn, backend).await?;
+        create_partitions(conn, backend).await?;
+        create_incoming(conn, backend).await?;
+        create_outgoing(conn, backend).await?;
+        create_dead_letters(conn, backend).await?;
+        create_processor(conn, backend).await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        let backend = conn.get_database_backend();
+
+        for table in [
+            "modkit_outbox_processor",
+            "modkit_outbox_dead_letters",
+            "modkit_outbox_outgoing",
+            "modkit_outbox_incoming",
+            "modkit_outbox_partitions",
+            "modkit_outbox_body",
+        ] {
+            conn.execute(Statement::from_string(
+                backend,
+                format!("DROP TABLE IF EXISTS {table}"),
+            ))
+            .await?;
+        }
+        Ok(())
+    }
+}
+
+async fn create_body(conn: &dyn ConnectionTrait, backend: DatabaseBackend) -> Result<(), DbErr> {
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_body (
+                id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                payload       BYTEA  NOT NULL,
+                payload_type  TEXT   NOT NULL,
+                created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+            )"
+            }
+            DatabaseBackend::Sqlite => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_body (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                payload       BLOB   NOT NULL,
+                payload_type  TEXT   NOT NULL,
+                created_at    TEXT   NOT NULL DEFAULT (datetime('now'))
+            )"
+            }
+            DatabaseBackend::MySql => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_body (
+                id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+                payload       LONGBLOB NOT NULL,
+                payload_type  TEXT     NOT NULL,
+                created_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+            )"
+            }
+        },
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn create_partitions(
+    conn: &dyn ConnectionTrait,
+    backend: DatabaseBackend,
+) -> Result<(), DbErr> {
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_partitions (
+                id        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                queue     TEXT     NOT NULL,
+                partition SMALLINT NOT NULL,
+                sequence  BIGINT   NOT NULL DEFAULT 0,
+                UNIQUE (queue, partition)
+            )"
+            }
+            DatabaseBackend::Sqlite => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_partitions (
+                id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                queue     TEXT    NOT NULL,
+                partition INTEGER NOT NULL,
+                sequence  INTEGER NOT NULL DEFAULT 0,
+                UNIQUE (queue, partition)
+            )"
+            }
+            DatabaseBackend::MySql => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_partitions (
+                id        BIGINT AUTO_INCREMENT PRIMARY KEY,
+                queue     VARCHAR(255) NOT NULL,
+                `partition` SMALLINT NOT NULL,
+                sequence  BIGINT   NOT NULL DEFAULT 0,
+                UNIQUE KEY (queue, `partition`)
+            )"
+            }
+        },
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn create_incoming(
+    conn: &dyn ConnectionTrait,
+    backend: DatabaseBackend,
+) -> Result<(), DbErr> {
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_incoming (
+                id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                partition_id BIGINT   NOT NULL REFERENCES modkit_outbox_partitions(id),
+                body_id      BIGINT   NOT NULL REFERENCES modkit_outbox_body(id),
+                created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+            )"
+            }
+            DatabaseBackend::Sqlite => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_incoming (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                partition_id INTEGER NOT NULL REFERENCES modkit_outbox_partitions(id),
+                body_id      INTEGER NOT NULL REFERENCES modkit_outbox_body(id),
+                created_at   TEXT    NOT NULL DEFAULT (datetime('now'))
+            )"
+            }
+            DatabaseBackend::MySql => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_incoming (
+                id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+                partition_id BIGINT NOT NULL,
+                body_id      BIGINT NOT NULL,
+                created_at   TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                FOREIGN KEY (partition_id) REFERENCES modkit_outbox_partitions(id),
+                FOREIGN KEY (body_id) REFERENCES modkit_outbox_body(id)
+            )"
+            }
+        },
+    ))
+    .await?;
+
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres | DatabaseBackend::Sqlite => {
+                "CREATE INDEX IF NOT EXISTS idx_modkit_outbox_incoming_partition \
+             ON modkit_outbox_incoming (partition_id, id)"
+            }
+            DatabaseBackend::MySql => {
+                "CREATE INDEX idx_modkit_outbox_incoming_partition \
+             ON modkit_outbox_incoming (partition_id, id)"
+            }
+        },
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn create_outgoing(
+    conn: &dyn ConnectionTrait,
+    backend: DatabaseBackend,
+) -> Result<(), DbErr> {
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_outgoing (
+                id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                partition_id BIGINT NOT NULL REFERENCES modkit_outbox_partitions(id),
+                body_id      BIGINT NOT NULL REFERENCES modkit_outbox_body(id),
+                seq          BIGINT NOT NULL,
+                created_at   TIMESTAMPTZ NOT NULL,
+                sequenced_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )"
+            }
+            DatabaseBackend::Sqlite => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_outgoing (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                partition_id INTEGER NOT NULL REFERENCES modkit_outbox_partitions(id),
+                body_id      INTEGER NOT NULL REFERENCES modkit_outbox_body(id),
+                seq          INTEGER NOT NULL,
+                created_at   TEXT    NOT NULL,
+                sequenced_at TEXT    NOT NULL DEFAULT (datetime('now'))
+            )"
+            }
+            DatabaseBackend::MySql => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_outgoing (
+                id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+                partition_id BIGINT NOT NULL,
+                body_id      BIGINT NOT NULL,
+                seq          BIGINT NOT NULL,
+                created_at   TIMESTAMP(6) NOT NULL,
+                sequenced_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                FOREIGN KEY (partition_id) REFERENCES modkit_outbox_partitions(id),
+                FOREIGN KEY (body_id) REFERENCES modkit_outbox_body(id)
+            )"
+            }
+        },
+    ))
+    .await?;
+
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres | DatabaseBackend::Sqlite => {
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_modkit_outbox_outgoing_partition_seq \
+             ON modkit_outbox_outgoing (partition_id, seq)"
+            }
+            DatabaseBackend::MySql => {
+                "CREATE UNIQUE INDEX idx_modkit_outbox_outgoing_partition_seq \
+             ON modkit_outbox_outgoing (partition_id, seq)"
+            }
+        },
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn create_dead_letters(
+    conn: &dyn ConnectionTrait,
+    backend: DatabaseBackend,
+) -> Result<(), DbErr> {
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_dead_letters (
+                id           BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                partition_id BIGINT NOT NULL REFERENCES modkit_outbox_partitions(id),
+                seq          BIGINT NOT NULL,
+                payload      BYTEA  NOT NULL,
+                payload_type TEXT   NOT NULL,
+                created_at   TIMESTAMPTZ NOT NULL,
+                failed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+                last_error   TEXT,
+                attempts     SMALLINT NOT NULL,
+                replayed_at  TIMESTAMPTZ
+            )"
+            }
+            DatabaseBackend::Sqlite => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_dead_letters (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                partition_id INTEGER NOT NULL REFERENCES modkit_outbox_partitions(id),
+                seq          INTEGER NOT NULL,
+                payload      BLOB   NOT NULL,
+                payload_type TEXT   NOT NULL,
+                created_at   TEXT    NOT NULL,
+                failed_at    TEXT    NOT NULL DEFAULT (datetime('now')),
+                last_error   TEXT,
+                attempts     INTEGER NOT NULL,
+                replayed_at  TEXT
+            )"
+            }
+            DatabaseBackend::MySql => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_dead_letters (
+                id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+                partition_id BIGINT NOT NULL,
+                seq          BIGINT NOT NULL,
+                payload      LONGBLOB NOT NULL,
+                payload_type TEXT     NOT NULL,
+                created_at   TIMESTAMP(6) NOT NULL,
+                failed_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                last_error   TEXT,
+                attempts     SMALLINT NOT NULL,
+                replayed_at  TIMESTAMP(6) NULL,
+                FOREIGN KEY (partition_id) REFERENCES modkit_outbox_partitions(id)
+            )"
+            }
+        },
+    ))
+    .await?;
+
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres | DatabaseBackend::Sqlite => {
+                "CREATE INDEX IF NOT EXISTS idx_modkit_outbox_dead_letters_pending \
+             ON modkit_outbox_dead_letters (failed_at) \
+             WHERE replayed_at IS NULL"
+            }
+            DatabaseBackend::MySql => {
+                "CREATE INDEX idx_modkit_outbox_dead_letters_pending \
+             ON modkit_outbox_dead_letters (failed_at, replayed_at)"
+            }
+        },
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn create_processor(
+    conn: &dyn ConnectionTrait,
+    backend: DatabaseBackend,
+) -> Result<(), DbErr> {
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_processor (
+                partition_id  BIGINT PRIMARY KEY REFERENCES modkit_outbox_partitions(id),
+                processed_seq BIGINT   NOT NULL DEFAULT 0,
+                attempts      SMALLINT NOT NULL DEFAULT 0,
+                last_error    TEXT,
+                locked_by     TEXT,
+                locked_until  TIMESTAMPTZ
+            )"
+            }
+            DatabaseBackend::Sqlite => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_processor (
+                partition_id  INTEGER PRIMARY KEY REFERENCES modkit_outbox_partitions(id),
+                processed_seq INTEGER NOT NULL DEFAULT 0,
+                attempts      INTEGER NOT NULL DEFAULT 0,
+                last_error    TEXT,
+                locked_by     TEXT,
+                locked_until  TEXT
+            )"
+            }
+            DatabaseBackend::MySql => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_processor (
+                partition_id  BIGINT PRIMARY KEY,
+                processed_seq BIGINT   NOT NULL DEFAULT 0,
+                attempts      SMALLINT NOT NULL DEFAULT 0,
+                last_error    TEXT,
+                locked_by     TEXT,
+                locked_until  TIMESTAMP(6) NULL,
+                FOREIGN KEY (partition_id) REFERENCES modkit_outbox_partitions(id)
+            )"
+            }
+        },
+    ))
+    .await?;
+    Ok(())
+}
+
+/// Returns all outbox migrations in dependency order.
+#[must_use]
+pub fn outbox_migrations() -> Vec<Box<dyn MigrationTrait>> {
+    vec![Box::new(CreateOutboxSchema)]
+}

--- a/libs/modkit-db/src/outbox/mod.rs
+++ b/libs/modkit-db/src/outbox/mod.rs
@@ -1,0 +1,115 @@
+//! Transactional outbox for reliable asynchronous message production.
+//!
+//! # Architecture
+//!
+//! Four-stage pipeline: **incoming → sequencer → outgoing → processor**.
+//!
+//! 1. **Enqueue** — messages are written atomically within business transactions
+//!    to the `incoming` table via [`Outbox::enqueue()`].
+//! 2. **Sequencer** — a background task claims incoming rows, assigns
+//!    per-partition sequence numbers, and writes to the `outgoing` table.
+//! 3. **Processor** — one long-lived task per partition reads from `outgoing`,
+//!    dispatches to the registered handler, and acks via cursor advance
+//!    (append-only — no deletes on the hot path).
+//! 4. **Reaper** — when a partition is idle, the processor bulk-deletes
+//!    processed outgoing and body rows.
+//!
+//! # Processing modes
+//!
+//! - **Transactional** — handler runs inside the DB transaction holding the
+//!   partition lock. Provides exactly-once semantics within the database.
+//! - **Decoupled** — handler runs outside any transaction, with lease-based
+//!   locking. Provides at-least-once delivery; handlers must be idempotent.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! let handle = Outbox::builder(db)
+//!     .poll_interval(Duration::from_millis(100))
+//!     .queue("orders", Partitions::of(4))
+//!         .decoupled(my_handler)
+//!     .start().await?;
+//! // ... enqueue via handle.outbox() ...
+//! handle.stop().await;
+//! ```
+//!
+//! # Backend notes
+//!
+//! - **`PostgreSQL`** — Full support. Uses `FOR UPDATE SKIP LOCKED` for partition
+//!   locking and `INSERT ... RETURNING` for body ID retrieval.
+//! - **`MySQL` 8.0+** — Requires `MySQL` 8.0 or later for `FOR UPDATE SKIP LOCKED`
+//!   support (added in 8.0.1). Earlier versions will fail at runtime when
+//!   attempting to acquire partition locks. Uses `LAST_INSERT_ID()` for body IDs.
+//! - **`SQLite`** — Single-process only. `SQLite` has no row-level locking; the
+//!   outbox relies on `SQLite`'s single-writer model. Suitable for development,
+//!   testing, and single-instance deployments. Not recommended for production
+//!   multi-process scenarios.
+//!
+//! # Dead letters
+//!
+//! Messages that a handler permanently rejects ([`HandlerResult::Reject`]) are
+//! moved to a dead-letter table with the original payload, partition, sequence,
+//! and error reason preserved. The outbox does **not** auto-replay dead letters;
+//! that policy is owned by the application.
+//!
+//! Dead letter operations are available as methods on [`Outbox`]:
+//! [`dead_letter_list`](Outbox::dead_letter_list),
+//! [`dead_letter_count`](Outbox::dead_letter_count),
+//! [`dead_letter_replay`](Outbox::dead_letter_replay), and
+//! [`dead_letter_purge`](Outbox::dead_letter_purge).
+//!
+//! ## Consumption patterns
+//!
+//! 1. **Scheduled background worker** — poll on a timer, replay if count > 0:
+//!
+//!    ```ignore
+//!    loop {
+//!        let count = outbox.dead_letter_count(&db, &DeadLetterFilter::default()).await?;
+//!        if count > 0 {
+//!            tracing::warn!(count, "dead letters detected — replaying");
+//!            outbox.dead_letter_replay(&db, &DeadLetterFilter::default()).await?;
+//!        }
+//!        tokio::time::sleep(Duration::from_secs(300)).await;
+//!    }
+//!    ```
+//!
+//! 2. **Admin REST endpoint** — expose list/replay/purge via HTTP for manual
+//!    investigation and recovery.
+//!
+//! 3. **On-demand CLI** — a maintenance command that replays or purges with
+//!    filters (by queue, partition, time range).
+//!
+//! Replayed messages go through the full pipeline (incoming → sequencer →
+//! outgoing → processor). Handlers must be idempotent — a replayed message
+//! may be delivered more than once if the handler previously produced
+//! side-effects before rejecting.
+
+mod builder;
+mod core;
+mod dead_letter;
+mod dialect;
+mod handler;
+mod manager;
+mod migrations;
+mod processor;
+mod sequencer;
+mod strategy;
+mod types;
+
+#[cfg(test)]
+#[cfg(feature = "sqlite")]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod integration_tests;
+
+pub use builder::QueueBuilder;
+pub use core::Outbox;
+pub use dead_letter::{DeadLetterFilter, DeadLetterMessage};
+pub use handler::{
+    Handler, HandlerResult, MessageHandler, OutboxMessage, PerMessageAdapter, TransactionalHandler,
+    TransactionalMessageHandler,
+};
+pub use manager::{OutboxBuilder, OutboxHandle};
+pub use migrations::outbox_migrations;
+pub use types::{EnqueueMessage, OutboxError, OutboxMessageId, Partitions};
+
+// Internal re-exports for tests and internal modules

--- a/libs/modkit-db/src/outbox/processor.rs
+++ b/libs/modkit-db/src/outbox/processor.rs
@@ -1,0 +1,637 @@
+use std::sync::Arc;
+
+use sea_orm::{ConnectionTrait, DbBackend, Statement, TransactionTrait};
+use tokio::sync::{Notify, Semaphore};
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+use super::dialect::{Dialect, ReaperSql};
+use super::handler::HandlerResult;
+use super::strategy::{ProcessContext, ProcessingStrategy};
+use super::types::{OutboxError, QueueConfig};
+use crate::Db;
+
+/// Max body IDs per batched DELETE in the reaper.
+const REAPER_CHUNK_SIZE: usize = 100;
+
+/// Per-partition adaptive batch sizing state machine.
+///
+/// Degrades to single-message mode on failure, ramps back up on consecutive
+/// successes. Analogous to TCP slow start.
+#[derive(Debug, Clone)]
+pub enum PartitionMode {
+    /// Normal operation — use configured `msg_batch_size`.
+    Normal,
+    /// Degraded after failure — process fewer messages at a time.
+    /// Ramps back up (doubling) on consecutive successes until reaching
+    /// the configured `msg_batch_size`, then transitions back to `Normal`.
+    Degraded {
+        effective_size: u32,
+        consecutive_successes: u32,
+    },
+}
+
+impl PartitionMode {
+    /// Returns the effective batch size for this mode.
+    pub(crate) fn effective_batch_size(&self, configured: u32) -> u32 {
+        match self {
+            Self::Normal => configured,
+            Self::Degraded { effective_size, .. } => *effective_size,
+        }
+    }
+
+    /// Transition after a handler result.
+    ///
+    /// `processed_count`: how many messages were successfully processed before
+    /// the batch ended. `Some` for `PerMessageAdapter` handlers, `None` for batch
+    /// handlers. On Retry/Reject, degradation uses `max(pc, 1)` when known,
+    /// or falls back to 1 when `None` (batch handler — we can't know where
+    /// the failure occurred).
+    pub(crate) fn transition(
+        &mut self,
+        result: &HandlerResult,
+        configured_batch_size: u32,
+        processed_count: Option<u32>,
+    ) {
+        match result {
+            HandlerResult::Success => match self {
+                Self::Normal => {}
+                Self::Degraded {
+                    effective_size,
+                    consecutive_successes,
+                } => {
+                    *consecutive_successes += 1;
+                    // Double the effective size on each consecutive success
+                    let next = effective_size.saturating_mul(2).min(configured_batch_size);
+                    if next >= configured_batch_size {
+                        *self = Self::Normal;
+                    } else {
+                        *effective_size = next;
+                    }
+                }
+            },
+            HandlerResult::Retry { .. } | HandlerResult::Reject { .. } => {
+                // Degrade: use max(processed_count, 1) as the new effective
+                // size. If the handler processed some messages before failing,
+                // we know the failure is at position pc+1, so we degrade to
+                // max(pc, 1) to isolate the poison message. For batch handlers
+                // (None), fall back to 1 (most conservative).
+                let degrade_to = processed_count.map_or(1, |pc| pc.max(1));
+                *self = Self::Degraded {
+                    effective_size: degrade_to,
+                    consecutive_successes: 0,
+                };
+            }
+        }
+    }
+}
+
+/// A per-partition processor parameterized by its processing strategy.
+///
+/// Each instance owns exactly one `partition_id` and runs as a long-lived
+/// tokio task. The strategy (`TransactionalStrategy` or `DecoupledStrategy`)
+/// is baked in at compile time via monomorphization.
+pub struct PartitionProcessor<S: ProcessingStrategy> {
+    strategy: S,
+    partition_id: i64,
+    config: QueueConfig,
+    notify: Arc<Notify>,
+    semaphore: Arc<Semaphore>,
+    backoff_until: Option<Instant>,
+    partition_mode: PartitionMode,
+}
+
+impl<S: ProcessingStrategy> PartitionProcessor<S> {
+    pub fn new(
+        strategy: S,
+        partition_id: i64,
+        config: QueueConfig,
+        notify: Arc<Notify>,
+        semaphore: Arc<Semaphore>,
+    ) -> Self {
+        Self {
+            strategy,
+            partition_id,
+            config,
+            notify,
+            semaphore,
+            backoff_until: None,
+            partition_mode: PartitionMode::Normal,
+        }
+    }
+
+    /// Main event loop. Runs until `cancel` fires.
+    pub async fn run(mut self, db: &Db, cancel: CancellationToken) -> Result<(), OutboxError> {
+        let sea_conn = db.sea_internal();
+        let backend = sea_conn.get_database_backend();
+        let dialect = Dialect::from(backend);
+        drop(sea_conn);
+
+        let mut has_more = false;
+        loop {
+            // Respect backoff — sleep precisely for the remaining duration
+            // instead of waking every poll_interval to re-check.
+            if let Some(until) = self.backoff_until.take() {
+                let now = Instant::now();
+                if now < until {
+                    let remaining = until - now;
+                    tokio::select! {
+                        () = cancel.cancelled() => break,
+                        () = tokio::time::sleep(remaining) => {},
+                    }
+                    if cancel.is_cancelled() {
+                        break;
+                    }
+                }
+            }
+
+            if !has_more {
+                tokio::select! {
+                    () = cancel.cancelled() => break,
+                    () = self.notify.notified() => {},
+                    () = tokio::time::sleep(self.config.poll_interval) => {},
+                }
+            }
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            // Acquire semaphore permit (bounded concurrency per queue)
+            let effective_size = self
+                .partition_mode
+                .effective_batch_size(self.config.msg_batch_size);
+
+            let result = {
+                let Ok(_permit) = self.semaphore.acquire().await else {
+                    break; // semaphore closed — shut down
+                };
+
+                let ctx = ProcessContext {
+                    db,
+                    backend,
+                    dialect,
+                    partition_id: self.partition_id,
+                };
+
+                // Use effective batch size from partition mode
+                let mut effective_config = self.config.clone();
+                effective_config.msg_batch_size = effective_size;
+
+                let child_cancel = cancel.child_token();
+                self.strategy
+                    .process(&ctx, &effective_config, child_cancel)
+                    .await?
+            }; // permit dropped here
+
+            if let Some(pr) = result {
+                has_more = pr.count >= effective_size;
+                // Clamp processed_count to batch count as defensive bound
+                let clamped_pc = pr.processed_count.map(|pc| pc.min(pr.count));
+                self.partition_mode.transition(
+                    &pr.handler_result,
+                    self.config.msg_batch_size,
+                    clamped_pc,
+                );
+                self.update_backoff(&pr.handler_result, pr.attempts_before);
+                if pr.count > 0 {
+                    debug!(
+                        partition_id = self.partition_id,
+                        count = pr.count,
+                        mode = ?self.partition_mode,
+                        "partition batch complete"
+                    );
+                }
+            } else {
+                has_more = false;
+                // Reaper: clean up processed outgoing + body rows when idle
+                self.reap(db, backend, &dialect).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Reaper: bulk-delete processed outgoing rows and their body rows.
+    async fn reap(
+        &self,
+        db: &Db,
+        backend: DbBackend,
+        dialect: &Dialect,
+    ) -> Result<(), OutboxError> {
+        let conn = db.sea_internal();
+        let row = conn
+            .query_one(Statement::from_sql_and_values(
+                backend,
+                dialect.read_processor(),
+                [self.partition_id.into()],
+            ))
+            .await?;
+        drop(conn);
+
+        let Some(row) = row else {
+            return Ok(());
+        };
+        let processed_seq: i64 = row.try_get_by_index(0).map_err(|e| {
+            OutboxError::Database(sea_orm::DbErr::Custom(format!("processed_seq column: {e}")))
+        })?;
+        if processed_seq == 0 {
+            return Ok(());
+        }
+
+        let sea_conn = db.sea_internal();
+        let txn = sea_conn.begin().await?;
+
+        match dialect.reaper_cleanup() {
+            ReaperSql::Cte(sql) => {
+                txn.execute(Statement::from_sql_and_values(
+                    backend,
+                    sql,
+                    [self.partition_id.into(), processed_seq.into()],
+                ))
+                .await?;
+            }
+            ReaperSql::TwoStep {
+                select_body_ids,
+                delete_outgoing,
+            } => {
+                let rows = txn
+                    .query_all(Statement::from_sql_and_values(
+                        backend,
+                        select_body_ids,
+                        [self.partition_id.into(), processed_seq.into()],
+                    ))
+                    .await?;
+
+                let body_ids: Vec<i64> = rows
+                    .iter()
+                    .filter_map(|r| r.try_get_by_index::<i64>(0).ok())
+                    .collect();
+
+                txn.execute(Statement::from_sql_and_values(
+                    backend,
+                    delete_outgoing,
+                    [self.partition_id.into(), processed_seq.into()],
+                ))
+                .await?;
+
+                // Batch body deletes — chunk to avoid exceeding DB parameter limits
+                for chunk in body_ids.chunks(REAPER_CHUNK_SIZE) {
+                    let delete_sql = dialect.build_delete_body_batch(chunk.len());
+                    let values: Vec<sea_orm::Value> = chunk.iter().map(|&id| id.into()).collect();
+                    txn.execute(Statement::from_sql_and_values(backend, &delete_sql, values))
+                        .await?;
+                }
+            }
+        }
+
+        txn.commit().await?;
+        Ok(())
+    }
+
+    fn update_backoff(&mut self, result: &HandlerResult, current_attempts: i16) {
+        match result {
+            HandlerResult::Retry { .. } => {
+                let attempts = current_attempts + 1;
+                #[allow(clippy::cast_possible_truncation)]
+                let base_ms = self.config.backoff_base.as_millis() as u64;
+                #[allow(clippy::cast_possible_truncation)]
+                let max_ms = self.config.backoff_max.as_millis() as u64;
+
+                #[allow(clippy::cast_sign_loss)]
+                let exp = (attempts as u32).saturating_sub(1).min(30);
+                let delay_ms = base_ms.saturating_mul(1u64 << exp).min(max_ms);
+
+                #[allow(clippy::integer_division)]
+                let jitter_ms = if delay_ms > 0 {
+                    rand_jitter(delay_ms / 4)
+                } else {
+                    0
+                };
+                let total_ms = delay_ms.saturating_add(jitter_ms);
+
+                self.backoff_until =
+                    Some(Instant::now() + std::time::Duration::from_millis(total_ms));
+            }
+            HandlerResult::Success | HandlerResult::Reject { .. } => {
+                self.backoff_until = None;
+            }
+        }
+    }
+}
+
+/// Simple deterministic-ish jitter without pulling in a PRNG crate.
+fn rand_jitter(max: u64) -> u64 {
+    if max == 0 {
+        return 0;
+    }
+    let nanos = u64::from(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos(),
+    );
+    nanos % max
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::super::strategy::{ProcessContext, ProcessResult, ProcessingStrategy};
+    use super::*;
+    use std::time::Duration;
+
+    fn make_config(base: Duration, max: Duration) -> QueueConfig {
+        QueueConfig {
+            backoff_base: base,
+            backoff_max: max,
+            ..Default::default()
+        }
+    }
+
+    fn make_processor_for_backoff(
+        base: Duration,
+        max: Duration,
+    ) -> PartitionProcessor<StubStrategy> {
+        PartitionProcessor {
+            strategy: StubStrategy,
+            partition_id: 1,
+            config: make_config(base, max),
+            notify: Arc::new(Notify::new()),
+            semaphore: Arc::new(Semaphore::new(1)),
+            backoff_until: None,
+            partition_mode: PartitionMode::Normal,
+        }
+    }
+
+    /// Stub strategy that is never called — only used for backoff unit tests.
+    struct StubStrategy;
+
+    impl ProcessingStrategy for StubStrategy {
+        async fn process(
+            &self,
+            _ctx: &ProcessContext<'_>,
+            _config: &QueueConfig,
+            _cancel: CancellationToken,
+        ) -> Result<Option<ProcessResult>, OutboxError> {
+            unimplemented!("stub")
+        }
+    }
+
+    #[test]
+    fn rand_jitter_zero_returns_zero() {
+        assert_eq!(rand_jitter(0), 0);
+    }
+
+    #[test]
+    fn rand_jitter_bounded() {
+        for _ in 0..100 {
+            let j = rand_jitter(1000);
+            assert!(j < 1000, "jitter {j} should be < 1000");
+        }
+    }
+
+    #[test]
+    fn backoff_on_retry_sets_deadline() {
+        let mut p = make_processor_for_backoff(Duration::from_millis(100), Duration::from_secs(10));
+        assert!(p.backoff_until.is_none());
+
+        p.update_backoff(
+            &HandlerResult::Retry {
+                reason: "fail".into(),
+            },
+            0,
+        );
+        assert!(p.backoff_until.is_some());
+    }
+
+    #[test]
+    fn backoff_on_success_clears_deadline() {
+        let mut p = make_processor_for_backoff(Duration::from_millis(100), Duration::from_secs(10));
+        // Set a backoff first
+        p.update_backoff(
+            &HandlerResult::Retry {
+                reason: "fail".into(),
+            },
+            0,
+        );
+        assert!(p.backoff_until.is_some());
+
+        // Success clears it
+        p.update_backoff(&HandlerResult::Success, 1);
+        assert!(p.backoff_until.is_none());
+    }
+
+    #[test]
+    fn backoff_on_reject_clears_deadline() {
+        let mut p = make_processor_for_backoff(Duration::from_millis(100), Duration::from_secs(10));
+        p.update_backoff(
+            &HandlerResult::Retry {
+                reason: "fail".into(),
+            },
+            0,
+        );
+        assert!(p.backoff_until.is_some());
+
+        p.update_backoff(
+            &HandlerResult::Reject {
+                reason: "bad".into(),
+            },
+            1,
+        );
+        assert!(p.backoff_until.is_none());
+    }
+
+    #[test]
+    fn backoff_exponential_growth_capped_by_max() {
+        let mut p =
+            make_processor_for_backoff(Duration::from_millis(100), Duration::from_millis(5000));
+
+        // First retry: ~100ms base
+        p.update_backoff(
+            &HandlerResult::Retry { reason: "x".into() },
+            0, // current_attempts=0, so attempts=1, exp=0, delay=100ms
+        );
+        let d1 = p.backoff_until.unwrap();
+
+        // Fifth retry: ~1600ms base (100 * 2^4), still under 5000ms max
+        p.update_backoff(
+            &HandlerResult::Retry { reason: "x".into() },
+            4, // current_attempts=4, so attempts=5, exp=4, delay=1600ms
+        );
+        let d5 = p.backoff_until.unwrap();
+        assert!(d5 > d1, "higher attempts should produce later deadline");
+
+        // Very high attempt: capped at max (5000ms)
+        p.update_backoff(&HandlerResult::Retry { reason: "x".into() }, 20);
+        // Just verify it doesn't panic and sets a deadline
+        assert!(p.backoff_until.is_some());
+    }
+
+    // ---- PartitionMode state machine tests ----
+
+    #[test]
+    fn partition_mode_normal_uses_configured_size() {
+        let mode = PartitionMode::Normal;
+        assert_eq!(mode.effective_batch_size(50), 50);
+    }
+
+    #[test]
+    fn partition_mode_degraded_uses_effective_size() {
+        let mode = PartitionMode::Degraded {
+            effective_size: 4,
+            consecutive_successes: 2,
+        };
+        assert_eq!(mode.effective_batch_size(50), 4);
+    }
+
+    #[test]
+    fn partition_mode_retry_degrades_to_one() {
+        let mut mode = PartitionMode::Normal;
+        mode.transition(
+            &HandlerResult::Retry {
+                reason: "fail".into(),
+            },
+            50,
+            None, // batch handler
+        );
+        assert!(matches!(
+            mode,
+            PartitionMode::Degraded {
+                effective_size: 1,
+                consecutive_successes: 0,
+            }
+        ));
+    }
+
+    #[test]
+    fn partition_mode_success_ramps_up() {
+        let mut mode = PartitionMode::Degraded {
+            effective_size: 1,
+            consecutive_successes: 0,
+        };
+        // 1 → 2
+        mode.transition(&HandlerResult::Success, 50, None);
+        assert!(matches!(
+            mode,
+            PartitionMode::Degraded {
+                effective_size: 2,
+                consecutive_successes: 1,
+            }
+        ));
+        // 2 → 4
+        mode.transition(&HandlerResult::Success, 50, None);
+        assert!(matches!(
+            mode,
+            PartitionMode::Degraded {
+                effective_size: 4,
+                ..
+            }
+        ));
+        // 4 → 8
+        mode.transition(&HandlerResult::Success, 50, None);
+        assert!(matches!(
+            mode,
+            PartitionMode::Degraded {
+                effective_size: 8,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn partition_mode_ramps_up_to_normal() {
+        let mut mode = PartitionMode::Degraded {
+            effective_size: 16,
+            consecutive_successes: 4,
+        };
+        // 16 → 32
+        mode.transition(&HandlerResult::Success, 32, None);
+        // Should transition back to Normal since 32 >= configured(32)
+        assert!(matches!(mode, PartitionMode::Normal));
+    }
+
+    #[test]
+    fn partition_mode_reject_in_normal_degrades() {
+        let mut mode = PartitionMode::Normal;
+        mode.transition(
+            &HandlerResult::Reject {
+                reason: "bad".into(),
+            },
+            50,
+            None, // batch handler — falls back to 1
+        );
+        assert!(matches!(
+            mode,
+            PartitionMode::Degraded {
+                effective_size: 1,
+                consecutive_successes: 0,
+            }
+        ));
+    }
+
+    #[test]
+    fn partition_mode_reject_with_processed_count() {
+        // PerMessageAdapter handler processed 3 msgs before poison at index 3
+        let mut mode = PartitionMode::Normal;
+        mode.transition(
+            &HandlerResult::Reject {
+                reason: "bad".into(),
+            },
+            50,
+            Some(3), // PerMessageAdapter processed 3 successfully
+        );
+        assert!(matches!(
+            mode,
+            PartitionMode::Degraded {
+                effective_size: 3,
+                consecutive_successes: 0,
+            }
+        ));
+    }
+
+    #[test]
+    fn partition_mode_retry_with_processed_count_zero() {
+        // PerMessageAdapter failed at the very first message
+        let mut mode = PartitionMode::Normal;
+        mode.transition(
+            &HandlerResult::Retry {
+                reason: "fail".into(),
+            },
+            50,
+            Some(0), // failed at first message
+        );
+        // max(0, 1) = 1
+        assert!(matches!(
+            mode,
+            PartitionMode::Degraded {
+                effective_size: 1,
+                consecutive_successes: 0,
+            }
+        ));
+    }
+
+    #[test]
+    fn partition_mode_success_in_normal_stays_normal() {
+        let mut mode = PartitionMode::Normal;
+        mode.transition(&HandlerResult::Success, 50, None);
+        assert!(matches!(mode, PartitionMode::Normal));
+    }
+
+    #[test]
+    fn partition_mode_full_recovery_cycle() {
+        let mut mode = PartitionMode::Normal;
+
+        // Retry → Degraded(1)
+        mode.transition(&HandlerResult::Retry { reason: "x".into() }, 8, None);
+        assert_eq!(mode.effective_batch_size(8), 1);
+
+        // Success: 1→2→4→8→Normal
+        mode.transition(&HandlerResult::Success, 8, None);
+        assert_eq!(mode.effective_batch_size(8), 2);
+        mode.transition(&HandlerResult::Success, 8, None);
+        assert_eq!(mode.effective_batch_size(8), 4);
+        mode.transition(&HandlerResult::Success, 8, None);
+        assert!(matches!(mode, PartitionMode::Normal));
+        assert_eq!(mode.effective_batch_size(8), 8);
+    }
+}

--- a/libs/modkit-db/src/outbox/sequencer.rs
+++ b/libs/modkit-db/src/outbox/sequencer.rs
@@ -1,0 +1,315 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+use super::Outbox;
+use super::dialect::{AllocSql, Dialect};
+use super::types::{OutboxError, SequencerConfig};
+use crate::Db;
+
+/// Per-partition notify map shared between sequencer and processors.
+type PartitionNotifyMap = Arc<HashMap<i64, Arc<Notify>>>;
+
+/// Background sequencer that consumes from incoming, assigns per-partition
+/// sequence numbers, and writes to outgoing.
+///
+/// Processes partitions in deterministic PK order within a single transaction.
+/// Uses `FOR UPDATE SKIP LOCKED` on Postgres/MySQL to allow concurrent
+/// sequencers without deadlocks.
+pub struct Sequencer {
+    config: SequencerConfig,
+    outbox: Arc<Outbox>,
+    notify: Arc<Notify>,
+    /// Per-partition notify map for direct signaling.
+    partition_notify: std::sync::RwLock<Option<PartitionNotifyMap>>,
+}
+
+/// Result of a single `sequence_batch` invocation.
+pub struct SequenceBatchResult {
+    /// Whether any single partition returned a full batch (hit the LIMIT).
+    pub any_partition_saturated: bool,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct ClaimedIncoming {
+    id: i64,
+    body_id: i64,
+    created_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl Sequencer {
+    /// Create a new sequencer.
+    #[must_use]
+    pub fn new(config: SequencerConfig, outbox: Arc<Outbox>, notify: Arc<Notify>) -> Self {
+        Self {
+            config,
+            outbox,
+            notify,
+            partition_notify: std::sync::RwLock::new(None),
+        }
+    }
+
+    /// Set the per-partition notify map. Called by the manager before spawning.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal `RwLock` is poisoned (another thread panicked
+    /// while holding it).
+    pub fn set_partition_notify(&self, map: PartitionNotifyMap) {
+        let mut guard = self
+            .partition_notify
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard = Some(map);
+    }
+
+    /// Run the sequencer loop until cancellation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a database operation fails.
+    pub async fn run(&self, db: &Db, cancel: CancellationToken) -> Result<(), OutboxError> {
+        let mut has_more = false;
+        loop {
+            if !has_more {
+                tokio::select! {
+                    () = cancel.cancelled() => break,
+                    () = self.notify.notified() => {}
+                    () = tokio::time::sleep(self.config.poll_interval) => {}
+                }
+            }
+            if cancel.is_cancelled() {
+                break;
+            }
+            let result = self.sequence_batch(db).await?;
+            has_more = result.any_partition_saturated;
+        }
+        Ok(())
+    }
+
+    /// Execute one sequencing cycle: iterate all partitions in PK order,
+    /// claim from incoming per-partition, assign sequences, write to outgoing.
+    /// Returns total number of items sequenced across all partitions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a database operation fails.
+    pub async fn sequence_batch(&self, db: &Db) -> Result<SequenceBatchResult, OutboxError> {
+        let partition_ids = self.outbox.all_partition_ids();
+        if partition_ids.is_empty() {
+            return Ok(SequenceBatchResult {
+                any_partition_saturated: false,
+            });
+        }
+
+        let conn = db.sea_internal();
+        let backend = conn.get_database_backend();
+        let dialect = Dialect::from(backend);
+        let txn = conn.begin().await?;
+
+        let mut total = 0u32;
+        let mut any_saturated = false;
+        let mut affected_partitions = Vec::new();
+
+        for partition_id in &partition_ids {
+            // Try to acquire a row lock; skip if held by another sequencer.
+            // Postgres/MySQL use FOR UPDATE SKIP LOCKED; SQLite returns None (no row locking).
+            if let Some(lock_sql) = dialect.lock_partition()
+                && !self
+                    .try_lock_partition(&txn, backend, *partition_id, lock_sql)
+                    .await?
+            {
+                continue;
+            }
+
+            // Claim incoming for this partition
+            let claimed = self
+                .claim_incoming_for_partition(&txn, backend, &dialect, *partition_id)
+                .await?;
+            if claimed.is_empty() {
+                continue;
+            }
+
+            #[allow(clippy::cast_possible_wrap)]
+            let item_count = claimed.len() as i64;
+
+            #[allow(clippy::cast_possible_truncation)]
+            let count = claimed.len() as u32;
+            if count >= self.config.batch_size {
+                any_saturated = true;
+            }
+
+            // Allocate sequences
+            let start_seq = self
+                .allocate_sequences(&txn, backend, &dialect, *partition_id, item_count)
+                .await?;
+
+            // Insert outgoing rows (batched)
+            let outgoing_sql = dialect.build_insert_outgoing_batch(claimed.len());
+            let mut values: Vec<sea_orm::Value> = Vec::with_capacity(claimed.len() * 4);
+            for (i, item) in claimed.iter().enumerate() {
+                #[allow(clippy::cast_possible_wrap)]
+                let seq = start_seq + 1 + i as i64;
+                values.push((*partition_id).into());
+                values.push(item.body_id.into());
+                values.push(seq.into());
+                values.push(item.created_at.into());
+            }
+            txn.execute(Statement::from_sql_and_values(
+                backend,
+                &outgoing_sql,
+                values,
+            ))
+            .await?;
+
+            total += count;
+            affected_partitions.push(*partition_id);
+        }
+
+        txn.commit().await?;
+
+        // Notify per-partition processors after commit
+        if let Some(map) = self
+            .partition_notify
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+        {
+            for pid in &affected_partitions {
+                if let Some(notify) = map.get(pid) {
+                    notify.notify_one();
+                }
+            }
+        }
+
+        if total > 0 {
+            debug!(
+                total,
+                partitions = affected_partitions.len(),
+                "sequenced batch"
+            );
+        }
+
+        Ok(SequenceBatchResult {
+            any_partition_saturated: any_saturated,
+        })
+    }
+
+    /// Try to acquire a row-level lock on the partition row.
+    /// Returns `true` if the lock was acquired, `false` if skipped.
+    async fn try_lock_partition(
+        &self,
+        txn: &impl ConnectionTrait,
+        backend: DbBackend,
+        partition_id: i64,
+        sql: &str,
+    ) -> Result<bool, OutboxError> {
+        let row = txn
+            .query_one(Statement::from_sql_and_values(
+                backend,
+                sql,
+                [partition_id.into()],
+            ))
+            .await?;
+        Ok(row.is_some())
+    }
+
+    /// Claim incoming items for a single partition.
+    ///
+    /// Uses SELECT-then-DELETE on all backends to guarantee FIFO order:
+    /// the SELECT returns rows ordered by `id`, and the caller assigns
+    /// sequences in that iteration order.
+    async fn claim_incoming_for_partition(
+        &self,
+        txn: &impl ConnectionTrait,
+        backend: DbBackend,
+        dialect: &Dialect,
+        partition_id: i64,
+    ) -> Result<Vec<ClaimedIncoming>, OutboxError> {
+        let claim = dialect.claim_incoming(self.config.batch_size);
+
+        // SELECT id, body_id, created_at ... ORDER BY id
+        let rows = ClaimedIncoming::find_by_statement(Statement::from_sql_and_values(
+            backend,
+            &claim.select,
+            [partition_id.into()],
+        ))
+        .all(txn)
+        .await?;
+
+        if rows.is_empty() {
+            return Ok(rows);
+        }
+
+        // DELETE the selected rows by id
+        let delete_sql = dialect.delete_incoming_batch(rows.len());
+        let values: Vec<sea_orm::Value> = rows.iter().map(|r| r.id.into()).collect();
+        txn.execute(Statement::from_sql_and_values(backend, &delete_sql, values))
+            .await?;
+
+        Ok(rows)
+    }
+
+    /// Atomically allocate sequence numbers for a partition.
+    /// Returns the `start_seq` (items get `start_seq` + 1, `start_seq` + 2, etc.).
+    async fn allocate_sequences(
+        &self,
+        txn: &impl ConnectionTrait,
+        backend: DbBackend,
+        dialect: &Dialect,
+        partition_id: i64,
+        count: i64,
+    ) -> Result<i64, OutboxError> {
+        match dialect.allocate_sequences() {
+            AllocSql::UpdateReturning(sql) => {
+                // Pg/SQLite: UPDATE ... RETURNING — $1 = partition_id, $2 = count
+                let row = txn
+                    .query_one(Statement::from_sql_and_values(
+                        backend,
+                        sql,
+                        [partition_id.into(), count.into()],
+                    ))
+                    .await?
+                    .ok_or_else(|| {
+                        OutboxError::Database(sea_orm::DbErr::Custom(
+                            "UPDATE RETURNING returned no row for sequence allocation".to_owned(),
+                        ))
+                    })?;
+                let start_seq: i64 = row.try_get_by_index(0).map_err(|e| {
+                    OutboxError::Database(sea_orm::DbErr::Custom(format!("start_seq column: {e}")))
+                })?;
+                Ok(start_seq)
+            }
+            AllocSql::UpdateThenSelect { update, select } => {
+                // MySQL: UPDATE then SELECT
+                // ? order: (count, partition_id) matching SQL occurrence
+                txn.execute(Statement::from_sql_and_values(
+                    backend,
+                    update,
+                    [count.into(), partition_id.into()],
+                ))
+                .await?;
+                let row = txn
+                    .query_one(Statement::from_sql_and_values(
+                        backend,
+                        select,
+                        [count.into(), partition_id.into()],
+                    ))
+                    .await?
+                    .ok_or_else(|| {
+                        OutboxError::Database(sea_orm::DbErr::Custom(
+                            "SELECT returned no row for sequence allocation".to_owned(),
+                        ))
+                    })?;
+                let start_seq: i64 = row.try_get_by_index(0).map_err(|e| {
+                    OutboxError::Database(sea_orm::DbErr::Custom(format!("start_seq column: {e}")))
+                })?;
+                Ok(start_seq)
+            }
+        }
+    }
+}

--- a/libs/modkit-db/src/outbox/strategy.rs
+++ b/libs/modkit-db/src/outbox/strategy.rs
@@ -1,0 +1,555 @@
+use std::collections::HashMap;
+
+use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
+use tokio_util::sync::CancellationToken;
+
+use super::dialect::Dialect;
+use super::handler::{Handler, HandlerResult, OutboxMessage, TransactionalHandler};
+use super::types::{OutboxError, QueueConfig};
+use crate::Db;
+
+/// Context for processing a single partition's batch.
+pub struct ProcessContext<'a> {
+    pub db: &'a Db,
+    pub backend: DbBackend,
+    pub dialect: Dialect,
+    pub partition_id: i64,
+}
+
+/// Sealed trait for compile-time processing mode dispatch.
+///
+/// Each implementation manages its own transaction scope. The processor
+/// delegates the entire read→handle→ack cycle to the strategy.
+pub trait ProcessingStrategy: Send + Sync {
+    /// Process one batch for the given partition.
+    ///
+    /// Returns `Ok(Some(result))` if work was done, `Ok(None)` if the
+    /// partition was empty or locked by another processor.
+    fn process(
+        &self,
+        ctx: &ProcessContext<'_>,
+        config: &QueueConfig,
+        cancel: CancellationToken,
+    ) -> impl std::future::Future<Output = Result<Option<ProcessResult>, OutboxError>> + Send;
+}
+
+/// Result of processing a batch.
+pub struct ProcessResult {
+    pub count: u32,
+    pub handler_result: HandlerResult,
+    pub attempts_before: i16,
+    /// Number of messages the handler successfully processed before the batch
+    /// completed (or failed). `Some` for `PerMessageAdapter`-wrapped handlers,
+    /// `None` for raw batch handlers. Used for partial-failure semantics.
+    pub processed_count: Option<u32>,
+}
+
+// ---- SQL row types ----
+
+#[derive(Debug, FromQueryResult)]
+struct ProcessorRow {
+    processed_seq: i64,
+    attempts: i16,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct OutgoingRow {
+    id: i64,
+    body_id: i64,
+    seq: i64,
+    created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct BodyRow {
+    id: i64,
+    payload: Vec<u8>,
+    payload_type: String,
+}
+
+// ---- Shared helpers ----
+
+async fn read_messages(
+    txn: &impl ConnectionTrait,
+    backend: DbBackend,
+    dialect: &Dialect,
+    partition_id: i64,
+    proc_row: &ProcessorRow,
+    msg_batch_size: u32,
+) -> Result<Vec<OutboxMessage>, OutboxError> {
+    // Use seq > processed_seq (not seq >= processed_seq + 1) — the cursor
+    // stores the last processed seq, so `>` is the natural predicate.
+    let outgoing_rows = OutgoingRow::find_by_statement(Statement::from_sql_and_values(
+        backend,
+        dialect.read_outgoing_batch(msg_batch_size),
+        [partition_id.into(), proc_row.processed_seq.into()],
+    ))
+    .all(txn)
+    .await?;
+
+    if outgoing_rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Batch body read: single SELECT ... WHERE id IN (...) instead of N+1 queries
+    let body_ids: Vec<i64> = outgoing_rows.iter().map(|r| r.body_id).collect();
+    let body_sql = dialect.build_read_body_batch(body_ids.len());
+    let body_values: Vec<sea_orm::Value> = body_ids.iter().map(|&id| id.into()).collect();
+    let body_rows = BodyRow::find_by_statement(Statement::from_sql_and_values(
+        backend,
+        &body_sql,
+        body_values,
+    ))
+    .all(txn)
+    .await?;
+
+    let body_map: HashMap<i64, BodyRow> = body_rows.into_iter().map(|b| (b.id, b)).collect();
+
+    let mut msgs = Vec::with_capacity(outgoing_rows.len());
+    for row in &outgoing_rows {
+        let body = body_map.get(&row.body_id).ok_or_else(|| {
+            OutboxError::Database(sea_orm::DbErr::Custom(format!(
+                "body row {} not found for outgoing {}",
+                row.body_id, row.id
+            )))
+        })?;
+
+        msgs.push(OutboxMessage {
+            partition_id,
+            seq: row.seq,
+            payload: body.payload.clone(),
+            payload_type: body.payload_type.clone(),
+            created_at: row.created_at,
+            attempts: proc_row.attempts,
+        });
+    }
+
+    Ok(msgs)
+}
+
+/// Append-only ack: only UPDATE `processed_seq`, no DELETEs.
+/// Reaper handles cleanup of processed outgoing + body rows.
+async fn ack(
+    txn: &impl ConnectionTrait,
+    backend: DbBackend,
+    dialect: &Dialect,
+    partition_id: i64,
+    msgs: &[OutboxMessage],
+    result: &HandlerResult,
+) -> Result<(), OutboxError> {
+    let last_seq = msgs.last().map_or(0, |m| m.seq);
+
+    match result {
+        HandlerResult::Success => {
+            txn.execute(Statement::from_sql_and_values(
+                backend,
+                dialect.advance_processed_seq(),
+                [last_seq.into(), partition_id.into()],
+            ))
+            .await?;
+        }
+        HandlerResult::Retry { reason } => {
+            txn.execute(Statement::from_sql_and_values(
+                backend,
+                dialect.record_retry(),
+                [reason.as_str().into(), partition_id.into()],
+            ))
+            .await?;
+        }
+        HandlerResult::Reject { reason } => {
+            for msg in msgs {
+                txn.execute(Statement::from_sql_and_values(
+                    backend,
+                    dialect.insert_dead_letter(),
+                    [
+                        partition_id.into(),
+                        msg.seq.into(),
+                        msg.payload.clone().into(),
+                        msg.payload_type.clone().into(),
+                        msg.created_at.into(),
+                        reason.as_str().into(),
+                        msg.attempts.into(),
+                    ],
+                ))
+                .await?;
+            }
+
+            txn.execute(Statement::from_sql_and_values(
+                backend,
+                dialect.advance_processed_seq(),
+                [last_seq.into(), partition_id.into()],
+            ))
+            .await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn try_lock_and_read_state(
+    txn: &impl ConnectionTrait,
+    backend: DbBackend,
+    dialect: &Dialect,
+    partition_id: i64,
+) -> Result<Option<ProcessorRow>, OutboxError> {
+    if let Some(lock_sql) = dialect.lock_processor() {
+        let row = txn
+            .query_one(Statement::from_sql_and_values(
+                backend,
+                lock_sql,
+                [partition_id.into()],
+            ))
+            .await?;
+        if row.is_none() {
+            return Ok(None);
+        }
+    }
+
+    let proc_row = ProcessorRow::find_by_statement(Statement::from_sql_and_values(
+        backend,
+        dialect.read_processor(),
+        [partition_id.into()],
+    ))
+    .one(txn)
+    .await?;
+
+    Ok(proc_row)
+}
+
+// ---- Transactional strategy ----
+
+/// Processes messages inside the DB transaction holding the partition lock.
+/// Handler can perform atomic DB writes alongside the ack.
+pub struct TransactionalStrategy {
+    handler: Box<dyn TransactionalHandler>,
+}
+
+impl TransactionalStrategy {
+    pub fn new(handler: Box<dyn TransactionalHandler>) -> Self {
+        Self { handler }
+    }
+}
+
+impl ProcessingStrategy for TransactionalStrategy {
+    async fn process(
+        &self,
+        ctx: &ProcessContext<'_>,
+        config: &QueueConfig,
+        cancel: CancellationToken,
+    ) -> Result<Option<ProcessResult>, OutboxError> {
+        let conn = ctx.db.sea_internal();
+        let txn = conn.begin().await?;
+
+        let Some(proc_row) =
+            try_lock_and_read_state(&txn, ctx.backend, &ctx.dialect, ctx.partition_id).await?
+        else {
+            txn.commit().await?;
+            return Ok(None);
+        };
+
+        let msgs = read_messages(
+            &txn,
+            ctx.backend,
+            &ctx.dialect,
+            ctx.partition_id,
+            &proc_row,
+            config.msg_batch_size,
+        )
+        .await?;
+        if msgs.is_empty() {
+            txn.commit().await?;
+            return Ok(None);
+        }
+
+        #[allow(clippy::cast_possible_truncation)]
+        let count = msgs.len() as u32;
+        let attempts_before = proc_row.attempts;
+
+        let result = self.handler.handle(&txn, &msgs, cancel).await;
+        #[allow(clippy::cast_possible_truncation)]
+        let pc = self.handler.processed_count().map(|n| n as u32);
+
+        // Transactional partial-failure semantics: on Reject/Retry the entire
+        // transaction (including any handler side-effects) is committed with
+        // the ack. Dead letters are created for all messages in the batch on
+        // Reject — even those the handler processed successfully — because
+        // the handler's successful work is atomic with the cursor advance.
+        // The `processed_count` is still recorded in ProcessResult so the
+        // PartitionMode state machine can degrade batch size intelligently.
+        ack(
+            &txn,
+            ctx.backend,
+            &ctx.dialect,
+            ctx.partition_id,
+            &msgs,
+            &result,
+        )
+        .await?;
+
+        txn.commit().await?;
+
+        Ok(Some(ProcessResult {
+            count,
+            handler_result: result,
+            attempts_before,
+            processed_count: pc,
+        }))
+    }
+}
+
+// ---- Decoupled strategy ----
+
+/// Processes messages outside any DB transaction.
+/// Uses lease-based 3-phase: acquire lease+read → handle → lease-guarded ack.
+pub struct DecoupledStrategy {
+    handler: Box<dyn Handler>,
+    worker_id: String,
+}
+
+impl DecoupledStrategy {
+    pub fn new(handler: Box<dyn Handler>, worker_id: String) -> Self {
+        Self { handler, worker_id }
+    }
+}
+
+impl ProcessingStrategy for DecoupledStrategy {
+    async fn process(
+        &self,
+        ctx: &ProcessContext<'_>,
+        config: &QueueConfig,
+        cancel: CancellationToken,
+    ) -> Result<Option<ProcessResult>, OutboxError> {
+        let lease_id = &self.worker_id;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let lease_secs = config.lease_duration.as_secs() as i64;
+
+        // Phase 1: Acquire lease + read messages
+        let (proc_row, msgs) = {
+            let sea_conn = ctx.db.sea_internal();
+            let txn = sea_conn.begin().await?;
+
+            // Acquire lease via dialect helper (encapsulates RETURNING vs SELECT fallback)
+            let proc_row = ctx
+                .dialect
+                .exec_lease_acquire(&txn, ctx.backend, lease_id, lease_secs, ctx.partition_id)
+                .await?
+                .map(|(processed_seq, attempts)| ProcessorRow {
+                    processed_seq,
+                    attempts,
+                });
+
+            let Some(mut proc_row) = proc_row else {
+                txn.commit().await?;
+                return Ok(None);
+            };
+
+            // lease_acquire increments attempts in the DB so a crash leaves
+            // a trace. Subtract 1 so the handler sees the pre-increment
+            // value (0 = first attempt, 1 = one previous attempt, etc.).
+            proc_row.attempts = proc_row.attempts.saturating_sub(1);
+
+            let msgs = read_messages(
+                &txn,
+                ctx.backend,
+                &ctx.dialect,
+                ctx.partition_id,
+                &proc_row,
+                config.msg_batch_size,
+            )
+            .await?;
+
+            txn.commit().await?;
+
+            if msgs.is_empty() {
+                // Release lease — nothing to process
+                let conn = ctx.db.sea_internal();
+                conn.execute(Statement::from_sql_and_values(
+                    ctx.backend,
+                    ctx.dialect.lease_release(),
+                    [ctx.partition_id.into(), lease_id.as_str().into()],
+                ))
+                .await?;
+                return Ok(None);
+            }
+
+            (proc_row, msgs)
+        };
+
+        #[allow(clippy::cast_possible_truncation)]
+        let count = msgs.len() as u32;
+        let attempts_before = proc_row.attempts;
+
+        // Phase 2: call handler outside any transaction
+        // Create a child token that fires at 80% of lease duration
+        let lease_cancel = cancel.child_token();
+        let lease_timer = {
+            let token = lease_cancel.clone();
+            let deadline = config.lease_duration.mul_f64(0.8);
+            tokio::spawn(async move {
+                tokio::time::sleep(deadline).await;
+                token.cancel();
+            })
+        };
+
+        let result = self.handler.handle(&msgs, lease_cancel).await;
+        #[allow(clippy::cast_possible_truncation)]
+        let pc = self.handler.processed_count().map(|n| n as u32);
+        lease_timer.abort();
+
+        // Phase 3: lease-guarded ack
+        let ack_conn = ctx.db.sea_internal();
+        let ack_txn = ack_conn.begin().await?;
+
+        let last_seq = msgs.last().map_or(0, |m| m.seq);
+
+        match &result {
+            HandlerResult::Success => {
+                let res = ack_txn
+                    .execute(Statement::from_sql_and_values(
+                        ctx.backend,
+                        ctx.dialect.lease_ack_advance(),
+                        [
+                            last_seq.into(),
+                            ctx.partition_id.into(),
+                            lease_id.as_str().into(),
+                        ],
+                    ))
+                    .await?;
+                if res.rows_affected() == 0 {
+                    tracing::error!(
+                        partition_id = ctx.partition_id,
+                        "lease expired before ack \u{2014} another processor may have taken over"
+                    );
+                    ack_txn.commit().await?;
+                    return Ok(None);
+                }
+            }
+            HandlerResult::Retry { reason } => {
+                // Retry: cursor not advanced — the same batch will be re-read.
+                // processed_count is carried in ProcessResult for PartitionMode
+                // degradation (batch size reduction), but no partial ack occurs.
+                let res = ack_txn
+                    .execute(Statement::from_sql_and_values(
+                        ctx.backend,
+                        ctx.dialect.lease_record_retry(),
+                        [
+                            reason.as_str().into(),
+                            ctx.partition_id.into(),
+                            lease_id.as_str().into(),
+                        ],
+                    ))
+                    .await?;
+                if res.rows_affected() == 0 {
+                    tracing::error!(
+                        partition_id = ctx.partition_id,
+                        "lease expired before retry ack"
+                    );
+                    ack_txn.commit().await?;
+                    return Ok(None);
+                }
+            }
+            HandlerResult::Reject { reason } => {
+                // Partial-failure semantics: when PerMessageAdapter reports
+                // processed_count, only dead-letter the unprocessed tail
+                // (msgs[pc..]). The successfully-processed prefix had its
+                // side-effects committed outside the DB transaction, so we
+                // don't dead-letter those. For batch handlers (pc = None),
+                // dead-letter the entire batch (existing behavior).
+                let skip = pc.map_or(0, |n| n as usize).min(msgs.len());
+                for msg in &msgs[skip..] {
+                    ack_txn
+                        .execute(Statement::from_sql_and_values(
+                            ctx.backend,
+                            ctx.dialect.insert_dead_letter(),
+                            [
+                                ctx.partition_id.into(),
+                                msg.seq.into(),
+                                msg.payload.clone().into(),
+                                msg.payload_type.clone().into(),
+                                msg.created_at.into(),
+                                reason.as_str().into(),
+                                msg.attempts.into(),
+                            ],
+                        ))
+                        .await?;
+                }
+
+                let res = ack_txn
+                    .execute(Statement::from_sql_and_values(
+                        ctx.backend,
+                        ctx.dialect.lease_ack_advance(),
+                        [
+                            last_seq.into(),
+                            ctx.partition_id.into(),
+                            lease_id.as_str().into(),
+                        ],
+                    ))
+                    .await?;
+                if res.rows_affected() == 0 {
+                    tracing::error!(
+                        partition_id = ctx.partition_id,
+                        "lease expired before reject ack"
+                    );
+                    ack_txn.commit().await?;
+                    return Ok(None);
+                }
+            }
+        }
+
+        ack_txn.commit().await?;
+
+        Ok(Some(ProcessResult {
+            count,
+            handler_result: result,
+            attempts_before,
+            processed_count: pc,
+        }))
+    }
+}
+
+/// Generate a worker ID in the format `"{name}-{XXXXXX}"` where XXXXXX
+/// is 6 random alphanumeric characters (A-Z, 0-9).
+pub fn generate_worker_id(queue_name: &str) -> String {
+    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos();
+    // Simple PRNG seeded from nanosecond clock — sufficient for worker ID uniqueness
+    let mut seed = u64::from(nanos) ^ u64::from(std::process::id());
+    let mut suffix = String::with_capacity(6);
+    for _ in 0..6 {
+        seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        let idx = ((seed >> 33) as usize) % CHARSET.len();
+        suffix.push(CHARSET[idx] as char);
+    }
+    format!("{queue_name}-{suffix}")
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_id_format() {
+        let id = generate_worker_id("orders");
+        assert!(id.starts_with("orders-"), "expected orders- prefix: {id}");
+        let suffix = &id["orders-".len()..];
+        assert_eq!(suffix.len(), 6, "suffix should be 6 chars: {suffix}");
+        assert!(
+            suffix
+                .chars()
+                .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit()),
+            "suffix should be A-Z0-9: {suffix}"
+        );
+    }
+
+    #[test]
+    fn worker_ids_differ() {
+        let id1 = generate_worker_id("q");
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        let id2 = generate_worker_id("q");
+        assert_ne!(id1, id2, "worker IDs should differ: {id1} vs {id2}");
+    }
+}

--- a/libs/modkit-db/src/outbox/types.rs
+++ b/libs/modkit-db/src/outbox/types.rs
@@ -1,0 +1,162 @@
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Default batch size for the sequencer (rows per cycle).
+pub const DEFAULT_SEQUENCER_BATCH_SIZE: u32 = 100;
+
+/// Default poll interval (safety net fallback for sequencer and processors).
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Default message batch size (messages per handler call per partition).
+pub const DEFAULT_MSG_BATCH_SIZE: u32 = 1;
+
+/// Default backoff base delay.
+pub const DEFAULT_BACKOFF_BASE: Duration = Duration::from_secs(1);
+
+/// Default backoff maximum delay.
+pub const DEFAULT_BACKOFF_MAX: Duration = Duration::from_secs(60);
+
+/// Default lease duration for decoupled mode partition locks.
+pub const DEFAULT_LEASE_DURATION: Duration = Duration::from_secs(30);
+
+/// Number of partitions for a queue. Must be a power of 2 in `1..=64`.
+///
+/// ```
+/// use modkit_db::outbox::Partitions;
+/// let p = Partitions::of(4);
+/// assert_eq!(p.count(), 4);
+/// ```
+///
+/// Invalid values panic at compile time when used as a const:
+/// ```compile_fail
+/// use modkit_db::outbox::Partitions;
+/// const BAD: Partitions = Partitions::of(3); // not a power of 2
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Partitions(u16);
+
+impl Partitions {
+    /// Create a partition count.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is not a power of 2 in `1..=64`.
+    #[must_use]
+    pub const fn of(n: u16) -> Self {
+        assert!(
+            n >= 1 && n <= 64 && n.is_power_of_two(),
+            "partition count must be a power of 2 between 1 and 64"
+        );
+        Self(n)
+    }
+
+    /// Returns the numeric partition count.
+    #[must_use]
+    pub const fn count(self) -> u16 {
+        self.0
+    }
+}
+
+/// Identifier for an enqueued outbox message (the `modkit_outbox_incoming.id`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct OutboxMessageId(pub i64);
+
+/// A single message to enqueue in the outbox.
+///
+/// Used with [`Outbox::enqueue_batch`] to enqueue multiple messages in one call.
+/// Each message specifies its target partition, the message payload (owned), and
+/// a payload type string (borrowed — typically a static string like a MIME type
+/// or schema identifier).
+#[derive(Debug)]
+pub struct EnqueueMessage<'a> {
+    /// Target partition index (0-based, within the queue's partition count).
+    pub partition: u32,
+    /// Message payload bytes. Ownership is transferred to the outbox.
+    pub payload: Vec<u8>,
+    /// Type tag for the payload (e.g. `"application/json"`, schema name).
+    pub payload_type: &'a str,
+}
+
+/// Errors from the outbox subsystem.
+#[derive(Debug, Error)]
+pub enum OutboxError {
+    #[error("queue '{0}' is not registered")]
+    QueueNotRegistered(String),
+
+    #[error("partition {partition} is out of range for queue '{queue}' (max {max})")]
+    PartitionOutOfRange {
+        queue: String,
+        partition: u32,
+        max: u32,
+    },
+
+    #[error("payload size {size} exceeds maximum {max}")]
+    PayloadTooLarge { size: usize, max: usize },
+
+    #[error("partition count mismatch for queue '{queue}': expected {expected}, found {found}")]
+    PartitionCountMismatch {
+        queue: String,
+        expected: u16,
+        found: usize,
+    },
+
+    #[error(transparent)]
+    Database(#[from] sea_orm::DbErr),
+}
+
+/// Configuration for the outbox subsystem.
+#[derive(Debug, Clone, Default)]
+pub struct OutboxConfig {
+    pub sequencer: SequencerConfig,
+}
+
+/// Configuration for the sequencer background task.
+#[derive(Debug, Clone)]
+pub struct SequencerConfig {
+    pub batch_size: u32,
+    pub poll_interval: Duration,
+}
+
+impl Default for SequencerConfig {
+    fn default() -> Self {
+        Self {
+            batch_size: DEFAULT_SEQUENCER_BATCH_SIZE,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+        }
+    }
+}
+
+/// Per-queue configuration with sensible defaults.
+#[derive(Debug, Clone)]
+pub struct QueueConfig {
+    /// Lease duration for decoupled mode partition locks.
+    /// Ignored for transactional mode. Default: 30s.
+    pub lease_duration: Duration,
+    /// Max partitions processed concurrently within this queue.
+    /// Default: `usize::MAX` (all partitions).
+    pub max_concurrent_partitions: usize,
+    /// Messages per handler call per partition. Default: 1.
+    pub msg_batch_size: u32,
+    /// Safety net fallback poll interval per partition. Default: 1s.
+    /// Not exposed in `QueueBuilder` — always uses the default. Override
+    /// only internally (e.g. integration tests).
+    pub(crate) poll_interval: Duration,
+    /// Base delay for exponential backoff on retry. Default: 1s.
+    pub backoff_base: Duration,
+    /// Maximum delay for exponential backoff on retry. Default: 60s.
+    pub backoff_max: Duration,
+}
+
+impl Default for QueueConfig {
+    fn default() -> Self {
+        Self {
+            lease_duration: DEFAULT_LEASE_DURATION,
+            max_concurrent_partitions: usize::MAX,
+            msg_batch_size: DEFAULT_MSG_BATCH_SIZE,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            backoff_base: DEFAULT_BACKOFF_BASE,
+            backoff_max: DEFAULT_BACKOFF_MAX,
+        }
+    }
+}

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -34,6 +34,9 @@ otel = [
     "dep:opentelemetry-otlp",
     "dep:tonic",
 ]
+# Transactional outbox pipeline (preview — API may change)
+preview-outbox = ["db", "modkit-db/preview-outbox"]
+
 bootstrap = [
     "db",
     "dep:serde-saphyr",


### PR DESCRIPTION
feat(outbox): implement transactional outbox module

Four-stage pipeline (incoming → sequencer → outgoing → processor) for reliable async message delivery within DB transactions. Multi-backend SQL dialect (Pg/SQLite/MySQL), batch and single-message handler traits, transactional and decoupled processing modes, dead letter management, orphaned body cleanup, and configurable concurrency with backoff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a complete Outbox subsystem: builder/handle to start/stop, sequencer, per-partition processors, strategies (transactional & decoupled), dead-letter management, dialect-aware SQL, migrations, and public APIs for enqueueing and queue configuration.

* **Documentation**
  * Added four runnable examples: transactional, retry→reject, dead-letter lifecycle, and multi-queue batch processing.

* **Tests**
  * Large suite of unit and integration tests covering end-to-end flows, retries, replays, purges, and backoff behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->