### PR TITLE
feat(mini-chat): add audit plugin trait and static-audit-plugin (tracing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,6 +1885,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-static-mini-chat-audit-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cf-mini-chat-sdk",
+ "cf-modkit",
+ "cf-modkit-macros",
+ "cf-types-registry-sdk",
+ "inventory",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "cf-static-mini-chat-model-policy-plugin"
 version = "0.4.0"
 dependencies = [
@@ -3854,6 +3870,7 @@ dependencies = [
  "cf-static-authn-plugin",
  "cf-static-authz-plugin",
  "cf-static-credstore-plugin",
+ "cf-static-mini-chat-audit-plugin",
  "cf-static-mini-chat-model-policy-plugin",
  "cf-static-tr-plugin",
  "cf-tenant-resolver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
     "modules/mini-chat/mini-chat-sdk",
     "modules/mini-chat/mini-chat",
     "modules/mini-chat/plugins/static-model-policy-plugin",
+    "modules/mini-chat/plugins/static-audit-plugin",
 ]
 exclude = ["fuzz"]
 resolver = "3"

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -18,7 +18,7 @@ static-tenants = ["dep:static-tr-plugin"]
 static-authn = ["dep:static-authn-plugin"]
 static-authz = ["dep:static-authz-plugin"]
 static-credstore = ["dep:static-credstore-plugin"]
-mini-chat = ["dep:mini-chat", "dep:static-mini-chat-model-policy-plugin"]
+mini-chat = ["dep:mini-chat", "dep:static-mini-chat-model-policy-plugin", "dep:static-mini-chat-audit-plugin"]
 otel = ["modkit/otel"]
 
 [dependencies]
@@ -62,6 +62,7 @@ clap = { workspace = true }
 # Optional mini-chat module
 mini-chat = { package = "cf-mini-chat", path = "../../modules/mini-chat/mini-chat", optional = true }
 static-mini-chat-model-policy-plugin = { package = "cf-static-mini-chat-model-policy-plugin", path = "../../modules/mini-chat/plugins/static-model-policy-plugin", optional = true }
+static-mini-chat-audit-plugin = { package = "cf-static-mini-chat-audit-plugin", path = "../../modules/mini-chat/plugins/static-audit-plugin", optional = true }
 
 # Optional example module
 users-info = { path = "../../examples/modkit/users-info/users-info", optional = true }

--- a/apps/hyperspot-server/src/registered_modules.rs
+++ b/apps/hyperspot-server/src/registered_modules.rs
@@ -42,6 +42,9 @@ use mini_chat as _;
 #[cfg(feature = "mini-chat")]
 use static_mini_chat_model_policy_plugin as _;
 
+#[cfg(feature = "mini-chat")]
+use static_mini_chat_audit_plugin as _;
+
 // === Example Features ===
 
 #[cfg(feature = "users-info-example")]

--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -153,6 +153,10 @@ modules:
       #       prefix: ""
       #       secret_ref: "cred://azure-openai-key-tenant-b"
 
+  static-mini-chat-audit-plugin:
+    config:
+      enabled: true
+
   static-mini-chat-model-policy-plugin:
     config:
       vendor: "hyperspot"

--- a/modules/mini-chat/mini-chat-sdk/src/audit_models.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/audit_models.rs
@@ -1,0 +1,283 @@
+use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+/// Requester type for audit events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RequesterType {
+    User,
+    System,
+}
+
+/// Attachment kind metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachmentKind {
+    Document,
+    Image,
+}
+
+/// Metadata for a file attachment included in a turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttachmentMetadata {
+    pub attachment_id: Uuid,
+    pub attachment_kind: AttachmentKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_used_in_turn: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub doc_summary: Option<String>,
+}
+
+/// Token usage reported by the provider for audit purposes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditUsageTokens {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+}
+
+/// Latency measurements for a turn.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LatencyMs {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttft_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_ms: Option<u64>,
+}
+
+/// License-level policy decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LicenseDecision {
+    pub feature: String,
+    pub decision: String,
+}
+
+/// Quota scope for quota decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuotaScope {
+    Tokens,
+    WebSearch,
+}
+
+/// Quota-level policy decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QuotaDecision {
+    pub decision: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quota_scope: Option<QuotaScope>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub downgrade_from: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub downgrade_reason: Option<String>,
+}
+
+/// Combined policy decisions for a turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyDecisions {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub license: Option<LicenseDecision>,
+    pub quota: QuotaDecision,
+}
+
+/// Tool call counts for a turn.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ToolCalls {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_search_calls: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub web_search_calls: Option<u64>,
+}
+
+/// Discriminator for [`TurnAuditEvent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnAuditEventType {
+    TurnCompleted,
+    TurnFailed,
+}
+
+impl std::fmt::Display for TurnAuditEventType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TurnCompleted => f.write_str("turn_completed"),
+            Self::TurnFailed => f.write_str("turn_failed"),
+        }
+    }
+}
+
+/// Full turn audit event — emitted after a turn completes or fails.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnAuditEvent {
+    pub event_type: TurnAuditEventType,
+    #[serde(with = "time::serde::rfc3339")]
+    pub timestamp: OffsetDateTime,
+    pub tenant_id: Uuid,
+    pub requester_type: RequesterType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+
+    pub user_id: Uuid,
+    pub chat_id: Uuid,
+    pub turn_id: Uuid,
+    pub request_id: Uuid,
+    pub selected_model: String,
+    pub effective_model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_version_applied: Option<u64>,
+    pub usage: AuditUsageTokens,
+    pub latency_ms: LatencyMs,
+    pub policy_decisions: PolicyDecisions,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    /// User prompt text. The caller MUST redact secret patterns and truncate
+    /// to 8 KiB before setting this field (see DESIGN.md "Audit content handling").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+    /// Assistant response text. The caller MUST redact secret patterns and
+    /// truncate to 8 KiB before setting this field (see DESIGN.md "Audit content handling").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<AttachmentMetadata>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<ToolCalls>,
+}
+
+/// Discriminator for [`TurnMutationAuditEvent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnMutationAuditEventType {
+    TurnRetry,
+    TurnEdit,
+}
+
+impl std::fmt::Display for TurnMutationAuditEventType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TurnRetry => f.write_str("turn_retry"),
+            Self::TurnEdit => f.write_str("turn_edit"),
+        }
+    }
+}
+
+/// Shared audit event structure for turn mutations (retry, edit).
+///
+/// Both retry and edit carry the same fields: the acting user, the chat,
+/// the original request being replaced, and the new request that replaces it.
+/// `event_type` distinguishes the two.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnMutationAuditEvent {
+    pub event_type: TurnMutationAuditEventType,
+    #[serde(with = "time::serde::rfc3339")]
+    pub timestamp: OffsetDateTime,
+    pub tenant_id: Uuid,
+    pub requester_type: RequesterType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+
+    pub actor_user_id: Uuid,
+    pub chat_id: Uuid,
+    pub original_request_id: Uuid,
+    pub new_request_id: Uuid,
+}
+
+impl TurnMutationAuditEvent {
+    /// Build a `turn_retry` audit event.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_retry(
+        timestamp: OffsetDateTime,
+        tenant_id: Uuid,
+        requester_type: RequesterType,
+        trace_id: Option<String>,
+        actor_user_id: Uuid,
+        chat_id: Uuid,
+        original_request_id: Uuid,
+        new_request_id: Uuid,
+    ) -> Self {
+        Self {
+            event_type: TurnMutationAuditEventType::TurnRetry,
+            timestamp,
+            tenant_id,
+            requester_type,
+            trace_id,
+            actor_user_id,
+            chat_id,
+            original_request_id,
+            new_request_id,
+        }
+    }
+
+    /// Build a `turn_edit` audit event.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_edit(
+        timestamp: OffsetDateTime,
+        tenant_id: Uuid,
+        requester_type: RequesterType,
+        trace_id: Option<String>,
+        actor_user_id: Uuid,
+        chat_id: Uuid,
+        original_request_id: Uuid,
+        new_request_id: Uuid,
+    ) -> Self {
+        Self {
+            event_type: TurnMutationAuditEventType::TurnEdit,
+            timestamp,
+            tenant_id,
+            requester_type,
+            trace_id,
+            actor_user_id,
+            chat_id,
+            original_request_id,
+            new_request_id,
+        }
+    }
+}
+
+/// Audit event emitted when a user retries a turn.
+pub type TurnRetryAuditEvent = TurnMutationAuditEvent;
+
+/// Audit event emitted when a user edits a turn.
+pub type TurnEditAuditEvent = TurnMutationAuditEvent;
+
+/// Discriminator for [`TurnDeleteAuditEvent`].
+///
+/// Single-variant: the event type is always `"turn_delete"`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TurnDeleteAuditEventType {
+    #[default]
+    #[serde(rename = "turn_delete")]
+    TurnDelete,
+}
+
+impl std::fmt::Display for TurnDeleteAuditEventType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("turn_delete")
+    }
+}
+
+/// Audit event emitted when a user deletes a turn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TurnDeleteAuditEvent {
+    pub event_type: TurnDeleteAuditEventType,
+    #[serde(with = "time::serde::rfc3339")]
+    pub timestamp: OffsetDateTime,
+    pub tenant_id: Uuid,
+    pub requester_type: RequesterType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+
+    pub actor_user_id: Uuid,
+    pub chat_id: Uuid,
+    pub request_id: Uuid,
+}

