### PR TITLE
Feat/mini chat streaming turn lifecycle

### DIFF
--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
@@ -221,7 +221,7 @@ async fn replay_response(
 /// emits ping keepalives, and respects cancellation.
 ///
 /// Implements `Stream<Item = Result<Event, Infallible>>` for Axum SSE.
-struct SseRelay {
+pub(crate) struct SseRelay {
     rx: mpsc::Receiver<StreamEvent>,
     cancel: CancellationToken,
     phase: StreamPhase,
@@ -232,7 +232,11 @@ struct SseRelay {
 }
 
 impl SseRelay {
-    fn new(rx: mpsc::Receiver<StreamEvent>, cancel: CancellationToken, ping_secs: u64) -> Self {
+    pub(crate) fn new(
+        rx: mpsc::Receiver<StreamEvent>,
+        cancel: CancellationToken,
+        ping_secs: u64,
+    ) -> Self {
         Self {
             rx,
             cancel,

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
@@ -1,46 +1,317 @@
 use std::sync::Arc;
+use std::time::Duration;
 
-use axum::Extension;
 use axum::extract::Path;
+use axum::response::sse::KeepAlive;
+use axum::response::{IntoResponse, Response, Sse};
+use axum::{Extension, Json};
 use modkit::api::prelude::*;
 use modkit_security::SecurityContext;
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+use utoipa::ToSchema;
 
+use super::messages::SseRelay;
+use crate::domain::repos::TurnRepository;
+use crate::domain::service::{MutationError, StreamError};
+use crate::domain::stream_events::StreamEvent;
+use crate::infra::db::entity::chat_turn::TurnState;
 use crate::module::AppServices;
 
-use super::not_implemented;
+// ════════════════════════════════════════════════════════════════════════════
+// GET turn status
+// ════════════════════════════════════════════════════════════════════════════
+
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct TurnStatusResponse {
+    request_id: uuid::Uuid,
+    state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    assistant_message_id: Option<uuid::Uuid>,
+    #[serde(with = "time::serde::rfc3339")]
+    updated_at: time::OffsetDateTime,
+}
+
+fn map_turn_state(state: &TurnState) -> &'static str {
+    match state {
+        TurnState::Running => "running",
+        TurnState::Completed => "done",
+        TurnState::Failed => "error",
+        TurnState::Cancelled => "cancelled",
+    }
+}
 
 /// GET /mini-chat/v1/chats/{id}/turns/{request_id}
 pub(crate) async fn get_turn(
-    Extension(_ctx): Extension<SecurityContext>,
-    Extension(_svc): Extension<Arc<AppServices>>,
-    Path((_chat_id, _request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> ApiResult<StatusCode> {
-    Err(not_implemented())
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<AppServices>>,
+    Path((chat_id, request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> ApiResult<Json<TurnStatusResponse>> {
+    // Authorization: read_turn scoped to chat
+    let scope = svc
+        .enforcer
+        .access_scope(
+            &ctx,
+            &crate::domain::service::resources::CHAT,
+            crate::domain::service::actions::READ_TURN,
+            Some(chat_id),
+        )
+        .await
+        .map_err(|_| Problem::new(StatusCode::NOT_FOUND, "turn_not_found", "Turn not found"))?;
+    let scope = scope.tenant_only();
+
+    let conn = svc.db.conn().map_err(|e| {
+        Problem::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Internal Error",
+            e.to_string(),
+        )
+    })?;
+
+    let turn = svc
+        .turn_repo
+        .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+        .await
+        .map_err(|e| {
+            Problem::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal Error",
+                e.to_string(),
+            )
+        })?
+        .ok_or_else(|| Problem::new(StatusCode::NOT_FOUND, "turn_not_found", "Turn not found"))?;
+
+    Ok(Json(TurnStatusResponse {
+        request_id: turn.request_id,
+        state: map_turn_state(&turn.state).to_owned(),
+        error_code: turn.error_code.clone(),
+        assistant_message_id: turn.assistant_message_id,
+        updated_at: turn.updated_at,
+    }))
 }
 
-/// POST /mini-chat/v1/chats/{id}/turns/{request_id}/retry
-pub(crate) async fn retry_turn(
-    Extension(_ctx): Extension<SecurityContext>,
-    Extension(_svc): Extension<Arc<AppServices>>,
-    Path((_chat_id, _request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> ApiResult<StatusCode> {
-    Err(not_implemented())
-}
+// ════════════════════════════════════════════════════════════════════════════
+// DELETE turn
+// ════════════════════════════════════════════════════════════════════════════
 
-/// PATCH /mini-chat/v1/chats/{id}/turns/{request_id}
-pub(crate) async fn edit_turn(
-    Extension(_ctx): Extension<SecurityContext>,
-    Extension(_svc): Extension<Arc<AppServices>>,
-    Path((_chat_id, _request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> ApiResult<StatusCode> {
-    Err(not_implemented())
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct DeleteTurnResponse {
+    request_id: uuid::Uuid,
+    deleted: bool,
 }
 
 /// DELETE /mini-chat/v1/chats/{id}/turns/{request_id}
 pub(crate) async fn delete_turn(
-    Extension(_ctx): Extension<SecurityContext>,
-    Extension(_svc): Extension<Arc<AppServices>>,
-    Path((_chat_id, _request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> ApiResult<StatusCode> {
-    Err(not_implemented())
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<AppServices>>,
+    Path((chat_id, request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> ApiResult<Json<DeleteTurnResponse>> {
+    let result = svc
+        .turns
+        .delete(&ctx, chat_id, request_id)
+        .await
+        .map_err(mutation_error_to_problem)?;
+
+    Ok(Json(DeleteTurnResponse {
+        request_id: result.request_id,
+        deleted: result.deleted,
+    }))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// POST retry turn
+// ════════════════════════════════════════════════════════════════════════════
+
+/// POST /mini-chat/v1/chats/{id}/turns/{request_id}/retry
+pub(crate) async fn retry_turn(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<AppServices>>,
+    Path((chat_id, request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> Response {
+    let mutation = match svc.turns.retry(&ctx, chat_id, request_id).await {
+        Ok(m) => m,
+        Err(e) => return mutation_error_to_problem(e).into_response(),
+    };
+
+    start_mutation_stream(&svc, ctx, chat_id, mutation).await
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// PATCH edit turn
+// ════════════════════════════════════════════════════════════════════════════
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct EditTurnRequest {
+    pub content: String,
+}
+
+impl modkit::api::api_dto::RequestApiDto for EditTurnRequest {}
+
+/// PATCH /mini-chat/v1/chats/{id}/turns/{request_id}
+pub(crate) async fn edit_turn(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<AppServices>>,
+    Path((chat_id, request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+    Json(body): Json<EditTurnRequest>,
+) -> Response {
+    if body.content.trim().is_empty() {
+        return Problem::new(
+            StatusCode::BAD_REQUEST,
+            "Bad Request",
+            "Edit content must not be empty",
+        )
+        .into_response();
+    }
+
+    let mutation = match svc
+        .turns
+        .edit(&ctx, chat_id, request_id, body.content)
+        .await
+    {
+        Ok(m) => m,
+        Err(e) => return mutation_error_to_problem(e).into_response(),
+    };
+
+    start_mutation_stream(&svc, ctx, chat_id, mutation).await
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Shared helpers
+// ════════════════════════════════════════════════════════════════════════════
+
+async fn start_mutation_stream(
+    svc: &AppServices,
+    ctx: SecurityContext,
+    chat_id: uuid::Uuid,
+    mutation: crate::domain::service::MutationResult,
+) -> Response {
+    let chat = match svc.chats.get_chat(&ctx, chat_id).await {
+        Ok(c) => c,
+        Err(e) => {
+            return Problem::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal Error",
+                e.to_string(),
+            )
+            .into_response();
+        }
+    };
+
+    let resolved = match svc
+        .models
+        .resolve_model(ctx.subject_id(), Some(chat.model))
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            return Problem::new(StatusCode::BAD_REQUEST, "Bad Request", e.to_string())
+                .into_response();
+        }
+    };
+
+    let capacity = svc.stream.channel_capacity();
+    let ping_secs = svc.stream.ping_interval_secs();
+    let (tx, rx) = mpsc::channel::<StreamEvent>(capacity);
+    let cancel = CancellationToken::new();
+
+    info!(
+        chat_id = %chat_id,
+        new_request_id = %mutation.new_request_id,
+        model = %resolved.model_id,
+        "starting mutation SSE stream"
+    );
+
+    let provider_handle = match svc
+        .stream
+        .run_stream_for_mutation(
+            ctx,
+            chat_id,
+            mutation.new_request_id,
+            mutation.new_turn_id,
+            mutation.user_content,
+            resolved,
+            cancel.clone(),
+            tx,
+        )
+        .await
+    {
+        Ok(handle) => handle,
+        Err(e) => return stream_error_to_response(e),
+    };
+
+    tokio::spawn(async move {
+        if let Err(e) = provider_handle.await {
+            tracing::error!(error = ?e, "provider task panicked");
+        }
+    });
+
+    let relay = SseRelay::new(rx, cancel, ping_secs);
+    Sse::new(relay)
+        .keep_alive(KeepAlive::new().interval(Duration::from_secs(30)))
+        .into_response()
+}
+
+/// Map `MutationError` to HTTP problem response.
+fn mutation_error_to_problem(err: MutationError) -> Problem {
+    match err {
+        MutationError::ChatNotFound { .. } => {
+            Problem::new(StatusCode::NOT_FOUND, "chat_not_found", "Chat not found")
+        }
+        MutationError::TurnNotFound { .. } => {
+            Problem::new(StatusCode::NOT_FOUND, "turn_not_found", "Turn not found")
+        }
+        MutationError::InsufficientPermissions => Problem::new(
+            StatusCode::FORBIDDEN,
+            "insufficient_permissions",
+            "You do not have permission to modify this turn",
+        ),
+        MutationError::InvalidTurnState { state } => Problem::new(
+            StatusCode::BAD_REQUEST,
+            "invalid_turn_state",
+            format!("Turn is in {state:?} state; only terminal turns can be mutated"),
+        ),
+        MutationError::NotLatestTurn => Problem::new(
+            StatusCode::CONFLICT,
+            "not_latest_turn",
+            "Only the most recent turn can be mutated",
+        ),
+        MutationError::GenerationInProgress => Problem::new(
+            StatusCode::CONFLICT,
+            "generation_in_progress",
+            "Another generation is already in progress for this chat",
+        ),
+        MutationError::Internal { message } => {
+            warn!(%message, "turn mutation internal error");
+            Problem::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal Error",
+                "An internal error occurred",
+            )
+        }
+    }
+}
+
+fn stream_error_to_response(err: StreamError) -> Response {
+    match err {
+        StreamError::QuotaExhausted {
+            error_code,
+            http_status,
+        } => {
+            let status = StatusCode::from_u16(http_status).unwrap_or(StatusCode::TOO_MANY_REQUESTS);
+            Problem::new(status, "Quota Exhausted", &error_code).into_response()
+        }
+        other => {
+            warn!(error = ?other, "post-mutation stream error");
+            Problem::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal Error",
+                "Failed to start streaming",
+            )
+            .into_response()
+        }
+    }
 }

--- a/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
@@ -55,6 +55,16 @@ pub trait MessageRepository: Send + Sync {
         params: InsertAssistantMessageParams,
     ) -> Result<MessageModel, DomainError>;
 
+    /// SELECT the user-role message for a given `(chat_id, request_id)`.
+    /// Used by retry/edit to retrieve the original user message content.
+    async fn find_user_message_by_request_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<Option<MessageModel>, DomainError>;
+
     /// SELECT messages for a turn by `(chat_id, request_id)` where not deleted.
     async fn find_by_chat_and_request_id<C: DBRunner>(
         &self,

--- a/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
@@ -128,4 +128,13 @@ pub trait TurnRepository: Send + Sync {
         scope: &AccessScope,
         chat_id: Uuid,
     ) -> Result<Option<TurnModel>, DomainError>;
+
+    /// SELECT the most recent non-deleted turn for a chat with `FOR UPDATE` row lock.
+    /// Used within mutation transactions to serialize concurrent retry/edit/delete.
+    async fn find_latest_for_update<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<TurnModel>, DomainError>;
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -28,6 +28,7 @@ mod stream_service;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 pub(crate) mod token_estimator;
+mod turn_service;
 
 pub(crate) use attachment_service::AttachmentService;
 pub(crate) use chat_service::ChatService;
@@ -37,6 +38,7 @@ pub(crate) use model_service::ModelService;
 pub(crate) use quota_service::QuotaService;
 pub(crate) use reaction_service::ReactionService;
 pub(crate) use stream_service::{StreamError, StreamService};
+pub(crate) use turn_service::{MutationError, MutationResult, TurnService};
 
 pub(crate) type DbProvider = DBProvider<modkit_db::DbError>;
 
@@ -120,6 +122,7 @@ pub(crate) struct AppServices<
     pub(crate) chats: ChatService<CR>,
     pub(crate) messages: MessageService<MR, CR>,
     pub(crate) stream: StreamService<TR, MR, QR, CR>,
+    pub(crate) turns: TurnService<TR, MR, CR>,
     pub(crate) reactions: ReactionService<RR, MR, CR>,
     pub(crate) attachments: AttachmentService<CR>,
     pub(crate) models: ModelService,
@@ -127,6 +130,8 @@ pub(crate) struct AppServices<
     pub(crate) finalization: Arc<FinalizationService<TR, MR>>,
     pub(crate) db: Arc<DbProvider>,
     pub(crate) message_repo: Arc<MR>,
+    pub(crate) turn_repo: Arc<TR>,
+    pub(crate) enforcer: PolicyEnforcer,
 }
 
 impl<
@@ -170,6 +175,14 @@ impl<
             Arc::clone(&quota_svc) as Arc<dyn QuotaSettler>,
         ));
 
+        let turns = TurnService::new(
+            Arc::clone(&db),
+            Arc::clone(&repos.turn),
+            Arc::clone(&repos.message),
+            Arc::clone(&repos.chat),
+            enforcer.clone(),
+        );
+
         Self {
             chats: ChatService::new(
                 Arc::clone(&db),
@@ -195,6 +208,7 @@ impl<
                 Arc::clone(&finalization),
                 Arc::clone(&quota_svc),
             ),
+            turns,
             reactions: ReactionService::new(
                 Arc::clone(&db),
                 Arc::clone(&repos.reaction),
@@ -209,11 +223,17 @@ impl<
                 Arc::clone(&repos.vector_store),
                 enforcer.clone(),
             ),
-            models: ModelService::new(Arc::clone(&db), enforcer, Arc::clone(model_resolver)),
+            models: ModelService::new(
+                Arc::clone(&db),
+                enforcer.clone(),
+                Arc::clone(model_resolver),
+            ),
             quota: Arc::clone(&quota_svc),
             finalization,
             db,
             message_repo: Arc::clone(&repos.message),
+            turn_repo: Arc::clone(&repos.turn),
+            enforcer,
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/replay.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/replay.rs
@@ -149,6 +149,16 @@ mod tests {
             unimplemented!()
         }
 
+        async fn find_user_message_by_request_id<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+            _: Uuid,
+        ) -> Result<Option<MessageModel>, DomainError> {
+            unimplemented!()
+        }
+
         async fn find_by_chat_and_request_id<C: DBRunner>(
             &self,
             _: &C,

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -657,6 +657,141 @@ impl<
 
         Ok(turn_id)
     }
+
+    /// Run streaming for an already-created turn (used by retry/edit mutations).
+    ///
+    /// The mutation transaction has already created the turn (state=running) and
+    /// user message. This method does quota preflight, writes reserves, resolves
+    /// the provider, and spawns the streaming task.
+    ///
+    /// Per design D3: mutation transaction commits first, streaming runs post-commit.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn run_stream_for_mutation(
+        &self,
+        ctx: SecurityContext,
+        chat_id: Uuid,
+        request_id: Uuid,
+        turn_id: Uuid,
+        content: String,
+        resolved_model: ResolvedModel,
+        cancel: CancellationToken,
+        tx: mpsc::Sender<StreamEvent>,
+    ) -> Result<tokio::task::JoinHandle<StreamOutcome>, StreamError> {
+        let model = resolved_model.model_id;
+        let provider_model_id = resolved_model.provider_model_id;
+        let provider_id = resolved_model.provider_id;
+        let tenant_id = ctx.subject_tenant_id();
+        let user_id = ctx.subject_id();
+        let scope = AccessScope::for_tenant(tenant_id);
+
+        // ── Preflight quota evaluate ────────────────────────────────────
+        let selected_model = model;
+        let computed = self
+            .quota
+            .preflight_evaluate(crate::domain::model::quota::PreflightInput {
+                tenant_id,
+                user_id,
+                selected_model: selected_model.clone(),
+                utf8_bytes: content.len() as u64,
+                num_images: 0,
+                tools_enabled: false,
+                web_search_enabled: false,
+                max_output_tokens_cap: self.streaming_config.max_output_tokens,
+            })
+            .await
+            .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
+
+        let pf = flatten_preflight(computed.decision.clone())?;
+        let period_starts = computed.periods.clone();
+
+        // ── Write quota reserves ────────────────────────────────────────
+        let quota_repo = Arc::clone(&self.quota.repo);
+        let computed_for_tx = computed;
+
+        if !computed_for_tx.buckets.is_empty() {
+            self.db
+                .transaction(|txn| {
+                    use crate::domain::repos::IncrementReserveParams;
+                    Box::pin(async move {
+                        let reserve_scope = AccessScope::for_tenant(computed_for_tx.tenant_id);
+                        for bucket in &computed_for_tx.buckets {
+                            for (period_type, period_start) in &computed_for_tx.periods {
+                                quota_repo
+                                    .increment_reserve(
+                                        txn,
+                                        &reserve_scope,
+                                        IncrementReserveParams {
+                                            tenant_id: computed_for_tx.tenant_id,
+                                            user_id: computed_for_tx.user_id,
+                                            period_type: period_type.clone(),
+                                            period_start: *period_start,
+                                            bucket: bucket.clone(),
+                                            amount_micro: computed_for_tx.reserved_credits_micro,
+                                        },
+                                    )
+                                    .await
+                                    .map_err(|e| {
+                                        modkit_db::DbError::Other(anyhow::Error::new(e))
+                                    })?;
+                            }
+                        }
+                        Ok(())
+                    })
+                })
+                .await
+                .map_err(|e| StreamError::TurnCreationFailed {
+                    source: DomainError::database(e.to_string()),
+                })?;
+        }
+
+        // ── Build finalization context + resolve provider + spawn ────────
+        let message_id = Uuid::new_v4();
+
+        let finalization_ctx = FinalizationCtx {
+            finalization_svc: Arc::clone(&self.finalization),
+            scope,
+            turn_id,
+            tenant_id,
+            chat_id,
+            request_id,
+            user_id,
+            message_id,
+            effective_model: pf.effective_model.clone(),
+            selected_model: selected_model.clone(),
+            reserve_tokens: pf.reserve_tokens,
+            max_output_tokens_applied: pf.max_output_tokens_applied,
+            reserved_credits_micro: pf.reserved_credits_micro,
+            policy_version_applied: pf.policy_version_applied,
+            minimal_generation_floor_applied: pf.minimal_generation_floor_applied,
+            quota_decision: pf.quota_decision,
+            downgrade_from: pf.downgrade_from,
+            downgrade_reason: pf.downgrade_reason,
+            period_starts,
+        };
+
+        let resolved_provider = self.provider_resolver.resolve(&provider_id).map_err(|e| {
+            StreamError::TurnCreationFailed {
+                source: DomainError::internal(format!("provider resolution: {e}")),
+            }
+        })?;
+        let api_path = resolved_provider
+            .api_path
+            .replace("{model}", &provider_model_id);
+        let proxy_path = format!("{}{api_path}", resolved_provider.upstream_alias);
+
+        Ok(spawn_provider_task(
+            resolved_provider.adapter,
+            proxy_path,
+            ctx,
+            content,
+            pf.effective_model,
+            provider_model_id,
+            pf.max_output_tokens_applied.cast_unsigned(),
+            cancel,
+            tx,
+            Some(finalization_ctx),
+        ))
+    }
 }
 
 /// Core provider task: reads from the LLM, translates events, and returns
@@ -1243,6 +1378,32 @@ mod tests {
                 ))]),
             }
         }
+
+        /// Provider that emits deltas then stops with `max_output_tokens` reason.
+        fn incomplete(deltas: &[&str]) -> Self {
+            let mut events: Vec<Result<TranslatedEvent, StreamingError>> = deltas
+                .iter()
+                .map(|text| {
+                    Ok(TranslatedEvent::Sse(ClientSseEvent::Delta {
+                        r#type: "text",
+                        content: (*text).to_owned(),
+                    }))
+                })
+                .collect();
+
+            events.push(Ok(TranslatedEvent::Terminal(TerminalOutcome::Incomplete {
+                reason: "max_output_tokens".to_owned(),
+                usage: Usage {
+                    input_tokens: 10,
+                    output_tokens: 4096,
+                },
+                partial_content: deltas.iter().copied().collect(),
+            })));
+
+            Self {
+                events: std::sync::Mutex::new(events),
+            }
+        }
     }
 
     #[async_trait::async_trait]
@@ -1358,6 +1519,54 @@ mod tests {
         let outcome = handle.await.expect("task should complete");
         assert_eq!(outcome.terminal, StreamTerminal::Failed);
         assert_eq!(outcome.error_code.as_deref(), Some("provider_timeout"));
+    }
+
+    /// Provider hitting `max_output_tokens` yields Incomplete outcome.
+    #[tokio::test]
+    async fn provider_incomplete_max_output_tokens() {
+        let provider: Arc<dyn LlmProvider> =
+            Arc::new(MockProvider::incomplete(&["Hello", ", wor"]));
+        let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
+        let cancel = CancellationToken::new();
+
+        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+            provider,
+            "test-alias".to_owned(),
+            mock_ctx(),
+            "hi".into(),
+            "test-model".into(),
+            "test-model".into(),
+            4096,
+            cancel,
+            tx,
+            None,
+        );
+
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            let is_term = ev.is_terminal();
+            events.push(ev);
+            if is_term {
+                break;
+            }
+        }
+
+        // 2 deltas + 1 done (incomplete maps to done event for client)
+        assert_eq!(events.len(), 3);
+        assert!(matches!(events[0], StreamEvent::Delta(_)));
+        assert!(matches!(events[1], StreamEvent::Delta(_)));
+        assert!(matches!(events[2], StreamEvent::Done(_)));
+
+        let outcome = handle.await.expect("task should complete");
+        assert_eq!(outcome.terminal, StreamTerminal::Incomplete);
+        assert_eq!(outcome.accumulated_text, "Hello, wor");
+        assert!(outcome.usage.is_some());
+        let usage = outcome.usage.unwrap();
+        assert_eq!(usage.output_tokens, 4096);
+        assert_eq!(
+            outcome.error_code.as_deref(),
+            Some("incomplete:max_output_tokens")
+        );
     }
 
     /// 6.6: Cancellation mid-stream.

--- a/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
@@ -1,0 +1,401 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::PolicyEnforcer;
+use modkit_macros::domain_model;
+use modkit_security::{AccessScope, SecurityContext};
+use tracing::info;
+use uuid::Uuid;
+
+use crate::domain::repos::{
+    ChatRepository, CreateTurnParams, InsertUserMessageParams, MessageRepository, TurnRepository,
+};
+use crate::infra::db::entity::chat_turn::{Model as TurnModel, TurnState};
+
+use super::{DbProvider, actions, resources};
+
+// ════════════════════════════════════════════════════════════════════════════
+// MutationError
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Error type for turn mutation operations (retry, edit, delete).
+/// Each variant maps to a specific HTTP status and error code.
+#[domain_model]
+#[derive(Debug)]
+pub enum MutationError {
+    ChatNotFound { chat_id: Uuid },
+    TurnNotFound { chat_id: Uuid, request_id: Uuid },
+    InsufficientPermissions,
+    InvalidTurnState { state: TurnState },
+    NotLatestTurn,
+    GenerationInProgress,
+    Internal { message: String },
+}
+
+impl std::fmt::Display for MutationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ChatNotFound { chat_id } => write!(f, "Chat not found: {chat_id}"),
+            Self::TurnNotFound {
+                chat_id,
+                request_id,
+            } => {
+                write!(f, "Turn {request_id} not found in chat {chat_id}")
+            }
+            Self::InsufficientPermissions => write!(f, "Insufficient permissions"),
+            Self::InvalidTurnState { state } => {
+                let label = match state {
+                    TurnState::Running => "running",
+                    TurnState::Completed => "completed",
+                    TurnState::Failed => "failed",
+                    TurnState::Cancelled => "cancelled",
+                };
+                write!(f, "Invalid turn state: {label}")
+            }
+            Self::NotLatestTurn => write!(f, "Target is not the latest turn"),
+            Self::GenerationInProgress => {
+                write!(f, "A generation is already in progress")
+            }
+            Self::Internal { message } => write!(f, "Internal error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for MutationError {}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Results
+// ════════════════════════════════════════════════════════════════════════════
+
+#[domain_model]
+#[derive(Debug)]
+pub struct DeleteResult {
+    pub request_id: Uuid,
+    pub deleted: bool,
+}
+
+/// Returned from retry/edit. Contains everything the handler needs to
+/// set up streaming via `StreamService::run_stream_for_mutation()`.
+#[domain_model]
+#[derive(Debug)]
+pub struct MutationResult {
+    pub new_request_id: Uuid,
+    pub new_turn_id: Uuid,
+    pub user_content: String,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// TurnService
+// ════════════════════════════════════════════════════════════════════════════
+
+#[domain_model]
+pub struct TurnService<
+    TR: TurnRepository + 'static,
+    MR: MessageRepository + 'static,
+    CR: ChatRepository + 'static,
+> {
+    pub(crate) db: Arc<DbProvider>,
+    pub(crate) turn_repo: Arc<TR>,
+    pub(crate) message_repo: Arc<MR>,
+    chat_repo: Arc<CR>,
+    enforcer: PolicyEnforcer,
+}
+
+impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepository + 'static>
+    TurnService<TR, MR, CR>
+{
+    pub(crate) fn new(
+        db: Arc<DbProvider>,
+        turn_repo: Arc<TR>,
+        message_repo: Arc<MR>,
+        chat_repo: Arc<CR>,
+        enforcer: PolicyEnforcer,
+    ) -> Self {
+        Self {
+            db,
+            turn_repo,
+            message_repo,
+            chat_repo,
+            enforcer,
+        }
+    }
+
+    // ── Delete ──────────────────────────────────────────────────────────
+
+    pub async fn delete(
+        &self,
+        ctx: &SecurityContext,
+        chat_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<DeleteResult, MutationError> {
+        info!(%chat_id, %request_id, "turn delete");
+
+        let turn_repo = Arc::clone(&self.turn_repo);
+        let chat_repo = Arc::clone(&self.chat_repo);
+        let enforcer = self.enforcer.clone();
+        let ctx_clone = ctx.clone();
+
+        self.db
+            .transaction(|tx| {
+                Box::pin(async move {
+                    let (scope, target) = validate_mutation(
+                        &enforcer,
+                        &*chat_repo,
+                        &*turn_repo,
+                        &ctx_clone,
+                        tx,
+                        chat_id,
+                        request_id,
+                    )
+                    .await
+                    .map_err(mutation_to_db_err)?;
+
+                    turn_repo
+                        .soft_delete(tx, &scope, target.id, None)
+                        .await
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
+
+                    Ok(DeleteResult {
+                        request_id,
+                        deleted: true,
+                    })
+                })
+            })
+            .await
+            .map_err(unwrap_mutation_err)
+    }
+
+    // ── Retry ───────────────────────────────────────────────────────────
+
+    pub async fn retry(
+        &self,
+        ctx: &SecurityContext,
+        chat_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<MutationResult, MutationError> {
+        info!(%chat_id, %request_id, "turn retry");
+        self.mutate_for_stream(ctx, chat_id, request_id, None).await
+    }
+
+    // ── Edit ────────────────────────────────────────────────────────────
+
+    pub async fn edit(
+        &self,
+        ctx: &SecurityContext,
+        chat_id: Uuid,
+        request_id: Uuid,
+        new_content: String,
+    ) -> Result<MutationResult, MutationError> {
+        info!(%chat_id, %request_id, "turn edit");
+        self.mutate_for_stream(ctx, chat_id, request_id, Some(new_content))
+            .await
+    }
+
+    // ── Shared retry/edit transaction ────────────────────────────────────
+
+    async fn mutate_for_stream(
+        &self,
+        ctx: &SecurityContext,
+        chat_id: Uuid,
+        request_id: Uuid,
+        override_content: Option<String>,
+    ) -> Result<MutationResult, MutationError> {
+        let new_request_id = Uuid::new_v4();
+        let new_turn_id = Uuid::new_v4();
+
+        let turn_repo = Arc::clone(&self.turn_repo);
+        let message_repo = Arc::clone(&self.message_repo);
+        let chat_repo = Arc::clone(&self.chat_repo);
+        let enforcer = self.enforcer.clone();
+        let ctx_clone = ctx.clone();
+
+        let user_content = self
+            .db
+            .transaction(|tx| {
+                Box::pin(async move {
+                    let (scope, target) = validate_mutation(
+                        &enforcer,
+                        &*chat_repo,
+                        &*turn_repo,
+                        &ctx_clone,
+                        tx,
+                        chat_id,
+                        request_id,
+                    )
+                    .await
+                    .map_err(mutation_to_db_err)?;
+
+                    // Retrieve original user message for content (retry) / attachments (edit)
+                    let original_msg = message_repo
+                        .find_user_message_by_request_id(tx, &scope, chat_id, request_id)
+                        .await
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?
+                        .ok_or_else(|| {
+                            modkit_db::DbError::Other(anyhow::anyhow!(
+                                "User message not found for turn {request_id}"
+                            ))
+                        })?;
+
+                    let user_content = override_content.unwrap_or(original_msg.content);
+
+                    // Soft-delete old turn with replacement link
+                    turn_repo
+                        .soft_delete(tx, &scope, target.id, Some(new_request_id))
+                        .await
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
+
+                    // Insert new running turn
+                    let tenant_id = ctx_clone.subject_tenant_id();
+                    let requester_type = ctx_clone.subject_type().unwrap_or("user").to_owned();
+
+                    turn_repo
+                        .create_turn(
+                            tx,
+                            &scope,
+                            CreateTurnParams {
+                                id: new_turn_id,
+                                tenant_id,
+                                chat_id,
+                                request_id: new_request_id,
+                                requester_type,
+                                requester_user_id: Some(ctx_clone.subject_id()),
+                                reserve_tokens: None,
+                                max_output_tokens_applied: None,
+                                reserved_credits_micro: None,
+                                policy_version_applied: None,
+                                effective_model: None,
+                                minimal_generation_floor_applied: None,
+                            },
+                        )
+                        .await
+                        .map_err(|e| {
+                            let err_str = e.to_string();
+                            if err_str.contains("unique") || err_str.contains("UNIQUE") {
+                                return mutation_to_db_err(MutationError::GenerationInProgress);
+                            }
+                            modkit_db::DbError::Other(anyhow::Error::new(e))
+                        })?;
+
+                    // Insert user message for the new turn
+                    message_repo
+                        .insert_user_message(
+                            tx,
+                            &scope,
+                            InsertUserMessageParams {
+                                id: Uuid::new_v4(),
+                                tenant_id,
+                                chat_id,
+                                request_id: new_request_id,
+                                content: user_content.clone(),
+                            },
+                        )
+                        .await
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
+
+                    Ok(user_content)
+                })
+            })
+            .await
+            .map_err(unwrap_mutation_err)?;
+
+        Ok(MutationResult {
+            new_request_id,
+            new_turn_id,
+            user_content,
+        })
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Shared validation (5-check sequence) — free function for use in closures
+// ════════════════════════════════════════════════════════════════════════════
+
+async fn validate_mutation<CR: ChatRepository, TR: TurnRepository>(
+    enforcer: &PolicyEnforcer,
+    chat_repo: &CR,
+    turn_repo: &TR,
+    ctx: &SecurityContext,
+    tx: &impl modkit_db::secure::DBRunner,
+    chat_id: Uuid,
+    request_id: Uuid,
+) -> Result<(AccessScope, TurnModel), MutationError> {
+    // 1. Load chat with authorization
+    let scope = enforcer
+        .access_scope(ctx, &resources::CHAT, actions::DELETE_TURN, Some(chat_id))
+        .await
+        .map_err(|_| MutationError::ChatNotFound { chat_id })?;
+
+    chat_repo
+        .get(tx, &scope, chat_id)
+        .await
+        .map_err(|e| MutationError::Internal {
+            message: e.to_string(),
+        })?
+        .ok_or(MutationError::ChatNotFound { chat_id })?;
+
+    let scope = scope.tenant_only();
+
+    // 2. Acquire target turn by request_id
+    let target = turn_repo
+        .find_by_chat_and_request_id(tx, &scope, chat_id, request_id)
+        .await
+        .map_err(|e| MutationError::Internal {
+            message: e.to_string(),
+        })?
+        .ok_or(MutationError::TurnNotFound {
+            chat_id,
+            request_id,
+        })?;
+
+    // 3. Verify ownership
+    if target.requester_user_id != Some(ctx.subject_id()) {
+        return Err(MutationError::InsufficientPermissions);
+    }
+
+    // 4. Verify terminal state
+    if !target.state.is_terminal() {
+        return Err(MutationError::InvalidTurnState {
+            state: target.state.clone(),
+        });
+    }
+
+    // 5. Verify latest turn (with FOR UPDATE for serialization)
+    let latest = turn_repo
+        .find_latest_for_update(tx, &scope, chat_id)
+        .await
+        .map_err(|e| MutationError::Internal {
+            message: e.to_string(),
+        })?;
+
+    match latest {
+        Some(ref l) if l.id == target.id => {} // target IS the latest — ok
+        _ => return Err(MutationError::NotLatestTurn),
+    }
+
+    Ok((scope, target))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Error helpers for transaction boundary crossing
+// ════════════════════════════════════════════════════════════════════════════
+
+fn mutation_to_db_err(e: MutationError) -> modkit_db::DbError {
+    modkit_db::DbError::Other(anyhow::Error::new(e))
+}
+
+fn unwrap_mutation_err(e: modkit_db::DbError) -> MutationError {
+    match e {
+        modkit_db::DbError::Other(anyhow_err) => match anyhow_err.downcast::<MutationError>() {
+            Ok(me) => me,
+            Err(other) => MutationError::Internal {
+                message: other.to_string(),
+            },
+        },
+        other => MutationError::Internal {
+            message: other.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "turn_service_test.rs"]
+mod tests;

--- a/modules/mini-chat/mini-chat/src/domain/service/turn_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/turn_service_test.rs
@@ -1,0 +1,460 @@
+use std::sync::Arc;
+
+use modkit_security::AccessScope;
+use uuid::Uuid;
+
+use crate::domain::repos::{ChatRepository, TurnRepository};
+use crate::domain::service::TurnService;
+use crate::domain::service::test_helpers::*;
+use crate::domain::service::turn_service::MutationError;
+use crate::infra::db::entity::chat_turn::TurnState;
+use crate::infra::db::repo;
+
+// ════════════════════════════════════════════════════════════════════════════
+// Helpers
+// ════════════════════════════════════════════════════════════════════════════
+
+async fn setup() -> (
+    TurnService<
+        repo::turn_repo::TurnRepository,
+        repo::message_repo::MessageRepository,
+        repo::chat_repo::ChatRepository,
+    >,
+    modkit_security::SecurityContext,
+    Uuid, // chat_id
+    Uuid, // tenant_id
+) {
+    let db = inmem_db().await;
+    let db = mock_db_provider(db);
+    let tenant_id = Uuid::new_v4();
+    let ctx = test_security_ctx(tenant_id);
+
+    let chat_repo = Arc::new(repo::chat_repo::ChatRepository::new(
+        modkit_db::odata::LimitCfg {
+            default: 20,
+            max: 100,
+        },
+    ));
+    let turn_repo = Arc::new(repo::turn_repo::TurnRepository);
+    let message_repo = Arc::new(repo::message_repo::MessageRepository::new(
+        modkit_db::odata::LimitCfg {
+            default: 20,
+            max: 100,
+        },
+    ));
+
+    // Create a chat first
+    let chat_id = Uuid::now_v7();
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = db.conn().unwrap();
+    chat_repo
+        .create(
+            &conn,
+            &scope,
+            crate::domain::models::Chat {
+                id: chat_id,
+                tenant_id,
+                user_id: ctx.subject_id(),
+                model: "gpt-5.2".to_owned(),
+                title: Some("Test chat".to_owned()),
+                is_temporary: false,
+                created_at: time::OffsetDateTime::now_utc(),
+                updated_at: time::OffsetDateTime::now_utc(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let svc = TurnService::new(
+        Arc::clone(&db),
+        turn_repo,
+        message_repo,
+        chat_repo,
+        mock_enforcer(),
+    );
+
+    (svc, ctx, chat_id, tenant_id)
+}
+
+/// Create a completed turn with a user message. Returns the `request_id`.
+async fn create_completed_turn(
+    db: &crate::domain::service::DbProvider,
+    turn_repo: &impl TurnRepository,
+    message_repo: &impl crate::domain::repos::MessageRepository,
+    tenant_id: Uuid,
+    chat_id: Uuid,
+    user_id: Uuid,
+) -> Uuid {
+    let request_id = Uuid::new_v4();
+    let turn_id = Uuid::new_v4();
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = db.conn().unwrap();
+
+    // Create turn
+    turn_repo
+        .create_turn(
+            &conn,
+            &scope,
+            crate::domain::repos::CreateTurnParams {
+                id: turn_id,
+                tenant_id,
+                chat_id,
+                request_id,
+                requester_type: "user".to_owned(),
+                requester_user_id: Some(user_id),
+                reserve_tokens: None,
+                max_output_tokens_applied: None,
+                reserved_credits_micro: None,
+                policy_version_applied: None,
+                effective_model: Some("gpt-5.2".to_owned()),
+                minimal_generation_floor_applied: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Create user message
+    message_repo
+        .insert_user_message(
+            &conn,
+            &scope,
+            crate::domain::repos::InsertUserMessageParams {
+                id: Uuid::new_v4(),
+                tenant_id,
+                chat_id,
+                request_id,
+                content: "Hello world".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+
+    // Create assistant message (required by FK on assistant_message_id)
+    let assistant_msg_id = Uuid::new_v4();
+    message_repo
+        .insert_assistant_message(
+            &conn,
+            &scope,
+            crate::domain::repos::InsertAssistantMessageParams {
+                id: assistant_msg_id,
+                tenant_id,
+                chat_id,
+                request_id,
+                content: "Assistant reply".to_owned(),
+                input_tokens: Some(10),
+                output_tokens: Some(5),
+                model: Some("gpt-5.2".to_owned()),
+                provider_response_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Transition to completed
+    turn_repo
+        .cas_update_state(
+            &conn,
+            &scope,
+            crate::domain::repos::CasTerminalParams {
+                turn_id,
+                state: TurnState::Completed,
+                error_code: None,
+                error_detail: None,
+                assistant_message_id: Some(assistant_msg_id),
+                provider_response_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    request_id
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 7.4: validate_mutation — 5 checks in order
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn delete_nonexistent_turn_returns_turn_not_found() {
+    let (svc, ctx, chat_id, _) = setup().await;
+    let fake_rid = Uuid::new_v4();
+
+    let err = svc.delete(&ctx, chat_id, fake_rid).await.unwrap_err();
+    assert!(
+        matches!(err, MutationError::TurnNotFound { .. }),
+        "expected TurnNotFound, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn delete_nonexistent_chat_returns_chat_not_found() {
+    let (svc, ctx, _, _) = setup().await;
+    let fake_chat = Uuid::new_v4();
+    let fake_rid = Uuid::new_v4();
+
+    let err = svc.delete(&ctx, fake_chat, fake_rid).await.unwrap_err();
+    assert!(
+        matches!(err, MutationError::ChatNotFound { .. }),
+        "expected ChatNotFound, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn delete_wrong_owner_returns_insufficient_permissions() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    // Create a turn with a DIFFERENT requester_user_id than ctx.subject_id()
+    let other_user_id = Uuid::new_v4();
+    let request_id = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        other_user_id,
+    )
+    .await;
+
+    // ctx.subject_id() != other_user_id → ownership check fails
+    let err = svc.delete(&ctx, chat_id, request_id).await.unwrap_err();
+    assert!(
+        matches!(err, MutationError::InsufficientPermissions),
+        "expected InsufficientPermissions, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn delete_running_turn_returns_invalid_turn_state() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    // Create a running turn (don't transition to completed)
+    let request_id = Uuid::new_v4();
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = svc.db.conn().unwrap();
+    svc.turn_repo
+        .create_turn(
+            &conn,
+            &scope,
+            crate::domain::repos::CreateTurnParams {
+                id: Uuid::new_v4(),
+                tenant_id,
+                chat_id,
+                request_id,
+                requester_type: "user".to_owned(),
+                requester_user_id: Some(ctx.subject_id()),
+                reserve_tokens: None,
+                max_output_tokens_applied: None,
+                reserved_credits_micro: None,
+                policy_version_applied: None,
+                effective_model: None,
+                minimal_generation_floor_applied: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let err = svc.delete(&ctx, chat_id, request_id).await.unwrap_err();
+    assert!(
+        matches!(
+            err,
+            MutationError::InvalidTurnState {
+                state: TurnState::Running
+            }
+        ),
+        "expected InvalidTurnState(Running), got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn delete_non_latest_turn_returns_not_latest() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    // Create two completed turns
+    let rid1 = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        ctx.subject_id(),
+    )
+    .await;
+    // Small delay to ensure different started_at
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    let _rid2 = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        ctx.subject_id(),
+    )
+    .await;
+
+    // Try to delete the FIRST turn (not the latest)
+    let err = svc.delete(&ctx, chat_id, rid1).await.unwrap_err();
+    assert!(
+        matches!(err, MutationError::NotLatestTurn),
+        "expected NotLatestTurn, got: {err:?}"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 7.1: TurnService::delete — success + edge cases
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn delete_success_returns_request_id_and_deleted_true() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    let request_id = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        ctx.subject_id(),
+    )
+    .await;
+
+    let result = svc.delete(&ctx, chat_id, request_id).await.unwrap();
+    assert_eq!(result.request_id, request_id);
+    assert!(result.deleted);
+
+    // Verify the turn is soft-deleted (deleted_at != NULL)
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = svc.db.conn().unwrap();
+    let turn = svc
+        .turn_repo
+        .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(turn.deleted_at.is_some());
+    assert!(turn.replaced_by_request_id.is_none());
+}
+
+#[tokio::test]
+async fn delete_already_deleted_turn_returns_not_latest() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    let request_id = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        ctx.subject_id(),
+    )
+    .await;
+
+    // Delete once
+    svc.delete(&ctx, chat_id, request_id).await.unwrap();
+
+    // Try to delete again — should fail (soft-deleted turns excluded from latest check)
+    let err = svc.delete(&ctx, chat_id, request_id).await.unwrap_err();
+    // After soft-delete, find_latest_for_update won't find the turn,
+    // so the turn won't match the latest. The exact error depends on
+    // whether there are other turns or not.
+    assert!(
+        matches!(
+            err,
+            MutationError::NotLatestTurn | MutationError::TurnNotFound { .. }
+        ),
+        "expected NotLatestTurn or TurnNotFound, got: {err:?}"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 7.2: TurnService::retry
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn retry_success_returns_new_request_id_and_content() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    let request_id = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        ctx.subject_id(),
+    )
+    .await;
+
+    let result = svc.retry(&ctx, chat_id, request_id).await.unwrap();
+    assert_ne!(result.new_request_id, request_id);
+    assert_eq!(result.user_content, "Hello world");
+
+    // Verify old turn is soft-deleted with replacement link
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = svc.db.conn().unwrap();
+    let old_turn = svc
+        .turn_repo
+        .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(old_turn.deleted_at.is_some());
+    assert_eq!(old_turn.replaced_by_request_id, Some(result.new_request_id));
+
+    // Verify new turn exists in running state
+    let new_turn = svc
+        .turn_repo
+        .find_by_chat_and_request_id(&conn, &scope, chat_id, result.new_request_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(new_turn.state, TurnState::Running);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 7.3: TurnService::edit
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn edit_success_returns_updated_content() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    let request_id = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        ctx.subject_id(),
+    )
+    .await;
+
+    let result = svc
+        .edit(&ctx, chat_id, request_id, "Updated content".to_owned())
+        .await
+        .unwrap();
+    assert_ne!(result.new_request_id, request_id);
+    assert_eq!(result.user_content, "Updated content");
+
+    // Verify old turn soft-deleted with replacement
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = svc.db.conn().unwrap();
+    let old_turn = svc
+        .turn_repo
+        .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(old_turn.deleted_at.is_some());
+    assert_eq!(old_turn.replaced_by_request_id, Some(result.new_request_id));
+}
+
+#[tokio::test]
+async fn edit_uses_same_validation_as_retry() {
+    let (svc, ctx, chat_id, _) = setup().await;
+
+    // Non-existent turn
+    let err = svc
+        .edit(&ctx, chat_id, Uuid::new_v4(), "new".to_owned())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, MutationError::TurnNotFound { .. }));
+}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
@@ -110,6 +110,27 @@ impl crate::domain::repos::MessageRepository for MessageRepository {
         Ok(secure_insert::<MessageEntity>(am, scope, runner).await?)
     }
 
+    async fn find_user_message_by_request_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<Option<MessageModel>, DomainError> {
+        Ok(MessageEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::RequestId.eq(request_id))
+                    .add(Column::Role.eq(MessageRole::User))
+                    .add(Column::DeletedAt.is_null()),
+            )
+            .secure()
+            .scope_with(scope)
+            .one(runner)
+            .await?)
+    }
+
     async fn find_by_chat_and_request_id<C: DBRunner>(
         &self,
         runner: &C,

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
@@ -2,7 +2,10 @@ use async_trait::async_trait;
 use modkit_db::secure::{DBRunner, SecureEntityExt, SecureUpdateExt, secure_insert};
 use modkit_security::AccessScope;
 use sea_orm::sea_query::Expr;
-use sea_orm::{ActiveEnum, ColumnTrait, Condition, EntityTrait, Order, QueryFilter, Set};
+use sea_orm::{
+    ActiveEnum, ColumnTrait, Condition, EntityTrait, Order, QueryFilter, QuerySelect, Set,
+    sea_query::LockType,
+};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -227,6 +230,27 @@ impl crate::domain::repos::TurnRepository for TurnRepository {
             .secure()
             .scope_with(scope)
             .order_by(Column::StartedAt, Order::Desc)
+            .one(runner)
+            .await?)
+    }
+
+    async fn find_latest_for_update<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<TurnModel>, DomainError> {
+        Ok(TurnEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::DeletedAt.is_null()),
+            )
+            .lock(LockType::Update)
+            .secure()
+            .scope_with(scope)
+            .order_by(Column::StartedAt, Order::Desc)
+            .order_by(Column::Id, Order::Desc)
             .one(runner)
             .await?)
     }


### PR DESCRIPTION
feat(mini-chat): implement turn mutations (GET status, retry, edit, delete)

- Add TurnService with atomic SELECT FOR UPDATE transactions for retry, edit, and delete. Retry/edit soft-delete the target turn, insert a new running turn, then delegate to StreamService::run_stream_for_mutation().
- Delete soft-deletes with no replacement. GET turn status is a thin handler mapping internal states to API states (completed→done, etc.).
- All mutations share a 5-check validation sequence (chat auth, turn exists, ownership, terminal state, latest turn) with uniform error codes across endpoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added turn management capabilities: retrieve turn status, delete turns, and edit turn content.
  * Implemented retry functionality for turns with real-time streaming updates via Server-Sent Events.
  * Enhanced authorization and validation for all turn operations.
  * Added comprehensive error handling with appropriate HTTP responses for turn mutations.

* **Tests**
  * Added test coverage for turn operations including deletion, retry, and edit workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->