### PR TITLE
feat(mini-chat): refine authz for /v1/chats/{id}/turns/{request_id} endpoints

### DIFF
--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
@@ -14,7 +14,6 @@ use tracing::{Instrument, info, warn};
 use utoipa::ToSchema;
 
 use super::messages::SseRelay;
-use crate::domain::repos::TurnRepository;
 use crate::domain::service::{MutationError, StreamError};
 use crate::domain::stream_events::StreamEvent;
 use crate::infra::db::entity::chat_turn::TurnState;
@@ -52,41 +51,11 @@ pub(crate) async fn get_turn(
     Extension(svc): Extension<Arc<AppServices>>,
     Path((chat_id, request_id)): Path<(uuid::Uuid, uuid::Uuid)>,
 ) -> ApiResult<Json<TurnStatusResponse>> {
-    // Authorization: read_turn scoped to chat
-    let scope = svc
-        .enforcer
-        .access_scope(
-            &ctx,
-            &crate::domain::service::resources::CHAT,
-            crate::domain::service::actions::READ_TURN,
-            Some(chat_id),
-        )
-        .await
-        .map_err(|_| Problem::new(StatusCode::NOT_FOUND, "turn_not_found", "Turn not found"))?;
-    let scope = scope.tenant_only();
-
-    let conn = svc.db.conn().map_err(|e| {
-        tracing::error!(error = %e, "failed to acquire DB connection for get_turn");
-        Problem::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Internal Error",
-            "An internal error occurred",
-        )
-    })?;
-
     let turn = svc
-        .turn_repo
-        .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+        .turns
+        .get(&ctx, chat_id, request_id)
         .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "failed to fetch turn from DB");
