### PR TITLE
feat(mini-chat): return attachment summaries in list messages response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "bytes",
  "cf-authz-resolver-sdk",
  "cf-mini-chat-sdk",

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -44,6 +44,9 @@ futures = { workspace = true }
 bytes = { workspace = true }
 regex = { workspace = true }
 
+# Encoding
+base64 = { workspace = true }
+
 # Serde and JSON
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/modules/mini-chat/mini-chat/src/api/rest/dto.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/dto.rs
@@ -6,7 +6,7 @@
 //! Stream event types live in `domain::stream_events`; SSE wire conversion
 //! and ordering enforcement live in `api::rest::sse`.
 
-use crate::domain::models::ChatDetail;
+use crate::domain::models::{AttachmentSummary, ChatDetail, ImgThumbnail};
 use time::OffsetDateTime;
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -74,7 +74,7 @@ pub struct MessageDto {
     pub request_id: Uuid,
     pub role: String,
     pub content: String,
-    pub attachment_ids: Vec<Uuid>,
+    pub attachments: Vec<AttachmentSummaryDto>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -92,11 +92,60 @@ impl From<crate::domain::models::Message> for MessageDto {
             request_id: m.request_id,
             role: m.role,
             content: m.content,
-            attachment_ids: m.attachment_ids,
+            attachments: m
+                .attachments
+                .into_iter()
+                .map(AttachmentSummaryDto::from)
+                .collect(),
             model: m.model,
             input_tokens: m.input_tokens,
             output_tokens: m.output_tokens,
             created_at: m.created_at,
+        }
+    }
+}
+
+/// Lightweight attachment metadata embedded in Message responses.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct AttachmentSummaryDto {
+    pub attachment_id: Uuid,
+    pub kind: String,
+    pub filename: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub img_thumbnail: Option<ImgThumbnailDto>,
+}
+
+impl From<AttachmentSummary> for AttachmentSummaryDto {
+    fn from(a: AttachmentSummary) -> Self {
+        Self {
+            attachment_id: a.attachment_id,
+            kind: a.kind,
+            filename: a.filename,
+            status: a.status,
+            img_thumbnail: a.img_thumbnail.map(ImgThumbnailDto::from),
+        }
+    }
+}
+
+/// Server-generated preview thumbnail for an image attachment.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct ImgThumbnailDto {
+    pub content_type: String,
+    pub width: i32,
+    pub height: i32,
+    pub data_base64: String,
+}
+
+impl From<ImgThumbnail> for ImgThumbnailDto {
+    fn from(t: ImgThumbnail) -> Self {
+        Self {
+            content_type: t.content_type,
+            width: t.width,
+            height: t.height,
+            data_base64: t.data_base64,
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/models.rs
+++ b/modules/mini-chat/mini-chat/src/domain/models.rs
@@ -65,11 +65,32 @@ pub struct Message {
     pub request_id: Uuid,
     pub role: String,
     pub content: String,
-    pub attachment_ids: Vec<Uuid>,
+    pub attachments: Vec<AttachmentSummary>,
     pub model: Option<String>,
     pub input_tokens: Option<i64>,
     pub output_tokens: Option<i64>,
     pub created_at: OffsetDateTime,
+}
+
+/// Lightweight attachment metadata embedded in Message objects.
+#[domain_model]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachmentSummary {
+    pub attachment_id: Uuid,
+    pub kind: String,
+    pub filename: String,
+    pub status: String,
+    pub img_thumbnail: Option<ImgThumbnail>,
+}
+
+/// Server-generated preview thumbnail for an image attachment.
+#[domain_model]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImgThumbnail {
+    pub content_type: String,
+    pub width: i32,
+    pub height: i32,
+    pub data_base64: String,
 }
 
 // ── Reaction ──

--- a/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use modkit_db::secure::DBRunner;
 use modkit_macros::domain_model;
@@ -5,6 +7,7 @@ use modkit_security::AccessScope;
 use uuid::Uuid;
 
 use crate::domain::error::DomainError;
+use crate::domain::models::AttachmentSummary;
 use crate::infra::db::entity::message::Model as MessageModel;
 
 /// Parameters for inserting a user message.
@@ -79,4 +82,14 @@ pub trait MessageRepository: Send + Sync {
         chat_id: Uuid,
         query: &modkit_odata::ODataQuery,
     ) -> Result<modkit_odata::Page<MessageModel>, DomainError>;
+
+    /// Batch-fetch attachment summaries for the given message IDs (single query).
+    /// Returns a map from `message_id` to its `AttachmentSummary` list.
+    async fn batch_attachment_summaries<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        message_ids: &[Uuid],
+    ) -> Result<HashMap<Uuid, Vec<AttachmentSummary>>, DomainError>;
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/message_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/message_service.rs
@@ -67,6 +67,13 @@ impl<MR: MessageRepository, CR: ChatRepository> MessageService<MR, CR> {
             .list_by_chat(&conn, &msg_scope, chat_id, query)
             .await?;
 
+        // Batch-fetch attachment summaries for all returned messages (single query).
+        let msg_ids: Vec<Uuid> = page.items.iter().map(|m| m.id).collect();
+        let mut att_map = self
+            .message_repo
+            .batch_attachment_summaries(&conn, &msg_scope, chat_id, &msg_ids)
+            .await?;
+
         let items: Vec<Message> = page
             .items
             .into_iter()
@@ -75,6 +82,7 @@ impl<MR: MessageRepository, CR: ChatRepository> MessageService<MR, CR> {
                 let request_id = m.request_id.ok_or_else(|| {
                     DomainError::internal("list_by_chat returned message with null request_id")
                 })?;
+                let attachments = att_map.remove(&m.id).unwrap_or_default();
                 Ok(Message {
                     id: m.id,
                     request_id,
@@ -84,7 +92,7 @@ impl<MR: MessageRepository, CR: ChatRepository> MessageService<MR, CR> {
                         MessageRole::System => "system".to_owned(),
                     },
                     content: m.content,
-                    attachment_ids: Vec::new(), // TODO: fetch attachment IDs and metadata in the future
+                    attachments,
                     model: m.model,
                     input_tokens: if m.input_tokens == 0 {
                         None

--- a/modules/mini-chat/mini-chat/src/domain/service/message_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/message_service_test.rs
@@ -1,7 +1,10 @@
 use std::sync::Arc;
 
+use modkit_db::secure::secure_insert;
 use modkit_odata::ODataQuery;
 use modkit_security::AccessScope;
+use sea_orm::Set;
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::domain::error::DomainError;
@@ -14,6 +17,8 @@ use crate::domain::service::test_helpers::{
     inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver, mock_thread_summary_repo,
     test_security_ctx,
 };
+use crate::infra::db::entity::attachment::{ActiveModel as AttAm, Entity as AttEntity};
+use crate::infra::db::entity::message_attachment::{ActiveModel as MaAm, Entity as MaEntity};
 use crate::infra::db::repo::chat_repo::ChatRepository as OrmChatRepository;
 use crate::infra::db::repo::message_repo::MessageRepository as OrmMessageRepository;
 
@@ -483,5 +488,351 @@ async fn list_messages_pagination_backward_cursor() {
     assert_eq!(
         back_ids, page1_ids,
         "Backward navigation must return to page 1 items"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Attachment integration tests
+// ════════════════════════════════════════════════════════════════════
+
+/// Insert an attachment row via `secure_insert`. Returns the attachment ID.
+async fn insert_attachment(
+    db_provider: &Arc<crate::domain::service::DbProvider>,
+    tenant_id: Uuid,
+    chat_id: Uuid,
+    kind: &str,
+    filename: &str,
+    status: &str,
+    img_thumbnail: Option<(Vec<u8>, i32, i32)>,
+) -> Uuid {
+    let now = OffsetDateTime::now_utc();
+    let att_id = Uuid::now_v7();
+    let (thumb_bytes, thumb_w, thumb_h) = match img_thumbnail {
+        Some((bytes, w, h)) => (Some(bytes), Some(w), Some(h)),
+        None => (None, None, None),
+    };
+    let am = AttAm {
+        id: Set(att_id),
+        tenant_id: Set(tenant_id),
+        chat_id: Set(chat_id),
+        uploaded_by_user_id: Set(Uuid::new_v4()),
+        filename: Set(filename.to_owned()),
+        content_type: Set("application/octet-stream".to_owned()),
+        size_bytes: Set(1024),
+        storage_backend: Set("azure".to_owned()),
+        provider_file_id: Set(None),
+        status: Set(status.to_owned()),
+        attachment_kind: Set(kind.to_owned()),
+        doc_summary: Set(None),
+        img_thumbnail: Set(thumb_bytes),
+        img_thumbnail_width: Set(thumb_w),
+        img_thumbnail_height: Set(thumb_h),
+        summary_model: Set(None),
+        summary_updated_at: Set(None),
+        cleanup_status: Set(None),
+        cleanup_attempts: Set(0),
+        last_cleanup_error: Set(None),
+        cleanup_updated_at: Set(None),
+        created_at: Set(now),
+        deleted_at: Set(None),
+    };
+    let conn = db_provider.conn().expect("conn");
+    let scope = AccessScope::allow_all();
+    secure_insert::<AttEntity>(am, &scope, &conn)
+        .await
+        .expect("insert attachment");
+    att_id
+}
+
+/// Link a message to an attachment via `message_attachments`.
+async fn link_message_attachment(
+    db_provider: &Arc<crate::domain::service::DbProvider>,
+    tenant_id: Uuid,
+    chat_id: Uuid,
+    message_id: Uuid,
+    attachment_id: Uuid,
+) {
+    let now = OffsetDateTime::now_utc();
+    let am = MaAm {
+        tenant_id: Set(tenant_id),
+        chat_id: Set(chat_id),
+        message_id: Set(message_id),
+        attachment_id: Set(attachment_id),
+        created_at: Set(now),
+    };
+    let conn = db_provider.conn().expect("conn");
+    let scope = AccessScope::allow_all();
+    secure_insert::<MaEntity>(am, &scope, &conn)
+        .await
+        .expect("link message attachment");
+}
+
+#[tokio::test]
+async fn list_messages_returns_attachments() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let chat_svc = build_chat_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let msg_svc = build_message_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let chat = chat_svc
+        .create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some("Attachments test".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat");
+
+    // Insert a user message
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = db_provider.conn().expect("conn");
+    let message_repo = OrmMessageRepository::new(limit_cfg());
+    let request_id = Uuid::new_v4();
+    let msg_id = Uuid::now_v7();
+
+    message_repo
+        .insert_user_message(
+            &conn,
+            &scope,
+            InsertUserMessageParams {
+                id: msg_id,
+                tenant_id,
+                chat_id: chat.id,
+                request_id,
+                content: "See attached".to_owned(),
+            },
+        )
+        .await
+        .expect("insert_user_message");
+
+    // Insert two attachments and link them to the message
+    let att_a = insert_attachment(
+        &db_provider,
+        tenant_id,
+        chat.id,
+        "document",
+        "report.pdf",
+        "ready",
+        None,
+    )
+    .await;
+    let att_b = insert_attachment(
+        &db_provider,
+        tenant_id,
+        chat.id,
+        "image",
+        "photo.webp",
+        "ready",
+        Some((vec![0xFF, 0xD8], 120, 80)),
+    )
+    .await;
+    link_message_attachment(&db_provider, tenant_id, chat.id, msg_id, att_a).await;
+    link_message_attachment(&db_provider, tenant_id, chat.id, msg_id, att_b).await;
+
+    // list_messages should return the message with both attachments
+    let page = msg_svc
+        .list_messages(&ctx, chat.id, &ODataQuery::default())
+        .await
+        .expect("list_messages");
+
+    assert_eq!(page.items.len(), 1);
+    let msg = &page.items[0];
+    assert_eq!(
+        msg.attachments.len(),
+        2,
+        "message should have 2 attachments"
+    );
+
+    let att_ids: Vec<Uuid> = msg.attachments.iter().map(|a| a.attachment_id).collect();
+    assert!(att_ids.contains(&att_a), "must contain att_a");
+    assert!(att_ids.contains(&att_b), "must contain att_b");
+
+    // Verify the image attachment has a thumbnail
+    let img_att = msg
+        .attachments
+        .iter()
+        .find(|a| a.attachment_id == att_b)
+        .expect("image attachment");
+    assert_eq!(img_att.kind, "image");
+    assert_eq!(img_att.filename, "photo.webp");
+    let thumb = img_att.img_thumbnail.as_ref().expect("thumbnail present");
+    assert_eq!(thumb.width, 120);
+    assert_eq!(thumb.height, 80);
+
+    // Verify the document attachment has no thumbnail
+    let doc_att = msg
+        .attachments
+        .iter()
+        .find(|a| a.attachment_id == att_a)
+        .expect("document attachment");
+    assert_eq!(doc_att.kind, "document");
+    assert!(doc_att.img_thumbnail.is_none());
+}
+
+#[tokio::test]
+async fn list_messages_no_attachments_returns_empty_vec() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let chat_svc = build_chat_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let msg_svc = build_message_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let chat = chat_svc
+        .create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some("No attachments".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat");
+
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = db_provider.conn().expect("conn");
+    let message_repo = OrmMessageRepository::new(limit_cfg());
+
+    message_repo
+        .insert_user_message(
+            &conn,
+            &scope,
+            InsertUserMessageParams {
+                id: Uuid::now_v7(),
+                tenant_id,
+                chat_id: chat.id,
+                request_id: Uuid::new_v4(),
+                content: "Plain message".to_owned(),
+            },
+        )
+        .await
+        .expect("insert_user_message");
+
+    let page = msg_svc
+        .list_messages(&ctx, chat.id, &ODataQuery::default())
+        .await
+        .expect("list_messages");
+
+    assert_eq!(page.items.len(), 1);
+    assert!(
+        page.items[0].attachments.is_empty(),
+        "message without links must have empty attachments"
+    );
+}
+
+#[tokio::test]
+async fn list_messages_mixed_messages_with_and_without_attachments() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let chat_svc = build_chat_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let msg_svc = build_message_service(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let chat = chat_svc
+        .create_chat(
+            &ctx,
+            NewChat {
+                model: None,
+                title: Some("Mixed".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat");
+
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = db_provider.conn().expect("conn");
+    let message_repo = OrmMessageRepository::new(limit_cfg());
+    let request_id = Uuid::new_v4();
+
+    // User message with attachment
+    let user_msg_id = Uuid::now_v7();
+    message_repo
+        .insert_user_message(
+            &conn,
+            &scope,
+            InsertUserMessageParams {
+                id: user_msg_id,
+                tenant_id,
+                chat_id: chat.id,
+                request_id,
+                content: "With file".to_owned(),
+            },
+        )
+        .await
+        .expect("insert_user_message");
+
+    let att_id = insert_attachment(
+        &db_provider,
+        tenant_id,
+        chat.id,
+        "document",
+        "notes.txt",
+        "ready",
+        None,
+    )
+    .await;
+    link_message_attachment(&db_provider, tenant_id, chat.id, user_msg_id, att_id).await;
+
+    // Assistant message without attachment
+    let asst_msg_id = Uuid::now_v7();
+    message_repo
+        .insert_assistant_message(
+            &conn,
+            &scope,
+            InsertAssistantMessageParams {
+                id: asst_msg_id,
+                tenant_id,
+                chat_id: chat.id,
+                request_id,
+                content: "Got it".to_owned(),
+                input_tokens: None,
+                output_tokens: None,
+                model: None,
+                provider_response_id: None,
+            },
+        )
+        .await
+        .expect("insert_assistant_message");
+
+    let page = msg_svc
+        .list_messages(&ctx, chat.id, &ODataQuery::default())
+        .await
+        .expect("list_messages");
+
+    assert_eq!(page.items.len(), 2);
+
+    let user_msg = page
+        .items
+        .iter()
+        .find(|m| m.id == user_msg_id)
+        .expect("user msg");
+    assert_eq!(user_msg.attachments.len(), 1);
+    assert_eq!(user_msg.attachments[0].attachment_id, att_id);
+
+    let asst_msg = page
+        .items
+        .iter()
+        .find(|m| m.id == asst_msg_id)
+        .expect("asst msg");
+    assert!(
+        asst_msg.attachments.is_empty(),
+        "assistant message must have no attachments"
     );
 }

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/attachment.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/attachment.rs
@@ -1,0 +1,42 @@
+use modkit_db::secure::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "attachments")]
+#[secure(tenant_col = "tenant_id", resource_col = "id", no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    pub uploaded_by_user_id: Uuid,
+    pub filename: String,
+    pub content_type: String,
+    pub size_bytes: i64,
+    pub storage_backend: String,
+    pub provider_file_id: Option<String>,
+    pub status: String,
+    pub attachment_kind: String,
+    #[sea_orm(column_type = "Text")]
+    pub doc_summary: Option<String>,
+    pub img_thumbnail: Option<Vec<u8>>,
+    pub img_thumbnail_width: Option<i32>,
+    pub img_thumbnail_height: Option<i32>,
+    #[allow(clippy::struct_field_names)]
+    pub summary_model: Option<String>,
+    pub summary_updated_at: Option<OffsetDateTime>,
+    pub cleanup_status: Option<String>,
+    pub cleanup_attempts: i32,
+    #[sea_orm(column_type = "Text")]
+    pub last_cleanup_error: Option<String>,
+    pub cleanup_updated_at: Option<OffsetDateTime>,
+    pub created_at: OffsetDateTime,
+    pub deleted_at: Option<OffsetDateTime>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/message_attachment.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/message_attachment.rs
@@ -1,0 +1,38 @@
+use modkit_db::secure::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use super::attachment::Entity as AttachmentEntity;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "message_attachments")]
+#[secure(tenant_col = "tenant_id", no_resource, no_owner, no_type)]
+pub struct Model {
+    pub tenant_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub chat_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub message_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub attachment_id: Uuid,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "AttachmentEntity",
+        from = "Column::AttachmentId",
+        to = "super::attachment::Column::Id"
+    )]
+    Attachment,
+}
+
+impl Related<AttachmentEntity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Attachment.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/mod.rs
@@ -1,5 +1,7 @@
+pub mod attachment;
 pub mod chat;
 pub mod chat_turn;
 pub mod message;
+pub mod message_attachment;
 pub mod message_reaction;
 pub mod quota_usage;

--- a/modules/mini-chat/mini-chat/src/infra/db/migrations/m20260302_000001_initial.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/migrations/m20260302_000001_initial.rs
@@ -35,6 +35,7 @@ DROP TABLE IF EXISTS user_model_prefs;
 DROP TABLE IF EXISTS quota_usage;
 DROP TABLE IF EXISTS chat_vector_stores;
 DROP TABLE IF EXISTS thread_summaries;
+DROP TABLE IF EXISTS message_attachments;
 DROP TABLE IF EXISTS attachments;
 DROP TABLE IF EXISTS chat_turns;
 DROP TABLE IF EXISTS messages;
@@ -84,6 +85,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_chat_request_role
 CREATE INDEX IF NOT EXISTS idx_messages_chat_created
     ON messages (chat_id, created_at)
     WHERE deleted_at IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_id_chat_id
+    ON messages (id, chat_id);
 
 -- 3. chat_turns
 CREATE TABLE IF NOT EXISTS chat_turns (
@@ -154,6 +157,24 @@ CREATE INDEX IF NOT EXISTS idx_attachments_tenant_chat
 CREATE INDEX IF NOT EXISTS idx_attachments_cleanup
     ON attachments (cleanup_status)
     WHERE cleanup_status IS NOT NULL AND deleted_at IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attachments_id_chat_id
+    ON attachments (id, chat_id);
+
+-- 4a. message_attachments
+CREATE TABLE IF NOT EXISTS message_attachments (
+    tenant_id       UUID NOT NULL,
+    chat_id         UUID NOT NULL,
+    message_id      UUID NOT NULL,
+    attachment_id   UUID NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (chat_id, message_id, attachment_id),
+    FOREIGN KEY (message_id, chat_id) REFERENCES messages(id, chat_id) ON DELETE CASCADE,
+    FOREIGN KEY (attachment_id, chat_id) REFERENCES attachments(id, chat_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_message_attachments_tenant_chat
+    ON message_attachments (tenant_id, chat_id);
+CREATE INDEX IF NOT EXISTS idx_message_attachments_attachment_chat
+    ON message_attachments (attachment_id, chat_id);
 
 -- 5. thread_summaries
 CREATE TABLE IF NOT EXISTS thread_summaries (
@@ -271,6 +292,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_chat_request_role
 CREATE INDEX IF NOT EXISTS idx_messages_chat_created
     ON messages (chat_id, created_at)
     WHERE deleted_at IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_id_chat_id
+    ON messages (id, chat_id);
 
 -- 3. chat_turns
 CREATE TABLE IF NOT EXISTS chat_turns (
@@ -341,6 +364,24 @@ CREATE INDEX IF NOT EXISTS idx_attachments_tenant_chat
 CREATE INDEX IF NOT EXISTS idx_attachments_cleanup
     ON attachments (cleanup_status)
     WHERE cleanup_status IS NOT NULL AND deleted_at IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attachments_id_chat_id
+    ON attachments (id, chat_id);
+
+-- 4a. message_attachments
+CREATE TABLE IF NOT EXISTS message_attachments (
+    tenant_id       TEXT NOT NULL,
+    chat_id         TEXT NOT NULL,
+    message_id      TEXT NOT NULL,
+    attachment_id   TEXT NOT NULL,
+    created_at      TEXT NOT NULL,
+    PRIMARY KEY (chat_id, message_id, attachment_id),
+    FOREIGN KEY (message_id, chat_id) REFERENCES messages(id, chat_id) ON DELETE CASCADE,
+    FOREIGN KEY (attachment_id, chat_id) REFERENCES attachments(id, chat_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_message_attachments_tenant_chat
+    ON message_attachments (tenant_id, chat_id);
+CREATE INDEX IF NOT EXISTS idx_message_attachments_attachment_chat
+    ON message_attachments (attachment_id, chat_id);
 
 -- 5. thread_summaries
 CREATE TABLE IF NOT EXISTS thread_summaries (

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
@@ -1,18 +1,43 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use modkit_db::odata::{LimitCfg, paginate_odata};
-use modkit_db::secure::{DBRunner, SecureEntityExt, secure_insert};
+use modkit_db::secure::{DBRunner, SecureEntityExt, exec_custom_all, secure_insert};
 use modkit_odata::{ODataQuery, Page, SortDir};
 use modkit_security::AccessScope;
-use sea_orm::{ColumnTrait, Condition, EntityTrait, Order, QueryFilter, Set};
+use sea_orm::{
+    ColumnTrait, Condition, EntityTrait, FromQueryResult, JoinType, Order, QueryFilter,
+    QuerySelect, RelationTrait, Set,
+};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::domain::error::DomainError;
+use crate::domain::models::{AttachmentSummary, ImgThumbnail};
 use crate::domain::repos::{InsertAssistantMessageParams, InsertUserMessageParams};
+use crate::infra::db::entity::attachment::Column as AttCol;
 use crate::infra::db::entity::message::{
     ActiveModel, Column, Entity as MessageEntity, MessageRole, Model as MessageModel,
 };
+use crate::infra::db::entity::message_attachment::{
+    Column as MaCol, Entity as MaEntity, Relation as MaRelation,
+};
 use crate::infra::db::odata_mapper::{MessageField, MessageODataMapper};
+
+/// Flat row returned by the `message_attachments` ⟕ attachments join query.
+#[derive(Debug, FromQueryResult)]
+struct AttachmentRow {
+    message_id: Uuid,
+    attachment_id: Uuid,
+    attachment_kind: String,
+    filename: String,
+    status: String,
+    img_thumbnail: Option<Vec<u8>>,
+    img_thumbnail_width: Option<i32>,
+    img_thumbnail_height: Option<i32>,
+}
 
 pub struct MessageRepository {
     limit_cfg: LimitCfg,
@@ -156,4 +181,77 @@ impl crate::domain::repos::MessageRepository for MessageRepository {
 
         Ok(page)
     }
+
+    async fn batch_attachment_summaries<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        message_ids: &[Uuid],
+    ) -> Result<HashMap<Uuid, Vec<AttachmentSummary>>, DomainError> {
+        if message_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let tenant_ids =
+            scope.all_uuid_values_for(modkit_security::pep_properties::OWNER_TENANT_ID);
+
+        // Single join query: message_attachments ⟕ attachments
+        // Selecting only the columns needed for AttachmentSummary.
+        let select = MaEntity::find()
+            .select_only()
+            .column(MaCol::MessageId)
+            .column_as(AttCol::Id, "attachment_id")
+            .column(AttCol::AttachmentKind)
+            .column(AttCol::Filename)
+            .column(AttCol::Status)
+            .column(AttCol::ImgThumbnail)
+            .column(AttCol::ImgThumbnailWidth)
+            .column(AttCol::ImgThumbnailHeight)
+            .join(JoinType::InnerJoin, MaRelation::Attachment.def())
+            .filter(
+                Condition::all()
+                    .add(MaCol::TenantId.is_in(tenant_ids))
+                    .add(MaCol::ChatId.eq(chat_id))
+                    .add(MaCol::MessageId.is_in(message_ids.iter().copied()))
+                    .add(AttCol::DeletedAt.is_null()),
+            )
+            .into_model::<AttachmentRow>();
+
+        let rows: Vec<AttachmentRow> = exec_custom_all(select, runner)
+            .await
+            .map_err(|e| DomainError::database(e.to_string()))?;
+
+        let mut map: HashMap<Uuid, Vec<AttachmentSummary>> =
+            HashMap::with_capacity(message_ids.len());
+        for row in rows {
+            let thumbnail = match (
+                row.img_thumbnail.as_ref(),
+                row.img_thumbnail_width,
+                row.img_thumbnail_height,
+            ) {
+                (Some(bytes), Some(w), Some(h)) if !bytes.is_empty() => Some(ImgThumbnail {
+                    content_type: "image/webp".to_owned(),
+                    width: w,
+                    height: h,
+                    data_base64: BASE64.encode(bytes),
+                }),
+                _ => None,
+            };
+            map.entry(row.message_id)
+                .or_default()
+                .push(AttachmentSummary {
+                    attachment_id: row.attachment_id,
+                    kind: row.attachment_kind,
+                    filename: row.filename,
+                    status: row.status,
+                    img_thumbnail: thumbnail,
+                });
+        }
+        Ok(map)
+    }
 }
+
+#[cfg(test)]
+#[path = "message_repo_test.rs"]
+mod tests;

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
@@ -8,7 +8,7 @@ use modkit_db::secure::{DBRunner, SecureEntityExt, exec_custom_all, secure_inser
 use modkit_odata::{ODataQuery, Page, SortDir};
 use modkit_security::AccessScope;
 use sea_orm::{
-    ColumnTrait, Condition, EntityTrait, FromQueryResult, JoinType, Order, QueryFilter,
+    ColumnTrait, Condition, EntityTrait, FromQueryResult, JoinType, Order, QueryFilter, QueryOrder,
     QuerySelect, RelationTrait, Set,
 };
 use time::OffsetDateTime;
@@ -216,6 +216,8 @@ impl crate::domain::repos::MessageRepository for MessageRepository {
                     .add(MaCol::MessageId.is_in(message_ids.iter().copied()))
                     .add(AttCol::DeletedAt.is_null()),
             )
+            .order_by(MaCol::CreatedAt, Order::Asc)
+            .order_by(AttCol::Id, Order::Asc)
             .into_model::<AttachmentRow>();
 
         let rows: Vec<AttachmentRow> = exec_custom_all(select, runner)

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo_test.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo_test.rs
@@ -1,0 +1,467 @@
+use std::sync::Arc;
+
+use modkit_db::DBProvider;
+use modkit_db::odata::LimitCfg;
+use modkit_db::secure::secure_insert;
+use modkit_security::AccessScope;
+use sea_orm::Set;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::domain::repos::{InsertUserMessageParams, MessageRepository as _};
+use crate::domain::service::test_helpers::{inmem_db, mock_db_provider};
+use crate::infra::db::entity::attachment::{ActiveModel as AttAm, Entity as AttEntity};
+use crate::infra::db::entity::message_attachment::{ActiveModel as MaAm, Entity as MaEntity};
+
+use super::MessageRepository;
+
+type Db = Arc<DBProvider<modkit_db::DbError>>;
+
+// ── Helpers ──
+
+fn scope() -> AccessScope {
+    AccessScope::allow_all()
+}
+
+fn limit_cfg() -> LimitCfg {
+    LimitCfg {
+        default: 20,
+        max: 100,
+    }
+}
+
+async fn test_db() -> Db {
+    mock_db_provider(inmem_db().await)
+}
+
+/// Insert a parent chat row (required by FK constraints).
+async fn insert_chat(db: &Db, tenant_id: Uuid, chat_id: Uuid) {
+    use crate::infra::db::entity::chat::{ActiveModel, Entity as ChatEntity};
+
+    let now = OffsetDateTime::now_utc();
+    let am = ActiveModel {
+        id: Set(chat_id),
+        tenant_id: Set(tenant_id),
+        user_id: Set(Uuid::new_v4()),
+        model: Set("gpt-5.2".to_owned()),
+        title: Set(Some("test".to_owned())),
+        is_temporary: Set(false),
+        created_at: Set(now),
+        updated_at: Set(now),
+        deleted_at: Set(None),
+    };
+    let conn = db.conn().unwrap();
+    secure_insert::<ChatEntity>(am, &scope(), &conn)
+        .await
+        .expect("insert chat");
+}
+
+/// Insert a user message row. Returns the message ID.
+async fn insert_user_message(db: &Db, tenant_id: Uuid, chat_id: Uuid) -> Uuid {
+    let repo = MessageRepository::new(limit_cfg());
+    let conn = db.conn().unwrap();
+    let msg_id = Uuid::now_v7();
+    repo.insert_user_message(
+        &conn,
+        &scope(),
+        InsertUserMessageParams {
+            id: msg_id,
+            tenant_id,
+            chat_id,
+            request_id: Uuid::new_v4(),
+            content: "hello".to_owned(),
+        },
+    )
+    .await
+    .expect("insert user message");
+    msg_id
+}
+
+/// Insert an attachment row. Returns the attachment ID.
+async fn insert_attachment(
+    db: &Db,
+    tenant_id: Uuid,
+    chat_id: Uuid,
+    kind: &str,
+    filename: &str,
+    status: &str,
+    img_thumbnail: Option<(Vec<u8>, i32, i32)>,
+) -> Uuid {
+    let now = OffsetDateTime::now_utc();
+    let att_id = Uuid::now_v7();
+    let (thumb_bytes, thumb_w, thumb_h) = match img_thumbnail {
+        Some((bytes, w, h)) => (Some(bytes), Some(w), Some(h)),
+        None => (None, None, None),
+    };
+    let am = AttAm {
+        id: Set(att_id),
+        tenant_id: Set(tenant_id),
+        chat_id: Set(chat_id),
+        uploaded_by_user_id: Set(Uuid::new_v4()),
+        filename: Set(filename.to_owned()),
+        content_type: Set("application/octet-stream".to_owned()),
+        size_bytes: Set(1024),
+        storage_backend: Set("azure".to_owned()),
+        provider_file_id: Set(None),
+        status: Set(status.to_owned()),
+        attachment_kind: Set(kind.to_owned()),
+        doc_summary: Set(None),
+        img_thumbnail: Set(thumb_bytes),
+        img_thumbnail_width: Set(thumb_w),
+        img_thumbnail_height: Set(thumb_h),
+        summary_model: Set(None),
+        summary_updated_at: Set(None),
+        cleanup_status: Set(None),
+        cleanup_attempts: Set(0),
+        last_cleanup_error: Set(None),
+        cleanup_updated_at: Set(None),
+        created_at: Set(now),
+        deleted_at: Set(None),
+    };
+    let conn = db.conn().unwrap();
+    secure_insert::<AttEntity>(am, &scope(), &conn)
+        .await
+        .expect("insert attachment");
+    att_id
+}
+
+/// Insert a soft-deleted attachment row. Returns the attachment ID.
+async fn insert_deleted_attachment(db: &Db, tenant_id: Uuid, chat_id: Uuid) -> Uuid {
+    let now = OffsetDateTime::now_utc();
+    let att_id = Uuid::now_v7();
+    let am = AttAm {
+        id: Set(att_id),
+        tenant_id: Set(tenant_id),
+        chat_id: Set(chat_id),
+        uploaded_by_user_id: Set(Uuid::new_v4()),
+        filename: Set("deleted.pdf".to_owned()),
+        content_type: Set("application/pdf".to_owned()),
+        size_bytes: Set(512),
+        storage_backend: Set("azure".to_owned()),
+        provider_file_id: Set(None),
+        status: Set("ready".to_owned()),
+        attachment_kind: Set("document".to_owned()),
+        doc_summary: Set(None),
+        img_thumbnail: Set(None),
+        img_thumbnail_width: Set(None),
+        img_thumbnail_height: Set(None),
+        summary_model: Set(None),
+        summary_updated_at: Set(None),
+        cleanup_status: Set(None),
+        cleanup_attempts: Set(0),
+        last_cleanup_error: Set(None),
+        cleanup_updated_at: Set(None),
+        created_at: Set(now),
+        deleted_at: Set(Some(now)),
+    };
+    let conn = db.conn().unwrap();
+    secure_insert::<AttEntity>(am, &scope(), &conn)
+        .await
+        .expect("insert deleted attachment");
+    att_id
+}
+
+/// Link a message to an attachment via `message_attachments`.
+async fn link_message_attachment(
+    db: &Db,
+    tenant_id: Uuid,
+    chat_id: Uuid,
+    message_id: Uuid,
+    attachment_id: Uuid,
+) {
+    let now = OffsetDateTime::now_utc();
+    let am = MaAm {
+        tenant_id: Set(tenant_id),
+        chat_id: Set(chat_id),
+        message_id: Set(message_id),
+        attachment_id: Set(attachment_id),
+        created_at: Set(now),
+    };
+    let conn = db.conn().unwrap();
+    secure_insert::<MaEntity>(am, &scope(), &conn)
+        .await
+        .expect("link message attachment");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// batch_attachment_summaries tests
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn batch_empty_message_ids_returns_empty() {
+    let db = test_db().await;
+    let repo = MessageRepository::new(limit_cfg());
+    let conn = db.conn().unwrap();
+    let scope = AccessScope::for_tenant(Uuid::new_v4());
+
+    let map = repo
+        .batch_attachment_summaries(&conn, &scope, Uuid::new_v4(), &[])
+        .await
+        .expect("batch empty");
+
+    assert!(map.is_empty());
+}
+
+#[tokio::test]
+async fn batch_no_attachments_returns_empty_map() {
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    insert_chat(&db, tenant_id, chat_id).await;
+    let msg_id = insert_user_message(&db, tenant_id, chat_id).await;
+
+    let repo = MessageRepository::new(limit_cfg());
+    let conn = db.conn().unwrap();
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    let map = repo
+        .batch_attachment_summaries(&conn, &scope, chat_id, &[msg_id])
+        .await
+        .expect("batch no attachments");
+
+    assert!(map.is_empty(), "no links -> empty map");
+}
+
+#[tokio::test]
+async fn batch_single_message_single_attachment() {
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    insert_chat(&db, tenant_id, chat_id).await;
+    let msg_id = insert_user_message(&db, tenant_id, chat_id).await;
+    let att_id = insert_attachment(
+        &db,
+        tenant_id,
+        chat_id,
+        "document",
+        "report.pdf",
+        "ready",
+        None,
+    )
+    .await;
+    link_message_attachment(&db, tenant_id, chat_id, msg_id, att_id).await;
+
+    let repo = MessageRepository::new(limit_cfg());
+    let conn = db.conn().unwrap();
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    let map = repo
+        .batch_attachment_summaries(&conn, &scope, chat_id, &[msg_id])
+        .await
+        .expect("batch");
+
+    assert_eq!(map.len(), 1);
+    let summaries = &map[&msg_id];
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].attachment_id, att_id);
+    assert_eq!(summaries[0].kind, "document");
+    assert_eq!(summaries[0].filename, "report.pdf");
+    assert_eq!(summaries[0].status, "ready");
+    assert!(summaries[0].img_thumbnail.is_none());
+}
+
+#[tokio::test]
+async fn batch_multiple_messages_multiple_attachments() {
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    insert_chat(&db, tenant_id, chat_id).await;
+
+    let msg1 = insert_user_message(&db, tenant_id, chat_id).await;
+    let msg2 = insert_user_message(&db, tenant_id, chat_id).await;
+
+    let att_a =
+        insert_attachment(&db, tenant_id, chat_id, "document", "a.pdf", "ready", None).await;
+    let att_b = insert_attachment(&db, tenant_id, chat_id, "image", "b.png", "ready", None).await;
+    let att_c = insert_attachment(
+        &db,
+        tenant_id,
+        chat_id,
+        "document",
+        "c.txt",
+        "processing",
+        None,
+    )
+    .await;
+
+    // msg1 → att_a, att_b
+    link_message_attachment(&db, tenant_id, chat_id, msg1, att_a).await;
+    link_message_attachment(&db, tenant_id, chat_id, msg1, att_b).await;
+    // msg2 → att_c
+    link_message_attachment(&db, tenant_id, chat_id, msg2, att_c).await;
+
+    let repo = MessageRepository::new(limit_cfg());
+    let conn = db.conn().unwrap();
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    let map = repo
+        .batch_attachment_summaries(&conn, &scope, chat_id, &[msg1, msg2])
+        .await
+        .expect("batch multi");
+
+    assert_eq!(map.len(), 2);
+    assert_eq!(map[&msg1].len(), 2);
+    assert_eq!(map[&msg2].len(), 1);
+    assert_eq!(map[&msg2][0].attachment_id, att_c);
+    assert_eq!(map[&msg2][0].status, "processing");
+}
+
+#[tokio::test]
+async fn batch_shared_attachment_across_messages() {
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    insert_chat(&db, tenant_id, chat_id).await;
+
+    let msg1 = insert_user_message(&db, tenant_id, chat_id).await;
+    let msg2 = insert_user_message(&db, tenant_id, chat_id).await;
+    let att_id = insert_attachment(
+        &db,
+        tenant_id,
+        chat_id,
+        "document",
+        "shared.pdf",
+        "ready",
+        None,
+    )
+    .await;
+
+    // Both messages reference the same attachment (M:N)
+    link_message_attachment(&db, tenant_id, chat_id, msg1, att_id).await;
+    link_message_attachment(&db, tenant_id, chat_id, msg2, att_id).await;
+
+    let repo = MessageRepository::new(limit_cfg());
+    let conn = db.conn().unwrap();
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    let map = repo
+        .batch_attachment_summaries(&conn, &scope, chat_id, &[msg1, msg2])
+        .await
+        .expect("batch shared");
+
+    assert_eq!(map.len(), 2);
+    assert_eq!(map[&msg1].len(), 1);
+    assert_eq!(map[&msg2].len(), 1);
+    assert_eq!(map[&msg1][0].attachment_id, att_id);
+    assert_eq!(map[&msg2][0].attachment_id, att_id);
+}
+
+#[tokio::test]
+async fn batch_with_img_thumbnail() {
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    insert_chat(&db, tenant_id, chat_id).await;
+
+    let msg_id = insert_user_message(&db, tenant_id, chat_id).await;
+    let thumb_bytes = vec![0xFF, 0xD8, 0xFF, 0xE0]; // fake image bytes
+    let att_id = insert_attachment(
+        &db,
+        tenant_id,
+        chat_id,
+        "image",
+        "photo.webp",
+        "ready",
+        Some((thumb_bytes.clone(), 120, 80)),
+    )
+    .await;
+    link_message_attachment(&db, tenant_id, chat_id, msg_id, att_id).await;
+
+    let repo = MessageRepository::new(limit_cfg());
+    let conn = db.conn().unwrap();
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    let map = repo
+        .batch_attachment_summaries(&conn, &scope, chat_id, &[msg_id])
+        .await
+        .expect("batch thumbnail");
+
+    let summaries = &map[&msg_id];
+    assert_eq!(summaries.len(), 1);
+    let thumb = summaries[0]
+        .img_thumbnail
+        .as_ref()
+        .expect("thumbnail present");
+    assert_eq!(thumb.content_type, "image/webp");
+    assert_eq!(thumb.width, 120);
+    assert_eq!(thumb.height, 80);
+    assert_eq!(thumb.data_base64, BASE64.encode(&thumb_bytes));
+}
+
+#[tokio::test]
+async fn batch_skips_soft_deleted_attachments() {
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    insert_chat(&db, tenant_id, chat_id).await;
+
+    let msg_id = insert_user_message(&db, tenant_id, chat_id).await;
+
+    // Insert a pre-deleted attachment (deleted_at set at insert time)
+    let att_id = insert_deleted_attachment(&db, tenant_id, chat_id).await;
+    link_message_attachment(&db, tenant_id, chat_id, msg_id, att_id).await;
+
+    let repo = MessageRepository::new(limit_cfg());
+    let conn = db.conn().unwrap();
+    let scope = AccessScope::for_tenant(tenant_id);
+
+    let map = repo
+        .batch_attachment_summaries(&conn, &scope, chat_id, &[msg_id])
+        .await
+        .expect("batch deleted");
+
+    assert!(map.is_empty(), "soft-deleted attachments must be excluded");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Tenant scope isolation
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn batch_cross_tenant_returns_empty() {
+    let db = test_db().await;
+    let tenant_a = Uuid::new_v4();
+    let tenant_b = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    insert_chat(&db, tenant_a, chat_id).await;
+
+    let msg_id = insert_user_message(&db, tenant_a, chat_id).await;
+    let att_id = insert_attachment(
+        &db,
+        tenant_a,
+        chat_id,
+        "document",
+        "secret.pdf",
+        "ready",
+        None,
+    )
+    .await;
+    link_message_attachment(&db, tenant_a, chat_id, msg_id, att_id).await;
+
+    let repo = MessageRepository::new(limit_cfg());
+    let conn = db.conn().unwrap();
+
+    // Query with tenant_b scope — should return nothing
+    let scope_b = AccessScope::for_tenant(tenant_b);
+    let map = repo
+        .batch_attachment_summaries(&conn, &scope_b, chat_id, &[msg_id])
+        .await
+        .expect("batch cross-tenant");
+
+    assert!(
+        map.is_empty(),
+        "cross-tenant query must not return attachments"
+    );
+
+    // Query with tenant_a scope — should work
+    let scope_a = AccessScope::for_tenant(tenant_a);
+    let map = repo
+        .batch_attachment_summaries(&conn, &scope_a, chat_id, &[msg_id])
+        .await
+        .expect("batch own tenant");
+
+    assert_eq!(map.len(), 1, "own tenant query must return attachments");
+}


### PR DESCRIPTION
- Replace bare attachment_ids with rich AttachmentSummary objects (kind, filename, status, optional img_thumbnail) on Message responses.
- Add batch_attachment_summaries repo method with a single JOIN query to avoid N+1.
- Introduce attachment and message_attachment DB entities and corresponding migration tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages now include full attachment details (filename, type, status) and support multiple attachments.
  * Image attachments show preview thumbnails with dimensions and embedded preview data.
  * Message listing returns attachments per message for richer context.

* **Database**
  * Schema updated to store attachments and message–attachment links, enabling per-message attachment retrieval.

* **Tests**
  * Added integration and repo tests covering attachment storage, linking, thumbnails, and cross-tenant behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->