### PR TITLE
refactor(mini-chat): deduplicate NoopOutboxEnqueuer in stream_service tests

### DIFF
--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -1287,6 +1287,21 @@ mod tests {
     use futures::stream;
     use oagw_sdk::error::StreamingError;
 
+    // ── Noop OutboxEnqueuer ──
+
+    #[allow(de0309_must_have_domain_model)]
+    struct NoopOutboxEnqueuer;
+    #[async_trait::async_trait]
+    impl crate::domain::repos::OutboxEnqueuer for NoopOutboxEnqueuer {
+        async fn enqueue_usage_event(
+            &self,
+            _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+            _event: mini_chat_sdk::UsageEvent,
+        ) -> Result<(), crate::domain::error::DomainError> {
+            Ok(())
+        }
+    }
+
     #[test]
     fn normalize_rate_limited() {
         let err = LlmProviderError::RateLimited {
@@ -1679,19 +1694,6 @@ mod tests {
                     charged_tokens: 0,
                     overshoot_capped: false,
                 })
-            }
-        }
-
-        #[domain_model]
-        struct NoopOutboxEnqueuer;
-        #[async_trait::async_trait]
-        impl crate::domain::repos::OutboxEnqueuer for NoopOutboxEnqueuer {
-            async fn enqueue_usage_event(
-                &self,
-                _runner: &(dyn modkit_db::secure::DBRunner + Sync),
-                _event: mini_chat_sdk::UsageEvent,
-            ) -> Result<(), crate::domain::error::DomainError> {
-                Ok(())
             }
         }
 
@@ -2466,19 +2468,6 @@ mod tests {
             }
         }
 
-        #[allow(de0309_must_have_domain_model)]
-        struct NoopOutboxEnqueuer2;
-        #[async_trait::async_trait]
-        impl crate::domain::repos::OutboxEnqueuer for NoopOutboxEnqueuer2 {
-            async fn enqueue_usage_event(
-                &self,
-                _runner: &(dyn modkit_db::secure::DBRunner + Sync),
-                _event: mini_chat_sdk::UsageEvent,
-            ) -> Result<(), crate::domain::error::DomainError> {
-                Ok(())
-            }
-        }
-
         let db = mock_db_provider(inmem_db().await);
         let tenant_id = Uuid::new_v4();
         let user_id = Uuid::new_v4();
@@ -2524,7 +2513,7 @@ mod tests {
             Arc::clone(&turn_repo_arc),
             Arc::clone(&message_repo_arc),
             Arc::new(NoopSettler) as Arc<dyn QuotaSettler>,
-            Arc::new(NoopOutboxEnqueuer2) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
+            Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
         ));
 
         let fctx = FinalizationCtx {
@@ -2656,19 +2645,6 @@ mod tests {
             }
         }
 
-        #[allow(de0309_must_have_domain_model)]
-        struct NoopOutboxEnqueuer3;
-        #[async_trait::async_trait]
-        impl crate::domain::repos::OutboxEnqueuer for NoopOutboxEnqueuer3 {
-            async fn enqueue_usage_event(
-                &self,
-                _runner: &(dyn modkit_db::secure::DBRunner + Sync),
-                _event: mini_chat_sdk::UsageEvent,
-            ) -> Result<(), crate::domain::error::DomainError> {
-                Ok(())
-            }
-        }
-
         let provider_resolver = Arc::new(ProviderResolver::single_provider(provider));
         let turn_repo = Arc::new(TurnRepo);
         let message_repo = Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
@@ -2680,7 +2656,7 @@ mod tests {
             Arc::clone(&turn_repo),
             Arc::clone(&message_repo),
             Arc::new(MockQuotaSettler) as Arc<dyn QuotaSettler>,
-            Arc::new(NoopOutboxEnqueuer3) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
+            Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
         ));
 
         let quota_svc = Arc::new(crate::domain::service::QuotaService::new(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests & Refactoring**
  * Consolidated and simplified test helpers and scaffolding to remove duplicated variants and standardize a no-op test implementation.
  * Streamlined test wiring across streaming-related tests for consistency.
  * No changes to public APIs or runtime behavior; no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->