### PR TITLE
chore: disable PR bots that send notification messages to Telegram since they are too verbose

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -14,7 +14,8 @@ permissions:
 
 jobs:
   unanswered-review-check:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Disabled to stop automated unresolved-comment reminders and Telegram notifications.
+    if: false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-reviewer-check.yml
+++ b/.github/workflows/pr-reviewer-check.yml
@@ -12,6 +12,8 @@ permissions:
 
 jobs:
   check-reviewers:
+    # Disabled to stop automated PR comments and Telegram notifications.
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Check reviewers and notify


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automated review checks and associated notifications in development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->