### PR TITLE
feat(mini-chat): wire OutboxEnqueuer into finalization transaction

### DIFF
--- a/modules/mini-chat/mini-chat/src/domain/repos/outbox_enqueuer.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/outbox_enqueuer.rs
@@ -15,7 +15,7 @@ use crate::domain::error::DomainError;
 /// `Vec<u8>` payloads. Mini-Chat needs a domain-oriented interface that:
 /// - Accepts a typed `UsageEvent` (from `mini-chat-sdk`; serialized by the implementation)
 /// - Resolves the queue name and partition from tenant context
-/// - Participates in the caller's transaction via `&impl DBRunner`
+/// - Participates in the caller's transaction via `&dyn DBRunner`
 /// - Returns domain errors, not infra-level `OutboxError`
 ///
 /// # Payload type
@@ -30,10 +30,8 @@ use crate::domain::error::DomainError;
 /// `Arc<modkit_db::outbox::Outbox>` and call `outbox.enqueue(runner, ...)`
 /// within the finalization transaction. The `Outbox::flush()` notification
 /// is sent after the transaction commits (by the finalization service).
-// TODO(P4): implement InfraOutboxEnqueuer backed by modkit_db::outbox::Outbox
-// TODO(P4): Wire into FinalizationService once modkit_db::outbox is merged.
+// TODO: implement InfraOutboxEnqueuer backed by modkit_db::outbox::Outbox
 #[async_trait::async_trait]
