### PR TITLE
refactor(modkit-db): replace exec_custom_all with project_all method on SecureSelect

### DIFF
--- a/libs/modkit-db/src/secure/cond.rs
+++ b/libs/modkit-db/src/secure/cond.rs
@@ -96,11 +96,11 @@ where
         match filter {
             ScopeFilter::Eq(eq) => {
                 let expr = scope_value_to_sea_expr(eq.value());
-                and_cond = and_cond.add(Expr::col(col).eq(expr));
+                and_cond = and_cond.add(col.into_expr().eq(expr));
             }
             ScopeFilter::In(inf) => {
                 let sea_values = scope_values_to_sea_values(inf.values());
-                and_cond = and_cond.add(Expr::col(col).is_in(sea_values));
+                and_cond = and_cond.add(col.is_in(sea_values));
             }
         }
     }

--- a/libs/modkit-db/src/secure/mod.rs
+++ b/libs/modkit-db/src/secure/mod.rs
@@ -151,7 +151,7 @@ pub use tx_config::{TxAccessMode, TxConfig, TxIsolationLevel};
 // Select operations
 pub use select::{
     Scoped, SecureEntityExt, SecureFindRelatedExt, SecureSelect, SecureSelectTwo,
-    SecureSelectTwoMany, Unscoped, exec_custom_all,
+    SecureSelectTwoMany, Unscoped,
 };
 
 // Update/Delete/Insert operations

--- a/libs/modkit-db/src/secure/select.rs
+++ b/libs/modkit-db/src/secure/select.rs
@@ -364,11 +364,54 @@ where
         self
     }
 
+    /// Execute a custom projection on this scoped query and return all results.
+    ///
+    /// The closure receives the inner
+    /// `Select<E>` (already scoped) and must return a
+    /// `Selector<SelectModel<T>>` — typically built via `.select_only()`,
+    /// `.column()`, `.group_by()`, `.into_model::<T>()`, etc.
+    ///
+    /// Because the method consumes `SecureSelect<E, Scoped>`, the compiler
+    /// guarantees that scope was applied before the projection runs.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let counts: Vec<ChatCount> = MsgEntity::find()
+    ///     .filter(condition)
+    ///     .secure()
+    ///     .scope_with(&scope)
+    ///     .project_all(conn, |q| {
+    ///         q.select_only()
+    ///          .column(MsgColumn::ChatId)
+    ///          .column_as(Expr::col(MsgColumn::Id).count(), "cnt")
+    ///          .group_by(MsgColumn::ChatId)
+    ///          .into_model::<ChatCount>()
+    ///     })
+    ///     .await?;
+    /// ```
+    ///
+    /// # Errors
+    /// Returns `ScopeError::Db` if the database query fails.
+    #[allow(clippy::disallowed_methods)]
+    pub async fn project_all<T, C, F>(self, runner: &C, project: F) -> Result<Vec<T>, ScopeError>
+    where
+        T: sea_orm::FromQueryResult + Send + Sync,
+        C: DBRunner,
+        F: FnOnce(sea_orm::Select<E>) -> sea_orm::Selector<sea_orm::SelectModel<T>>,
+    {
+        let selector = project(self.inner);
+        match DBRunnerInternal::as_seaorm(runner) {
+            SeaOrmRunner::Conn(db) => Ok(selector.all(db).await?),
+            SeaOrmRunner::Tx(tx) => Ok(selector.all(tx).await?),
+        }
+    }
+
     /// Unwrap the inner `SeaORM` `Select` for advanced use cases.
     ///
