### PR TITLE
feat(outbox): replace replayed_at with dead letter state machine

### DIFF
--- a/libs/modkit-db/examples/outbox_dead_letters.rs
+++ b/libs/modkit-db/examples/outbox_dead_letters.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::use_debug)]
 
-//! Dead letter lifecycle: reject -> list -> replay -> process -> purge.
+//! Dead letter lifecycle: reject -> list -> replay -> resolve -> cleanup.
 //!
 //! Run:
 //!   cargo run -p cf-modkit-db --example `outbox_dead_letters` --features sqlite,preview-outbox
@@ -8,8 +8,8 @@
 use std::time::Duration;
 
 use modkit_db::outbox::{
-    DeadLetterFilter, HandlerResult, MessageHandler, Outbox, OutboxMessage, Partitions,
-    outbox_migrations,
+    DeadLetterFilter, DeadLetterScope, HandlerResult, MessageHandler, Outbox, OutboxMessage,
+    Partitions, outbox_migrations,
 };
 use modkit_db::{ConnectOpts, connect_db, migration_runner::run_migrations_for_testing};
 
@@ -25,20 +25,6 @@ impl MessageHandler for RejectAll {
         HandlerResult::Reject {
             reason: "bad format".into(),
         }
-    }
-}
-
-struct SucceedAll;
-
-#[async_trait::async_trait]
-impl MessageHandler for SucceedAll {
-    async fn handle(
-        &self,
-        msg: &OutboxMessage,
-        _cancel: tokio_util::sync::CancellationToken,
-    ) -> HandlerResult {
-        println!("  replayed seq={} processed OK", msg.seq);
-        HandlerResult::Success
     }
 }
 
@@ -80,7 +66,7 @@ async fn main() -> anyhow::Result<()> {
 
     // List
     let items = outbox
-        .dead_letter_list(&db, &DeadLetterFilter::default())
+        .dead_letter_list(&db.conn()?, &DeadLetterFilter::default())
         .await?;
     println!("Dead letters: {}", items.len());
     for dl in &items {
@@ -91,37 +77,35 @@ async fn main() -> anyhow::Result<()> {
         );
     }
 
-    // Replay 1 entry back into the pipeline
+    // Replay 1 entry — claims it for reprocessing
     let replayed = outbox
         .dead_letter_replay(
-            &db,
-            &DeadLetterFilter {
-                limit: Some(1),
-                ..Default::default()
-            },
+            &db.conn()?,
+            &DeadLetterScope::default().limit(1),
+            Duration::from_secs(60),
         )
         .await?;
-    println!("Replayed: {replayed}");
+    println!("Replayed: {}", replayed.len());
 
-    // Process the replayed message with a success handler
-    let h2 = Outbox::builder(db.clone())
-        .poll_interval(Duration::from_millis(50))
-        .queue("events", Partitions::of(1))
-        .decoupled(SucceedAll)
-        .start()
-        .await?;
-    h2.outbox().flush();
-    tokio::time::sleep(Duration::from_secs(1)).await;
-    h2.stop().await;
+    // Resolve the replayed messages (mark as successfully handled)
+    let ids: Vec<i64> = replayed.iter().map(|m| m.id).collect();
+    let resolved = outbox.dead_letter_resolve(&db.conn()?, &ids).await?;
+    println!("Resolved: {resolved}");
 
-    // Purge all (force=true deletes even non-replayed entries)
-    let purged = outbox
-        .dead_letter_purge(&db, &DeadLetterFilter::default(), true)
+    // Discard remaining pending dead letters
+    let discarded = outbox
+        .dead_letter_discard(&db.conn()?, &DeadLetterScope::default())
         .await?;
-    println!("Purged: {purged}");
+    println!("Discarded: {discarded}");
+
+    // Cleanup terminal-state entries (resolved + discarded)
+    let cleaned = outbox
+        .dead_letter_cleanup(&db.conn()?, &DeadLetterScope::default())
+        .await?;
+    println!("Cleaned up: {cleaned}");
 
     let remaining = outbox
-        .dead_letter_count(&db, &DeadLetterFilter::default())
+        .dead_letter_count(&db.conn()?, &DeadLetterFilter::default())
         .await?;
     println!("Remaining: {remaining}");
     assert_eq!(remaining, 0);

--- a/libs/modkit-db/examples/outbox_retry_reject.rs
+++ b/libs/modkit-db/examples/outbox_retry_reject.rs
@@ -88,7 +88,7 @@ async fn main() -> anyhow::Result<()> {
 
     let items = handle
         .outbox()
-        .dead_letter_list(&db, &DeadLetterFilter::default())
+        .dead_letter_list(&db.conn()?, &DeadLetterFilter::default())
         .await?;
     for dl in &items {
         println!(

--- a/libs/modkit-db/src/outbox/core.rs
+++ b/libs/modkit-db/src/outbox/core.rs
@@ -318,18 +318,21 @@ impl Outbox {
         Ok(incoming_id)
     }
 
-    // -- Dead letter operations --
-
     /// List dead-lettered messages with optional filtering.
+    ///
+    /// Dead letters are an **exceptional recovery mechanism** for messages that
+    /// handlers explicitly rejected. They are operator-level tools, not part of
+    /// the normal processing pipeline. If dead letter replay is a regular part
+    /// of your workflow, consider fixing the handler instead.
     ///
     /// # Errors
     /// Returns error if the database operation fails.
     pub async fn dead_letter_list(
         &self,
-        db: &Db,
+        db: &(impl crate::secure::DBRunner + Sync),
         filter: &super::dead_letter::DeadLetterFilter,
     ) -> Result<Vec<super::dead_letter::DeadLetterMessage>, OutboxError> {
-        super::dead_letter::dead_letter_list(db, filter).await
+        super::dead_letter::dead_letter_list(db.as_seaorm(), filter).await
     }
 
     /// Count dead-lettered messages matching the filter.
@@ -338,36 +341,75 @@ impl Outbox {
     /// Returns error if the database operation fails.
     pub async fn dead_letter_count(
         &self,
-        db: &Db,
+        db: &(impl crate::secure::DBRunner + Sync),
         filter: &super::dead_letter::DeadLetterFilter,
     ) -> Result<u64, OutboxError> {
-        super::dead_letter::dead_letter_count(db, filter).await
+        super::dead_letter::dead_letter_count(db.as_seaorm(), filter).await
     }
 
-    /// Replay dead-lettered messages: re-insert into incoming, set `replayed_at`.
+    /// Claim dead letters for reprocessing. Returns the claimed messages.
+    ///
+    /// The caller decides what to do — process inline, re-enqueue, etc.
+    /// Call `dead_letter_resolve()` on success or `dead_letter_reject()` on failure.
     ///
     /// # Errors
     /// Returns error if the database operation fails.
     pub async fn dead_letter_replay(
         &self,
-        db: &Db,
-        filter: &super::dead_letter::DeadLetterFilter,
-    ) -> Result<u64, OutboxError> {
-        super::dead_letter::dead_letter_replay(db, filter).await
+        db: &(impl crate::secure::DBRunner + Sync),
+        scope: &super::dead_letter::DeadLetterScope,
+        timeout: std::time::Duration,
+    ) -> Result<Vec<super::dead_letter::DeadLetterMessage>, OutboxError> {
+        super::dead_letter::dead_letter_replay(db.as_seaorm(), scope, timeout).await
     }
 
-    /// Permanently delete dead-lettered messages.
-    /// Only purges already-replayed messages unless `force = true`.
+    /// Transition claimed dead letters to `resolved`.
     ///
     /// # Errors
     /// Returns error if the database operation fails.
-    pub async fn dead_letter_purge(
+    pub async fn dead_letter_resolve(
         &self,
-        db: &Db,
-        filter: &super::dead_letter::DeadLetterFilter,
-        force: bool,
+        db: &(impl crate::secure::DBRunner + Sync),
+        ids: &[i64],
     ) -> Result<u64, OutboxError> {
-        super::dead_letter::dead_letter_purge(db, filter, force).await
+        super::dead_letter::dead_letter_resolve(db.as_seaorm(), ids).await
+    }
+
+    /// Transition claimed dead letters back to `pending` with attempts++.
+    ///
+    /// # Errors
+    /// Returns error if the database operation fails.
+    pub async fn dead_letter_reject(
+        &self,
+        db: &(impl crate::secure::DBRunner + Sync),
+        ids: &[i64],
+        reason: &str,
+    ) -> Result<u64, OutboxError> {
+        super::dead_letter::dead_letter_reject(db.as_seaorm(), ids, reason).await
+    }
+
+    /// Discard pending dead letters — transitions to `discarded`.
+    ///
+    /// # Errors
+    /// Returns error if the database operation fails.
+    pub async fn dead_letter_discard(
+        &self,
+        db: &(impl crate::secure::DBRunner + Sync),
+        scope: &super::dead_letter::DeadLetterScope,
+    ) -> Result<u64, OutboxError> {
+        super::dead_letter::dead_letter_discard(db.as_seaorm(), scope).await
+    }
+
+    /// Delete terminal-state dead letters (`resolved` + `discarded`).
+    ///
+    /// # Errors
+    /// Returns error if the database operation fails.
+    pub async fn dead_letter_cleanup(
+        &self,
+        db: &(impl crate::secure::DBRunner + Sync),
+        scope: &super::dead_letter::DeadLetterScope,
+    ) -> Result<u64, OutboxError> {
+        super::dead_letter::dead_letter_cleanup(db.as_seaorm(), scope).await
     }
 
     /// Notify the sequencer that new items are available.

--- a/libs/modkit-db/src/outbox/dead_letter.rs
+++ b/libs/modkit-db/src/outbox/dead_letter.rs
@@ -1,10 +1,99 @@
+//! # Dead letters
+//!
+//! Dead letters hold messages that a handler explicitly rejected via
+//! [`HandlerResult::Reject`]. They are an **exceptional recovery mechanism**,
+//! not a routine processing path.
+//!
+//! **If you find yourself replaying dead letters frequently, the handler logic
+//! needs fixing — not the dead letter infrastructure.**
+//!
+//! ## Status lifecycle
+//!
+//! ```text
+//!                   replay()                       resolve()
+//!   pending ──────────────────► reprocessing ──────────────────► resolved
+//!      │  ▲                          │
+//!      │  │  reject()                │  reject()
+//!      │  └──────────────────────────┘
+//!      │
+//!      │  discard()
+//!      └───────────────────────────────────────────────────────► discarded
+//! ```
+//!
+//! ## Operations
+//!
+//! | Operation  | Purpose | Parameter | Concurrency |
+//! |------------|---------|-----------|-------------|
+//! | `list`     | Inspect dead letters | `&DeadLetterFilter` | Safe |
+//! | `count`    | Count matching | `&DeadLetterFilter` | Safe |
+//! | `replay`   | Claim for reprocessing | `&DeadLetterScope` + `Duration` | Row-locked |
+//! | `resolve`  | Mark as resolved | `&[i64]` | Safe |
+//! | `reject`   | Return to pending | `&[i64]` + reason | Safe |
+//! | `discard`  | Soft-delete | `&DeadLetterScope` | Row-locked |
+//! | `cleanup`  | Delete terminal states | `&DeadLetterScope` | Safe |
+
 use std::fmt::Write as _;
+use std::time::Duration;
 
-use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
+use sea_orm::{
+    ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait, TryGetError,
+    TryGetable,
+};
 
-use super::dialect::Dialect;
 use super::types::OutboxError;
-use crate::Db;
+use crate::secure::SeaOrmRunner;
+
+/// Dead letter lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeadLetterStatus {
+    Pending,
+    Reprocessing,
+    Resolved,
+    Discarded,
+}
+
+impl std::fmt::Display for DeadLetterStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => f.write_str("pending"),
+            Self::Reprocessing => f.write_str("reprocessing"),
+            Self::Resolved => f.write_str("resolved"),
+            Self::Discarded => f.write_str("discarded"),
+        }
+    }
+}
+
+impl std::str::FromStr for DeadLetterStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "reprocessing" => Ok(Self::Reprocessing),
+            "resolved" => Ok(Self::Resolved),
+            "discarded" => Ok(Self::Discarded),
+            other => Err(format!("invalid dead letter status: {other}")),
+        }
+    }
+}
+
+impl TryGetable for DeadLetterStatus {
+    fn try_get_by<I: sea_orm::ColIdx>(
+        res: &sea_orm::QueryResult,
+        idx: I,
+    ) -> Result<Self, TryGetError> {
+        let val: String = res.try_get_by(idx)?;
+        val.parse()
+            .map_err(|e: String| TryGetError::DbErr(sea_orm::DbErr::Type(e)))
+    }
+}
+
+fn runner_backend(runner: &SeaOrmRunner<'_>) -> DbBackend {
+    match runner {
+        SeaOrmRunner::Conn(c) => c.get_database_backend(),
+        SeaOrmRunner::Tx(t) => t.get_database_backend(),
+    }
+}
 
 /// A dead-lettered message with self-contained payload.
 #[derive(Debug, FromQueryResult)]
