### PR TITLE
fix(mini-chat): use Google-style custom method colon syntax for stream route

### DIFF
--- a/modules/mini-chat/docs/openapi.json
+++ b/modules/mini-chat/docs/openapi.json
@@ -837,7 +837,7 @@
         }
       }
     },
-    "/v1/chats/{id}/turns/{request_id}:retry": {
+    "/v1/chats/{id}/turns/{request_id}/retry": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ChatId"

--- a/modules/mini-chat/mini-chat/src/api/rest/dto.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/dto.rs
@@ -224,7 +224,7 @@ pub struct ModelListDto {
 // Streaming request DTOs
 // ════════════════════════════════════════════════════════════════════════════
 
-/// Request body for `POST /v1/chats/{id}/messages/stream`.
+/// Request body for `POST /v1/chats/{id}/messages:stream`.
 #[derive(Debug, Clone, serde::Deserialize, ToSchema)]
 pub struct StreamMessageRequest {
     /// Message content (must be non-empty).

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
@@ -37,7 +37,7 @@ pub(crate) async fn list_messages(
     Ok(Json(page))
 }
 
-/// POST /mini-chat/v1/chats/{id}/messages/stream
+/// POST /mini-chat/v1/chats/{id}/messages:stream
 ///
 /// Pre-stream validation returns JSON errors. On success, opens an SSE
 /// connection and relays events from the provider through a bounded channel.

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/messages.rs
@@ -43,12 +43,8 @@ pub(super) fn register_message_routes(
         .standard_errors(openapi)
         .register(router, openapi);
 
-    // TODO: DESIGN.md specifies Google-style custom method `messages:stream`, but Axum's
-    // matchit router doesn't support mixed param+literal segments. Consider adding a
-    // rewrite middleware in api-gateway to map `:verb` → `/verb` so clients can use the
-    // colon syntax externally while Axum routes via `/stream` internally.
-    // POST {prefix}/v1/chats/{id}/messages/stream
-    router = OperationBuilder::post(format!("{prefix}/v1/chats/{{id}}/messages/stream"))
+    // POST {prefix}/v1/chats/{id}/messages:stream
+    router = OperationBuilder::post(format!("{prefix}/v1/chats/{{id}}/messages:stream"))
         .operation_id("mini_chat.stream_message")
         .summary("Send a message and stream the response via SSE")
         .tag("messages")

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/turns.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/turns.rs
@@ -24,11 +24,13 @@ pub(super) fn register_turn_routes(
         .standard_errors(openapi)
         .register(router, openapi);
 
-    // TODO: DESIGN.md specifies Google-style custom method `{request_id}:retry`, but Axum's
-    // matchit router doesn't support mixed param+literal segments. Consider adding a
-    // rewrite middleware in api-gateway to map `:verb` → `/verb` so clients can use the
-    // colon syntax externally while Axum routes via `/retry` internally.
     // POST {prefix}/v1/chats/{id}/turns/{request_id}/retry
+    //
+    // TODO: DESIGN.md specifies Google-style `{request_id}:retry` (AIP-136), but
+    // axum 0.8 pins matchit =0.8.4 which cannot split `{param}:suffix` in one
+    // segment. Using `/retry` as a sub-resource until axum bumps matchit ≥0.8.6
+    // which adds suffix support.
+    // Tracking: https://github.com/tokio-rs/axum/issues/3140
     router = OperationBuilder::post(format!(
         "{prefix}/v1/chats/{{id}}/turns/{{request_id}}/retry"
     ))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API endpoint path formats for streaming messages and retry operations to use consistent conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->