-#[allow(dead_code)]
 pub trait OutboxEnqueuer: Send + Sync {
     /// Enqueue a usage event within the caller's transaction.
     ///
@@ -47,9 +45,9 @@ pub trait OutboxEnqueuer: Send + Sync {
     /// transaction — the outbox enqueue is only reached by the CAS winner.
     ///
     /// Returns `Ok(())` on success. Returns `Err` on database error.
-    async fn enqueue_usage_event<C: DBRunner>(
+    async fn enqueue_usage_event(
         &self,
-        runner: &C,
+        runner: &(dyn DBRunner + Sync),
         event: UsageEvent,
     ) -> Result<(), DomainError>;
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use modkit_macros::domain_model;
 use tracing::{debug, error, warn};
 
+use mini_chat_sdk::{UsageEvent, UsageTokens};
+
 use crate::domain::error::DomainError;
 use crate::domain::model::billing_outcome::{
     BillingDerivation, BillingDerivationInput, BillingOutcome, derive_billing_outcome,
@@ -10,9 +12,10 @@ use crate::domain::model::billing_outcome::{
 use crate::domain::model::finalization::{
     FinalizationInput, FinalizationOutcome, has_known_usage, settlement_path_from_billing,
 };
-use crate::domain::model::quota::SettlementInput;
+use crate::domain::model::quota::{SettlementInput, SettlementMethod, SettlementOutcome};
 use crate::domain::repos::{
-    CasTerminalParams, InsertAssistantMessageParams, MessageRepository, TurnRepository,
+    CasTerminalParams, InsertAssistantMessageParams, MessageRepository, OutboxEnqueuer,
+    TurnRepository,
 };
 use crate::domain::service::quota_settler::QuotaSettler;
 use crate::infra::db::entity::chat_turn::TurnState;
@@ -37,7 +40,7 @@ pub struct FinalizationService<TR: TurnRepository + 'static, MR: MessageReposito
     turn_repo: Arc<TR>,
     message_repo: Arc<MR>,
     quota_settler: Arc<dyn QuotaSettler>,
-    // TODO(P4): add Arc<dyn OutboxEnqueuer> once UsageEvent type is real (task 6.1)
+    outbox_enqueuer: Arc<dyn OutboxEnqueuer>,
 }
 
 impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> FinalizationService<TR, MR> {
@@ -46,12 +49,14 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
         turn_repo: Arc<TR>,
         message_repo: Arc<MR>,
         quota_settler: Arc<dyn QuotaSettler>,
+        outbox_enqueuer: Arc<dyn OutboxEnqueuer>,
     ) -> Self {
         Self {
             db,
             turn_repo,
             message_repo,
             quota_settler,
+            outbox_enqueuer,
         }
     }
 
@@ -119,6 +124,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
         let turn_repo = Arc::clone(&self.turn_repo);
         let message_repo = Arc::clone(&self.message_repo);
         let quota_settler = Arc::clone(&self.quota_settler);
+        let outbox_enqueuer = Arc::clone(&self.outbox_enqueuer);
         let input = input.clone();
 
         let tx_result = self
@@ -220,9 +226,11 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
                     }
 
                     // 5. Enqueue outbox event via domain trait
-                    // TODO(P4): enqueue UsageEvent once real type exists (task 6.1)
-                    // let event = build_usage_event(&input, &billing, &settlement_outcome);
-                    // outbox_enqueuer.enqueue_usage_event(tx, event).await.map_err(to_db)?;
+                    let event = build_usage_event(&input, billing, &settlement_outcome);
+                    outbox_enqueuer
+                        .enqueue_usage_event(tx, event)
+                        .await
+                        .map_err(to_db)?;
 
                     // 6. Return outcome
                     Ok(FinalizationOutcome {
@@ -283,6 +291,43 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
     }
 }
 
+fn build_usage_event(
+    input: &FinalizationInput,
+    billing: BillingDerivation,
+    settlement: &SettlementOutcome,
+) -> UsageEvent {
+    let terminal_state = match input.terminal_state {
+        TurnState::Running => "running",
+        TurnState::Completed => "completed",
+        TurnState::Failed => "failed",
+        TurnState::Cancelled => "cancelled",
+    };
+    let settlement_method = match settlement.settlement_method {
+        SettlementMethod::Actual => "actual",
+        SettlementMethod::Estimated => "estimated",
+        SettlementMethod::Released => "released",
+    };
+    UsageEvent {
+        tenant_id: input.tenant_id,
+        user_id: input.user_id,
+        chat_id: input.chat_id,
+        turn_id: input.turn_id,
+        request_id: input.request_id,
+        effective_model: input.effective_model.clone(),
+        selected_model: input.selected_model.clone(),
+        terminal_state: terminal_state.to_owned(),
+        billing_outcome: billing.outcome.as_str().to_owned(),
+        usage: input.usage.map(|u| UsageTokens {
+            input_tokens: u.input_tokens.cast_unsigned(),
+            output_tokens: u.output_tokens.cast_unsigned(),
+        }),
+        actual_credits_micro: settlement.actual_credits_micro,
+        settlement_method: settlement_method.to_owned(),
+        policy_version_applied: input.policy_version_applied,
+        timestamp: time::OffsetDateTime::now_utc(),
+    }
+}
+
 /// Internal error type to distinguish message persistence failure
 /// from other domain errors, enabling the retry-as-failed logic.
 #[domain_model]
@@ -329,6 +374,22 @@ mod tests {
         }
     }
 
+    // ── Noop OutboxEnqueuer ──
+
+    #[domain_model]
+    struct NoopOutboxEnqueuer;
+
+    #[async_trait::async_trait]
+    impl OutboxEnqueuer for NoopOutboxEnqueuer {
+        async fn enqueue_usage_event(
+            &self,
+            _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+            _event: mini_chat_sdk::UsageEvent,
+        ) -> Result<(), DomainError> {
+            Ok(())
+        }
+    }
+
     fn build_finalization_service(db: Arc<DbProvider>) -> FinalizationService<TurnRepo, MsgRepo> {
         FinalizationService::new(
             db,
@@ -338,6 +399,7 @@ mod tests {
                 max: 100,
             })),
             Arc::new(MockQuotaSettler),
+            Arc::new(NoopOutboxEnqueuer),
         )
     }
 
@@ -567,6 +629,7 @@ mod tests {
                 max: 100,
             })),
             Arc::new(FailingQuotaSettler),
+            Arc::new(NoopOutboxEnqueuer),
         );
 
         let tenant_id = Uuid::new_v4();

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -7,12 +7,13 @@ use modkit_macros::domain_model;
 
 use crate::config::{EstimationBudgets, QuotaConfig, StreamingConfig};
 use crate::domain::repos::{
-    AttachmentRepository, ChatRepository, MessageRepository, ModelResolver, PolicySnapshotProvider,
-    QuotaUsageRepository, ReactionRepository, ThreadSummaryRepository, TurnRepository,
-    UserLimitsProvider, VectorStoreRepository,
+    AttachmentRepository, ChatRepository, MessageRepository, ModelResolver, OutboxEnqueuer,
+    PolicySnapshotProvider, QuotaUsageRepository, ReactionRepository, ThreadSummaryRepository,
+    TurnRepository, UserLimitsProvider, VectorStoreRepository,
 };
 use crate::domain::service::quota_settler::QuotaSettler;
 use crate::infra::llm::provider_resolver::ProviderResolver;