@@ -18,114 +107,287 @@ pub struct DeadLetterMessage {
     pub failed_at: chrono::DateTime<chrono::Utc>,
     pub last_error: Option<String>,
     pub attempts: i16,
-    pub replayed_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub status: DeadLetterStatus,
+    pub completed_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub deadline: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-/// Filter for dead letter queries.
-pub struct DeadLetterFilter {
+/// Row-targeting scope shared by all dead letter operations.
+///
+/// Used by `replay`, `discard`, `cleanup`. Does NOT include `status` — those
+/// operations hardcode their own status logic.
+#[derive(Debug, Default)]
+pub struct DeadLetterScope {
     pub partition_id: Option<i64>,
     pub queue: Option<String>,
-    pub failed_after: Option<chrono::DateTime<chrono::Utc>>,
-    pub failed_before: Option<chrono::DateTime<chrono::Utc>>,
-    /// Filter to entries where `replayed_at IS NULL` (default: true).
-    pub only_pending: bool,
+    pub payload_type: Option<String>,
     pub limit: Option<u32>,
+}
+
+impl DeadLetterScope {
+    #[must_use]
+    pub fn partition(mut self, id: i64) -> Self {
+        self.partition_id = Some(id);
+        self
+    }
+
+    #[must_use]
+    pub fn queue(mut self, queue: impl Into<String>) -> Self {
+        self.queue = Some(queue.into());
+        self
+    }
+
+    #[must_use]
+    pub fn payload_type(mut self, pt: impl Into<String>) -> Self {
+        self.payload_type = Some(pt.into());
+        self
+    }
+
+    #[must_use]
+    pub fn limit(mut self, n: u32) -> Self {
+        self.limit = Some(n);
+        self
+    }
+}
+
+/// Full filter for querying dead letters. Used by `list` and `count`.
+///
+/// Default: `status = Some(Pending)`, empty scope.
+pub struct DeadLetterFilter {
+    pub scope: DeadLetterScope,
+    pub status: Option<DeadLetterStatus>,
+}
+
+impl DeadLetterFilter {
+    /// Start from a scope, defaulting to `status = Some(Pending)`.
+    #[must_use]
+    pub fn from_scope(scope: DeadLetterScope) -> Self {
+        Self {
+            scope,
+            status: Some(DeadLetterStatus::Pending),
+        }
+    }
+
+    #[must_use]
+    pub fn partition(mut self, id: i64) -> Self {
+        self.scope.partition_id = Some(id);
+        self
+    }
+
+    #[must_use]
+    pub fn queue(mut self, queue: impl Into<String>) -> Self {
+        self.scope.queue = Some(queue.into());
+        self
+    }
+
+    #[must_use]
+    pub fn payload_type(mut self, pt: impl Into<String>) -> Self {
+        self.scope.payload_type = Some(pt.into());
+        self
+    }
+
+    #[must_use]
+    pub fn limit(mut self, n: u32) -> Self {
+        self.scope.limit = Some(n);
+        self
+    }
+
+    #[must_use]
+    pub fn status(mut self, status: DeadLetterStatus) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    /// Match all statuses (no status filter).
+    #[must_use]
+    pub fn any_status(mut self) -> Self {
+        self.status = None;
+        self
+    }
 }
 
 impl Default for DeadLetterFilter {
     fn default() -> Self {
         Self {
-            partition_id: None,
-            queue: None,
-            failed_after: None,
-            failed_before: None,
-            only_pending: true,
-            limit: None,
+            scope: DeadLetterScope::default(),
+            status: Some(DeadLetterStatus::Pending),
         }
     }
 }
 
 /// List dead-lettered messages with optional filtering.
-pub async fn dead_letter_list(
-    db: &Db,
+pub(super) async fn dead_letter_list(
+    runner: SeaOrmRunner<'_>,
     filter: &DeadLetterFilter,
 ) -> Result<Vec<DeadLetterMessage>, OutboxError> {
-    let conn = db.sea_internal();
-    let backend = conn.get_database_backend();
+    let backend = runner_backend(&runner);
     let (sql, values) = build_select_query(backend, filter);
+    let stmt = Statement::from_sql_and_values(backend, &sql, values);
 
-    let rows =
-        DeadLetterMessage::find_by_statement(Statement::from_sql_and_values(backend, &sql, values))
-            .all(&conn)
-            .await?;
+    let rows = match &runner {
+        SeaOrmRunner::Conn(c) => DeadLetterMessage::find_by_statement(stmt).all(*c).await?,
+        SeaOrmRunner::Tx(t) => DeadLetterMessage::find_by_statement(stmt).all(*t).await?,
+    };
     Ok(rows)
 }
 
 /// Count dead-lettered messages matching the filter.
-pub async fn dead_letter_count(db: &Db, filter: &DeadLetterFilter) -> Result<u64, OutboxError> {
+pub(super) async fn dead_letter_count(
+    runner: SeaOrmRunner<'_>,
+    filter: &DeadLetterFilter,
+) -> Result<u64, OutboxError> {
     #[derive(Debug, FromQueryResult)]
     struct Count {
         cnt: i64,
     }
 
-    let conn = db.sea_internal();
-    let backend = conn.get_database_backend();
+    let backend = runner_backend(&runner);
     let (sql, values) = build_count_query(backend, filter);
+    let stmt = Statement::from_sql_and_values(backend, &sql, values);
 
-    let row = Count::find_by_statement(Statement::from_sql_and_values(backend, &sql, values))
-        .one(&conn)
-        .await?;
+    let row = match &runner {
+        SeaOrmRunner::Conn(c) => Count::find_by_statement(stmt).one(*c).await?,
+        SeaOrmRunner::Tx(t) => Count::find_by_statement(stmt).one(*t).await?,
+    };
 
     #[allow(clippy::cast_sign_loss)]
     Ok(row.map_or(0, |r| r.cnt as u64))
 }
 
-/// Replay dead-lettered messages: re-insert into incoming, set `replayed_at`.
-pub async fn dead_letter_replay(db: &Db, filter: &DeadLetterFilter) -> Result<u64, OutboxError> {
-    let conn = db.sea_internal();
-    let backend = conn.get_database_backend();
-    let dialect = Dialect::from(backend);
-    let txn = conn.begin().await?;
+/// Claim dead letters for reprocessing. Transitions `pending → reprocessing`
+/// and reclaims orphaned `reprocessing` rows whose deadline has expired.
+///
+/// Returns the claimed messages. The caller decides what to do with them —
+/// re-enqueue, process inline, forward elsewhere. Use `dead_letter_resolve()`
+/// on success or `dead_letter_reject()` on failure.
+///
+/// On Postgres and `MySQL`, uses `FOR UPDATE SKIP LOCKED` to prevent concurrent
+/// callers from claiming the same rows.
+pub(super) async fn dead_letter_replay(
+    runner: SeaOrmRunner<'_>,
+    scope: &DeadLetterScope,
+    timeout: Duration,
+) -> Result<Vec<DeadLetterMessage>, OutboxError> {
+    let backend = runner_backend(&runner);
 
-    let (sql, values) = build_select_query(backend, filter);
+    let txn = match &runner {
+        SeaOrmRunner::Conn(c) => c.begin().await?,
+        SeaOrmRunner::Tx(t) => t.begin().await?,
+    };
+
+    let (sql, values) = build_replay_select(backend, scope);
     let rows =
         DeadLetterMessage::find_by_statement(Statement::from_sql_and_values(backend, &sql, values))
             .all(&txn)
             .await?;
 
-    let count = rows.len();
-    if count == 0 {
+    if rows.is_empty() {
+        txn.commit().await?;
+        return Ok(Vec::new());
+    }
+
+    let dl_ids: Vec<i64> = rows.iter().map(|r| r.id).collect();
+    let claim_sql = build_batch_claim(backend, dl_ids.len());
+    let mut claim_values: Vec<sea_orm::Value> = Vec::with_capacity(1 + dl_ids.len());
+    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    claim_values.push((timeout.as_secs() as i64).into());
+    for &id in &dl_ids {
+        claim_values.push(id.into());
+    }
+    txn.execute(Statement::from_sql_and_values(
+        backend,
+        &claim_sql,
+        claim_values,
+    ))
+    .await?;
+
+    txn.commit().await?;
+    Ok(rows)
+}
+
+/// Transition `reprocessing → resolved`. Called after successfully handling
+/// claimed dead letters.
+///
+/// Returns count of resolved rows. Rows not in `reprocessing` state are
+/// skipped (returns 0 for those).
+pub(super) async fn dead_letter_resolve(
+    runner: SeaOrmRunner<'_>,
+    ids: &[i64],
+) -> Result<u64, OutboxError> {
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    let backend = runner_backend(&runner);
+    let sql = build_batch_resolve(backend, ids.len());
+    let values: Vec<sea_orm::Value> = ids.iter().map(|&id| id.into()).collect();
+    let stmt = Statement::from_sql_and_values(backend, &sql, values);
+    let result = match &runner {
+        SeaOrmRunner::Conn(c) => c.execute(stmt).await?,
+        SeaOrmRunner::Tx(t) => t.execute(stmt).await?,
+    };
+    Ok(result.rows_affected())
+}
+
+/// Transition `reprocessing → pending` with attempts++, `failed_at` refreshed,
+/// `last_error` updated. Called when handling a claimed dead letter fails.
+///
+/// Returns count of rejected rows.
+pub(super) async fn dead_letter_reject(
+    runner: SeaOrmRunner<'_>,
+    ids: &[i64],
+    reason: &str,
+) -> Result<u64, OutboxError> {
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    let backend = runner_backend(&runner);
+    let sql = build_batch_reject(backend, ids.len());
+    let mut values: Vec<sea_orm::Value> = Vec::with_capacity(1 + ids.len());
+    values.push(reason.to_owned().into());
+    for &id in ids {
+        values.push(id.into());
+    }
+    let stmt = Statement::from_sql_and_values(backend, &sql, values);
+    let result = match &runner {
+        SeaOrmRunner::Conn(c) => c.execute(stmt).await?,
+        SeaOrmRunner::Tx(t) => t.execute(stmt).await?,
+    };
+    Ok(result.rows_affected())
+}
+
+/// Discard pending dead letters — transitions `pending → discarded`.
+///
+/// Uses `FOR UPDATE SKIP LOCKED` for concurrent safety.
+pub(super) async fn dead_letter_discard(
+    runner: SeaOrmRunner<'_>,
+    scope: &DeadLetterScope,
+) -> Result<u64, OutboxError> {
+    #[derive(Debug, FromQueryResult)]
+    struct Id {
+        id: i64,
+    }
+
+    let backend = runner_backend(&runner);
+
+    let txn = match &runner {
+        SeaOrmRunner::Conn(c) => c.begin().await?,
+        SeaOrmRunner::Tx(t) => t.begin().await?,
+    };
+
+    let (sql, values) = build_discard_select(backend, scope);
+
+    let rows = Id::find_by_statement(Statement::from_sql_and_values(backend, &sql, values))
+        .all(&txn)
+        .await?;
+
+    if rows.is_empty() {
         txn.commit().await?;
         return Ok(0);
     }
 
-    // Re-insert body rows and incoming rows via dialect helpers
-    let payloads: Vec<(&[u8], &str)> = rows
-        .iter()
-        .map(|r| (r.payload.as_slice(), r.payload_type.as_str()))
-        .collect();
-    let body_ids = dialect
-        .exec_insert_body_batch(&txn, backend, &payloads)
-        .await?;
-
-    let entries: Vec<(i64, i64)> = rows
-        .iter()
-        .zip(&body_ids)
-        .map(|(r, &bid)| (r.partition_id, bid))
-        .collect();
-    dialect
-        .exec_insert_incoming_batch(&txn, backend, &entries)
-        .await?;
-
-    // Batch replayed_at update
-    let now: sea_orm::Value = chrono::Utc::now().into();
-    let dl_ids: Vec<i64> = rows.iter().map(|r| r.id).collect();
-    let update_sql = build_batch_replayed_at_update(backend, dl_ids.len());
-    let mut update_values: Vec<sea_orm::Value> = Vec::with_capacity(1 + dl_ids.len());
-    update_values.push(now);
-    for &id in &dl_ids {
-        update_values.push(id.into());
-    }
+    let ids: Vec<i64> = rows.iter().map(|r| r.id).collect();
+    let update_sql = build_batch_discard(backend, ids.len());
+    let update_values: Vec<sea_orm::Value> = ids.iter().map(|&id| id.into()).collect();
     txn.execute(Statement::from_sql_and_values(
         backend,
         &update_sql,
@@ -136,39 +398,23 @@ pub async fn dead_letter_replay(db: &Db, filter: &DeadLetterFilter) -> Result<u6
     txn.commit().await?;
 
     #[allow(clippy::cast_possible_truncation)]
-    Ok(count as u64)
+    Ok(ids.len() as u64)
 }
 
-/// Permanently delete dead-lettered messages.
-/// Only purges messages where `replayed_at IS NOT NULL` (already replayed)
-/// unless `force = true`.
-pub async fn dead_letter_purge(
-    db: &Db,
-    filter: &DeadLetterFilter,
-    force: bool,
+/// Delete terminal-state dead letters (`resolved` + `discarded`).
+///
+/// `pending` and `reprocessing` rows are always preserved.
+pub(super) async fn dead_letter_cleanup(
+    runner: SeaOrmRunner<'_>,
+    scope: &DeadLetterScope,
 ) -> Result<u64, OutboxError> {
-    let conn = db.sea_internal();
-    let backend = conn.get_database_backend();
-
-    let effective_filter = DeadLetterFilter {
-        partition_id: filter.partition_id,
-        queue: filter.queue.clone(),
-        failed_after: filter.failed_after,
-        failed_before: filter.failed_before,
-        only_pending: false,
-        limit: filter.limit,
+    let backend = runner_backend(&runner);
+    let (sql, values) = build_delete_query(backend, scope);
+    let stmt = Statement::from_sql_and_values(backend, &sql, values);
+    let result = match &runner {
+        SeaOrmRunner::Conn(c) => c.execute(stmt).await?,
+        SeaOrmRunner::Tx(t) => t.execute(stmt).await?,
     };
-
-    let (sql, values) = if force {
-        build_delete_query(backend, &effective_filter, false)
-    } else {
-        build_delete_query(backend, &effective_filter, true)
-    };
-
-    let result = conn
-        .execute(Statement::from_sql_and_values(backend, &sql, values))
-        .await?;
-
     Ok(result.rows_affected())
 }
 
@@ -178,6 +424,7 @@ struct QueryBuilder {
     param_idx: usize,
     has_where: bool,
     is_mysql: bool,
+    is_sqlite: bool,
 }
 
 impl QueryBuilder {
@@ -188,6 +435,7 @@ impl QueryBuilder {
             param_idx: 1,
             has_where: false,
             is_mysql: backend == DbBackend::MySql,
+            is_sqlite: backend == DbBackend::Sqlite,
         }
     }
 
@@ -226,14 +474,35 @@ impl QueryBuilder {
         }
         (self.sql, self.values)
     }
+
+    fn finish_no_order(mut self, limit: Option<u32>) -> (String, Vec<sea_orm::Value>) {
+        if let Some(n) = limit {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = write!(self.sql, " LIMIT {n}");
+        }
+        (self.sql, self.values)
+    }
+
+    fn finish_locking_no_order(
+        self,
+        limit: Option<u32>,
+        for_update: bool,
+    ) -> (String, Vec<sea_orm::Value>) {
+        let is_sqlite = self.is_sqlite;
+        let (mut sql, values) = self.finish_no_order(limit);
+        if for_update && !is_sqlite {
+            sql.push_str(" FOR UPDATE SKIP LOCKED");
+        }
+        (sql, values)
+    }
 }
 
-fn apply_filters(qb: &mut QueryBuilder, filter: &DeadLetterFilter) {
-    if let Some(pid) = filter.partition_id {
+fn apply_scope(qb: &mut QueryBuilder, scope: &DeadLetterScope) {
+    if let Some(pid) = scope.partition_id {
         let idx = qb.param_idx;
         qb.add_condition(&format!("d.partition_id = ${idx}"), pid.into());
     }
-    if let Some(ref queue) = filter.queue {
+    if let Some(ref queue) = scope.queue {
         let idx = qb.param_idx;
         qb.add_condition(
             &format!(
@@ -242,31 +511,34 @@ fn apply_filters(qb: &mut QueryBuilder, filter: &DeadLetterFilter) {
             queue.clone().into(),
         );
     }
-    if let Some(after) = filter.failed_after {
+    if let Some(ref payload_type) = scope.payload_type {
         let idx = qb.param_idx;
-        qb.add_condition(&format!("d.failed_at >= ${idx}"), after.into());
-    }
-    if let Some(before) = filter.failed_before {
-        let idx = qb.param_idx;
-        qb.add_condition(&format!("d.failed_at < ${idx}"), before.into());
-    }
-    if filter.only_pending {
-        qb.add_raw_condition("d.replayed_at IS NULL");
+        qb.add_condition(
+            &format!("d.payload_type = ${idx}"),
+            payload_type.clone().into(),
+        );
     }
 }
+
+fn apply_filter(qb: &mut QueryBuilder, filter: &DeadLetterFilter) {
+    apply_scope(qb, &filter.scope);
+    if let Some(status) = filter.status {
+        let idx = qb.param_idx;
+        qb.add_condition(&format!("d.status = ${idx}"), status.to_string().into());
+    }
+}
+
+const SELECT_COLUMNS: &str = "SELECT d.id, d.partition_id, d.seq, d.payload, d.payload_type, \
+     d.created_at, d.failed_at, d.last_error, d.attempts, d.status, d.completed_at, d.deadline \
+     FROM modkit_outbox_dead_letters d";
 
 fn build_select_query(
     backend: DbBackend,
     filter: &DeadLetterFilter,
 ) -> (String, Vec<sea_orm::Value>) {
-    let mut qb = QueryBuilder::new(
-        "SELECT d.id, d.partition_id, d.seq, d.payload, d.payload_type, d.created_at, \
-         d.failed_at, d.last_error, d.attempts, d.replayed_at \
-         FROM modkit_outbox_dead_letters d",
-        backend,
-    );
-    apply_filters(&mut qb, filter);
-    qb.finish(filter.limit)
+    let mut qb = QueryBuilder::new(SELECT_COLUMNS, backend);
+    apply_filter(&mut qb, filter);
+    qb.finish(filter.scope.limit)
 }
 
 fn build_count_query(
@@ -277,44 +549,72 @@ fn build_count_query(
         "SELECT COUNT(*) AS cnt FROM modkit_outbox_dead_letters d",
         backend,
     );
-    apply_filters(&mut qb, filter);
-    // Count doesn't need ORDER BY or LIMIT but we strip them
-    let (mut sql, values) = qb.finish(None);
-    // Remove the ORDER BY clause for count queries
-    if let Some(pos) = sql.find(" ORDER BY") {
-        sql.truncate(pos);
-    }
-    (sql, values)
+    apply_filter(&mut qb, filter);
+    qb.finish_no_order(None)
 }
 
-/// Build a direct DELETE query with the same filter conditions as SELECT.
-/// Uses `DELETE FROM ... WHERE id IN (SELECT id FROM ... )` subquery approach
-/// for all backends — this avoids alias issues (`SQLite`/`MySQL` don't support
-/// aliases on DELETE targets) and handles LIMIT correctly (`SQLite` doesn't
-/// support `DELETE ... LIMIT`).
+/// Build a DELETE query for cleanup — only terminal states.
 fn build_delete_query(
     backend: DbBackend,
-    filter: &DeadLetterFilter,
-    only_replayed: bool,
+    scope: &DeadLetterScope,
 ) -> (String, Vec<sea_orm::Value>) {
     let mut inner_qb = QueryBuilder::new("SELECT d.id FROM modkit_outbox_dead_letters d", backend);
-    apply_filters(&mut inner_qb, filter);
-    if only_replayed {
-        inner_qb.add_raw_condition("d.replayed_at IS NOT NULL");
-    }
-    let (inner_sql, values) = inner_qb.finish(filter.limit);
+    apply_scope(&mut inner_qb, scope);
+    inner_qb.add_raw_condition("d.status IN ('resolved', 'discarded')");
+    let (inner_sql, values) = inner_qb.finish_locking_no_order(scope.limit, true);
     let sql = format!("DELETE FROM modkit_outbox_dead_letters WHERE id IN ({inner_sql})");
     (sql, values)
 }
 
-/// Build `UPDATE modkit_outbox_dead_letters SET replayed_at = ? WHERE id IN (?, ?, ...)`.
-fn build_batch_replayed_at_update(backend: DbBackend, count: usize) -> String {
-    let is_mysql = backend == DbBackend::MySql;
-    let mut sql = String::from("UPDATE modkit_outbox_dead_letters SET replayed_at = ");
-    if is_mysql {
-        sql.push('?');
+/// Build the replay SELECT with orphan recovery: pending rows + expired reprocessing rows.
+fn build_replay_select(
+    backend: DbBackend,
+    scope: &DeadLetterScope,
+) -> (String, Vec<sea_orm::Value>) {
+    let mut qb = QueryBuilder::new(SELECT_COLUMNS, backend);
+    apply_scope(&mut qb, scope);
+    let now_fn = db_now(backend);
+    qb.add_raw_condition(&format!(
+        "(d.status = 'pending' OR (d.status = 'reprocessing' AND d.deadline < {now_fn}))"
+    ));
+    // ORDER BY deadline NULLS FIRST (pending rows first), then id
+    // Note: finish_no_order without limit — ORDER BY and LIMIT appended manually
+    let is_sqlite = qb.is_sqlite;
+    let (mut sql, values) = qb.finish_no_order(None);
+    if is_sqlite {
+        // SQLite: NULL sorts first by default with ASC
+        sql.push_str(" ORDER BY d.deadline ASC, d.id ASC");
     } else {
-        sql.push_str("$1");
+        sql.push_str(" ORDER BY d.deadline ASC NULLS FIRST, d.id ASC");
+    }
+    if let Some(n) = scope.limit {
+        #[allow(clippy::let_underscore_must_use)]
+        let _ = write!(sql, " LIMIT {n}");
+    }
+    if !is_sqlite {
+        sql.push_str(" FOR UPDATE SKIP LOCKED");
+    }
+    (sql, values)
+}
+
+/// Build `UPDATE ... SET status = 'reprocessing', deadline = now() + timeout WHERE id IN (...)`.
+fn build_batch_claim(backend: DbBackend, count: usize) -> String {
+    let is_mysql = backend == DbBackend::MySql;
+    let now_fn = db_now(backend);
+    let mut sql =
+        String::from("UPDATE modkit_outbox_dead_letters SET status = 'reprocessing', deadline = ");
+    match backend {
+        DbBackend::Postgres => {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = write!(sql, "{now_fn} + $1 * INTERVAL '1 second'");
+        }
+        DbBackend::MySql => {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = write!(sql, "DATE_ADD({now_fn}, INTERVAL ? SECOND)");
+        }
+        DbBackend::Sqlite => {
+            sql.push_str("datetime('now', '+' || $1 || ' seconds')");
+        }
     }
     sql.push_str(" WHERE id IN (");
     for i in 0..count {
@@ -325,11 +625,99 @@ fn build_batch_replayed_at_update(backend: DbBackend, count: usize) -> String {
             sql.push('?');
         } else {
             #[allow(clippy::let_underscore_must_use)]
-            let _ = write!(sql, "${}", i + 2); // $2, $3, ...
+            let _ = write!(sql, "${}", i + 2);
         }
     }
     sql.push(')');
     sql
+}
+
+/// Build `UPDATE ... SET status = 'resolved', completed_at = now(), deadline = NULL WHERE id IN (...) AND status = 'reprocessing'`.
+fn build_batch_resolve(backend: DbBackend, count: usize) -> String {
+    let is_mysql = backend == DbBackend::MySql;
+    let now_fn = db_now(backend);
+    let mut sql = format!(
+        "UPDATE modkit_outbox_dead_letters SET status = 'resolved', completed_at = {now_fn}, deadline = NULL WHERE id IN ("
+    );
+    for i in 0..count {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        if is_mysql {
+            sql.push('?');
+        } else {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = write!(sql, "${}", i + 1);
+        }
+    }
+    sql.push_str(") AND status = 'reprocessing'");
+    sql
+}
+
+/// Build `UPDATE ... SET status = 'pending', attempts = attempts + 1, last_error = $reason, failed_at = now(), deadline = NULL WHERE id IN (...) AND status = 'reprocessing'`.
+fn build_batch_reject(backend: DbBackend, count: usize) -> String {
+    let is_mysql = backend == DbBackend::MySql;
+    let now_fn = db_now(backend);
+    // First param is the reason string, then IDs
+    let mut sql = format!(
+        "UPDATE modkit_outbox_dead_letters SET status = 'pending', attempts = attempts + 1, \
+         last_error = {reason}, failed_at = {now_fn}, deadline = NULL WHERE id IN (",
+        reason = if is_mysql { "?" } else { "$1" },
+    );
+    for i in 0..count {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        if is_mysql {
+            sql.push('?');
+        } else {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = write!(sql, "${}", i + 2);
+        }
+    }
+    sql.push_str(") AND status = 'reprocessing'");
+    sql
+}
+
+/// Build discard SELECT: pending rows only, with FOR UPDATE SKIP LOCKED.
+fn build_discard_select(
+    backend: DbBackend,
+    scope: &DeadLetterScope,
+) -> (String, Vec<sea_orm::Value>) {
+    let mut qb = QueryBuilder::new("SELECT d.id FROM modkit_outbox_dead_letters d", backend);
+    apply_scope(&mut qb, scope);
+    qb.add_raw_condition("d.status = 'pending'");
+    qb.finish_locking_no_order(scope.limit, true)
+}
+
+/// Build `UPDATE ... SET status = 'discarded', completed_at = now() WHERE id IN (...)`.
+fn build_batch_discard(backend: DbBackend, count: usize) -> String {
+    let is_mysql = backend == DbBackend::MySql;
+    let now_fn = db_now(backend);
+    let mut sql = format!(
+        "UPDATE modkit_outbox_dead_letters SET status = 'discarded', completed_at = {now_fn} WHERE id IN ("
+    );
+    for i in 0..count {
+        if i > 0 {
+            sql.push_str(", ");
+        }
+        if is_mysql {
+            sql.push('?');
+        } else {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = write!(sql, "${}", i + 1);
+        }
+    }
+    sql.push(')');
+    sql
+}
+
+fn db_now(backend: DbBackend) -> &'static str {
+    match backend {
+        DbBackend::Postgres => "now()",
+        DbBackend::MySql => "CURRENT_TIMESTAMP(6)",
+        DbBackend::Sqlite => "datetime('now')",
+    }
 }
 
 #[cfg(test)]
@@ -337,56 +725,85 @@ fn build_batch_replayed_at_update(backend: DbBackend, count: usize) -> String {
 mod tests {
     use super::*;
 
+    // --- Filter / scope tests ---
+
     #[test]
     fn build_query_empty_filter_pg() {
         let filter = DeadLetterFilter::default();
         let (sql, values) = build_select_query(DbBackend::Postgres, &filter);
-        assert!(sql.contains("replayed_at IS NULL"));
-        assert!(values.is_empty());
-    }
-
-    #[test]
-    fn build_query_partition_filter_pg() {
-        let filter = DeadLetterFilter {
-            partition_id: Some(42),
-            ..Default::default()
-        };
-        let (sql, values) = build_select_query(DbBackend::Postgres, &filter);
-        assert!(sql.contains("partition_id = $1"));
+        assert!(sql.contains("d.status = $1"));
         assert_eq!(values.len(), 1);
     }
 
     #[test]
-    fn build_query_all_fields_pg() {
-        let filter = DeadLetterFilter {
-            partition_id: Some(1),
-            queue: Some("orders".into()),
-            failed_after: Some(chrono::Utc::now()),
-            failed_before: Some(chrono::Utc::now()),
-            only_pending: true,
-            limit: Some(10),
-        };
+    fn build_query_partition_filter_pg() {
+        let filter = DeadLetterFilter::default().partition(42);
         let (sql, values) = build_select_query(DbBackend::Postgres, &filter);
-        assert!(sql.contains("$1"));
-        assert!(sql.contains("$2"));
-        assert!(sql.contains("$3"));
-        assert!(sql.contains("$4"));
+        assert!(sql.contains("partition_id = $1"));
+        assert!(sql.contains("d.status = $2"));
+        assert_eq!(values.len(), 2);
+    }
+
+    #[test]
+    fn build_query_all_fields_pg() {
+        let filter = DeadLetterFilter::default()
+            .partition(1)
+            .queue("orders")
+            .payload_type("order.created")
+            .limit(10);
+        let (sql, values) = build_select_query(DbBackend::Postgres, &filter);
+        assert!(sql.contains("$1")); // partition_id
+        assert!(sql.contains("$2")); // queue
+        assert!(sql.contains("$3")); // payload_type
+        assert!(sql.contains("$4")); // status
         assert!(sql.contains("LIMIT 10"));
         assert_eq!(values.len(), 4);
     }
 
     #[test]
     fn build_query_mysql_uses_question_marks() {
-        let filter = DeadLetterFilter {
-            partition_id: Some(1),
-            queue: Some("q".into()),
-            ..Default::default()
-        };
+        let filter = DeadLetterFilter::default().partition(1).queue("q");
         let (sql, values) = build_select_query(DbBackend::MySql, &filter);
         assert!(sql.contains('?'));
         assert!(!sql.contains('$'));
-        assert_eq!(values.len(), 2);
+        assert_eq!(values.len(), 3); // partition_id, queue, status
     }
+
+    #[test]
+    fn scope_payload_type_filter() {
+        let scope = DeadLetterScope::default().payload_type("order.created");
+        let mut qb = QueryBuilder::new("SELECT 1 FROM t d", DbBackend::Postgres);
+        apply_scope(&mut qb, &scope);
+        let (sql, values) = qb.finish_no_order(None);
+        assert!(sql.contains("d.payload_type = $1"));
+        assert_eq!(values.len(), 1);
+    }
+
+    #[test]
+    fn filter_by_resolved_status() {
+        let filter = DeadLetterFilter::default().status(DeadLetterStatus::Resolved);
+        let (sql, _) = build_select_query(DbBackend::Postgres, &filter);
+        assert!(sql.contains("d.status = $1"));
+    }
+
+    #[test]
+    fn filter_by_reprocessing_status() {
+        let filter = DeadLetterFilter::default().status(DeadLetterStatus::Reprocessing);
+        let (sql, values) = build_select_query(DbBackend::Postgres, &filter);
+        assert!(sql.contains("d.status = $1"));
+        assert_eq!(values.len(), 1);
+    }
+
+    #[test]
+    fn filter_no_status() {
+        let filter = DeadLetterFilter::default().any_status();
+        let (sql, values) = build_select_query(DbBackend::Postgres, &filter);
+        // Column list contains d.status, but WHERE clause should not filter on it
+        assert!(!sql.contains("d.status = $"));
+        assert!(values.is_empty());
+    }
+
+    // --- Count ---
 
     #[test]
     fn count_query_has_no_order_by() {
@@ -394,5 +811,175 @@ mod tests {
         let (sql, _) = build_count_query(DbBackend::Postgres, &filter);
         assert!(sql.contains("COUNT(*)"));
         assert!(!sql.contains("ORDER BY"));
+    }
+
+    // --- Replay ---
+
+    #[test]
+    fn replay_query_includes_orphan_recovery() {
+        let scope = DeadLetterScope::default();
+        let (sql, _) = build_replay_select(DbBackend::Postgres, &scope);
+        assert!(sql.contains("d.status = 'pending'"));
+        assert!(sql.contains("d.status = 'reprocessing'"));
+        assert!(sql.contains("d.deadline < now()"));
+    }
+
+    #[test]
+    fn replay_query_pg_has_for_update() {
+        let scope = DeadLetterScope::default();
+        let (sql, _) = build_replay_select(DbBackend::Postgres, &scope);
+        assert!(sql.contains("FOR UPDATE SKIP LOCKED"));
+    }
+
+    #[test]
+    fn replay_query_mysql_has_for_update() {
+        let scope = DeadLetterScope::default();
+        let (sql, _) = build_replay_select(DbBackend::MySql, &scope);
+        assert!(sql.contains("FOR UPDATE SKIP LOCKED"));
+    }
+
+    #[test]
+    fn replay_query_sqlite_no_for_update() {
+        let scope = DeadLetterScope::default();
+        let (sql, _) = build_replay_select(DbBackend::Sqlite, &scope);
+        assert!(!sql.contains("FOR UPDATE"));
+    }
+
+    #[test]
+    fn replay_claim_sets_deadline() {
+        let sql = build_batch_claim(DbBackend::Postgres, 2);
+        assert!(sql.contains("status = 'reprocessing'"));
+        assert!(sql.contains("deadline = now()"));
+        assert!(sql.contains("$1 * INTERVAL '1 second'"));
+        assert!(sql.contains("$2"));
+        assert!(sql.contains("$3"));
+    }
+
+    #[test]
+    fn replay_claim_mysql() {
+        let sql = build_batch_claim(DbBackend::MySql, 1);
+        assert!(sql.contains("DATE_ADD(CURRENT_TIMESTAMP(6), INTERVAL ? SECOND)"));
+    }
+
+    #[test]
+    fn replay_claim_sqlite() {
+        let sql = build_batch_claim(DbBackend::Sqlite, 1);
+        assert!(sql.contains("datetime('now', '+' || $1 || ' seconds')"));
+    }
+
+    // --- Resolve / Reject ---
+
+    #[test]
+    fn resolve_sql_per_backend() {
+        for backend in [DbBackend::Postgres, DbBackend::MySql, DbBackend::Sqlite] {
+            let sql = build_batch_resolve(backend, 2);
+            assert!(sql.contains("status = 'resolved'"));
+            assert!(sql.contains("AND status = 'reprocessing'"));
+            assert!(sql.contains("deadline = NULL"));
+        }
+    }
+
+    #[test]
+    fn resolve_uses_db_now() {
+        let sql = build_batch_resolve(DbBackend::Postgres, 1);
+        assert!(sql.contains("completed_at = now()"));
+        let sql = build_batch_resolve(DbBackend::MySql, 1);
+        assert!(sql.contains("completed_at = CURRENT_TIMESTAMP(6)"));
+        let sql = build_batch_resolve(DbBackend::Sqlite, 1);
+        assert!(sql.contains("completed_at = datetime('now')"));
+    }
+
+    #[test]
+    fn reject_sql_per_backend() {
+        for backend in [DbBackend::Postgres, DbBackend::MySql, DbBackend::Sqlite] {
+            let sql = build_batch_reject(backend, 2);
+            assert!(sql.contains("status = 'pending'"));
+            assert!(sql.contains("attempts = attempts + 1"));
+            assert!(sql.contains("AND status = 'reprocessing'"));
+            assert!(sql.contains("deadline = NULL"));
+        }
+    }
+
+    #[test]
+    fn reject_uses_db_now() {
+        let sql = build_batch_reject(DbBackend::Postgres, 1);
+        assert!(sql.contains("failed_at = now()"));
+        let sql = build_batch_reject(DbBackend::MySql, 1);
+        assert!(sql.contains("failed_at = CURRENT_TIMESTAMP(6)"));
+        let sql = build_batch_reject(DbBackend::Sqlite, 1);
+        assert!(sql.contains("failed_at = datetime('now')"));
+    }
+
+    // --- Discard ---
+
+    #[test]
+    fn discard_query_has_for_update() {
+        for backend in [DbBackend::Postgres, DbBackend::MySql] {
+            let scope = DeadLetterScope::default();
+            let (sql, _) = build_discard_select(backend, &scope);
+            assert!(sql.contains("FOR UPDATE SKIP LOCKED"));
+            assert!(sql.contains("d.status = 'pending'"));
+        }
+    }
+
+    #[test]
+    fn discard_query_sqlite_no_for_update() {
+        let scope = DeadLetterScope::default();
+        let (sql, _) = build_discard_select(DbBackend::Sqlite, &scope);
+        assert!(!sql.contains("FOR UPDATE"));
+    }
+
+    // --- Cleanup ---
+
+    #[test]
+    fn cleanup_deletes_terminal_only() {
+        let scope = DeadLetterScope::default();
+        let (sql, _) = build_delete_query(DbBackend::Postgres, &scope);
+        assert!(sql.contains("d.status IN ('resolved', 'discarded')"));
+        assert!(!sql.contains("'pending'"));
+    }
+
+    // --- List ---
+
+    #[test]
+    fn list_query_never_locks() {
+        let filter = DeadLetterFilter::default();
+        for backend in [DbBackend::Postgres, DbBackend::MySql, DbBackend::Sqlite] {
+            let (sql, _) = build_select_query(backend, &filter);
+            assert!(!sql.contains("FOR UPDATE"));
+        }
+    }
+
+    // --- Status enum ---
+
+    #[test]
+    fn status_display_and_parse() {
+        for status in [
+            DeadLetterStatus::Pending,
+            DeadLetterStatus::Reprocessing,
+            DeadLetterStatus::Resolved,
+            DeadLetterStatus::Discarded,
+        ] {
+            let s = status.to_string();
+            let parsed: DeadLetterStatus = s.parse().unwrap();
+            assert_eq!(parsed, status);
+        }
+    }
+
+    #[test]
+    fn status_invalid_parse() {
+        assert!("unknown".parse::<DeadLetterStatus>().is_err());
+    }
+
+    // --- Column list ---
+
+    #[test]
+    fn select_includes_new_columns() {
+        let filter = DeadLetterFilter::default().any_status();
+        let (sql, _) = build_select_query(DbBackend::Postgres, &filter);
+        assert!(sql.contains("d.status"));
+        assert!(sql.contains("d.completed_at"));
+        assert!(sql.contains("d.deadline"));
+        assert!(!sql.contains("d.replayed_at"));
     }
 }

--- a/libs/modkit-db/src/outbox/integration_tests.rs
+++ b/libs/modkit-db/src/outbox/integration_tests.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
 use tokio_util::sync::CancellationToken;
 
-use super::dead_letter::DeadLetterFilter;
+use super::dead_letter::{DeadLetterFilter, DeadLetterScope};
 use super::dialect::Dialect;
 use super::handler::{
     Handler, HandlerResult, MessageHandler, OutboxMessage, PerMessageAdapter, TransactionalHandler,
@@ -70,7 +70,9 @@ struct DeadLetterSnapshot {
     payload_type: String,
     last_error: Option<String>,
     attempts: i16,
-    replayed_at: Option<String>,
+    status: String,
+    completed_at: Option<String>,
+    deadline: Option<String>,
 }
 
 // ======================================================================
@@ -273,13 +275,16 @@ async fn read_dead_letters(db: &Db) -> Vec<DeadLetterSnapshot> {
         payload_type: String,
         last_error: Option<String>,
         attempts: i16,
-        replayed_at: Option<String>,
+        status: String,
+        completed_at: Option<String>,
+        deadline: Option<String>,
     }
     let conn = db.sea_internal();
     Row::find_by_statement(Statement::from_string(
         DbBackend::Sqlite,
         "SELECT id, partition_id, seq, payload, payload_type, last_error, \
-         attempts, CAST(replayed_at AS TEXT) AS replayed_at \
+         attempts, status, CAST(completed_at AS TEXT) AS completed_at, \
+         CAST(deadline AS TEXT) AS deadline \
          FROM modkit_outbox_dead_letters ORDER BY seq",
     ))
     .all(&conn)
@@ -294,7 +299,9 @@ async fn read_dead_letters(db: &Db) -> Vec<DeadLetterSnapshot> {
         payload_type: r.payload_type,
         last_error: r.last_error,
         attempts: r.attempts,
-        replayed_at: r.replayed_at,
+        status: r.status,
+        completed_at: r.completed_at,
+        deadline: r.deadline,
     })
     .collect()
 }
@@ -1145,7 +1152,7 @@ async fn transactional_reject_creates_dead_letter_and_advances() {
     assert_eq!(dls[0].payload, b"poison");
     assert_eq!(dls[0].payload_type, "text/plain");
     assert_eq!(dls[0].attempts, 0);
-    assert!(dls[0].replayed_at.is_none());
+    assert_eq!(dls[0].status, "pending");
 }
 
 #[tokio::test]
@@ -1760,14 +1767,15 @@ async fn dead_letter_list_returns_correct_fields() {
 
     let items = t
         .outbox
-        .dead_letter_list(&db, &DeadLetterFilter::default())
+        .dead_letter_list(&db.conn().unwrap(), &DeadLetterFilter::default())
         .await
         .unwrap();
     assert_eq!(items.len(), 3);
     for item in &items {
         assert_eq!(item.partition_id, pid);
         assert_eq!(item.last_error.as_deref(), Some("permanently bad"));
-        assert!(item.replayed_at.is_none());
+        assert_eq!(item.status, super::dead_letter::DeadLetterStatus::Pending);
+        assert!(item.completed_at.is_none());
     }
 }
 
@@ -1781,14 +1789,14 @@ async fn dead_letter_count_matches_list() {
 
     let count = t
         .outbox
-        .dead_letter_count(&db, &DeadLetterFilter::default())
+        .dead_letter_count(&db.conn().unwrap(), &DeadLetterFilter::default())
         .await
         .unwrap();
     assert_eq!(count, 3);
 }
 
 #[tokio::test]
-async fn dead_letter_replay_reinserts_and_sets_replayed_at() {
+async fn dead_letter_replay_claims_and_sets_reprocessing() {
     let db = setup_db("ch9_dl_replay").await;
     let t = make_default_test_outbox();
     t.outbox.register_queue(&db, "q", 1).await.unwrap();
@@ -1797,18 +1805,20 @@ async fn dead_letter_replay_reinserts_and_sets_replayed_at() {
 
     let replayed = t
         .outbox
-        .dead_letter_replay(&db, &DeadLetterFilter::default())
+        .dead_letter_replay(
+            &db.conn().unwrap(),
+            &DeadLetterScope::default(),
+            Duration::from_secs(60),
+        )
         .await
         .unwrap();
-    assert_eq!(replayed, 1);
+    assert_eq!(replayed.len(), 1);
 
-    // New incoming row created
-    assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 1);
-
-    // Dead letter now has replayed_at set
+    // Dead letter now has status=reprocessing and a deadline
     let dls = read_dead_letters(&db).await;
     assert_eq!(dls.len(), 1);
-    assert!(dls[0].replayed_at.is_some());
+    assert_eq!(dls[0].status, "reprocessing");
+    assert!(dls[0].deadline.is_some());
 }
 
 #[tokio::test]
@@ -1816,62 +1826,63 @@ async fn dead_letter_full_replay_roundtrip() {
     let db = setup_db("ch9_dl_roundtrip").await;
     let t = make_default_test_outbox();
     t.outbox.register_queue(&db, "q", 1).await.unwrap();
-    let pid = t.outbox.all_partition_ids()[0];
 
     // Reject
     create_dead_letters(&t, &db, "q", 0, &["msg"]).await;
 
-    // Replay → re-sequence → process with success handler
-    t.outbox
-        .dead_letter_replay(&db, &DeadLetterFilter::default())
+    // Replay (claim) → resolve
+    let replayed = t
+        .outbox
+        .dead_letter_replay(
+            &db.conn().unwrap(),
+            &DeadLetterScope::default(),
+            Duration::from_secs(60),
+        )
         .await
         .unwrap();
-    run_sequencer_once(&t, &db).await;
+    assert_eq!(replayed.len(), 1);
 
-    let count = Arc::new(AtomicU32::new(0));
-    let config = QueueConfig::default();
-    run_decoupled(
-        &db,
-        pid,
-        CountingSuccessHandler {
-            count: count.clone(),
-        },
-        &config,
-    )
-    .await;
+    let ids: Vec<i64> = replayed.iter().map(|m| m.id).collect();
+    let resolved = t
+        .outbox
+        .dead_letter_resolve(&db.conn().unwrap(), &ids)
+        .await
+        .unwrap();
+    assert_eq!(resolved, 1);
 
-    assert_eq!(count.load(Ordering::Relaxed), 1);
-    let snap = read_processor_state(&db, pid).await;
-    assert_eq!(snap.processed_seq, 2); // seq 1 was rejected, seq 2 is the replay
+    // Dead letter is now resolved
+    let dls = read_dead_letters(&db).await;
+    assert_eq!(dls.len(), 1);
+    assert_eq!(dls[0].status, "resolved");
+    assert!(dls[0].completed_at.is_some());
 }
 
 #[tokio::test]
-async fn dead_letter_purge_non_force_only_replayed() {
-    let db = setup_db("ch9_dl_purge_soft").await;
+async fn dead_letter_cleanup_only_terminal() {
+    let db = setup_db("ch9_dl_cleanup_soft").await;
     let t = make_default_test_outbox();
     t.outbox.register_queue(&db, "q", 1).await.unwrap();
 
     // Create 2 dead letters
     create_dead_letters(&t, &db, "q", 0, &["a", "b"]).await;
 
-    // Replay only 1 (by limit)
-    let filter_one = DeadLetterFilter {
-        limit: Some(1),
-        ..Default::default()
-    };
-    t.outbox.dead_letter_replay(&db, &filter_one).await.unwrap();
+    // Replay only 1 (by limit), then resolve it
+    let scope_one = DeadLetterScope::default().limit(1);
+    let replayed = t
+        .outbox
+        .dead_letter_replay(&db.conn().unwrap(), &scope_one, Duration::from_secs(60))
+        .await
+        .unwrap();
+    let ids: Vec<i64> = replayed.iter().map(|m| m.id).collect();
+    t.outbox
+        .dead_letter_resolve(&db.conn().unwrap(), &ids)
+        .await
+        .unwrap();
 
-    // Purge non-force — should only delete the replayed one
+    // Cleanup — should only delete the resolved one
     let deleted = t
         .outbox
-        .dead_letter_purge(
-            &db,
-            &DeadLetterFilter {
-                only_pending: false,
-                ..Default::default()
-            },
-            false,
-        )
+        .dead_letter_cleanup(&db.conn().unwrap(), &DeadLetterScope::default())
         .await
         .unwrap();
     assert_eq!(deleted, 1);
@@ -1879,42 +1890,41 @@ async fn dead_letter_purge_non_force_only_replayed() {
     // 1 pending dead letter remains
     let remaining = t
         .outbox
-        .dead_letter_count(&db, &DeadLetterFilter::default())
+        .dead_letter_count(&db.conn().unwrap(), &DeadLetterFilter::default())
         .await
         .unwrap();
     assert_eq!(remaining, 1);
 }
 
 #[tokio::test]
-async fn dead_letter_purge_force_deletes_all() {
-    let db = setup_db("ch9_dl_purge_force").await;
+async fn dead_letter_discard_then_cleanup_deletes_all() {
+    let db = setup_db("ch9_dl_discard_cleanup").await;
     let t = make_default_test_outbox();
     t.outbox.register_queue(&db, "q", 1).await.unwrap();
 
     create_dead_letters(&t, &db, "q", 0, &["a", "b", "c"]).await;
 
-    let deleted = t
+    // Discard all pending
+    let discarded = t
         .outbox
-        .dead_letter_purge(
-            &db,
-            &DeadLetterFilter {
-                only_pending: false,
-                ..Default::default()
-            },
-            true,
-        )
+        .dead_letter_discard(&db.conn().unwrap(), &DeadLetterScope::default())
         .await
         .unwrap();
-    assert_eq!(deleted, 3);
+    assert_eq!(discarded, 3);
+
+    // Cleanup terminal entries
+    let cleaned = t
+        .outbox
+        .dead_letter_cleanup(&db.conn().unwrap(), &DeadLetterScope::default())
+        .await
+        .unwrap();
+    assert_eq!(cleaned, 3);
 
     let remaining = t
         .outbox
         .dead_letter_count(
-            &db,
-            &DeadLetterFilter {
-                only_pending: false,
-                ..Default::default()
-            },
+            &db.conn().unwrap(),
+            &DeadLetterFilter::default().any_status(),
         )
         .await
         .unwrap();
@@ -1932,18 +1942,20 @@ async fn dead_letter_filter_by_partition() {
     create_dead_letters(&t, &db, "q", 0, &["a0"]).await;
     create_dead_letters(&t, &db, "q", 1, &["b1", "b2"]).await;
 
-    let filter_p0 = DeadLetterFilter {
-        partition_id: Some(ids[0]),
-        ..Default::default()
-    };
-    let items = t.outbox.dead_letter_list(&db, &filter_p0).await.unwrap();
+    let filter_p0 = DeadLetterFilter::default().partition(ids[0]);
+    let items = t
+        .outbox
+        .dead_letter_list(&db.conn().unwrap(), &filter_p0)
+        .await
+        .unwrap();
     assert_eq!(items.len(), 1);
 
-    let filter_p1 = DeadLetterFilter {
-        partition_id: Some(ids[1]),
-        ..Default::default()
-    };
-    let items = t.outbox.dead_letter_list(&db, &filter_p1).await.unwrap();
+    let filter_p1 = DeadLetterFilter::default().partition(ids[1]);
+    let items = t
+        .outbox
+        .dead_letter_list(&db.conn().unwrap(), &filter_p1)
+        .await
+        .unwrap();
     assert_eq!(items.len(), 2);
 }
 
@@ -1955,11 +1967,12 @@ async fn dead_letter_filter_with_limit() {
 
     create_dead_letters(&t, &db, "q", 0, &["a", "b", "c", "d", "e"]).await;
 
-    let filter = DeadLetterFilter {
-        limit: Some(2),
-        ..Default::default()
-    };
-    let items = t.outbox.dead_letter_list(&db, &filter).await.unwrap();
+    let filter = DeadLetterFilter::default().limit(2);
+    let items = t
+        .outbox
+        .dead_letter_list(&db.conn().unwrap(), &filter)
+        .await
+        .unwrap();
     assert_eq!(items.len(), 2);
 }
 
@@ -2143,45 +2156,33 @@ async fn e2e_reject_replay_success() {
     let db = setup_db("ch11_reject_replay").await;
     let t = make_default_test_outbox();
     t.outbox.register_queue(&db, "q", 1).await.unwrap();
-    let pid = t.outbox.all_partition_ids()[0];
 
     // Reject
     create_dead_letters(&t, &db, "q", 0, &["msg"]).await;
 
-    // Replay → re-sequence → process with success
-    t.outbox
-        .dead_letter_replay(&db, &DeadLetterFilter::default())
+    // Replay (claim) → resolve
+    let replayed = t
+        .outbox
+        .dead_letter_replay(
+            &db.conn().unwrap(),
+            &DeadLetterScope::default(),
+            Duration::from_secs(60),
+        )
         .await
         .unwrap();
-    run_sequencer_once(&t, &db).await;
+    assert_eq!(replayed.len(), 1);
 
-    let count = Arc::new(AtomicU32::new(0));
-    let config = QueueConfig::default();
-    run_decoupled(
-        &db,
-        pid,
-        CountingSuccessHandler {
-            count: count.clone(),
-        },
-        &config,
-    )
-    .await;
+    let ids: Vec<i64> = replayed.iter().map(|m| m.id).collect();
+    t.outbox
+        .dead_letter_resolve(&db.conn().unwrap(), &ids)
+        .await
+        .unwrap();
 
-    // Reap
-    run_reaper(&db, pid).await;
-
-    assert_eq!(count.load(Ordering::Relaxed), 1);
-    let snap = read_processor_state(&db, pid).await;
-    assert_eq!(snap.processed_seq, 2);
-
-    // Dead letter has replayed_at set
+    // Dead letter has status=resolved and completed_at set
     let dls = read_dead_letters(&db).await;
     assert_eq!(dls.len(), 1);
-    assert!(dls[0].replayed_at.is_some());
-
-    // Body and outgoing cleaned up
-    assert_eq!(count_rows(&db, "modkit_outbox_outgoing").await, 0);
-    assert_eq!(count_rows(&db, "modkit_outbox_body").await, 0);
+    assert_eq!(dls[0].status, "resolved");
+    assert!(dls[0].completed_at.is_some());
 }
 
 #[tokio::test]

--- a/libs/modkit-db/src/outbox/migrations.rs
+++ b/libs/modkit-db/src/outbox/migrations.rs
@@ -1,10 +1,23 @@
 use sea_orm::{ConnectionTrait, DatabaseBackend, DbErr, Statement};
 use sea_orm_migration::prelude::*;
 
-/// Single migration that creates the entire outbox schema.
+/// Single migration that creates the entire outbox schema from scratch.
 ///
 /// Tables are created in FK dependency order:
 /// body → partitions → incoming → outgoing → dead-letters → processor
+///
+/// # Idempotency
+///
+/// All `CREATE TABLE` statements use `IF NOT EXISTS` so the migration is safe
+/// to re-run (e.g., after a partial failure).  `CREATE INDEX` statements do
+/// **not** — `MySQL` has no `IF NOT EXISTS` syntax for indexes, and keeping the
+/// Pg/SQLite paths consistent avoids a false sense of safety on only some
+/// backends.  Because each index immediately follows its `CREATE TABLE IF NOT
+/// EXISTS`, the index can only pre-exist if the migration crashed between the
+/// two statements *and* the migration runner retries without rolling back.
+/// The sea-orm migration framework tracks completed migrations, so this edge
+/// case requires a crash mid-transaction — acceptable for a `preview-outbox`
+/// alpha feature with no production deployments.
 struct CreateOutboxSchema;
 
 impl MigrationName for CreateOutboxSchema {
@@ -165,11 +178,7 @@ async fn create_incoming(
     conn.execute(Statement::from_string(
         backend,
         match backend {
-            DatabaseBackend::Postgres | DatabaseBackend::Sqlite => {
-                "CREATE INDEX IF NOT EXISTS idx_modkit_outbox_incoming_partition \
-             ON modkit_outbox_incoming (partition_id, id)"
-            }
-            DatabaseBackend::MySql => {
+            DatabaseBackend::Postgres | DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
                 "CREATE INDEX idx_modkit_outbox_incoming_partition \
              ON modkit_outbox_incoming (partition_id, id)"
             }
@@ -225,11 +234,7 @@ async fn create_outgoing(
     conn.execute(Statement::from_string(
         backend,
         match backend {
-            DatabaseBackend::Postgres | DatabaseBackend::Sqlite => {
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_modkit_outbox_outgoing_partition_seq \
-             ON modkit_outbox_outgoing (partition_id, seq)"
-            }
-            DatabaseBackend::MySql => {
+            DatabaseBackend::Postgres | DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
                 "CREATE UNIQUE INDEX idx_modkit_outbox_outgoing_partition_seq \
              ON modkit_outbox_outgoing (partition_id, seq)"
             }
@@ -257,7 +262,9 @@ async fn create_dead_letters(
                 failed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
                 last_error   TEXT,
                 attempts     SMALLINT NOT NULL,
-                replayed_at  TIMESTAMPTZ
+                status       TEXT NOT NULL DEFAULT 'pending',
+                completed_at TIMESTAMPTZ,
+                deadline     TIMESTAMPTZ
             )"
             }
             DatabaseBackend::Sqlite => {
@@ -271,7 +278,9 @@ async fn create_dead_letters(
                 failed_at    TEXT    NOT NULL DEFAULT (datetime('now')),
                 last_error   TEXT,
                 attempts     INTEGER NOT NULL,
-                replayed_at  TEXT
+                status       TEXT    NOT NULL DEFAULT 'pending',
+                completed_at TEXT,
+                deadline     TEXT
             )"
             }
             DatabaseBackend::MySql => {
@@ -285,7 +294,9 @@ async fn create_dead_letters(
                 failed_at    TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
                 last_error   TEXT,
                 attempts     SMALLINT NOT NULL,
-                replayed_at  TIMESTAMP(6) NULL,
+                status       VARCHAR(20) NOT NULL DEFAULT 'pending',
+                completed_at TIMESTAMP(6) NULL,
+                deadline     TIMESTAMP(6) NULL,
                 FOREIGN KEY (partition_id) REFERENCES modkit_outbox_partitions(id)
             )"
             }
@@ -293,17 +304,34 @@ async fn create_dead_letters(
     ))
     .await?;
 
+    // Index for replay query (status = 'pending' OR (status = 'reprocessing' AND deadline < now()))
     conn.execute(Statement::from_string(
         backend,
         match backend {
-            DatabaseBackend::Postgres | DatabaseBackend::Sqlite => {
-                "CREATE INDEX IF NOT EXISTS idx_modkit_outbox_dead_letters_pending \
-             ON modkit_outbox_dead_letters (failed_at) \
-             WHERE replayed_at IS NULL"
+            DatabaseBackend::Postgres => {
+                "CREATE INDEX idx_modkit_outbox_dl_replayable \
+             ON modkit_outbox_dead_letters (status, deadline) \
+             WHERE status IN ('pending', 'reprocessing')"
             }
-            DatabaseBackend::MySql => {
-                "CREATE INDEX idx_modkit_outbox_dead_letters_pending \
-             ON modkit_outbox_dead_letters (failed_at, replayed_at)"
+            DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
+                "CREATE INDEX idx_modkit_outbox_dl_status_deadline \
+             ON modkit_outbox_dead_letters (status, deadline)"
+            }
+        },
+    ))
+    .await?;
+
+    // Index for list queries with status filter + ORDER BY failed_at DESC
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres => {
+                "CREATE INDEX idx_modkit_outbox_dl_status_failed \
+             ON modkit_outbox_dead_letters (status, failed_at DESC)"
+            }
+            DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
+                "CREATE INDEX idx_modkit_outbox_dl_status_failed \
+             ON modkit_outbox_dead_letters (status, failed_at)"
             }
         },
     ))

--- a/libs/modkit-db/src/outbox/mod.rs
+++ b/libs/modkit-db/src/outbox/mod.rs
@@ -55,34 +55,34 @@
 //! Dead letter operations are available as methods on [`Outbox`]:
 //! [`dead_letter_list`](Outbox::dead_letter_list),
 //! [`dead_letter_count`](Outbox::dead_letter_count),
-//! [`dead_letter_replay`](Outbox::dead_letter_replay), and
-//! [`dead_letter_purge`](Outbox::dead_letter_purge).
+//! [`dead_letter_replay`](Outbox::dead_letter_replay),
+//! [`dead_letter_resolve`](Outbox::dead_letter_resolve),
+//! [`dead_letter_reject`](Outbox::dead_letter_reject),
+//! [`dead_letter_discard`](Outbox::dead_letter_discard), and
+//! [`dead_letter_cleanup`](Outbox::dead_letter_cleanup).
 //!
-//! ## Consumption patterns
+//! Dead letters have a status lifecycle: `pending → reprocessing → resolved`
+//! (or `pending → discarded`). The [`DeadLetterStatus`] enum tracks this.
 //!
-//! 1. **Scheduled background worker** — poll on a timer, replay if count > 0:
+//! ## Example: application-level consumption
 //!
-//!    ```ignore
-//!    loop {
-//!        let count = outbox.dead_letter_count(&db, &DeadLetterFilter::default()).await?;
-//!        if count > 0 {
-//!            tracing::warn!(count, "dead letters detected — replaying");
-//!            outbox.dead_letter_replay(&db, &DeadLetterFilter::default()).await?;
-//!        }
-//!        tokio::time::sleep(Duration::from_secs(300)).await;
-//!    }
-//!    ```
+//! The library provides the building blocks; the application decides **when**
+//! and **how** to use them. `dead_letter_replay` claims messages (sets them
+//! to `reprocessing` with a deadline) and returns them — the application
+//! then processes and calls `resolve` or `reject`.
 //!
-//! 2. **Admin REST endpoint** — expose list/replay/purge via HTTP for manual
-//!    investigation and recovery.
+//! ```ignore
+//! use std::time::Duration;
 //!
-//! 3. **On-demand CLI** — a maintenance command that replays or purges with
-//!    filters (by queue, partition, time range).
-//!
-//! Replayed messages go through the full pipeline (incoming → sequencer →
-//! outgoing → processor). Handlers must be idempotent — a replayed message
-//! may be delivered more than once if the handler previously produced
-//! side-effects before rejecting.
+//! let scope = DeadLetterScope::default().payload_type("order.created");
+//! let msgs = outbox.dead_letter_replay(&conn, &scope, Duration::from_secs(60)).await?;
+//! for msg in &msgs {
+//!     match my_handler(&msg.payload).await {
+//!         Ok(_)  => outbox.dead_letter_resolve(&conn, &[msg.id]).await?,
+//!         Err(e) => outbox.dead_letter_reject(&conn, &[msg.id], &e.to_string()).await?,
+//!     };
+//! }
+//! ```
 
 mod builder;
 mod core;
@@ -103,7 +103,7 @@ mod integration_tests;
 
 pub use builder::QueueBuilder;
 pub use core::Outbox;
-pub use dead_letter::{DeadLetterFilter, DeadLetterMessage};
+pub use dead_letter::{DeadLetterFilter, DeadLetterMessage, DeadLetterScope, DeadLetterStatus};
 pub use handler::{
     Handler, HandlerResult, MessageHandler, OutboxMessage, PerMessageAdapter, TransactionalHandler,
     TransactionalMessageHandler,


### PR DESCRIPTION
feat(outbox): replace replayed_at with dead letter state machine 

Dead letters now follow a 4-state lifecycle (pending → reprocessing -> resolved/discarded) instead of a nullable replayed_at timestamp.

- Add DeadLetterStatus enum with TryGetable for sea_orm FromQueryResult
- Split DeadLetterFilter into DeadLetterScope (replay/discard/cleanup) and DeadLetterFilter (list/count) with fluent builder API
- Rewrite dead_letter_replay() as claim-only: sets status to reprocessing with a deadline, returns messages to the caller
- Add dead_letter_resolve(), dead_letter_reject(), dead_letter_discard()
- Rename dead_letter_purge() to dead_letter_cleanup(), drop force flag, always delete terminal states only (resolved + discarded)
- Add deadline-based orphan recovery for abandoned reprocessing rows
- Use DB-side timestamps exclusively (no chrono::Utc::now())
- Add QueryBuilder::finish_no_order() replacing string truncation hack
- Update m001 migration in-place (alpha, no production deployments)
- Add payload_type to DeadLetterScope for per-type filtering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced dead-letter management with new operations: replay, resolve, reject, discard, and cleanup.
  * Introduced DeadLetterStatus with lifecycle states: Pending, Reprocessing, Resolved, and Discarded.
  * Added DeadLetterScope for scoped dead-letter queries and filtering.

* **Refactor**
  * Updated dead-letter APIs for improved database connection handling.
  * Extended database schema with status tracking and completion timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->