-    /// # Safety
-    /// The caller must ensure they don't remove or bypass the security
-    /// conditions that were applied during `.scope_with()`.
+    /// Prefer [`project_all`](Self::project_all) for custom projections —
+    /// it preserves compile-time scope enforcement. Use `into_inner()` only
+    /// when the query must be passed to an API that requires a raw `Select<E>`
+    /// (e.g., `paginate_odata`).
     #[must_use]
     pub fn into_inner(self) -> sea_orm::Select<E> {
         self.inner
@@ -741,43 +784,6 @@ where
 
         // Apply scope to the related entity
         select.secure().scope_with(scope)
-    }
-}
-
-// =============================================================================
-// Free functions for advanced query execution
-// =============================================================================
-
-/// Execute a custom `SelectModel` query through a database runner.
-///
-/// This enables advanced queries (e.g., GROUP BY with aggregates) that build
-/// a custom `Selector` from a scoped `SecureSelect::into_inner()` +
-/// `QuerySelect` transformations + `.into_model::<T>()`.
-///
-/// # Safety contract
-///
-/// This is an **escape hatch** that accepts a raw `sea_orm::Selector` and
-/// therefore bypasses the compile-time scope enforcement provided by
-/// [`SecureSelect`] / [`SecureSelectTwo`]. The caller **must** ensure that
-/// the input `Selector` was derived from a previously scoped query (e.g.,
-/// via `SecureSelect::into_inner()`) so that the correct tenant/scope
-/// WHERE clause is already present. Passing an unscoped selector will
-/// silently skip row-level security filtering.
-///
-/// # Errors
-/// Returns `ScopeError::Db` if the database query fails.
-#[allow(clippy::disallowed_methods)]
-pub async fn exec_custom_all<T, C>(
-    select: sea_orm::Selector<sea_orm::SelectModel<T>>,
-    runner: &C,
-) -> Result<Vec<T>, ScopeError>
-where
-    T: sea_orm::FromQueryResult + Send + Sync,
-    C: DBRunner,
-{
-    match DBRunnerInternal::as_seaorm(runner) {
-        SeaOrmRunner::Conn(db) => Ok(select.all(db).await?),
-        SeaOrmRunner::Tx(tx) => Ok(select.all(tx).await?),
     }
 }
 

--- a/libs/modkit-db/tests/sqlite/mod.rs
+++ b/libs/modkit-db/tests/sqlite/mod.rs
@@ -10,6 +10,7 @@ mod manager;
 mod options;
 mod pooling_tests;
 mod secure_insert_tenant_validation;
+mod secure_select_project_all;
 mod secure_update_tenant_safety;
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod sqlite_tests;

