### PR TITLE
feat(mini-chat): update policy plugin API and add SDK/plugin tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,7 @@ dependencies = [
  "serde",
  "serde_json",
  "time",
+ "tokio",
  "tracing",
  "uuid",
 ]

--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -158,36 +158,173 @@ modules:
       vendor: "hyperspot"
       priority: 100
       model_catalog:
+        # ── GPT-4.1 (Premium) ──
         - model_id: "gpt-4.1"
           provider_model_id: "gpt-4.1"
           display_name: "GPT-4.1"
+          description: "Most capable model"
+          version: "4.1"
+          provider_id: "azure_openai"
+          provider_display_name: "Azure OpenAI"
+          icon: ""
           tier: Premium
-          global_enabled: true
-          is_default: true
-          input_tokens_credit_multiplier_micro: 3000000
-          output_tokens_credit_multiplier_micro: 15000000
+          enabled: true
           multimodal_capabilities: ["VISION_INPUT"]
           context_window: 1047576
           max_output_tokens: 32768
-          description: "Most capable model"
-          provider_display_name: "Azure OpenAI"
+          max_input_tokens: 1047576
+          input_tokens_credit_multiplier_micro: 3000000
+          output_tokens_credit_multiplier_micro: 15000000
           multiplier_display: "3x"
-          provider_id: "azure_openai"
+          estimation_budgets:
+            bytes_per_token_conservative: 4
+            fixed_overhead_tokens: 100
+            safety_margin_pct: 10
+            image_token_budget: 1000
+            tool_surcharge_tokens: 500
+            web_search_surcharge_tokens: 500
+            minimal_generation_floor: 50
+          max_retrieved_chunks_per_turn: 5
+          general_config:
+            type: ""
+            tier: "premium"
+            available_from: "1970-01-01T00:00:00Z"
+            max_file_size_mb: 25
+            api_params:
+              temperature: 0.7
+              top_p: 1.0
+              frequency_penalty: 0.0
+              presence_penalty: 0.0
+              stop: []
+            features:
+              streaming: true
+              function_calling: true
+              structured_output: true
+              fine_tuning: false
+              distillation: false
+              fim_completion: false
+              chat_prefix_completion: false
+            input_type:
+              text: true
+              image: true
+              audio: false
+              video: false
+            tool_support:
+              web_search: true
+              file_search: true
+              image_generation: false
+              code_interpreter: false
+              computer_use: false
+              mcp: false
+            supported_endpoints:
+              chat_completions: true
+              responses: true
+              realtime: false
+              assistants: false
+              batch_api: false
+              fine_tuning: false
+              embeddings: false
+              videos: false
+              image_generation: false
+              image_edit: false
+              audio_speech_generation: false
+              audio_transcription: false
+              audio_translation: false
+              moderations: false
+              completions: false
+            token_policy:
+              input_tokens_credit_multiplier: 3.0
+              output_tokens_credit_multiplier: 15.0
+            performance:
+              response_latency_ms: 800
+              speed_tokens_per_second: 75
+          preference:
+            is_default: true
+            sort_order: 0
+
+        # ── GPT-4.1 Mini (Standard) ──
         - model_id: "gpt-4.1-mini"
           provider_model_id: "gpt-4.1-mini"
           display_name: "GPT-4.1 Mini"
+          description: "Fast and efficient model"
+          version: "4.1"
+          provider_id: "azure_openai"
+          provider_display_name: "Azure OpenAI"
+          icon: ""
           tier: Standard
-          global_enabled: true
-          is_default: false
-          input_tokens_credit_multiplier_micro: 1000000
-          output_tokens_credit_multiplier_micro: 3000000
+          enabled: true
           multimodal_capabilities: ["VISION_INPUT"]
           context_window: 1047576
           max_output_tokens: 32768
-          description: "Fast and efficient model"
-          provider_display_name: "Azure OpenAI"
+          max_input_tokens: 1047576
+          input_tokens_credit_multiplier_micro: 1000000
+          output_tokens_credit_multiplier_micro: 3000000
           multiplier_display: "1x"
-          provider_id: "azure_openai"
+          estimation_budgets:
+            bytes_per_token_conservative: 4
+            fixed_overhead_tokens: 100
+            safety_margin_pct: 10
+            image_token_budget: 1000
+            tool_surcharge_tokens: 500
+            web_search_surcharge_tokens: 500
+            minimal_generation_floor: 50
+          max_retrieved_chunks_per_turn: 5
+          general_config:
+            type: ""
+            tier: "standard"
+            available_from: "1970-01-01T00:00:00Z"
+            max_file_size_mb: 25
+            api_params:
+              temperature: 0.7
+              top_p: 1.0
+              frequency_penalty: 0.0
+              presence_penalty: 0.0
+              stop: []
+            features:
+              streaming: true
+              function_calling: true
+              structured_output: true
+              fine_tuning: false
+              distillation: false
+              fim_completion: false
+              chat_prefix_completion: false
+            input_type:
+              text: true
+              image: true
+              audio: false
+              video: false
+            tool_support:
+              web_search: false
+              file_search: false
+              image_generation: false
+              code_interpreter: false
+              computer_use: false
+              mcp: false
+            supported_endpoints:
+              chat_completions: true
+              responses: true
+              realtime: false
+              assistants: false
+              batch_api: false
+              fine_tuning: false
+              embeddings: false
+              videos: false
+              image_generation: false
+              image_edit: false
+              audio_speech_generation: false
+              audio_transcription: false
+              audio_translation: false
+              moderations: false
+              completions: false
+            token_policy:
+              input_tokens_credit_multiplier: 1.0
+              output_tokens_credit_multiplier: 3.0
+            performance:
+              response_latency_ms: 400
+              speed_tokens_per_second: 150
+          preference:
+            is_default: false
+            sort_order: 1
 
 tracing:
   enabled: false

--- a/modules/mini-chat/docs/DESIGN.md
+++ b/modules/mini-chat/docs/DESIGN.md
@@ -276,6 +276,7 @@ Global emergency flags / kill switches (P1): operators MUST have a way to immedi
 - `force_standard_tier` — if enabled, all requests MUST use the standard-tier model regardless of quota state or user selection.
 - `disable_file_search` — if enabled, `file_search` tool calls MUST be skipped; responses proceed without retrieval.
 - `disable_web_search` — if enabled, requests with `web_search.enabled=true` MUST be rejected with HTTP 400 and error code `web_search_disabled` before opening an SSE stream. The system MUST NOT silently ignore the parameter.
+- `disable_images` — if enabled, image uploads and image attachments MUST be rejected; requests containing image content MUST be rejected with HTTP 400 and error code `images_disabled` before opening an SSE stream.
 
 Ownership: these flags are owned and operated by platform configuration (P1: deployment config). Long-term, they are expected to be owned by Settings Service / License Manager with privileged operator access.
 
@@ -3555,9 +3556,9 @@ Contents (logically):
 
 **Estimation Budgets Source (P1)**:
 
-In P1, `estimation_budgets` (image_token_budget, tool_surcharge_tokens, web_search_surcharge_tokens, bytes_per_token_conservative, fixed_overhead_tokens, safety_margin_pct, minimal_generation_floor) are configured **locally in MiniChat** via Kubernetes ConfigMap (or equivalent deployment configuration file). CCM PolicySnapshot in P1 does NOT include `estimation_budgets`.
+In P1, `estimation_budgets` (image_token_budget, tool_surcharge_tokens, web_search_surcharge_tokens, bytes_per_token_conservative, fixed_overhead_tokens, safety_margin_pct, minimal_generation_floor) are embedded **per-model** in the policy snapshot catalog (each `ModelCatalogEntry` carries its own `estimation_budgets`). This allows per-model tuning of estimation parameters.
 
-These budgets are used ONLY for preflight reserve estimation and admission control. They MUST be loaded at MiniChat startup and validated (non-negative values, sane bounds, `minimal_generation_floor <= max_output_tokens`). ConfigMap/config changes are operationally expected to be rolled out consistently across MiniChat pods (best-effort operational note; config drift detection is out of scope for P1).
+These budgets are used ONLY for preflight reserve estimation and admission control. Values are delivered as part of the policy plugin configuration and are validated at startup (non-negative values, sane bounds, `minimal_generation_floor <= max_output_tokens`). Because they are part of the model catalog entry, changes to `estimation_budgets` for a model constitute a catalog change and trigger a policy version bump.
 
 - `user_limits` (per user allocation; delivered/derived per-user, but tied to `policy_version`):
 