+use crate::infra::outbox::InfraOutboxEnqueuer;
 
 mod attachment_service;
 mod chat_service;
@@ -168,11 +169,14 @@ impl<
             quota_config,
         ));
 
+        let outbox_enqueuer: Arc<dyn OutboxEnqueuer> = Arc::new(InfraOutboxEnqueuer::new());
+
         let finalization = Arc::new(FinalizationService::new(
             Arc::clone(&db),
             Arc::clone(&repos.turn),
             Arc::clone(&repos.message),
             Arc::clone(&quota_svc) as Arc<dyn QuotaSettler>,
+            outbox_enqueuer,
         ));
 
         let turns = TurnService::new(

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -1682,6 +1682,19 @@ mod tests {
             }
         }
 
+        #[domain_model]
+        struct NoopOutboxEnqueuer;
+        #[async_trait::async_trait]
+        impl crate::domain::repos::OutboxEnqueuer for NoopOutboxEnqueuer {
+            async fn enqueue_usage_event(
+                &self,
+                _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+                _event: mini_chat_sdk::UsageEvent,
+            ) -> Result<(), crate::domain::error::DomainError> {
+                Ok(())
+            }
+        }
+
         let provider_resolver = Arc::new(ProviderResolver::single_provider(provider));
         let turn_repo = Arc::new(TurnRepo);
         let message_repo = Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
@@ -1693,6 +1706,7 @@ mod tests {
             Arc::clone(&turn_repo),
             Arc::clone(&message_repo),
             Arc::new(MockQuotaSettler) as Arc<dyn QuotaSettler>,
+            Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
         ));
 
         // QuotaService with permissive defaults — model catalog includes
@@ -2452,6 +2466,19 @@ mod tests {
             }
         }
 
+        #[allow(de0309_must_have_domain_model)]
+        struct NoopOutboxEnqueuer2;
+        #[async_trait::async_trait]
+        impl crate::domain::repos::OutboxEnqueuer for NoopOutboxEnqueuer2 {
+            async fn enqueue_usage_event(
+                &self,
+                _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+                _event: mini_chat_sdk::UsageEvent,
+            ) -> Result<(), crate::domain::error::DomainError> {
+                Ok(())
+            }
+        }
+
         let db = mock_db_provider(inmem_db().await);
         let tenant_id = Uuid::new_v4();
         let user_id = Uuid::new_v4();
@@ -2497,6 +2524,7 @@ mod tests {
             Arc::clone(&turn_repo_arc),
             Arc::clone(&message_repo_arc),
             Arc::new(NoopSettler) as Arc<dyn QuotaSettler>,
+            Arc::new(NoopOutboxEnqueuer2) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
         ));
 
         let fctx = FinalizationCtx {
@@ -2628,6 +2656,19 @@ mod tests {
             }
         }
 
+        #[allow(de0309_must_have_domain_model)]
+        struct NoopOutboxEnqueuer3;
+        #[async_trait::async_trait]
+        impl crate::domain::repos::OutboxEnqueuer for NoopOutboxEnqueuer3 {
+            async fn enqueue_usage_event(
+                &self,
+                _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+                _event: mini_chat_sdk::UsageEvent,
+            ) -> Result<(), crate::domain::error::DomainError> {
+                Ok(())
+            }
+        }
+
         let provider_resolver = Arc::new(ProviderResolver::single_provider(provider));
         let turn_repo = Arc::new(TurnRepo);
         let message_repo = Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