--- a/modules/mini-chat/mini-chat-sdk/src/error.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/error.rs
@@ -10,6 +10,33 @@ pub enum MiniChatModelPolicyPluginError {
     Internal(String),
 }
 
+/// Errors returned by `MiniChatAuditPluginClientV1` methods.
+///
+/// Mirrors `PublishError` transient/permanent classification so callers can
+/// decide whether to retry or record the failure as permanent.
+#[derive(Debug, Error)]
+pub enum MiniChatAuditPluginError {
+    /// Transient failure — safe to retry (network timeout, broker unavailable).
+    #[error("transient audit plugin error: {0}")]
+    Transient(String),
+
+    /// Permanent failure — do not retry (schema mismatch, auth rejected).
+    #[error("permanent audit plugin error: {0}")]
+    Permanent(String),
+}
+
+impl MiniChatAuditPluginError {
+    #[must_use]
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::Transient(_))
+    }
+
+    #[must_use]
+    pub fn is_permanent(&self) -> bool {
+        matches!(self, Self::Permanent(_))
+    }
+}
+
 /// Errors returned by `publish_usage()`.
 #[derive(Debug, Error)]
 pub enum PublishError {

--- a/modules/mini-chat/mini-chat-sdk/src/gts.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/gts.rs
@@ -20,3 +20,19 @@ use modkit::gts::BaseModkitPluginV1;
     properties = ""
 )]
 pub struct MiniChatModelPolicyPluginSpecV1;
