### PR TITLE
fix(mini-chat): return 204 No Content from delete turn endpoint

### DIFF
--- a/modules/mini-chat/docs/DESIGN.md
+++ b/modules/mini-chat/docs/DESIGN.md
@@ -2303,13 +2303,7 @@ PATCH MUST NOT introduce a separate execution path for settlement or outbox emis
 
 **Request body**: none
 
-**Response** (success): `200 OK` with (`chat_id` omitted — already in URL path):
-```json
-{
-  "request_id": "uuid",
-  "deleted": true
-}
-```
+**Response** (success): `204 No Content` (no body).
 
 **Errors**: same as retry (except no streaming).
 

--- a/modules/mini-chat/docs/openapi.json
+++ b/modules/mini-chat/docs/openapi.json
@@ -794,19 +794,8 @@
         "summary": "Delete the last turn",
         "description": "Soft-deletes the most recent turn (user message + assistant response). Only the latest non-deleted turn in a terminal state may be deleted. No replacement turn is created.",
         "responses": {
-          "200": {
-            "description": "Turn deleted.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TurnDeleteResponse"
-                },
-                "example": {
-                  "request_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-                  "deleted": true
-                }
-              }
-            }
+          "204": {
+            "description": "Turn deleted."
           },
           "400": {
             "description": "Turn not in terminal state. Code: `invalid_turn_state`.",
@@ -1453,20 +1442,6 @@
           "updated_at": {
             "type": "string",
             "format": "date-time"
-          }
-        }
-      },
-      "TurnDeleteResponse": {
-        "type": "object",
-        "required": ["request_id", "deleted"],
-        "properties": {
-          "request_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "deleted": {
-            "type": "boolean",
-            "const": true
           }
         }
       },

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
@@ -101,29 +101,19 @@ pub(crate) async fn get_turn(
 // DELETE turn
 // ════════════════════════════════════════════════════════════════════════════
 
-#[derive(Debug, Serialize, ToSchema)]
-pub(crate) struct DeleteTurnResponse {
-    request_id: uuid::Uuid,
-    deleted: bool,
-}
-
 /// DELETE /mini-chat/v1/chats/{id}/turns/{request_id}
 #[tracing::instrument(skip(svc, ctx), fields(chat_id = %chat_id, turn_request_id = %request_id))]
 pub(crate) async fn delete_turn(
     Extension(ctx): Extension<SecurityContext>,
     Extension(svc): Extension<Arc<AppServices>>,
     Path((chat_id, request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> ApiResult<Json<DeleteTurnResponse>> {
-    let result = svc
-        .turns
+) -> ApiResult<impl IntoResponse> {
+    svc.turns
         .delete(&ctx, chat_id, request_id)
         .await
         .map_err(|e| mutation_error_to_problem(&e))?;
 
-    Ok(Json(DeleteTurnResponse {
-        request_id: result.request_id,
-        deleted: result.deleted,
-    }))
+    Ok(no_content().into_response())
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
@@ -66,13 +66,6 @@ impl std::error::Error for MutationError {}
 // Results
 // ════════════════════════════════════════════════════════════════════════════
 
-#[domain_model]
-#[derive(Debug)]
-pub struct DeleteResult {
-    pub request_id: Uuid,
-    pub deleted: bool,
-}
-
 /// Returned from retry/edit. Contains everything the handler needs to
 /// set up streaming via `StreamService::run_stream_for_mutation()`.
 #[domain_model]
@@ -126,7 +119,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
         ctx: &SecurityContext,
         chat_id: Uuid,
         request_id: Uuid,
-    ) -> Result<DeleteResult, MutationError> {
+    ) -> Result<(), MutationError> {
         info!(%chat_id, %request_id, "turn delete");
 
         let turn_repo = Arc::clone(&self.turn_repo);
@@ -154,10 +147,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
                         .await
                         .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
 
-                    Ok(DeleteResult {
-                        request_id,
-                        deleted: true,
-                    })
+                    Ok(())
                 })
             })
             .await

--- a/modules/mini-chat/mini-chat/src/domain/service/turn_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/turn_service_test.rs
@@ -304,7 +304,7 @@ async fn delete_non_latest_turn_returns_not_latest() {
 // ════════════════════════════════════════════════════════════════════════════
 
 #[tokio::test]
-async fn delete_success_returns_request_id_and_deleted_true() {
+async fn delete_success_soft_deletes_turn() {
     let (svc, ctx, chat_id, tenant_id) = setup().await;
 
     let request_id = create_completed_turn(
@@ -317,9 +317,7 @@ async fn delete_success_returns_request_id_and_deleted_true() {
     )
     .await;
 
-    let result = svc.delete(&ctx, chat_id, request_id).await.unwrap();
-    assert_eq!(result.request_id, request_id);
-    assert!(result.deleted);
+    svc.delete(&ctx, chat_id, request_id).await.unwrap();
 
     // Verify the turn is soft-deleted (deleted_at != NULL)
     let scope = AccessScope::for_tenant(tenant_id);


### PR DESCRIPTION
Replace 200 JSON response with 204 No Content for the delete turn operation, removing the unnecessary DeleteTurnResponse DTO and DeleteResult domain model. Update DESIGN.md and OpenAPI spec accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Delete turn API responses now return HTTP 204 No Content instead of HTTP 200 with a response body, reducing response payload size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->