--- a/libs/modkit-db/tests/sqlite/secure_select_project_all.rs
+++ b/libs/modkit-db/tests/sqlite/secure_select_project_all.rs
@@ -1,0 +1,572 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Integration tests for `SecureSelect::project_all`.
+//!
+//! Security contract:
+//! - No raw SQL in tests.
+//! - Schema is created via `sea-orm-migration` definitions executed by the migration runner.
+
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::secure::{Db, DbConn, ScopableEntity, SecureEntityExt, secure_insert};
+use modkit_db::{ConnectOpts, connect_db};
+use modkit_security::{AccessScope, pep_properties};
+use sea_orm::entity::prelude::*;
+use sea_orm::sea_query::Expr;
+use sea_orm::{FromQueryResult, JoinType, QueryFilter, QuerySelect, RelationTrait, Set};
+use sea_orm_migration::prelude as mig;
+use uuid::Uuid;
+
+// ════════════════════════════════════════════════════════════════════
+// Test entities
+// ════════════════════════════════════════════════════════════════════
+
+mod order_ent {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "project_all_orders")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub category: String,
+        pub amount: i64,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(has_many = "super::item_ent::Entity")]
+        Items,
+    }
+
+    impl Related<super::item_ent::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Items.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+impl ScopableEntity for order_ent::Entity {
+    fn tenant_col() -> Option<<Self as EntityTrait>::Column> {
+        Some(order_ent::Column::TenantId)
+    }
+    fn resource_col() -> Option<<Self as EntityTrait>::Column> {
+        Some(order_ent::Column::Id)
+    }
+    fn owner_col() -> Option<<Self as EntityTrait>::Column> {
+        None
+    }
+    fn type_col() -> Option<<Self as EntityTrait>::Column> {
+        None
+    }
+    fn resolve_property(property: &str) -> Option<<Self as EntityTrait>::Column> {
+        match property {
+            p if p == pep_properties::OWNER_TENANT_ID => Self::tenant_col(),
+            p if p == pep_properties::RESOURCE_ID => Self::resource_col(),
+            _ => None,
+        }
+    }
+}
+
+mod item_ent {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, DeriveEntityModel)]
+    #[sea_orm(table_name = "project_all_items")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub tenant_id: Uuid,
+        pub order_id: Uuid,
+        pub qty: i64,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {
+        #[sea_orm(
+            belongs_to = "super::order_ent::Entity",
+            from = "Column::OrderId",
+            to = "super::order_ent::Column::Id"
+        )]
+        Order,
+    }
+
+    impl Related<super::order_ent::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::Order.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+impl ScopableEntity for item_ent::Entity {
+    fn tenant_col() -> Option<<Self as EntityTrait>::Column> {
+        Some(item_ent::Column::TenantId)
+    }
+    fn resource_col() -> Option<<Self as EntityTrait>::Column> {
+        Some(item_ent::Column::Id)
+    }
+    fn owner_col() -> Option<<Self as EntityTrait>::Column> {
+        None
+    }
+    fn type_col() -> Option<<Self as EntityTrait>::Column> {
+        None
+    }
+    fn resolve_property(property: &str) -> Option<<Self as EntityTrait>::Column> {
+        match property {
+            p if p == pep_properties::OWNER_TENANT_ID => Self::tenant_col(),
+            p if p == pep_properties::RESOURCE_ID => Self::resource_col(),
+            _ => None,
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Migration
+// ════════════════════════════════════════════════════════════════════
+
+struct CreateProjectAllTables;
+
+impl mig::MigrationName for CreateProjectAllTables {
+    fn name(&self) -> &'static str {
+        "m001_create_project_all_tables"
+    }
+}
+
+#[async_trait::async_trait]
+impl mig::MigrationTrait for CreateProjectAllTables {
+    async fn up(&self, manager: &mig::SchemaManager) -> Result<(), mig::DbErr> {
+        manager
+            .create_table(
+                mig::Table::create()
+                    .table(mig::Alias::new("project_all_orders"))
+                    .if_not_exists()
+                    .col(
+                        mig::ColumnDef::new(mig::Alias::new("id"))
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        mig::ColumnDef::new(mig::Alias::new("tenant_id"))
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        mig::ColumnDef::new(mig::Alias::new("category"))
+                            .string()
+                            .not_null(),
+                    )
+                    .col(
+                        mig::ColumnDef::new(mig::Alias::new("amount"))
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                mig::Table::create()
+                    .table(mig::Alias::new("project_all_items"))
+                    .if_not_exists()
+                    .col(
+                        mig::ColumnDef::new(mig::Alias::new("id"))
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        mig::ColumnDef::new(mig::Alias::new("tenant_id"))
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        mig::ColumnDef::new(mig::Alias::new("order_id"))
+                            .uuid()
+                            .not_null(),
+                    )
+                    .col(
+                        mig::ColumnDef::new(mig::Alias::new("qty"))
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &mig::SchemaManager) -> Result<(), mig::DbErr> {
+        manager
+            .drop_table(
+                mig::Table::drop()
+                    .table(mig::Alias::new("project_all_items"))
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_table(
+                mig::Table::drop()
+                    .table(mig::Alias::new("project_all_orders"))
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Test helpers
+// ════════════════════════════════════════════════════════════════════
+
+struct TestDb {
+    db: Db,
+}
+
+impl TestDb {
+    async fn new() -> Self {
+        let test_id = Uuid::new_v4();
+        let dsn = format!("sqlite:file:memdb_project_all_{test_id}?mode=memory&cache=shared");
+        let opts = ConnectOpts {
+            max_conns: Some(1),
+            min_conns: Some(1),
+            ..Default::default()
+        };
+        let db = connect_db(&dsn, opts).await.expect("db connect");
+
+        run_migrations_for_testing(&db, vec![Box::new(CreateProjectAllTables)])
+            .await
+            .expect("migrate");
+
+        Self { db }
+    }
+
+    fn conn(&self) -> DbConn<'_> {
+        self.db.conn().expect("conn")
+    }
+}
+
+async fn insert_order(
+    conn: &DbConn<'_>,
+    scope: &AccessScope,
+    tenant_id: Uuid,
+    category: &str,
+    amount: i64,
+) -> Uuid {
+    let id = Uuid::new_v4();
+    let am = order_ent::ActiveModel {
+        id: Set(id),
+        tenant_id: Set(tenant_id),
+        category: Set(category.to_owned()),
+        amount: Set(amount),
+    };
+    secure_insert::<order_ent::Entity>(am, scope, conn)
+        .await
+        .expect("insert order");
+    id
+}
+
+async fn insert_item(
+    conn: &DbConn<'_>,
+    scope: &AccessScope,
+    tenant_id: Uuid,
+    order_id: Uuid,
+    qty: i64,
+) -> Uuid {
+    let id = Uuid::new_v4();
+    let am = item_ent::ActiveModel {
+        id: Set(id),
+        tenant_id: Set(tenant_id),
+        order_id: Set(order_id),
+        qty: Set(qty),
+    };
+    secure_insert::<item_ent::Entity>(am, scope, conn)
+        .await
+        .expect("insert item");
+    id
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Projection models
+// ════════════════════════════════════════════════════════════════════
+
+#[derive(Debug, FromQueryResult)]
+struct CategoryTotal {
+    category: String,
+    total: i64,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct OrderItemCount {
+    order_id: Uuid,
+    cnt: i64,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct SingleColumn {
+    category: String,
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Tests: basic projection (GROUP BY + aggregate)
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn project_all_group_by_aggregate() {
+    let db = TestDb::new().await;
+    let conn = db.conn();
+    let tid = Uuid::new_v4();
+    let scope = AccessScope::for_tenant(tid);
+
+    insert_order(&conn, &scope, tid, "books", 10).await;
+    insert_order(&conn, &scope, tid, "books", 20).await;
+    insert_order(&conn, &scope, tid, "electronics", 50).await;
+
+    let mut rows: Vec<CategoryTotal> = order_ent::Entity::find()
+        .secure()
+        .scope_with(&scope)
+        .project_all(&conn, |q| {
+            q.select_only()
+                .column(order_ent::Column::Category)
+                .column_as(Expr::col(order_ent::Column::Amount).sum(), "total")
+                .group_by(order_ent::Column::Category)
+                .into_model::<CategoryTotal>()
+        })
+        .await
+        .expect("project_all aggregate");
+
+    rows.sort_by(|a, b| a.category.cmp(&b.category));
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].category, "books");
+    assert_eq!(rows[0].total, 30);
+    assert_eq!(rows[1].category, "electronics");
+    assert_eq!(rows[1].total, 50);
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Tests: tenant isolation
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn project_all_cross_tenant_returns_empty() {
+    let db = TestDb::new().await;
+    let conn = db.conn();
+    let tid_a = Uuid::new_v4();
+    let tid_b = Uuid::new_v4();
+    let scope_a = AccessScope::for_tenant(tid_a);
+    let scope_b = AccessScope::for_tenant(tid_b);
+
+    insert_order(&conn, &scope_a, tid_a, "books", 10).await;
+    insert_order(&conn, &scope_a, tid_a, "books", 20).await;
+
+    // Query with scope_b — must see nothing from tenant A
+    let rows: Vec<CategoryTotal> = order_ent::Entity::find()
+        .secure()
+        .scope_with(&scope_b)
+        .project_all(&conn, |q| {
+            q.select_only()
+                .column(order_ent::Column::Category)
+                .column_as(Expr::col(order_ent::Column::Amount).sum(), "total")
+                .group_by(order_ent::Column::Category)
+                .into_model::<CategoryTotal>()
+        })
+        .await
+        .expect("project_all cross-tenant");
+
+    assert!(rows.is_empty(), "cross-tenant must return empty");
+}
+
+#[tokio::test]
+async fn project_all_deny_all_scope_returns_empty() {
+    let db = TestDb::new().await;
+    let conn = db.conn();
+    let tid = Uuid::new_v4();
+    let scope = AccessScope::for_tenant(tid);
+    let deny_scope = AccessScope::default();
+
+    insert_order(&conn, &scope, tid, "books", 10).await;
+
+    let rows: Vec<SingleColumn> = order_ent::Entity::find()
+        .secure()
+        .scope_with(&deny_scope)
+        .project_all(&conn, |q| {
+            q.select_only()
+                .column(order_ent::Column::Category)
+                .into_model::<SingleColumn>()
+        })
+        .await
+        .expect("project_all deny scope");
+
+    assert!(rows.is_empty(), "deny-all scope must return empty");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Tests: empty result
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn project_all_no_data_returns_empty() {
+    let db = TestDb::new().await;
+    let conn = db.conn();
+    let tid = Uuid::new_v4();
+    let scope = AccessScope::for_tenant(tid);
+
+    let rows: Vec<CategoryTotal> = order_ent::Entity::find()
+        .secure()
+        .scope_with(&scope)
+        .project_all(&conn, |q| {
+            q.select_only()
+                .column(order_ent::Column::Category)
+                .column_as(Expr::col(order_ent::Column::Amount).sum(), "total")
+                .group_by(order_ent::Column::Category)
+                .into_model::<CategoryTotal>()
+        })
+        .await
+        .expect("project_all empty");
+
+    assert!(rows.is_empty());
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Tests: select_only without aggregation (column projection)
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn project_all_select_only_columns() {
+    let db = TestDb::new().await;
+    let conn = db.conn();
+    let tid = Uuid::new_v4();
+    let scope = AccessScope::for_tenant(tid);
+
+    insert_order(&conn, &scope, tid, "books", 10).await;
+    insert_order(&conn, &scope, tid, "electronics", 50).await;
+
+    let mut rows: Vec<SingleColumn> = order_ent::Entity::find()
+        .secure()
+        .scope_with(&scope)
+        .project_all(&conn, |q| {
+            q.select_only()
+                .column(order_ent::Column::Category)
+                .into_model::<SingleColumn>()
+        })
+        .await
+        .expect("project_all columns");
+
+    rows.sort_by(|a, b| a.category.cmp(&b.category));
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].category, "books");
+    assert_eq!(rows[1].category, "electronics");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Tests: JOIN + projection (shared column names like tenant_id)
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn project_all_with_join_disambiguates_tenant_id() {
+    let db = TestDb::new().await;
+    let conn = db.conn();
+    let tid = Uuid::new_v4();
+    let scope = AccessScope::for_tenant(tid);
+
+    let o1 = insert_order(&conn, &scope, tid, "books", 10).await;
+    let o2 = insert_order(&conn, &scope, tid, "electronics", 50).await;
+
+    // o1 has 3 items, o2 has 1 item
+    insert_item(&conn, &scope, tid, o1, 2).await;
+    insert_item(&conn, &scope, tid, o1, 3).await;
+    insert_item(&conn, &scope, tid, o1, 1).await;
+    insert_item(&conn, &scope, tid, o2, 5).await;
+
+    // JOIN orders ← items, GROUP BY order_id, COUNT(*)
+    // Both tables have tenant_id — this tests that scope_with generates
+    // table-qualified SQL even through a join.
+    let mut rows: Vec<OrderItemCount> = order_ent::Entity::find()
+        .join(JoinType::InnerJoin, order_ent::Relation::Items.def())
+        .secure()
+        .scope_with(&scope)
+        .project_all(&conn, |q| {
+            q.select_only()
+                .column_as(order_ent::Column::Id, "order_id")
+                .column_as(item_ent::Column::Id.count(), "cnt")
+                .group_by(order_ent::Column::Id)
+                .into_model::<OrderItemCount>()
+        })
+        .await
+        .expect("project_all join");
+
+    rows.sort_by_key(|r| r.cnt);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].order_id, o2);
+    assert_eq!(rows[0].cnt, 1);
+    assert_eq!(rows[1].order_id, o1);
+    assert_eq!(rows[1].cnt, 3);
+}
+
+#[tokio::test]
+async fn project_all_join_cross_tenant_isolation() {
+    let db = TestDb::new().await;
+    let conn = db.conn();
+    let tid_a = Uuid::new_v4();
+    let tid_b = Uuid::new_v4();
+    let scope_a = AccessScope::for_tenant(tid_a);
+    let scope_b = AccessScope::for_tenant(tid_b);
+
+    let o1 = insert_order(&conn, &scope_a, tid_a, "books", 10).await;
+    insert_item(&conn, &scope_a, tid_a, o1, 2).await;
+
+    // Query with tenant B scope — must return empty even with a join
+    let rows: Vec<OrderItemCount> = order_ent::Entity::find()
+        .join(JoinType::InnerJoin, order_ent::Relation::Items.def())
+        .secure()
+        .scope_with(&scope_b)
+        .project_all(&conn, |q| {
+            q.select_only()
+                .column_as(order_ent::Column::Id, "order_id")
+                .column_as(item_ent::Column::Id.count(), "cnt")
+                .group_by(order_ent::Column::Id)
+                .into_model::<OrderItemCount>()
+        })
+        .await
+        .expect("project_all join cross-tenant");
+
+    assert!(rows.is_empty(), "cross-tenant join must return empty");
+}
+
+// ════════════════════════════════════════════════════════════════════
+// Tests: filter + projection combined
+// ════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn project_all_with_pre_filter() {
+    let db = TestDb::new().await;
+    let conn = db.conn();
+    let tid = Uuid::new_v4();
+    let scope = AccessScope::for_tenant(tid);
+
+    insert_order(&conn, &scope, tid, "books", 10).await;
+    insert_order(&conn, &scope, tid, "books", 20).await;
+    insert_order(&conn, &scope, tid, "electronics", 50).await;
+
+    // Pre-filter to only "books" before projection
+    let rows: Vec<CategoryTotal> = order_ent::Entity::find()
+        .filter(order_ent::Column::Category.eq("books"))
+        .secure()
+        .scope_with(&scope)
+        .project_all(&conn, |q| {
+            q.select_only()
+                .column(order_ent::Column::Category)
+                .column_as(Expr::col(order_ent::Column::Amount).sum(), "total")
+                .group_by(order_ent::Column::Category)
+                .into_model::<CategoryTotal>()
+        })
+        .await
+        .expect("project_all with filter");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].category, "books");
+    assert_eq!(rows[0].total, 30);
+}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/chat_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/chat_repo.rs
@@ -4,8 +4,7 @@ use crate::domain::models::Chat;
 use async_trait::async_trait;
 use modkit_db::odata::{LimitCfg, paginate_odata};
 use modkit_db::secure::{
-    DBRunner, SecureEntityExt, SecureUpdateExt, exec_custom_all, secure_insert,
-    secure_update_with_scope,
+    DBRunner, SecureEntityExt, SecureUpdateExt, secure_insert, secure_update_with_scope,
 };
 use modkit_odata::{ODataQuery, Page, SortDir};
 use modkit_security::AccessScope;
@@ -187,8 +186,7 @@ impl crate::domain::repos::ChatRepository for ChatRepository {
             return Ok(HashMap::new());
         }
 
-        // Build scoped SELECT, then use into_inner() to add GROUP BY
-        let scoped = MsgEntity::find()
+        let rows = MsgEntity::find()
             .filter(
                 sea_orm::Condition::all()
                     .add(Expr::col(MsgColumn::ChatId).is_in(chat_ids.iter().copied()))
@@ -196,17 +194,15 @@ impl crate::domain::repos::ChatRepository for ChatRepository {
             )
             .secure()
             .scope_with(scope)
-            .into_inner();
-
-        // Transform into a GROUP BY query: SELECT chat_id, COUNT(*) FROM ... GROUP BY chat_id
-        let selector = scoped
-            .select_only()
-            .column(MsgColumn::ChatId)
-            .column_as(Expr::col(MsgColumn::Id).count(), "cnt")
-            .group_by(MsgColumn::ChatId)
-            .into_model::<ChatMessageCount>();
-
-        let rows = exec_custom_all(selector, conn).await.map_err(db_err)?;
+            .project_all(conn, |q| {
+                q.select_only()
+                    .column(MsgColumn::ChatId)
+                    .column_as(Expr::col(MsgColumn::Id).count(), "cnt")
+                    .group_by(MsgColumn::ChatId)
+                    .into_model::<ChatMessageCount>()
+            })
+            .await
+            .map_err(db_err)?;
 
         let mut counts = HashMap::with_capacity(rows.len());
         for row in rows {

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use modkit_db::odata::{LimitCfg, paginate_odata};
-use modkit_db::secure::{DBRunner, SecureEntityExt, exec_custom_all, secure_insert};
+use modkit_db::secure::{DBRunner, SecureEntityExt, secure_insert};
 use modkit_odata::{ODataQuery, Page, SortDir};
 use modkit_security::AccessScope;
 use sea_orm::{
@@ -193,34 +193,32 @@ impl crate::domain::repos::MessageRepository for MessageRepository {
             return Ok(HashMap::new());
         }
 
-        let tenant_ids =
-            scope.all_uuid_values_for(modkit_security::pep_properties::OWNER_TENANT_ID);
-
         // Single join query: message_attachments ⟕ attachments
         // Selecting only the columns needed for AttachmentSummary.
-        let select = MaEntity::find()
-            .select_only()
-            .column(MaCol::MessageId)
-            .column_as(AttCol::Id, "attachment_id")
-            .column(AttCol::AttachmentKind)
-            .column(AttCol::Filename)
-            .column(AttCol::Status)
-            .column(AttCol::ImgThumbnail)
-            .column(AttCol::ImgThumbnailWidth)
-            .column(AttCol::ImgThumbnailHeight)
+        let rows: Vec<AttachmentRow> = MaEntity::find()
             .join(JoinType::InnerJoin, MaRelation::Attachment.def())
             .filter(
                 Condition::all()
-                    .add(MaCol::TenantId.is_in(tenant_ids))
                     .add(MaCol::ChatId.eq(chat_id))
                     .add(MaCol::MessageId.is_in(message_ids.iter().copied()))
                     .add(AttCol::DeletedAt.is_null()),
             )
-            .order_by(MaCol::CreatedAt, Order::Asc)
-            .order_by(AttCol::Id, Order::Asc)
-            .into_model::<AttachmentRow>();
-
-        let rows: Vec<AttachmentRow> = exec_custom_all(select, runner)
+            .secure()
+            .scope_with(scope)
+            .project_all(runner, |q| {
+                q.select_only()
+                    .column(MaCol::MessageId)
+                    .column_as(AttCol::Id, "attachment_id")
+                    .column(AttCol::AttachmentKind)
+                    .column(AttCol::Filename)
+                    .column(AttCol::Status)
+                    .column(AttCol::ImgThumbnail)
+                    .column(AttCol::ImgThumbnailWidth)
+                    .column(AttCol::ImgThumbnailHeight)
+                    .order_by(MaCol::CreatedAt, Order::Asc)
+                    .order_by(AttCol::Id, Order::Asc)
+                    .into_model::<AttachmentRow>()
+            })
             .await
             .map_err(|e| DomainError::database(e.to_string()))?;
 


### PR DESCRIPTION
- Add project_all() to SecureSelect<E, Scoped> that preserves compile-time scope enforcement for custom projections (GROUP BY, aggregates)
- Remove exec_custom_all() free function which was an unsafe escape hatch bypassing scope guarantees
- Fix deprecated Expr::col(col).eq/is_in calls to use col.into_expr().eq / col.is_in
- Update mini-chat repos to use the new project_all API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a safe projection API for secure database queries to simplify custom projections and execution.

* **Refactor**
  * Replaced older custom-execution patterns with the new projection-based approach across repos.
  * Reduced public API surface by removing an escape-hatch execution path and updated imports/usages accordingly.

* **Tests**
  * Added comprehensive integration tests validating projections, joins, aggregates, and tenant scope isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->