+
+/// GTS type definition for mini-chat audit plugin instances.
+///
+/// # Instance ID Format
+///
+/// ```text
+/// gts.x.core.modkit.plugin.v1~<vendor>.<package>.mini_chat_audit.plugin.v1~
+/// ```
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = BaseModkitPluginV1,
+    schema_id = "gts.x.core.modkit.plugin.v1~x.core.mini_chat_audit.plugin.v1~",
+    description = "Mini-Chat Audit plugin specification",
+    properties = ""
+)]
+pub struct MiniChatAuditPluginSpecV1;

--- a/modules/mini-chat/mini-chat-sdk/src/lib.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/lib.rs
@@ -1,12 +1,19 @@
+pub mod audit_models;
 pub mod error;
 pub mod gts;
 pub mod models;
 pub mod plugin_api;
 
-pub use error::{MiniChatModelPolicyPluginError, PublishError};
-pub use gts::MiniChatModelPolicyPluginSpecV1;
+pub use audit_models::{
+    AttachmentKind, AttachmentMetadata, AuditUsageTokens, LatencyMs, LicenseDecision,
+    PolicyDecisions, QuotaDecision, QuotaScope, RequesterType, ToolCalls, TurnAuditEvent,
+    TurnAuditEventType, TurnDeleteAuditEvent, TurnDeleteAuditEventType, TurnEditAuditEvent,
+    TurnMutationAuditEvent, TurnMutationAuditEventType, TurnRetryAuditEvent,
+};
+pub use error::{MiniChatAuditPluginError, MiniChatModelPolicyPluginError, PublishError};
+pub use gts::{MiniChatAuditPluginSpecV1, MiniChatModelPolicyPluginSpecV1};
 pub use models::{
     KillSwitches, ModelCatalogEntry, ModelTier, PolicySnapshot, PolicyVersionInfo, TierLimits,
     UsageEvent, UsageTokens, UserLimits,
 };
