### PR TITLE
feat(mini-chat): wire real outbox pipeline for usage events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
  "cf-modkit-security",
  "cf-oagw-sdk",
  "cf-types-registry-sdk",
+ "chrono",
  "futures",
  "http",
  "inventory",

--- a/libs/modkit-db/src/db_provider.rs
+++ b/libs/modkit-db/src/db_provider.rs
@@ -41,6 +41,15 @@ where
         }
     }
 
+    /// Returns a clone of the inner [`Db`] handle.
+    ///
+    /// Cheap (clones an inner `Arc`). Useful when the caller needs the raw
+    /// `Db` — e.g. to pass to [`Outbox::builder`](crate::outbox::Outbox::builder).
+    #[must_use]
+    pub fn db(&self) -> Db {
+        (*self.db).clone()
+    }
+
     /// Create a non-transactional database runner.
     ///
     /// # Errors

--- a/libs/modkit-db/src/outbox/core.rs
+++ b/libs/modkit-db/src/outbox/core.rs
@@ -205,7 +205,7 @@ impl Outbox {
     /// Returns an error on validation failure or database error.
     pub async fn enqueue(
         &self,
-        db: &(impl crate::secure::DBRunner + Sync),
+        db: &(impl crate::secure::DBRunner + Sync + ?Sized),
         queue: &str,
         partition: u32,
         payload: Vec<u8>,
@@ -230,7 +230,7 @@ impl Outbox {
     /// Returns an error on validation failure or database error.
     pub async fn enqueue_batch(
         &self,
-        db: &(impl crate::secure::DBRunner + Sync),
+        db: &(impl crate::secure::DBRunner + Sync + ?Sized),
         queue: &str,
         items: &[EnqueueMessage<'_>],
     ) -> Result<Vec<OutboxMessageId>, OutboxError> {

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -71,9 +71,12 @@ thiserror = { workspace = true }
 
 # Local dependencies
 modkit = { workspace = true }
-modkit-db = { workspace = true, features = ["sqlite", "pg"] }
+modkit-db = { workspace = true, features = ["sqlite", "pg", "preview-outbox"] }
 modkit-db-macros = { workspace = true }
 modkit-security = { workspace = true }
 modkit-macros = { workspace = true }
 modkit-odata = { workspace = true, features = ["with-utoipa"] }
+
+[dev-dependencies]
+chrono = { workspace = true }
 

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -300,9 +300,9 @@ impl OutboxConfig {
         if self.queue_name.trim().is_empty() {
             return Err("outbox queue_name must not be empty".to_owned());
         }
-        if !(1..=64).contains(&self.num_partitions) {
+        if !(1..=64).contains(&self.num_partitions) || !self.num_partitions.is_power_of_two() {
             return Err(format!(
-                "outbox num_partitions must be 1-64, got {}",
+                "outbox num_partitions must be a power of 2 in 1-64, got {}",
                 self.num_partitions
             ));
         }

--- a/modules/mini-chat/mini-chat/src/domain/repos/outbox_enqueuer.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/outbox_enqueuer.rs
@@ -26,11 +26,10 @@ use crate::domain::error::DomainError;
 ///
 /// # Implementation note
 ///
-/// The infra implementation (`InfraOutboxEnqueuer`) will hold an
-/// `Arc<modkit_db::outbox::Outbox>` and call `outbox.enqueue(runner, ...)`
+/// The infra implementation (`InfraOutboxEnqueuer`) holds an
+/// `Arc<modkit_db::outbox::Outbox>` and calls `outbox.enqueue(runner, ...)`
 /// within the finalization transaction. The `Outbox::flush()` notification
 /// is sent after the transaction commits (by the finalization service).
-// TODO: implement InfraOutboxEnqueuer backed by modkit_db::outbox::Outbox
 #[async_trait::async_trait]
 pub trait OutboxEnqueuer: Send + Sync {
     /// Enqueue a usage event within the caller's transaction.
@@ -50,4 +49,14 @@ pub trait OutboxEnqueuer: Send + Sync {
         runner: &(dyn DBRunner + Sync),
         event: UsageEvent,
     ) -> Result<(), DomainError>;
+
+    /// Notify the outbox sequencer that new events are available.
+    ///
+    /// Called after the transaction that contains `enqueue_usage_event` commits.
+    /// Multiple flush calls coalesce — calling flush 10 times results in at most
+    /// one sequencer wakeup.
+    ///
+    /// This is outbox-wide: it wakes the sequencer for ALL registered queues,
+    /// so a single flush call suffices regardless of which queue was written to.
+    fn flush(&self);
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
@@ -79,7 +79,10 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
 
         match result {
             Ok(outcome) => {
-                // Emit side effects after transaction commit.
+                // Post-commit side effects (outside transaction).
+                if outcome.won_cas {
+                    self.outbox_enqueuer.flush();
+                }
                 if let Some(billing) = outcome.billing_outcome {
                     Self::emit_post_commit_side_effects(&input, billing);
                 }
@@ -107,6 +110,9 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
                                 DomainError::internal(format!("unexpected retry failure: {e2}"))
                             }
                         })?;
+                if retry_outcome.won_cas {
+                    self.outbox_enqueuer.flush();
+                }
                 if let Some(billing) = retry_outcome.billing_outcome {
                     Self::emit_post_commit_side_effects(&retry_input, billing);
                 }
@@ -374,10 +380,24 @@ mod tests {
         }
     }
 
-    // ── Noop OutboxEnqueuer ──
+    // ── Noop OutboxEnqueuer (with flush tracking) ──
 
     #[domain_model]
-    struct NoopOutboxEnqueuer;
+    struct NoopOutboxEnqueuer {
+        flush_count: std::sync::atomic::AtomicU32,
+    }
+
+    impl NoopOutboxEnqueuer {
+        fn new() -> Self {
+            Self {
+                flush_count: std::sync::atomic::AtomicU32::new(0),
+            }
+        }
+
+        fn flush_count(&self) -> u32 {
+            self.flush_count.load(std::sync::atomic::Ordering::Relaxed)
+        }
+    }
 
     #[async_trait::async_trait]
     impl OutboxEnqueuer for NoopOutboxEnqueuer {
@@ -388,10 +408,21 @@ mod tests {
         ) -> Result<(), DomainError> {
             Ok(())
         }
+
+        fn flush(&self) {
+            self.flush_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
     }
 
-    fn build_finalization_service(db: Arc<DbProvider>) -> FinalizationService<TurnRepo, MsgRepo> {
-        FinalizationService::new(
+    fn build_finalization_service(
+        db: Arc<DbProvider>,
+    ) -> (
+        FinalizationService<TurnRepo, MsgRepo>,
+        Arc<NoopOutboxEnqueuer>,
+    ) {
+        let outbox = Arc::new(NoopOutboxEnqueuer::new());
+        let svc = FinalizationService::new(
             db,
             Arc::new(TurnRepo),
             Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
@@ -399,8 +430,9 @@ mod tests {
                 max: 100,
             })),
             Arc::new(MockQuotaSettler),
-            Arc::new(NoopOutboxEnqueuer),
-        )
+            outbox.clone(),
+        );
+        (svc, outbox)
     }
 
     /// Insert a parent chat row (FK constraint).
@@ -511,7 +543,7 @@ mod tests {
     #[tokio::test]
     async fn cas_winner_completes_finalization() {
         let db = mock_db_provider(inmem_db().await);
-        let svc = build_finalization_service(Arc::clone(&db));
+        let (svc, outbox) = build_finalization_service(Arc::clone(&db));
 
         let tenant_id = Uuid::new_v4();
         let chat_id = Uuid::new_v4();
@@ -538,6 +570,11 @@ mod tests {
         assert!(outcome.won_cas, "should be CAS winner");
         assert!(outcome.billing_outcome.is_some());
         assert!(outcome.settlement_outcome.is_some());
+        assert_eq!(
+            outbox.flush_count(),
+            1,
+            "flush should be called once after CAS win"
+        );
 
         // Verify turn is now in completed state
         let conn = db.conn().unwrap();
@@ -556,7 +593,7 @@ mod tests {
     #[tokio::test]
     async fn cas_loser_returns_no_side_effects() {
         let db = mock_db_provider(inmem_db().await);
-        let svc = build_finalization_service(Arc::clone(&db));
+        let (svc, outbox) = build_finalization_service(Arc::clone(&db));
 
         let tenant_id = Uuid::new_v4();
         let chat_id = Uuid::new_v4();
@@ -598,6 +635,12 @@ mod tests {
         assert!(!outcome2.won_cas, "second finalizer should lose CAS");
         assert!(outcome2.billing_outcome.is_none());
         assert!(outcome2.settlement_outcome.is_none());
+        // First call won CAS → 1 flush. Second lost CAS → no additional flush.
+        assert_eq!(
+            outbox.flush_count(),
+            1,
+            "flush should only be called for CAS winner"
+        );
     }
 
     // ── 3.8: Transaction rollback on failure leaves turn in running state ──
@@ -629,7 +672,7 @@ mod tests {
                 max: 100,
             })),
             Arc::new(FailingQuotaSettler),
-            Arc::new(NoopOutboxEnqueuer),
+            Arc::new(NoopOutboxEnqueuer::new()),
         );
 
         let tenant_id = Uuid::new_v4();

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -13,7 +13,6 @@ use crate::domain::repos::{
 };
 use crate::domain::service::quota_settler::QuotaSettler;
 use crate::infra::llm::provider_resolver::ProviderResolver;
-use crate::infra::outbox::InfraOutboxEnqueuer;
 
 mod attachment_service;
 mod chat_service;
@@ -155,6 +154,7 @@ impl<
         limits_provider: Arc<dyn UserLimitsProvider>,
         estimation_budgets: EstimationBudgets,
         quota_config: QuotaConfig,
+        outbox_enqueuer: Arc<dyn OutboxEnqueuer>,
     ) -> Self {
         let enforcer = PolicyEnforcer::new(authz);
 
@@ -168,8 +168,6 @@ impl<
             estimation_budgets,
             quota_config,
         ));
-
-        let outbox_enqueuer: Arc<dyn OutboxEnqueuer> = Arc::new(InfraOutboxEnqueuer::new());
 
         let finalization = Arc::new(FinalizationService::new(
             Arc::clone(&db),

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -1314,6 +1314,8 @@ mod tests {
         ) -> Result<(), crate::domain::error::DomainError> {
             Ok(())
         }
+
+        fn flush(&self) {}
     }
 
     #[test]

--- a/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
@@ -32,7 +32,7 @@ impl ModelPolicyGateway {
     }
 
     /// Lazily resolve the policy plugin from `ClientHub`.
-    async fn get_policy_plugin(
+    pub(crate) async fn get_policy_plugin(
         &self,
     ) -> Result<Arc<dyn MiniChatModelPolicyPluginClientV1>, DomainError> {
         let instance_id = self

--- a/modules/mini-chat/mini-chat/src/infra/outbox.rs
+++ b/modules/mini-chat/mini-chat/src/infra/outbox.rs
@@ -1,34 +1,41 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
-use mini_chat_sdk::UsageEvent;
-use tracing::warn;
+use mini_chat_sdk::{PublishError, UsageEvent};
+use modkit_db::outbox::Outbox;
+use tracing::{info, warn};
 
 use crate::domain::error::DomainError;
 use crate::domain::repos::OutboxEnqueuer;
-
-const USAGE_QUEUE: &str = "mini-chat.usage_snapshot";
-const NUM_PARTITIONS: u32 = 4;
 
 /// Infrastructure implementation of [`OutboxEnqueuer`].
 ///
 /// Serializes `UsageEvent` to JSON and inserts into the outbox table
 /// within the caller's transaction via `modkit_db::outbox::Outbox::enqueue()`.
-///
-/// TODO: replace stub with real implementation once `modkit_db::outbox`
-/// is merged from the `transactional-outbox` branch. The implementation should:
-/// - Hold `Arc<modkit_db::outbox::Outbox>`
-/// - Call `outbox.enqueue(runner, queue_name, partition, payload).await`
-pub struct InfraOutboxEnqueuer;
+pub struct InfraOutboxEnqueuer {
+    outbox: Arc<Outbox>,
+    queue_name: String,
+    num_partitions: u32,
+}
 
 impl InfraOutboxEnqueuer {
-    pub(crate) fn new() -> Self {
-        Self
+    pub(crate) fn new(outbox: Arc<Outbox>, queue_name: String, num_partitions: u32) -> Self {
+        Self {
+            outbox,
+            queue_name,
+            num_partitions,
+        }
     }
 
-    fn partition_for(tenant_id: uuid::Uuid) -> u32 {
+    fn partition_for(&self, tenant_id: uuid::Uuid) -> u32 {
+        Self::compute_partition(tenant_id, self.num_partitions)
+    }
+
+    fn compute_partition(tenant_id: uuid::Uuid, num_partitions: u32) -> u32 {
         let hash = tenant_id.as_u128();
         #[allow(clippy::cast_possible_truncation)]
         {
-            (hash % u128::from(NUM_PARTITIONS)) as u32
+            (hash % u128::from(num_partitions)) as u32
         }
     }
 }
@@ -37,22 +44,468 @@ impl InfraOutboxEnqueuer {
 impl OutboxEnqueuer for InfraOutboxEnqueuer {
     async fn enqueue_usage_event(
         &self,
-        _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+        runner: &(dyn modkit_db::secure::DBRunner + Sync),
         event: UsageEvent,
     ) -> Result<(), DomainError> {
-        let partition = Self::partition_for(event.tenant_id);
+        let partition = self.partition_for(event.tenant_id);
         let payload = serde_json::to_vec(&event)
             .map_err(|e| DomainError::internal(format!("serialize UsageEvent: {e}")))?;
-        let payload_json = String::from_utf8_lossy(&payload);
 
-        warn!(
-            queue = USAGE_QUEUE,
-            partition = partition,
-            payload = %payload_json,
-            "outbox enqueue stub - event NOT persisted (modkit_db::outbox not yet wired)"
+        self.outbox
+            .enqueue(
+                runner,
+                &self.queue_name,
+                partition,
+                payload,
+                "application/json",
+            )
+            .await
+            .map_err(|e| DomainError::internal(format!("outbox enqueue: {e}")))?;
+
+        info!(
+            queue = %self.queue_name,
+            partition,
+            tenant_id = %event.tenant_id,
+            turn_id = %event.turn_id,
+            "usage event enqueued"
         );
 
-        // TODO: replace with real outbox.enqueue(runner, queue_name, partition, payload)
         Ok(())
+    }
+
+    fn flush(&self) {
+        self.outbox.flush();
+    }
+}
+
+/// Trait for lazily resolving the model-policy plugin.
+///
+/// Production code uses `ModelPolicyGateway` (lazy GTS resolution).
+/// Tests provide a direct `Arc<dyn MiniChatModelPolicyPluginClientV1>`.
+#[async_trait]
+pub trait PolicyPluginProvider: Send + Sync {
+    async fn get_plugin(
+        &self,
+    ) -> Result<
+        Arc<dyn mini_chat_sdk::MiniChatModelPolicyPluginClientV1>,
+        crate::domain::error::DomainError,
+    >;
+}
+
+#[async_trait]
+impl PolicyPluginProvider for crate::infra::model_policy::ModelPolicyGateway {
+    async fn get_plugin(
+        &self,
+    ) -> Result<
+        Arc<dyn mini_chat_sdk::MiniChatModelPolicyPluginClientV1>,
+        crate::domain::error::DomainError,
+    > {
+        self.get_policy_plugin().await
+    }
+}
+
+/// Delivers usage events to the model-policy plugin via `publish_usage()`.
+///
+/// Deserializes `OutboxMessage.payload` into `UsageEvent`, resolves the plugin
+/// lazily via [`PolicyPluginProvider`], calls `publish_usage()`, and maps
+/// `PublishError` variants to outbox `HandlerResult`:
+/// - `Ok(())` → `Success` (ack + advance cursor)
+/// - `PublishError::Transient` → `Retry` (exponential backoff, redelivery)
+/// - `PublishError::Permanent` → `Reject` (dead-letter for manual inspection)
+/// - Deserialization failure → `Reject` (corrupt payload, permanent)
+/// - Plugin resolution failure → `Retry` (transient - plugin may not be ready yet)
+pub struct UsageEventHandler {
+    pub(crate) plugin_provider: Arc<dyn PolicyPluginProvider>,
+}
+
+#[async_trait]
+impl modkit_db::outbox::MessageHandler for UsageEventHandler {
+    async fn handle(
+        &self,
+        msg: &modkit_db::outbox::OutboxMessage,
+        _cancel: tokio_util::sync::CancellationToken,
+    ) -> modkit_db::outbox::HandlerResult {
+        let event = match serde_json::from_slice::<UsageEvent>(&msg.payload) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::error!(
+                    partition_id = msg.partition_id,
+                    seq = msg.seq,
+                    payload_len = msg.payload.len(),
+                    "usage event deserialization failed: {e}"
+                );
+                return modkit_db::outbox::HandlerResult::Reject {
+                    reason: format!("deserialization failed: {e}"),
+                };
+            }
+        };
+
+        info!(
+            tenant_id = %event.tenant_id,
+            user_id = %event.user_id,
+            turn_id = %event.turn_id,
+            request_id = %event.request_id,
+            effective_model = %event.effective_model,
+            billing_outcome = ?event.billing_outcome,
+            settlement_method = ?event.settlement_method,
+            actual_credits_micro = event.actual_credits_micro,
+            partition_id = msg.partition_id,
+            seq = msg.seq,
+            "publishing usage event to plugin"
+        );
+
+        let plugin = match self.plugin_provider.get_plugin().await {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(
+                    partition_id = msg.partition_id,
+                    seq = msg.seq,
+                    error = %e,
+                    "failed to resolve policy plugin - will retry"
+                );
+                return modkit_db::outbox::HandlerResult::Retry {
+                    reason: format!("plugin resolution failed: {e}"),
+                };
+            }
+        };
+
+        match plugin.publish_usage(event).await {
+            Ok(()) => modkit_db::outbox::HandlerResult::Success,
+            Err(PublishError::Transient(reason)) => {
+                warn!(
+                    partition_id = msg.partition_id,
+                    seq = msg.seq,
+                    %reason,
+                    "publish_usage transient failure - will retry"
+                );
+                modkit_db::outbox::HandlerResult::Retry { reason }
+            }
+            Err(PublishError::Permanent(reason)) => {
+                tracing::error!(
+                    partition_id = msg.partition_id,
+                    seq = msg.seq,
+                    %reason,
+                    "publish_usage permanent failure - dead-lettering"
+                );
+                modkit_db::outbox::HandlerResult::Reject { reason }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mini_chat_sdk::{
+        MiniChatModelPolicyPluginClientV1, MiniChatModelPolicyPluginError, PolicySnapshot,
+        PolicyVersionInfo, PublishError, UserLimits,
+    };
+    use modkit_db::outbox::{HandlerResult, MessageHandler, OutboxMessage};
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use time::OffsetDateTime;
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
+    fn make_usage_event() -> UsageEvent {
+        UsageEvent {
+            tenant_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            chat_id: Uuid::new_v4(),
+            turn_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            effective_model: "gpt-4o".to_owned(),
+            selected_model: "gpt-4o".to_owned(),
+            terminal_state: "completed".to_owned(),
+            billing_outcome: "charged".to_owned(),
+            usage: None,
+            actual_credits_micro: 500,
+            settlement_method: "quota".to_owned(),
+            policy_version_applied: 1,
+            timestamp: OffsetDateTime::now_utc(),
+        }
+    }
+
+    fn make_outbox_message(payload: Vec<u8>) -> OutboxMessage {
+        OutboxMessage {
+            partition_id: 1,
+            seq: 42,
+            payload,
+            payload_type: "application/json".to_owned(),
+            created_at: chrono::Utc::now(),
+            attempts: 0,
+        }
+    }
+
+    /// Mock plugin that records `publish_usage` calls and returns a configurable result.
+    struct MockPlugin {
+        result: std::sync::Mutex<Result<(), PublishError>>,
+        call_count: AtomicU32,
+        notifier: tokio::sync::Notify,
+    }
+
+    impl MockPlugin {
+        fn ok() -> Arc<Self> {
+            Arc::new(Self {
+                result: std::sync::Mutex::new(Ok(())),
+                call_count: AtomicU32::new(0),
+                notifier: tokio::sync::Notify::new(),
+            })
+        }
+
+        fn transient(reason: &str) -> Arc<Self> {
+            Arc::new(Self {
+                result: std::sync::Mutex::new(Err(PublishError::Transient(reason.to_owned()))),
+                call_count: AtomicU32::new(0),
+                notifier: tokio::sync::Notify::new(),
+            })
+        }
+
+        fn permanent(reason: &str) -> Arc<Self> {
+            Arc::new(Self {
+                result: std::sync::Mutex::new(Err(PublishError::Permanent(reason.to_owned()))),
+                call_count: AtomicU32::new(0),
+                notifier: tokio::sync::Notify::new(),
+            })
+        }
+
+        fn calls(&self) -> u32 {
+            self.call_count.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl MiniChatModelPolicyPluginClientV1 for MockPlugin {
+        async fn get_current_policy_version(
+            &self,
+            _user_id: Uuid,
+        ) -> Result<PolicyVersionInfo, MiniChatModelPolicyPluginError> {
+            unimplemented!("not needed in outbox tests")
+        }
+
+        async fn get_policy_snapshot(
+            &self,
+            _user_id: Uuid,
+            _policy_version: u64,
+        ) -> Result<PolicySnapshot, MiniChatModelPolicyPluginError> {
+            unimplemented!("not needed in outbox tests")
+        }
+
+        async fn get_user_limits(
+            &self,
+            _user_id: Uuid,
+            _policy_version: u64,
+        ) -> Result<UserLimits, MiniChatModelPolicyPluginError> {
+            unimplemented!("not needed in outbox tests")
+        }
+
+        async fn publish_usage(&self, _payload: UsageEvent) -> Result<(), PublishError> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            let result = {
+                let guard = self.result.lock().unwrap();
+                match &*guard {
+                    Ok(()) => Ok(()),
+                    Err(PublishError::Transient(r)) => Err(PublishError::Transient(r.clone())),
+                    Err(PublishError::Permanent(r)) => Err(PublishError::Permanent(r.clone())),
+                }
+            };
+            self.notifier.notify_one();
+            result
+        }
+    }
+
+    /// Wraps a mock plugin as a [`PolicyPluginProvider`] for tests.
+    struct MockProvider {
+        plugin: Arc<dyn MiniChatModelPolicyPluginClientV1>,
+    }
+
+    #[async_trait]
+    impl PolicyPluginProvider for MockProvider {
+        async fn get_plugin(
+            &self,
+        ) -> Result<Arc<dyn MiniChatModelPolicyPluginClientV1>, crate::domain::error::DomainError>
+        {
+            Ok(self.plugin.clone())
+        }
+    }
+
+    fn make_handler(plugin: &Arc<dyn MiniChatModelPolicyPluginClientV1>) -> UsageEventHandler {
+        UsageEventHandler {
+            plugin_provider: Arc::new(MockProvider {
+                plugin: plugin.clone(),
+            }),
+        }
+    }
+
+    // ── 7.1: partition_for returns values in [0, num_partitions) ──
+
+    #[test]
+    fn partition_for_returns_in_range() {
+        for num_partitions in [1, 2, 4, 8, 16, 32, 64] {
+            for _ in 0..100 {
+                let tenant_id = Uuid::new_v4();
+                let p = InfraOutboxEnqueuer::compute_partition(tenant_id, num_partitions);
+                assert!(
+                    p < num_partitions,
+                    "partition {p} >= num_partitions {num_partitions} for tenant {tenant_id}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn partition_for_deterministic() {
+        let tenant_id = Uuid::new_v4();
+        let a = InfraOutboxEnqueuer::compute_partition(tenant_id, 4);
+        let b = InfraOutboxEnqueuer::compute_partition(tenant_id, 4);
+        assert_eq!(a, b);
+    }
+
+    // ── 7.2 / 7.7: UsageEventHandler returns Success when plugin returns Ok ──
+
+    #[tokio::test]
+    async fn handler_success_for_valid_event() {
+        let plugin = MockPlugin::ok();
+        let handler = make_handler(&(plugin.clone() as Arc<dyn MiniChatModelPolicyPluginClientV1>));
+        let event = make_usage_event();
+        let payload = serde_json::to_vec(&event).unwrap();
+        let msg = make_outbox_message(payload);
+
+        let result = handler.handle(&msg, CancellationToken::new()).await;
+        assert!(matches!(result, HandlerResult::Success));
+        assert_eq!(plugin.calls(), 1);
+    }
+
+    // ── 7.3: UsageEventHandler returns Reject for invalid payload ──
+
+    #[tokio::test]
+    async fn handler_reject_for_invalid_payload() {
+        let plugin = MockPlugin::ok();
+        let handler = make_handler(&(plugin.clone() as Arc<dyn MiniChatModelPolicyPluginClientV1>));
+        let msg = make_outbox_message(b"not json".to_vec());
+
+        let result = handler.handle(&msg, CancellationToken::new()).await;
+        match result {
+            HandlerResult::Reject { reason } => {
+                assert!(
+                    reason.contains("deserialization failed"),
+                    "unexpected reason: {reason}"
+                );
+            }
+            HandlerResult::Success => panic!("expected Reject, got Success"),
+            HandlerResult::Retry { reason } => panic!("expected Reject, got Retry({reason})"),
+        }
+        // Plugin should not be called for invalid payload.
+        assert_eq!(plugin.calls(), 0);
+    }
+
+    // ── 7.8: UsageEventHandler returns Retry on PublishError::Transient ──
+
+    #[tokio::test]
+    async fn handler_retry_on_transient_error() {
+        let plugin = MockPlugin::transient("network timeout");
+        let handler = make_handler(&(plugin.clone() as Arc<dyn MiniChatModelPolicyPluginClientV1>));
+        let event = make_usage_event();
+        let payload = serde_json::to_vec(&event).unwrap();
+        let msg = make_outbox_message(payload);
+
+        let result = handler.handle(&msg, CancellationToken::new()).await;
+        match result {
+            HandlerResult::Retry { reason } => {
+                assert_eq!(reason, "network timeout");
+            }
+            HandlerResult::Success => panic!("expected Retry, got Success"),
+            HandlerResult::Reject { reason } => {
+                panic!("expected Retry, got Reject({reason})")
+            }
+        }
+        assert_eq!(plugin.calls(), 1);
+    }
+
+    // ── 7.9: UsageEventHandler returns Reject on PublishError::Permanent ──
+
+    #[tokio::test]
+    async fn handler_reject_on_permanent_error() {
+        let plugin = MockPlugin::permanent("schema mismatch");
+        let handler = make_handler(&(plugin.clone() as Arc<dyn MiniChatModelPolicyPluginClientV1>));
+        let event = make_usage_event();
+        let payload = serde_json::to_vec(&event).unwrap();
+        let msg = make_outbox_message(payload);
+
+        let result = handler.handle(&msg, CancellationToken::new()).await;
+        match result {
+            HandlerResult::Reject { reason } => {
+                assert_eq!(reason, "schema mismatch");
+            }
+            HandlerResult::Success => panic!("expected Reject, got Success"),
+            HandlerResult::Retry { reason } => {
+                panic!("expected Reject, got Retry({reason})")
+            }
+        }
+        assert_eq!(plugin.calls(), 1);
+    }
+
+    // ── 7.5 / 7.10: Integration test — full pipeline with mock plugin ──
+
+    #[tokio::test]
+    async fn full_pipeline_enqueue_and_deliver() {
+        use modkit_db::outbox::{Outbox, Partitions};
+        use modkit_db::{ConnectOpts, connect_db, migration_runner::run_migrations_for_testing};
+        use std::time::Duration;
+
+        // Mock plugin that tracks calls.
+        let plugin = MockPlugin::ok();
+
+        // Set up in-memory DB with outbox migrations.
+        let db = connect_db(
+            "sqlite:file:outbox_integration?mode=memory&cache=shared",
+            ConnectOpts {
+                max_conns: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("connect");
+
+        run_migrations_for_testing(&db, modkit_db::outbox::outbox_migrations())
+            .await
+            .expect("outbox migrations");
+
+        // Start outbox pipeline with the real UsageEventHandler + mock plugin.
+        let handle = Outbox::builder(db.clone())
+            .poll_interval(Duration::from_millis(20))
+            .queue("test.usage", Partitions::of(1))
+            .decoupled(UsageEventHandler {
+                plugin_provider: Arc::new(MockProvider {
+                    plugin: plugin.clone(),
+                }),
+            })
+            .start()
+            .await
+            .expect("outbox start");
+
+        let outbox = Arc::clone(handle.outbox());
+
+        // Enqueue a usage event using InfraOutboxEnqueuer.
+        let enqueuer = InfraOutboxEnqueuer::new(outbox, "test.usage".to_owned(), 1);
+        let event = make_usage_event();
+        let conn = db.conn().expect("conn");
+        enqueuer
+            .enqueue_usage_event(&conn, event)
+            .await
+            .expect("enqueue");
+        enqueuer.flush();
+
+        // Wait for the handler to process (notification-based, no fixed sleep).
+        tokio::time::timeout(Duration::from_secs(5), plugin.notifier.notified())
+            .await
+            .expect("plugin should have been called within 5s");
+
+        assert_eq!(
+            plugin.calls(),
+            1,
+            "publish_usage should have been called once"
+        );
+
+        handle.stop().await;
     }
 }

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -1,17 +1,21 @@
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
 use authz_resolver_sdk::AuthZResolverClient;
 use mini_chat_sdk::{MiniChatAuditPluginSpecV1, MiniChatModelPolicyPluginSpecV1};
 use modkit::api::OpenApiRegistry;
+use modkit::contracts::RunnableCapability;
 use modkit::{DatabaseCapability, Module, ModuleCtx, RestApiCapability};
+use modkit_db::outbox::{Outbox, OutboxHandle, Partitions};
 use oagw_sdk::ServiceGatewayClientV1;
 use sea_orm_migration::MigrationTrait;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 use types_registry_sdk::{RegisterResult, TypesRegistryClient};
 
 use crate::api::rest::routes;
 use crate::domain::service::{AppServices as GenericAppServices, Repositories};
+use crate::infra::outbox::{InfraOutboxEnqueuer, UsageEventHandler};
 
 pub(crate) type AppServices = GenericAppServices<
     TurnRepository,
@@ -38,11 +42,12 @@ pub const DEFAULT_URL_PREFIX: &str = "/mini-chat";
 #[modkit::module(
     name = "mini-chat",
     deps = ["types-registry", "authz-resolver", "oagw"],
-    capabilities = [db, rest],
+    capabilities = [db, rest, stateful],
 )]
 pub struct MiniChatModule {
     service: OnceLock<Arc<AppServices>>,
     url_prefix: OnceLock<String>,
+    outbox_handle: Mutex<Option<OutboxHandle>>,
 }
 
 impl Default for MiniChatModule {
@@ -50,6 +55,7 @@ impl Default for MiniChatModule {
         Self {
             service: OnceLock::new(),
             url_prefix: OnceLock::new(),
+            outbox_handle: Mutex::new(None),
         }
     }
 }
@@ -108,7 +114,55 @@ impl Module for MiniChatModule {
             .set(cfg.url_prefix)
             .map_err(|_| anyhow::anyhow!("{} url_prefix already set", Self::MODULE_NAME))?;
 
-        let db = Arc::new(ctx.db_required()?);
+        let db_provider = ctx.db_required()?;
+        let db = Arc::new(db_provider);
+
+        // Create the model-policy gateway early for both outbox handler and services.
+        let model_policy_gw = Arc::new(ModelPolicyGateway::new(ctx.client_hub(), vendor));
+
+        // Start the outbox pipeline eagerly in init() (migrations ran in phase 2, DB is ready).
+        // The framework guarantees stop() is called on init failure, so the pipeline
+        // will be shut down cleanly if any later init step errors.
+        // The handler resolves the plugin lazily on first message delivery,
+        // avoiding a hard dependency on plugin availability during init().
+        let outbox_db = db.db();
+        let num_partitions = cfg.outbox.num_partitions;
+        let queue_name = cfg.outbox.queue_name.clone();
+
+        let outbox_handle =
+            Outbox::builder(outbox_db)
+                .queue(
+                    &queue_name,
+                    Partitions::of(u16::try_from(num_partitions).map_err(|_| {
+                        anyhow::anyhow!("num_partitions {num_partitions} exceeds u16")
+                    })?),
+                )
+                .decoupled(UsageEventHandler {
+                    plugin_provider: model_policy_gw.clone(),
+                })
+                .start()
+                .await
+                .map_err(|e| anyhow::anyhow!("outbox start: {e}"))?;
+
+        let outbox = Arc::clone(outbox_handle.outbox());
+        let outbox_enqueuer =
+            Arc::new(InfraOutboxEnqueuer::new(outbox, queue_name, num_partitions));
+
+        {
+            let mut guard = self
+                .outbox_handle
+                .lock()
+                .map_err(|e| anyhow::anyhow!("outbox_handle lock: {e}"))?;
+            if guard.is_some() {
+                return Err(anyhow::anyhow!(
+                    "{} outbox_handle already set",
+                    Self::MODULE_NAME
+                ));
+            }
+            *guard = Some(outbox_handle);
+        }
+
+        info!("Outbox pipeline started");
 
         let authz = ctx
             .client_hub()
@@ -142,7 +196,6 @@ impl Module for MiniChatModule {
             vector_store: Arc::new(VectorStoreRepository),
         };
 
-        let model_policy_gw = Arc::new(ModelPolicyGateway::new(ctx.client_hub(), vendor));
         let services = Arc::new(AppServices::new(
             &repos,
             db,
@@ -154,6 +207,7 @@ impl Module for MiniChatModule {
             model_policy_gw as Arc<dyn crate::domain::repos::UserLimitsProvider>,
             cfg.estimation_budgets,
             cfg.quota,
+            outbox_enqueuer,
         ));
 
         self.service
@@ -169,7 +223,9 @@ impl DatabaseCapability for MiniChatModule {
     fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
         use sea_orm_migration::MigratorTrait;
         info!("Providing mini-chat database migrations");
-        crate::infra::db::migrations::Migrator::migrations()
+        let mut m = crate::infra::db::migrations::Migrator::migrations();
+        m.extend(modkit_db::outbox::outbox_migrations());
+        m
     }
 }
 
@@ -194,6 +250,34 @@ impl RestApiCapability for MiniChatModule {
         let router = routes::register_routes(router, openapi, Arc::clone(services), prefix);
         info!("Mini-chat REST routes registered successfully");
         Ok(router)
+    }
+}
+
+#[async_trait]
+impl RunnableCapability for MiniChatModule {
+    async fn start(&self, _cancel: CancellationToken) -> anyhow::Result<()> {
+        // Outbox pipeline already started in init().
+        Ok(())
+    }
+
+    async fn stop(&self, cancel: CancellationToken) -> anyhow::Result<()> {
+        let handle = self
+            .outbox_handle
+            .lock()
+            .map_err(|e| anyhow::anyhow!("outbox_handle lock: {e}"))?
+            .take();
+        if let Some(handle) = handle {
+            info!("Stopping outbox pipeline");
+            tokio::select! {
+                () = handle.stop() => {
+                    info!("Outbox pipeline stopped");
+                }
+                () = cancel.cancelled() => {
+                    info!("Outbox pipeline stop cancelled by framework deadline");
+                }
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Replace the InfraOutboxEnqueuer stub (log-and-discard) with a real implementation backed by modkit_db::outbox::Outbox. Usage events are now persisted atomically within the finalization transaction and delivered via a decoupled logging handler.

- InfraOutboxEnqueuer holds Arc<Outbox>, delegates to Outbox::enqueue()
- UsageEventHandler (MessageHandler) deserializes and logs delivered events rejects corrupt payloads to dead-letter queue
- Outbox pipeline started in Module::init(), stopped via RunnableCapability
- flush() added to OutboxEnqueuer trait, called after CAS win in finalization
- OutboxConfig validation: num_partitions must be power-of-2 in 1-64
- modkit-db: add ?Sized to Outbox::enqueue/enqueue_batch for dyn DBRunner
- modkit-db: add DBProvider::db() accessor for Outbox::builder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated outbox into mini-chat: concrete infra enqueuer, usage-event handler, lazy plugin resolution, and lifecycle wiring to start/stop the outbox pipeline.

* **Configuration Changes**
  * Outbox partition count must be a power of two between 1–64.

* **Behavioral Improvements**
  * Enqueue now performs real delivery with logging; outbox flush notifications occur post-commit on CAS wins.

* **Tests**
  * Expanded unit and integration tests for partitioning, handler outcomes, and end-to-end delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->