### PR TITLE
feat(mini-chat): enforce per-model max_output_tokens and atomic prefl…

### DIFF
--- a/dylint_lints/Cargo.lock
+++ b/dylint_lints/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.2.14"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.2.14"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db-macros"
-version = "0.2.14"
+version = "0.3.2"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-error2",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors"
-version = "0.2.14"
+version = "0.3.2"
 dependencies = [
  "axum 0.8.8",
  "http",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
-version = "0.2.14"
+version = "0.3.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros"
-version = "0.2.14"
+version = "0.3.2"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.2.14"
+version = "0.3.2"
 dependencies = [
  "base64",
  "bigdecimal",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.2.14"
+version = "0.3.2"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-security",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-security"
-version = "0.2.14"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "postcard",
@@ -688,7 +688,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-utils"
-version = "0.2.14"
+version = "0.3.2"
 dependencies = [
  "humantime",
  "serde",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdk-directory"
-version = "0.1.15"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdks"
-version = "0.1.15"
+version = "0.1.18"
 dependencies = [
  "cf-system-sdk-directory",
 ]

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
@@ -19,8 +19,9 @@ use tracing::{debug, info, warn};
 
 use crate::api::rest::dto::{MessageDto, StreamMessageRequest};
 use crate::api::rest::sse::{StreamEventKind, StreamPhase};
-use crate::domain::service::StreamError;
+use crate::domain::service::{StreamError, replay};
 use crate::domain::stream_events::StreamEvent;
+use crate::infra::db::entity::chat_turn::Model as TurnModel;
 use crate::module::AppServices;
 
 /// GET /mini-chat/v1/chats/{id}/messages
@@ -69,9 +70,10 @@ pub(crate) async fn stream_message(
         }
     };
 
+    let selected_model = chat.model;
     let resolved = match svc
         .models
-        .resolve_model(ctx.subject_id(), Some(chat.model))
+        .resolve_model(ctx.subject_id(), Some(selected_model.clone()))
         .await
     {
         Ok(r) => r,
@@ -106,6 +108,9 @@ pub(crate) async fn stream_message(
         .await
     {
         Ok(handle) => handle,
+        Err(StreamError::Replay { turn }) => {
+            return replay_response(&svc, &selected_model, &turn, ping_secs).await;
+        }
         Err(e) => return stream_error_response(e),
     };
 
@@ -128,6 +133,8 @@ pub(crate) async fn stream_message(
 fn stream_error_response(err: StreamError) -> Response {
     match err {
         StreamError::Replay { .. } => {
+            // Completed turns are handled by replay_response(); this arm covers
+            // the defensive case where Replay leaks through without interception.
             Problem::new(StatusCode::CONFLICT, "Conflict", "Duplicate request_id").into_response()
         }
         StreamError::Conflict { message, .. } => {
@@ -149,7 +156,61 @@ fn stream_error_response(err: StreamError) -> Response {
             )
             .into_response()
         }
+        StreamError::QuotaExhausted {
+            error_code,
+            http_status,
+        } => {
+            let status = StatusCode::from_u16(http_status).unwrap_or(StatusCode::TOO_MANY_REQUESTS);
+            Problem::new(status, "Quota Exhausted", &error_code).into_response()
+        }
     }
+}
+
+/// Build an SSE replay response for a completed turn.
+///
+/// Fetches stored assistant content and emits `delta` + `done` events through
+/// the same `SseRelay` infrastructure as normal streaming.
+async fn replay_response(
+    svc: &AppServices,
+    selected_model: &str,
+    turn: &TurnModel,
+    ping_secs: u64,
+) -> Response {
+    let scope = modkit_security::AccessScope::allow_all().tenant_only();
+
+    let events = match replay::replay_turn(
+        &svc.db,
+        &*svc.message_repo,
+        &scope,
+        turn,
+        selected_model,
+    )
+    .await
+    {
+        Ok(ev) => ev,
+        Err(e) => {
+            warn!(error = %e, turn_id = %turn.id, "replay failed");
+            return Problem::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal Error",
+                "Failed to replay turn",
+            )
+            .into_response();
+        }
+    };
+
+    let (tx, rx) = mpsc::channel::<StreamEvent>(4);
+    tokio::spawn(async move {
+        drop(tx.send(events.delta).await);
+        drop(tx.send(events.done).await);
+    });
+
+    let cancel = CancellationToken::new();
+    let relay = SseRelay::new(rx, cancel, ping_secs);
+
+    Sse::new(relay)
+        .keep_alive(KeepAlive::new().interval(Duration::from_secs(30)))
+        .into_response()
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -111,6 +111,11 @@ pub struct StreamingConfig {
     /// Valid range: 5–60 (default 15).
     #[serde(default = "default_ping_interval")]
     pub sse_ping_interval_seconds: u16,
+
+    /// Maximum output tokens sent to the preflight reserve.
+    /// Default 32768 (matching common model limits).
+    #[serde(default = "default_max_output_tokens")]
+    pub max_output_tokens: u32,
 }
 
 impl Default for StreamingConfig {
@@ -118,8 +123,13 @@ impl Default for StreamingConfig {
         Self {
             sse_channel_capacity: default_channel_capacity(),
             sse_ping_interval_seconds: default_ping_interval(),
+            max_output_tokens: default_max_output_tokens(),
         }
     }
+}
+
+fn default_max_output_tokens() -> u32 {
+    32_768
 }
 
 impl StreamingConfig {

--- a/modules/mini-chat/mini-chat/src/domain/model/quota.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/quota.rs
@@ -83,7 +83,7 @@ pub struct PreflightInput {
     pub num_images: u32,
     pub tools_enabled: bool,
     pub web_search_enabled: bool,
-    pub max_output_tokens: u32,
+    pub max_output_tokens_cap: u32,
 }
 
 /// Input to `settle()`.

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -23,6 +23,7 @@ mod model_service;
 mod quota_service;
 pub(crate) mod quota_settler;
 mod reaction_service;
+pub(crate) mod replay;
 mod stream_service;
 #[cfg(test)]
 pub(crate) mod test_helpers;
@@ -114,12 +115,14 @@ pub(crate) struct AppServices<
 > {
     pub(crate) chats: ChatService<CR>,
     pub(crate) messages: MessageService<MR, CR>,
-    pub(crate) stream: StreamService<TR, MR, CR>,
+    pub(crate) stream: StreamService<TR, MR, QR, CR>,
     pub(crate) reactions: ReactionService<RR, MR, CR>,
     pub(crate) attachments: AttachmentService<CR>,
     pub(crate) models: ModelService,
-    pub(crate) quota: QuotaService<QR>,
+    pub(crate) quota: Arc<QuotaService<QR>>,
     pub(crate) finalization: Arc<FinalizationService<TR, MR>>,
+    pub(crate) db: Arc<DbProvider>,
+    pub(crate) message_repo: Arc<MR>,
 }
 
 impl<
@@ -145,14 +148,13 @@ impl<
     ) -> Self {
         let enforcer = PolicyEnforcer::new(authz);
 
-        // Type-erase QuotaService<QR> → Arc<dyn QuotaSettler> for FinalizationService (D2).
-        // QuotaService is stateless (holds only Arc refs and Copy configs), so a second
-        // instance is functionally identical to sharing via Arc.
-        let quota_settler: Arc<dyn QuotaSettler> = Arc::new(QuotaService::new(
+        // Shared QuotaService used by both StreamService (preflight) and
+        // FinalizationService (settlement via QuotaSettler trait).
+        let quota_svc = Arc::new(QuotaService::new(
             Arc::clone(&db),
             Arc::clone(&repos.quota),
-            Arc::clone(&policy_provider),
-            Arc::clone(&limits_provider),
+            policy_provider,
+            limits_provider,
             estimation_budgets,
             quota_config,
         ));
@@ -161,7 +163,7 @@ impl<
             Arc::clone(&db),
             Arc::clone(&repos.turn),
             Arc::clone(&repos.message),
-            quota_settler,
+            Arc::clone(&quota_svc) as Arc<dyn QuotaSettler>,
         ));
 
         Self {
@@ -187,6 +189,7 @@ impl<
                 provider_resolver,
                 streaming_config,
                 Arc::clone(&finalization),
+                Arc::clone(&quota_svc),
             ),
             reactions: ReactionService::new(
                 Arc::clone(&db),
@@ -208,15 +211,10 @@ impl<
                 enforcer,
                 Arc::clone(model_resolver),
             ),
-            quota: QuotaService::new(
-                db,
-                Arc::clone(&repos.quota),
-                policy_provider,
-                limits_provider,
-                estimation_budgets,
-                quota_config,
-            ),
+            quota: Arc::clone(&quota_svc),
             finalization,
+            db,
+            message_repo: Arc::clone(&repos.message),
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
@@ -37,7 +37,7 @@ use super::DbProvider;
 #[domain_model]
 pub struct QuotaService<QR: QuotaUsageRepository> {
     db: Arc<DbProvider>,
-    repo: Arc<QR>,
+    pub(crate) repo: Arc<QR>,
     policy_provider: Arc<dyn PolicySnapshotProvider>,
     limits_provider: Arc<dyn UserLimitsProvider>,
     estimation_budgets: EstimationBudgets,
@@ -227,14 +227,31 @@ fn to_db(e: DomainError) -> modkit_db::DbError {
     modkit_db::DbError::Other(anyhow::anyhow!(e))
 }
 
-// ── preflight_reserve ──
+// ── PreflightComputed ──
+
+/// Intermediate result from `preflight_evaluate()`.
+/// Contains the decision and all data needed for `preflight_write_reserve()`.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct PreflightComputed {
+    pub decision: PreflightDecision,
+    pub(crate) buckets: Vec<String>,
+    pub(crate) reserved_credits_micro: i64,
+    pub(crate) periods: Vec<(PeriodType, time::Date)>,
+    pub(crate) tenant_id: uuid::Uuid,
+    pub(crate) user_id: uuid::Uuid,
+}
+
+// ── preflight_evaluate + preflight_write_reserve ──
 
 impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
-    pub async fn preflight_reserve(
+    /// Evaluate preflight: external I/O, token estimation, cascade decision.
+    /// Does NOT write reserves — call `preflight_write_reserve` in the caller's transaction.
+    pub async fn preflight_evaluate(
         &self,
         input: PreflightInput,
-    ) -> Result<PreflightDecision, DomainError> {
-        // 1. Resolve policy
+    ) -> Result<PreflightComputed, DomainError> {
+        // 1. Resolve policy (external I/O)
         let policy_version = self
             .policy_provider
             .get_current_version(input.user_id)
@@ -255,12 +272,11 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                 num_images: input.num_images,
                 tools_enabled: input.tools_enabled,
                 web_search_enabled: input.web_search_enabled,
-                max_output_tokens: input.max_output_tokens,
             },
             &self.estimation_budgets,
         );
 
-        // 3. Find selected model's multipliers for initial reserve computation
+        // 3. Find selected model's multipliers for conservative initial reserve
         let catalog_entry = snapshot
             .model_catalog
             .iter()
@@ -276,10 +292,10 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
             },
         );
 
-        // 4. Compute reserve credits
+        // 4. Conservative initial reserve using config cap (pre-cascade)
         let initial_reserved = credits_micro_checked(
             estimation.estimated_input_tokens,
-            u64::from(input.max_output_tokens),
+            u64::from(input.max_output_tokens_cap),
             in_mult,
             out_mult,
         )
@@ -292,12 +308,12 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
             .map_err(|e| DomainError::internal(e.to_string()))?;
         let periods = vec![(PeriodType::Daily, now), (PeriodType::Monthly, month_start)];
 
-        // 6. Transaction: lock rows, cascade, reserve
+        // 6. Read-only transaction: lock rows, run cascade
         let repo = Arc::clone(&self.repo);
         let tenant_id = input.tenant_id;
         let user_id = input.user_id;
         let selected_model = input.selected_model.clone();
-        let max_output_tokens = input.max_output_tokens;
+        let max_output_tokens_cap = input.max_output_tokens_cap;
         let estimation_budgets = self.estimation_budgets;
 
         let tx_result = self
@@ -338,10 +354,17 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                     let decision = Self::resolve_effective_model(&selected_model, &cascade_ctx);
 
                     match decision {
-                        CascadeDecision::Reject => Ok(PreflightDecision::Reject {
-                            error_code: "quota_exceeded".to_owned(),
-                            http_status: 429,
-                            quota_scope: "tokens".to_owned(),
+                        CascadeDecision::Reject => Ok(PreflightComputed {
+                            decision: PreflightDecision::Reject {
+                                error_code: "quota_exceeded".to_owned(),
+                                http_status: 429,
+                                quota_scope: "tokens".to_owned(),
+                            },
+                            buckets: vec![],
+                            reserved_credits_micro: 0,
+                            periods: periods.clone(),
+                            tenant_id,
+                            user_id,
                         }),
                         CascadeDecision::Allow {
                             ref effective_model,
@@ -354,73 +377,58 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                         } => {
                             let effective_model = effective_model.clone();
 
-                            // Recompute credits if downgraded
-                            let final_reserved = if effective_model == selected_model {
-                                initial_reserved
-                            } else {
-                                let eff_entry = snapshot
-                                    .model_catalog
-                                    .iter()
-                                    .find(|m| m.model_id == effective_model)
-                                    .ok_or_else(|| {
-                                        to_db(DomainError::internal(
-                                            "effective model not in catalog",
-                                        ))
-                                    })?;
-                                credits_micro_checked(
-                                    estimation.estimated_input_tokens,
-                                    max_output_tokens as u64,
-                                    eff_entry.input_tokens_credit_multiplier_micro,
-                                    eff_entry.output_tokens_credit_multiplier_micro,
-                                )
-                                .map_err(|e| to_db(DomainError::internal(e.to_string())))?
-                            };
+                            // Look up effective model's catalog entry for per-model max_output
+                            let eff_entry = snapshot
+                                .model_catalog
+                                .iter()
+                                .find(|m| m.model_id == effective_model)
+                                .ok_or_else(|| {
+                                    to_db(DomainError::internal("effective model not in catalog"))
+                                })?;
 
-                            let buckets: Vec<&str> = match tier {
-                                ModelTier::Premium => vec!["total", "tier:premium"],
-                                ModelTier::Standard => vec!["total"],
-                            };
+                            // Resolve per-model max_output_tokens: min(catalog, config cap)
+                            let max_output_tokens_applied =
+                                std::cmp::min(eff_entry.max_output_tokens, max_output_tokens_cap);
 
-                            use crate::domain::repos::IncrementReserveParams;
-                            for bucket in &buckets {
-                                for (period_type, period_start) in &periods {
-                                    repo.increment_reserve(
-                                        tx,
-                                        &scope,
-                                        IncrementReserveParams {
-                                            tenant_id,
-                                            user_id,
-                                            period_type: period_type.clone(),
-                                            period_start: *period_start,
-                                            bucket: (*bucket).to_owned(),
-                                            amount_micro: final_reserved,
-                                        },
-                                    )
-                                    .await
-                                    .map_err(to_db)?;
+                            // Recompute credits with effective model's multipliers and resolved max_output
+                            let final_reserved = credits_micro_checked(
+                                estimation.estimated_input_tokens,
+                                max_output_tokens_applied as u64,
+                                eff_entry.input_tokens_credit_multiplier_micro,
+                                eff_entry.output_tokens_credit_multiplier_micro,
+                            )
+                            .map_err(|e| to_db(DomainError::internal(e.to_string())))?;
+
+                            let buckets: Vec<String> = match tier {
+                                ModelTier::Premium => {
+                                    vec!["total".to_owned(), "tier:premium".to_owned()]
                                 }
-                            }
+                                ModelTier::Standard => vec!["total".to_owned()],
+                            };
 
-                            let reserve_tokens = estimation.reserve_tokens as i64;
-                            let max_output_tokens_applied = max_output_tokens as i32;
+                            let reserve_tokens = estimation
+                                .estimated_input_tokens
+                                .saturating_add(max_output_tokens_applied as u64)
+                                as i64;
+                            let max_output_tokens_applied = max_output_tokens_applied as i32;
                             let policy_version_applied = policy_version as i64;
                             let minimal_generation_floor_applied =
                                 estimation_budgets.minimal_generation_floor as i32;
 
-                            match decision {
-                                CascadeDecision::Allow { .. } => Ok(PreflightDecision::Allow {
+                            let preflight_decision = match decision {
+                                CascadeDecision::Allow { .. } => PreflightDecision::Allow {
                                     effective_model,
                                     reserve_tokens,
                                     max_output_tokens_applied,
                                     reserved_credits_micro: final_reserved,
                                     policy_version_applied,
                                     minimal_generation_floor_applied,
-                                }),
+                                },
                                 CascadeDecision::Downgrade {
                                     downgrade_from,
                                     reason,
                                     ..
-                                } => Ok(PreflightDecision::Downgrade {
+                                } => PreflightDecision::Downgrade {
                                     effective_model,
                                     reserve_tokens,
                                     max_output_tokens_applied,
@@ -429,9 +437,18 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                                     minimal_generation_floor_applied,
                                     downgrade_from,
                                     downgrade_reason: reason,
-                                }),
+                                },
                                 CascadeDecision::Reject => unreachable!(),
-                            }
+                            };
+
+                            Ok(PreflightComputed {
+                                decision: preflight_decision,
+                                buckets,
+                                reserved_credits_micro: final_reserved,
+                                periods: periods.clone(),
+                                tenant_id,
+                                user_id,
+                            })
                         }
                     }
                 })
@@ -439,6 +456,96 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
             .await;
 
         tx_result.map_err(DomainError::from)
+    }
+
+    /// Write the reserve increments. Call inside the caller's transaction
+    /// alongside turn/message creation for atomicity.
+    pub async fn preflight_write_reserve(
+        &self,
+        runner: &impl DBRunner,
+        computed: &PreflightComputed,
+    ) -> Result<(), DomainError> {
+        // No-op for Reject decisions
+        if computed.buckets.is_empty() {
+            return Ok(());
+        }
+
+        let scope = AccessScope::for_tenant(computed.tenant_id);
+
+        use crate::domain::repos::IncrementReserveParams;
+        for bucket in &computed.buckets {
+            for (period_type, period_start) in &computed.periods {
+                self.repo
+                    .increment_reserve(
+                        runner,
+                        &scope,
+                        IncrementReserveParams {
+                            tenant_id: computed.tenant_id,
+                            user_id: computed.user_id,
+                            period_type: period_type.clone(),
+                            period_start: *period_start,
+                            bucket: bucket.clone(),
+                            amount_micro: computed.reserved_credits_micro,
+                        },
+                    )
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Combined evaluate + write for backward compatibility.
+    /// Delegates to `preflight_evaluate` + `preflight_write_reserve`.
+    pub async fn preflight_reserve(
+        &self,
+        input: PreflightInput,
+    ) -> Result<PreflightDecision, DomainError> {
+        let computed = self.preflight_evaluate(input).await?;
+
+        // Write reserve in its own transaction (legacy behavior)
+        let repo = Arc::clone(&self.repo);
+        let buckets = computed.buckets.clone();
+        let reserved_credits_micro = computed.reserved_credits_micro;
+        let periods = computed.periods.clone();
+        let tenant_id = computed.tenant_id;
+        let user_id = computed.user_id;
+
+        if !buckets.is_empty() {
+            self.db
+                .transaction(|tx| {
+                    let buckets = buckets.clone();
+                    let periods = periods.clone();
+                    Box::pin(async move {
+                        let scope = AccessScope::for_tenant(tenant_id);
+
+                        use crate::domain::repos::IncrementReserveParams;
+                        for bucket in &buckets {
+                            for (period_type, period_start) in &periods {
+                                repo.increment_reserve(
+                                    tx,
+                                    &scope,
+                                    IncrementReserveParams {
+                                        tenant_id,
+                                        user_id,
+                                        period_type: period_type.clone(),
+                                        period_start: *period_start,
+                                        bucket: bucket.clone(),
+                                        amount_micro: reserved_credits_micro,
+                                    },
+                                )
+                                .await
+                                .map_err(to_db)?;
+                            }
+                        }
+                        Ok(())
+                    })
+                })
+                .await
+                .map_err(DomainError::from)?;
+        }
+
+        Ok(computed.decision)
     }
 }
 
@@ -1367,7 +1474,7 @@ mod tests {
             num_images: 0,
             tools_enabled: false,
             web_search_enabled: false,
-            max_output_tokens: 1000,
+            max_output_tokens_cap: 4096,
         }
     }
 
@@ -1393,12 +1500,95 @@ mod tests {
             } => {
                 assert_eq!(effective_model, "gpt-5");
                 assert!(reserve_tokens > 0);
-                assert_eq!(max_output_tokens_applied, 1000);
+                assert_eq!(max_output_tokens_applied, 4096);
                 assert!(reserved_credits_micro > 0);
                 assert_eq!(policy_version_applied, 1);
                 assert!(minimal_generation_floor_applied > 0);
             }
             other => panic!("expected Allow, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preflight_max_output_tokens_capped_by_model_catalog() {
+        // Task 3.7: model max_output_tokens=4096, config cap=32768 → applied=4096
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let snapshot = default_snapshot(); // catalog has max_output_tokens: 4096
+        let svc = make_test_service(Arc::clone(&db), snapshot, 1.10);
+
+        let mut input = preflight_input("gpt-5");
+        input.max_output_tokens_cap = 32768; // config cap much larger than model
+
+        let result = svc.preflight_reserve(input).await.unwrap();
+        match result {
+            PreflightDecision::Allow {
+                max_output_tokens_applied,
+                ..
+            } => {
+                assert_eq!(max_output_tokens_applied, 4096); // model's value wins
+            }
+            other => panic!("expected Allow, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preflight_max_output_tokens_capped_by_config() {
+        // Task 3.8: model max_output_tokens=65536, config cap=32768 → applied=32768
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let mut snapshot = default_snapshot();
+        for entry in &mut snapshot.model_catalog {
+            entry.max_output_tokens = 65536;
+        }
+        let svc = make_test_service(Arc::clone(&db), snapshot, 1.10);
+
+        let mut input = preflight_input("gpt-5");
+        input.max_output_tokens_cap = 32768;
+
+        let result = svc.preflight_reserve(input).await.unwrap();
+        match result {
+            PreflightDecision::Allow {
+                max_output_tokens_applied,
+                ..
+            } => {
+                assert_eq!(max_output_tokens_applied, 32768); // config cap wins
+            }
+            other => panic!("expected Allow, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preflight_downgrade_uses_effective_model_max_output() {
+        // Task 3.9: downgrade to model with different max_output_tokens
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let mut snapshot = default_snapshot();
+        // Premium model: max_output_tokens=8192, Standard: max_output_tokens=2048
+        for entry in &mut snapshot.model_catalog {
+            if entry.tier == ModelTier::Premium {
+                entry.max_output_tokens = 8192;
+            } else {
+                entry.max_output_tokens = 2048;
+            }
+        }
+        snapshot.kill_switches.force_standard_tier = true; // force downgrade
+        let svc = make_test_service(Arc::clone(&db), snapshot, 1.10);
+
+        let mut input = preflight_input("gpt-5");
+        input.max_output_tokens_cap = 32768;
+
+        let result = svc.preflight_reserve(input).await.unwrap();
+        match result {
+            PreflightDecision::Downgrade {
+                max_output_tokens_applied,
+                effective_model,
+                ..
+            } => {
+                assert_eq!(effective_model, "gpt-5-mini");
+                assert_eq!(max_output_tokens_applied, 2048); // standard model's value
+            }
+            other => panic!("expected Downgrade, got {other:?}"),
         }
     }
 
@@ -1531,6 +1721,92 @@ mod tests {
         assert!(
             !rows.iter().any(|r| r.bucket == "tier:premium"),
             "tier:premium should NOT be reserved"
+        );
+    }
+
+    // ── preflight_evaluate / preflight_write_reserve tests ──
+
+    #[tokio::test]
+    async fn preflight_evaluate_returns_decision_without_writing() {
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let snapshot = default_snapshot();
+        let svc = make_test_service(Arc::clone(&db), snapshot, 1.10);
+
+        let computed = svc
+            .preflight_evaluate(preflight_input("gpt-5"))
+            .await
+            .unwrap();
+        assert!(matches!(computed.decision, PreflightDecision::Allow { .. }));
+
+        // Verify NO rows were written to quota_usage
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::for_tenant(Uuid::nil());
+        use crate::domain::repos::QuotaUsageRepository as QURepo;
+        let repo = QuotaUsageRepo;
+        let rows = repo
+            .find_bucket_rows(&conn, &scope, Uuid::nil(), Uuid::nil())
+            .await
+            .unwrap();
+        assert!(rows.is_empty(), "evaluate must not write quota_usage rows");
+    }
+
+    #[tokio::test]
+    async fn preflight_write_reserve_increments_buckets() {
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let snapshot = default_snapshot();
+        let svc = make_test_service(Arc::clone(&db), snapshot, 1.10);
+
+        let computed = svc
+            .preflight_evaluate(preflight_input("gpt-5"))
+            .await
+            .unwrap();
+
+        // Write inside a transaction
+        db.transaction(|tx| {
+            let svc_repo = Arc::new(QuotaUsageRepo);
+            let computed = computed.clone();
+            Box::pin(async move {
+                let scope = AccessScope::for_tenant(computed.tenant_id);
+                use crate::domain::repos::IncrementReserveParams;
+                for bucket in &computed.buckets {
+                    for (period_type, period_start) in &computed.periods {
+                        svc_repo
+                            .increment_reserve(
+                                tx,
+                                &scope,
+                                IncrementReserveParams {
+                                    tenant_id: computed.tenant_id,
+                                    user_id: computed.user_id,
+                                    period_type: period_type.clone(),
+                                    period_start: *period_start,
+                                    bucket: bucket.clone(),
+                                    amount_micro: computed.reserved_credits_micro,
+                                },
+                            )
+                            .await
+                            .map_err(to_db)?;
+                    }
+                }
+                Ok(())
+            })
+        })
+        .await
+        .unwrap();
+
+        // Verify rows WERE written
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::for_tenant(Uuid::nil());
+        use crate::domain::repos::QuotaUsageRepository as QURepo;
+        let repo = QuotaUsageRepo;
+        let rows = repo
+            .find_bucket_rows(&conn, &scope, Uuid::nil(), Uuid::nil())
+            .await
+            .unwrap();
+        assert!(
+            rows.iter().any(|r| r.reserved_credits_micro > 0),
+            "write_reserve should have incremented quota_usage"
         );
     }
 

--- a/modules/mini-chat/mini-chat/src/domain/service/replay.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/replay.rs
@@ -1,0 +1,393 @@
+//! Side-effect-free replay for completed turns.
+//!
+//! Structurally separated from the streaming execution path: this module
+//! accepts only read-only dependencies (`DbProvider`, `MessageRepository`)
+//! and cannot access `QuotaService`, outbox, provider, or finalization types.
+
+use crate::domain::error::DomainError;
+use crate::domain::repos::MessageRepository;
+use crate::domain::stream_events::{DeltaData, DoneData, StreamEvent};
+use crate::infra::db::entity::chat_turn::Model as TurnModel;
+use crate::infra::llm::Usage;
+use modkit_security::AccessScope;
+
+use super::DbProvider;
+
+/// Pair of SSE events produced by replay.
+#[derive(Debug)]
+#[allow(de0309_must_have_domain_model)]
+pub struct ReplayEvents {
+    pub delta: StreamEvent,
+    pub done: StreamEvent,
+}
+
+/// Reconstruct SSE events from a completed turn's persisted data.
+///
+/// # Errors
+/// - `DomainError::InternalError` if `assistant_message_id` is `None`
+/// - `DomainError::InternalError` if the assistant message is not found
+/// - `DomainError::Database` on connection / query failure
+pub async fn replay_turn<MR: MessageRepository>(
+    db: &DbProvider,
+    message_repo: &MR,
+    scope: &AccessScope,
+    turn: &TurnModel,
+    selected_model: &str,
+) -> Result<ReplayEvents, DomainError> {
+    let assistant_msg_id = turn.assistant_message_id.ok_or_else(|| {
+        DomainError::internal(format!(
+            "completed turn {} has no assistant_message_id",
+            turn.id
+        ))
+    })?;
+
+    let conn = db.conn().map_err(DomainError::from)?;
+
+    let message = message_repo
+        .get_by_chat(&conn, scope, assistant_msg_id, turn.chat_id)
+        .await?
+        .ok_or_else(|| {
+            DomainError::internal(format!(
+                "assistant message {} not found for turn {}",
+                assistant_msg_id, turn.id
+            ))
+        })?;
+
+    let delta = StreamEvent::Delta(DeltaData {
+        r#type: "text",
+        content: message.content,
+    });
+
+    let done = StreamEvent::Done(Box::new(DoneData {
+        message_id: Some(assistant_msg_id.to_string()),
+        usage: Some(Usage {
+            input_tokens: message.input_tokens,
+            output_tokens: message.output_tokens,
+        }),
+        effective_model: turn.effective_model.clone().unwrap_or_default(),
+        selected_model: selected_model.to_owned(),
+        quota_decision: reconstruct_quota_decision(turn, selected_model),
+        downgrade_from: reconstruct_downgrade_from(turn, selected_model),
+        downgrade_reason: None,
+    }));
+
+    Ok(ReplayEvents { delta, done })
+}
+
+fn reconstruct_quota_decision(turn: &TurnModel, selected_model: &str) -> String {
+    match &turn.effective_model {
+        Some(effective) if effective != selected_model => "downgrade".to_owned(),
+        _ => "allow".to_owned(),
+    }
+}
+
+fn reconstruct_downgrade_from(turn: &TurnModel, selected_model: &str) -> Option<String> {
+    match &turn.effective_model {
+        Some(effective) if effective != selected_model => Some(selected_model.to_owned()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::domain::repos::{
+        InsertAssistantMessageParams, InsertUserMessageParams,
+        MessageRepository as MessageRepositoryTrait,
+    };
+    use crate::domain::service::test_helpers::{inmem_db, mock_db_provider};
+    use crate::infra::db::entity::chat_turn::TurnState;
+    use crate::infra::db::entity::message::{MessageRole, Model as MessageModel};
+    use async_trait::async_trait;
+    use modkit_db::secure::DBRunner;
+    use modkit_security::AccessScope;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use time::OffsetDateTime;
+    use uuid::Uuid;
+
+    // ── Minimal mock MessageRepository ──────────────────────────────────
+
+    #[allow(de0309_must_have_domain_model)]
+    struct MockMessageRepo {
+        messages: Mutex<HashMap<(Uuid, Uuid), MessageModel>>,
+    }
+
+    impl MockMessageRepo {
+        fn new() -> Self {
+            Self {
+                messages: Mutex::new(HashMap::new()),
+            }
+        }
+
+        fn insert(&self, msg_id: Uuid, chat_id: Uuid, model: MessageModel) {
+            self.messages
+                .lock()
+                .unwrap()
+                .insert((msg_id, chat_id), model);
+        }
+    }
+
+    #[async_trait]
+    impl MessageRepositoryTrait for MockMessageRepo {
+        async fn insert_user_message<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: InsertUserMessageParams,
+        ) -> Result<MessageModel, DomainError> {
+            unimplemented!()
+        }
+
+        async fn insert_assistant_message<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: InsertAssistantMessageParams,
+        ) -> Result<MessageModel, DomainError> {
+            unimplemented!()
+        }
+
+        async fn find_by_chat_and_request_id<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+            _: Uuid,
+        ) -> Result<Vec<MessageModel>, DomainError> {
+            unimplemented!()
+        }
+
+        async fn get_by_chat<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            msg_id: Uuid,
+            chat_id: Uuid,
+        ) -> Result<Option<MessageModel>, DomainError> {
+            Ok(self
+                .messages
+                .lock()
+                .unwrap()
+                .get(&(msg_id, chat_id))
+                .cloned())
+        }
+
+        async fn list_by_chat<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+            _: &modkit_odata::ODataQuery,
+        ) -> Result<modkit_odata::Page<MessageModel>, DomainError> {
+            unimplemented!()
+        }
+
+        async fn batch_attachment_summaries<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+            _: &[Uuid],
+        ) -> Result<HashMap<Uuid, Vec<crate::domain::models::AttachmentSummary>>, DomainError>
+        {
+            unimplemented!()
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    fn make_completed_turn(
+        assistant_message_id: Option<Uuid>,
+        effective_model: Option<String>,
+    ) -> TurnModel {
+        TurnModel {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            chat_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            requester_type: "user".to_owned(),
+            requester_user_id: Some(Uuid::new_v4()),
+            state: TurnState::Completed,
+            provider_name: None,
+            provider_response_id: None,
+            assistant_message_id,
+            error_code: None,
+            error_detail: None,
+            reserve_tokens: Some(1000),
+            max_output_tokens_applied: Some(500),
+            reserved_credits_micro: Some(100),
+            policy_version_applied: Some(1),
+            effective_model,
+            minimal_generation_floor_applied: Some(10),
+            deleted_at: None,
+            replaced_by_request_id: None,
+            started_at: OffsetDateTime::now_utc(),
+            completed_at: Some(OffsetDateTime::now_utc()),
+            updated_at: OffsetDateTime::now_utc(),
+        }
+    }
+
+    fn make_message(id: Uuid, chat_id: Uuid, content: &str) -> MessageModel {
+        MessageModel {
+            id,
+            tenant_id: Uuid::new_v4(),
+            chat_id,
+            request_id: Some(Uuid::new_v4()),
+            role: MessageRole::Assistant,
+            content: content.to_owned(),
+            content_type: "text/plain".to_owned(),
+            token_estimate: 10,
+            provider_response_id: None,
+            request_kind: None,
+            features_used: serde_json::json!({}),
+            input_tokens: 100,
+            output_tokens: 50,
+            model: Some("gpt-5.2".to_owned()),
+            is_compressed: false,
+            created_at: OffsetDateTime::now_utc(),
+            deleted_at: None,
+        }
+    }
+
+    // ── 5.1: Happy path ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn replay_turn_happy_path() {
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let scope = AccessScope::allow_all().tenant_only();
+
+        let msg_id = Uuid::new_v4();
+        let turn = make_completed_turn(Some(msg_id), Some("gpt-5.2".to_owned()));
+        let msg = make_message(msg_id, turn.chat_id, "Hello from assistant");
+
+        let repo = MockMessageRepo::new();
+        repo.insert(msg_id, turn.chat_id, msg);
+
+        let result = replay_turn(&db, &repo, &scope, &turn, "gpt-5.2")
+            .await
+            .expect("replay should succeed");
+
+        // Verify delta
+        match &result.delta {
+            StreamEvent::Delta(d) => {
+                assert_eq!(d.content, "Hello from assistant");
+                assert_eq!(d.r#type, "text");
+            }
+            other => panic!("expected Delta, got {other:?}"),
+        }
+
+        // Verify done
+        match &result.done {
+            StreamEvent::Done(d) => {
+                assert_eq!(d.message_id, Some(msg_id.to_string()));
+                assert_eq!(d.effective_model, "gpt-5.2");
+                assert_eq!(d.selected_model, "gpt-5.2");
+                let usage = d.usage.as_ref().expect("usage should be present");
+                assert_eq!(usage.input_tokens, 100);
+                assert_eq!(usage.output_tokens, 50);
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    // ── 5.2: No downgrade ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn replay_turn_no_downgrade() {
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let scope = AccessScope::allow_all().tenant_only();
+
+        let msg_id = Uuid::new_v4();
+        let turn = make_completed_turn(Some(msg_id), Some("gpt-5.2".to_owned()));
+        let msg = make_message(msg_id, turn.chat_id, "content");
+
+        let repo = MockMessageRepo::new();
+        repo.insert(msg_id, turn.chat_id, msg);
+
+        let result = replay_turn(&db, &repo, &scope, &turn, "gpt-5.2")
+            .await
+            .unwrap();
+
+        match &result.done {
+            StreamEvent::Done(d) => {
+                assert_eq!(d.quota_decision, "allow");
+                assert!(d.downgrade_from.is_none());
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    // ── 5.3: Downgrade detected ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn replay_turn_downgrade_detected() {
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let scope = AccessScope::allow_all().tenant_only();
+
+        let msg_id = Uuid::new_v4();
+        // effective_model differs from selected_model → downgrade
+        let turn = make_completed_turn(Some(msg_id), Some("gpt-5-mini".to_owned()));
+        let msg = make_message(msg_id, turn.chat_id, "content");
+
+        let repo = MockMessageRepo::new();
+        repo.insert(msg_id, turn.chat_id, msg);
+
+        let result = replay_turn(&db, &repo, &scope, &turn, "gpt-5.2")
+            .await
+            .unwrap();
+
+        match &result.done {
+            StreamEvent::Done(d) => {
+                assert_eq!(d.quota_decision, "downgrade");
+                assert_eq!(d.downgrade_from.as_deref(), Some("gpt-5.2"));
+                assert_eq!(d.effective_model, "gpt-5-mini");
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    // ── 5.4: Missing assistant_message_id ──────────────────────────────
+
+    #[tokio::test]
+    async fn replay_turn_missing_assistant_message_id() {
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let scope = AccessScope::allow_all().tenant_only();
+
+        let turn = make_completed_turn(None, Some("gpt-5.2".to_owned()));
+        let repo = MockMessageRepo::new();
+
+        let err = replay_turn(&db, &repo, &scope, &turn, "gpt-5.2")
+            .await
+            .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(msg.contains("no assistant_message_id"), "got: {msg}");
+    }
+
+    // ── 5.5: Message not found ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn replay_turn_message_not_found() {
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let scope = AccessScope::allow_all().tenant_only();
+
+        let msg_id = Uuid::new_v4();
+        let turn = make_completed_turn(Some(msg_id), Some("gpt-5.2".to_owned()));
+        // Don't insert any message → get_by_chat returns None
+        let repo = MockMessageRepo::new();
+
+        let err = replay_turn(&db, &repo, &scope, &turn, "gpt-5.2")
+            .await
+            .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(msg.contains("not found"), "got: {msg}");
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -12,8 +12,8 @@ use uuid::Uuid;
 use crate::config::StreamingConfig;
 use crate::domain::error::DomainError;
 use crate::domain::repos::{
-    ChatRepository, CreateTurnParams, InsertUserMessageParams, MessageRepository, TurnRepository,
-    model_resolver::ResolvedModel,
+    ChatRepository, CreateTurnParams, InsertUserMessageParams, MessageRepository,
+    QuotaUsageRepository, TurnRepository, model_resolver::ResolvedModel,
 };
 use crate::domain::stream_events::{DoneData, ErrorData, StreamEvent};
 use crate::infra::db::entity::chat_turn::{Model as TurnModel, TurnState};
@@ -92,6 +92,11 @@ pub enum StreamError {
     AuthorizationFailed { source: DomainError },
     /// Chat does not exist or is not visible to the caller.
     ChatNotFound { chat_id: Uuid },
+    /// Quota exhausted — preflight rejected the request.
+    QuotaExhausted {
+        error_code: String,
+        http_status: u16,
+    },
 }
 
 impl From<authz_resolver_sdk::EnforcerError> for StreamError {
@@ -221,6 +226,79 @@ fn normalize_error(err: &LlmProviderError) -> (String, String) {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
+// PreflightResult — flattened preflight outcome for run_stream()
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Flattened preflight fields used by `run_stream()` after `preflight_reserve()`.
+#[domain_model]
+struct PreflightResult {
+    effective_model: String,
+    reserve_tokens: i64,
+    max_output_tokens_applied: i32,
+    reserved_credits_micro: i64,
+    policy_version_applied: i64,
+    minimal_generation_floor_applied: i32,
+    quota_decision: String,
+    downgrade_from: Option<String>,
+    downgrade_reason: Option<String>,
+}
+
+/// Convert a `PreflightDecision` into a flat `PreflightResult` or a `StreamError`.
+fn flatten_preflight(
+    decision: crate::domain::model::quota::PreflightDecision,
+) -> Result<PreflightResult, StreamError> {
+    use crate::domain::model::quota::PreflightDecision;
+    match decision {
+        PreflightDecision::Allow {
+            effective_model,
+            reserve_tokens,
+            max_output_tokens_applied,
+            reserved_credits_micro,
+            policy_version_applied,
+            minimal_generation_floor_applied,
+        } => Ok(PreflightResult {
+            effective_model,
+            reserve_tokens,
+            max_output_tokens_applied,
+            reserved_credits_micro,
+            policy_version_applied,
+            minimal_generation_floor_applied,
+            quota_decision: "allow".to_owned(),
+            downgrade_from: None,
+            downgrade_reason: None,
+        }),
+        PreflightDecision::Downgrade {
+            effective_model,
+            reserve_tokens,
+            max_output_tokens_applied,
+            reserved_credits_micro,
+            policy_version_applied,
+            minimal_generation_floor_applied,
+            downgrade_from,
+            downgrade_reason,
+        } => Ok(PreflightResult {
+            effective_model,
+            reserve_tokens,
+            max_output_tokens_applied,
+            reserved_credits_micro,
+            policy_version_applied,
+            minimal_generation_floor_applied,
+            quota_decision: "downgrade".to_owned(),
+            downgrade_from: Some(downgrade_from),
+            downgrade_reason: Some(downgrade_reason.as_str().to_owned()),
+        }),
+        PreflightDecision::Reject {
+            error_code,
+            http_status,
+            ..
+        } => Err(StreamError::QuotaExhausted {
+            error_code,
+            http_status,
+        }),
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 // StreamService
 // ════════════════════════════════════════════════════════════════════════════
 
@@ -234,6 +312,7 @@ fn normalize_error(err: &LlmProviderError) -> (String, String) {
 pub struct StreamService<
     TR: TurnRepository + 'static,
     MR: MessageRepository + 'static,
+    QR: QuotaUsageRepository + 'static,
     CR: ChatRepository,
 > {
     db: Arc<DbProvider>,
@@ -244,10 +323,15 @@ pub struct StreamService<
     provider_resolver: Arc<ProviderResolver>,
     streaming_config: StreamingConfig,
     finalization: Arc<crate::domain::service::finalization_service::FinalizationService<TR, MR>>,
+    quota: Arc<crate::domain::service::QuotaService<QR>>,
 }
 
-impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepository>
-    StreamService<TR, MR, CR>
+impl<
+    TR: TurnRepository + 'static,
+    MR: MessageRepository + 'static,
+    QR: QuotaUsageRepository + 'static,
+    CR: ChatRepository,
+> StreamService<TR, MR, QR, CR>
 {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -261,6 +345,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
         finalization: Arc<
             crate::domain::service::finalization_service::FinalizationService<TR, MR>,
         >,
+        quota: Arc<crate::domain::service::QuotaService<QR>>,
     ) -> Self {
         Self {
             db,
@@ -271,6 +356,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
             provider_resolver,
             streaming_config,
             finalization,
+            quota,
         }
     }
 
@@ -329,15 +415,24 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
 
         let scope = scope.tenant_only();
 
-        // ── Idempotency check ──
+        // ── Idempotency check (DESIGN §3.7 Check Priority Order) ──
         if let Some(existing_turn) = self
             .turn_repo
             .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
             .await
             .map_err(|e| StreamError::TurnCreationFailed { source: e })?
         {
-            return Err(StreamError::Replay {
-                turn: Box::new(existing_turn),
+            return Err(match existing_turn.state {
+                TurnState::Completed => StreamError::Replay {
+                    turn: Box::new(existing_turn),
+                },
+                _ => StreamError::Conflict {
+                    code: "request_id_conflict".to_owned(),
+                    message: format!(
+                        "Turn for request_id {request_id} exists with state {:?}",
+                        existing_turn.state
+                    ),
+                },
             });
         }
 
@@ -354,21 +449,72 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
             });
         }
 
-        // ── Insert user message + create turn (atomic) ──
+        // ── Preflight quota evaluate (external I/O, no DB writes) ──
+        let selected_model = model;
+        let computed = self
+            .quota
+            .preflight_evaluate(crate::domain::model::quota::PreflightInput {
+                tenant_id,
+                user_id,
+                selected_model: selected_model.clone(),
+                utf8_bytes: content.len() as u64,
+                num_images: 0,
+                tools_enabled: false,
+                web_search_enabled: false,
+                max_output_tokens_cap: self.streaming_config.max_output_tokens,
+            })
+            .await
+            .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
+
+        let pf = flatten_preflight(computed.decision.clone())?;
+
+        // Period boundaries from the computed preflight (used by finalization for settlement)
+        let period_starts = computed.periods.clone();
+
+        // ── Single transaction: reserve + user message + turn ──
         let user_msg_id = Uuid::new_v4();
         let turn_id = Uuid::new_v4();
         let requester_type = ctx.subject_type().unwrap_or("user").to_owned();
-        let effective_model = model.clone();
 
         let message_repo = Arc::clone(&self.message_repo);
         let turn_repo = Arc::clone(&self.turn_repo);
+        let quota_repo = Arc::clone(&self.quota.repo);
         let content_clone = content.clone();
         let scope_tx = scope.clone();
-        let effective_model_tx = effective_model.clone();
+        let effective_model_tx = pf.effective_model.clone();
+        let computed_for_tx = computed;
 
         self.db
             .transaction(|tx| {
+                use crate::domain::repos::IncrementReserveParams;
                 Box::pin(async move {
+                    // 1. Write quota reserve
+                    if !computed_for_tx.buckets.is_empty() {
+                        let reserve_scope = AccessScope::for_tenant(computed_for_tx.tenant_id);
+                        for bucket in &computed_for_tx.buckets {
+                            for (period_type, period_start) in &computed_for_tx.periods {
+                                quota_repo
+                                    .increment_reserve(
+                                        tx,
+                                        &reserve_scope,
+                                        IncrementReserveParams {
+                                            tenant_id: computed_for_tx.tenant_id,
+                                            user_id: computed_for_tx.user_id,
+                                            period_type: period_type.clone(),
+                                            period_start: *period_start,
+                                            bucket: bucket.clone(),
+                                            amount_micro: computed_for_tx.reserved_credits_micro,
+                                        },
+                                    )
+                                    .await
+                                    .map_err(|e| {
+                                        modkit_db::DbError::Other(anyhow::Error::new(e))
+                                    })?;
+                            }
+                        }
+                    }
+
+                    // 2. Insert user message
                     message_repo
                         .insert_user_message(
                             tx,
@@ -384,6 +530,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
                         .await
                         .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
 
+                    // 3. Create turn
                     turn_repo
                         .create_turn(
                             tx,
@@ -395,12 +542,14 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
                                 request_id,
                                 requester_type,
                                 requester_user_id: Some(user_id),
-                                reserve_tokens: None,
-                                max_output_tokens_applied: None,
-                                reserved_credits_micro: None,
-                                policy_version_applied: None,
+                                reserve_tokens: Some(pf.reserve_tokens),
+                                max_output_tokens_applied: Some(pf.max_output_tokens_applied),
+                                reserved_credits_micro: Some(pf.reserved_credits_micro),
+                                policy_version_applied: Some(pf.policy_version_applied),
                                 effective_model: Some(effective_model_tx),
-                                minimal_generation_floor_applied: None,
+                                minimal_generation_floor_applied: Some(
+                                    pf.minimal_generation_floor_applied,
+                                ),
                             },
                         )
                         .await
@@ -423,12 +572,6 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
         // Pre-generate assistant message ID (sent in DoneData and used in CAS)
         let message_id = Uuid::new_v4();
 
-        // TODO(P3→P4): populate quota fields from PreflightDecision once preflight
-        // is wired in. For now, use conservative placeholder values so that
-        // settlement validation passes and turns finalize correctly.
-        // reserve_tokens must be large enough to avoid overshoot-capping on
-        // normal responses; max_output_tokens_applied and
-        // minimal_generation_floor_applied must be positive.
         let finalization_ctx = FinalizationCtx {
             finalization_svc: Arc::clone(&self.finalization),
             scope,
@@ -438,17 +581,17 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
             request_id,
             user_id,
             message_id,
-            effective_model: effective_model.clone(),
-            selected_model: model.clone(),
-            reserve_tokens: 1_000_000,
-            max_output_tokens_applied: 32_768,
-            reserved_credits_micro: 0,
-            policy_version_applied: 1,
-            minimal_generation_floor_applied: 50,
-            quota_decision: "allow".to_owned(),
-            downgrade_from: None,
-            downgrade_reason: None,
-            period_starts: Vec::new(),
+            effective_model: pf.effective_model.clone(),
+            selected_model: selected_model.clone(),
+            reserve_tokens: pf.reserve_tokens,
+            max_output_tokens_applied: pf.max_output_tokens_applied,
+            reserved_credits_micro: pf.reserved_credits_micro,
+            policy_version_applied: pf.policy_version_applied,
+            minimal_generation_floor_applied: pf.minimal_generation_floor_applied,
+            quota_decision: pf.quota_decision,
+            downgrade_from: pf.downgrade_from,
+            downgrade_reason: pf.downgrade_reason,
+            period_starts,
         };
 
         let resolved_provider = self.provider_resolver.resolve(&provider_id).map_err(|e| {
@@ -457,7 +600,9 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
             }
         })?;
         // Build the full OAGW proxy path: {alias}{api_path} with {model} substituted.
-        let api_path = resolved_provider.api_path.replace("{model}", &model);
+        let api_path = resolved_provider
+            .api_path
+            .replace("{model}", &pf.effective_model);
         let proxy_path = format!("{}{api_path}", resolved_provider.upstream_alias);
 
         Ok(spawn_provider_task(
@@ -465,7 +610,8 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
             proxy_path,
             ctx,
             content,
-            model,
+            pf.effective_model,
+            pf.max_output_tokens_applied.cast_unsigned(),
             cancel,
             tx,
             Some(finalization_ctx),
@@ -494,6 +640,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
     ctx: SecurityContext,
     content: String,
     model: String,
+    max_output_tokens: u32,
     cancel: CancellationToken,
     tx: mpsc::Sender<StreamEvent>,
     fin_ctx: Option<FinalizationCtx<TR, MR>>,
@@ -506,6 +653,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
         // Build the LLM request
         let request = LlmRequestBuilder::new(&model)
             .message(LlmMessage::user(&content))
+            .max_output_tokens(u64::from(max_output_tokens))
             .build_streaming();
 
         // Call the provider to start streaming
@@ -752,8 +900,8 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                 .send(StreamEvent::Done(Box::new(DoneData {
                                     message_id: msg_id_str.clone(),
                                     usage: Some(usage),
-                                    effective_model: model.clone(),
-                                    selected_model: model.clone(),
+                                    effective_model: fctx.effective_model.clone(),
+                                    selected_model: fctx.selected_model.clone(),
                                     quota_decision: fctx.quota_decision.clone(),
                                     downgrade_from: fctx.downgrade_from.clone(),
                                     downgrade_reason: fctx.downgrade_reason.clone(),
@@ -768,8 +916,8 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                 .send(StreamEvent::Done(Box::new(DoneData {
                                     message_id: msg_id_str.clone(),
                                     usage: Some(usage),
-                                    effective_model: model.clone(),
-                                    selected_model: model.clone(),
+                                    effective_model: fctx.effective_model.clone(),
+                                    selected_model: fctx.selected_model.clone(),
                                     quota_decision: "allow".into(),
                                     downgrade_from: None,
                                     downgrade_reason: None,
@@ -837,8 +985,8 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                 .send(StreamEvent::Done(Box::new(DoneData {
                                     message_id: msg_id_str.clone(),
                                     usage: Some(usage),
-                                    effective_model: model.clone(),
-                                    selected_model: model.clone(),
+                                    effective_model: fctx.effective_model.clone(),
+                                    selected_model: fctx.selected_model.clone(),
                                     quota_decision: fctx.quota_decision.clone(),
                                     downgrade_from: fctx.downgrade_from.clone(),
                                     downgrade_reason: fctx.downgrade_reason.clone(),
@@ -852,8 +1000,8 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                 .send(StreamEvent::Done(Box::new(DoneData {
                                     message_id: msg_id_str.clone(),
                                     usage: Some(usage),
-                                    effective_model: model.clone(),
-                                    selected_model: model.clone(),
+                                    effective_model: fctx.effective_model.clone(),
+                                    selected_model: fctx.selected_model.clone(),
                                     quota_decision: "allow".into(),
                                     downgrade_from: None,
                                     downgrade_reason: None,
@@ -1100,6 +1248,7 @@ mod tests {
             mock_ctx(),
             "hi".into(),
             "test-model".into(),
+            4096,
             cancel,
             tx,
             None,
@@ -1144,6 +1293,7 @@ mod tests {
             mock_ctx(),
             "hi".into(),
             "test-model".into(),
+            4096,
             cancel,
             tx,
             None,
@@ -1221,6 +1371,7 @@ mod tests {
             mock_ctx(),
             "hi".into(),
             "test-model".into(),
+            4096,
             cancel.clone(),
             tx,
             None,
@@ -1242,14 +1393,16 @@ mod tests {
     // ── Pre-stream check tests (7.6) ──
 
     use crate::domain::service::test_helpers::{
-        inmem_db, mock_db_provider, mock_enforcer, test_security_ctx_with_id,
+        MockPolicySnapshotProvider, MockUserLimitsProvider, inmem_db, mock_db_provider,
+        mock_enforcer, test_security_ctx_with_id,
     };
+    use crate::infra::db::repo::quota_usage_repo::QuotaUsageRepository as OrmQuotaUsageRepo;
 
     /// Build a `StreamService` with real DB repos and a mock LLM provider.
     fn build_stream_service(
         db: Arc<DbProvider>,
         provider: Arc<dyn LlmProvider>,
-    ) -> StreamService<TurnRepo, MsgRepo, OrmChatRepo> {
+    ) -> StreamService<TurnRepo, MsgRepo, OrmQuotaUsageRepo, OrmChatRepo> {
         use crate::domain::service::finalization_service::FinalizationService;
         use crate::domain::service::quota_settler::QuotaSettler;
 
@@ -1289,6 +1442,52 @@ mod tests {
             Arc::new(MockQuotaSettler) as Arc<dyn QuotaSettler>,
         ));
 
+        // QuotaService with permissive defaults — model catalog includes
+        // "gpt-5.2" (standard) so that preflight allows test requests.
+        let quota_svc = Arc::new(crate::domain::service::QuotaService::new(
+            Arc::clone(&db),
+            Arc::new(OrmQuotaUsageRepo),
+            Arc::new(MockPolicySnapshotProvider::new(
+                mini_chat_sdk::PolicySnapshot {
+                    user_id: Uuid::nil(),
+                    policy_version: 1,
+                    model_catalog: vec![mini_chat_sdk::ModelCatalogEntry {
+                        model_id: "gpt-5.2".to_owned(),
+                        display_name: "GPT 5.2".to_owned(),
+                        tier: mini_chat_sdk::ModelTier::Standard,
+                        global_enabled: true,
+                        is_default: true,
+                        input_tokens_credit_multiplier_micro: 1_000_000,
+                        output_tokens_credit_multiplier_micro: 1_000_000,
+                        multimodal_capabilities: vec![],
+                        context_window: 128_000,
+                        max_output_tokens: 4096,
+                        description: String::new(),
+                        provider_display_name: String::new(),
+                        multiplier_display: "1x".to_owned(),
+                        provider_id: "openai".to_owned(),
+                    }],
+                    kill_switches: mini_chat_sdk::KillSwitches::default(),
+                },
+            )),
+            Arc::new(MockUserLimitsProvider::new(mini_chat_sdk::UserLimits {
+                user_id: Uuid::nil(),
+                policy_version: 1,
+                standard: mini_chat_sdk::TierLimits {
+                    limit_daily_credits_micro: 100_000_000,
+                    limit_monthly_credits_micro: 1_000_000_000,
+                },
+                premium: mini_chat_sdk::TierLimits {
+                    limit_daily_credits_micro: 50_000_000,
+                    limit_monthly_credits_micro: 500_000_000,
+                },
+            })),
+            crate::config::EstimationBudgets::default(),
+            crate::config::QuotaConfig {
+                overshoot_tolerance_factor: 1.10,
+            },
+        ));
+
         StreamService::new(
             db,
             turn_repo,
@@ -1301,6 +1500,7 @@ mod tests {
             provider_resolver,
             crate::config::StreamingConfig::default(),
             finalization,
+            quota_svc,
         )
     }
 
@@ -1409,6 +1609,237 @@ mod tests {
             matches!(err, StreamError::Replay { .. }),
             "expected Replay, got: {err:?}"
         );
+    }
+
+    /// 6.2: Running turn with same `request_id` → Conflict (not Replay).
+    #[tokio::test]
+    async fn idempotency_running_turn_returns_conflict() {
+        let db = mock_db_provider(inmem_db().await);
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        insert_test_chat(&db, tenant_id, user_id, chat_id).await;
+
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::completed(&["hi"]));
+        let svc = build_stream_service(db.clone(), provider);
+
+        // Pre-create a running turn (default state after create_turn)
+        let scope = AccessScope::allow_all();
+        let conn = db.conn().unwrap();
+        let turn_repo = TurnRepo;
+        turn_repo
+            .create_turn(
+                &conn,
+                &scope,
+                CreateTurnParams {
+                    id: Uuid::new_v4(),
+                    tenant_id,
+                    chat_id,
+                    request_id,
+                    requester_type: "user".to_owned(),
+                    requester_user_id: None,
+                    reserve_tokens: None,
+                    max_output_tokens_applied: None,
+                    reserved_credits_micro: None,
+                    policy_version_applied: None,
+                    effective_model: None,
+                    minimal_generation_floor_applied: None,
+                },
+            )
+            .await
+            .expect("create turn");
+
+        let ctx = test_security_ctx_with_id(tenant_id, user_id);
+        let (tx, _rx) = mpsc::channel(32);
+        let cancel = CancellationToken::new();
+
+        let err = svc
+            .run_stream(
+                ctx,
+                chat_id,
+                request_id,
+                "hello".into(),
+                ResolvedModel {
+                    model_id: "gpt-5.2".into(),
+                    provider_id: "openai".into(),
+                },
+                cancel,
+                tx,
+            )
+            .await
+            .expect_err("should be Conflict");
+
+        match err {
+            StreamError::Conflict { code, .. } => {
+                assert_eq!(code, "request_id_conflict");
+            }
+            other => panic!("expected Conflict, got: {other:?}"),
+        }
+    }
+
+    /// 6.3: Failed turn with same `request_id` → Conflict (not Replay).
+    #[tokio::test]
+    async fn idempotency_failed_turn_returns_conflict() {
+        let db = mock_db_provider(inmem_db().await);
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        insert_test_chat(&db, tenant_id, user_id, chat_id).await;
+
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::completed(&["hi"]));
+        let svc = build_stream_service(db.clone(), provider);
+
+        let scope = AccessScope::allow_all();
+        let conn = db.conn().unwrap();
+        let turn_repo = TurnRepo;
+        let turn = turn_repo
+            .create_turn(
+                &conn,
+                &scope,
+                CreateTurnParams {
+                    id: Uuid::new_v4(),
+                    tenant_id,
+                    chat_id,
+                    request_id,
+                    requester_type: "user".to_owned(),
+                    requester_user_id: None,
+                    reserve_tokens: None,
+                    max_output_tokens_applied: None,
+                    reserved_credits_micro: None,
+                    policy_version_applied: None,
+                    effective_model: None,
+                    minimal_generation_floor_applied: None,
+                },
+            )
+            .await
+            .expect("create turn");
+
+        turn_repo
+            .cas_update_state(
+                &conn,
+                &scope,
+                CasTerminalParams {
+                    turn_id: turn.id,
+                    state: TurnState::Failed,
+                    error_code: Some("provider_error".to_owned()),
+                    error_detail: Some("timeout".to_owned()),
+                    assistant_message_id: None,
+                    provider_response_id: None,
+                },
+            )
+            .await
+            .expect("fail turn");
+
+        let ctx = test_security_ctx_with_id(tenant_id, user_id);
+        let (tx, _rx) = mpsc::channel(32);
+        let cancel = CancellationToken::new();
+
+        let err = svc
+            .run_stream(
+                ctx,
+                chat_id,
+                request_id,
+                "hello".into(),
+                ResolvedModel {
+                    model_id: "gpt-5.2".into(),
+                    provider_id: "openai".into(),
+                },
+                cancel,
+                tx,
+            )
+            .await
+            .expect_err("should be Conflict");
+
+        match err {
+            StreamError::Conflict { code, .. } => {
+                assert_eq!(code, "request_id_conflict");
+            }
+            other => panic!("expected Conflict, got: {other:?}"),
+        }
+    }
+
+    /// 6.4: Cancelled turn with same `request_id` → Conflict (not Replay).
+    #[tokio::test]
+    async fn idempotency_cancelled_turn_returns_conflict() {
+        let db = mock_db_provider(inmem_db().await);
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        insert_test_chat(&db, tenant_id, user_id, chat_id).await;
+
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::completed(&["hi"]));
+        let svc = build_stream_service(db.clone(), provider);
+
+        let scope = AccessScope::allow_all();
+        let conn = db.conn().unwrap();
+        let turn_repo = TurnRepo;
+        let turn = turn_repo
+            .create_turn(
+                &conn,
+                &scope,
+                CreateTurnParams {
+                    id: Uuid::new_v4(),
+                    tenant_id,
+                    chat_id,
+                    request_id,
+                    requester_type: "user".to_owned(),
+                    requester_user_id: None,
+                    reserve_tokens: None,
+                    max_output_tokens_applied: None,
+                    reserved_credits_micro: None,
+                    policy_version_applied: None,
+                    effective_model: None,
+                    minimal_generation_floor_applied: None,
+                },
+            )
+            .await
+            .expect("create turn");
+
+        turn_repo
+            .cas_update_state(
+                &conn,
+                &scope,
+                CasTerminalParams {
+                    turn_id: turn.id,
+                    state: TurnState::Cancelled,
+                    error_code: None,
+                    error_detail: None,
+                    assistant_message_id: None,
+                    provider_response_id: None,
+                },
+            )
+            .await
+            .expect("cancel turn");
+
+        let ctx = test_security_ctx_with_id(tenant_id, user_id);
+        let (tx, _rx) = mpsc::channel(32);
+        let cancel = CancellationToken::new();
+
+        let err = svc
+            .run_stream(
+                ctx,
+                chat_id,
+                request_id,
+                "hello".into(),
+                ResolvedModel {
+                    model_id: "gpt-5.2".into(),
+                    provider_id: "openai".into(),
+                },
+                cancel,
+                tx,
+            )
+            .await
+            .expect_err("should be Conflict");
+
+        match err {
+            StreamError::Conflict { code, .. } => {
+                assert_eq!(code, "request_id_conflict");
+            }
+            other => panic!("expected Conflict, got: {other:?}"),
+        }
     }
 
     /// 7.6: Parallel turn guard — returns Conflict when a running turn exists.
@@ -1750,6 +2181,500 @@ mod tests {
             }
             other => panic!("expected ChatNotFound, got: {other:?}"),
         }
+    }
+
+    /// 8.6: `DoneData` uses `fctx.effective_model` / `fctx.selected_model` when they differ.
+    ///
+    /// Constructs a `FinalizationCtx` with `effective_model = "gpt-4o-mini"` and
+    /// `selected_model = "gpt-4o"`, then verifies the Done SSE event reflects both.
+    #[tokio::test]
+    async fn done_data_uses_fctx_model_fields_when_they_differ() {
+        use crate::domain::service::finalization_service::FinalizationService;
+        use crate::domain::service::quota_settler::QuotaSettler;
+
+        #[allow(de0309_must_have_domain_model)]
+        struct NoopSettler;
+        #[async_trait::async_trait]
+        impl QuotaSettler for NoopSettler {
+            async fn settle_in_tx(
+                &self,
+                _tx: &modkit_db::secure::DbTx<'_>,
+                _scope: &AccessScope,
+                _input: crate::domain::model::quota::SettlementInput,
+            ) -> Result<
+                crate::domain::model::quota::SettlementOutcome,
+                crate::domain::error::DomainError,
+            > {
+                Ok(crate::domain::model::quota::SettlementOutcome {
+                    settlement_method: crate::domain::model::quota::SettlementMethod::Released,
+                    actual_credits_micro: 0,
+                    charged_tokens: 0,
+                    overshoot_capped: false,
+                })
+            }
+        }
+
+        let db = mock_db_provider(inmem_db().await);
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let message_id = Uuid::new_v4();
+        insert_test_chat(&db, tenant_id, user_id, chat_id).await;
+
+        // Create a running turn in DB so that CAS finalization succeeds
+        let scope = AccessScope::allow_all();
+        let conn = db.conn().unwrap();
+        let turn_repo = TurnRepo;
+        turn_repo
+            .create_turn(
+                &conn,
+                &scope,
+                CreateTurnParams {
+                    id: turn_id,
+                    tenant_id,
+                    chat_id,
+                    request_id,
+                    requester_type: "user".to_owned(),
+                    requester_user_id: Some(user_id),
+                    reserve_tokens: Some(5000),
+                    max_output_tokens_applied: Some(4096),
+                    reserved_credits_micro: Some(250),
+                    policy_version_applied: Some(1),
+                    effective_model: Some("gpt-4o-mini".to_owned()),
+                    minimal_generation_floor_applied: Some(50),
+                },
+            )
+            .await
+            .expect("create turn");
+
+        let turn_repo_arc = Arc::new(TurnRepo);
+        let message_repo_arc = Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
+            default: 20,
+            max: 100,
+        }));
+        let finalization_svc = Arc::new(FinalizationService::new(
+            Arc::clone(&db),
+            Arc::clone(&turn_repo_arc),
+            Arc::clone(&message_repo_arc),
+            Arc::new(NoopSettler) as Arc<dyn QuotaSettler>,
+        ));
+
+        let fctx = FinalizationCtx {
+            finalization_svc,
+            scope,
+            turn_id,
+            tenant_id,
+            chat_id,
+            request_id,
+            user_id,
+            message_id,
+            effective_model: "gpt-4o-mini".to_owned(),
+            selected_model: "gpt-4o".to_owned(),
+            reserve_tokens: 5000,
+            max_output_tokens_applied: 4096,
+            reserved_credits_micro: 250,
+            policy_version_applied: 1,
+            minimal_generation_floor_applied: 50,
+            quota_decision: "downgrade".to_owned(),
+            downgrade_from: Some("gpt-4o".to_owned()),
+            downgrade_reason: Some("premium_exhausted".to_owned()),
+            period_starts: Vec::new(),
+        };
+
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::completed(&["Hello"]));
+        let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
+        let cancel = CancellationToken::new();
+
+        let handle = spawn_provider_task(
+            provider,
+            "test-alias".to_owned(),
+            mock_ctx(),
+            "hi".into(),
+            "gpt-4o-mini".into(), // effective_model passed as the model param
+            4096,
+            cancel,
+            tx,
+            Some(fctx),
+        );
+
+        // Collect events
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            let is_term = ev.is_terminal();
+            events.push(ev);
+            if is_term {
+                break;
+            }
+        }
+
+        let _outcome = handle.await.expect("task should complete");
+
+        // Find the Done event and verify model fields
+        let done = events
+            .iter()
+            .find_map(|ev| match ev {
+                StreamEvent::Done(d) => Some(d),
+                _ => None,
+            })
+            .expect("should have a Done event");
+
+        assert_eq!(
+            done.effective_model, "gpt-4o-mini",
+            "effective_model should be the downgraded model"
+        );
+        assert_eq!(
+            done.selected_model, "gpt-4o",
+            "selected_model should be the user's original choice"
+        );
+        assert_eq!(done.quota_decision, "downgrade");
+        assert_eq!(done.downgrade_from.as_deref(), Some("gpt-4o"));
+        assert_eq!(done.downgrade_reason.as_deref(), Some("premium_exhausted"));
+    }
+
+    // ── Preflight wiring tests (11.x) ──
+
+    fn make_catalog_entry(
+        id: &str,
+        tier: mini_chat_sdk::ModelTier,
+    ) -> mini_chat_sdk::ModelCatalogEntry {
+        mini_chat_sdk::ModelCatalogEntry {
+            model_id: id.to_owned(),
+            display_name: id.to_owned(),
+            tier,
+            global_enabled: true,
+            is_default: tier == mini_chat_sdk::ModelTier::Standard,
+            input_tokens_credit_multiplier_micro: 1_000_000,
+            output_tokens_credit_multiplier_micro: 1_000_000,
+            multimodal_capabilities: vec![],
+            context_window: 128_000,
+            max_output_tokens: 4096,
+            description: String::new(),
+            provider_display_name: String::new(),
+            multiplier_display: "1x".to_owned(),
+            provider_id: "openai".to_owned(),
+        }
+    }
+
+    fn build_stream_service_with_catalog(
+        db: Arc<DbProvider>,
+        provider: Arc<dyn LlmProvider>,
+        catalog: Vec<mini_chat_sdk::ModelCatalogEntry>,
+        limits: mini_chat_sdk::UserLimits,
+    ) -> StreamService<TurnRepo, MsgRepo, OrmQuotaUsageRepo, OrmChatRepo> {
+        use crate::domain::service::finalization_service::FinalizationService;
+        use crate::domain::service::quota_settler::QuotaSettler;
+
+        #[allow(de0309_must_have_domain_model)]
+        struct MockQuotaSettler;
+        #[async_trait::async_trait]
+        impl QuotaSettler for MockQuotaSettler {
+            async fn settle_in_tx(
+                &self,
+                _tx: &modkit_db::secure::DbTx<'_>,
+                _scope: &AccessScope,
+                _input: crate::domain::model::quota::SettlementInput,
+            ) -> Result<
+                crate::domain::model::quota::SettlementOutcome,
+                crate::domain::error::DomainError,
+            > {
+                Ok(crate::domain::model::quota::SettlementOutcome {
+                    settlement_method: crate::domain::model::quota::SettlementMethod::Released,
+                    actual_credits_micro: 0,
+                    charged_tokens: 0,
+                    overshoot_capped: false,
+                })
+            }
+        }
+
+        let provider_resolver = Arc::new(ProviderResolver::single_provider(provider));
+        let turn_repo = Arc::new(TurnRepo);
+        let message_repo = Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
+            default: 20,
+            max: 100,
+        }));
+        let finalization = Arc::new(FinalizationService::new(
+            Arc::clone(&db),
+            Arc::clone(&turn_repo),
+            Arc::clone(&message_repo),
+            Arc::new(MockQuotaSettler) as Arc<dyn QuotaSettler>,
+        ));
+
+        let quota_svc = Arc::new(crate::domain::service::QuotaService::new(
+            Arc::clone(&db),
+            Arc::new(OrmQuotaUsageRepo),
+            Arc::new(MockPolicySnapshotProvider::new(
+                mini_chat_sdk::PolicySnapshot {
+                    user_id: Uuid::nil(),
+                    policy_version: 1,
+                    model_catalog: catalog,
+                    kill_switches: mini_chat_sdk::KillSwitches::default(),
+                },
+            )),
+            Arc::new(MockUserLimitsProvider::new(limits)),
+            crate::config::EstimationBudgets::default(),
+            crate::config::QuotaConfig {
+                overshoot_tolerance_factor: 1.10,
+            },
+        ));
+
+        StreamService::new(
+            db,
+            turn_repo,
+            message_repo,
+            Arc::new(OrmChatRepo::new(modkit_db::odata::LimitCfg {
+                default: 20,
+                max: 100,
+            })),
+            mock_enforcer(),
+            provider_resolver,
+            crate::config::StreamingConfig::default(),
+            finalization,
+            quota_svc,
+        )
+    }
+
+    fn permissive_limits() -> mini_chat_sdk::UserLimits {
+        mini_chat_sdk::UserLimits {
+            user_id: Uuid::nil(),
+            policy_version: 1,
+            standard: mini_chat_sdk::TierLimits {
+                limit_daily_credits_micro: 100_000_000,
+                limit_monthly_credits_micro: 1_000_000_000,
+            },
+            premium: mini_chat_sdk::TierLimits {
+                limit_daily_credits_micro: 50_000_000,
+                limit_monthly_credits_micro: 500_000_000,
+            },
+        }
+    }
+
+    /// 11.1: Allow path populates `FinalizationCtx` with real quota fields.
+    #[tokio::test]
+    async fn preflight_allow_populates_real_quota_fields() {
+        let db = mock_db_provider(inmem_db().await);
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        insert_test_chat(&db, tenant_id, user_id, chat_id).await;
+
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::completed(&["Hello"]));
+        let catalog = vec![make_catalog_entry(
+            "gpt-5.2",
+            mini_chat_sdk::ModelTier::Standard,
+        )];
+        let svc =
+            build_stream_service_with_catalog(db.clone(), provider, catalog, permissive_limits());
+
+        let ctx = test_security_ctx_with_id(tenant_id, user_id);
+        let (tx, mut rx) = mpsc::channel(32);
+        let cancel = CancellationToken::new();
+
+        let handle = svc
+            .run_stream(
+                ctx,
+                chat_id,
+                Uuid::new_v4(),
+                "hello".into(),
+                ResolvedModel {
+                    model_id: "gpt-5.2".into(),
+                    provider_id: "openai".into(),
+                },
+                cancel,
+                tx,
+            )
+            .await
+            .expect("should succeed");
+
+        // Drain events
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            let is_term = ev.is_terminal();
+            events.push(ev);
+            if is_term {
+                break;
+            }
+        }
+
+        let _outcome = handle.await.expect("task should complete");
+
+        // Verify Done event has allow quota_decision
+        let done = events
+            .iter()
+            .find_map(|ev| match ev {
+                StreamEvent::Done(d) => Some(d),
+                _ => None,
+            })
+            .expect("should have a Done event");
+
+        assert_eq!(done.quota_decision, "allow");
+        assert_eq!(done.effective_model, "gpt-5.2");
+        assert_eq!(done.selected_model, "gpt-5.2");
+        assert!(done.downgrade_from.is_none());
+
+        // Verify turn was created with real quota fields (not placeholder 1_000_000)
+        let scope = AccessScope::allow_all().tenant_only();
+        let conn = db.conn().unwrap();
+        let turn_repo = TurnRepo;
+        let turn = turn_repo
+            .find_latest_turn(&conn, &scope, chat_id)
+            .await
+            .expect("find turn")
+            .expect("turn should exist");
+
+        assert!(
+            turn.reserve_tokens.unwrap() < 1_000_000,
+            "reserve_tokens should be from real preflight, not placeholder 1_000_000"
+        );
+        assert!(
+            turn.reserved_credits_micro.unwrap() > 0,
+            "reserved_credits_micro should be from real preflight, not placeholder 0"
+        );
+    }
+
+    /// 11.3: Reject path returns `StreamError::QuotaExhausted`.
+    #[tokio::test]
+    async fn preflight_reject_returns_quota_exhausted() {
+        let db = mock_db_provider(inmem_db().await);
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        insert_test_chat(&db, tenant_id, user_id, chat_id).await;
+
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::completed(&["Hello"]));
+        // Exhausted limits: 0 credits for all tiers
+        let limits = mini_chat_sdk::UserLimits {
+            user_id: Uuid::nil(),
+            policy_version: 1,
+            standard: mini_chat_sdk::TierLimits {
+                limit_daily_credits_micro: 0,
+                limit_monthly_credits_micro: 0,
+            },
+            premium: mini_chat_sdk::TierLimits {
+                limit_daily_credits_micro: 0,
+                limit_monthly_credits_micro: 0,
+            },
+        };
+        let catalog = vec![make_catalog_entry(
+            "gpt-5.2",
+            mini_chat_sdk::ModelTier::Standard,
+        )];
+        let svc = build_stream_service_with_catalog(db, provider, catalog, limits);
+
+        let ctx = test_security_ctx_with_id(tenant_id, user_id);
+        let (tx, _rx) = mpsc::channel(32);
+        let cancel = CancellationToken::new();
+
+        let err = svc
+            .run_stream(
+                ctx,
+                chat_id,
+                Uuid::new_v4(),
+                "hello".into(),
+                ResolvedModel {
+                    model_id: "gpt-5.2".into(),
+                    provider_id: "openai".into(),
+                },
+                cancel,
+                tx,
+            )
+            .await
+            .expect_err("should be QuotaExhausted");
+
+        match err {
+            StreamError::QuotaExhausted {
+                error_code,
+                http_status,
+            } => {
+                assert_eq!(http_status, 429);
+                assert!(!error_code.is_empty());
+            }
+            other => panic!("expected QuotaExhausted, got: {other:?}"),
+        }
+    }
+
+    /// 11.2: Downgrade path sets `effective_model` != `selected_model`.
+    #[tokio::test]
+    async fn preflight_downgrade_sets_correct_model_fields() {
+        let db = mock_db_provider(inmem_db().await);
+        let tenant_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        insert_test_chat(&db, tenant_id, user_id, chat_id).await;
+
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::completed(&["Hello"]));
+        // Catalog with premium model "gpt-5" and standard fallback "gpt-5-mini"
+        let catalog = vec![
+            make_catalog_entry("gpt-5", mini_chat_sdk::ModelTier::Premium),
+            make_catalog_entry("gpt-5-mini", mini_chat_sdk::ModelTier::Standard),
+        ];
+        // Premium limits are 0 → forces downgrade to standard
+        let limits = mini_chat_sdk::UserLimits {
+            user_id: Uuid::nil(),
+            policy_version: 1,
+            standard: mini_chat_sdk::TierLimits {
+                limit_daily_credits_micro: 100_000_000,
+                limit_monthly_credits_micro: 1_000_000_000,
+            },
+            premium: mini_chat_sdk::TierLimits {
+                limit_daily_credits_micro: 0,
+                limit_monthly_credits_micro: 0,
+            },
+        };
+        let svc = build_stream_service_with_catalog(db, provider, catalog, limits);
+
+        let ctx = test_security_ctx_with_id(tenant_id, user_id);
+        let (tx, mut rx) = mpsc::channel(32);
+        let cancel = CancellationToken::new();
+
+        let handle = svc
+            .run_stream(
+                ctx,
+                chat_id,
+                Uuid::new_v4(),
+                "hello".into(),
+                ResolvedModel {
+                    model_id: "gpt-5".into(),
+                    provider_id: "openai".into(),
+                },
+                cancel,
+                tx,
+            )
+            .await
+            .expect("should succeed (downgrade, not reject)");
+
+        // Drain events
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            let is_term = ev.is_terminal();
+            events.push(ev);
+            if is_term {
+                break;
+            }
+        }
+
+        let _outcome = handle.await.expect("task should complete");
+
+        // Verify Done event reflects downgrade
+        let done = events
+            .iter()
+            .find_map(|ev| match ev {
+                StreamEvent::Done(d) => Some(d),
+                _ => None,
+            })
+            .expect("should have a Done event");
+
+        assert_eq!(done.quota_decision, "downgrade");
+        assert_eq!(
+            done.effective_model, "gpt-5-mini",
+            "should be downgraded model"
+        );
+        assert_eq!(
+            done.selected_model, "gpt-5",
+            "should be original selected model"
+        );
+        assert_eq!(done.downgrade_from.as_deref(), Some("gpt-5"));
     }
 
     /// Non-existent chat returns `ChatNotFound`.

--- a/modules/mini-chat/mini-chat/src/domain/service/token_estimator.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/token_estimator.rs
@@ -13,7 +13,6 @@ pub struct EstimationInput {
     pub num_images: u32,
     pub tools_enabled: bool,
     pub web_search_enabled: bool,
-    pub max_output_tokens: u32,
 }
 
 /// Result of token estimation.
@@ -21,7 +20,6 @@ pub struct EstimationInput {
 #[allow(dead_code)]
 pub struct EstimationResult {
     pub estimated_input_tokens: u64,
-    pub reserve_tokens: u64,
 }
 
 /// Estimate input tokens and reserve from request metadata.
@@ -64,11 +62,9 @@ pub fn estimate_tokens(input: &EstimationInput, budgets: &EstimationBudgets) -> 
         .saturating_add(image_surcharge)
         .saturating_add(tool_surcharge)
         .saturating_add(web_search_surcharge);
-    let reserve_tokens = estimated_input_tokens.saturating_add(u64::from(input.max_output_tokens));
 
     EstimationResult {
         estimated_input_tokens,
-        reserve_tokens,
     }
 }
 
@@ -95,14 +91,12 @@ mod tests {
             num_images: 0,
             tools_enabled: false,
             web_search_enabled: false,
-            max_output_tokens: 1000,
         };
         let result = estimate_tokens(&input, &default_budgets());
 
         // base = ceil(4000/4) + 100 = 1000 + 100 = 1100
         // with margin = ceil(1100 * 1.10) = ceil(1210.0) = 1210
         assert_eq!(result.estimated_input_tokens, 1210);
-        assert_eq!(result.reserve_tokens, 1210 + 1000);
     }
 
     #[test]
@@ -112,7 +106,6 @@ mod tests {
             num_images: 3,
             tools_enabled: false,
             web_search_enabled: false,
-            max_output_tokens: 500,
         };
         let result = estimate_tokens(&input, &default_budgets());
 
@@ -128,7 +121,6 @@ mod tests {
             num_images: 0,
             tools_enabled: true,
             web_search_enabled: true,
-            max_output_tokens: 100,
         };
         let result = estimate_tokens(&input, &default_budgets());
 
@@ -143,14 +135,12 @@ mod tests {
             num_images: 2,
             tools_enabled: true,
             web_search_enabled: true,
-            max_output_tokens: 1000,
         };
         let result = estimate_tokens(&input, &default_budgets());
 
         // text: ceil(4000/4)+100 = 1100, margin: ceil(1100.0*1.1)=1210
         // images: 2*1000=2000, tool: 500, web: 500
         assert_eq!(result.estimated_input_tokens, 1210 + 2000 + 500 + 500);
-        assert_eq!(result.reserve_tokens, 1210 + 2000 + 500 + 500 + 1000);
     }
 
     #[test]
@@ -160,13 +150,11 @@ mod tests {
             num_images: 0,
             tools_enabled: false,
             web_search_enabled: false,
-            max_output_tokens: 100,
         };
         let result = estimate_tokens(&input, &default_budgets());
 
         // base = 100 (overhead only), margin: ceil(100*110/100) = 110
         assert_eq!(result.estimated_input_tokens, 110);
-        assert_eq!(result.reserve_tokens, 210);
     }
 
     #[test]
@@ -181,7 +169,6 @@ mod tests {
             num_images: 0,
             tools_enabled: false,
             web_search_enabled: false,
-            max_output_tokens: 0,
         };
         let result = estimate_tokens(&input, &budgets);
 


### PR DESCRIPTION
feat(mini-chat): enforce per-model max_output_tokens and atomic preflight reserve

- Send max_output_tokens_applied as hard cap to LLM provider via LlmRequestBuilder
- Resolve max_output_tokens as min(catalog_entry.max_output_tokens, config_cap) per model after cascade
- Rename PreflightInput.max_output_tokens → max_output_tokens_cap (deployment ceiling)
- Simplify estimate_tokens(): remove max_output_tokens from input and reserve_tokens from output
- Split preflight_reserve() into preflight_evaluate() (I/O + cascade) + preflight_write_reserve() (increment only)
- Merge quota reserve + user message + turn creation into single DB transaction in run_stream()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added replay functionality for completed conversation turns.
  * Introduced configurable maximum token output limits.
  * Enhanced quota management with improved evaluation workflows.

* **Improvements**
  * Better handling of quota exhaustion with appropriate error responses.
  * Automatic model downgrading when quota limits are approached.
  * Improved token usage tracking and validation throughout conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->