-pub use plugin_api::MiniChatModelPolicyPluginClientV1;
+pub use plugin_api::{MiniChatAuditPluginClientV1, MiniChatModelPolicyPluginClientV1};

--- a/modules/mini-chat/mini-chat-sdk/src/plugin_api.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/plugin_api.rs
@@ -1,7 +1,10 @@
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use crate::error::{MiniChatModelPolicyPluginError, PublishError};
+use crate::audit_models::{
+    TurnAuditEvent, TurnDeleteAuditEvent, TurnEditAuditEvent, TurnRetryAuditEvent,
+};
+use crate::error::{MiniChatAuditPluginError, MiniChatModelPolicyPluginError, PublishError};
 use crate::models::{PolicySnapshot, PolicyVersionInfo, UsageEvent, UserLimits};
 
 /// Plugin API trait for mini-chat model policy implementations.
@@ -36,4 +39,52 @@ pub trait MiniChatModelPolicyPluginClientV1: Send + Sync {
     /// Called by the outbox processor after the finalization transaction
     /// commits. Plugins can forward the event to external billing systems.
     async fn publish_usage(&self, payload: UsageEvent) -> Result<(), PublishError>;
+}
+
+/// Plugin API trait for mini-chat audit event publishing.
+///
+/// Plugins implement this trait to receive audit events from the mini-chat
+/// module. The mini-chat module discovers plugins via GTS types-registry and
+/// dispatches audit events to all registered implementations.
+///
+/// # Caller contract
+///
+/// The **caller** (mini-chat domain service) MUST redact secret patterns and
+/// truncate string content (max 8 KiB per field) *before* invoking any method
+/// on this trait. Plugins MUST assume all content fields are already sanitized.
+/// See DESIGN.md "Audit content handling (P1)" for the full redaction rule table.
+///
+/// # Delivery semantics
+///
+/// Audit emission is best-effort (fire-and-forget after DB commit). There is no
+/// transactional outbox for audit events. If the process crashes between DB
+/// commit and audit emission, the event is lost. Callers SHOULD track emission
+/// outcomes via `mini_chat_audit_emit_total{result}` metrics.
+///
+/// # Independence
+///
+/// When multiple audit plugin instances are registered, each MUST be
+/// independent. A failure in one plugin MUST NOT prevent delivery to others.
+#[async_trait]
+pub trait MiniChatAuditPluginClientV1: Send + Sync {
+    /// Emit a turn audit event (turn completed or failed).
+    async fn emit_turn_audit(&self, event: TurnAuditEvent) -> Result<(), MiniChatAuditPluginError>;
+
+    /// Emit a turn-retry audit event.
+    async fn emit_turn_retry_audit(
+        &self,
+        event: TurnRetryAuditEvent,
+    ) -> Result<(), MiniChatAuditPluginError>;
+
+    /// Emit a turn-edit audit event.
+    async fn emit_turn_edit_audit(
+        &self,
+        event: TurnEditAuditEvent,
+    ) -> Result<(), MiniChatAuditPluginError>;
+
+    /// Emit a turn-delete audit event.
+    async fn emit_turn_delete_audit(
+        &self,
+        event: TurnDeleteAuditEvent,
+    ) -> Result<(), MiniChatAuditPluginError>;
 }

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use authz_resolver_sdk::AuthZResolverClient;
-use mini_chat_sdk::MiniChatModelPolicyPluginSpecV1;
+use mini_chat_sdk::{MiniChatAuditPluginSpecV1, MiniChatModelPolicyPluginSpecV1};
 use modkit::api::OpenApiRegistry;
 use modkit::{DatabaseCapability, Module, ModuleCtx, RestApiCapability};
 use oagw_sdk::ServiceGatewayClientV1;
@@ -86,22 +86,23 @@ impl Module for MiniChatModule {
             ));
         }
 
-        // Register model-policy plugin schema in types-registry
         let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