@@ -2639,6 +2680,7 @@ mod tests {
             Arc::clone(&turn_repo),
             Arc::clone(&message_repo),
             Arc::new(MockQuotaSettler) as Arc<dyn QuotaSettler>,
+            Arc::new(NoopOutboxEnqueuer3) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
         ));
 
         let quota_svc = Arc::new(crate::domain::service::QuotaService::new(

--- a/modules/mini-chat/mini-chat/src/infra/outbox.rs
+++ b/modules/mini-chat/mini-chat/src/infra/outbox.rs
@@ -1,69 +1,58 @@
-#![allow(dead_code)]
-
 use async_trait::async_trait;
 use mini_chat_sdk::UsageEvent;
-use modkit_db::secure::DBRunner;
-use tracing::debug;
+use tracing::warn;
 
 use crate::domain::error::DomainError;
 use crate::domain::repos::OutboxEnqueuer;
+
+const USAGE_QUEUE: &str = "mini-chat.usage_snapshot";
+const NUM_PARTITIONS: u32 = 4;
 
 /// Infrastructure implementation of [`OutboxEnqueuer`].
 ///
 /// Serializes `UsageEvent` to JSON and inserts into the outbox table
 /// within the caller's transaction via `modkit_db::outbox::Outbox::enqueue()`.
 ///
-/// TODO(P4): replace stub with real implementation once `modkit_db::outbox`
+/// TODO: replace stub with real implementation once `modkit_db::outbox`
 /// is merged from the `transactional-outbox` branch. The implementation should:
 /// - Hold `Arc<modkit_db::outbox::Outbox>`
-/// - Serialize `event` to `serde_json::to_vec(&event)?`
-/// - Derive partition from `event.tenant_id` (e.g., hash % `num_partitions`)
 /// - Call `outbox.enqueue(runner, queue_name, partition, payload).await`
-pub struct InfraOutboxEnqueuer {
-    queue_name: String,
-    num_partitions: u32,
-}
+pub struct InfraOutboxEnqueuer;
 
 impl InfraOutboxEnqueuer {
-    pub(crate) fn new(queue_name: String, num_partitions: u32) -> Self {
-        Self {
-            queue_name,
-            num_partitions,
-        }
+    pub(crate) fn new() -> Self {
+        Self
     }
 
-    fn partition_for(&self, tenant_id: uuid::Uuid) -> u32 {
-        // Simple hash-based partition assignment
+    fn partition_for(tenant_id: uuid::Uuid) -> u32 {
         let hash = tenant_id.as_u128();
-        #[allow(clippy::cast_possible_truncation)] // result is bounded by num_partitions (u32)
+        #[allow(clippy::cast_possible_truncation)]
         {
-            (hash % u128::from(self.num_partitions)) as u32
+            (hash % u128::from(NUM_PARTITIONS)) as u32
         }
     }
 }
 
 #[async_trait]
 impl OutboxEnqueuer for InfraOutboxEnqueuer {
-    async fn enqueue_usage_event<C: DBRunner>(
+    async fn enqueue_usage_event(
         &self,
-        _runner: &C,
+        _runner: &(dyn modkit_db::secure::DBRunner + Sync),
         event: UsageEvent,
     ) -> Result<(), DomainError> {
-        let _partition = self.partition_for(event.tenant_id);
-        let _payload = serde_json::to_vec(&event)
-            .map_err(|e| DomainError::internal(format!("failed to serialize UsageEvent: {e}")))?;
+        let partition = Self::partition_for(event.tenant_id);
+        let payload = serde_json::to_vec(&event)
+            .map_err(|e| DomainError::internal(format!("serialize UsageEvent: {e}")))?;
+        let payload_json = String::from_utf8_lossy(&payload);
 
-        debug!(
-            turn_id = %event.turn_id,
-            queue = %self.queue_name,
-            partition = _partition,
-            "outbox enqueue stub (modkit_db::outbox not yet available)"
+        warn!(
+            queue = USAGE_QUEUE,
+            partition = partition,
+            payload = %payload_json,
+            "outbox enqueue stub - event NOT persisted (modkit_db::outbox not yet wired)"
         );
 
-        // TODO(P4): replace with real outbox.enqueue() call:
-        // self.outbox.enqueue(runner, &self.queue_name, partition, payload).await
-        //     .map_err(|e| DomainError::internal(format!("outbox enqueue failed: {e}")))?;
-
+        // TODO: replace with real outbox.enqueue(runner, queue_name, partition, payload)
         Ok(())
     }
 }


### PR DESCRIPTION
feat(mini-chat): wire OutboxEnqueuer into finalization transaction

- Add outbox_enqueuer: Arc<dyn OutboxEnqueuer> to FinalizationService
- Implement build_usage_event() mapping FinalizationInput → UsageEvent
- Call enqueue at step 5 of CAS transaction (after settlement, before outcome)
- Upgrade InfraOutboxEnqueuer stub: full JSON payload at warn level
- Make OutboxEnqueuer trait dyn-compatible (&dyn DBRunner instead of generic)
- Remove dead_code annotations, add NoopOutboxEnqueuer to all test sites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactoring**
  * Streamlined internal service architecture and dependency management
  * Enhanced event processing infrastructure
  * Improved database transaction handling patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->