### PR TITLE
fix(oagw): remove unused credentials config and fix static-credstore owner IDs

### DIFF
--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -166,17 +166,17 @@ modules:
       secrets:
         # Test-only fake client ID, not a real credential
         - tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
-          owner_id: "00000000-df51-5b42-9538-d2b56b7ee953"
+          owner_id: "11111111-6a88-4768-9dfc-6bcd5187d9ed"
           key: "openai-key"
           value: "sk-test-e2e-fake-key"
         # Test-only fake credentials for OAuth2 client ID and secret
         - tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
-          owner_id: "00000000-df51-5b42-9538-d2b56b7ee953"
+          owner_id: "11111111-6a88-4768-9dfc-6bcd5187d9ed"
           key: "test-oauth2-client-id"
           value: "test-client-id"
         # Test-only fake client secret, not a real credential
         - tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
-          owner_id: "00000000-df51-5b42-9538-d2b56b7ee953"
+          owner_id: "11111111-6a88-4768-9dfc-6bcd5187d9ed"
           key: "test-oauth2-client-secret"
           value: "test-client-secret"
 
@@ -245,11 +245,7 @@ modules:
   oagw:
     config:
       proxy_timeout_secs: 2
-      allow_http_upstream: true # Only for testing - do not enable in production without proper security controls 
-      credentials:
-        "cred://openai-key": "sk-test-e2e-fake-key"  # Test-only fake key, not a real credential
-        "cred://test-oauth2-client-id": "test-client-id" # Test-only fake client ID, not a real credential
-        "cred://test-oauth2-client-secret": "test-client-secret" # Test-only fake client secret, not a real credential
+      allow_http_upstream: true # Only for testing - do not enable in production without proper security controls
 
 # OpenTelemetry tracing configuration
 tracing:

--- a/modules/system/oagw/oagw/src/config.rs
+++ b/modules/system/oagw/oagw/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt, time::Duration};
+use std::{fmt, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
@@ -12,11 +12,6 @@ pub struct OagwConfig {
     pub max_body_size_bytes: usize,
     #[serde(default)]
     pub allow_http_upstream: bool,
-    /// Optional credentials to pre-load into the in-memory credential resolver.
-    /// Keys are secret references (e.g., `cred://openai-key`), values are secrets.
-    /// Intended for development and testing only.
-    #[serde(default)]
-    pub credentials: HashMap<String, String>,
     /// TTL in seconds for cached OAuth2 access tokens.
     /// Default: 300 (5 minutes). Kept short because there is currently no
     /// cache-invalidation mechanism — a revoked or rotated token remains
@@ -35,7 +30,6 @@ impl Default for OagwConfig {
             proxy_timeout_secs: default_proxy_timeout_secs(),
             max_body_size_bytes: default_max_body_size_bytes(),
             allow_http_upstream: false,
-            credentials: HashMap::new(),
             token_cache_ttl_secs: default_token_cache_ttl_secs(),
             token_cache_capacity: default_token_cache_capacity(),
         }

--- a/testing/e2e/modules/oagw/conftest.py
+++ b/testing/e2e/modules/oagw/conftest.py
@@ -28,7 +28,7 @@ def mock_upstream_url():
 @pytest.fixture
 def tenant_id():
     """Fixed tenant UUID for test isolation."""
-    return "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    return "00000000-df51-5b42-9538-d2b56b7ee953"
 
 
 @pytest.fixture

--- a/testing/e2e/modules/oagw/mock_upstream.py
+++ b/testing/e2e/modules/oagw/mock_upstream.py
@@ -261,7 +261,7 @@ class MockUpstreamServer:
                     writer.close()
                 except RuntimeError:
                     # Event loop may already be closing/shutdown.
-                    return
+                    pass
                 try:
                     await writer.wait_closed()
                 except (ConnectionError, RuntimeError):


### PR DESCRIPTION
- Cleaned up in-memory `credentials` and associated configuration from `oagw` module.
- Updated `owner_id` as part of `e2e-local.yaml` configuration to match [default subject id](https://github.com/cyberfabric/cyberfabric-core/blob/main/libs/modkit-security/src/constants.rs#L21).
- Updated oagw module tenant id to match [default tenant id](https://github.com/cyberfabric/cyberfabric-core/blob/main/libs/modkit-security/src/constants.rs#L12) in e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test environment credentials and tenant identifier used by end-to-end tests.
  * Removed legacy credential mappings from runtime configuration.
* **Bug Fixes**
  * Improved mock server shutdown to ensure connections are cleaned up reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->