### PR TITLE
docs(mini-chat): add README and API smoke test script

### DIFF
--- a/modules/mini-chat/README.md
+++ b/modules/mini-chat/README.md
@@ -1,0 +1,101 @@
+# Mini-Chat Module
+
+AI chat module for Cyber Fabric. Provides a REST API for managing chats, messages (with SSE streaming), models, reactions, and attachments.
+
+## Directory Structure
+
+```
+modules/mini-chat/
+├── mini-chat/          # Main module crate
+│   └── src/
+│       ├── api/        # REST handlers, routes, DTOs, SSE
+│       ├── domain/     # Business logic, services, repository traits
+│       └── infra/      # DB entities/repos, LLM providers, model policy
+├── mini-chat-sdk/      # SDK crate (contract types, plugin API, GTS IDs)
+├── plugins/
+│   └── static-model-policy-plugin/  # Dev plugin: static model catalog from config
+├── scripts/
+│   └── smoke-test-api.py            # API smoke test (stdlib-only Python)
+└── docs/               # PRD, DESIGN, ADRs, OpenAPI spec
+```
+
+## Running Locally
+
+```bash
+make mini-chat
+```
+
+This starts the server at `http://127.0.0.1:8087` with SQLite, mock auth, and single-tenant mode.
+
+### Configuration
+
+Config file: **`config/mini-chat.yaml`**
+
+#### Setting the LLM API key
+
+Find the `static-credstore-plugin` section and set your key:
+
+```yaml
+static-credstore-plugin:
+  config:
+    secrets:
+      - key: "azure-openai-key"
+        value: "<YOUR_API_KEY>"
+```
+
+#### Setting the LLM provider endpoint
+
+Find the `mini-chat` -> `config` -> `providers` section:
+
+```yaml
+mini-chat:
+  config:
+    providers:
+      azure_openai:
+        kind: openai_responses
+        host: "<your-resource>.openai.azure.com"
+        api_path: "/openai/v1/responses"
+        auth_config:
+          secret_ref: "cred://azure-openai-key"
+```
+
+## API
+
+Base URL: `http://127.0.0.1:8087/mini-chat/v1`
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/mini-chat/v1/models` | List available models |
+| GET | `/mini-chat/v1/models/{id}` | Get model details |
+| POST | `/mini-chat/v1/chats` | Create a chat |
+| GET | `/mini-chat/v1/chats` | List chats |
+| GET | `/mini-chat/v1/chats/{id}` | Get a chat |
+| PATCH | `/mini-chat/v1/chats/{id}` | Update a chat |
+| DELETE | `/mini-chat/v1/chats/{id}` | Delete a chat |
+| POST | `/mini-chat/v1/chats/{id}/messages/stream` | Send message (SSE) |
+| GET | `/mini-chat/v1/chats/{id}/messages` | List messages |
+| PUT | `/mini-chat/v1/chats/{id}/messages/{mid}/reaction` | Set reaction |
+| DELETE | `/mini-chat/v1/chats/{id}/messages/{mid}/reaction` | Remove reaction |
+| GET | `/mini-chat/v1/chats/{id}/turns/{rid}` | Get turn status |
+| POST | `/mini-chat/v1/chats/{id}/turns/{rid}/retry` | Retry a failed turn (SSE) |
+| PATCH | `/mini-chat/v1/chats/{id}/turns/{rid}` | Edit turn (SSE) |
+| DELETE | `/mini-chat/v1/chats/{id}/turns/{rid}` | Delete a turn |
+
+OpenAPI docs (when server is running): http://127.0.0.1:8087/docs
+
+## Smoke Test
+
+```bash
+# All steps (requires a valid API key for SSE streaming)
+python3 modules/mini-chat/scripts/smoke-test-api.py
+
+# Skip SSE streaming (no real API key needed)
+python3 modules/mini-chat/scripts/smoke-test-api.py --no-sse
+```
+
+## Documentation
+
+- [PRD](docs/PRD.md)
+- [Design](docs/DESIGN.md)
+- [ADRs](docs/ADR/)
+- [OpenAPI spec](docs/openapi.json)

--- a/modules/mini-chat/scripts/smoke-test-api.py
+++ b/modules/mini-chat/scripts/smoke-test-api.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Mini-Chat smoke test script (stdlib only).
+
+Prerequisites:
+  1. Server is running:  make mini-chat
+  2. Set your API key in config/mini-chat.yaml
+     (static-credstore-plugin -> secrets -> value)
+
+Usage (from the repo root):
+  python3 modules/mini-chat/scripts/smoke-test-api.py                                  # run all steps
+  python3 modules/mini-chat/scripts/smoke-test-api.py --no-sse                         # skip SSE streaming (no real API key)
+  python3 modules/mini-chat/scripts/smoke-test-api.py --base-url http://host:port      # custom server address
+  python3 modules/mini-chat/scripts/smoke-test-api.py --api-url-prefix /x              # custom route prefix
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+NO_SSE = "--no-sse" in sys.argv
+
+def _parse_arg(flag: str, default: str) -> str:
+    for i, arg in enumerate(sys.argv):
+        if arg == flag and i + 1 < len(sys.argv):
+            return sys.argv[i + 1].strip()
+    return default
+
+def _parse_base_url() -> str:
+    url = _parse_arg("--base-url", "http://127.0.0.1:8087")
+    return url.rstrip("/")
+
+def _parse_prefix() -> str:
+    p = _parse_arg("--api-url-prefix", "/mini-chat")
+    return p if p.startswith("/") else f"/{p}"
+
+BASE = _parse_base_url()
+PREFIX = _parse_prefix()
+
+
+# -- Helpers ------------------------------------------------------------------
+
+def bold(text: str) -> None:
+    print(f"\033[1m{text}\033[0m")
+
+
+def ok(text: str) -> None:
+    print(f"\033[32m✓ {text}\033[0m")
+
+
+def fail(text: str) -> None:
+    print(f"\033[31m✗ {text}\033[0m")
+    sys.exit(1)
+
+
+def skip(text: str) -> None:
+    print(f"  (skipped — {text})")
+    ok("Skipped")
+
+
+def request(
+    method: str,
+    path: str,
+    body: dict[str, Any] | None = None,
+    *,
+    expect_status: int | None = None,
+) -> tuple[int, Any]:
+    """Send an HTTP request and return (status_code, parsed_json | None)."""
+    url = f"{BASE}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            status = resp.status
+            raw = resp.read().decode()
+            parsed = json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        status = e.code
+        raw = e.read().decode()
+        parsed = json.loads(raw) if raw else None
+
+    if expect_status is not None and status != expect_status:
+        fail(f"{method} {path} → {status} (expected {expect_status})\n  {parsed}")
+    return status, parsed
+
+
+def sse_request(path: str, body: dict[str, Any]) -> tuple[list[str], str | None]:
+    """Send a POST request and read SSE events.
+
+    Returns (raw_lines, assistant_message_id | None).
+    """
+    url = f"{BASE}{path}"
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(url, data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+
+    lines: list[str] = []
+    msg_id: str | None = None
+
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        for raw_line in resp:
+            line = raw_line.decode().rstrip("\n")
+            lines.append(line)
+            if line.startswith("data:") and "message_id" in line:
+                try:
+                    payload = json.loads(line[len("data:"):].strip())
+                    if "message_id" in payload:
+                        msg_id = payload["message_id"]
+                except (json.JSONDecodeError, KeyError):
+                    pass
+
+    return lines, msg_id
+
+
+# -- Tests --------------------------------------------------------------------
+
+def test_health() -> None:
+    bold("Health check")
+    request("GET", "/health", expect_status=200)
+    ok("Server is healthy")
+
+
+def test_list_models() -> tuple[str, str]:
+    """Returns (first_model_id, first_model_display_name)."""
+    bold("\n0. List models")
+    _, data = request("GET", f"{PREFIX}/v1/models", expect_status=200)
+    items = data["items"]
+    print(json.dumps(data, indent=2))
+    if not items:
+        fail("No models returned")
+    ok(f"Got {len(items)} models")
+    return items[0]["model_id"], items[0].get("display_name", "")
+
+
+def test_get_model(model_id: str) -> None:
+    bold("\n0b. Get single model")
+    _, data = request("GET", f"{PREFIX}/v1/models/{model_id}", expect_status=200)
+    print(json.dumps(data, indent=2))
+    if data["model_id"] != model_id:
+        fail(f"Expected model_id={model_id}, got {data['model_id']}")
+    ok(f"Got model detail: {model_id}")
+
+
+def test_create_chat(model: str) -> str:
+    bold("\n1. Create chat")
+    _, data = request(
+        "POST", f"{PREFIX}/v1/chats",
+        {"title": "Smoke Test Chat", "model": model},
+        expect_status=201,
+    )
+    print(json.dumps(data, indent=2))
+    chat_id = data["id"]
+    if not chat_id:
+        fail("No chat id returned")
+    ok(f"Created chat: {chat_id}")
+    return chat_id
+
+
+def test_get_chat(chat_id: str) -> None:
+    bold("\n1b. Get single chat")
+    _, data = request("GET", f"{PREFIX}/v1/chats/{chat_id}", expect_status=200)
+    print(json.dumps(data, indent=2))
+    if data["id"] != chat_id:
+        fail(f"Expected id={chat_id}, got {data['id']}")
+    ok(f"Got chat: {chat_id}")
+
+
+def test_update_chat(chat_id: str) -> None:
+    bold("\n1c. Update chat title")
+    _, data = request(
+        "PATCH", f"{PREFIX}/v1/chats/{chat_id}",
+        {"title": "Updated Smoke Title"},
+        expect_status=200,
+    )
+    print(json.dumps(data, indent=2))
+    if data.get("title") != "Updated Smoke Title":
+        fail(f"Expected title='Updated Smoke Title', got '{data.get('title')}'")
+    ok("Updated chat title")
+
+
+def test_list_chats(chat_id: str) -> None:
+    bold("\n2. List chats")
+    _, data = request("GET", f"{PREFIX}/v1/chats", expect_status=200)
+    print(json.dumps(data, indent=2))
+    found = any(c["id"] == chat_id for c in data["items"])
+    if not found:
+        fail(f"Chat {chat_id} not found in list")
+    ok(f"Chat {chat_id} found in list")
+
+
+def test_send_message(chat_id: str, content: str, label: str) -> str | None:
+    bold(f"\n{label} (SSE stream)")
+    if NO_SSE:
+        skip("configure a real API key to test")
+        return None
+    lines, msg_id = sse_request(
+        f"{PREFIX}/v1/chats/{chat_id}/messages:stream",
+        {"content": content},
+    )
+    output = "\n".join(lines)
+    print(output)
+    if "event: done" in output:
+        ok(f"Streamed successfully (msg_id: {msg_id})")
+    elif "event: error" in output:
+        fail("Stream returned error")
+    else:
+        fail("Unexpected SSE output")
+    return msg_id
+
+
+def test_list_messages(chat_id: str, expected_count: int) -> list[dict[str, Any]]:
+    """Returns the list of message dicts (empty list when skipped)."""
+    bold("\n5. List messages")
+    if NO_SSE:
+        skip("no messages to list")
+        return []
+    _, data = request(
+        "GET", f"{PREFIX}/v1/chats/{chat_id}/messages", expect_status=200,
+    )
+    print(json.dumps(data, indent=2))
+    items = data["items"]
+    count = len(items)
+    if count != expected_count:
+        fail(f"Expected {expected_count} messages, got {count}")
+    ok(f"Got {count} messages ({expected_count // 2} user + {expected_count // 2} assistant)")
+    return items
+
+
+def test_reactions(chat_id: str, msg_id: str | None) -> None:
+    bold("\n6. Reactions")
+    if NO_SSE or not msg_id:
+        skip("no messages to react to")
+        return
+
+    # 6a. Set like
+    _, data = request(
+        "PUT", f"{PREFIX}/v1/chats/{chat_id}/messages/{msg_id}/reaction",
+        {"reaction": "like"},
+        expect_status=200,
+    )
+    if data["reaction"] != "like":
+        fail(f"Expected 'like', got '{data['reaction']}'")
+    ok("6a. Set like reaction")
+
+    # 6b. Change to dislike
+    _, data = request(
+        "PUT", f"{PREFIX}/v1/chats/{chat_id}/messages/{msg_id}/reaction",
+        {"reaction": "dislike"},
+        expect_status=200,
+    )
+    if data["reaction"] != "dislike":
+        fail(f"Expected 'dislike', got '{data['reaction']}'")
+    ok("6b. Changed to dislike")
+
+    # 6c. Delete reaction
+    status, _ = request(
+        "DELETE", f"{PREFIX}/v1/chats/{chat_id}/messages/{msg_id}/reaction",
+    )
+    if status != 204:
+        fail(f"Delete reaction returned {status}")
+    ok("6c. Deleted reaction")
+
+
+def test_get_turn(chat_id: str, request_id: str) -> None:
+    bold("\n7. Get turn status")
+    _, data = request(
+        "GET", f"{PREFIX}/v1/chats/{chat_id}/turns/{request_id}",
+        expect_status=200,
+    )
+    print(json.dumps(data, indent=2))
+    if data["request_id"] != request_id:
+        fail(f"Expected request_id={request_id}, got {data['request_id']}")
+    state = data["state"]
+    if state not in ("done", "running", "error", "cancelled"):
+        fail(f"Unexpected turn state: {state}")
+    ok(f"Got turn {request_id} (state={state})")
+
+
+def test_delete_turn(chat_id: str, request_id: str) -> None:
+    bold("\n8. Delete turn")
+    status, data = request(
+        "DELETE", f"{PREFIX}/v1/chats/{chat_id}/turns/{request_id}",
+    )
+    if status not in (200, 204):
+        fail(f"Delete turn returned {status}")
+    if status == 200 and data:
+        print(json.dumps(data, indent=2))
+    ok(f"Deleted turn {request_id}")
+
+
+def test_turns(chat_id: str, messages: list[dict[str, Any]]) -> None:
+    """Test turn API using request_ids extracted from messages."""
+    if NO_SSE or not messages:
+        bold("\n7-8. Turns")
+        skip("no messages — turn tests require SSE")
+        return
+
+    # Collect unique request_ids (each turn has a user + assistant message pair)
+    request_ids = list(dict.fromkeys(m["request_id"] for m in messages))
+
+    # 7. Get turn status for each request_id
+    for rid in request_ids:
+        test_get_turn(chat_id, rid)
+
+    # 8. Delete the last turn (most recent)
+    test_delete_turn(chat_id, request_ids[-1])
+
+
+def test_delete_chat(chat_id: str) -> None:
+    bold("\n9. Delete test chat")
+    status, _ = request("DELETE", f"{PREFIX}/v1/chats/{chat_id}")
+    if status != 204:
+        fail(f"Delete returned {status}")
+    ok(f"Deleted chat {chat_id}")
+
+
+# -- Main --------------------------------------------------------------------
+
+def main() -> None:
+    test_health()
+
+    model_id, _ = test_list_models()
+    test_get_model(model_id)
+
+    chat_id = test_create_chat(model_id)
+    test_get_chat(chat_id)
+    test_update_chat(chat_id)
+    test_list_chats(chat_id)
+
+    msg1_id = test_send_message(chat_id, "What is 2+2? Answer with just the number.", "3. Send message 1")
+    msg2_id = test_send_message(chat_id, "And what is 3+3?", "4. Send message 2")
+
+    messages = test_list_messages(chat_id, expected_count=4)
+    test_reactions(chat_id, msg1_id)
+    test_turns(chat_id, messages)
+    test_delete_chat(chat_id)
+
+    bold("\nAll checks passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add module README with directory structure, setup instructions, API reference, and config guide
- Add stdlib-only Python smoke test covering health, models, chats, messages, reactions, and turns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added README for the mini-chat module with setup, local run instructions, configuration guidance, and a comprehensive reference for REST and streaming API endpoints.

* **Tests**
  * Added a Python-based smoke test for end-to-end validation of the mini-chat API; CLI-configurable, supports optional streaming (SSE) checks, and exercises health, models, chats, messages, reactions, turns, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->