@@ -3623,7 +3624,7 @@ A PolicySnapshot is a versioned, immutable configuration object published by CCM
 - `policy_version` (monotonic identifier)
 - `model_catalog` (model entries with credit multipliers, capabilities, tier, display metadata)
 - `estimation_budgets` (fixed surcharge token budgets for preflight reserve estimation). **Source split (normative)**: the fields `bytes_per_token_conservative`, `fixed_overhead_tokens`, `safety_margin_pct`, `image_token_budget`, `tool_surcharge_tokens`, and `web_search_surcharge_tokens` are part of this PolicySnapshot and versioned by `policy_version`. The field `minimal_generation_floor` is sourced from the MiniChat ConfigMap (NOT from this PolicySnapshot) and is captured per-turn into `chat_turns.minimal_generation_floor_applied` at preflight. PolicySnapshot-sourced values take effect when CCM publishes a new `policy_version`. ConfigMap-sourced values take effect on the next preflight after the ConfigMap is reloaded.
-- global kill switches (`disable_premium_tier`, `force_standard_tier`, `disable_web_search`)
+- global kill switches (`disable_premium_tier`, `force_standard_tier`, `disable_web_search`, `disable_file_search`, `disable_images`)
 
 PolicySnapshot rules:
 
@@ -3975,8 +3976,8 @@ mini-chat selects `effective_model` (with downgrade if needed) based on the curr
 
 Then it computes:
 
-- `estimated_text_tokens` — sum of text content, metadata, and retrieved chunks (see ConfigMap `estimation_budgets`, line 3194)
-- `image_surcharge_tokens` — if images present, apply `estimation_budgets.image_token_budget` per image (ConfigMap-defined conservative estimate, line 3195)
+- `estimated_text_tokens` — sum of text content, metadata, and retrieved chunks (see `estimation_budgets` from the selected model's catalog entry, section 5.2.1)
+- `image_surcharge_tokens` — if images present, apply `estimation_budgets.image_token_budget` per image (per-model conservative estimate from catalog entry, section 5.2.1)
 - `tool_surcharge_tokens` — apply `estimation_budgets.tool_surcharge_tokens` if tool use enabled (line 3196)
 - `web_search_surcharge_tokens` — apply `estimation_budgets.web_search_surcharge_tokens` if web search enabled (line 3197)
 - `max_output_tokens_applied` — the `max_output_tokens` value used for this turn; persisted on `chat_turns.max_output_tokens_applied` (immutable after insert)
@@ -5824,11 +5825,11 @@ A monotonic, strictly increasing integer that identifies a specific immutable po
 **Bump Triggers**:
 - Changes to model catalog
 - Changes to credit multipliers (`input_tokens_credit_multiplier`, `output_tokens_credit_multiplier`)
-- Changes to kill switches (`disable_premium_tier`, `force_standard_tier`, `disable_web_search`)
+- Changes to kill switches (`disable_premium_tier`, `force_standard_tier`, `disable_web_search`, `disable_file_search`, `disable_images`)
 - User allocation logic changes affecting `GetUserLimits` output
 - User entitlements/plan changes
 
-**Note (P1)**: Estimation budgets (image_token_budget, tool_surcharge_tokens, web_search_surcharge_tokens, etc.) are configured **locally in MiniChat ConfigMap**, NOT in CCM PolicySnapshot. Changes to estimation budgets do NOT trigger CCM policy version bumps. See section 5.2.1 "Estimation Budgets Source (P1)" for details.
+**Note (P1)**: Estimation budgets (image_token_budget, tool_surcharge_tokens, web_search_surcharge_tokens, etc.) are embedded **per-model in the policy snapshot catalog** (each `ModelCatalogEntry` carries its own `estimation_budgets`). Changes to `estimation_budgets` for a model constitute a catalog change and MUST trigger a policy version bump. See section 5.2.1 "Estimation Budgets Source (P1)" for details.
 
 **MiniChat Integration**:
 - MiniChat caches snapshots keyed by `(user_id, policy_version)`.
@@ -5899,7 +5900,8 @@ A monotonic, strictly increasing integer that identifies a specific immutable po
     ],
     "kill_switches": {
       "disable_web_search": false,
-      "disable_file_search": false
+      "disable_file_search": false,
+      "disable_images": false
     }
   }
 }
@@ -5911,10 +5913,10 @@ A monotonic, strictly increasing integer that identifies a specific immutable po
 - `provider_display_name` is UI-only and MUST NOT be a routing key, deployment handle, or internal provider identifier.
 
 **P1 Note — Estimation Budgets**:
-- In P1, `estimation_budgets` (image_token_budget, tool_surcharge_tokens, web_search_surcharge_tokens, bytes_per_token_conservative, fixed_overhead_tokens, safety_margin_pct, minimal_generation_floor) are NOT supplied by CCM.
-- `estimation_budgets` are configured locally in MiniChat via Kubernetes ConfigMap (or equivalent deployment config file).
-- MiniChat persists `minimal_generation_floor_applied` per turn (on `chat_turns` table) for deterministic estimated settlement independent of ConfigMap changes.
-- CCM PolicySnapshot in P1 MUST NOT include `estimation_budgets` fields. The snapshot example above omits them intentionally.
+- In P1, `estimation_budgets` (image_token_budget, tool_surcharge_tokens, web_search_surcharge_tokens, bytes_per_token_conservative, fixed_overhead_tokens, safety_margin_pct, minimal_generation_floor) are embedded **per-model** in each `ModelCatalogEntry` within the PolicySnapshot.
+- This enables per-model tuning of estimation parameters (e.g. different `bytes_per_token_conservative` for different model families).
+- MiniChat persists `minimal_generation_floor_applied` per turn (on `chat_turns` table) for deterministic estimated settlement independent of future policy changes.
+- CCM PolicySnapshot MUST include `estimation_budgets` on each model catalog entry.
 
 **Multimodal Capability Flags**: Enumerated values include:
 - `VISION_INPUT`
@@ -6132,6 +6134,7 @@ All fields below are per-model entries inside the catalog.
 |-----------|------|---------|--------|---------------|
 | `disable_web_search` | `bool` | — | **CCM API**: `GET /policies/{v}` | `snapshot.kill_switches.disable_web_search` |
 | `disable_file_search` | `bool` | — | **CCM API**: `GET /policies/{v}` | `snapshot.kill_switches.disable_file_search` |
+| `disable_images` | `bool` | — | **CCM API**: `GET /policies/{v}` | `snapshot.kill_switches.disable_images` |
 | `disable_premium_tier` | `bool` | — | **n/a** | Not present in current CCM API; design-only |
 | `force_standard_tier` | `bool` | — | **n/a** | Not present in current CCM API; design-only |
 
@@ -6177,15 +6180,17 @@ All fields below are per-model entries inside the catalog.
 
 ### B.5.2 Estimation budgets (preflight reserve)
 
+Estimation budgets are embedded **per-model** in the policy snapshot catalog. Each `ModelCatalogEntry` carries its own `estimation_budgets`, allowing per-model tuning.
+
 | Parameter | Type | Default | Source |
 |-----------|------|---------|--------|
-| `estimation_budgets.bytes_per_token_conservative` | — | — | **ConfigMap** |
-| `estimation_budgets.fixed_overhead_tokens` | — | — | **ConfigMap** |
-| `estimation_budgets.safety_margin_pct` | — | — | **ConfigMap** |
-| `estimation_budgets.image_token_budget` | — | — | **ConfigMap** |
-| `estimation_budgets.tool_surcharge_tokens` | — | — | **ConfigMap** |
-| `estimation_budgets.web_search_surcharge_tokens` | — | — | **ConfigMap** |
-| `estimation_budgets.minimal_generation_floor` | — | — | **ConfigMap** |
+| `estimation_budgets.bytes_per_token_conservative` | — | — | **PolicySnapshot** (per-model catalog entry) |
+| `estimation_budgets.fixed_overhead_tokens` | — | — | **PolicySnapshot** (per-model catalog entry) |
+| `estimation_budgets.safety_margin_pct` | — | — | **PolicySnapshot** (per-model catalog entry) |
+| `estimation_budgets.image_token_budget` | — | — | **PolicySnapshot** (per-model catalog entry) |
+| `estimation_budgets.tool_surcharge_tokens` | — | — | **PolicySnapshot** (per-model catalog entry) |
+| `estimation_budgets.web_search_surcharge_tokens` | — | — | **PolicySnapshot** (per-model catalog entry) |
+| `estimation_budgets.minimal_generation_floor` | — | — | **PolicySnapshot** (per-model catalog entry) |
 
 ### B.5.3 Overshoot tolerance
 