-        let schema_str = MiniChatModelPolicyPluginSpecV1::gts_schema_with_refs_as_string();
-        let mut schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
-        if let Some(obj) = schema_json.as_object_mut() {
-            obj.insert(
-                "additionalProperties".to_owned(),
-                serde_json::Value::Bool(false),
-            );
-        }
-        let results = registry.register(vec![schema_json]).await?;
-        RegisterResult::ensure_all_ok(&results)?;
-        info!(
-            schema_id = %MiniChatModelPolicyPluginSpecV1::gts_schema_id(),
-            "Registered model-policy plugin schema in types-registry"
-        );
+        register_plugin_schemas(
+            &*registry,
+            &[
+                (
+                    MiniChatModelPolicyPluginSpecV1::gts_schema_with_refs_as_string(),
+                    MiniChatModelPolicyPluginSpecV1::gts_schema_id(),
+                    "model-policy",
+                ),
+                (
+                    MiniChatAuditPluginSpecV1::gts_schema_with_refs_as_string(),
+                    MiniChatAuditPluginSpecV1::gts_schema_id(),
+                    "audit",
+                ),
+            ],
+        )
+        .await?;
 
         self.url_prefix
             .set(cfg.url_prefix)
@@ -194,4 +195,28 @@ impl RestApiCapability for MiniChatModule {
         info!("Mini-chat REST routes registered successfully");
         Ok(router)
     }
+}
+
+async fn register_plugin_schemas(
+    registry: &dyn TypesRegistryClient,
+    schemas: &[(String, &str, &str)],
+) -> anyhow::Result<()> {
+    let mut payload = Vec::with_capacity(schemas.len());
+    for (schema_str, schema_id, _label) in schemas {
+        let mut schema_json: serde_json::Value = serde_json::from_str(schema_str)?;
+        let obj = schema_json
+            .as_object_mut()
+            .ok_or_else(|| anyhow::anyhow!("schema {schema_id} is not a JSON object"))?;
+        obj.insert(
+            "additionalProperties".to_owned(),
+            serde_json::Value::Bool(false),
+        );
+        payload.push(schema_json);
+    }
+    let results = registry.register(payload).await?;
+    RegisterResult::ensure_all_ok(&results)?;
+    for (_schema_str, schema_id, label) in schemas {
+        info!(schema_id = %schema_id, "Registered {label} plugin schema in types-registry");
+    }
+    Ok(())
 }

--- a/modules/mini-chat/plugins/static-audit-plugin/Cargo.toml
+++ b/modules/mini-chat/plugins/static-audit-plugin/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "cf-static-mini-chat-audit-plugin"
+description = "Static audit plugin for mini-chat — logs audit events via tracing"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-module"]
+categories = ["artificial-intelligence"]
+
+[lib]
+name = "static_mini_chat_audit_plugin"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Plugin SDK
+mini-chat-sdk = { package = "cf-mini-chat-sdk", path = "../../mini-chat-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", path = "../../../system/types-registry/types-registry-sdk" }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-macros = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# Required by modkit::module macro
+inventory = { workspace = true }

--- a/modules/mini-chat/plugins/static-audit-plugin/README.md
+++ b/modules/mini-chat/plugins/static-audit-plugin/README.md
@@ -1,0 +1,48 @@
+# Static Mini-Chat Audit Plugin
+
+Mini-chat audit plugin that logs audit events via `tracing`. Designed for development, testing, and deployments where a full eventing backend is unnecessary.
+
+## Overview
+
+The `cf-static-mini-chat-audit-plugin` implements `MiniChatAuditPluginClientV1` and emits structured log records for four audit event types:
+
+- **`emit_turn_audit`** — completed chat turn (prompt, response, usage, policy decisions)
+- **`emit_turn_retry_audit`** — turn retry (mutation of an existing turn)
+- **`emit_turn_edit_audit`** — turn edit (prompt replacement)
+- **`emit_turn_delete_audit`** — turn deletion
+
+The plugin registers itself via the types registry as a `MiniChatAuditPluginSpecV1` instance and is discovered by the `mini-chat` module through `ClientHub`.
+
+## Configuration
+
+Add the plugin section under your module configuration:
+
+```yaml
+static-mini-chat-audit-plugin:
+  config:
+    enabled: true   # default: true
+```
+
+When `enabled: false`, the plugin still registers in the types registry and `ClientHub`, but all `emit_*` methods return immediately without logging.
+
+## Architecture
+
+```text
+module.rs          ModKit module — init, config loading, GTS registration
+config.rs          YAML config model (enabled flag)
+domain/
+  service.rs       Service — holds enabled state
+  client.rs        MiniChatAuditPluginClientV1 impl (structured tracing logs)
+  mod.rs           Re-exports
+```
+
+### Init sequence
+
+1. Load `StaticMiniChatAuditPluginConfig` from module config
+2. Create `Service` with the `enabled` flag
+3. Register GTS plugin instance in types-registry
+4. Register `MiniChatAuditPluginClientV1` scoped client in `ClientHub`
+
+## License
+
+Apache-2.0