-            Problem::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Internal Error",
-                "An internal error occurred",
-            )
-        })?
-        .ok_or_else(|| Problem::new(StatusCode::NOT_FOUND, "turn_not_found", "Turn not found"))?;
+        .map_err(|e| mutation_error_to_problem(&e))?;
 
     Ok(Json(TurnStatusResponse {
         request_id: turn.request_id,
@@ -281,13 +250,9 @@ fn mutation_error_to_problem(err: &MutationError) -> Problem {
         MutationError::TurnNotFound { .. } => {
             Problem::new(StatusCode::NOT_FOUND, "turn_not_found", "Turn not found")
         }
-        MutationError::InsufficientPermissions => {
-            warn!("insufficient permissions for turn mutation");
-            Problem::new(
-                StatusCode::FORBIDDEN,
-                "insufficient_permissions",
-                "You do not have permission to modify this turn",
-            )
+        MutationError::Forbidden => {
+            warn!("access denied for turn mutation");
+            Problem::new(StatusCode::FORBIDDEN, "forbidden", "Access denied")
         }
         MutationError::InvalidTurnState { state } => Problem::new(
             StatusCode::BAD_REQUEST,

--- a/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use authz_resolver_sdk::PolicyEnforcer;
+use authz_resolver_sdk::{EnforcerError, PolicyEnforcer};
 use modkit_macros::domain_model;
 use modkit_security::{AccessScope, SecurityContext};
 use tracing::info;
@@ -24,7 +24,7 @@ use super::{DbProvider, actions, resources};
 pub enum MutationError {
     ChatNotFound { chat_id: Uuid },
     TurnNotFound { chat_id: Uuid, request_id: Uuid },
-    InsufficientPermissions,
+    Forbidden,
     InvalidTurnState { state: TurnState },
     NotLatestTurn,
     GenerationInProgress,
@@ -41,7 +41,7 @@ impl std::fmt::Display for MutationError {
             } => {
                 write!(f, "Turn {request_id} not found in chat {chat_id}")
             }
-            Self::InsufficientPermissions => write!(f, "Insufficient permissions"),
+            Self::Forbidden => write!(f, "Access denied"),
             Self::InvalidTurnState { state } => {
                 let label = match state {
                     TurnState::Running => "running",
@@ -61,6 +61,28 @@ impl std::fmt::Display for MutationError {
 }
 
 impl std::error::Error for MutationError {}
+
+impl From<EnforcerError> for MutationError {
+    #[allow(clippy::cognitive_complexity)]
+    fn from(e: EnforcerError) -> Self {
+        match e {
+            EnforcerError::Denied { ref deny_reason } => {
+                tracing::warn!(deny_reason = ?deny_reason, "AuthZ denied access");
+                Self::Forbidden
+            }
+            EnforcerError::CompileFailed(ref err) => {
+                tracing::warn!(error = %err, "AuthZ constraint compile failed - access denied");
+                Self::Forbidden
+            }
+            EnforcerError::EvaluationFailed(ref err) => {
+                tracing::error!(error = %err, "AuthZ evaluation failed (internal error)");
+                Self::Internal {
+                    message: err.to_string(),
+                }
+            }
+        }
+    }
+}
 
 // ════════════════════════════════════════════════════════════════════════════
 // Results
@@ -119,6 +141,46 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
         }
     }
 
+    // ── Get ─────────────────────────────────────────────────────────────
+
+    pub async fn get(
+        &self,
+        ctx: &SecurityContext,
+        chat_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<TurnModel, MutationError> {
+        let scope = self
+            .enforcer
+            .access_scope(ctx, &resources::CHAT, actions::READ_TURN, Some(chat_id))
+            .await?;
+
+        let conn = self.db.conn().map_err(|e| MutationError::Internal {
+            message: e.to_string(),
+        })?;
+
+        // Verify chat exists (scoped by authz)
+        self.chat_repo
+            .get(&conn, &scope, chat_id)
+            .await
+            .map_err(|e| MutationError::Internal {
+                message: e.to_string(),
+            })?
+            .ok_or(MutationError::ChatNotFound { chat_id })?;
+
+        let scope = scope.tenant_only();
+
+        self.turn_repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .map_err(|e| MutationError::Internal {
+                message: e.to_string(),
+            })?
+            .ok_or(MutationError::TurnNotFound {
+                chat_id,
+                request_id,
+            })
+    }
+
     // ── Delete ──────────────────────────────────────────────────────────
 
     pub async fn delete(
@@ -129,18 +191,23 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
     ) -> Result<DeleteResult, MutationError> {
         info!(%chat_id, %request_id, "turn delete");
 
+        let scope = self
+            .enforcer
+            .access_scope(ctx, &resources::CHAT, actions::DELETE_TURN, Some(chat_id))
+            .await?;
+
         let turn_repo = Arc::clone(&self.turn_repo);
         let chat_repo = Arc::clone(&self.chat_repo);
-        let enforcer = self.enforcer.clone();
+        let scope_tx = scope.clone();
         let ctx_clone = ctx.clone();
 
         self.db
             .transaction(|tx| {
                 Box::pin(async move {
                     let (scope, target) = validate_mutation(
-                        &enforcer,
                         &*chat_repo,
                         &*turn_repo,
+                        &scope_tx,
                         &ctx_clone,
                         tx,
                         chat_id,
@@ -173,7 +240,12 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
         request_id: Uuid,
     ) -> Result<MutationResult, MutationError> {
         info!(%chat_id, %request_id, "turn retry");
-        self.mutate_for_stream(ctx, chat_id, request_id, None).await
+        let scope = self
+            .enforcer
+            .access_scope(ctx, &resources::CHAT, actions::RETRY_TURN, Some(chat_id))
+            .await?;
+        self.mutate_for_stream(ctx, scope, chat_id, request_id, None)
+            .await
     }
 
     // ── Edit ────────────────────────────────────────────────────────────
@@ -186,7 +258,11 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
         new_content: String,
     ) -> Result<MutationResult, MutationError> {
         info!(%chat_id, %request_id, "turn edit");
-        self.mutate_for_stream(ctx, chat_id, request_id, Some(new_content))
+        let scope = self
+            .enforcer
+            .access_scope(ctx, &resources::CHAT, actions::EDIT_TURN, Some(chat_id))
+            .await?;
+        self.mutate_for_stream(ctx, scope, chat_id, request_id, Some(new_content))
             .await
     }
 
@@ -195,6 +271,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
     async fn mutate_for_stream(
         &self,
         ctx: &SecurityContext,
+        chat_scope: AccessScope,
         chat_id: Uuid,
         request_id: Uuid,
         override_content: Option<String>,
@@ -205,7 +282,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
         let turn_repo = Arc::clone(&self.turn_repo);
         let message_repo = Arc::clone(&self.message_repo);
         let chat_repo = Arc::clone(&self.chat_repo);
-        let enforcer = self.enforcer.clone();
+        let scope_tx = chat_scope.clone();
         let ctx_clone = ctx.clone();
 
         let user_content = self
@@ -213,9 +290,9 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
             .transaction(|tx| {
                 Box::pin(async move {
                     let (scope, target) = validate_mutation(
-                        &enforcer,
                         &*chat_repo,
                         &*turn_repo,
+                        &scope_tx,
                         &ctx_clone,
                         tx,
                         chat_id,
@@ -310,29 +387,24 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
 // ════════════════════════════════════════════════════════════════════════════
 
 async fn validate_mutation<CR: ChatRepository, TR: TurnRepository>(
-    enforcer: &PolicyEnforcer,
     chat_repo: &CR,
     turn_repo: &TR,
+    chat_scope: &AccessScope,
     ctx: &SecurityContext,
     tx: &impl modkit_db::secure::DBRunner,
     chat_id: Uuid,
     request_id: Uuid,
 ) -> Result<(AccessScope, TurnModel), MutationError> {
-    // 1. Load chat with authorization
-    let scope = enforcer
-        .access_scope(ctx, &resources::CHAT, actions::DELETE_TURN, Some(chat_id))
-        .await
-        .map_err(|_| MutationError::ChatNotFound { chat_id })?;
-
+    // 1. Verify chat exists with pre-computed authorization scope
     chat_repo
-        .get(tx, &scope, chat_id)
+        .get(tx, chat_scope, chat_id)
         .await
         .map_err(|e| MutationError::Internal {
             message: e.to_string(),
         })?
         .ok_or(MutationError::ChatNotFound { chat_id })?;
 
-    let scope = scope.tenant_only();
+    let scope = chat_scope.tenant_only();
 
     // 2. Acquire target turn by request_id
     let target = turn_repo
@@ -348,7 +420,7 @@ async fn validate_mutation<CR: ChatRepository, TR: TurnRepository>(
 
     // 3. Verify ownership
     if target.requester_user_id != Some(ctx.subject_id()) {
-        return Err(MutationError::InsufficientPermissions);
+        return Err(MutationError::Forbidden);
     }
 
     // 4. Verify terminal state

--- a/modules/mini-chat/mini-chat/src/domain/service/turn_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/turn_service_test.rs
@@ -171,6 +171,90 @@ async fn create_completed_turn(
 }
 
 // ════════════════════════════════════════════════════════════════════════════
+// TurnService::get
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn get_returns_completed_turn() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    let request_id = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        ctx.subject_id(),
+    )
+    .await;
+
+    let turn = svc.get(&ctx, chat_id, request_id).await.unwrap();
+    assert_eq!(turn.request_id, request_id);
+    assert_eq!(turn.chat_id, chat_id);
+    assert_eq!(turn.state, TurnState::Completed);
+    assert!(turn.assistant_message_id.is_some());
+}
+
+#[tokio::test]
+async fn get_returns_running_turn() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    let request_id = Uuid::new_v4();
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = svc.db.conn().unwrap();
+    svc.turn_repo
+        .create_turn(
+            &conn,
+            &scope,
+            crate::domain::repos::CreateTurnParams {
+                id: Uuid::new_v4(),
+                tenant_id,
+                chat_id,
+                request_id,
+                requester_type: "user".to_owned(),
+                requester_user_id: Some(ctx.subject_id()),
+                reserve_tokens: None,
+                max_output_tokens_applied: None,
+                reserved_credits_micro: None,
+                policy_version_applied: None,
+                effective_model: None,
+                minimal_generation_floor_applied: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let turn = svc.get(&ctx, chat_id, request_id).await.unwrap();
+    assert_eq!(turn.request_id, request_id);
+    assert_eq!(turn.state, TurnState::Running);
+}
+
+#[tokio::test]
+async fn get_nonexistent_turn_returns_not_found() {
+    let (svc, ctx, chat_id, _) = setup().await;
+
+    let err = svc.get(&ctx, chat_id, Uuid::new_v4()).await.unwrap_err();
+    assert!(
+        matches!(err, MutationError::TurnNotFound { .. }),
+        "expected TurnNotFound, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn get_nonexistent_chat_returns_chat_not_found() {
+    let (svc, ctx, _, _) = setup().await;
+
+    let err = svc
+        .get(&ctx, Uuid::new_v4(), Uuid::new_v4())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, MutationError::ChatNotFound { .. }),
+        "expected ChatNotFound, got: {err:?}"
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 // 7.4: validate_mutation — 5 checks in order
 // ════════════════════════════════════════════════════════════════════════════
 
@@ -200,7 +284,7 @@ async fn delete_nonexistent_chat_returns_chat_not_found() {
 }
 
 #[tokio::test]
-async fn delete_wrong_owner_returns_insufficient_permissions() {
+async fn delete_wrong_owner_returns_forbidden() {
     let (svc, ctx, chat_id, tenant_id) = setup().await;
 
     // Create a turn with a DIFFERENT requester_user_id than ctx.subject_id()
@@ -218,8 +302,8 @@ async fn delete_wrong_owner_returns_insufficient_permissions() {
     // ctx.subject_id() != other_user_id → ownership check fails
     let err = svc.delete(&ctx, chat_id, request_id).await.unwrap_err();
     assert!(
-        matches!(err, MutationError::InsufficientPermissions),
-        "expected InsufficientPermissions, got: {err:?}"
+        matches!(err, MutationError::Forbidden),
+        "expected Forbidden, got: {err:?}"
     );
 }
 


### PR DESCRIPTION
- Move authorization checks from REST handler into TurnService for get/delete/retry/edit
- Avoid using PEP->PDP requests (AuthZ) within db transaction
- Add TurnService::get() method with proper authz scoping
- Convert EnforcerError to MutationError via From impl for cleaner error propagation
- Rename InsufficientPermissions to Forbidden for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization error handling with clearer messaging when access is denied.
  
* **Refactor**
  * Streamlined internal data access patterns and authorization validation flows to enhance consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->