--- a/modules/mini-chat/mini-chat-sdk/src/lib.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/lib.rs
@@ -6,7 +6,7 @@ pub mod plugin_api;
 pub use error::{MiniChatModelPolicyPluginError, PublishError};
 pub use gts::MiniChatModelPolicyPluginSpecV1;
 pub use models::{
-    KillSwitches, ModelCatalogEntry, ModelTier, PolicySnapshot, PolicyVersionInfo, TierLimits,
-    UsageEvent, UsageTokens, UserLimits,
+    EstimationBudgets, KillSwitches, ModelCatalogEntry, ModelGeneralConfig, ModelPreference,
+    ModelTier, PolicySnapshot, PolicyVersionInfo, TierLimits, UsageEvent, UsageTokens, UserLimits,
 };
 pub use plugin_api::MiniChatModelPolicyPluginClientV1;

--- a/modules/mini-chat/mini-chat-sdk/src/models.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/models.rs
@@ -10,7 +10,8 @@ pub struct PolicyVersionInfo {
     pub generated_at: OffsetDateTime,
 }
 
-/// Full policy snapshot for a given version, including the model catalog.
+/// Full policy snapshot for a given version, including the model catalog
+/// and kill switches (API: `PolicyByVersionResponse`).
 #[derive(Debug, Clone)]
 pub struct PolicySnapshot {
     pub user_id: Uuid,
@@ -27,44 +28,207 @@ pub struct KillSwitches {
     pub force_standard_tier: bool,
     pub disable_web_search: bool,
     pub disable_file_search: bool,
+    pub disable_images: bool,
 }
 
-/// A single model in the catalog.
+/// A single model in the catalog (API: `PolicyModelCatalogItem`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelCatalogEntry {
+    /// Provider-level model identifier (e.g. "gpt-4").
     pub model_id: String,
     /// The model ID on the provider side (e.g., `"gpt-5.2"` for `OpenAI`,
     /// `"claude-opus-4-6"` for Anthropic). Sent in LLM API requests.
     pub provider_model_id: String,
+    /// Display name shown in UI (may differ from `name`).
     pub display_name: String,
+    /// Short description of the model.
+    pub description: String,
+    /// Model version string.
+    pub version: String,
+    /// LLM provider CTI identifier.
+    pub provider_id: String,
+    /// Routing identifier for provider resolution. Maps to a key in
+    /// `MiniChatConfig.providers`. Values: `"openai"`, `"azure_openai"`.
+    pub provider_display_name: String,
+    /// URL to model icon.
+    pub icon: String,
+    /// Model tier (standard or premium).
     pub tier: ModelTier,
-    pub global_enabled: bool,
-    pub is_default: bool,
-    /// Credit multiplier for input tokens (micro-credits per 1000 tokens).
-    pub input_tokens_credit_multiplier_micro: u64,
-    /// Credit multiplier for output tokens (micro-credits per 1000 tokens).
-    pub output_tokens_credit_multiplier_micro: u64,
-    /// Model capabilities, e.g. `VISION_INPUT`, `IMAGE_GENERATION`.
+    pub enabled: bool,
+    /// Multimodal capability flags, e.g. `VISION_INPUT`, `IMAGE_GENERATION`.
     pub multimodal_capabilities: Vec<String>,
     /// Maximum context window size in tokens.
     pub context_window: u32,
     /// Maximum output tokens the model can generate.
     pub max_output_tokens: u32,
-    /// Human-readable model description.
-    pub description: String,
-    /// Display name for the provider (e.g. `OpenAI`).
-    pub provider_display_name: String,
+    /// Maximum input tokens per request.
+    pub max_input_tokens: u32,
+    /// Credit multiplier for input tokens (micro-credits per 1000 tokens).
+    pub input_tokens_credit_multiplier_micro: u64,
+    /// Credit multiplier for output tokens (micro-credits per 1000 tokens).
+    pub output_tokens_credit_multiplier_micro: u64,
     /// Human-readable multiplier display string (e.g. "1x", "3x").
     pub multiplier_display: String,
-    /// Routing identifier for provider resolution. Maps to a key in
-    /// `MiniChatConfig.providers`. Values: `"openai"`, `"azure_openai"`.
-    pub provider_id: String,
+    /// Per-model token estimation budgets for preflight reserve.
+    pub estimation_budgets: EstimationBudgets,
+    /// Top-k chunks returned by similarity search per `file_search` call.
+    pub max_retrieved_chunks_per_turn: u32,
+    /// Full general config captured at snapshot time.
+    pub general_config: ModelGeneralConfig,
+    /// Tenant preference settings captured at snapshot time.
+    pub preference: ModelPreference,
+}
+
+/// Per-model token estimation budget parameters (API: `PolicyModelEstimationBudgets`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct EstimationBudgets {
+    /// Conservative bytes-per-token ratio for text estimation.
+    pub bytes_per_token_conservative: u32,
+    /// Constant overhead for protocol/framing tokens.
+    pub fixed_overhead_tokens: u32,
+    /// Percentage safety margin applied to text estimation (e.g. 10 means 10%).
+    pub safety_margin_pct: u32,
+    /// Tokens per image for vision surcharge.
+    pub image_token_budget: u32,
+    /// Fixed token overhead when `file_search` tool is included.
+    pub tool_surcharge_tokens: u32,
+    /// Fixed token overhead when `web_search` is enabled.
+    pub web_search_surcharge_tokens: u32,
+    /// Minimum generation token budget guaranteed regardless of input estimates.
+    pub minimal_generation_floor: u32,
+}
+
+impl Default for EstimationBudgets {
+    fn default() -> Self {
+        Self {
+            bytes_per_token_conservative: 4,
+            fixed_overhead_tokens: 100,
+            safety_margin_pct: 10,
+            image_token_budget: 1000,
+            tool_surcharge_tokens: 500,
+            web_search_surcharge_tokens: 500,
+            minimal_generation_floor: 50,
+        }
+    }
+}
+
+/// LLM API inference parameters (API: `PolicyModelApiParams`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelApiParams {
+    pub temperature: f64,
+    pub top_p: f64,
+    pub frequency_penalty: f64,
+    pub presence_penalty: f64,
+    pub stop: Vec<String>,
+}
+
+/// Feature capability flags (API: `PolicyModelFeatures`).
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelFeatures {
+    pub streaming: bool,
+    pub function_calling: bool,
+    pub structured_output: bool,
+    pub fine_tuning: bool,
+    pub distillation: bool,
+    pub fim_completion: bool,
+    pub chat_prefix_completion: bool,
+}
+
+/// Supported input modalities (API: `PolicyModelInputType`).
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelInputType {
+    pub text: bool,
+    pub image: bool,
+    pub audio: bool,
+    pub video: bool,
+}
+
+/// Tool support flags (API: `PolicyModelToolSupport`).
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelToolSupport {
+    pub web_search: bool,
+    pub file_search: bool,
+    pub image_generation: bool,
+    pub code_interpreter: bool,
+    pub computer_use: bool,
+    pub mcp: bool,
+}
+
+/// Supported API endpoints (API: `PolicyModelSupportedEndpoints`).
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelSupportedEndpoints {
+    pub chat_completions: bool,
+    pub responses: bool,
+    pub realtime: bool,
+    pub assistants: bool,
+    pub batch_api: bool,
+    pub fine_tuning: bool,
+    pub embeddings: bool,
+    pub videos: bool,
+    pub image_generation: bool,
+    pub image_edit: bool,
+    pub audio_speech_generation: bool,
+    pub audio_transcription: bool,
+    pub audio_translation: bool,
+    pub moderations: bool,
+    pub completions: bool,
+}
+
+/// Token credit multipliers (API: `PolicyModelTokenPolicy`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelTokenPolicy {
+    pub input_tokens_credit_multiplier: f64,
+    pub output_tokens_credit_multiplier: f64,
+}
+
+/// Estimated performance characteristics (API: `PolicyModelPerformance`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelPerformance {
+    pub response_latency_ms: u32,
+    pub speed_tokens_per_second: u32,
+}
+
+/// General configuration from Settings Service (API: `PolicyModelGeneralConfig`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelGeneralConfig {
+    /// CTI type identifier of the config.
+    #[serde(rename = "type")]
+    pub config_type: String,
+    /// Model tier CTI identifier.
+    pub tier: String,
+    pub available_from: OffsetDateTime,
+    pub max_file_size_mb: u32,
+    pub api_params: ModelApiParams,
+    pub features: ModelFeatures,
+    pub input_type: ModelInputType,
+    pub tool_support: ModelToolSupport,
+    pub supported_endpoints: ModelSupportedEndpoints,
+    pub token_policy: ModelTokenPolicy,
+    pub performance: ModelPerformance,
+}
+
+/// Per-tenant preference settings (API: `PolicyModelPreference`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelPreference {
+    pub is_default: bool,
+    /// Display order in the UI.
+    pub sort_order: i32,
 }
 
 /// Model pricing/capability tier.