--- a/modules/mini-chat/plugins/static-audit-plugin/src/config.rs
+++ b/modules/mini-chat/plugins/static-audit-plugin/src/config.rs
@@ -1,0 +1,23 @@
+use serde::Deserialize;
+
+/// Plugin configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StaticMiniChatAuditPluginConfig {
+    /// When `false`, the plugin registers but does not emit audit events.
+    /// Defaults to `true`.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+impl Default for StaticMiniChatAuditPluginConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+        }
+    }
+}
+
+const fn default_enabled() -> bool {
+    true
+}

--- a/modules/mini-chat/plugins/static-audit-plugin/src/domain/client.rs
+++ b/modules/mini-chat/plugins/static-audit-plugin/src/domain/client.rs
@@ -1,0 +1,88 @@
+use async_trait::async_trait;
+use mini_chat_sdk::{
+    MiniChatAuditPluginClientV1, MiniChatAuditPluginError, TurnAuditEvent, TurnDeleteAuditEvent,
+    TurnEditAuditEvent, TurnRetryAuditEvent,
+};
+use tracing::info;
+
+use super::service::Service;
+
+#[async_trait]
+impl MiniChatAuditPluginClientV1 for Service {
+    async fn emit_turn_audit(&self, event: TurnAuditEvent) -> Result<(), MiniChatAuditPluginError> {
+        if !self.enabled {
+            return Ok(());
+        }
+        info!(
+            event_type = %event.event_type,
+            tenant_id = %event.tenant_id,
+            user_id = %event.user_id,
+            chat_id = %event.chat_id,
+            turn_id = %event.turn_id,
+            request_id = %event.request_id,
+            selected_model = %event.selected_model,
+            effective_model = %event.effective_model,
+            input_tokens = event.usage.input_tokens,
+            output_tokens = event.usage.output_tokens,
+            error_code = event.error_code.as_deref(),
+            "audit: turn event"
+        );
+        Ok(())
+    }
+
+    async fn emit_turn_retry_audit(
+        &self,
+        event: TurnRetryAuditEvent,
+    ) -> Result<(), MiniChatAuditPluginError> {
+        if !self.enabled {
+            return Ok(());
+        }
+        info!(
+            event_type = %event.event_type,
+            tenant_id = %event.tenant_id,
+            actor_user_id = %event.actor_user_id,
+            chat_id = %event.chat_id,
+            original_request_id = %event.original_request_id,
+            new_request_id = %event.new_request_id,
+            "audit: turn retry event"
+        );
+        Ok(())
+    }
+
+    async fn emit_turn_edit_audit(
+        &self,
+        event: TurnEditAuditEvent,
+    ) -> Result<(), MiniChatAuditPluginError> {
+        if !self.enabled {
+            return Ok(());
+        }
+        info!(
+            event_type = %event.event_type,
+            tenant_id = %event.tenant_id,
+            actor_user_id = %event.actor_user_id,
+            chat_id = %event.chat_id,
+            original_request_id = %event.original_request_id,
+            new_request_id = %event.new_request_id,
+            "audit: turn edit event"
+        );
+        Ok(())
+    }
+
+    async fn emit_turn_delete_audit(
+        &self,
+        event: TurnDeleteAuditEvent,
+    ) -> Result<(), MiniChatAuditPluginError> {
+        if !self.enabled {
+            return Ok(());
+        }
+        info!(
+            event_type = %event.event_type,
+            tenant_id = %event.tenant_id,
+            actor_user_id = %event.actor_user_id,
+            chat_id = %event.chat_id,
+            request_id = %event.request_id,
+            "audit: turn delete event"
+        );
+        Ok(())
+    }
+}

--- a/modules/mini-chat/plugins/static-audit-plugin/src/domain/mod.rs
+++ b/modules/mini-chat/plugins/static-audit-plugin/src/domain/mod.rs
@@ -1,0 +1,4 @@
+mod client;
+pub mod service;
+
+pub use service::Service;

