### PR TITLE
feat(credstore): add global secret support to static credstore plugin

### DIFF
--- a/modules/credstore/plugins/static-credstore-plugin/src/config.rs
+++ b/modules/credstore/plugins/static-credstore-plugin/src/config.rs
@@ -32,10 +32,25 @@ impl Default for StaticCredStorePluginConfig {
 #[serde(deny_unknown_fields)]
 pub struct SecretConfig {
     /// Tenant that owns this secret.
-    pub tenant_id: Uuid,
+    ///
+    /// - `None` → **global** secret, accessible by any tenant (uses
+    ///   `SharingMode::Shared` on the wire but stored in a separate
+    ///   global map in the static plugin).
+    /// - `Some` with `SharingMode::Shared` → **shared** secret scoped to
+    ///   this tenant, visible to descendants via gateway hierarchy walk-up.
+    /// - `Some` with `SharingMode::Tenant` → **tenant** secret, visible
+    ///   only within this tenant.
+    ///
+    /// `owner_id` cannot be set without `tenant_id`.
+    pub tenant_id: Option<Uuid>,
 
     /// Owner (subject) of this secret.
-    pub owner_id: Uuid,
+    /// Requires `tenant_id` to be set.
+    ///
+    /// At lookup, matched against `SecurityContext::subject_id()`.
+    /// When `None`, the returned `SecretMetadata::owner_id` is filled
+    /// from `SecurityContext::subject_id()` of the caller.
+    pub owner_id: Option<Uuid>,
 
     /// Secret reference key (validated as `SecretRef` at init).
     pub key: String,
@@ -44,8 +59,25 @@ pub struct SecretConfig {
     pub value: String,
 
     /// Sharing mode for this secret.
-    #[serde(default)]
-    pub sharing: SharingMode,
+    /// When `None`, inferred from `tenant_id`/`owner_id`:
+    /// - `tenant_id=None` → `Shared`
+    /// - `tenant_id=Some`, `owner_id=None` → `Tenant`
+    /// - `tenant_id=Some`, `owner_id=Some` → `Private`
+    pub sharing: Option<SharingMode>,
+}
+
+impl SecretConfig {
+    /// Resolve the effective sharing mode from the explicit value or the
+    /// `tenant_id`/`owner_id` combination.
+    #[must_use]
+    pub fn resolve_sharing(&self) -> SharingMode {
+        self.sharing
+            .unwrap_or(match (self.tenant_id, self.owner_id) {
+                (None, _) => SharingMode::Shared,
+                (Some(_), None) => SharingMode::Tenant,
+                (Some(_), Some(_)) => SharingMode::Private,
+            })
+    }
 }
 
 impl core::fmt::Debug for SecretConfig {
@@ -55,7 +87,7 @@ impl core::fmt::Debug for SecretConfig {
             .field("owner_id", &self.owner_id)
             .field("key", &self.key)
             .field("value", &"<redacted>")
-            .field("sharing", &self.sharing)
+            .field("sharing", &self.resolve_sharing())
             .finish()
     }
 }
@@ -75,18 +107,61 @@ secrets:
     value: "sk-test-123"
 "#;
 
-        let parsed: Result<StaticCredStorePluginConfig, _> = serde_saphyr::from_str(yaml);
-        assert!(parsed.is_ok());
-
-        let cfg = match parsed {
-            Ok(cfg) => cfg,
-            Err(e) => panic!("failed to parse config: {e}"),
-        };
+        let cfg: StaticCredStorePluginConfig = serde_saphyr::from_str(yaml).unwrap();
 
         assert_eq!(cfg.vendor, "hyperspot");
         assert_eq!(cfg.priority, 100);
         assert_eq!(cfg.secrets.len(), 1);
-        assert_eq!(cfg.secrets[0].sharing, SharingMode::Tenant);
+        assert!(cfg.secrets[0].sharing.is_none());
+        assert_eq!(cfg.secrets[0].resolve_sharing(), SharingMode::Private);
+    }
+
+    #[test]
+    fn config_allows_omitted_tenant_and_owner() {
+        let yaml = r#"
+secrets:
+  - key: "global_api_key"
+    value: "sk-global"
+"#;
+
+        let cfg: StaticCredStorePluginConfig = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(cfg.secrets.len(), 1);
+        assert!(cfg.secrets[0].tenant_id.is_none());
+        assert!(cfg.secrets[0].owner_id.is_none());
+        assert!(cfg.secrets[0].sharing.is_none());
+        assert_eq!(cfg.secrets[0].resolve_sharing(), SharingMode::Shared);
+    }
+
+    #[test]
+    fn config_allows_partial_tenant_only() {
+        let yaml = r#"
+secrets:
+  - tenant_id: "00000000-0000-0000-0000-000000000001"
+    key: "scoped_key"
+    value: "val"
+"#;
+
+        let cfg: StaticCredStorePluginConfig = serde_saphyr::from_str(yaml).unwrap();
+        assert!(cfg.secrets[0].tenant_id.is_some());
+        assert!(cfg.secrets[0].owner_id.is_none());
+        assert!(cfg.secrets[0].sharing.is_none());
+        assert_eq!(cfg.secrets[0].resolve_sharing(), SharingMode::Tenant);
+    }
+
+    #[test]
+    fn config_explicit_sharing_overrides_default() {
+        let yaml = r#"
+secrets:
+  - tenant_id: "00000000-0000-0000-0000-000000000001"
+    owner_id: "00000000-0000-0000-0000-000000000002"
+    key: "key"
+    value: "val"
+    sharing: "tenant"
+"#;
+
+        let cfg: StaticCredStorePluginConfig = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(cfg.secrets[0].sharing, Some(SharingMode::Tenant));
+        assert_eq!(cfg.secrets[0].resolve_sharing(), SharingMode::Tenant);
     }
 
     #[test]

--- a/modules/credstore/plugins/static-credstore-plugin/src/domain/client.rs
+++ b/modules/credstore/plugins/static-credstore-plugin/src/domain/client.rs
@@ -13,17 +13,28 @@ impl CredStorePluginClientV1 for Service {
         ctx: &SecurityContext,
         key: &SecretRef,
     ) -> Result<Option<SecretMetadata>, CredStoreError> {
-        let tenant_id = ctx.subject_tenant_id();
-
-        let Some(entry) = self.get(tenant_id, key) else {
+        let Some(entry) = self.get(ctx, key) else {
             return Ok(None);
+        };
+
+        // For Shared/Tenant entries the stored owner_id/owner_tenant_id are nil
+        // placeholders — resolve them from the caller's security context.
+        let owner_id = if entry.owner_id.is_nil() {
+            ctx.subject_id()
+        } else {
+            entry.owner_id
+        };
+        let owner_tenant_id = if entry.owner_tenant_id.is_nil() {
+            ctx.subject_tenant_id()
+        } else {
+            entry.owner_tenant_id
         };
 
         Ok(Some(SecretMetadata {
             value: SecretValue::new(entry.value.as_bytes().to_vec()),
-            owner_id: entry.owner_id,
+            owner_id,
             sharing: entry.sharing,
-            owner_tenant_id: entry.owner_tenant_id,
+            owner_tenant_id,
         }))
     }
 }
@@ -43,26 +54,31 @@ mod tests {
         Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap()
     }
 
-    fn owner() -> Uuid {
+    fn owner_a() -> Uuid {
         Uuid::parse_str("33333333-3333-3333-3333-333333333333").unwrap()
     }
 
-    fn ctx_for_tenant(tenant_id: Uuid) -> SecurityContext {
+    fn owner_b() -> Uuid {
+        Uuid::parse_str("44444444-4444-4444-4444-444444444444").unwrap()
+    }
+
+    fn ctx(tenant_id: Uuid, subject_id: Uuid) -> SecurityContext {
         SecurityContext::builder()
-            .subject_id(owner())
+            .subject_id(subject_id)
             .subject_tenant_id(tenant_id)
             .build()
             .unwrap()
     }
 
+    /// Private secret: `tenant_a` + `owner_a`.
     fn service_with_single_secret() -> Service {
         let cfg = StaticCredStorePluginConfig {
             secrets: vec![SecretConfig {
-                tenant_id: tenant_a(),
-                owner_id: owner(),
+                tenant_id: Some(tenant_a()),
+                owner_id: Some(owner_a()),
                 key: "openai_api_key".to_owned(),
                 value: "sk-test-123".to_owned(),
-                sharing: credstore_sdk::SharingMode::Tenant,
+                sharing: None,
             }],
             ..StaticCredStorePluginConfig::default()
         };
@@ -71,19 +87,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn get_returns_metadata_for_matching_tenant_and_key() {
+    async fn get_returns_metadata_for_matching_tenant_and_owner() {
         let service = service_with_single_secret();
         let plugin: &dyn CredStorePluginClientV1 = &service;
         let key = SecretRef::new("openai_api_key").unwrap();
 
-        let result = plugin.get(&ctx_for_tenant(tenant_a()), &key).await;
-        assert!(result.is_ok());
-
-        let metadata = result.unwrap();
-        assert!(metadata.is_some());
-        let metadata = metadata.unwrap();
+        let metadata = plugin
+            .get(&ctx(tenant_a(), owner_a()), &key)
+            .await
+            .unwrap()
+            .unwrap();
         assert_eq!(metadata.value.as_bytes(), b"sk-test-123");
-        assert_eq!(metadata.owner_id, owner());
+        assert_eq!(metadata.owner_id, owner_a());
         assert_eq!(metadata.owner_tenant_id, tenant_a());
     }
 
@@ -93,9 +108,18 @@ mod tests {
         let plugin: &dyn CredStorePluginClientV1 = &service;
         let key = SecretRef::new("openai_api_key").unwrap();
 
-        let result = plugin.get(&ctx_for_tenant(tenant_b()), &key).await;
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        let result = plugin.get(&ctx(tenant_b(), owner_a()), &key).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_for_other_owner() {
+        let service = service_with_single_secret();
+        let plugin: &dyn CredStorePluginClientV1 = &service;
+        let key = SecretRef::new("openai_api_key").unwrap();
+
+        let result = plugin.get(&ctx(tenant_a(), owner_b()), &key).await.unwrap();
+        assert!(result.is_none());
     }
 
     #[tokio::test]
@@ -104,9 +128,8 @@ mod tests {
         let plugin: &dyn CredStorePluginClientV1 = &service;
         let key = SecretRef::new("missing").unwrap();
 
-        let result = plugin.get(&ctx_for_tenant(tenant_a()), &key).await;
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        let result = plugin.get(&ctx(tenant_a(), owner_a()), &key).await.unwrap();
+        assert!(result.is_none());
     }
 
     #[tokio::test]
@@ -115,8 +138,127 @@ mod tests {
         let plugin: &dyn CredStorePluginClientV1 = &service;
         let key = SecretRef::new("openai_api_key").unwrap();
 
-        let result = plugin.get(&ctx_for_tenant(tenant_a()), &key).await;
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        let result = plugin.get(&ctx(tenant_a(), owner_a()), &key).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    // --- Shared secret fills owner from SecurityContext ---
+
+    #[tokio::test]
+    async fn shared_secret_resolves_owner_from_context() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: None,
+                owner_id: None,
+                key: "global_key".to_owned(),
+                value: "global-val".to_owned(),
+                sharing: None,
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let plugin: &dyn CredStorePluginClientV1 = &service;
+        let key = SecretRef::new("global_key").unwrap();
+
+        let metadata = plugin
+            .get(&ctx(tenant_a(), owner_b()), &key)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(metadata.value.as_bytes(), b"global-val");
+        assert_eq!(metadata.owner_id, owner_b());
+        assert_eq!(metadata.owner_tenant_id, tenant_a());
+    }
+
+    // --- Tenant secret fills owner from SecurityContext ---
+
+    #[tokio::test]
+    async fn tenant_secret_resolves_owner_from_context() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: Some(tenant_a()),
+                owner_id: None,
+                key: "scoped_key".to_owned(),
+                value: "scoped-val".to_owned(),
+                sharing: None,
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let plugin: &dyn CredStorePluginClientV1 = &service;
+        let key = SecretRef::new("scoped_key").unwrap();
+
+        let metadata = plugin
+            .get(&ctx(tenant_a(), owner_b()), &key)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(metadata.owner_id, owner_b());
+        assert_eq!(metadata.owner_tenant_id, tenant_a());
+    }
+
+    // --- Lookup precedence via plugin ---
+
+    #[tokio::test]
+    async fn private_takes_precedence_over_tenant_and_shared_via_plugin() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![
+                SecretConfig {
+                    tenant_id: None,
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "shared-val".to_owned(),
+                    sharing: None,
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "tenant-val".to_owned(),
+                    sharing: None,
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: Some(owner_a()),
+                    key: "k".to_owned(),
+                    value: "private-val".to_owned(),
+                    sharing: None,
+                },
+            ],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let plugin: &dyn CredStorePluginClientV1 = &service;
+        let key = SecretRef::new("k").unwrap();
+
+        // owner_a in tenant_a → Private
+        let meta = plugin
+            .get(&ctx(tenant_a(), owner_a()), &key)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(meta.value.as_bytes(), b"private-val");
+        assert_eq!(meta.owner_id, owner_a());
+
+        // owner_b in tenant_a → Tenant (owner resolved from ctx)
+        let meta = plugin
+            .get(&ctx(tenant_a(), owner_b()), &key)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(meta.value.as_bytes(), b"tenant-val");
+        assert_eq!(meta.owner_id, owner_b());
+
+        // tenant_b → Shared (owner resolved from ctx)
+        let meta = plugin
+            .get(&ctx(tenant_b(), owner_b()), &key)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(meta.value.as_bytes(), b"shared-val");
+        assert_eq!(meta.owner_id, owner_b());
+        assert_eq!(meta.owner_tenant_id, tenant_b());
     }
 }

--- a/modules/credstore/plugins/static-credstore-plugin/src/domain/service.rs
+++ b/modules/credstore/plugins/static-credstore-plugin/src/domain/service.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use credstore_sdk::{OwnerId, SecretRef, SecretValue, SharingMode, TenantId};
 use modkit_macros::domain_model;
+use modkit_security::SecurityContext;
 
 use crate::config::StaticCredStorePluginConfig;
 
@@ -9,57 +10,195 @@ use crate::config::StaticCredStorePluginConfig;
 #[domain_model]
 pub struct SecretEntry {
     pub value: SecretValue,
-    pub owner_id: OwnerId,
     pub sharing: SharingMode,
+    pub owner_id: OwnerId,
     pub owner_tenant_id: TenantId,
 }
 
 /// Static credstore service.
 ///
-/// Stores secrets in a two-level `HashMap<TenantId, HashMap<SecretRef, SecretEntry>>`
-/// built at init from YAML configuration.
+/// Secrets are stored in four maps based on their resolved `SharingMode`
+/// and whether a `tenant_id` is present:
+///
+/// - **`Private`**: keyed by `(TenantId, OwnerId, SecretRef)` — accessible only
+///   when both tenant and subject match.
+/// - **`Tenant`**: keyed by `(TenantId, SecretRef)` — accessible by any subject
+///   within the matching tenant.
+/// - **`Shared`**: keyed by `(TenantId, SecretRef)` — tenant-scoped but
+///   accessible by descendant tenants via hierarchical resolution in the
+///   gateway. The plugin stores them per-tenant; walk-up is the gateway's job.
+/// - **Global**: keyed by `SecretRef` only — no `tenant_id`; returned as
+///   fallback for any caller. Not a `SharingMode` variant; it is an
+///   operational shortcut specific to the static plugin.
+///
+/// Lookup order: **Private → Tenant → Shared → Global** (most specific first).
 #[domain_model]
+#[allow(clippy::struct_field_names)]
 pub struct Service {
-    secrets: HashMap<TenantId, HashMap<SecretRef, SecretEntry>>,
+    private_secrets: HashMap<(TenantId, OwnerId, SecretRef), SecretEntry>,
+    tenant_secrets: HashMap<(TenantId, SecretRef), SecretEntry>,
+    shared_secrets: HashMap<(TenantId, SecretRef), SecretEntry>,
+    global_secrets: HashMap<SecretRef, SecretEntry>,
 }
 
 impl Service {
     /// Create a service from plugin configuration.
     ///
-    /// Validates each secret key via `SecretRef::new` and builds the lookup map.
+    /// Validates each secret key via `SecretRef::new` and builds the lookup maps.
     ///
     /// # Errors
     ///
-    /// Returns an error if any configured key fails `SecretRef` validation.
+    /// Returns an error if:
+    /// - any configured key fails `SecretRef` validation
+    /// - duplicate keys within the same sharing scope
+    /// - a global secret has an explicit sharing mode other than `Shared`
+    /// - a secret without `owner_id` has an explicit `SharingMode::Private`
+    /// - `tenant_id` or `owner_id` is an explicit nil UUID
+    /// - `owner_id` is set without `tenant_id`
     pub fn from_config(cfg: &StaticCredStorePluginConfig) -> anyhow::Result<Self> {
-        let mut secrets: HashMap<TenantId, HashMap<SecretRef, SecretEntry>> = HashMap::new();
+        let mut private_secrets: HashMap<(TenantId, OwnerId, SecretRef), SecretEntry> =
+            HashMap::new();
+        let mut tenant_secrets: HashMap<(TenantId, SecretRef), SecretEntry> = HashMap::new();
+        let mut shared_secrets: HashMap<(TenantId, SecretRef), SecretEntry> = HashMap::new();
+        let mut global_secrets: HashMap<SecretRef, SecretEntry> = HashMap::new();
 
         for entry in &cfg.secrets {
-            let key = SecretRef::new(&entry.key)?;
-            let secret_entry = SecretEntry {
-                value: SecretValue::from(entry.value.as_str()),
-                owner_id: entry.owner_id,
-                sharing: entry.sharing,
-                owner_tenant_id: entry.tenant_id,
-            };
-            let tenant_map = secrets.entry(entry.tenant_id).or_default();
-            if tenant_map.contains_key(&key) {
+            if entry.tenant_id == Some(TenantId::nil()) {
+                anyhow::bail!("secret '{}': tenant_id must not be nil UUID", entry.key);
+            }
+            if entry.owner_id == Some(OwnerId::nil()) {
+                anyhow::bail!("secret '{}': owner_id must not be nil UUID", entry.key);
+            }
+
+            if entry.tenant_id.is_none() && entry.owner_id.is_some() {
                 anyhow::bail!(
-                    "duplicate secret key '{}' for tenant {}",
-                    entry.key,
-                    entry.tenant_id
+                    "secret '{}': owner_id cannot be set without tenant_id",
+                    entry.key
                 );
             }
-            tenant_map.insert(key, secret_entry);
+
+            let sharing = entry.resolve_sharing();
+
+            if entry.owner_id.is_none() && sharing == SharingMode::Private {
+                anyhow::bail!(
+                    "secret '{}' with sharing mode 'private' requires an explicit owner_id",
+                    entry.key
+                );
+            }
+
+            let key = SecretRef::new(&entry.key)?;
+
+            match (sharing, entry.tenant_id) {
+                (SharingMode::Shared, None) => {
+                    // Global secret: no tenant_id, accessible by any caller.
+                    let secret_entry = SecretEntry {
+                        value: SecretValue::from(entry.value.as_str()),
+                        sharing,
+                        owner_id: OwnerId::nil(),
+                        owner_tenant_id: TenantId::nil(),
+                    };
+                    if global_secrets.contains_key(&key) {
+                        anyhow::bail!("duplicate global secret key '{}'", entry.key);
+                    }
+                    global_secrets.insert(key, secret_entry);
+                }
+                (SharingMode::Shared, Some(tenant_id)) => {
+                    // Shared secret: tenant-scoped, visible to descendants
+                    // via gateway hierarchical resolution.
+                    let secret_entry = SecretEntry {
+                        value: SecretValue::from(entry.value.as_str()),
+                        sharing,
+                        owner_id: OwnerId::nil(),
+                        owner_tenant_id: tenant_id,
+                    };
+                    let map_key = (tenant_id, key);
+                    if shared_secrets.contains_key(&map_key) {
+                        anyhow::bail!(
+                            "duplicate shared secret key '{}' for tenant {}",
+                            entry.key,
+                            tenant_id
+                        );
+                    }
+                    shared_secrets.insert(map_key, secret_entry);
+                }
+                (SharingMode::Tenant, _) => {
+                    let tenant_id = entry.tenant_id.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "secret '{}': tenant sharing mode requires tenant_id",
+                            entry.key
+                        )
+                    })?;
+                    let secret_entry = SecretEntry {
+                        value: SecretValue::from(entry.value.as_str()),
+                        sharing,
+                        owner_id: OwnerId::nil(),
+                        owner_tenant_id: tenant_id,
+                    };
+                    let map_key = (tenant_id, key);
+                    if tenant_secrets.contains_key(&map_key) {
+                        anyhow::bail!(
+                            "duplicate tenant secret key '{}' for tenant {}",
+                            entry.key,
+                            tenant_id
+                        );
+                    }
+                    tenant_secrets.insert(map_key, secret_entry);
+                }
+                (SharingMode::Private, _) => {
+                    let tenant_id = entry.tenant_id.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "secret '{}': private sharing mode requires tenant_id",
+                            entry.key
+                        )
+                    })?;
+                    // owner_id is guaranteed Some by the validation above.
+                    let owner_id = entry.owner_id.ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "secret '{}': private sharing mode requires owner_id",
+                            entry.key
+                        )
+                    })?;
+                    let secret_entry = SecretEntry {
+                        value: SecretValue::from(entry.value.as_str()),
+                        sharing,
+                        owner_id,
+                        owner_tenant_id: tenant_id,
+                    };
+                    let map_key = (tenant_id, owner_id, key);
+                    if private_secrets.contains_key(&map_key) {
+                        anyhow::bail!(
+                            "duplicate private secret key '{}' for tenant {} owner {}",
+                            entry.key,
+                            tenant_id,
+                            owner_id
+                        );
+                    }
+                    private_secrets.insert(map_key, secret_entry);
+                }
+            }
         }
 