+///
+/// Serializes as `"Standard"` / `"Premium"` (`PascalCase`).
+/// Accepts lowercase aliases (`"standard"`, `"premium"`) on deserialization
+/// for compatibility with CCM and DESIGN maps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ModelTier {
+    #[serde(alias = "standard")]
     Standard,
+    #[serde(alias = "premium")]
     Premium,
 }
 
@@ -112,4 +276,195 @@ pub struct UsageEvent {
     pub settlement_method: String,
     pub policy_version_applied: i64,
     pub timestamp: OffsetDateTime,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── KillSwitches::default safety invariant ──
+    // All kill switches must default to false; a new field defaulting to true
+    // would accidentally disable functionality across all tenants.
+
+    #[test]
+    fn kill_switches_default_all_disabled() {
+        let ks = KillSwitches::default();
+        assert!(!ks.disable_premium_tier);
+        assert!(!ks.force_standard_tier);
+        assert!(!ks.disable_web_search);
+        assert!(!ks.disable_file_search);
+        assert!(!ks.disable_images);
+    }
+
+    // ── EstimationBudgets::default spec values ──
+    // These defaults are specified in DESIGN.md §B.5.2 and used as the
+    // ConfigMap fallback. Changing them silently would alter token estimation
+    // for every deployment that relies on defaults.
+
+    #[test]
+    fn estimation_budgets_default_matches_spec() {
+        let eb = EstimationBudgets::default();
+        assert_eq!(eb.bytes_per_token_conservative, 4);
+        assert_eq!(eb.fixed_overhead_tokens, 100);
+        assert_eq!(eb.safety_margin_pct, 10);
+        assert_eq!(eb.image_token_budget, 1000);
+        assert_eq!(eb.tool_surcharge_tokens, 500);
+        assert_eq!(eb.web_search_surcharge_tokens, 500);
+        assert_eq!(eb.minimal_generation_floor, 50);
+    }
+
+    // ── ModelGeneralConfig: serde(rename = "type") contract ──
+    // The upstream API sends `"type"` not `"config_type"`. If the rename
+    // attribute is removed, deserialization from the real API breaks.
+
+    fn sample_general_config() -> ModelGeneralConfig {
+        ModelGeneralConfig {
+            config_type: "model.general.v1".to_owned(),
+            tier: "premium".to_owned(),
+            available_from: OffsetDateTime::UNIX_EPOCH,
+            max_file_size_mb: 25,
+            api_params: ModelApiParams {
+                temperature: 0.7,
+                top_p: 1.0,
+                frequency_penalty: 0.0,
+                presence_penalty: 0.0,
+                stop: vec![],
+            },
+            features: ModelFeatures {
+                streaming: true,
+                function_calling: false,
+                structured_output: false,
+                fine_tuning: false,
+                distillation: false,
+                fim_completion: false,
+                chat_prefix_completion: false,
+            },
+            input_type: ModelInputType {
+                text: true,
+                image: false,
+                audio: false,
+                video: false,
+            },
+            tool_support: ModelToolSupport {
+                web_search: false,
+                file_search: false,
+                image_generation: false,
+                code_interpreter: false,
+                computer_use: false,
+                mcp: false,
+            },
+            supported_endpoints: ModelSupportedEndpoints {
+                chat_completions: true,
+                responses: false,
+                realtime: false,
+                assistants: false,
+                batch_api: false,
+                fine_tuning: false,
+                embeddings: false,
+                videos: false,
+                image_generation: false,
+                image_edit: false,
+                audio_speech_generation: false,
+                audio_transcription: false,
+                audio_translation: false,
+                moderations: false,
+                completions: false,
+            },
+            token_policy: ModelTokenPolicy {
+                input_tokens_credit_multiplier: 1.0,
+                output_tokens_credit_multiplier: 3.0,
+            },
+            performance: ModelPerformance {
+                response_latency_ms: 500,
+                speed_tokens_per_second: 100,
+            },
+        }
+    }
+
+    #[test]
+    fn general_config_serializes_type_not_config_type() {
+        let config = sample_general_config();
+        let json = serde_json::to_value(&config).unwrap();
+
+        assert!(json.get("type").is_some(), "expected JSON key 'type'");
+        assert!(
+            json.get("config_type").is_none(),
+            "config_type must not appear in JSON output"
+        );
+        assert_eq!(json["type"], "model.general.v1");
+    }
+
+    #[test]
+    fn general_config_serde_roundtrip_preserves_rename() {
+        let original = sample_general_config();
+        let json = serde_json::to_value(&original).unwrap();
+        let deserialized: ModelGeneralConfig = serde_json::from_value(json).unwrap();
+
+        assert_eq!(deserialized.config_type, original.config_type);
+        assert_eq!(deserialized.tier, original.tier);
+    }
+
+    // ── ModelTier serde representation ──
+    // Serializes as PascalCase ("Standard"/"Premium") for the UI/API.
+    // Accepts lowercase aliases for CCM/DESIGN compatibility.
+
+    #[test]
+    fn model_tier_serializes_as_pascal_case() {
+        let json = serde_json::to_value(ModelTier::Premium).unwrap();
+        assert_eq!(json, serde_json::json!("Premium"));
+
+        let json = serde_json::to_value(ModelTier::Standard).unwrap();
+        assert_eq!(json, serde_json::json!("Standard"));
+    }
+
+    #[test]
+    fn model_tier_deserializes_lowercase_aliases() {
+        let premium: ModelTier = serde_json::from_value(serde_json::json!("premium")).unwrap();
+        assert_eq!(premium, ModelTier::Premium);
+
+        let standard: ModelTier = serde_json::from_value(serde_json::json!("standard")).unwrap();
+        assert_eq!(standard, ModelTier::Standard);
+    }
+
+    #[test]
+    fn model_tier_rejects_unknown_casing() {
+        let result = serde_json::from_value::<ModelTier>(serde_json::json!("PREMIUM"));
+        assert!(result.is_err());
+    }
+
+    // ── KillSwitches serde roundtrip ──
+    // Verifies that enabled switches survive serialization and that
+    // the default (all-off) state roundtrips correctly.
+
+    #[test]
+    fn kill_switches_serde_roundtrip_with_enabled_switches() {
+        let ks = KillSwitches {
+            disable_premium_tier: true,
+            force_standard_tier: false,
+            disable_web_search: true,
+            disable_file_search: false,
+            disable_images: true,
+        };
+        let json = serde_json::to_value(&ks).unwrap();
+        let deserialized: KillSwitches = serde_json::from_value(json).unwrap();
+
+        assert!(deserialized.disable_premium_tier);
+        assert!(!deserialized.force_standard_tier);
+        assert!(deserialized.disable_web_search);
+        assert!(!deserialized.disable_file_search);
+        assert!(deserialized.disable_images);
+    }
+
+    #[test]
+    fn kill_switches_default_roundtrips_all_false() {
+        let ks = KillSwitches::default();
+        let json = serde_json::to_value(&ks).unwrap();
+        let deserialized: KillSwitches = serde_json::from_value(json).unwrap();
+
+        assert!(!deserialized.disable_premium_tier);
+        assert!(!deserialized.force_standard_tier);
+        assert!(!deserialized.disable_web_search);
+        assert!(!deserialized.disable_file_search);
+        assert!(!deserialized.disable_images);
+    }
 }