--- a/modules/mini-chat/plugins/static-audit-plugin/src/domain/service.rs
+++ b/modules/mini-chat/plugins/static-audit-plugin/src/domain/service.rs
@@ -1,0 +1,9 @@
+use modkit_macros::domain_model;
+/// Service for the static audit plugin.
+///
+/// When `enabled` is `false`, all emit methods return `Ok(())` immediately
+/// without writing to the log.
+#[domain_model]
+pub struct Service {
+    pub enabled: bool,
+}

--- a/modules/mini-chat/plugins/static-audit-plugin/src/lib.rs
+++ b/modules/mini-chat/plugins/static-audit-plugin/src/lib.rs
@@ -1,0 +1,7 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+pub mod config;
+pub mod domain;
+pub mod module;
+
+pub use module::StaticMiniChatAuditPlugin;

--- a/modules/mini-chat/plugins/static-audit-plugin/src/module.rs
+++ b/modules/mini-chat/plugins/static-audit-plugin/src/module.rs
@@ -1,0 +1,80 @@
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use mini_chat_sdk::{MiniChatAuditPluginClientV1, MiniChatAuditPluginSpecV1};
+use modkit::Module;
+use modkit::client_hub::ClientScope;
+use modkit::context::ModuleCtx;
+use modkit::gts::BaseModkitPluginV1;
+use tracing::info;
+use types_registry_sdk::{RegisterResult, TypesRegistryClient};
+
+use crate::config::StaticMiniChatAuditPluginConfig;
+use crate::domain::Service;
+
+const VENDOR: &str = "cyber-fabric";
+const PRIORITY: i16 = 100;
+
+/// Static audit plugin module for mini-chat.
+///
+/// Logs all audit events via `tracing` for development and testing.
+/// When `enabled: false` in config, the plugin registers normally but
+/// all emit methods return immediately without logging.
+#[modkit::module(
+    name = "static-mini-chat-audit-plugin",
+    deps = ["types-registry"]
+)]
+pub struct StaticMiniChatAuditPlugin {
+    service: OnceLock<Arc<Service>>,
+}
+
+impl Default for StaticMiniChatAuditPlugin {
+    fn default() -> Self {
+        Self {
+            service: OnceLock::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Module for StaticMiniChatAuditPlugin {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        let cfg: StaticMiniChatAuditPluginConfig = ctx.config()?;
+        info!(
+            enabled = cfg.enabled,
+            "Loaded static mini-chat audit plugin configuration"
+        );
+
+        let service = Arc::new(Service {
+            enabled: cfg.enabled,
+        });
+        self.service
+            .set(service.clone())
+            .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
+
+        let instance_id =
+            MiniChatAuditPluginSpecV1::gts_make_instance_id("x.core._.static_mini_chat_audit.v1");
+
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
+        let instance = BaseModkitPluginV1::<MiniChatAuditPluginSpecV1> {
+            id: instance_id.clone(),
+            vendor: VENDOR.to_owned(),
+            priority: PRIORITY,
+            properties: MiniChatAuditPluginSpecV1,
+        };
+        let instance_json = serde_json::to_value(&instance)?;
+
+        let results = registry.register(vec![instance_json]).await?;
+        RegisterResult::ensure_all_ok(&results)?;
+
+        let api: Arc<dyn MiniChatAuditPluginClientV1> = service;
+        ctx.client_hub()
+            .register_scoped::<dyn MiniChatAuditPluginClientV1>(
+                ClientScope::gts_id(&instance_id),
+                api,
+            );
+
+        info!(instance_id = %instance_id, "Static mini-chat audit plugin registered");
+        Ok(())
+    }
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -263,3 +263,8 @@ git_release_enable = false
 name = "cf-mini-chat"
 changelog_update = false
 git_release_enable = false
+
+[[package]]
+name = "cf-static-mini-chat-audit-plugin"
+changelog_update = false
+git_release_enable = false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mini-chat audit: rich structured audit events (turn, retry, edit, delete) and a public audit plugin client for emitting them; included a static logging audit plugin for development/testing.

* **Chores**
  * Integrated the plugin into the workspace and server registration, added default-enabled configuration, packaging metadata, and comprehensive README documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->