### PR TITLE
chore(release-plz): remove gix index before crates release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -182,6 +182,9 @@ jobs:
       - name: cargo test (workspace)
         run: make test-no-macros
 
+      - name: Clear cargo registry index (workaround gix slotmap overflow)
+        run: rm -rf ~/.cargo/registry/index
+
       - name: release-plz release
         uses: release-plz/action@52440b50d383aa252927de395c8b2c1e0a9cf8e9 # v0.3.155
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow reliability by adding a pre-release maintenance step to clear the Cargo registry index to avoid registry-related build failures.
  * This reduces intermittent release breaks caused by registry caching/state issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->