--- a/modules/mini-chat/mini-chat-sdk/src/plugin_api.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/plugin_api.rs
@@ -17,14 +17,15 @@ pub trait MiniChatModelPolicyPluginClientV1: Send + Sync {
         user_id: Uuid,
     ) -> Result<PolicyVersionInfo, MiniChatModelPolicyPluginError>;
 
-    /// Get the policy snapshot for a given version.
+    /// Get the full policy snapshot for a given version, including
+    /// model catalog and kill switches.
     async fn get_policy_snapshot(
         &self,
         user_id: Uuid,
         policy_version: u64,
     ) -> Result<PolicySnapshot, MiniChatModelPolicyPluginError>;
 
-    /// Get per-user credit allocations for a specific policy version.
+    /// Get per-user credit limits for a specific policy version.
     async fn get_user_limits(
         &self,
         user_id: Uuid,

--- a/modules/mini-chat/mini-chat/src/domain/service/model_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/model_service_test.rs
@@ -6,20 +6,20 @@ use uuid::Uuid;
 use crate::domain::error::DomainError;
 use crate::domain::service::model_service::ModelService;
 use crate::domain::service::test_helpers::{
-    MockModelResolver, inmem_db, mock_db_provider, mock_denying_enforcer, mock_enforcer,
-    test_security_ctx,
+    MockModelResolver, TestCatalogEntryParams, inmem_db, mock_db_provider, mock_denying_enforcer,
+    mock_enforcer, test_catalog_entry, test_security_ctx,
 };
 
 // ── Test Helpers ──
 
 fn mock_catalog() -> Vec<ModelCatalogEntry> {
     vec![
-        ModelCatalogEntry {
+        test_catalog_entry(TestCatalogEntryParams {
             model_id: "gpt-5.2".to_owned(),
             provider_model_id: "gpt-5.2-2025-03-26".to_owned(),
             display_name: "GPT-5.2".to_owned(),
             tier: ModelTier::Premium,
-            global_enabled: true,
+            enabled: true,
             is_default: true,
             input_tokens_credit_multiplier_micro: 2_000_000,
             output_tokens_credit_multiplier_micro: 6_000_000,
@@ -30,13 +30,13 @@ fn mock_catalog() -> Vec<ModelCatalogEntry> {
             provider_display_name: "OpenAI".to_owned(),
             multiplier_display: "2x".to_owned(),
             provider_id: "openai".to_owned(),
-        },
-        ModelCatalogEntry {
+        }),
+        test_catalog_entry(TestCatalogEntryParams {
             model_id: "gpt-5-mini".to_owned(),
             provider_model_id: "gpt-5-mini-2025-03-26".to_owned(),
             display_name: "GPT-5 Mini".to_owned(),
             tier: ModelTier::Standard,
-            global_enabled: true,
+            enabled: true,
             is_default: false,
             input_tokens_credit_multiplier_micro: 1_000_000,
             output_tokens_credit_multiplier_micro: 3_000_000,
@@ -47,13 +47,13 @@ fn mock_catalog() -> Vec<ModelCatalogEntry> {
             provider_display_name: "OpenAI".to_owned(),
             multiplier_display: "1x".to_owned(),
             provider_id: "openai".to_owned(),
-        },
-        ModelCatalogEntry {
+        }),
+        test_catalog_entry(TestCatalogEntryParams {
             model_id: "disabled-model".to_owned(),
             provider_model_id: "disabled-model-2025-03-26".to_owned(),
             display_name: "Disabled Model".to_owned(),
             tier: ModelTier::Standard,
-            global_enabled: false,
+            enabled: false,
             is_default: false,
             input_tokens_credit_multiplier_micro: 1_000_000,
             output_tokens_credit_multiplier_micro: 3_000_000,
@@ -64,7 +64,7 @@ fn mock_catalog() -> Vec<ModelCatalogEntry> {
             provider_display_name: "OpenAI".to_owned(),
             multiplier_display: "1x".to_owned(),
             provider_id: "openai".to_owned(),
-        },
+        }),
     ]
 }
 

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use mini_chat_sdk::{ModelTier, PolicySnapshot, UserLimits};
+use mini_chat_sdk::{ModelCatalogEntry, ModelTier, PolicySnapshot, UserLimits};
 use modkit_db::secure::DBRunner;
 use modkit_macros::domain_model;
 use modkit_security::AccessScope;
@@ -102,7 +102,7 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
         let selected_entry = catalog.iter().find(|m| m.model_id == selected_model);
 
         let (selected_tier, mut downgrade_reason) = match selected_entry {
-            Some(e) if e.global_enabled => (e.tier, None),
+            Some(e) if e.enabled => (e.tier, None),
             Some(e) => {
                 // Model exists but is disabled — cascade from its own tier
                 (e.tier, Some(DowngradeReason::ModelDisabled))
@@ -161,11 +161,20 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
             }
 
             // 3d. Select concrete model for this tier
+            //     Prefer the explicitly requested model when it belongs to this
+            //     tier and is enabled; fall back to the tier default or any
+            //     enabled model otherwise.
+            let tier_matches = |m: &&ModelCatalogEntry| m.tier == tier && m.enabled;
             let model = catalog
                 .iter()
-                .filter(|m| m.tier == tier && m.global_enabled)
-                .find(|m| m.is_default)
-                .or_else(|| catalog.iter().find(|m| m.tier == tier && m.global_enabled));
+                .find(|m| tier_matches(m) && m.model_id == selected_model)
+                .or_else(|| {
+                    catalog
+                        .iter()
+                        .filter(|m| tier_matches(m))
+                        .find(|m| m.preference.is_default)
+                })
+                .or_else(|| catalog.iter().find(|m| tier_matches(m)));
 
             let Some(effective) = model else {
                 continue; // all models in tier are individually disabled
@@ -193,12 +202,15 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
 
 /// Map bucket name + `period_type` to the correct limit from `UserLimits`.
 fn limit_credits_micro(bucket: &str, period_type: &PeriodType, limits: &UserLimits) -> i64 {
-    match (bucket, period_type) {
-        ("total", PeriodType::Daily) => limits.standard.limit_daily_credits_micro,
-        ("total", PeriodType::Monthly) => limits.standard.limit_monthly_credits_micro,
-        ("tier:premium", PeriodType::Daily) => limits.premium.limit_daily_credits_micro,
-        ("tier:premium", PeriodType::Monthly) => limits.premium.limit_monthly_credits_micro,
-        _ => 0, // unknown bucket — no budget
+    let tier = match bucket {
+        "total" => &limits.standard,
+        "tier:premium" => &limits.premium,
+        _ => return 0, // unknown bucket — no budget
+    };
+
+    match period_type {
+        PeriodType::Daily => tier.limit_daily_credits_micro,
+        PeriodType::Monthly => tier.limit_monthly_credits_micro,
     }
 }
 
@@ -280,7 +292,7 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
         let catalog_entry = snapshot
             .model_catalog
             .iter()
-            .find(|m| m.model_id == input.selected_model && m.global_enabled);
+            .find(|m| m.model_id == input.selected_model && m.enabled);
 
         let (in_mult, out_mult) = catalog_entry.map_or(
             (1_000_000, 1_000_000), // fallback for disabled models
@@ -813,16 +825,17 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::service::test_helpers::{TestCatalogEntryParams, test_catalog_entry};
     use mini_chat_sdk::{KillSwitches, ModelCatalogEntry, TierLimits};
     use uuid::Uuid;
 
     fn make_model(id: &str, tier: ModelTier, enabled: bool, is_default: bool) -> ModelCatalogEntry {
-        ModelCatalogEntry {
+        test_catalog_entry(TestCatalogEntryParams {
             model_id: id.to_owned(),
             provider_model_id: format!("provider-{id}"),
             display_name: id.to_owned(),
             tier,
-            global_enabled: enabled,
+            enabled,
             is_default,
             input_tokens_credit_multiplier_micro: 1_000_000,
             output_tokens_credit_multiplier_micro: 1_000_000,
@@ -833,7 +846,7 @@ mod tests {
             provider_display_name: String::new(),
             multiplier_display: "1x".to_owned(),
             provider_id: "openai".to_owned(),
-        }
+        })
     }
 
     fn default_limits() -> UserLimits {
@@ -1013,7 +1026,7 @@ mod tests {
     fn disabled_model_triggers_downgrade() {
         let mut snapshot = default_snapshot();
         // Disable the selected premium model
-        snapshot.model_catalog[0].global_enabled = false;
+        snapshot.model_catalog[0].enabled = false;
         let limits = default_limits();
         let today = OffsetDateTime::now_utc().date();
         let periods = default_periods(today);
@@ -1037,7 +1050,7 @@ mod tests {
     fn disabled_standard_model_does_not_escalate_to_premium() {
         let mut snapshot = default_snapshot();
         // Disable the standard model (index 1 = gpt-5-mini)
-        snapshot.model_catalog[1].global_enabled = false;
+        snapshot.model_catalog[1].enabled = false;
         let limits = default_limits();
         let today = OffsetDateTime::now_utc().date();
         let periods = default_periods(today);
@@ -1056,10 +1069,42 @@ mod tests {
     }
 
     #[test]
+    fn requested_non_default_model_is_preserved() {
+        // Regression: selecting a non-default model in the same tier must NOT
+        // silently rewrite to the tier default.
+        let snapshot = PolicySnapshot {
+            user_id: Uuid::nil(),
+            policy_version: 1,
+            model_catalog: vec![
+                make_model("std-default", ModelTier::Standard, true, true),
+                make_model("std-other", ModelTier::Standard, true, false),
+            ],
+            kill_switches: KillSwitches::default(),
+        };
+        let limits = default_limits();
+        let today = OffsetDateTime::now_utc().date();
+        let periods = default_periods(today);
+        let ctx = CascadeContext {
+            snapshot: &snapshot,
+            user_limits: &limits,
+            usage_rows: &[],
+            reserve_credits_micro: 1_000,
+            periods: &periods,
+        };
+        match QuotaService::<crate::infra::db::repo::quota_usage_repo::QuotaUsageRepository>::resolve_effective_model("std-other", &ctx) {
+            CascadeDecision::Allow { effective_model, tier } => {
+                assert_eq!(effective_model, "std-other", "must preserve explicitly requested model");
+                assert_eq!(tier, ModelTier::Standard);
+            }
+            other => panic!("expected Allow with std-other, got {:?}", cascade_debug(&other)),
+        }
+    }
+
+    #[test]
     fn all_models_disabled_returns_reject() {
         let mut snapshot = default_snapshot();
         for m in &mut snapshot.model_catalog {
-            m.global_enabled = false;
+            m.enabled = false;
         }
         let limits = default_limits();
         let today = OffsetDateTime::now_utc().date();

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -1661,8 +1661,8 @@ mod tests {
     // ── Pre-stream check tests (7.6) ──
 
     use crate::domain::service::test_helpers::{
-        MockPolicySnapshotProvider, MockUserLimitsProvider, inmem_db, mock_db_provider,
-        mock_enforcer, test_security_ctx_with_id,
+        MockPolicySnapshotProvider, MockUserLimitsProvider, TestCatalogEntryParams, inmem_db,
+        mock_db_provider, mock_enforcer, test_catalog_entry, test_security_ctx_with_id,
     };
     use crate::infra::db::repo::quota_usage_repo::QuotaUsageRepository as OrmQuotaUsageRepo;
 
@@ -1720,12 +1720,12 @@ mod tests {
                 mini_chat_sdk::PolicySnapshot {
                     user_id: Uuid::nil(),
                     policy_version: 1,
-                    model_catalog: vec![mini_chat_sdk::ModelCatalogEntry {
+                    model_catalog: vec![test_catalog_entry(TestCatalogEntryParams {
                         model_id: "gpt-5.2".to_owned(),
                         provider_model_id: "gpt-5.2-2025-03-26".to_owned(),
                         display_name: "GPT 5.2".to_owned(),
                         tier: mini_chat_sdk::ModelTier::Standard,
-                        global_enabled: true,
+                        enabled: true,
                         is_default: true,
                         input_tokens_credit_multiplier_micro: 1_000_000,
                         output_tokens_credit_multiplier_micro: 1_000_000,
@@ -1736,7 +1736,7 @@ mod tests {
                         provider_display_name: String::new(),
                         multiplier_display: "1x".to_owned(),
                         provider_id: "openai".to_owned(),
-                    }],
+                    })],
                     kill_switches: mini_chat_sdk::KillSwitches::default(),
                 },
             )),
@@ -2595,12 +2595,12 @@ mod tests {
         id: &str,
         tier: mini_chat_sdk::ModelTier,
     ) -> mini_chat_sdk::ModelCatalogEntry {
-        mini_chat_sdk::ModelCatalogEntry {
+        test_catalog_entry(TestCatalogEntryParams {
             model_id: id.to_owned(),
             provider_model_id: format!("provider-{id}"),
             display_name: id.to_owned(),
             tier,
-            global_enabled: true,
+            enabled: true,
             is_default: tier == mini_chat_sdk::ModelTier::Standard,
             input_tokens_credit_multiplier_micro: 1_000_000,
             output_tokens_credit_multiplier_micro: 1_000_000,
@@ -2611,7 +2611,7 @@ mod tests {
             provider_display_name: String::new(),
             multiplier_display: "1x".to_owned(),
             provider_id: "openai".to_owned(),
-        }
+        })
     }
 
     fn build_stream_service_with_catalog(

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -136,12 +136,12 @@ impl MockModelResolver {
 impl Default for MockModelResolver {
     fn default() -> Self {
         Self::new(vec![
-            ModelCatalogEntry {
+            test_catalog_entry(TestCatalogEntryParams {
                 model_id: "gpt-5.2".to_owned(),
                 provider_model_id: "gpt-5.2-2025-03-26".to_owned(),
                 display_name: "GPT-5.2".to_owned(),
                 tier: mini_chat_sdk::ModelTier::Premium,
-                global_enabled: true,
+                enabled: true,
                 is_default: true,
                 input_tokens_credit_multiplier_micro: 2_000_000,
                 output_tokens_credit_multiplier_micro: 6_000_000,
@@ -152,13 +152,13 @@ impl Default for MockModelResolver {
                 provider_display_name: "OpenAI".to_owned(),
                 multiplier_display: "2x".to_owned(),
                 provider_id: "openai".to_owned(),
-            },
-            ModelCatalogEntry {
+            }),
+            test_catalog_entry(TestCatalogEntryParams {
                 model_id: "gpt-5-mini".to_owned(),
                 provider_model_id: "gpt-5-mini-2025-03-26".to_owned(),
                 display_name: "GPT-5 Mini".to_owned(),
                 tier: mini_chat_sdk::ModelTier::Standard,
-                global_enabled: false,
+                enabled: false,
                 is_default: false,
                 input_tokens_credit_multiplier_micro: 1_000_000,
                 output_tokens_credit_multiplier_micro: 3_000_000,
@@ -169,7 +169,7 @@ impl Default for MockModelResolver {
                 provider_display_name: "OpenAI".to_owned(),
                 multiplier_display: "1x".to_owned(),
                 provider_id: "openai".to_owned(),
-            },
+            }),
         ])
     }
 }
@@ -186,8 +186,8 @@ impl ModelResolver for MockModelResolver {
             None => {
                 let default = catalog
                     .iter()
-                    .find(|m| m.is_default && m.global_enabled)
-                    .or_else(|| catalog.iter().find(|m| m.global_enabled));
+                    .find(|m| m.preference.is_default && m.enabled)
+                    .or_else(|| catalog.iter().find(|m| m.enabled));
                 match default {
                     Some(e) => Ok(ResolvedModel::from(e)),
                     None => Err(DomainError::invalid_model("no models available in catalog")),
@@ -195,7 +195,7 @@ impl ModelResolver for MockModelResolver {
             }
             Some(m) if m.is_empty() => Err(DomainError::invalid_model("model must not be empty")),
             Some(m) => {
-                let entry = catalog.iter().find(|e| e.model_id == m && e.global_enabled);
+                let entry = catalog.iter().find(|e| e.model_id == m && e.enabled);
                 match entry {
                     Some(e) => Ok(ResolvedModel::from(e)),
                     None => Err(DomainError::invalid_model(&m)),
@@ -208,7 +208,7 @@ impl ModelResolver for MockModelResolver {
         let catalog = self.catalog.lock().unwrap();
         Ok(catalog
             .iter()
-            .filter(|m| m.global_enabled)
+            .filter(|m| m.enabled)
             .map(ResolvedModel::from)
             .collect())
     }
@@ -221,7 +221,7 @@ impl ModelResolver for MockModelResolver {
         let catalog = self.catalog.lock().unwrap();
         catalog
             .iter()
-            .find(|m| m.model_id == model_id && m.global_enabled)
+            .find(|m| m.model_id == model_id && m.enabled)
             .map(ResolvedModel::from)
             .ok_or_else(|| DomainError::model_not_found(model_id))
     }
@@ -311,6 +311,130 @@ pub fn mock_db_provider(db: Db) -> Arc<DBProvider<modkit_db::DbError>> {
 // ── Mock Policy Snapshot Provider ──
 
 use mini_chat_sdk::{PolicySnapshot, UserLimits};
+
+/// Parameters for building a test [`ModelCatalogEntry`].
+pub struct TestCatalogEntryParams {
+    pub model_id: String,
+    pub provider_model_id: String,
+    pub display_name: String,
+    pub tier: mini_chat_sdk::ModelTier,
+    pub enabled: bool,
+    pub is_default: bool,
+    pub input_tokens_credit_multiplier_micro: u64,
+    pub output_tokens_credit_multiplier_micro: u64,
+    pub multimodal_capabilities: Vec<String>,
+    pub context_window: u32,
+    pub max_output_tokens: u32,
+    pub description: String,
+    pub provider_display_name: String,
+    pub multiplier_display: String,
+    pub provider_id: String,
+}
+
+/// Build a [`ModelCatalogEntry`] for tests, filling in new required fields with defaults.
+#[allow(clippy::cast_precision_loss)]
+pub fn test_catalog_entry(params: TestCatalogEntryParams) -> ModelCatalogEntry {
+    use mini_chat_sdk::models::*;
+    use time::OffsetDateTime;
+
+    let tier_str = match params.tier {
+        mini_chat_sdk::ModelTier::Premium => "premium",
+        mini_chat_sdk::ModelTier::Standard => "standard",
+    };
+    let input_mult = params.input_tokens_credit_multiplier_micro as f64 / 1_000_000.0;
+    let output_mult = params.output_tokens_credit_multiplier_micro as f64 / 1_000_000.0;
+    let has_vision = params
+        .multimodal_capabilities
+        .iter()
+        .any(|c| c == "VISION_INPUT");
+
+    ModelCatalogEntry {
+        model_id: params.model_id,
+        provider_model_id: params.provider_model_id,
+        display_name: params.display_name,
+        description: params.description,
+        version: String::new(),
+        provider_id: params.provider_id,
+        provider_display_name: params.provider_display_name,
+        icon: String::new(),
+        tier: params.tier,
+        enabled: params.enabled,
+        multimodal_capabilities: params.multimodal_capabilities,
+        context_window: params.context_window,
+        max_output_tokens: params.max_output_tokens,
+        max_input_tokens: params.context_window,
+        input_tokens_credit_multiplier_micro: params.input_tokens_credit_multiplier_micro,
+        output_tokens_credit_multiplier_micro: params.output_tokens_credit_multiplier_micro,
+        multiplier_display: params.multiplier_display.clone(),
+        estimation_budgets: EstimationBudgets::default(),
+        max_retrieved_chunks_per_turn: 5,
+        general_config: ModelGeneralConfig {
+            config_type: String::new(),
+            tier: tier_str.to_owned(),
+            available_from: OffsetDateTime::UNIX_EPOCH,
+            max_file_size_mb: 25,
+            api_params: ModelApiParams {
+                temperature: 0.7,
+                top_p: 1.0,
+                frequency_penalty: 0.0,
+                presence_penalty: 0.0,
+                stop: vec![],
+            },
+            features: ModelFeatures {
+                streaming: true,
+                function_calling: true,
+                structured_output: true,
+                fine_tuning: false,
+                distillation: false,
+                fim_completion: false,
+                chat_prefix_completion: false,
+            },
+            input_type: ModelInputType {
+                text: true,
+                image: has_vision,
+                audio: false,
+                video: false,
+            },
+            tool_support: ModelToolSupport {
+                web_search: false,
+                file_search: false,
+                image_generation: false,
+                code_interpreter: false,
+                computer_use: false,
+                mcp: false,
+            },
+            supported_endpoints: ModelSupportedEndpoints {
+                chat_completions: true,
+                responses: false,
+                realtime: false,
+                assistants: false,
+                batch_api: false,
+                fine_tuning: false,
+                embeddings: false,
+                videos: false,
+                image_generation: false,
+                image_edit: false,
+                audio_speech_generation: false,
+                audio_transcription: false,
+                audio_translation: false,
+                moderations: false,
+                completions: false,
+            },
+            token_policy: ModelTokenPolicy {
+                input_tokens_credit_multiplier: input_mult,
+                output_tokens_credit_multiplier: output_mult,
+            },
+            performance: ModelPerformance {
+                response_latency_ms: 500,
+                speed_tokens_per_second: 100,
+            },
+        },
+        preference: ModelPreference {
+            is_default: params.is_default,
+            sort_order: 0,
+        },
+    }
+}
 
 pub struct MockPolicySnapshotProvider {
     snapshot: Mutex<PolicySnapshot>,

--- a/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
@@ -100,8 +100,8 @@ impl ModelResolver for ModelPolicyGateway {
                 let default = snapshot
                     .model_catalog
                     .iter()
-                    .find(|m| m.is_default && m.global_enabled)
-                    .or_else(|| snapshot.model_catalog.iter().find(|m| m.global_enabled));
+                    .find(|m| m.preference.is_default && m.enabled)
+                    .or_else(|| snapshot.model_catalog.iter().find(|m| m.enabled));
 
                 match default {
                     Some(entry) => Ok(ResolvedModel::from(entry)),
@@ -115,7 +115,7 @@ impl ModelResolver for ModelPolicyGateway {
                 let entry = snapshot
                     .model_catalog
                     .iter()
-                    .find(|m| m.model_id == model && m.global_enabled);
+                    .find(|m| m.model_id == model && m.enabled);
 
                 match entry {
                     Some(e) => Ok(ResolvedModel::from(e)),
@@ -131,7 +131,7 @@ impl ModelResolver for ModelPolicyGateway {
         Ok(snapshot
             .model_catalog
             .iter()
-            .filter(|m| m.global_enabled)
+            .filter(|m| m.enabled)
             .map(ResolvedModel::from)
             .collect())
     }
@@ -146,7 +146,7 @@ impl ModelResolver for ModelPolicyGateway {
         snapshot
             .model_catalog
             .iter()
-            .find(|m| m.model_id == model_id && m.global_enabled)
+            .find(|m| m.model_id == model_id && m.enabled)
             .map(ResolvedModel::from)
             .ok_or_else(|| DomainError::model_not_found(model_id))
     }

--- a/modules/mini-chat/plugins/static-model-policy-plugin/Cargo.toml
+++ b/modules/mini-chat/plugins/static-model-policy-plugin/Cargo.toml
@@ -41,3 +41,6 @@ tracing = { workspace = true }
 
 # Required by modkit::module macro
 inventory = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/modules/mini-chat/plugins/static-model-policy-plugin/src/domain/client.rs
+++ b/modules/mini-chat/plugins/static-model-policy-plugin/src/domain/client.rs
@@ -46,6 +46,7 @@ impl MiniChatModelPolicyPluginClientV1 for Service {
         if policy_version != 1 {
             return Err(MiniChatModelPolicyPluginError::NotFound);
         }
+
         Ok(UserLimits {
             user_id,
             policy_version,
@@ -62,5 +63,260 @@ impl MiniChatModelPolicyPluginClientV1 for Service {
             "static plugin: publish_usage no-op"
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::StaticMiniChatPolicyPluginConfig;
+    use mini_chat_sdk::{
+        EstimationBudgets, ModelCatalogEntry, ModelGeneralConfig, ModelPreference, ModelTier,
+        models::{
+            ModelApiParams, ModelFeatures, ModelInputType, ModelPerformance,
+            ModelSupportedEndpoints, ModelTokenPolicy, ModelToolSupport,
+        },
+    };
+    use time::OffsetDateTime;
+
+    fn make_entry(model_id: &str, tier: ModelTier) -> ModelCatalogEntry {
+        let tier_str = match tier {
+            ModelTier::Standard => "standard",
+            ModelTier::Premium => "premium",
+        };
+        ModelCatalogEntry {
+            model_id: model_id.to_owned(),
+            provider_model_id: format!("{model_id}-v1"),
+            display_name: model_id.to_owned(),
+            description: String::new(),
+            version: String::new(),
+            provider_id: "default".to_owned(),
+            provider_display_name: "Default".to_owned(),
+            icon: String::new(),
+            tier,
+            enabled: true,
+            multimodal_capabilities: vec![],
+            context_window: 128_000,
+            max_output_tokens: 16_384,
+            max_input_tokens: 128_000,
+            input_tokens_credit_multiplier_micro: 1_000_000,
+            output_tokens_credit_multiplier_micro: 3_000_000,
+            multiplier_display: "1x".to_owned(),
+            estimation_budgets: EstimationBudgets::default(),
+            max_retrieved_chunks_per_turn: 5,
+            general_config: ModelGeneralConfig {
+                config_type: String::new(),
+                tier: tier_str.to_owned(),
+                available_from: OffsetDateTime::UNIX_EPOCH,
+                max_file_size_mb: 25,
+                api_params: ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                },
+                features: ModelFeatures {
+                    streaming: true,
+                    function_calling: true,
+                    structured_output: true,
+                    fine_tuning: false,
+                    distillation: false,
+                    fim_completion: false,
+                    chat_prefix_completion: false,
+                },
+                input_type: ModelInputType {
+                    text: true,
+                    image: false,
+                    audio: false,
+                    video: false,
+                },
+                tool_support: ModelToolSupport {
+                    web_search: false,
+                    file_search: false,
+                    image_generation: false,
+                    code_interpreter: false,
+                    computer_use: false,
+                    mcp: false,
+                },
+                supported_endpoints: ModelSupportedEndpoints {
+                    chat_completions: true,
+                    responses: false,
+                    realtime: false,
+                    assistants: false,
+                    batch_api: false,
+                    fine_tuning: false,
+                    embeddings: false,
+                    videos: false,
+                    image_generation: false,
+                    image_edit: false,
+                    audio_speech_generation: false,
+                    audio_transcription: false,
+                    audio_translation: false,
+                    moderations: false,
+                    completions: false,
+                },
+                token_policy: ModelTokenPolicy {
+                    input_tokens_credit_multiplier: 1.0,
+                    output_tokens_credit_multiplier: 3.0,
+                },
+                performance: ModelPerformance {
+                    response_latency_ms: 500,
+                    speed_tokens_per_second: 100,
+                },
+            },
+            preference: ModelPreference {
+                is_default: false,
+                sort_order: 0,
+            },
+        }
+    }
+
+    fn test_service() -> Service {
+        let cfg = StaticMiniChatPolicyPluginConfig::default();
+        Service::new(
+            vec![
+                make_entry("standard-model", ModelTier::Standard),
+                make_entry("premium-model", ModelTier::Premium),
+            ],
+            cfg.kill_switches,
+            cfg.default_standard_limits,
+            cfg.default_premium_limits,
+        )
+    }
+
+    // ── get_current_policy_version ──
+
+    #[tokio::test]
+    async fn policy_version_echoes_user_id() {
+        let svc = test_service();
+        let user_id = Uuid::new_v4();
+        let info = svc.get_current_policy_version(user_id).await.unwrap();
+
+        assert_eq!(info.user_id, user_id);
+        assert_eq!(info.policy_version, 1);
+    }
+
+    #[tokio::test]
+    async fn policy_version_timestamp_is_recent() {
+        let before = OffsetDateTime::now_utc();
+        let svc = test_service();
+        let info = svc
+            .get_current_policy_version(Uuid::new_v4())
+            .await
+            .unwrap();
+        let after = OffsetDateTime::now_utc();
+
+        assert!(info.generated_at >= before);
+        assert!(info.generated_at <= after);
+    }
+
+    // ── get_policy_snapshot: version gating ──
+
+    #[tokio::test]
+    async fn snapshot_version_1_returns_catalog() {
+        let svc = test_service();
+        let user_id = Uuid::new_v4();
+        let snap = svc.get_policy_snapshot(user_id, 1).await.unwrap();
+
+        assert_eq!(snap.user_id, user_id);
+        assert_eq!(snap.policy_version, 1);
+        assert_eq!(snap.model_catalog.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn snapshot_wrong_version_returns_not_found() {
+        let svc = test_service();
+        for version in [0, 2, 100, u64::MAX] {
+            let result = svc.get_policy_snapshot(Uuid::new_v4(), version).await;
+            assert!(
+                matches!(result, Err(MiniChatModelPolicyPluginError::NotFound)),
+                "version {version} should return NotFound"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_preserves_kill_switch_state() {
+        let mut cfg = StaticMiniChatPolicyPluginConfig::default();
+        cfg.kill_switches.disable_premium_tier = true;
+        cfg.kill_switches.disable_web_search = true;
+
+        let svc = Service::new(
+            cfg.model_catalog,
+            cfg.kill_switches,
+            cfg.default_standard_limits,
+            cfg.default_premium_limits,
+        );
+        let snap = svc.get_policy_snapshot(Uuid::new_v4(), 1).await.unwrap();
+
+        assert!(snap.kill_switches.disable_premium_tier);
+        assert!(snap.kill_switches.disable_web_search);
+        assert!(!snap.kill_switches.force_standard_tier);
+    }
+
+    #[tokio::test]
+    async fn snapshot_contains_both_tiers() {
+        let svc = test_service();
+        let snap = svc.get_policy_snapshot(Uuid::new_v4(), 1).await.unwrap();
+
+        let has_premium = snap
+            .model_catalog
+            .iter()
+            .any(|m| m.tier == ModelTier::Premium);
+        let has_standard = snap
+            .model_catalog
+            .iter()
+            .any(|m| m.tier == ModelTier::Standard);
+
+        assert!(has_premium, "catalog must include a premium model");
+        assert!(has_standard, "catalog must include a standard model");
+    }
+
+    // ── get_user_limits: version gating ──
+
+    #[tokio::test]
+    async fn user_limits_version_1_returns_configured_limits() {
+        let svc = test_service();
+        let user_id = Uuid::new_v4();
+        let limits = svc.get_user_limits(user_id, 1).await.unwrap();
+
+        assert_eq!(limits.user_id, user_id);
+        assert_eq!(limits.policy_version, 1);
+        // Default config: standard daily > premium daily
+        assert!(
+            limits.standard.limit_daily_credits_micro > limits.premium.limit_daily_credits_micro,
+            "standard daily limit should exceed premium daily limit"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_limits_wrong_version_returns_not_found() {
+        let svc = test_service();
+        for version in [0, 2, 100, u64::MAX] {
+            let result = svc.get_user_limits(Uuid::new_v4(), version).await;
+            assert!(
+                matches!(result, Err(MiniChatModelPolicyPluginError::NotFound)),
+                "version {version} should return NotFound"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn user_limits_reflect_custom_config() {
+        let mut cfg = StaticMiniChatPolicyPluginConfig::default();
+        cfg.default_standard_limits.limit_daily_credits_micro = 42;
+        cfg.default_premium_limits.limit_monthly_credits_micro = 99;
+
+        let svc = Service::new(
+            cfg.model_catalog,
+            cfg.kill_switches,
+            cfg.default_standard_limits,
+            cfg.default_premium_limits,
+        );
+        let limits = svc.get_user_limits(Uuid::new_v4(), 1).await.unwrap();
+
+        assert_eq!(limits.standard.limit_daily_credits_micro, 42);
+        assert_eq!(limits.premium.limit_monthly_credits_micro, 99);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new models (GPT-5.2, GPT-5-Mini, GPT-5-Nano) and richer per-model metadata.
  * Introduced structured per-model configs: estimation budgets, token policies, capabilities, UX and performance settings.
  * Per-model preference blocks for explicit defaulting and ordering.

* **Improvements**
  * Model selection now respects per-model preferences and enabled state when choosing defaults.
  * Policy responses and docs now include full model catalog and kill-switches (including image disable).
  * Added tests validating defaults and serialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->