### PR TITLE
fix(mini-chat): add RFC 3339 serde for OffsetDateTime fields in SDK models

### DIFF
--- a/modules/mini-chat/mini-chat-sdk/src/models.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/models.rs
@@ -200,6 +200,7 @@ pub struct ModelGeneralConfig {
     pub config_type: String,
     /// Model tier CTI identifier.
     pub tier: String,
+    #[serde(with = "time::serde::rfc3339")]
     pub available_from: OffsetDateTime,
     pub max_file_size_mb: u32,
     pub api_params: ModelApiParams,
@@ -275,6 +276,7 @@ pub struct UsageEvent {
     pub actual_credits_micro: i64,
     pub settlement_method: String,
     pub policy_version_applied: i64,
+    #[serde(with = "time::serde::rfc3339")]
     pub timestamp: OffsetDateTime,
 }
 


### PR DESCRIPTION
Without explicit serde format, OffsetDateTime fields failed to serialize/deserialize correctly. Add time::serde::rfc3339 attribute to available_from and timestamp fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp serialization across data models to properly format all date and time fields using RFC3339 standard format for improved compatibility with external systems and integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->