### PR TITLE
refactor(mini-chat): improve structured logging and tracing spans

### DIFF
--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -34,6 +34,10 @@ logging:
     console_level: debug
     file: "logs/api.log"
     file_level: debug
+  mini_chat:
+    console_level: debug
+    file: "logs/mini-chat.log"
+    file_level: debug
 
 modules:
   api-gateway:

--- a/modules/mini-chat/mini-chat/src/api/rest/error.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/error.rs
@@ -68,8 +68,8 @@ impl From<DomainError> for Problem {
             )
             .with_trace_id(trace_id.unwrap_or_default()),
 
-            DomainError::Database { .. } | DomainError::InternalError { .. } => {
-                tracing::error!(error = ?e, "Internal error occurred");
+            DomainError::Database { message } | DomainError::InternalError { message } => {
+                tracing::error!(error_message = %message, "internal error occurred");
                 Problem::new(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "Internal Error",

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
@@ -15,7 +15,7 @@ use modkit_security::SecurityContext;
 use tokio::sync::mpsc;
 use tokio::time::{Interval, interval};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{Instrument, debug, info, warn};
 
 use crate::api::rest::dto::{MessageDto, StreamMessageRequest};
 use crate::api::rest::sse::{StreamEventKind, StreamPhase};
@@ -25,7 +25,7 @@ use crate::infra::db::entity::chat_turn::Model as TurnModel;
 use crate::module::AppServices;
 
 /// GET /mini-chat/v1/chats/{id}/messages
-#[tracing::instrument(skip(svc, ctx, query))]
+#[tracing::instrument(skip(svc, ctx, query), fields(chat_id = %chat_id))]
 pub(crate) async fn list_messages(
     Extension(ctx): Extension<SecurityContext>,
     Extension(svc): Extension<Arc<AppServices>>,
@@ -41,6 +41,7 @@ pub(crate) async fn list_messages(
 ///
 /// Pre-stream validation returns JSON errors. On success, opens an SSE
 /// connection and relays events from the provider through a bounded channel.
+#[tracing::instrument(skip(svc, ctx, body), fields(chat_id = %chat_id, turn_request_id))]
 pub(crate) async fn stream_message(
     Extension(ctx): Extension<SecurityContext>,
     Extension(svc): Extension<Arc<AppServices>>,
@@ -57,16 +58,24 @@ pub(crate) async fn stream_message(
         .into_response();
     }
 
+    // Resolve request_id early so it's available for error logging below.
+    let request_id = body.request_id.unwrap_or_else(uuid::Uuid::new_v4);
+    tracing::Span::current().record("turn_request_id", tracing::field::display(request_id));
+
     // ── Resolve model + provider from chat ─────────────────────────────
     let chat = match svc.chats.get_chat(&ctx, chat_id).await {
         Ok(c) => c,
         Err(e) => {
-            let status = if e.to_string().contains("not found") {
-                StatusCode::NOT_FOUND
+            let (status, detail) = if e.to_string().contains("not found") {
+                (StatusCode::NOT_FOUND, e.to_string())
             } else {
-                StatusCode::INTERNAL_SERVER_ERROR
+                warn!(error = %e, "failed to fetch chat for stream");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "An internal error occurred".to_owned(),
+                )
             };
-            return Problem::new(status, "Error", e.to_string()).into_response();
+            return Problem::new(status, "Error", detail).into_response();
         }
     };
 
@@ -78,6 +87,7 @@ pub(crate) async fn stream_message(
     {
         Ok(r) => r,
         Err(e) => {
+            warn!(error = %e, model = %selected_model, "model resolution failed");
             return Problem::new(StatusCode::BAD_REQUEST, "Bad Request", e.to_string())
                 .into_response();
         }
@@ -89,9 +99,7 @@ pub(crate) async fn stream_message(
     let (tx, rx) = mpsc::channel::<StreamEvent>(capacity);
     let cancel = CancellationToken::new();
 
-    let request_id = body.request_id.unwrap_or_else(uuid::Uuid::new_v4);
-
-    info!(chat_id = %chat_id, %request_id, model = %resolved.model_id, provider_id = %resolved.provider_id, "starting SSE stream");
+    info!(model = %resolved.model_id, provider_id = %resolved.provider_id, "starting SSE stream");
 
     // Pre-stream checks + spawn the provider task
     let provider_handle = match svc
@@ -111,15 +119,19 @@ pub(crate) async fn stream_message(
         Err(StreamError::Replay { turn }) => {
             return replay_response(&svc, &selected_model, &turn, ping_secs).await;
         }
-        Err(e) => return stream_error_response(e),
+        Err(e) => return stream_error_response(&e),
     };
 
     // Monitor provider task for panics
-    tokio::spawn(async move {
-        if let Err(e) = provider_handle.await {
-            tracing::error!(error = ?e, "provider task panicked");
+    let monitor_span = tracing::Span::current();
+    tokio::spawn(
+        async move {
+            if let Err(e) = provider_handle.await {
+                tracing::error!(error = ?e, "provider task panicked");
+            }
         }
-    });
+        .instrument(monitor_span),
+    );
 
     // Build the SSE relay stream
     let relay = SseRelay::new(rx, cancel, ping_secs);
@@ -130,24 +142,29 @@ pub(crate) async fn stream_message(
 }
 
 /// Map a [`StreamError`] to an appropriate HTTP error response.
-fn stream_error_response(err: StreamError) -> Response {
+///
+/// Caller is expected to be within an instrumented span that carries
+/// `chat_id` and `turn_request_id` fields.
+#[allow(clippy::cognitive_complexity)]
+fn stream_error_response(err: &StreamError) -> Response {
     match err {
         StreamError::Replay { .. } => {
             // Completed turns are handled by replay_response(); this arm covers
             // the defensive case where Replay leaks through without interception.
             Problem::new(StatusCode::CONFLICT, "Conflict", "Duplicate request_id").into_response()
         }
-        StreamError::Conflict { message, .. } => {
-            Problem::new(StatusCode::CONFLICT, "Conflict", &message).into_response()
+        StreamError::Conflict { message, code } => {
+            info!(conflict_code = %code, "stream request conflict");
+            Problem::new(StatusCode::CONFLICT, "Conflict", message).into_response()
         }
         StreamError::ChatNotFound { .. } => {
             Problem::new(StatusCode::NOT_FOUND, "Not Found", "Chat not found").into_response()
         }
-        StreamError::AuthorizationFailed { ref source } => {
+        StreamError::AuthorizationFailed { source } => {
             warn!(error = %source, "stream authorization failed");
             Problem::new(StatusCode::FORBIDDEN, "Forbidden", "Access denied").into_response()
         }
-        StreamError::TurnCreationFailed { ref source } => {
+        StreamError::TurnCreationFailed { source } => {
             warn!(error = %source, "pre-stream turn creation failed");
             Problem::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -160,8 +177,10 @@ fn stream_error_response(err: StreamError) -> Response {
             error_code,
             http_status,
         } => {
-            let status = StatusCode::from_u16(http_status).unwrap_or(StatusCode::TOO_MANY_REQUESTS);
-            Problem::new(status, "Quota Exhausted", &error_code).into_response()
+            info!(error_code = %error_code, http_status = *http_status, "quota exhausted, request rejected");
+            let status =
+                StatusCode::from_u16(*http_status).unwrap_or(StatusCode::TOO_MANY_REQUESTS);
+            Problem::new(status, "Quota Exhausted", error_code).into_response()
         }
     }
 }
@@ -317,12 +336,16 @@ impl Stream for SseRelay {
             }
             Poll::Ready(None) => {
                 // Channel closed — provider task exited
-                debug!("provider channel closed");
                 this.done = true;
 
                 // If no terminal event was received, emit an error to honour
                 // the SSE contract (streams must end with done or error).
-                if !this.phase.is_terminal() {
+                if this.phase.is_terminal() {
+                    debug!("provider channel closed");
+                } else {
+                    warn!(
+                        "provider channel closed without terminal event - emitting synthetic error"
+                    );
                     let error_event = StreamEvent::Error(crate::domain::stream_events::ErrorData {
                         code: "stream_interrupted".to_owned(),
                         message: "Provider stream ended unexpectedly".to_owned(),

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/reactions.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/reactions.rs
@@ -9,7 +9,7 @@ use crate::api::rest::dto::{ReactionDto, SetReactionReq};
 use crate::module::AppServices;
 
 /// PUT /mini-chat/v1/chats/{id}/messages/{msg_id}/reaction
-#[tracing::instrument(skip(svc, ctx, req_body))]
+#[tracing::instrument(skip(svc, ctx, req_body), fields(chat_id = %chat_id, msg_id = %msg_id))]
 pub(crate) async fn put_reaction(
     Extension(ctx): Extension<SecurityContext>,
     Extension(svc): Extension<Arc<AppServices>>,
@@ -24,7 +24,7 @@ pub(crate) async fn put_reaction(
 }
 
 /// DELETE /mini-chat/v1/chats/{id}/messages/{msg_id}/reaction
-#[tracing::instrument(skip(svc, ctx))]
+#[tracing::instrument(skip(svc, ctx), fields(chat_id = %chat_id, msg_id = %msg_id))]
 pub(crate) async fn delete_reaction(
     Extension(ctx): Extension<SecurityContext>,
     Extension(svc): Extension<Arc<AppServices>>,

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
@@ -10,7 +10,7 @@ use modkit_security::SecurityContext;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{Instrument, info, warn};
 use utoipa::ToSchema;
 
 use super::messages::SseRelay;
@@ -46,6 +46,7 @@ fn map_turn_state(state: &TurnState) -> &'static str {
 }
 
 /// GET /mini-chat/v1/chats/{id}/turns/{request_id}
+#[tracing::instrument(skip(svc, ctx), fields(chat_id = %chat_id, turn_request_id = %request_id))]
 pub(crate) async fn get_turn(
     Extension(ctx): Extension<SecurityContext>,
     Extension(svc): Extension<Arc<AppServices>>,
@@ -65,10 +66,11 @@ pub(crate) async fn get_turn(
     let scope = scope.tenant_only();
 
     let conn = svc.db.conn().map_err(|e| {
+        tracing::error!(error = %e, "failed to acquire DB connection for get_turn");
         Problem::new(
             StatusCode::INTERNAL_SERVER_ERROR,
             "Internal Error",
-            e.to_string(),
+            "An internal error occurred",
         )
     })?;
 
@@ -77,10 +79,11 @@ pub(crate) async fn get_turn(
         .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
         .await
         .map_err(|e| {
+            tracing::error!(error = %e, "failed to fetch turn from DB");
             Problem::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Internal Error",
-                e.to_string(),
+                "An internal error occurred",
             )
         })?
         .ok_or_else(|| Problem::new(StatusCode::NOT_FOUND, "turn_not_found", "Turn not found"))?;
@@ -105,6 +108,7 @@ pub(crate) struct DeleteTurnResponse {
 }
 
 /// DELETE /mini-chat/v1/chats/{id}/turns/{request_id}
+#[tracing::instrument(skip(svc, ctx), fields(chat_id = %chat_id, turn_request_id = %request_id))]
 pub(crate) async fn delete_turn(
     Extension(ctx): Extension<SecurityContext>,
     Extension(svc): Extension<Arc<AppServices>>,
@@ -114,7 +118,7 @@ pub(crate) async fn delete_turn(
         .turns
         .delete(&ctx, chat_id, request_id)
         .await
-        .map_err(mutation_error_to_problem)?;
+        .map_err(|e| mutation_error_to_problem(&e))?;
 
     Ok(Json(DeleteTurnResponse {
         request_id: result.request_id,
@@ -127,6 +131,7 @@ pub(crate) async fn delete_turn(
 // ════════════════════════════════════════════════════════════════════════════
 
 /// POST /mini-chat/v1/chats/{id}/turns/{request_id}/retry
+#[tracing::instrument(skip(svc, ctx), fields(chat_id = %chat_id, turn_request_id = %request_id))]
 pub(crate) async fn retry_turn(
     Extension(ctx): Extension<SecurityContext>,
     Extension(svc): Extension<Arc<AppServices>>,
@@ -134,7 +139,7 @@ pub(crate) async fn retry_turn(
 ) -> Response {
     let mutation = match svc.turns.retry(&ctx, chat_id, request_id).await {
         Ok(m) => m,
-        Err(e) => return mutation_error_to_problem(e).into_response(),
+        Err(e) => return mutation_error_to_problem(&e).into_response(),
     };
 
     start_mutation_stream(&svc, ctx, chat_id, mutation).await
@@ -152,6 +157,7 @@ pub struct EditTurnRequest {
 impl modkit::api::api_dto::RequestApiDto for EditTurnRequest {}
 
 /// PATCH /mini-chat/v1/chats/{id}/turns/{request_id}
+#[tracing::instrument(skip(svc, ctx, body), fields(chat_id = %chat_id, turn_request_id = %request_id))]
 pub(crate) async fn edit_turn(
     Extension(ctx): Extension<SecurityContext>,
     Extension(svc): Extension<Arc<AppServices>>,
@@ -173,7 +179,7 @@ pub(crate) async fn edit_turn(
         .await
     {
         Ok(m) => m,
-        Err(e) => return mutation_error_to_problem(e).into_response(),
+        Err(e) => return mutation_error_to_problem(&e).into_response(),
     };
 
     start_mutation_stream(&svc, ctx, chat_id, mutation).await
@@ -183,6 +189,7 @@ pub(crate) async fn edit_turn(
 // Shared helpers
 // ════════════════════════════════════════════════════════════════════════════
 
+#[allow(clippy::cognitive_complexity)]
 async fn start_mutation_stream(
     svc: &AppServices,
     ctx: SecurityContext,
@@ -192,15 +199,17 @@ async fn start_mutation_stream(
     let chat = match svc.chats.get_chat(&ctx, chat_id).await {
         Ok(c) => c,
         Err(e) => {
+            warn!(error = %e, "failed to fetch chat for mutation stream");
             return Problem::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Internal Error",
-                e.to_string(),
+                "An internal error occurred",
             )
             .into_response();
         }
     };
 
+    let chat_model = chat.model.clone();
     let resolved = match svc
         .models
         .resolve_model(ctx.subject_id(), Some(chat.model))
@@ -208,6 +217,7 @@ async fn start_mutation_stream(
     {
         Ok(r) => r,
         Err(e) => {
+            warn!(error = %e, model = %chat_model, "model resolution failed for mutation stream");
             return Problem::new(StatusCode::BAD_REQUEST, "Bad Request", e.to_string())
                 .into_response();
         }
@@ -240,14 +250,18 @@ async fn start_mutation_stream(
         .await
     {
         Ok(handle) => handle,
-        Err(e) => return stream_error_to_response(e),
+        Err(e) => return stream_error_to_response(&e),
     };
 
-    tokio::spawn(async move {
-        if let Err(e) = provider_handle.await {
-            tracing::error!(error = ?e, "provider task panicked");
+    let monitor_span = tracing::Span::current();
+    tokio::spawn(
+        async move {
+            if let Err(e) = provider_handle.await {
+                tracing::error!(error = ?e, "provider task panicked");
+            }
         }
-    });
+        .instrument(monitor_span),
+    );
 
     let relay = SseRelay::new(rx, cancel, ping_secs);
     Sse::new(relay)
@@ -256,7 +270,10 @@ async fn start_mutation_stream(
 }
 
 /// Map `MutationError` to HTTP problem response.
-fn mutation_error_to_problem(err: MutationError) -> Problem {
+///
+/// Caller is expected to be within an instrumented span that carries
+/// `chat_id` and `turn_request_id` fields.
+fn mutation_error_to_problem(err: &MutationError) -> Problem {
     match err {
         MutationError::ChatNotFound { .. } => {
             Problem::new(StatusCode::NOT_FOUND, "chat_not_found", "Chat not found")
@@ -264,11 +281,14 @@ fn mutation_error_to_problem(err: MutationError) -> Problem {
         MutationError::TurnNotFound { .. } => {
             Problem::new(StatusCode::NOT_FOUND, "turn_not_found", "Turn not found")
         }
-        MutationError::InsufficientPermissions => Problem::new(
-            StatusCode::FORBIDDEN,
-            "insufficient_permissions",
-            "You do not have permission to modify this turn",
-        ),
+        MutationError::InsufficientPermissions => {
+            warn!("insufficient permissions for turn mutation");
+            Problem::new(
+                StatusCode::FORBIDDEN,
+                "insufficient_permissions",
+                "You do not have permission to modify this turn",
+            )
+        }
         MutationError::InvalidTurnState { state } => Problem::new(
             StatusCode::BAD_REQUEST,
             "invalid_turn_state",
@@ -285,7 +305,7 @@ fn mutation_error_to_problem(err: MutationError) -> Problem {
             "Another generation is already in progress for this chat",
         ),
         MutationError::Internal { message } => {
-            warn!(%message, "turn mutation internal error");
+            warn!(error_message = %message, "turn mutation internal error");
             Problem::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Internal Error",
@@ -295,14 +315,18 @@ fn mutation_error_to_problem(err: MutationError) -> Problem {
     }
 }
 
-fn stream_error_to_response(err: StreamError) -> Response {
+/// Caller is expected to be within an instrumented span that carries
+/// `chat_id` and `turn_request_id` fields.
+fn stream_error_to_response(err: &StreamError) -> Response {
     match err {
         StreamError::QuotaExhausted {
             error_code,
             http_status,
         } => {
-            let status = StatusCode::from_u16(http_status).unwrap_or(StatusCode::TOO_MANY_REQUESTS);
-            Problem::new(status, "Quota Exhausted", &error_code).into_response()
+            info!(error_code = %error_code, http_status = *http_status, "quota exhausted, mutation rejected");
+            let status =
+                StatusCode::from_u16(*http_status).unwrap_or(StatusCode::TOO_MANY_REQUESTS);
+            Problem::new(status, "Quota Exhausted", error_code).into_response()
         }
         other => {
             warn!(error = ?other, "post-mutation stream error");

--- a/modules/mini-chat/mini-chat/src/domain/error.rs
+++ b/modules/mini-chat/mini-chat/src/domain/error.rs
@@ -152,12 +152,19 @@ impl From<ScopeError> for DomainError {
 }
 
 impl From<authz_resolver_sdk::EnforcerError> for DomainError {
+    #[allow(clippy::cognitive_complexity)]
     fn from(e: authz_resolver_sdk::EnforcerError) -> Self {
-        tracing::error!(error = %e, "AuthZ scope resolution failed");
         match e {
-            authz_resolver_sdk::EnforcerError::Denied { .. }
-            | authz_resolver_sdk::EnforcerError::CompileFailed(_) => Self::Forbidden,
+            authz_resolver_sdk::EnforcerError::Denied { ref deny_reason } => {
+                tracing::warn!(deny_reason = ?deny_reason, "AuthZ denied access");
+                Self::Forbidden
+            }
+            authz_resolver_sdk::EnforcerError::CompileFailed(ref err) => {
+                tracing::warn!(error = %err, "AuthZ constraint compile failed - access denied");
+                Self::Forbidden
+            }
             authz_resolver_sdk::EnforcerError::EvaluationFailed(ref err) => {
+                tracing::error!(error = %err, "AuthZ evaluation failed (internal error)");
                 Self::internal(err.to_string())
             }
         }

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -6,7 +6,7 @@ use modkit_macros::domain_model;
 use modkit_security::{AccessScope, SecurityContext};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{Instrument, debug, info, warn};
 use uuid::Uuid;
 
 use crate::config::StreamingConfig;
@@ -821,6 +821,18 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
     tx: mpsc::Sender<StreamEvent>,
     fin_ctx: Option<FinalizationCtx<TR, MR>>,
 ) -> tokio::task::JoinHandle<StreamOutcome> {
+    let span = if let Some(ref fctx) = fin_ctx {
+        tracing::info_span!(
+            "provider_stream",
+            chat_id = %fctx.chat_id,
+            turn_request_id = %fctx.request_id,
+            turn_id = %fctx.turn_id,
+            model = %model,
+        )
+    } else {
+        tracing::info_span!("provider_stream", model = %model)
+    };
+
     tokio::spawn(async move {
         let stream_start = std::time::Instant::now();
         let mut first_token_time: Option<std::time::Duration> = None;
@@ -841,6 +853,11 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
             Ok(s) => s,
             Err(e) => {
                 // Provider failed before any events — finalize first, then emit error.
+                warn!(
+                    error = %e,
+                    raw_detail = e.raw_detail().unwrap_or(""),
+                    "LLM provider failed before stream start"
+                );
                 let (code, message) = normalize_error(&e);
 
                 if let Some(ref fctx) = fin_ctx {
@@ -916,9 +933,8 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                 if first_token_time.is_none() {
                                     let ttft = stream_start.elapsed();
                                     first_token_time = Some(ttft);
-                                    debug!(
+                                    info!(
                                         time_to_first_token_ms = ttft.as_millis() as u64,
-                                        model = %model,
                                         "first token received"
                                     );
                                 }
@@ -927,7 +943,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                             let stream_event = StreamEvent::from(client_event);
                             if tx.send(stream_event).await.is_err() {
                                 // Receiver dropped (client disconnect handled by relay)
-                                debug!("channel closed, exiting provider task");
+                                info!("channel closed (client disconnect), exiting provider task");
                                 break;
                             }
                         }
@@ -999,7 +1015,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
             let elapsed = stream_start.elapsed();
             info!(
                 terminal = "cancelled",
-                model = %model,
                 duration_ms = elapsed.as_millis() as u64,
                 "stream cancelled"
             );
@@ -1044,7 +1059,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                 let elapsed = stream_start.elapsed();
                 info!(
                     terminal = "completed",
-                    model = %model,
                     input_tokens = usage.input_tokens,
                     output_tokens = usage.output_tokens,
                     duration_ms = elapsed.as_millis() as u64,
@@ -1137,7 +1151,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                 let elapsed = stream_start.elapsed();
                 warn!(
                     terminal = "incomplete",
-                    model = %model,
                     reason = %reason,
                     duration_ms = elapsed.as_millis() as u64,
                     "stream incomplete"
@@ -1210,12 +1223,13 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                 }
             }
             TerminalOutcome::Failed { error, usage, .. } => {
+                let raw_detail = error.raw_detail().map(ToOwned::to_owned);
                 let (code, message) = normalize_error(&error);
                 let elapsed = stream_start.elapsed();
                 warn!(
                     terminal = "failed",
-                    model = %model,
                     error_code = %code,
+                    raw_detail = raw_detail.as_deref().unwrap_or(""),
                     duration_ms = elapsed.as_millis() as u64,
                     "stream failed"
                 );
@@ -1270,7 +1284,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                 }
             }
         }
-    })
+    }.instrument(span))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Add tracing::instrument spans with chat_id/turn_request_id fields to all handlers
- Propagate span context to spawned provider/monitor tasks via .instrument()
- Replace debug!() with error-level logs where appropriate and redact internal details from HTTP responses
- Add dedicated mini_chat logging config section
- Change error helper functions to take references instead of owned values
- Normalize log field names (error_message, error_code, raw_detail) for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages with specific error details instead of generic messages
  * Enhanced error handling for message streaming and turn operation failures
  * Refined error tracking and logging across chat workflows

* **Chores**
  * Expanded logging configuration with dedicated debug stream for chat operations
  * Added detailed tracing instrumentation to API handlers for improved diagnostics
  * Refined logging levels to provide more contextual information during operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->