### PR TITLE
feat(modkit): add #[derive(ExpandEnv)] for config field env var expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,6 +1296,7 @@ dependencies = [
  "cf-modkit-macros",
  "cf-modkit-odata",
  "cf-modkit-sdk",
+ "cf-modkit-utils",
  "cf-system-sdks",
  "chrono",
  "dashmap",
@@ -1315,7 +1316,6 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
- "regex",
  "schemars 1.2.1",
  "sea-orm-migration",
  "serde",
@@ -1389,7 +1389,6 @@ dependencies = [
  "dashmap",
  "dirs",
  "figment",
- "regex",
  "rust_decimal",
  "ryu",
  "sea-orm",
@@ -1606,8 +1605,10 @@ name = "cf-modkit-utils"
 version = "0.4.0"
 dependencies = [
  "humantime",
+ "regex",
  "serde",
  "serde_json",
+ "temp-env",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,6 +1501,7 @@ dependencies = [
  "cf-modkit-security",
  "cf-modkit-transport-grpc",
  "inventory",
+ "serde",
  "tokio",
  "tokio-util",
  "tonic",

--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -119,7 +119,7 @@ modules:
           auth_config:
             header: "api-key"
             prefix: ""
-            secret_ref: "cred://azure-openai-key"
+            secret_ref: "cred://${AZURE_API_KEY}"
 
       # ── Azure OpenAI example (uncomment and set your endpoint) ──────────
       #   azure_openai:
@@ -131,7 +131,7 @@ modules:
       #     auth_config:
       #       header: "api-key"
       #       prefix: ""
-      #       secret_ref: "cred://azure-openai-key"
+      #       secret_ref: "cred://${AZURE_API_KEY}"
       #
       # ── Per-tenant Azure example (each tenant has its own endpoint) ─────
       #   azure_openai_tenant_a:

--- a/libs/modkit-db/Cargo.toml
+++ b/libs/modkit-db/Cargo.toml
@@ -67,7 +67,6 @@ bigdecimal = { workspace = true }
 rust_decimal = { workspace = true }
 ryu = { workspace = true }
 url = { workspace = true }
-regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 dashmap = { workspace = true }

--- a/libs/modkit-db/src/lib.rs
+++ b/libs/modkit-db/src/lib.rs
@@ -232,6 +232,15 @@ pub enum DbError {
     ConnRequestedInsideTx,
 }
 
+impl From<modkit_utils::env_expand::ExpandEnvError> for DbError {
+    fn from(err: modkit_utils::env_expand::ExpandEnvError) -> Self {
+        match err {
+            modkit_utils::env_expand::ExpandEnvError::Var { source, .. } => Self::EnvVar(source),
+            modkit_utils::env_expand::ExpandEnvError::Regex(msg) => Self::InvalidParameter(msg),
+        }
+    }
+}
+
 impl From<crate::secure::ScopeError> for DbError {
     fn from(value: crate::secure::ScopeError) -> Self {
         // Scope errors are not infra connection errors, but they still originate from the DB

--- a/libs/modkit-db/src/lib.rs
+++ b/libs/modkit-db/src/lib.rs
@@ -181,8 +181,11 @@ pub enum DbError {
     #[error("SQLite pragma error: {0}")]
     SqlitePragma(String),
 
-    #[error("Environment variable error: {0}")]
-    EnvVar(#[from] std::env::VarError),
+    #[error("Environment variable '{name}': {source}")]
+    EnvVar {
+        name: String,
+        source: std::env::VarError,
+    },
 
     #[error("URL parsing error: {0}")]
     UrlParse(#[from] url::ParseError),
@@ -232,11 +235,13 @@ pub enum DbError {
     ConnRequestedInsideTx,
 }
 
-impl From<modkit_utils::env_expand::ExpandEnvError> for DbError {
-    fn from(err: modkit_utils::env_expand::ExpandEnvError) -> Self {
+impl From<modkit_utils::var_expand::ExpandVarsError> for DbError {
+    fn from(err: modkit_utils::var_expand::ExpandVarsError) -> Self {
         match err {
-            modkit_utils::env_expand::ExpandEnvError::Var { source, .. } => Self::EnvVar(source),
-            modkit_utils::env_expand::ExpandEnvError::Regex(msg) => Self::InvalidParameter(msg),
+            modkit_utils::var_expand::ExpandVarsError::Var { name, source } => {
+                Self::EnvVar { name, source }
+            }
+            modkit_utils::var_expand::ExpandVarsError::Regex(msg) => Self::InvalidParameter(msg),
         }
     }
 }

--- a/libs/modkit-db/src/options.rs
+++ b/libs/modkit-db/src/options.rs
@@ -1,5 +1,7 @@
 //! Database connection options and configuration types.
 
+use modkit_utils::env_expand::expand_env_vars;
+
 use crate::config::{DbConnConfig, DbEngineCfg, GlobalDatabaseConfig, PoolCfg};
 use crate::{DbError, DbHandle, Result};
 
@@ -685,22 +687,6 @@ fn parse_sqlite_path_from_dsn(dsn: &str) -> Result<std::path::PathBuf> {
             "Invalid SQLite DSN: {dsn}"
         )))
     }
-}
-
-/// Expand environment variables in a string.
-fn expand_env_vars(input: &str) -> Result<String> {
-    let re = regex::Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
-        .map_err(|e| DbError::InvalidParameter(e.to_string()))?;
-    let mut result = input.to_owned();
-
-    for caps in re.captures_iter(input) {
-        let full_match = &caps[0];
-        let var_name = &caps[1];
-        let value = std::env::var(var_name)?;
-        result = result.replace(full_match, &value);
-    }
-
-    Ok(result)
 }
 
 /// Resolve password from environment variable if it starts with ${VAR}.

--- a/libs/modkit-db/src/options.rs
+++ b/libs/modkit-db/src/options.rs
@@ -1,6 +1,6 @@
 //! Database connection options and configuration types.
 
-use modkit_utils::env_expand::expand_env_vars;
+use modkit_utils::var_expand::expand_env_vars;
 
 use crate::config::{DbConnConfig, DbEngineCfg, GlobalDatabaseConfig, PoolCfg};
 use crate::{DbError, DbHandle, Result};
@@ -693,7 +693,10 @@ fn parse_sqlite_path_from_dsn(dsn: &str) -> Result<std::path::PathBuf> {
 fn resolve_password(password: &str) -> Result<String> {
     if password.starts_with("${") && password.ends_with('}') {
         let var_name = &password[2..password.len() - 1];
-        Ok(std::env::var(var_name)?)
+        std::env::var(var_name).map_err(|source| DbError::EnvVar {
+            name: var_name.to_owned(),
+            source,
+        })
     } else {
         Ok(password.to_owned())
     }

--- a/libs/modkit-macros-tests/Cargo.toml
+++ b/libs/modkit-macros-tests/Cargo.toml
@@ -28,4 +28,5 @@ inventory = { workspace = true }
 modkit = { workspace = true }
 modkit-security = { workspace = true }
 modkit-transport-grpc = { workspace = true }
+serde = { workspace = true }
 tonic = { workspace = true }

--- a/libs/modkit-macros-tests/tests/ui/fail/expand_vars_unsupported_type.rs
+++ b/libs/modkit-macros-tests/tests/ui/fail/expand_vars_unsupported_type.rs
@@ -1,0 +1,9 @@
+use modkit_macros::ExpandVars;
+
+#[derive(ExpandVars)]
+struct Cfg {
+    #[expand_vars]
+    retries: u32,
+}
+
+fn main() {}

--- a/libs/modkit-macros-tests/tests/ui/fail/expand_vars_unsupported_type.stderr
+++ b/libs/modkit-macros-tests/tests/ui/fail/expand_vars_unsupported_type.stderr
@@ -1,0 +1,7 @@
+error[E0599]: no method named `expand_vars` found for type `u32` in the current scope
+ --> tests/ui/fail/expand_vars_unsupported_type.rs:3:10
+  |
+3 | #[derive(ExpandVars)]
+  |          ^^^^^^^^^^ method not found in `u32`
+  |
+  = note: this error originates in the derive macro `ExpandVars` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/libs/modkit-macros-tests/tests/ui/pass/expand_vars_no_marked_fields.rs
+++ b/libs/modkit-macros-tests/tests/ui/pass/expand_vars_no_marked_fields.rs
@@ -1,0 +1,9 @@
+use modkit_macros::ExpandVars;
+
+#[derive(ExpandVars)]
+struct Cfg {
+    retries: u32,
+    enabled: bool,
+}
+
+fn main() {}

--- a/libs/modkit-macros-tests/tests/ui/pass/expand_vars_string_fields.rs
+++ b/libs/modkit-macros-tests/tests/ui/pass/expand_vars_string_fields.rs
@@ -1,0 +1,26 @@
+use modkit_macros::ExpandVars;
+use std::collections::HashMap;
+
+#[derive(ExpandVars)]
+struct Inner {
+    #[expand_vars]
+    secret: String,
+    #[expand_vars]
+    label: Option<String>,
+    count: u32,
+}
+
+#[derive(ExpandVars)]
+struct Cfg {
+    #[expand_vars]
+    api_key: String,
+    #[expand_vars]
+    endpoint: Option<String>,
+    #[expand_vars]
+    providers: HashMap<String, Inner>,
+    #[expand_vars]
+    tags: Vec<Inner>,
+    retries: u32,
+}
+
+fn main() {}

--- a/libs/modkit-macros/src/expand_vars.rs
+++ b/libs/modkit-macros/src/expand_vars.rs
@@ -1,0 +1,53 @@
+//! Implementation of `#[derive(ExpandVars)]` with `#[expand_vars]` field attribute.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields};
+
+pub fn derive(input: &DeriveInput) -> TokenStream {
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let fields = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(named) => &named.named,
+            _ => {
+                return syn::Error::new_spanned(
+                    &input.ident,
+                    "ExpandVars can only be derived for structs with named fields",
+                )
+                .to_compile_error();
+            }
+        },
+        _ => {
+            return syn::Error::new_spanned(
+                &input.ident,
+                "ExpandVars can only be derived for structs",
+            )
+            .to_compile_error();
+        }
+    };
+
+    let expand_stmts: Vec<_> = fields
+        .iter()
+        .filter(|f| f.attrs.iter().any(|a| a.path().is_ident("expand_vars")))
+        .filter_map(|f| f.ident.as_ref())
+        .map(|ident| {
+            quote! { self.#ident.expand_vars()?; }
+        })
+        .collect();
+
+    quote! {
+        impl #impl_generics ::modkit::var_expand::ExpandVars for #name #ty_generics
+            #where_clause
+        {
+            fn expand_vars(
+                &mut self,
+            ) -> ::std::result::Result<(), ::modkit::var_expand::ExpandVarsError> {
+                use ::modkit::var_expand::ExpandVars as _;
+                #(#expand_stmts)*
+                Ok(())
+            }
+        }
+    }
+}

--- a/libs/modkit-macros/src/lib.rs
+++ b/libs/modkit-macros/src/lib.rs
@@ -11,6 +11,7 @@ use syn::{
 
 mod api_dto;
 mod domain_model;
+mod expand_vars;
 mod grpc_client;
 mod utils;
 
@@ -1236,4 +1237,26 @@ pub fn api_dto(attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn domain_model(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);
     TokenStream::from(domain_model::expand_domain_model(&input))
+}
+
+/// Derive macro that implements [`modkit::var_expand::ExpandVars`].
+///
+/// Mark individual `String` or `Option<String>` fields with `#[expand_vars]`
+/// to have `${VAR}` placeholders expanded from environment variables when
+/// `expand_vars()` is called.
+///
+/// ```ignore
+/// #[derive(Deserialize, Default, ExpandVars)]
+/// pub struct MyConfig {
+///     #[expand_vars]
+///     pub api_key: String,
+///     #[expand_vars]
+///     pub endpoint: Option<String>,
+///     pub retries: u32, // not expanded
+/// }
+/// ```
+#[proc_macro_derive(ExpandVars, attributes(expand_vars))]
+pub fn derive_expand_vars(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(expand_vars::derive(&input))
 }

--- a/libs/modkit-utils/Cargo.toml
+++ b/libs/modkit-utils/Cargo.toml
@@ -23,7 +23,9 @@ humantime-serde = ["dep:humantime", "dep:serde"]
 [dependencies]
 serde = { workspace = true, optional = true }
 humantime = { workspace = true, optional = true }
+regex = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+temp-env = { workspace = true }

--- a/libs/modkit-utils/src/env_expand.rs
+++ b/libs/modkit-utils/src/env_expand.rs
@@ -1,0 +1,154 @@
+//! Single-pass expansion of `${VAR}` placeholders from environment variables.
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// Error returned by [`expand_env_vars`].
+#[derive(Debug)]
+pub enum ExpandEnvError {
+    /// An environment variable referenced by the input is missing or contains invalid Unicode.
+    Var {
+        name: String,
+        source: std::env::VarError,
+    },
+    /// The internal regex failed to compile (should never happen with a literal pattern).
+    Regex(String),
+}
+
+impl std::fmt::Display for ExpandEnvError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Var { name, source } => {
+                write!(f, "environment variable '{name}': {source}")
+            }
+            Self::Regex(msg) => write!(f, "env expansion regex error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ExpandEnvError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Var { source, .. } => Some(source),
+            Self::Regex(_) => None,
+        }
+    }
+}
+
+/// Expand `${VAR_NAME}` placeholders in `input` with values from the environment.
+///
+/// Uses single-pass `Regex::replace_all` so that values themselves containing
+/// `${...}` are **not** re-expanded.  Fails on the first unresolvable variable.
+///
+/// # Errors
+///
+/// Returns [`ExpandEnvError::Var`] if a referenced environment variable is missing
+/// or contains invalid Unicode.
+pub fn expand_env_vars(input: &str) -> Result<String, ExpandEnvError> {
+    static RE: LazyLock<Result<Regex, String>> =
+        LazyLock::new(|| Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}").map_err(|e| e.to_string()));
+    let re = RE.as_ref().map_err(|e| ExpandEnvError::Regex(e.clone()))?;
+
+    let mut err: Option<ExpandEnvError> = None;
+    let result = re.replace_all(input, |caps: &regex::Captures| {
+        if err.is_some() {
+            return String::new();
+        }
+        let name = &caps[1];
+        match std::env::var(name) {
+            Ok(val) => val,
+            Err(e) => {
+                err = Some(ExpandEnvError::Var {
+                    name: name.to_owned(),
+                    source: e,
+                });
+                String::new()
+            }
+        }
+    });
+    if let Some(e) = err {
+        return Err(e);
+    }
+    Ok(result.into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passthrough_when_no_placeholders() {
+        let result = expand_env_vars("plain string without vars").unwrap();
+        assert_eq!(result, "plain string without vars");
+    }
+
+    #[test]
+    fn single_variable() {
+        temp_env::with_vars([("EXPAND_SINGLE", Some("replaced"))], || {
+            let result = expand_env_vars("prefix_${EXPAND_SINGLE}_suffix").unwrap();
+            assert_eq!(result, "prefix_replaced_suffix");
+        });
+    }
+
+    #[test]
+    fn multiple_variables() {
+        temp_env::with_vars(
+            [
+                ("EXPAND_HOST", Some("localhost")),
+                ("EXPAND_PORT", Some("5432")),
+            ],
+            || {
+                let result = expand_env_vars("${EXPAND_HOST}:${EXPAND_PORT}").unwrap();
+                assert_eq!(result, "localhost:5432");
+            },
+        );
+    }
+
+    #[test]
+    fn missing_var_returns_error_with_name() {
+        temp_env::with_vars([("EXPAND_MISSING_CANARY", None::<&str>)], || {
+            let err = expand_env_vars("${EXPAND_MISSING_CANARY}").unwrap_err();
+            assert!(
+                matches!(&err, ExpandEnvError::Var { name, .. } if name == "EXPAND_MISSING_CANARY")
+            );
+            let msg = err.to_string();
+            assert!(
+                msg.contains("EXPAND_MISSING_CANARY"),
+                "error should contain var name, got: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn fails_on_first_missing_variable() {
+        temp_env::with_vars(
+            [
+                ("EXPAND_FIRST_MISS", None::<&str>),
+                ("EXPAND_SECOND_OK", Some("present")),
+            ],
+            || {
+                let err = expand_env_vars("${EXPAND_FIRST_MISS}_${EXPAND_SECOND_OK}").unwrap_err();
+                assert!(
+                    matches!(&err, ExpandEnvError::Var { name, .. } if name == "EXPAND_FIRST_MISS")
+                );
+            },
+        );
+    }
+
+    /// Regression: values containing `${...}` must not be re-expanded.
+    /// Input `${A}_${B}` with A=`${B}` and B=`val` must yield `${B}_val`, not `val_val`.
+    #[test]
+    fn no_double_expansion() {
+        temp_env::with_vars(
+            [
+                ("EXPAND_TEST_A", Some("${EXPAND_TEST_B}")),
+                ("EXPAND_TEST_B", Some("val")),
+            ],
+            || {
+                let result = expand_env_vars("${EXPAND_TEST_A}_${EXPAND_TEST_B}").unwrap();
+                assert_eq!(result, "${EXPAND_TEST_B}_val");
+            },
+        );
+    }
+}

--- a/libs/modkit-utils/src/lib.rs
+++ b/libs/modkit-utils/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+pub mod env_expand;
 #[cfg(feature = "humantime-serde")]
 pub mod humantime_serde;
 

--- a/libs/modkit-utils/src/lib.rs
+++ b/libs/modkit-utils/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
-pub mod env_expand;
 #[cfg(feature = "humantime-serde")]
 pub mod humantime_serde;
+pub mod var_expand;
 
 pub mod secret_string;
 pub use secret_string::SecretString;

--- a/libs/modkit-utils/src/var_expand.rs
+++ b/libs/modkit-utils/src/var_expand.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 
 /// Error returned by [`expand_env_vars`].
 #[derive(Debug)]
-pub enum ExpandEnvError {
+pub enum ExpandVarsError {
     /// An environment variable referenced by the input is missing or contains invalid Unicode.
     Var {
         name: String,
@@ -16,7 +16,7 @@ pub enum ExpandEnvError {
     Regex(String),
 }
 
-impl std::fmt::Display for ExpandEnvError {
+impl std::fmt::Display for ExpandVarsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Var { name, source } => {
@@ -27,7 +27,7 @@ impl std::fmt::Display for ExpandEnvError {
     }
 }
 
-impl std::error::Error for ExpandEnvError {
+impl std::error::Error for ExpandVarsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Var { source, .. } => Some(source),
@@ -43,14 +43,14 @@ impl std::error::Error for ExpandEnvError {
 ///
 /// # Errors
 ///
-/// Returns [`ExpandEnvError::Var`] if a referenced environment variable is missing
+/// Returns [`ExpandVarsError::Var`] if a referenced environment variable is missing
 /// or contains invalid Unicode.
-pub fn expand_env_vars(input: &str) -> Result<String, ExpandEnvError> {
+pub fn expand_env_vars(input: &str) -> Result<String, ExpandVarsError> {
     static RE: LazyLock<Result<Regex, String>> =
         LazyLock::new(|| Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}").map_err(|e| e.to_string()));
-    let re = RE.as_ref().map_err(|e| ExpandEnvError::Regex(e.clone()))?;
+    let re = RE.as_ref().map_err(|e| ExpandVarsError::Regex(e.clone()))?;
 
-    let mut err: Option<ExpandEnvError> = None;
+    let mut err: Option<ExpandVarsError> = None;
     let result = re.replace_all(input, |caps: &regex::Captures| {
         if err.is_some() {
             return String::new();
@@ -59,7 +59,7 @@ pub fn expand_env_vars(input: &str) -> Result<String, ExpandEnvError> {
         match std::env::var(name) {
             Ok(val) => val,
             Err(e) => {
-                err = Some(ExpandEnvError::Var {
+                err = Some(ExpandVarsError::Var {
                     name: name.to_owned(),
                     source: e,
                 });
@@ -71,6 +71,62 @@ pub fn expand_env_vars(input: &str) -> Result<String, ExpandEnvError> {
         return Err(e);
     }
     Ok(result.into_owned())
+}
+
+/// Trait for types whose `String` fields can be expanded from environment variables.
+///
+/// Typically derived via `#[derive(ExpandVars)]` from `modkit-macros`.
+/// Fields marked with `#[expand_vars]` will have `${VAR}` placeholders
+/// replaced with the corresponding environment variable values.
+///
+/// # Errors
+///
+/// Returns [`ExpandVarsError`] if a referenced environment variable is missing
+/// or contains invalid Unicode.
+pub trait ExpandVars {
+    /// Expand `${VAR}` placeholders in marked fields from environment variables.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExpandVarsError`] if a referenced environment variable is missing
+    /// or contains invalid Unicode.
+    fn expand_vars(&mut self) -> Result<(), ExpandVarsError>;
+}
+
+impl ExpandVars for String {
+    fn expand_vars(&mut self) -> Result<(), ExpandVarsError> {
+        *self = expand_env_vars(self)?;
+        Ok(())
+    }
+}
+
+impl<T: ExpandVars> ExpandVars for Option<T> {
+    fn expand_vars(&mut self) -> Result<(), ExpandVarsError> {
+        if let Some(inner) = self {
+            inner.expand_vars()?;
+        }
+        Ok(())
+    }
+}
+
+impl<T: ExpandVars> ExpandVars for Vec<T> {
+    fn expand_vars(&mut self) -> Result<(), ExpandVarsError> {
+        for item in self {
+            item.expand_vars()?;
+        }
+        Ok(())
+    }
+}
+
+impl<K, V: ExpandVars, S: std::hash::BuildHasher> ExpandVars
+    for std::collections::HashMap<K, V, S>
+{
+    fn expand_vars(&mut self) -> Result<(), ExpandVarsError> {
+        for val in self.values_mut() {
+            val.expand_vars()?;
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -110,7 +166,7 @@ mod tests {
         temp_env::with_vars([("EXPAND_MISSING_CANARY", None::<&str>)], || {
             let err = expand_env_vars("${EXPAND_MISSING_CANARY}").unwrap_err();
             assert!(
-                matches!(&err, ExpandEnvError::Var { name, .. } if name == "EXPAND_MISSING_CANARY")
+                matches!(&err, ExpandVarsError::Var { name, .. } if name == "EXPAND_MISSING_CANARY")
             );
             let msg = err.to_string();
             assert!(
@@ -130,7 +186,7 @@ mod tests {
             || {
                 let err = expand_env_vars("${EXPAND_FIRST_MISS}_${EXPAND_SECOND_OK}").unwrap_err();
                 assert!(
-                    matches!(&err, ExpandEnvError::Var { name, .. } if name == "EXPAND_FIRST_MISS")
+                    matches!(&err, ExpandVarsError::Var { name, .. } if name == "EXPAND_FIRST_MISS")
                 );
             },
         );

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -42,7 +42,6 @@ bootstrap = [
     "dep:file-rotate",
     "dep:tracing-log",
     "dep:chrono",
-    "dep:regex",
     "dep:url",
     "dep:dsn",
     "dep:supports-color",
@@ -69,7 +68,7 @@ file-rotate = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 dsn = { workspace = true, optional = true }
-regex = { workspace = true, optional = true }
+modkit-utils = { workspace = true }
 
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/libs/modkit/src/api/error_layer.rs
+++ b/libs/modkit/src/api/error_layer.rs
@@ -103,6 +103,21 @@ pub fn map_error_to_problem(error: &dyn Any, instance: &str, trace_id: Option<St
             )
             .with_code("CONFIG_INVALID")
             .with_type("https://errors.example.com/CONFIG_INVALID"),
+
+            ConfigError::VarExpand { module, source } => {
+                tracing::error!(
+                    module = %module,
+                    error = %source,
+                    "Environment variable expansion failed in module config"
+                );
+                Problem::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Configuration Error",
+                    format!("Module '{module}' has invalid environment-backed configuration"),
+                )
+                .with_code("CONFIG_ENV_EXPAND")
+                .with_type("https://errors.example.com/CONFIG_ENV_EXPAND")
+            }
         };
 
         problem = problem.with_instance(instance);
@@ -211,6 +226,42 @@ mod tests {
         assert_eq!(problem.code, "INTERNAL_ERROR");
         assert_eq!(problem.instance, "/tests/v1/test");
         assert_eq!(problem.trace_id, Some("trace456".to_owned()));
+    }
+
+    #[test]
+    fn test_config_var_expand_error_sanitizes_detail() {
+        let source = modkit_utils::var_expand::ExpandVarsError::Var {
+            name: "SECRET_API_KEY".to_owned(),
+            source: std::env::VarError::NotPresent,
+        };
+        let error = ConfigError::VarExpand {
+            module: "my_mod".to_owned(),
+            source,
+        };
+        let problem = error.into_problem("/tests/v1/test", Some("trace789".to_owned()));
+
+        assert_eq!(problem.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(problem.code, "CONFIG_ENV_EXPAND");
+        assert_eq!(
+            problem.type_url,
+            "https://errors.example.com/CONFIG_ENV_EXPAND"
+        );
+        assert_eq!(problem.instance, "/tests/v1/test");
+        assert_eq!(problem.trace_id, Some("trace789".to_owned()));
+
+        // Detail MUST NOT leak the env var name or the underlying error message.
+        assert!(
+            !problem.detail.contains("SECRET_API_KEY"),
+            "detail must not contain env var name, got: {}",
+            problem.detail,
+        );
+        assert!(
+            !problem.detail.contains("not present"),
+            "detail must not contain source error text, got: {}",
+            problem.detail,
+        );
+        // It should still mention the module name (non-sensitive).
+        assert!(problem.detail.contains("my_mod"));
     }
 
     #[test]

--- a/libs/modkit/src/bootstrap/config/mod.rs
+++ b/libs/modkit/src/bootstrap/config/mod.rs
@@ -396,23 +396,7 @@ fn merge_module_files(
 /// # Errors
 /// Returns an error if any referenced env var is missing.
 pub fn expand_env_in_dsn(dsn: &str) -> Result<String> {
-    use std::env;
-
-    let mut result = dsn.to_owned();
-    // TODO: Think about other way
-    let re = regex::Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)}")?;
-
-    for cap in re.captures_iter(dsn) {
-        let full_match = &cap[0];
-        let var_name = &cap[1];
-
-        let value = env::var(var_name)
-            .with_context(|| format!("Environment variable '{var_name}' not found in DSN"))?;
-
-        result = result.replace(full_match, &value);
-    }
-
-    Ok(result)
+    modkit_utils::env_expand::expand_env_vars(dsn).map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 /// Resolves password: if it contains ${VAR}, expands from environment variable; otherwise returns as-is.

--- a/libs/modkit/src/bootstrap/config/mod.rs
+++ b/libs/modkit/src/bootstrap/config/mod.rs
@@ -396,7 +396,7 @@ fn merge_module_files(
 /// # Errors
 /// Returns an error if any referenced env var is missing.
 pub fn expand_env_in_dsn(dsn: &str) -> Result<String> {
-    modkit_utils::env_expand::expand_env_vars(dsn).map_err(|e| anyhow::anyhow!("{e}"))
+    modkit_utils::var_expand::expand_env_vars(dsn).map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 /// Resolves password: if it contains ${VAR}, expands from environment variable; otherwise returns as-is.

--- a/libs/modkit/src/config.rs
+++ b/libs/modkit/src/config.rs
@@ -27,6 +27,12 @@ pub enum ConfigError {
         #[source]
         source: serde_json::Error,
     },
+    #[error("variable expansion failed for module '{module}': {source}")]
+    VarExpand {
+        module: String,
+        #[source]
+        source: modkit_utils::var_expand::ExpandVarsError,
+    },
 }
 
 /// Provider of module-specific configuration (raw JSON sections only).

--- a/libs/modkit/src/context.rs
+++ b/libs/modkit/src/context.rs
@@ -234,6 +234,39 @@ impl ModuleCtx {
         module_config_or_default(self.config_provider.as_ref(), &self.module_name)
     }
 
+    /// Like [`config()`](Self::config), but additionally expands `${VAR}` placeholders
+    /// in fields marked with `#[expand_vars]` (requires `#[derive(ExpandVars)]` on the config
+    /// struct).
+    ///
+    /// Modules that do not need environment variable expansion should use [`config()`](Self::config).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// #[derive(serde::Deserialize, Default, ExpandVars)]
+    /// struct MyConfig {
+    ///     #[expand_vars]
+    ///     api_key: String,
+    ///     timeout_ms: u64,
+    /// }
+    ///
+    /// let config: MyConfig = ctx.config_expanded()?;
+    /// ```
+    ///
+    /// # Errors
+    /// Returns `ConfigError` if deserialization fails or if environment variable expansion fails.
+    pub fn config_expanded<T>(&self) -> Result<T, ConfigError>
+    where
+        T: DeserializeOwned + Default + crate::var_expand::ExpandVars,
+    {
+        let mut cfg: T = self.config()?;
+        cfg.expand_vars().map_err(|e| ConfigError::VarExpand {
+            module: self.module_name.to_string(),
+            source: e,
+        })?;
+        Ok(cfg)
+    }
+
     /// Get the raw JSON value of the module's config section.
     /// Returns the 'config' field from: modules.<name> = { database: ..., config: ... }
     #[must_use]
@@ -373,5 +406,209 @@ mod tests {
         );
 
         assert_eq!(ctx.instance_id(), instance_id);
+    }
+
+    // --- config_expanded tests ---
+
+    #[derive(Debug, PartialEq, Deserialize, Default, modkit_macros::ExpandVars)]
+    struct ExpandableConfig {
+        #[expand_vars]
+        #[serde(default)]
+        api_key: String,
+        #[expand_vars]
+        #[serde(default)]
+        endpoint: Option<String>,
+        #[serde(default)]
+        retries: u32,
+    }
+
+    fn make_ctx(module_name: &str, config_json: serde_json::Value) -> ModuleCtx {
+        let mut modules = HashMap::new();
+        modules.insert(module_name.to_owned(), config_json);
+        let provider = Arc::new(MockConfigProvider { modules });
+        ModuleCtx::new(
+            module_name,
+            Uuid::new_v4(),
+            provider,
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            None,
+        )
+    }
+
+    #[test]
+    fn config_expanded_resolves_env_vars() {
+        let ctx = make_ctx(
+            "expand_mod",
+            json!({
+                "config": {
+                    "api_key": "${MODKIT_TEST_KEY}",
+                    "endpoint": "https://${MODKIT_TEST_HOST}/api",
+                    "retries": 3
+                }
+            }),
+        );
+
+        temp_env::with_vars(
+            [
+                ("MODKIT_TEST_KEY", Some("secret-42")),
+                ("MODKIT_TEST_HOST", Some("example.com")),
+            ],
+            || {
+                let cfg: ExpandableConfig = ctx.config_expanded().unwrap();
+                assert_eq!(cfg.api_key, "secret-42");
+                assert_eq!(cfg.endpoint.as_deref(), Some("https://example.com/api"));
+                assert_eq!(cfg.retries, 3);
+            },
+        );
+    }
+
+    #[test]
+    fn config_expanded_returns_error_on_missing_var() {
+        let ctx = make_ctx(
+            "expand_mod",
+            json!({
+                "config": {
+                    "api_key": "${MODKIT_TEST_MISSING_VAR_XYZ}"
+                }
+            }),
+        );
+
+        temp_env::with_vars([("MODKIT_TEST_MISSING_VAR_XYZ", None::<&str>)], || {
+            let err = ctx.config_expanded::<ExpandableConfig>().unwrap_err();
+            assert!(
+                matches!(err, ConfigError::VarExpand { ref module, .. } if module == "expand_mod"),
+                "expected EnvExpand error, got: {err:?}"
+            );
+        });
+    }
+
+    #[test]
+    fn config_expanded_skips_none_option_fields() {
+        let ctx = make_ctx(
+            "expand_mod",
+            json!({
+                "config": {
+                    "api_key": "literal-key",
+                    "retries": 5
+                }
+            }),
+        );
+
+        let cfg: ExpandableConfig = ctx.config_expanded().unwrap();
+        assert_eq!(cfg.api_key, "literal-key");
+        assert_eq!(cfg.endpoint, None);
+        assert_eq!(cfg.retries, 5);
+    }
+
+    #[test]
+    fn config_expanded_falls_back_to_default_when_missing() {
+        let ctx = make_ctx("missing_mod", json!({}));
+        let cfg: ExpandableConfig = ctx.config_expanded().unwrap();
+        assert_eq!(cfg, ExpandableConfig::default());
+    }
+
+    // --- nested struct expansion ---
+
+    #[derive(Debug, PartialEq, Deserialize, Default, modkit_macros::ExpandVars)]
+    struct NestedProvider {
+        #[expand_vars]
+        #[serde(default)]
+        host: String,
+        #[expand_vars]
+        #[serde(default)]
+        token: Option<String>,
+        #[expand_vars]
+        #[serde(default)]
+        auth_config: Option<HashMap<String, String>>,
+        #[serde(default)]
+        port: u16,
+    }
+
+    #[derive(Debug, PartialEq, Deserialize, Default, modkit_macros::ExpandVars)]
+    struct NestedConfig {
+        #[expand_vars]
+        #[serde(default)]
+        name: String,
+        #[expand_vars]
+        #[serde(default)]
+        providers: HashMap<String, NestedProvider>,
+        #[expand_vars]
+        #[serde(default)]
+        tags: Vec<String>,
+    }
+
+    #[test]
+    fn config_expanded_resolves_nested_structs() {
+        let ctx = make_ctx(
+            "nested_mod",
+            json!({
+                "config": {
+                    "name": "${MODKIT_NESTED_NAME}",
+                    "providers": {
+                        "primary": {
+                            "host": "${MODKIT_NESTED_HOST}",
+                            "token": "${MODKIT_NESTED_TOKEN}",
+                            "auth_config": {
+                                "header": "X-Api-Key",
+                                "secret_ref": "${MODKIT_NESTED_SECRET}"
+                            },
+                            "port": 443
+                        }
+                    },
+                    "tags": ["${MODKIT_NESTED_TAG}", "literal"]
+                }
+            }),
+        );
+
+        temp_env::with_vars(
+            [
+                ("MODKIT_NESTED_NAME", Some("my-service")),
+                ("MODKIT_NESTED_HOST", Some("api.example.com")),
+                ("MODKIT_NESTED_TOKEN", Some("sk-secret")),
+                ("MODKIT_NESTED_SECRET", Some("key-12345")),
+                ("MODKIT_NESTED_TAG", Some("production")),
+            ],
+            || {
+                let cfg: NestedConfig = ctx.config_expanded().unwrap();
+                assert_eq!(cfg.name, "my-service");
+                assert_eq!(cfg.tags, vec!["production", "literal"]);
+
+                let primary = cfg.providers.get("primary").expect("primary provider");
+                assert_eq!(primary.host, "api.example.com");
+                assert_eq!(primary.token.as_deref(), Some("sk-secret"));
+                assert_eq!(primary.port, 443);
+
+                let auth = primary.auth_config.as_ref().expect("auth_config present");
+                assert_eq!(auth.get("header").map(String::as_str), Some("X-Api-Key"));
+                assert_eq!(
+                    auth.get("secret_ref").map(String::as_str),
+                    Some("key-12345")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn config_expanded_nested_missing_var_returns_error() {
+        let ctx = make_ctx(
+            "nested_mod",
+            json!({
+                "config": {
+                    "name": "ok",
+                    "providers": {
+                        "bad": { "host": "${MODKIT_NESTED_GONE}", "port": 80 }
+                    }
+                }
+            }),
+        );
+
+        temp_env::with_vars([("MODKIT_NESTED_GONE", None::<&str>)], || {
+            let err = ctx.config_expanded::<NestedConfig>().unwrap_err();
+            assert!(
+                matches!(err, ConfigError::VarExpand { ref module, .. } if module == "nested_mod"),
+                "expected EnvExpand, got: {err:?}"
+            );
+        });
     }
 }

--- a/libs/modkit/src/lib.rs
+++ b/libs/modkit/src/lib.rs
@@ -94,7 +94,10 @@ pub use client_hub::ClientHub;
 pub use registry::ModuleRegistry;
 
 // Re-export the macros from the proc-macro crate
-pub use modkit_macros::{lifecycle, module};
+pub use modkit_macros::{ExpandVars, lifecycle, module};
+
+// Re-export var_expand module so derive-generated impls resolve via ::modkit::var_expand
+pub use modkit_utils::var_expand;
 
 // Core module contracts and traits
 pub mod contracts;

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::infra::llm::ProviderKind;
 use crate::module::DEFAULT_URL_PREFIX;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, modkit_macros::ExpandVars)]
 #[serde(deny_unknown_fields)]
 pub struct MiniChatConfig {
     #[serde(default = "default_url_prefix")]
@@ -21,12 +21,13 @@ pub struct MiniChatConfig {
     #[serde(default)]
     pub outbox: OutboxConfig,
     /// Provider registry. Key = `provider_id` (matches [`ModelCatalogEntry::provider_id`]).
+    #[expand_vars]
     #[serde(default = "default_providers")]
     pub providers: HashMap<String, ProviderEntry>,
 }
 
 /// Configuration for a single LLM provider.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, modkit_macros::ExpandVars)]
 #[serde(deny_unknown_fields)]
 pub struct ProviderEntry {
     /// Which adapter to use (e.g., `openai_responses`, `openai_chat_completions`).
@@ -49,6 +50,8 @@ pub struct ProviderEntry {
     #[serde(default)]
     pub auth_plugin_type: Option<String>,
     /// Auth plugin config (e.g., `header`, `prefix`, `secret_ref`).
+    /// Values support `${VAR}` env expansion via [`config_expanded()`].
+    #[expand_vars]
     #[serde(default)]
     pub auth_config: Option<HashMap<String, String>>,
 }

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -59,7 +59,7 @@ impl Module for MiniChatModule {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         info!("Initializing {} module", Self::MODULE_NAME);
 
-        let cfg: crate::config::MiniChatConfig = ctx.config()?;
+        let cfg: crate::config::MiniChatConfig = ctx.config_expanded()?;
         cfg.streaming
             .validate()
             .map_err(|e| anyhow::anyhow!("streaming config: {e}"))?;


### PR DESCRIPTION
Introduce ExpandVars trait + derive macro that expands ${VAR} placeholders
in config struct fields marked with #[expand_vars]. Supports String,
Option<String>, Vec<T>, HashMap<K,V>, and nested structs recursively.

- modkit: config_expanded() method on ModuleCtx (backward-compatible,
  existing config() unchanged)
- modkit: ConfigError::EnvExpand variant + error_layer mapping
- mini-chat: apply ExpandEnv to ProviderEntry.auth_config values

Two identical expand-env-vars implementations existed — `expand_env_vars`
in modkit-db and `expand_env_in_dsn` in modkit/bootstrap/config — with
the latter also carrying the double-expansion bug.

Introduce `modkit_utils::env_expand` with the single canonical
implementation and wire both crates to use it.

Key fixes over the original code:
- Single-pass Regex::replace_all prevents double-expansion when an env
  var value itself contains ${...} syntax
- LazyLock<Result<Regex, ...>> avoids unwrap (clippy::unwrap_used deny)
- First-error semantics: stops on the first missing variable instead of
  silently overwriting earlier errors
- ExpandEnvError carries the variable name for better diagnostics

Note: This PR incorporates the fixes proposed in https://github.com/cyberfabric/cyberfabric-core/pull/824 for the `expand_env_vars()` function. Thanks to @lizreu for the investigation and the original proposal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration supports ${VAR} environment-variable expansion.
  * New derive macro enables automatic env-var expansion for marked config fields.
  * Config retrieval gains an expanded-reading API that returns expanded values.

* **Bug Fixes**
  * Configuration error reporting sanitized to avoid leaking sensitive env details.

* **Tests**
  * Added unit and UI tests covering expansion behavior and error cases.

* **Documentation**
  * Configuration examples updated to show env-var usage for secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->