-        Ok(Self { secrets })
+        Ok(Self {
+            private_secrets,
+            tenant_secrets,
+            shared_secrets,
+            global_secrets,
+        })
     }
 
-    /// Look up a secret by tenant ID and key.
+    /// Look up a secret using the caller's security context.
+    ///
+    /// Lookup order: **Private → Tenant → Shared → Global** (most specific first).
     #[must_use]
-    pub fn get(&self, tenant_id: TenantId, key: &SecretRef) -> Option<&SecretEntry> {
-        self.secrets.get(&tenant_id)?.get(key)
+    pub fn get(&self, ctx: &SecurityContext, key: &SecretRef) -> Option<&SecretEntry> {
+        let tenant_id = ctx.subject_tenant_id();
+        let subject_id = ctx.subject_id();
+
+        self.private_secrets
+            .get(&(tenant_id, subject_id, key.clone()))
+            .or_else(|| self.tenant_secrets.get(&(tenant_id, key.clone())))
+            .or_else(|| self.shared_secrets.get(&(tenant_id, key.clone())))
+            .or_else(|| self.global_secrets.get(key))
     }
 }
 
@@ -78,18 +217,31 @@ mod tests {
         Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap()
     }
 
-    fn owner() -> Uuid {
+    fn owner_a() -> Uuid {
         Uuid::parse_str("33333333-3333-3333-3333-333333333333").unwrap()
     }
 
+    fn owner_b() -> Uuid {
+        Uuid::parse_str("44444444-4444-4444-4444-444444444444").unwrap()
+    }
+
+    fn ctx(tenant_id: Uuid, subject_id: Uuid) -> SecurityContext {
+        SecurityContext::builder()
+            .subject_id(subject_id)
+            .subject_tenant_id(tenant_id)
+            .build()
+            .unwrap()
+    }
+
+    /// Default config: `tenant_a` + `owner_a` → Private secret.
     fn cfg_with_single_secret() -> StaticCredStorePluginConfig {
         StaticCredStorePluginConfig {
             secrets: vec![SecretConfig {
-                tenant_id: tenant_a(),
-                owner_id: owner(),
+                tenant_id: Some(tenant_a()),
+                owner_id: Some(owner_a()),
                 key: "openai_api_key".to_owned(),
                 value: "sk-test-123".to_owned(),
-                sharing: SharingMode::Tenant,
+                sharing: None,
             }],
             ..StaticCredStorePluginConfig::default()
         }
@@ -99,11 +251,11 @@ mod tests {
     fn from_config_rejects_invalid_secret_ref() {
         let cfg = StaticCredStorePluginConfig {
             secrets: vec![SecretConfig {
-                tenant_id: tenant_a(),
-                owner_id: owner(),
+                tenant_id: Some(tenant_a()),
+                owner_id: Some(owner_a()),
                 key: "invalid:key".to_owned(),
                 value: "value".to_owned(),
-                sharing: SharingMode::Tenant,
+                sharing: None,
             }],
             ..StaticCredStorePluginConfig::default()
         };
@@ -112,28 +264,34 @@ mod tests {
         assert!(result.is_err());
     }
 
+    // --- Private secret lookup ---
+
     #[test]
-    fn get_returns_secret_for_matching_tenant_and_key() {
+    fn private_secret_returned_for_matching_tenant_and_owner() {
         let service = Service::from_config(&cfg_with_single_secret()).unwrap();
         let key = SecretRef::new("openai_api_key").unwrap();
 
-        let entry = service.get(tenant_a(), &key);
-        assert!(entry.is_some());
-
-        let entry = entry.unwrap();
+        let entry = service.get(&ctx(tenant_a(), owner_a()), &key).unwrap();
         assert_eq!(entry.value.as_bytes(), b"sk-test-123");
-        assert_eq!(entry.owner_id, owner());
+        assert_eq!(entry.owner_id, owner_a());
         assert_eq!(entry.owner_tenant_id, tenant_a());
-        assert_eq!(entry.sharing, SharingMode::Tenant);
+        assert_eq!(entry.sharing, SharingMode::Private);
     }
 
     #[test]
-    fn get_returns_none_for_different_tenant() {
+    fn private_secret_not_returned_for_different_owner() {
         let service = Service::from_config(&cfg_with_single_secret()).unwrap();
         let key = SecretRef::new("openai_api_key").unwrap();
 
-        let entry = service.get(tenant_b(), &key);
-        assert!(entry.is_none());
+        assert!(service.get(&ctx(tenant_a(), owner_b()), &key).is_none());
+    }
+
+    #[test]
+    fn private_secret_not_returned_for_different_tenant() {
+        let service = Service::from_config(&cfg_with_single_secret()).unwrap();
+        let key = SecretRef::new("openai_api_key").unwrap();
+
+        assert!(service.get(&ctx(tenant_b(), owner_a()), &key).is_none());
     }
 
     #[test]
@@ -141,24 +299,241 @@ mod tests {
         let service = Service::from_config(&cfg_with_single_secret()).unwrap();
         let key = SecretRef::new("missing").unwrap();
 
-        let entry = service.get(tenant_a(), &key);
-        assert!(entry.is_none());
+        assert!(service.get(&ctx(tenant_a(), owner_a()), &key).is_none());
     }
 
     #[test]
-    fn from_config_rejects_duplicate_key_for_same_tenant() {
+    fn from_config_with_empty_secrets_returns_none() {
+        let cfg = StaticCredStorePluginConfig::default();
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("any-key").unwrap();
+        assert!(service.get(&ctx(tenant_a(), owner_a()), &key).is_none());
+    }
+
+    // --- Tenant secret lookup ---
+
+    #[test]
+    fn tenant_secret_returned_for_any_subject_in_same_tenant() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: Some(tenant_a()),
+                owner_id: None,
+                key: "team_key".to_owned(),
+                value: "team-val".to_owned(),
+                sharing: None,
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("team_key").unwrap();
+
+        let e1 = service.get(&ctx(tenant_a(), owner_a()), &key).unwrap();
+        assert_eq!(e1.value.as_bytes(), b"team-val");
+        assert_eq!(e1.sharing, SharingMode::Tenant);
+
+        let e2 = service.get(&ctx(tenant_a(), owner_b()), &key).unwrap();
+        assert_eq!(e2.value.as_bytes(), b"team-val");
+
+        assert!(service.get(&ctx(tenant_b(), owner_a()), &key).is_none());
+    }
+
+    // --- Global secret lookup ---
+
+    #[test]
+    fn global_secret_returned_for_any_tenant_and_subject() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: None,
+                owner_id: None,
+                key: "global_key".to_owned(),
+                value: "global-val".to_owned(),
+                sharing: None,
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("global_key").unwrap();
+
+        let e1 = service.get(&ctx(tenant_a(), owner_a()), &key).unwrap();
+        assert_eq!(e1.value.as_bytes(), b"global-val");
+        assert_eq!(e1.sharing, SharingMode::Shared);
+
+        let e2 = service.get(&ctx(tenant_b(), owner_b()), &key).unwrap();
+        assert_eq!(e2.value.as_bytes(), b"global-val");
+    }
+
+    // --- Shared (tenant-scoped) secret lookup ---
+
+    #[test]
+    fn shared_secret_returned_only_for_owning_tenant() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: Some(tenant_a()),
+                owner_id: None,
+                key: "shared_key".to_owned(),
+                value: "shared-val".to_owned(),
+                sharing: Some(SharingMode::Shared),
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("shared_key").unwrap();
+
+        // Same tenant — accessible
+        let e = service.get(&ctx(tenant_a(), owner_a()), &key).unwrap();
+        assert_eq!(e.value.as_bytes(), b"shared-val");
+        assert_eq!(e.sharing, SharingMode::Shared);
+        assert_eq!(e.owner_tenant_id, tenant_a());
+
+        // Different tenant — not accessible at plugin level
+        // (gateway walk-up would call the plugin with parent tenant_id)
+        assert!(service.get(&ctx(tenant_b(), owner_a()), &key).is_none());
+    }
+
+    // --- Lookup precedence: Private > Tenant > Shared > Global ---
+
+    #[test]
+    fn private_takes_precedence_over_tenant_shared_and_global() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![
+                SecretConfig {
+                    tenant_id: None,
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "global-val".to_owned(),
+                    sharing: None,
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "shared-val".to_owned(),
+                    sharing: Some(SharingMode::Shared),
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "tenant-val".to_owned(),
+                    sharing: None,
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: Some(owner_a()),
+                    key: "k".to_owned(),
+                    value: "private-val".to_owned(),
+                    sharing: None,
+                },
+            ],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("k").unwrap();
+
+        // owner_a in tenant_a → Private
+        let e = service.get(&ctx(tenant_a(), owner_a()), &key).unwrap();
+        assert_eq!(e.value.as_bytes(), b"private-val");
+        assert_eq!(e.sharing, SharingMode::Private);
+
+        // owner_b in tenant_a → Tenant (no private match)
+        let e = service.get(&ctx(tenant_a(), owner_b()), &key).unwrap();
+        assert_eq!(e.value.as_bytes(), b"tenant-val");
+        assert_eq!(e.sharing, SharingMode::Tenant);
+
+        // tenant_b → Global (no private, tenant, or shared match)
+        let e = service.get(&ctx(tenant_b(), owner_a()), &key).unwrap();
+        assert_eq!(e.value.as_bytes(), b"global-val");
+        assert_eq!(e.sharing, SharingMode::Shared);
+    }
+
+    #[test]
+    fn tenant_takes_precedence_over_shared_and_global() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![
+                SecretConfig {
+                    tenant_id: None,
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "global-val".to_owned(),
+                    sharing: None,
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "shared-val".to_owned(),
+                    sharing: Some(SharingMode::Shared),
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "tenant-val".to_owned(),
+                    sharing: None,
+                },
+            ],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("k").unwrap();
+
+        let e = service.get(&ctx(tenant_a(), owner_a()), &key).unwrap();
+        assert_eq!(e.value.as_bytes(), b"tenant-val");
+
+        let e = service.get(&ctx(tenant_b(), owner_a()), &key).unwrap();
+        assert_eq!(e.value.as_bytes(), b"global-val");
+    }
+
+    #[test]
+    fn shared_takes_precedence_over_global() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![
+                SecretConfig {
+                    tenant_id: None,
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "global-val".to_owned(),
+                    sharing: None,
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "shared-val".to_owned(),
+                    sharing: Some(SharingMode::Shared),
+                },
+            ],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("k").unwrap();
+
+        // tenant_a has a shared secret → takes precedence over global
+        let e = service.get(&ctx(tenant_a(), owner_a()), &key).unwrap();
+        assert_eq!(e.value.as_bytes(), b"shared-val");
+        assert_eq!(e.sharing, SharingMode::Shared);
+
+        // tenant_b has no shared secret → falls through to global
+        let e = service.get(&ctx(tenant_b(), owner_a()), &key).unwrap();
+        assert_eq!(e.value.as_bytes(), b"global-val");
+    }
+
+    // --- Duplicate key validation ---
+
+    #[test]
+    fn from_config_rejects_duplicate_private_key() {
         let secret = SecretConfig {
-            tenant_id: tenant_a(),
-            owner_id: owner(),
-            key: "openai_api_key".to_owned(),
-            value: "sk-first".to_owned(),
-            sharing: SharingMode::Tenant,
+            tenant_id: Some(tenant_a()),
+            owner_id: Some(owner_a()),
+            key: "dup".to_owned(),
+            value: "v1".to_owned(),
+            sharing: None,
         };
         let cfg = StaticCredStorePluginConfig {
             secrets: vec![
                 secret.clone(),
                 SecretConfig {
-                    value: "sk-second".to_owned(),
+                    value: "v2".to_owned(),
                     ..secret
                 },
             ],
@@ -166,30 +541,416 @@ mod tests {
         };
 
         match Service::from_config(&cfg) {
-            Ok(_) => panic!("expected error for duplicate key"),
+            Ok(_) => panic!("expected error for duplicate private key"),
             Err(e) => {
-                let msg = e.to_string();
-                assert!(msg.contains("duplicate"), "expected 'duplicate' in: {msg}");
+                let err = e.to_string();
+                assert!(err.contains("duplicate"), "expected 'duplicate' in: {err}");
+                assert!(err.contains("dup"), "expected key name in: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn from_config_rejects_duplicate_tenant_key() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "dup".to_owned(),
+                    value: "v1".to_owned(),
+                    sharing: None,
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "dup".to_owned(),
+                    value: "v2".to_owned(),
+                    sharing: None,
+                },
+            ],
+            ..StaticCredStorePluginConfig::default()
+        };
+
+        match Service::from_config(&cfg) {
+            Ok(_) => panic!("expected error for duplicate tenant key"),
+            Err(e) => {
+                let err = e.to_string();
+                assert!(err.contains("duplicate"), "expected 'duplicate' in: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn from_config_rejects_duplicate_global_key() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![
+                SecretConfig {
+                    tenant_id: None,
+                    owner_id: None,
+                    key: "dup".to_owned(),
+                    value: "v1".to_owned(),
+                    sharing: None,
+                },
+                SecretConfig {
+                    tenant_id: None,
+                    owner_id: None,
+                    key: "dup".to_owned(),
+                    value: "v2".to_owned(),
+                    sharing: None,
+                },
+            ],
+            ..StaticCredStorePluginConfig::default()
+        };
+
+        match Service::from_config(&cfg) {
+            Ok(_) => panic!("expected error for duplicate global key"),
+            Err(e) => {
+                let err = e.to_string();
+                assert!(err.contains("duplicate"), "expected 'duplicate' in: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn from_config_rejects_duplicate_shared_key() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "dup".to_owned(),
+                    value: "v1".to_owned(),
+                    sharing: Some(SharingMode::Shared),
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "dup".to_owned(),
+                    value: "v2".to_owned(),
+                    sharing: Some(SharingMode::Shared),
+                },
+            ],
+            ..StaticCredStorePluginConfig::default()
+        };
+
+        match Service::from_config(&cfg) {
+            Ok(_) => panic!("expected error for duplicate shared key"),
+            Err(e) => {
+                let err = e.to_string();
+                assert!(err.contains("duplicate"), "expected 'duplicate' in: {err}");
+            }
+        }
+    }
+
+    // --- Config validation ---
+
+    #[test]
+    fn from_config_rejects_non_shared_global_secret() {
+        for mode in [SharingMode::Private, SharingMode::Tenant] {
+            let cfg = StaticCredStorePluginConfig {
+                secrets: vec![SecretConfig {
+                    tenant_id: None,
+                    owner_id: None,
+                    key: "global_key".to_owned(),
+                    value: "val".to_owned(),
+                    sharing: Some(mode),
+                }],
+                ..StaticCredStorePluginConfig::default()
+            };
+
+            assert!(
+                Service::from_config(&cfg).is_err(),
+                "expected error for global secret with {mode:?} sharing"
+            );
+        }
+    }
+
+    #[test]
+    fn from_config_rejects_private_without_owner_id() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: Some(tenant_a()),
+                owner_id: None,
+                key: "private_key".to_owned(),
+                value: "val".to_owned(),
+                sharing: Some(SharingMode::Private),
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+
+        match Service::from_config(&cfg) {
+            Ok(_) => panic!("expected error for private without owner_id"),
+            Err(e) => {
+                let err = e.to_string();
+                assert!(err.contains("requires an explicit owner_id"), "got: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn from_config_rejects_owner_id_without_tenant_id() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: None,
+                owner_id: Some(owner_a()),
+                key: "bad_key".to_owned(),
+                value: "val".to_owned(),
+                sharing: None,
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+
+        match Service::from_config(&cfg) {
+            Ok(_) => panic!("expected error for owner_id without tenant_id"),
+            Err(e) => {
+                let err = e.to_string();
                 assert!(
-                    msg.contains("openai_api_key"),
-                    "expected key name in: {msg}"
-                );
-                assert!(
-                    msg.contains(&tenant_a().to_string()),
-                    "expected tenant id in: {msg}"
+                    err.contains("owner_id cannot be set without tenant_id"),
+                    "got: {err}"
                 );
             }
         }
     }
 
     #[test]
-    fn from_config_with_empty_secrets_returns_none_for_any_lookup() {
-        let cfg = StaticCredStorePluginConfig::default();
+    fn from_config_accepts_shared_with_tenant_id() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: Some(tenant_a()),
+                owner_id: None,
+                key: "k".to_owned(),
+                value: "v".to_owned(),
+                sharing: Some(SharingMode::Shared),
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+
         let service = Service::from_config(&cfg).unwrap();
-        let key = SecretRef::new("any-key").unwrap();
-        assert!(
-            service.get(tenant_a(), &key).is_none(),
-            "empty config must return None for any lookup"
+        let key = SecretRef::new("k").unwrap();
+        let e = service.get(&ctx(tenant_a(), owner_a()), &key).unwrap();
+        assert_eq!(e.sharing, SharingMode::Shared);
+        assert_eq!(e.owner_tenant_id, tenant_a());
+    }
+
+    #[test]
+    fn from_config_rejects_nil_tenant_id() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: Some(Uuid::nil()),
+                owner_id: Some(owner_a()),
+                key: "k".to_owned(),
+                value: "v".to_owned(),
+                sharing: None,
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+
+        match Service::from_config(&cfg) {
+            Ok(_) => panic!("expected error for nil tenant_id"),
+            Err(e) => {
+                let err = e.to_string();
+                assert!(err.contains("tenant_id must not be nil UUID"), "got: {err}");
+            }
+        }
+    }
+
+    #[test]
+    fn from_config_rejects_nil_owner_id() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: Some(tenant_a()),
+                owner_id: Some(Uuid::nil()),
+                key: "k".to_owned(),
+                value: "v".to_owned(),
+                sharing: None,
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+
+        match Service::from_config(&cfg) {
+            Ok(_) => panic!("expected error for nil owner_id"),
+            Err(e) => {
+                let err = e.to_string();
+                assert!(err.contains("owner_id must not be nil UUID"), "got: {err}");
+            }
+        }
+    }
+
+    // --- Sharing mode defaults ---
+
+    #[test]
+    fn default_sharing_is_shared_for_global() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: None,
+                owner_id: None,
+                key: "g".to_owned(),
+                value: "v".to_owned(),
+                sharing: None,
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("g").unwrap();
+        assert_eq!(
+            service
+                .get(&ctx(tenant_a(), owner_a()), &key)
+                .unwrap()
+                .sharing,
+            SharingMode::Shared
         );
+    }
+
+    #[test]
+    fn default_sharing_is_tenant_for_scoped_without_owner() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: Some(tenant_a()),
+                owner_id: None,
+                key: "t".to_owned(),
+                value: "v".to_owned(),
+                sharing: None,
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("t").unwrap();
+        assert_eq!(
+            service
+                .get(&ctx(tenant_a(), owner_a()), &key)
+                .unwrap()
+                .sharing,
+            SharingMode::Tenant
+        );
+    }
+
+    #[test]
+    fn default_sharing_is_private_for_scoped_with_owner() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: Some(tenant_a()),
+                owner_id: Some(owner_a()),
+                key: "p".to_owned(),
+                value: "v".to_owned(),
+                sharing: None,
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("p").unwrap();
+        assert_eq!(
+            service
+                .get(&ctx(tenant_a(), owner_a()), &key)
+                .unwrap()
+                .sharing,
+            SharingMode::Private
+        );
+    }
+
+    #[test]
+    fn explicit_sharing_overrides_default() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![SecretConfig {
+                tenant_id: Some(tenant_a()),
+                owner_id: Some(owner_a()),
+                key: "k".to_owned(),
+                value: "v".to_owned(),
+                sharing: Some(SharingMode::Tenant),
+            }],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("k").unwrap();
+        assert_eq!(
+            service
+                .get(&ctx(tenant_a(), owner_a()), &key)
+                .unwrap()
+                .sharing,
+            SharingMode::Tenant
+        );
+    }
+
+    // --- Same key in different scopes ---
+
+    #[test]
+    fn allows_same_key_in_different_tenants() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "api_key".to_owned(),
+                    value: "val-a".to_owned(),
+                    sharing: None,
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_b()),
+                    owner_id: None,
+                    key: "api_key".to_owned(),
+                    value: "val-b".to_owned(),
+                    sharing: None,
+                },
+            ],
+            ..StaticCredStorePluginConfig::default()
+        };
+        let service = Service::from_config(&cfg).unwrap();
+        let key = SecretRef::new("api_key").unwrap();
+
+        assert_eq!(
+            service
+                .get(&ctx(tenant_a(), owner_a()), &key)
+                .unwrap()
+                .value
+                .as_bytes(),
+            b"val-a"
+        );
+        assert_eq!(
+            service
+                .get(&ctx(tenant_b(), owner_a()), &key)
+                .unwrap()
+                .value
+                .as_bytes(),
+            b"val-b"
+        );
+    }
+
+    #[test]
+    fn same_key_across_all_four_scopes() {
+        let cfg = StaticCredStorePluginConfig {
+            secrets: vec![
+                SecretConfig {
+                    tenant_id: None,
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "global".to_owned(),
+                    sharing: None,
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "shared".to_owned(),
+                    sharing: Some(SharingMode::Shared),
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: None,
+                    key: "k".to_owned(),
+                    value: "tenant".to_owned(),
+                    sharing: None,
+                },
+                SecretConfig {
+                    tenant_id: Some(tenant_a()),
+                    owner_id: Some(owner_a()),
+                    key: "k".to_owned(),
+                    value: "private".to_owned(),
+                    sharing: None,
+                },
+            ],
+            ..StaticCredStorePluginConfig::default()
+        };
+
+        assert!(Service::from_config(&cfg).is_ok());
     }
 }


### PR DESCRIPTION
- Split storage into four maps: private, tenant, shared, global
  - Shared: keyed by (TenantId, SecretRef) — tenant-scoped,
    visible to descendants via gateway hierarchical walk-up
  - Global: keyed by SecretRef only — no tenant_id, fallback
    for any caller (static plugin operational shortcut)
- Lookup order: Private → Tenant → Shared → Global
- Allow SharingMode::Shared with tenant_id (tenant-scoped shared)
- Config: tenant_id=None defaults to Shared (global); tenant_id
  with explicit sharing: shared creates tenant-scoped shared secret
- Update config.rs doc comments for tenant_id semantics
- Update tests for 4-tier model and new precedence rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit secret scopes: private, tenant, shared, and global with deterministic resolution.
  * Owner and tenant IDs can be omitted and will be resolved from the caller's security context when applicable.

* **Improvements**
  * Lookups now follow Private → Tenant → Shared → Global precedence based on context.
  * Stronger validation and clearer errors for scope/ownership rules.

* **Tests**
  * Expanded coverage for scope resolution, precedence, and context-driven ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->