### PR TITLE
feat(outbox): add two-tier semaphore, reaper, query profiler, and benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "annotate-snippets"
 version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1013,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,6 +1398,7 @@ dependencies = [
  "cf-modkit-security",
  "cf-modkit-utils",
  "chrono",
+ "criterion",
  "dashmap",
  "dirs",
  "figment",
@@ -1406,6 +1419,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "trybuild",
  "url",
  "uuid",
@@ -2090,6 +2105,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2342,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -4122,6 +4198,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4132,6 +4219,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -4898,6 +4994,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -5825,7 +5927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -5846,7 +5948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7614,7 +7716,7 @@ dependencies = [
  "ferroid",
  "futures",
  "http",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
@@ -7758,6 +7860,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -468,6 +468,7 @@ proc-macro-error2 = "2.0"
 
 # Testing utilities
 trybuild = "1"
+criterion = { version = "0.5", default-features = false }
 testcontainers = { version = "0.27", default-features = false, features = ["aws-lc-rs"] }
 testcontainers-modules = { version = "0.15", default-features = false, features = ["aws-lc-rs", "postgres", "mysql"] }
 httpmock = "0.8"

--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,53 @@ test-db: test-sqlite test-pg test-mysql
 test-users-info-pg:
 	cargo test -p users-info --features "integration" -- --nocapture
 
+# -------- Benchmarks --------
+
+.PHONY: bench-pg bench-pg-profiler bench-mysql bench-mariadb bench-sqlite bench-db \
+       bench-pg-longhaul bench-mysql-longhaul bench-mariadb-longhaul bench-sqlite-longhaul bench-db-longhaul
+
+## Run outbox throughput benchmarks against PostgreSQL
+bench-pg:
+	cargo bench -p cf-modkit-db --features pg,preview-outbox --bench outbox_throughput -- postgres
+
+## Run outbox benchmarks against PostgreSQL with query profiler (logs → /tmp/outbox_bench.log)
+bench-pg-profiler:
+	RUST_LOG=info cargo bench -p cf-modkit-db --features pg,outbox-profiler --bench outbox_throughput -- postgres
+
+## Run outbox throughput benchmarks against MySQL
+bench-mysql:
+	cargo bench -p cf-modkit-db --features mysql,preview-outbox --bench outbox_throughput -- mysql
+
+## Run outbox throughput benchmarks against MariaDB
+bench-mariadb:
+	cargo bench -p cf-modkit-db --features mysql,preview-outbox --bench outbox_throughput -- mariadb
+
+## Run outbox throughput benchmarks against SQLite
+bench-sqlite:
+	cargo bench -p cf-modkit-db --features sqlite,preview-outbox --bench outbox_throughput -- sqlite
+
+## Run outbox throughput benchmarks against all database engines
+bench-db: bench-pg bench-mysql bench-mariadb bench-sqlite
+
+## Run long-haul (1M+10M) outbox benchmarks against PostgreSQL
+bench-pg-longhaul:
+	cargo bench -p cf-modkit-db --features pg,preview-outbox --bench outbox_throughput -- postgres_longhaul
+
+## Run long-haul (1M+10M) outbox benchmarks against MySQL
+bench-mysql-longhaul:
+	cargo bench -p cf-modkit-db --features mysql,preview-outbox --bench outbox_throughput -- mysql_longhaul
+
+## Run long-haul (1M+10M) outbox benchmarks against MariaDB
+bench-mariadb-longhaul:
+	cargo bench -p cf-modkit-db --features mysql,preview-outbox --bench outbox_throughput -- mariadb_longhaul
+
+## Run long-haul (100K 1P) outbox benchmarks against SQLite
+bench-sqlite-longhaul:
+	cargo bench -p cf-modkit-db --features sqlite,preview-outbox --bench outbox_throughput -- sqlite_longhaul
+
+## Run long-haul outbox benchmarks against all database engines
+bench-db-longhaul: bench-pg-longhaul bench-mysql-longhaul bench-mariadb-longhaul bench-sqlite-longhaul
+
 # -------- E2E tests --------
 
 .PHONY: e2e e2e-local e2e-local-smoke e2e-docker e2e-docker-smoke

--- a/dylint_lints/Cargo.lock
+++ b/dylint_lints/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.3.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -538,6 +538,7 @@ dependencies = [
  "cf-modkit-macros",
  "cf-modkit-odata",
  "cf-modkit-sdk",
+ "cf-modkit-utils",
  "cf-system-sdks",
  "dashmap",
  "figment",
@@ -572,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.3.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -585,7 +586,6 @@ dependencies = [
  "dashmap",
  "dirs",
  "figment",
- "regex",
  "rust_decimal",
  "ryu",
  "sea-orm",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db-macros"
-version = "0.3.2"
+version = "0.5.0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro-error2",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors"
-version = "0.3.2"
+version = "0.5.0"
 dependencies = [
  "axum 0.8.8",
  "http",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
-version = "0.3.2"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-macros"
-version = "0.3.2"
+version = "0.5.0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -647,7 +647,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.3.2"
+version = "0.5.0"
 dependencies = [
  "base64",
  "bigdecimal",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.3.2"
+version = "0.5.0"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-security",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-security"
-version = "0.3.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "postcard",
@@ -688,16 +688,17 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-utils"
-version = "0.3.2"
+version = "0.5.0"
 dependencies = [
  "humantime",
+ "regex",
  "serde",
  "zeroize",
 ]
 
 [[package]]
 name = "cf-system-sdk-directory"
-version = "0.1.18"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -705,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cf-system-sdks"
-version = "0.1.18"
+version = "0.1.21"
 dependencies = [
  "cf-system-sdk-directory",
 ]

--- a/libs/modkit-db/Cargo.toml
+++ b/libs/modkit-db/Cargo.toml
@@ -49,6 +49,10 @@ integration = []
 # Transactional outbox pipeline (preview — API may change)
 preview-outbox = ["dep:tokio-util"]
 
+# Outbox query profiler — instruments all SQL operations and emits periodic
+# tracing reports. Zero-cost when disabled.
+outbox-profiler = ["preview-outbox"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
@@ -93,7 +97,13 @@ required-features = ["sqlite", "preview-outbox"]
 name = "outbox_batch_multi_queue"
 required-features = ["sqlite", "preview-outbox"]
 
+[[bench]]
+name = "outbox_throughput"
+harness = false
+required-features = ["preview-outbox"]
+
 [dev-dependencies]
+criterion = { workspace = true, features = ["html_reports"] }
 tempfile = { workspace = true }
 serde-saphyr = { workspace = true }
 testcontainers = { workspace = true }
@@ -102,3 +112,5 @@ tokio = { workspace = true }
 anyhow = { workspace = true }
 temp-env = { workspace = true }
 trybuild = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-appender = { workspace = true }

--- a/libs/modkit-db/benches/outbox_throughput.rs
+++ b/libs/modkit-db/benches/outbox_throughput.rs
@@ -1,0 +1,1475 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::missing_panics_doc,
+    clippy::doc_markdown,
+    clippy::cast_possible_truncation,
+    clippy::integer_division,
+    clippy::let_underscore_must_use,
+    clippy::non_ascii_literal,
+    clippy::manual_assert,
+    dead_code
+)]
+
+//! Outbox throughput benchmarks with per-partition ordering verification.
+//!
+//! Run via Makefile targets:
+//!   `make bench-pg`       -- Postgres only
+//!   `make bench-mysql`    -- MySQL only
+//!   `make bench-mariadb`  -- MariaDB only
+//!   `make bench-db`       -- All engines
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
+
+use criterion::{Criterion, Throughput, criterion_group};
+use dashmap::DashMap;
+use tokio::runtime::Runtime;
+use tokio::sync::Notify;
+
+use modkit_db::outbox::{
+    EnqueueMessage, Handler, HandlerResult, Outbox, OutboxHandle, OutboxMessage, Partitions,
+    outbox_migrations,
+};
+use modkit_db::{ConnectOpts, Db, connect_db, migration_runner::run_migrations_for_testing};
+use tokio_util::sync::CancellationToken;
+
+// Global counter shared across all bench_fn! expansions.
+// Each macro expansion previously declared its own static ITER_COUNTER,
+// restarting at 0 — so bench families produced colliding queue names
+// like "bench_0", "bench_1" that reused rows from earlier families.
+// A single global counter ensures process-wide unique queue names.
+static GLOBAL_ITER_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Messages for 1P/1C profile — multiple of 64 for even partition distribution.
+const MSG_1P: usize = 64 * 157; // 10_048
+
+/// Messages for 16P/16C profile.
+const MSG_16P: usize = 64 * 1_563; // 100_032
+
+/// Batch size for batch enqueue mode.
+const BATCH_SIZE: usize = 100;
+
+/// Number of partitions.
+const PARTITIONS: u16 = 64;
+
+/// Messages for 1M long-haul profile.
+const MSG_1M: usize = 64 * 15_625; // 1_000_000
+
+/// Messages for 10M long-haul profile.
+const MSG_10M: usize = 64 * 156_250; // 10_000_000
+
+/// SQLite long-haul cap — 100K single-thread only (single-writer engine).
+const MSG_SQLITE_LONGHAUL: usize = 64 * 1_563; // 100_032
+
+/// Number of concurrent producers in the 16P profile.
+const NUM_PRODUCERS: usize = 16;
+
+/// Max partitions processed concurrently by the outbox pipeline.
+/// Aligned with pool size: max_conns >= MAX_CONCURRENT_PARTITIONS + NUM_PRODUCERS + 5.
+const MAX_CONCURRENT_PARTITIONS: usize = 16;
+
+/// Timeout for standard benchmarks (120s).
+const TIMEOUT_STANDARD: Duration = Duration::from_secs(120);
+
+/// Timeout for 1M long-haul benchmarks (5 min).
+const TIMEOUT_1M: Duration = Duration::from_secs(300);
+
+/// Timeout for 10M long-haul benchmarks (30 min).
+const TIMEOUT_10M: Duration = Duration::from_secs(1800);
+
+// ---------------------------------------------------------------------------
+// BenchState — shared state for handler + verification
+// ---------------------------------------------------------------------------
+
+struct BenchState {
+    /// partition_id → payload sequence numbers in consumption order
+    consumed: Arc<DashMap<i64, Vec<u64>>>,
+    /// partition_id → DB-assigned seq values in consumption order
+    db_seqs: Arc<DashMap<i64, Vec<i64>>>,
+    /// Total messages consumed so far
+    counter: Arc<AtomicUsize>,
+    /// Signaled when counter reaches expected_total
+    notify: Arc<Notify>,
+    /// Target message count
+    expected_total: usize,
+}
+
+impl BenchState {
+    fn new(expected_total: usize) -> Self {
+        Self {
+            consumed: Arc::new(DashMap::new()),
+            db_seqs: Arc::new(DashMap::new()),
+            counter: Arc::new(AtomicUsize::new(0)),
+            notify: Arc::new(Notify::new()),
+            expected_total,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BenchHandler — captures consumed messages for verification
+// ---------------------------------------------------------------------------
+
+struct BenchHandler {
+    consumed: Arc<DashMap<i64, Vec<u64>>>,
+    db_seqs: Arc<DashMap<i64, Vec<i64>>>,
+    counter: Arc<AtomicUsize>,
+    notify: Arc<Notify>,
+    expected_total: usize,
+}
+
+#[async_trait::async_trait]
+impl Handler for BenchHandler {
+    async fn handle(&self, msgs: &[OutboxMessage], _cancel: CancellationToken) -> HandlerResult {
+        for msg in msgs {
+            // Parse payload "partition:seq"
+            let payload = std::str::from_utf8(&msg.payload).unwrap();
+            let (_, seq_str) = payload.split_once(':').unwrap();
+            let seq: u64 = seq_str.parse().unwrap();
+
+            self.consumed.entry(msg.partition_id).or_default().push(seq);
+            self.db_seqs
+                .entry(msg.partition_id)
+                .or_default()
+                .push(msg.seq);
+
+            let prev = self.counter.fetch_add(1, Ordering::Relaxed);
+            if prev + 1 >= self.expected_total {
+                self.notify.notify_one();
+            }
+        }
+        HandlerResult::Success
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wait for consumption completion
+// ---------------------------------------------------------------------------
+
+async fn wait_for_completion(state: &BenchState, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if state.counter.load(Ordering::Acquire) >= state.expected_total {
+            return;
+        }
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .unwrap_or(Duration::ZERO);
+        if remaining.is_zero() {
+            let got = state.counter.load(Ordering::Acquire);
+            panic!(
+                "Timeout: expected {} messages consumed, got {got} ({} missing)",
+                state.expected_total,
+                state.expected_total - got
+            );
+        }
+        // Sleep until notified or remaining timeout
+        let _ = tokio::time::timeout(remaining, state.notify.notified()).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ordering & completeness verification
+// ---------------------------------------------------------------------------
+
+fn verify_ordering(state: &BenchState, total: usize) {
+    let msgs_per_partition = total / PARTITIONS as usize;
+
+    // All 64 partitions present
+    assert_eq!(
+        state.consumed.len(),
+        PARTITIONS as usize,
+        "expected {PARTITIONS} partitions in results, got {}",
+        state.consumed.len()
+    );
+
+    for entry in state.consumed.iter() {
+        let partition = *entry.key();
+        let seqs = entry.value();
+
+        // Completeness: correct count
+        assert_eq!(
+            seqs.len(),
+            msgs_per_partition,
+            "partition {partition}: expected {msgs_per_partition} messages, got {}",
+            seqs.len()
+        );
+
+        // Payload-seq completeness: all expected sequences present (order may differ in 16P)
+        let actual: HashSet<u64> = seqs.iter().copied().collect();
+        let expected: HashSet<u64> = (0..msgs_per_partition as u64).collect();
+        assert_eq!(
+            actual,
+            expected,
+            "partition {partition}: payload sequence mismatch — \
+             missing: {:?}, extra: {:?}",
+            expected.difference(&actual).collect::<Vec<_>>(),
+            actual.difference(&expected).collect::<Vec<_>>()
+        );
+    }
+
+    // DB-seq ordering: must be strictly monotonically increasing per partition
+    for entry in state.db_seqs.iter() {
+        let partition = *entry.key();
+        let db_seqs = entry.value();
+        for i in 1..db_seqs.len() {
+            assert!(
+                db_seqs[i] > db_seqs[i - 1],
+                "partition {partition}: DB seq ordering violation at position {i}: \
+                 seq[{}]={} >= seq[{i}]={}",
+                i - 1,
+                db_seqs[i - 1],
+                db_seqs[i]
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Producer functions
+// ---------------------------------------------------------------------------
+
+async fn produce_single_range(
+    outbox: &Arc<Outbox>,
+    db: &Db,
+    queue: &str,
+    start: usize,
+    end: usize,
+) {
+    for i in start..end {
+        let partition = (i % PARTITIONS as usize) as u32;
+        let seq = i / PARTITIONS as usize;
+        let payload = format!("{partition}:{seq}").into_bytes();
+        let o = Arc::clone(outbox);
+        let q = queue.to_owned();
+        let (_, result) = o
+            .transaction(db.clone(), |tx| {
+                let o2 = Arc::clone(&o);
+                Box::pin(async move {
+                    o2.enqueue(tx, &q, partition, payload, "bench/seq")
+                        .await
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    Ok(())
+                })
+            })
+            .await;
+        result.unwrap();
+    }
+}
+
+async fn produce_batch_range(outbox: &Arc<Outbox>, db: &Db, queue: &str, start: usize, end: usize) {
+    for chunk_start in (start..end).step_by(BATCH_SIZE) {
+        let chunk_end = (chunk_start + BATCH_SIZE).min(end);
+        let messages: Vec<EnqueueMessage<'_>> = (chunk_start..chunk_end)
+            .map(|i| {
+                let partition = (i % PARTITIONS as usize) as u32;
+                let seq = i / PARTITIONS as usize;
+                EnqueueMessage {
+                    partition,
+                    payload: format!("{partition}:{seq}").into_bytes(),
+                    payload_type: "bench/seq",
+                }
+            })
+            .collect();
+        let o = Arc::clone(outbox);
+        let q = queue.to_owned();
+        let (_, result) = o
+            .transaction(db.clone(), |tx| {
+                let o2 = Arc::clone(&o);
+                Box::pin(async move {
+                    o2.enqueue_batch(tx, &q, &messages)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                    Ok(())
+                })
+            })
+            .await;
+        result.unwrap();
+    }
+}
+
+async fn produce_single(outbox: &Arc<Outbox>, db: &Db, queue: &str, total: usize) {
+    produce_single_range(outbox, db, queue, 0, total).await;
+}
+
+async fn produce_batch(outbox: &Arc<Outbox>, db: &Db, queue: &str, total: usize) {
+    produce_batch_range(outbox, db, queue, 0, total).await;
+}
+
+async fn produce_concurrent_single(outbox: &Arc<Outbox>, db: &Db, queue: &str, total: usize) {
+    let per_producer = total / NUM_PRODUCERS;
+    let mut handles = Vec::with_capacity(NUM_PRODUCERS);
+    for producer_id in 0..NUM_PRODUCERS {
+        let start = producer_id * per_producer;
+        let end = if producer_id == NUM_PRODUCERS - 1 {
+            total
+        } else {
+            start + per_producer
+        };
+        let outbox = Arc::clone(outbox);
+        let db = db.clone();
+        let q = queue.to_owned();
+        handles.push(tokio::spawn(async move {
+            produce_single_range(&outbox, &db, &q, start, end).await;
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+}
+
+async fn produce_concurrent_batch(outbox: &Arc<Outbox>, db: &Db, queue: &str, total: usize) {
+    let per_producer = total / NUM_PRODUCERS;
+    let mut handles = Vec::with_capacity(NUM_PRODUCERS);
+    for producer_id in 0..NUM_PRODUCERS {
+        let start = producer_id * per_producer;
+        let end = if producer_id == NUM_PRODUCERS - 1 {
+            total
+        } else {
+            start + per_producer
+        };
+        let outbox = Arc::clone(outbox);
+        let db = db.clone();
+        let q = queue.to_owned();
+        handles.push(tokio::spawn(async move {
+            produce_batch_range(&outbox, &db, &q, start, end).await;
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline setup
+// ---------------------------------------------------------------------------
+
+/// Each iteration uses a unique queue name to avoid interference from
+/// previous iterations' leftover data. The sequencer and processors only
+/// operate on partitions belonging to their queue.
+fn iter_queue_name(iter: u64) -> String {
+    format!("bench_{iter}")
+}
+
+async fn setup_pipeline(
+    db_url: &str,
+    expected_total: usize,
+    queue_name: &str,
+) -> (Db, OutboxHandle, Arc<BenchState>) {
+    setup_pipeline_with(db_url, expected_total, queue_name, Duration::from_secs(30)).await
+}
+
+async fn setup_pipeline_with(
+    db_url: &str,
+    expected_total: usize,
+    queue_name: &str,
+    vacuum_cooldown: Duration,
+) -> (Db, OutboxHandle, Arc<BenchState>) {
+    // DecoupledStrategy uses up to 3 connections per processor cycle (lease+read,
+    // handler, ack), so peak demand is: processors*2 + producers + sequencer + headroom.
+    let max_conns = if db_url.starts_with("sqlite") {
+        1
+    } else {
+        (MAX_CONCURRENT_PARTITIONS as u32) * 2 + (NUM_PRODUCERS as u32) + 5
+    };
+    let db = connect_db(
+        db_url,
+        ConnectOpts {
+            max_conns: Some(max_conns),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let state = Arc::new(BenchState::new(expected_total));
+    let handler = BenchHandler {
+        consumed: Arc::clone(&state.consumed),
+        db_seqs: Arc::clone(&state.db_seqs),
+        counter: Arc::clone(&state.counter),
+        notify: Arc::clone(&state.notify),
+        expected_total,
+    };
+
+    let handle = Outbox::builder(db.clone())
+        .poll_interval(Duration::from_millis(10))
+        .sequencer_batch_size(500)
+        .vacuum_cooldown(vacuum_cooldown)
+        .queue(queue_name, Partitions::of(PARTITIONS))
+        .max_concurrent_partitions(MAX_CONCURRENT_PARTITIONS)
+        .msg_batch_size(50)
+        .batch_decoupled(handler)
+        .start()
+        .await
+        .unwrap();
+
+    (db, handle, state)
+}
+
+/// Delete all data from outbox tables after each iteration. Prevents
+/// unbounded row accumulation across iterations in the shared database.
+///
+/// Deletion order respects FK constraints: child tables first, then parents.
+async fn cleanup_outbox_tables(db_url: &str) {
+    use sea_orm::{ConnectionTrait, Database, Statement};
+
+    // Tables in FK-safe deletion order (children before parents).
+    const TABLES: &[&str] = &[
+        "modkit_outbox_dead_letters",
+        "modkit_outbox_outgoing",
+        "modkit_outbox_incoming",
+        "modkit_outbox_vacuum_counter",
+        "modkit_outbox_processor",
+        "modkit_outbox_body",
+        "modkit_outbox_partitions",
+    ];
+
+    let db = Database::connect(db_url).await.unwrap();
+    let backend = db.get_database_backend();
+    for table in TABLES {
+        let sql = format!("DELETE FROM {table}");
+        db.execute(Statement::from_string(backend, sql))
+            .await
+            .unwrap();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Container helpers + TCP wait
+// ---------------------------------------------------------------------------
+
+async fn wait_for_tcp(host: &str, port: u16, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if tokio::net::TcpStream::connect((host, port)).await.is_ok() {
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!("Timeout waiting for {host}:{port}");
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+// --- Postgres ---
+
+#[cfg(feature = "pg")]
+mod pg_container {
+    use super::{
+        ConnectOpts, Duration, OnceLock, Runtime, connect_db, outbox_migrations,
+        run_migrations_for_testing, wait_for_tcp,
+    };
+    use testcontainers::{ContainerAsync, ContainerRequest, ImageExt, runners::AsyncRunner};
+    use testcontainers_modules::postgres::Postgres;
+
+    pub struct PgContainer {
+        pub url: String,
+        _container: ContainerAsync<Postgres>,
+    }
+
+    static PG: OnceLock<PgContainer> = OnceLock::new();
+
+    pub fn get_pg(rt: &Runtime) -> &'static PgContainer {
+        PG.get_or_init(|| {
+            rt.block_on(async {
+                let container = ContainerRequest::from(Postgres::default())
+                    .with_env_var("POSTGRES_PASSWORD", "pass")
+                    .with_env_var("POSTGRES_USER", "user")
+                    .with_env_var("POSTGRES_DB", "bench")
+                    .start()
+                    .await
+                    .unwrap();
+                let port = container.get_host_port_ipv4(5432).await.unwrap();
+                wait_for_tcp("127.0.0.1", port, Duration::from_secs(30)).await;
+                let url = format!("postgres://user:pass@127.0.0.1:{port}/bench");
+
+                // Run migrations once
+                let db = connect_db(&url, ConnectOpts::default()).await.unwrap();
+                run_migrations_for_testing(&db, outbox_migrations())
+                    .await
+                    .unwrap();
+
+                PgContainer {
+                    url,
+                    _container: container,
+                }
+            })
+        })
+    }
+}
+
+// --- MySQL ---
+
+#[cfg(feature = "mysql")]
+mod mysql_container {
+    use super::{
+        ConnectOpts, Duration, OnceLock, Runtime, connect_db, outbox_migrations,
+        run_migrations_for_testing, wait_for_tcp,
+    };
+    use testcontainers::{ContainerAsync, ContainerRequest, ImageExt, runners::AsyncRunner};
+    use testcontainers_modules::mysql::Mysql;
+
+    pub struct MysqlContainer {
+        pub url: String,
+        _container: ContainerAsync<Mysql>,
+    }
+
+    static MYSQL: OnceLock<MysqlContainer> = OnceLock::new();
+
+    pub fn get_mysql(rt: &Runtime) -> &'static MysqlContainer {
+        MYSQL.get_or_init(|| {
+            rt.block_on(async {
+                let container = ContainerRequest::from(Mysql::default())
+                    .with_env_var("MYSQL_ROOT_PASSWORD", "root")
+                    .with_env_var("MYSQL_USER", "user")
+                    .with_env_var("MYSQL_PASSWORD", "pass")
+                    .with_env_var("MYSQL_DATABASE", "bench")
+                    .start()
+                    .await
+                    .unwrap();
+                let port = container.get_host_port_ipv4(3306).await.unwrap();
+                wait_for_tcp("127.0.0.1", port, Duration::from_secs(60)).await;
+                let url = format!("mysql://user:pass@127.0.0.1:{port}/bench");
+
+                let db = connect_db(&url, ConnectOpts::default()).await.unwrap();
+                run_migrations_for_testing(&db, outbox_migrations())
+                    .await
+                    .unwrap();
+
+                MysqlContainer {
+                    url,
+                    _container: container,
+                }
+            })
+        })
+    }
+}
+
+// --- MariaDB ---
+
+#[cfg(feature = "mysql")]
+mod mariadb_container {
+    use super::{
+        ConnectOpts, Duration, OnceLock, Runtime, connect_db, outbox_migrations,
+        run_migrations_for_testing, wait_for_tcp,
+    };
+    use testcontainers::core::{ContainerPort, WaitFor};
+    use testcontainers::{
+        ContainerAsync, ContainerRequest, GenericImage, ImageExt, runners::AsyncRunner,
+    };
+
+    pub struct MariaContainer {
+        pub url: String,
+        _container: ContainerAsync<GenericImage>,
+    }
+
+    static MARIADB: OnceLock<MariaContainer> = OnceLock::new();
+
+    fn mariadb_image() -> GenericImage {
+        GenericImage::new("mariadb", "lts")
+            .with_wait_for(WaitFor::message_on_stderr("ready for connections"))
+            .with_exposed_port(ContainerPort::Tcp(3306))
+    }
+
+    pub fn get_mariadb(rt: &Runtime) -> &'static MariaContainer {
+        MARIADB.get_or_init(|| {
+            rt.block_on(async {
+                let container = ContainerRequest::from(mariadb_image())
+                    .with_env_var("MYSQL_ROOT_PASSWORD", "root")
+                    .with_env_var("MYSQL_USER", "user")
+                    .with_env_var("MYSQL_PASSWORD", "pass")
+                    .with_env_var("MYSQL_DATABASE", "bench")
+                    .start()
+                    .await
+                    .unwrap();
+                let port = container.get_host_port_ipv4(3306).await.unwrap();
+                wait_for_tcp("127.0.0.1", port, Duration::from_secs(60)).await;
+                let url = format!("mysql://user:pass@127.0.0.1:{port}/bench");
+
+                let db = connect_db(&url, ConnectOpts::default()).await.unwrap();
+                run_migrations_for_testing(&db, outbox_migrations())
+                    .await
+                    .unwrap();
+
+                MariaContainer {
+                    url,
+                    _container: container,
+                }
+            })
+        })
+    }
+}
+
+// --- SQLite ---
+
+#[cfg(feature = "sqlite")]
+mod sqlite_setup {
+    use super::{
+        ConnectOpts, Db, OnceLock, Runtime, connect_db, outbox_migrations,
+        run_migrations_for_testing,
+    };
+
+    /// In-memory SQLite with shared cache. We keep `_db` alive so the
+    /// in-memory database survives across `setup_pipeline` reconnections.
+    pub struct SqliteDb {
+        pub url: String,
+        _db: Db,
+    }
+
+    static SQLITE: OnceLock<SqliteDb> = OnceLock::new();
+
+    pub fn get_sqlite(rt: &Runtime) -> &'static SqliteDb {
+        SQLITE.get_or_init(|| {
+            rt.block_on(async {
+                let url = "sqlite:file:outbox_bench?mode=memory&cache=shared".to_owned();
+
+                let db = connect_db(
+                    &url,
+                    ConnectOpts {
+                        max_conns: Some(1),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+                run_migrations_for_testing(&db, outbox_migrations())
+                    .await
+                    .unwrap();
+
+                SqliteDb { url, _db: db }
+            })
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generic benchmark runner — uses a macro to avoid lifetime issues with closures
+// ---------------------------------------------------------------------------
+
+/// Runs a benchmark for a given database URL and producer function.
+///
+/// We use an iteration counter to give each criterion iteration a unique queue
+/// name, ensuring complete isolation between iterations without needing to
+/// truncate tables.
+macro_rules! bench_fn {
+    ($c:expr, $group_name:expr, $bench_name:expr, $db_url:expr, $msg_count:expr, $rt:expr, $producer:path) => {
+        bench_fn!(
+            $c,
+            $group_name,
+            $bench_name,
+            $db_url,
+            $msg_count,
+            $rt,
+            $producer,
+            TIMEOUT_STANDARD,
+            10,
+            30,
+            5,
+            Duration::from_secs(30)
+        )
+    };
+    ($c:expr, $group_name:expr, $bench_name:expr, $db_url:expr, $msg_count:expr, $rt:expr, $producer:path, $timeout:expr, $samples:expr, $measure_secs:expr, $warmup_secs:expr) => {
+        bench_fn!(
+            $c,
+            $group_name,
+            $bench_name,
+            $db_url,
+            $msg_count,
+            $rt,
+            $producer,
+            $timeout,
+            $samples,
+            $measure_secs,
+            $warmup_secs,
+            Duration::from_secs(5)
+        )
+    };
+    ($c:expr, $group_name:expr, $bench_name:expr, $db_url:expr, $msg_count:expr, $rt:expr, $producer:path, $timeout:expr, $samples:expr, $measure_secs:expr, $warmup_secs:expr, $vacuum_cooldown:expr) => {{
+        let mut group = $c.benchmark_group($group_name);
+        group.throughput(Throughput::Elements($msg_count as u64));
+        group.sample_size($samples);
+        group.measurement_time(Duration::from_secs($measure_secs));
+        group.warm_up_time(Duration::from_secs($warmup_secs));
+
+        group.bench_function($bench_name, |b| {
+            b.iter_custom(|iters| {
+                $rt.block_on(async {
+                    let mut total = Duration::ZERO;
+                    for _ in 0..iters {
+                        let iter_id = GLOBAL_ITER_COUNTER.fetch_add(1, Ordering::Relaxed);
+                        let queue = iter_queue_name(iter_id);
+                        let (db, handle, state) =
+                            setup_pipeline_with($db_url, $msg_count, &queue, $vacuum_cooldown)
+                                .await;
+
+                        let start = Instant::now();
+                        $producer(handle.outbox(), &db, &queue, $msg_count).await;
+                        wait_for_completion(&state, $timeout).await;
+                        total += start.elapsed();
+
+                        verify_ordering(&state, $msg_count);
+                        handle.stop().await;
+                        drop(db); // close pool before cleanup
+                        cleanup_outbox_tables($db_url).await;
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
+                    total
+                })
+            });
+        });
+        group.finish();
+    }};
+}
+
+// ---------------------------------------------------------------------------
+// Postgres benchmarks
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "pg")]
+fn pg_1p1c_single(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let pg = pg_container::get_pg(&rt);
+    bench_fn!(
+        c,
+        "postgres",
+        "1p1c_single",
+        &pg.url,
+        MSG_1P,
+        rt,
+        produce_single
+    );
+}
+
+#[cfg(feature = "pg")]
+fn pg_1p1c_batch(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let pg = pg_container::get_pg(&rt);
+    bench_fn!(
+        c,
+        "postgres",
+        "1p1c_batch",
+        &pg.url,
+        MSG_1P,
+        rt,
+        produce_batch
+    );
+}
+
+#[cfg(feature = "pg")]
+fn pg_16p16c_single(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let pg = pg_container::get_pg(&rt);
+    bench_fn!(
+        c,
+        "postgres",
+        "16p16c_single",
+        &pg.url,
+        MSG_16P,
+        rt,
+        produce_concurrent_single
+    );
+}
+
+#[cfg(feature = "pg")]
+fn pg_16p16c_batch(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let pg = pg_container::get_pg(&rt);
+    bench_fn!(
+        c,
+        "postgres",
+        "16p16c_batch",
+        &pg.url,
+        MSG_16P,
+        rt,
+        produce_concurrent_batch
+    );
+}
+
+// --- Postgres long-haul (1M) ---
+
+#[cfg(feature = "pg")]
+fn pg_1m_single(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let pg = pg_container::get_pg(&rt);
+    bench_fn!(
+        c,
+        "postgres_longhaul",
+        "1m_16p_single",
+        &pg.url,
+        MSG_1M,
+        rt,
+        produce_concurrent_single,
+        TIMEOUT_1M,
+        10,
+        120,
+        1
+    );
+}
+
+#[cfg(feature = "pg")]
+fn pg_1m_batch(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let pg = pg_container::get_pg(&rt);
+    bench_fn!(
+        c,
+        "postgres_longhaul",
+        "1m_16p_batch",
+        &pg.url,
+        MSG_1M,
+        rt,
+        produce_concurrent_batch,
+        TIMEOUT_1M,
+        10,
+        120,
+        1
+    );
+}
+
+// --- Postgres long-haul (10M) ---
+
+#[cfg(feature = "pg")]
+fn pg_10m_single(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let pg = pg_container::get_pg(&rt);
+    bench_fn!(
+        c,
+        "postgres_longhaul",
+        "10m_16p_single",
+        &pg.url,
+        MSG_10M,
+        rt,
+        produce_concurrent_single,
+        TIMEOUT_10M,
+        10,
+        600,
+        1
+    );
+}
+
+#[cfg(feature = "pg")]
+fn pg_10m_batch(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let pg = pg_container::get_pg(&rt);
+    bench_fn!(
+        c,
+        "postgres_longhaul",
+        "10m_16p_batch",
+        &pg.url,
+        MSG_10M,
+        rt,
+        produce_concurrent_batch,
+        TIMEOUT_10M,
+        10,
+        600,
+        1
+    );
+}
+
+#[cfg(feature = "pg")]
+criterion_group!(
+    postgres_bench,
+    pg_1p1c_single,
+    pg_1p1c_batch,
+    pg_16p16c_single,
+    pg_16p16c_batch
+);
+
+#[cfg(feature = "pg")]
+criterion_group!(
+    postgres_longhaul,
+    pg_1m_single,
+    pg_1m_batch,
+    pg_10m_single,
+    pg_10m_batch
+);
+
+// ---------------------------------------------------------------------------
+// MySQL benchmarks
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "mysql")]
+fn mysql_1p1c_single(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mysql = mysql_container::get_mysql(&rt);
+    bench_fn!(
+        c,
+        "mysql",
+        "1p1c_single",
+        &mysql.url,
+        MSG_1P,
+        rt,
+        produce_single
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn mysql_1p1c_batch(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mysql = mysql_container::get_mysql(&rt);
+    bench_fn!(
+        c,
+        "mysql",
+        "1p1c_batch",
+        &mysql.url,
+        MSG_1P,
+        rt,
+        produce_batch
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn mysql_16p16c_single(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let mysql = mysql_container::get_mysql(&rt);
+    bench_fn!(
+        c,
+        "mysql",
+        "16p16c_single",
+        &mysql.url,
+        MSG_16P,
+        rt,
+        produce_concurrent_single
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn mysql_16p16c_batch(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let mysql = mysql_container::get_mysql(&rt);
+    bench_fn!(
+        c,
+        "mysql",
+        "16p16c_batch",
+        &mysql.url,
+        MSG_16P,
+        rt,
+        produce_concurrent_batch
+    );
+}
+
+// --- MySQL long-haul (1M) ---
+
+#[cfg(feature = "mysql")]
+fn mysql_1m_single(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let mysql = mysql_container::get_mysql(&rt);
+    bench_fn!(
+        c,
+        "mysql_longhaul",
+        "1m_16p_single",
+        &mysql.url,
+        MSG_1M,
+        rt,
+        produce_concurrent_single,
+        TIMEOUT_1M,
+        10,
+        120,
+        1
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn mysql_1m_batch(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let mysql = mysql_container::get_mysql(&rt);
+    bench_fn!(
+        c,
+        "mysql_longhaul",
+        "1m_16p_batch",
+        &mysql.url,
+        MSG_1M,
+        rt,
+        produce_concurrent_batch,
+        TIMEOUT_1M,
+        10,
+        120,
+        1
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn mysql_10m_single(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let mysql = mysql_container::get_mysql(&rt);
+    bench_fn!(
+        c,
+        "mysql_longhaul",
+        "10m_16p_single",
+        &mysql.url,
+        MSG_10M,
+        rt,
+        produce_concurrent_single,
+        TIMEOUT_10M,
+        10,
+        600,
+        1
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn mysql_10m_batch(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let mysql = mysql_container::get_mysql(&rt);
+    bench_fn!(
+        c,
+        "mysql_longhaul",
+        "10m_16p_batch",
+        &mysql.url,
+        MSG_10M,
+        rt,
+        produce_concurrent_batch,
+        TIMEOUT_10M,
+        10,
+        600,
+        1
+    );
+}
+
+#[cfg(feature = "mysql")]
+criterion_group!(
+    mysql_bench,
+    mysql_1p1c_single,
+    mysql_1p1c_batch,
+    mysql_16p16c_single,
+    mysql_16p16c_batch
+);
+
+#[cfg(feature = "mysql")]
+criterion_group!(
+    mysql_longhaul,
+    mysql_1m_single,
+    mysql_1m_batch,
+    mysql_10m_single,
+    mysql_10m_batch
+);
+
+// ---------------------------------------------------------------------------
+// MariaDB benchmarks
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "mysql")]
+fn maria_1p1c_single(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let maria = mariadb_container::get_mariadb(&rt);
+    bench_fn!(
+        c,
+        "mariadb",
+        "1p1c_single",
+        &maria.url,
+        MSG_1P,
+        rt,
+        produce_single
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn maria_1p1c_batch(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let maria = mariadb_container::get_mariadb(&rt);
+    bench_fn!(
+        c,
+        "mariadb",
+        "1p1c_batch",
+        &maria.url,
+        MSG_1P,
+        rt,
+        produce_batch
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn maria_16p16c_single(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let maria = mariadb_container::get_mariadb(&rt);
+    bench_fn!(
+        c,
+        "mariadb",
+        "16p16c_single",
+        &maria.url,
+        MSG_16P,
+        rt,
+        produce_concurrent_single
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn maria_16p16c_batch(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let maria = mariadb_container::get_mariadb(&rt);
+    bench_fn!(
+        c,
+        "mariadb",
+        "16p16c_batch",
+        &maria.url,
+        MSG_16P,
+        rt,
+        produce_concurrent_batch
+    );
+}
+
+// --- MariaDB long-haul (1M) ---
+
+#[cfg(feature = "mysql")]
+fn maria_1m_single(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let maria = mariadb_container::get_mariadb(&rt);
+    bench_fn!(
+        c,
+        "mariadb_longhaul",
+        "1m_16p_single",
+        &maria.url,
+        MSG_1M,
+        rt,
+        produce_concurrent_single,
+        TIMEOUT_1M,
+        10,
+        120,
+        1
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn maria_1m_batch(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let maria = mariadb_container::get_mariadb(&rt);
+    bench_fn!(
+        c,
+        "mariadb_longhaul",
+        "1m_16p_batch",
+        &maria.url,
+        MSG_1M,
+        rt,
+        produce_concurrent_batch,
+        TIMEOUT_1M,
+        10,
+        120,
+        1
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn maria_10m_single(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let maria = mariadb_container::get_mariadb(&rt);
+    bench_fn!(
+        c,
+        "mariadb_longhaul",
+        "10m_16p_single",
+        &maria.url,
+        MSG_10M,
+        rt,
+        produce_concurrent_single,
+        TIMEOUT_10M,
+        10,
+        600,
+        1
+    );
+}
+
+#[cfg(feature = "mysql")]
+fn maria_10m_batch(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let maria = mariadb_container::get_mariadb(&rt);
+    bench_fn!(
+        c,
+        "mariadb_longhaul",
+        "10m_16p_batch",
+        &maria.url,
+        MSG_10M,
+        rt,
+        produce_concurrent_batch,
+        TIMEOUT_10M,
+        10,
+        600,
+        1
+    );
+}
+
+#[cfg(feature = "mysql")]
+criterion_group!(
+    mariadb_bench,
+    maria_1p1c_single,
+    maria_1p1c_batch,
+    maria_16p16c_single,
+    maria_16p16c_batch
+);
+
+#[cfg(feature = "mysql")]
+criterion_group!(
+    mariadb_longhaul,
+    maria_1m_single,
+    maria_1m_batch,
+    maria_10m_single,
+    maria_10m_batch
+);
+
+// ---------------------------------------------------------------------------
+// SQLite benchmarks
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "sqlite")]
+fn sqlite_1p1c_single(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let sq = sqlite_setup::get_sqlite(&rt);
+    bench_fn!(
+        c,
+        "sqlite",
+        "1p1c_single",
+        &sq.url,
+        MSG_1P,
+        rt,
+        produce_single
+    );
+}
+
+#[cfg(feature = "sqlite")]
+fn sqlite_1p1c_batch(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let sq = sqlite_setup::get_sqlite(&rt);
+    bench_fn!(
+        c,
+        "sqlite",
+        "1p1c_batch",
+        &sq.url,
+        MSG_1P,
+        rt,
+        produce_batch
+    );
+}
+
+#[cfg(feature = "sqlite")]
+fn sqlite_16p16c_single(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let sq = sqlite_setup::get_sqlite(&rt);
+    bench_fn!(
+        c,
+        "sqlite",
+        "16p16c_single",
+        &sq.url,
+        MSG_16P,
+        rt,
+        produce_concurrent_single
+    );
+}
+
+#[cfg(feature = "sqlite")]
+fn sqlite_16p16c_batch(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(16)
+        .enable_all()
+        .build()
+        .unwrap();
+    let sq = sqlite_setup::get_sqlite(&rt);
+    bench_fn!(
+        c,
+        "sqlite",
+        "16p16c_batch",
+        &sq.url,
+        MSG_16P,
+        rt,
+        produce_concurrent_batch
+    );
+}
+
+// SQLite long-haul: only 1P/1C with capped volume (single-writer bottleneck)
+#[cfg(feature = "sqlite")]
+fn sqlite_longhaul_single(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let sq = sqlite_setup::get_sqlite(&rt);
+    bench_fn!(
+        c,
+        "sqlite_longhaul",
+        "100k_1p_single",
+        &sq.url,
+        MSG_SQLITE_LONGHAUL,
+        rt,
+        produce_single,
+        TIMEOUT_1M,
+        10,
+        120,
+        1
+    );
+}
+
+#[cfg(feature = "sqlite")]
+fn sqlite_longhaul_batch(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let sq = sqlite_setup::get_sqlite(&rt);
+    bench_fn!(
+        c,
+        "sqlite_longhaul",
+        "100k_1p_batch",
+        &sq.url,
+        MSG_SQLITE_LONGHAUL,
+        rt,
+        produce_batch,
+        TIMEOUT_1M,
+        10,
+        120,
+        1
+    );
+}
+
+#[cfg(feature = "sqlite")]
+criterion_group!(
+    sqlite_bench,
+    sqlite_1p1c_single,
+    sqlite_1p1c_batch,
+    sqlite_16p16c_single,
+    sqlite_16p16c_batch
+);
+
+#[cfg(feature = "sqlite")]
+criterion_group!(
+    sqlite_longhaul_group,
+    sqlite_longhaul_single,
+    sqlite_longhaul_batch
+);
+
+// ---------------------------------------------------------------------------
+// Tracing setup — logs to /tmp/outbox_bench.log
+// ---------------------------------------------------------------------------
+
+fn setup_tracing() -> tracing_appender::non_blocking::WorkerGuard {
+    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+    let log_file = std::fs::File::create("/tmp/outbox_bench.log")
+        .expect("failed to create /tmp/outbox_bench.log");
+    let (non_blocking, guard) = tracing_appender::non_blocking(log_file);
+
+    tracing_subscriber::registry()
+        .with(
+            fmt::layer()
+                .with_writer(non_blocking)
+                .with_ansi(false)
+                .with_target(true)
+                .with_level(true),
+        )
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .init();
+
+    eprintln!("Benchmark logs → /tmp/outbox_bench.log");
+    guard
+}
+
+// ---------------------------------------------------------------------------
+// Custom main — tracing + criterion + docker cleanup
+// ---------------------------------------------------------------------------
+
+#[cfg(not(any(feature = "pg", feature = "mysql", feature = "sqlite")))]
+compile_error!(
+    "outbox_throughput benchmark requires at least one database feature: pg, mysql, or sqlite"
+);
+
+fn main() {
+    let guard = setup_tracing();
+
+    // Run criterion benchmark groups
+    #[cfg(feature = "pg")]
+    {
+        postgres_bench();
+        postgres_longhaul();
+    }
+    #[cfg(feature = "mysql")]
+    {
+        mysql_bench();
+        mysql_longhaul();
+        mariadb_bench();
+        mariadb_longhaul();
+    }
+    #[cfg(feature = "sqlite")]
+    {
+        sqlite_bench();
+        sqlite_longhaul_group();
+    }
+
+    criterion::Criterion::default()
+        .configure_from_args()
+        .final_summary();
+
+    // Flush tracing
+    drop(guard);
+}

--- a/libs/modkit-db/src/outbox/builder.rs
+++ b/libs/modkit-db/src/outbox/builder.rs
@@ -44,6 +44,24 @@ impl QueueBuilder {
     }
 
     /// Max partitions processed concurrently within this queue.
+    ///
+    /// Each active partition processor acquires a DB connection from the pool,
+    /// so this value must be aligned with the connection pool size.  A safe
+    /// lower-bound for the pool is:
+    ///
+    /// ```text
+    /// max_connections >= max_concurrent_partitions
+    ///                  + producer_threads
+    ///                  + maintenance_total  (sequencer + vacuum share this)
+    ///                  + 1                  (sequencer batch processing)
+    /// ```
+    ///
+    /// The `maintenance_total` budget is a shared semaphore pool configured
+    /// via [`OutboxBuilder::maintenance(high, low)`]. The semaphore pool
+    /// is sized at `high + low`. Low-priority tasks (vacuum) are capped
+    /// to `low` permits, ensuring `high` permits remain for the sequencer.
+    ///
+    /// Defaults to `usize::MAX` (all partitions may run concurrently).
     #[must_use]
     pub fn max_concurrent_partitions(mut self, n: usize) -> Self {
         self.config.max_concurrent_partitions = n;
@@ -103,17 +121,25 @@ impl QueueBuilder {
         let handler = Arc::new(handler);
         let config = self.config.clone();
 
-        let make_spawn_fn: DeferredSpawnFactory = Box::new(move |pid, _outbox| {
+        let make_spawn_fn: DeferredSpawnFactory = Box::new(move |pid, outbox| {
             let strategy =
                 TransactionalStrategy::new(Box::new(ArcTransactionalHandler(Arc::clone(&handler))));
             let config = config.clone();
+            #[cfg(feature = "outbox-profiler")]
+            let profiler = outbox.profiler_arc();
+            let _ = &outbox; // suppress unused warning when profiler feature is off
 
             Box::new(
                 move |db: Db,
                       cancel: CancellationToken,
                       notify: Arc<Notify>,
                       sem: Arc<Semaphore>| {
-                    let processor = PartitionProcessor::new(strategy, pid, config, notify, sem);
+                    #[allow(unused_mut)]
+                    let mut processor = PartitionProcessor::new(strategy, pid, config, notify, sem);
+                    #[cfg(feature = "outbox-profiler")]
+                    if let Some(p) = profiler {
+                        processor.set_profiler(p);
+                    }
                     tokio::spawn(async move {
                         if let Err(e) = processor.run(&db, cancel).await {
                             tracing::error!(error = %e, partition_id = pid, "partition processor exited with error");
@@ -140,18 +166,26 @@ impl QueueBuilder {
         let config = self.config.clone();
         let queue_name = self.name.clone();
 
-        let make_spawn_fn: DeferredSpawnFactory = Box::new(move |pid, _outbox| {
+        let make_spawn_fn: DeferredSpawnFactory = Box::new(move |pid, outbox| {
             let worker_id = generate_worker_id(&queue_name);
             let strategy =
                 DecoupledStrategy::new(Box::new(ArcHandler(Arc::clone(&handler))), worker_id);
             let config = config.clone();
+            #[cfg(feature = "outbox-profiler")]
+            let profiler = outbox.profiler_arc();
+            let _ = &outbox;
 
             Box::new(
                 move |db: Db,
                       cancel: CancellationToken,
                       notify: Arc<Notify>,
                       sem: Arc<Semaphore>| {
-                    let processor = PartitionProcessor::new(strategy, pid, config, notify, sem);
+                    #[allow(unused_mut)]
+                    let mut processor = PartitionProcessor::new(strategy, pid, config, notify, sem);
+                    #[cfg(feature = "outbox-profiler")]
+                    if let Some(p) = profiler {
+                        processor.set_profiler(p);
+                    }
                     tokio::spawn(async move {
                         if let Err(e) = processor.run(&db, cancel).await {
                             tracing::error!(error = %e, partition_id = pid, "partition processor exited with error");

--- a/libs/modkit-db/src/outbox/core.rs
+++ b/libs/modkit-db/src/outbox/core.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement};
+use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
 use tokio::sync::{Notify, RwLock};
 
 use super::dialect::Dialect;
@@ -27,6 +27,8 @@ pub struct Outbox {
     /// Rebuilt on each `register_queue` call.
     all_partition_ids: RwLock<Vec<i64>>,
     sequencer_notify: Arc<Notify>,
+    #[cfg(feature = "outbox-profiler")]
+    profiler: Option<Arc<super::profiler::QueryProfiler>>,
 }
 
 #[derive(Debug, FromQueryResult)]
@@ -52,7 +54,27 @@ impl Outbox {
             partition_to_queue: DashMap::new(),
             all_partition_ids: RwLock::new(Vec::new()),
             sequencer_notify,
+            #[cfg(feature = "outbox-profiler")]
+            profiler: None,
         }
+    }
+
+    /// Attach a query profiler. Called by the builder when the feature is enabled.
+    #[cfg(feature = "outbox-profiler")]
+    pub(crate) fn set_profiler(&mut self, profiler: Arc<super::profiler::QueryProfiler>) {
+        self.profiler = Some(profiler);
+    }
+
+    /// Returns a reference to the profiler if attached.
+    #[cfg(feature = "outbox-profiler")]
+    pub(crate) fn profiler(&self) -> Option<&super::profiler::QueryProfiler> {
+        self.profiler.as_deref()
+    }
+
+    /// Returns an `Arc` clone of the profiler if attached.
+    #[cfg(feature = "outbox-profiler")]
+    pub(crate) fn profiler_arc(&self) -> Option<Arc<super::profiler::QueryProfiler>> {
+        self.profiler.clone()
     }
 
     /// Register a queue with `num_partitions` partitions `[0, num_partitions)`.
@@ -78,10 +100,18 @@ impl Outbox {
         queue: &str,
         num_partitions: u16,
     ) -> Result<(), OutboxError> {
-        let ids = self
-            .ensure_partition_rows(db, queue, num_partitions)
-            .await?;
-        self.ensure_processor_rows(db, &ids).await?;
+        let conn = db.sea_internal();
+        let txn = conn.begin().await?;
+        let backend = txn.get_database_backend();
+        let dialect = Dialect::from(backend);
+
+        let ids =
+            Self::ensure_partition_rows(&txn, backend, &dialect, queue, num_partitions).await?;
+        Self::ensure_processor_rows(&txn, backend, &dialect, &ids).await?;
+        Self::ensure_vacuum_counter_rows(&txn, backend, &dialect, &ids).await?;
+
+        txn.commit().await?;
+
         self.populate_caches(queue, &ids).await;
         Ok(())
     }
@@ -90,22 +120,19 @@ impl Outbox {
     ///
     /// Returns the partition IDs (PKs) for the queue — whether they were
     /// already present or freshly inserted.
-    async fn ensure_partition_rows(
-        &self,
-        db: &Db,
+    async fn ensure_partition_rows<C: ConnectionTrait>(
+        conn: &C,
+        backend: DbBackend,
+        dialect: &Dialect,
         queue: &str,
         num_partitions: u16,
     ) -> Result<Vec<i64>, OutboxError> {
-        let conn = db.sea_internal();
-        let backend = conn.get_database_backend();
-        let dialect = Dialect::from(backend);
-
         let existing = PartitionRow::find_by_statement(Statement::from_sql_and_values(
             backend,
             dialect.register_queue_select(),
             [queue.into()],
         ))
-        .all(&conn)
+        .all(conn)
         .await?;
 
         if !existing.is_empty() {
@@ -136,7 +163,7 @@ impl Outbox {
             dialect.register_queue_select(),
             [queue.into()],
         ))
-        .all(&conn)
+        .all(conn)
         .await?;
 
         Ok(rows.into_iter().map(|r| r.id).collect())
@@ -144,15 +171,35 @@ impl Outbox {
 
     /// Insert a processor row for each partition ID (idempotent via
     /// `ON CONFLICT DO NOTHING`).
-    async fn ensure_processor_rows(&self, db: &Db, ids: &[i64]) -> Result<(), OutboxError> {
-        let conn = db.sea_internal();
-        let backend = conn.get_database_backend();
-        let dialect = Dialect::from(backend);
-
+    async fn ensure_processor_rows<C: ConnectionTrait>(
+        conn: &C,
+        backend: DbBackend,
+        dialect: &Dialect,
+        ids: &[i64],
+    ) -> Result<(), OutboxError> {
         for &id in ids {
             conn.execute(Statement::from_sql_and_values(
                 backend,
                 dialect.insert_processor_row(),
+                [id.into()],
+            ))
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// Insert a vacuum counter row for each partition ID (idempotent via
+    /// `ON CONFLICT DO NOTHING`).
+    async fn ensure_vacuum_counter_rows<C: ConnectionTrait>(
+        conn: &C,
+        backend: DbBackend,
+        dialect: &Dialect,
+        ids: &[i64],
+    ) -> Result<(), OutboxError> {
+        for &id in ids {
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                dialect.insert_vacuum_counter_row(),
                 [id.into()],
             ))
             .await?;
@@ -214,9 +261,19 @@ impl Outbox {
         Self::validate_payload(&payload)?;
         let partition_id = self.resolve_partition(queue, partition)?;
 
+        #[cfg(feature = "outbox-profiler")]
+        let mut body_guard = self
+            .profiler()
+            .map(|p| p.measure(super::profiler::Op::EnqueueInsertBody));
+
         let runner = db.as_seaorm();
         let incoming_id =
             Self::insert_body_and_incoming(&runner, partition_id, payload, payload_type).await?;
+
+        #[cfg(feature = "outbox-profiler")]
+        if let Some(g) = body_guard.as_mut() {
+            g.set_rows(1);
+        }
 
         Ok(OutboxMessageId(incoming_id))
     }
@@ -242,8 +299,19 @@ impl Outbox {
             resolved.push(partition_id);
         }
 
+        #[cfg(feature = "outbox-profiler")]
+        let mut body_guard = self
+            .profiler()
+            .map(|p| p.measure(super::profiler::Op::EnqueueInsertBody));
+
         let runner = db.as_seaorm();
         let ids = Self::insert_batch(&runner, &resolved, items).await?;
+
+        #[cfg(feature = "outbox-profiler")]
+        if let Some(g) = body_guard.as_mut() {
+            #[allow(clippy::cast_possible_truncation)]
+            g.set_rows(ids.len() as u64);
+        }
 
         Ok(ids)
     }

--- a/libs/modkit-db/src/outbox/dialect.rs
+++ b/libs/modkit-db/src/outbox/dialect.rs
@@ -29,15 +29,15 @@ impl From<DbBackend> for Dialect {
     }
 }
 
-/// SQL for the Reaper's bulk cleanup operation.
-pub enum ReaperSql {
-    /// Postgres: single CTE statement that deletes outgoing and body rows atomically.
-    Cte(&'static str),
-    /// SQLite/MySQL: two-step — select `body_ids`, then delete outgoing, then delete bodies.
-    TwoStep {
-        select_body_ids: &'static str,
-        delete_outgoing: &'static str,
-    },
+/// SQL for the vacuum's bounded-chunk cleanup operation.
+///
+/// Strategy: SELECT a bounded chunk of (id, `body_id`) from outgoing, then
+/// DELETE those outgoing rows by ID, then DELETE body rows by ID.
+/// The caller loops while `deleted == batch_size` (more work likely).
+pub struct VacuumSql {
+    /// SELECT id, `body_id` with LIMIT for bounded chunk deletion.
+    /// Parameters: `partition_id`, `processed_seq`, limit.
+    pub select_outgoing_chunk: &'static str,
 }
 
 /// SQL for the sequencer's claim-incoming operation.
@@ -134,7 +134,7 @@ impl Dialect {
 
     /// Returns the `MySQL` query to retrieve the last auto-generated ID.
     fn last_insert_id() -> &'static str {
-        "SELECT LAST_INSERT_ID() AS id"
+        "SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS id"
     }
 }
 
@@ -169,14 +169,6 @@ impl Dialect {
     pub fn build_read_body_batch(self, count: usize) -> String {
         let mut sql =
             String::from("SELECT id, payload, payload_type FROM modkit_outbox_body WHERE id IN (");
-        self.append_in_placeholders(&mut sql, count);
-        sql.push(')');
-        sql
-    }
-
-    /// Build `DELETE FROM modkit_outbox_body WHERE id IN (...)`.
-    pub fn build_delete_body_batch(self, count: usize) -> String {
-        let mut sql = String::from("DELETE FROM modkit_outbox_body WHERE id IN (");
         self.append_in_placeholders(&mut sql, count);
         sql.push(')');
         sql
@@ -757,41 +749,40 @@ impl Dialect {
         }
     }
 
-    /// Reaper: delete processed outgoing rows and their body rows atomically.
-    pub fn reaper_cleanup(self) -> ReaperSql {
+    /// Vacuum: bounded-chunk cleanup.
+    ///
+    /// Returns SQL to SELECT a bounded chunk of (id, `body_id`) from outgoing.
+    /// The caller deletes those rows by ID, then loops while
+    /// `deleted == batch_size`.
+    pub fn vacuum_cleanup(self) -> VacuumSql {
         match self {
-            Self::Postgres => ReaperSql::Cte(
-                "WITH deleted_outgoing AS ( \
-                    DELETE FROM modkit_outbox_outgoing \
-                    WHERE partition_id = $1 AND seq <= $2 \
-                    RETURNING body_id \
-                 ) \
-                 DELETE FROM modkit_outbox_body \
-                 WHERE id IN (SELECT body_id FROM deleted_outgoing)",
-            ),
-            Self::Sqlite | Self::MySql => ReaperSql::TwoStep {
-                select_body_ids: match self {
-                    Self::Sqlite => {
-                        "SELECT body_id FROM modkit_outbox_outgoing \
-                         WHERE partition_id = $1 AND seq <= $2"
-                    }
-                    _ => {
-                        "SELECT body_id FROM modkit_outbox_outgoing \
-                         WHERE partition_id = ? AND seq <= ?"
-                    }
-                },
-                delete_outgoing: match self {
-                    Self::Sqlite => {
-                        "DELETE FROM modkit_outbox_outgoing \
-                         WHERE partition_id = $1 AND seq <= $2"
-                    }
-                    _ => {
-                        "DELETE FROM modkit_outbox_outgoing \
-                         WHERE partition_id = ? AND seq <= ?"
-                    }
-                },
+            Self::Postgres | Self::Sqlite => VacuumSql {
+                select_outgoing_chunk: "SELECT id, body_id FROM modkit_outbox_outgoing \
+                                        WHERE partition_id = $1 AND seq <= $2 \
+                                        ORDER BY seq LIMIT $3",
+            },
+            Self::MySql => VacuumSql {
+                select_outgoing_chunk: "SELECT id, body_id FROM modkit_outbox_outgoing \
+                                        WHERE partition_id = ? AND seq <= ? \
+                                        ORDER BY seq LIMIT ?",
             },
         }
+    }
+
+    /// Build `DELETE FROM modkit_outbox_outgoing WHERE id IN ($1, $2, ...)`.
+    pub fn build_delete_outgoing_batch(self, count: usize) -> String {
+        let mut sql = String::from("DELETE FROM modkit_outbox_outgoing WHERE id IN (");
+        self.append_in_placeholders(&mut sql, count);
+        sql.push(')');
+        sql
+    }
+
+    /// Build `DELETE FROM modkit_outbox_body WHERE id IN (...)`.
+    pub fn build_delete_body_batch(self, count: usize) -> String {
+        let mut sql = String::from("DELETE FROM modkit_outbox_body WHERE id IN (");
+        self.append_in_placeholders(&mut sql, count);
+        sql.push(')');
+        sql
     }
 
     pub fn read_processor(self) -> &'static str {
@@ -803,6 +794,97 @@ impl Dialect {
             Self::MySql => {
                 "SELECT processed_seq, attempts \
                  FROM modkit_outbox_processor WHERE partition_id = ?"
+            }
+        }
+    }
+}
+
+// -- Vacuum counter queries --
+
+impl Dialect {
+    /// Bump the vacuum counter for a partition (called by processor on ack).
+    pub fn bump_vacuum_counter(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "UPDATE modkit_outbox_vacuum_counter \
+                 SET counter = counter + 1 WHERE partition_id = $1"
+            }
+            Self::MySql => {
+                "UPDATE modkit_outbox_vacuum_counter \
+                 SET counter = counter + 1 WHERE partition_id = ?"
+            }
+        }
+    }
+
+    /// Fetch dirty partitions paginated by `partition_id` cursor.
+    /// Returns `(partition_id, counter)` for partitions with `counter > 0`.
+    pub fn fetch_dirty_partitions(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "SELECT partition_id, counter \
+                 FROM modkit_outbox_vacuum_counter \
+                 WHERE counter > 0 AND partition_id > $1 \
+                 ORDER BY partition_id LIMIT $2"
+            }
+            Self::MySql => {
+                "SELECT partition_id, counter \
+                 FROM modkit_outbox_vacuum_counter \
+                 WHERE counter > 0 AND partition_id > ? \
+                 ORDER BY partition_id LIMIT ?"
+            }
+        }
+    }
+
+    /// Decrement vacuum counter by snapshot value, floored at 0.
+    pub fn decrement_vacuum_counter(self) -> &'static str {
+        match self {
+            Self::Postgres => {
+                "UPDATE modkit_outbox_vacuum_counter \
+                 SET counter = GREATEST(counter - $1, 0) \
+                 WHERE partition_id = $2"
+            }
+            Self::Sqlite => {
+                "UPDATE modkit_outbox_vacuum_counter \
+                 SET counter = MAX(counter - $1, 0) \
+                 WHERE partition_id = $2"
+            }
+            Self::MySql => {
+                "UPDATE modkit_outbox_vacuum_counter \
+                 SET counter = GREATEST(counter - ?, 0) \
+                 WHERE partition_id = ?"
+            }
+        }
+    }
+
+    /// Reset vacuum counter to 0. Used by integration tests for state cleanup.
+    #[cfg(test)]
+    pub fn reset_vacuum_counter(self) -> &'static str {
+        match self {
+            Self::Postgres | Self::Sqlite => {
+                "UPDATE modkit_outbox_vacuum_counter \
+                 SET counter = 0 WHERE partition_id = $1"
+            }
+            Self::MySql => {
+                "UPDATE modkit_outbox_vacuum_counter \
+                 SET counter = 0 WHERE partition_id = ?"
+            }
+        }
+    }
+
+    /// Insert a vacuum counter row (idempotent, for `register_queue`).
+    pub fn insert_vacuum_counter_row(self) -> &'static str {
+        match self {
+            Self::Postgres => {
+                "INSERT INTO modkit_outbox_vacuum_counter (partition_id) \
+                 VALUES ($1) ON CONFLICT (partition_id) DO NOTHING"
+            }
+            Self::Sqlite => {
+                "INSERT OR IGNORE INTO modkit_outbox_vacuum_counter (partition_id) \
+                 VALUES ($1)"
+            }
+            Self::MySql => {
+                "INSERT IGNORE INTO modkit_outbox_vacuum_counter (partition_id) \
+                 VALUES (?)"
             }
         }
     }
@@ -1027,5 +1109,83 @@ mod tests {
         let mysql = Dialect::MySql.insert_dead_letter();
         assert!(mysql.contains('?'));
         assert!(!mysql.contains('$'));
+    }
+
+    // -- Vacuum counter dialect tests --
+
+    #[test]
+    fn bump_vacuum_counter_placeholders() {
+        let pg = Dialect::Postgres.bump_vacuum_counter();
+        assert!(pg.contains("$1"));
+        assert!(pg.contains("modkit_outbox_vacuum_counter"));
+        assert!(pg.contains("counter + 1"));
+
+        let mysql = Dialect::MySql.bump_vacuum_counter();
+        assert!(mysql.contains('?'));
+        assert!(!mysql.contains('$'));
+    }
+
+    #[test]
+    fn fetch_dirty_partitions_placeholders() {
+        let pg = Dialect::Postgres.fetch_dirty_partitions();
+        assert!(pg.contains("$1"));
+        assert!(pg.contains("$2"));
+        assert!(pg.contains("counter > 0"));
+        assert!(pg.contains("ORDER BY partition_id"));
+
+        let mysql = Dialect::MySql.fetch_dirty_partitions();
+        assert!(mysql.contains('?'));
+        assert!(!mysql.contains('$'));
+    }
+
+    #[test]
+    fn decrement_vacuum_counter_placeholders() {
+        let pg = Dialect::Postgres.decrement_vacuum_counter();
+        assert!(pg.contains("GREATEST"));
+        assert!(pg.contains("$1"));
+        assert!(pg.contains("$2"));
+
+        let sqlite = Dialect::Sqlite.decrement_vacuum_counter();
+        assert!(sqlite.contains("MAX"));
+        assert!(sqlite.contains("$1"));
+
+        let mysql = Dialect::MySql.decrement_vacuum_counter();
+        assert!(mysql.contains("GREATEST"));
+        assert!(mysql.contains('?'));
+    }
+
+    #[test]
+    fn reset_vacuum_counter_placeholders() {
+        let pg = Dialect::Postgres.reset_vacuum_counter();
+        assert!(pg.contains("counter = 0"));
+        assert!(pg.contains("$1"));
+
+        let mysql = Dialect::MySql.reset_vacuum_counter();
+        assert!(mysql.contains('?'));
+    }
+
+    #[test]
+    fn insert_vacuum_counter_row_placeholders() {
+        let pg = Dialect::Postgres.insert_vacuum_counter_row();
+        assert!(pg.contains("$1"));
+        assert!(pg.contains("ON CONFLICT"));
+
+        let sqlite = Dialect::Sqlite.insert_vacuum_counter_row();
+        assert!(sqlite.contains("INSERT OR IGNORE"));
+
+        let mysql = Dialect::MySql.insert_vacuum_counter_row();
+        assert!(mysql.contains("INSERT IGNORE"));
+        assert!(mysql.contains('?'));
+    }
+
+    #[test]
+    fn vacuum_cleanup_placeholders() {
+        let pg = Dialect::Postgres.vacuum_cleanup();
+        assert!(pg.select_outgoing_chunk.contains("$1"));
+        assert!(pg.select_outgoing_chunk.contains("$2"));
+        assert!(pg.select_outgoing_chunk.contains("$3"));
+
+        let mysql = Dialect::MySql.vacuum_cleanup();
+        assert!(mysql.select_outgoing_chunk.contains('?'));
     }
 }

--- a/libs/modkit-db/src/outbox/handler.rs
+++ b/libs/modkit-db/src/outbox/handler.rs
@@ -23,7 +23,7 @@ pub struct OutboxMessage {
 pub enum HandlerResult {
     /// All messages processed successfully. The processor advances the cursor
     /// past the last message. Processed outgoing and body rows are cleaned up
-    /// asynchronously by the reaper.
+    /// asynchronously by the vacuum.
     Success,
     /// Transient failure. The cursor is not advanced; the same batch will be
     /// retried with exponential backoff. The `attempts` counter is incremented.

--- a/libs/modkit-db/src/outbox/integration_tests.rs
+++ b/libs/modkit-db/src/outbox/integration_tests.rs
@@ -9,14 +9,15 @@
 //!   1. Registration  →  2. Enqueue  →  3. Sequencer
 //!   4. Transactional Processing  →  5. Decoupled Processing
 //!   6. Crash Detection & Recovery  →  7. Backoff & Adaptive Batching
-//!   8. Reaper  →  9. Dead Letters  →  10. Builder API
+//!   8. Vacuum  →  9. Dead Letters  →  10. Builder API
 //!   11. End-to-End Lifecycle
 
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
+use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement};
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use super::dead_letter::{DeadLetterFilter, DeadLetterScope};
@@ -109,6 +110,7 @@ fn make_sequencer(t: &TestOutbox, config: SequencerConfig) -> Sequencer {
         config,
         Arc::clone(&t.outbox),
         Arc::clone(&t.sequencer_notify),
+        Arc::new(Semaphore::new(64)),
     )
 }
 
@@ -1073,6 +1075,8 @@ async fn run_transactional(
         backend,
         dialect,
         partition_id,
+        #[cfg(feature = "outbox-profiler")]
+        profiler: None,
     };
     strategy
         .process(&ctx, config, CancellationToken::new())
@@ -1205,6 +1209,8 @@ async fn run_decoupled(
         backend,
         dialect,
         partition_id,
+        #[cfg(feature = "outbox-profiler")]
+        profiler: None,
     };
     strategy
         .process(&ctx, config, CancellationToken::new())
@@ -1558,11 +1564,12 @@ async fn adaptive_batch_isolates_poison_message() {
 }
 
 // ======================================================================
-// Chapter 8: Reaper
+// Chapter 8: Vacuum
 // ======================================================================
 
-/// Run the reaper by processing an empty partition (reaper triggers on idle).
-async fn run_reaper(db: &Db, partition_id: i64) {
+/// Run the vacuum for a single partition: read `processed_seq`, delete
+/// outgoing + body rows in batches, then reset the vacuum counter.
+async fn run_vacuum(db: &Db, partition_id: i64) {
     #[derive(Debug, FromQueryResult)]
     struct ProcRow {
         processed_seq: i64,
@@ -1586,55 +1593,62 @@ async fn run_reaper(db: &Db, partition_id: i64) {
         return;
     }
 
-    let txn = conn.begin().await.unwrap();
-    match dialect.reaper_cleanup() {
-        super::dialect::ReaperSql::Cte(sql) => {
-            txn.execute(Statement::from_sql_and_values(
+    let vacuum_sql = dialect.vacuum_cleanup();
+
+    // Fetch outgoing rows in bounded chunks.
+    loop {
+        let rows = conn
+            .query_all(Statement::from_sql_and_values(
                 backend,
-                sql,
-                [partition_id.into(), proc_row.processed_seq.into()],
+                vacuum_sql.select_outgoing_chunk,
+                [
+                    partition_id.into(),
+                    proc_row.processed_seq.into(),
+                    10_000i64.into(),
+                ],
             ))
             .await
             .unwrap();
+        if rows.is_empty() {
+            break;
         }
-        super::dialect::ReaperSql::TwoStep {
-            select_body_ids,
-            delete_outgoing,
-        } => {
-            let rows = txn
-                .query_all(Statement::from_sql_and_values(
-                    backend,
-                    select_body_ids,
-                    [partition_id.into(), proc_row.processed_seq.into()],
-                ))
+        let outgoing_ids: Vec<i64> = rows
+            .iter()
+            .filter_map(|r| r.try_get_by_index::<i64>(0).ok())
+            .collect();
+        let body_ids: Vec<i64> = rows
+            .iter()
+            .filter_map(|r| r.try_get_by_index::<i64>(1).ok())
+            .collect();
+        // Delete outgoing by ID
+        let del_out = dialect.build_delete_outgoing_batch(outgoing_ids.len());
+        let values: Vec<sea_orm::Value> = outgoing_ids.iter().map(|&id| id.into()).collect();
+        conn.execute(Statement::from_sql_and_values(backend, &del_out, values))
+            .await
+            .unwrap();
+        // Delete body by ID
+        if !body_ids.is_empty() {
+            let del_body = dialect.build_delete_body_batch(body_ids.len());
+            let values: Vec<sea_orm::Value> = body_ids.iter().map(|&id| id.into()).collect();
+            conn.execute(Statement::from_sql_and_values(backend, &del_body, values))
                 .await
                 .unwrap();
-            let body_ids: Vec<i64> = rows
-                .iter()
-                .filter_map(|r| r.try_get_by_index::<i64>(0).ok())
-                .collect();
-            txn.execute(Statement::from_sql_and_values(
-                backend,
-                delete_outgoing,
-                [partition_id.into(), proc_row.processed_seq.into()],
-            ))
-            .await
-            .unwrap();
-            if !body_ids.is_empty() {
-                let sql = dialect.build_delete_body_batch(body_ids.len());
-                let values: Vec<sea_orm::Value> = body_ids.iter().map(|&id| id.into()).collect();
-                txn.execute(Statement::from_sql_and_values(backend, &sql, values))
-                    .await
-                    .unwrap();
-            }
         }
     }
-    txn.commit().await.unwrap();
+
+    // Reset vacuum counter after cleanup.
+    conn.execute(Statement::from_sql_and_values(
+        backend,
+        dialect.reset_vacuum_counter(),
+        [partition_id.into()],
+    ))
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
-async fn reaper_deletes_processed_outgoing_and_body_rows() {
-    let db = setup_db("ch8_reaper_deletes").await;
+async fn vacuum_deletes_processed_outgoing_and_body_rows() {
+    let db = setup_db("ch8_vacuum_deletes").await;
     let t = make_default_test_outbox();
     t.outbox.register_queue(&db, "q", 1).await.unwrap();
     let pid = t.outbox.all_partition_ids()[0];
@@ -1658,7 +1672,7 @@ async fn reaper_deletes_processed_outgoing_and_body_rows() {
     .await;
 
     // Reap
-    run_reaper(&db, pid).await;
+    run_vacuum(&db, pid).await;
 
     assert_eq!(count_rows(&db, "modkit_outbox_outgoing").await, 0);
     assert_eq!(count_rows(&db, "modkit_outbox_body").await, 0);
@@ -1668,8 +1682,8 @@ async fn reaper_deletes_processed_outgoing_and_body_rows() {
 }
 
 #[tokio::test]
-async fn reaper_skips_when_processed_seq_is_zero() {
-    let db = setup_db("ch8_reaper_skip").await;
+async fn vacuum_skips_when_processed_seq_is_zero() {
+    let db = setup_db("ch8_vacuum_skip").await;
     let t = make_default_test_outbox();
     t.outbox.register_queue(&db, "q", 1).await.unwrap();
     let pid = t.outbox.all_partition_ids()[0];
@@ -1677,7 +1691,7 @@ async fn reaper_skips_when_processed_seq_is_zero() {
     enqueue_and_sequence(&t, &db, "q", 0, &["a"]).await;
 
     // Don't process — cursor at 0
-    run_reaper(&db, pid).await;
+    run_vacuum(&db, pid).await;
 
     assert_eq!(
         count_rows(&db, "modkit_outbox_outgoing").await,
@@ -1687,8 +1701,8 @@ async fn reaper_skips_when_processed_seq_is_zero() {
 }
 
 #[tokio::test]
-async fn reaper_preserves_unprocessed_rows() {
-    let db = setup_db("ch8_reaper_preserves").await;
+async fn vacuum_preserves_unprocessed_rows() {
+    let db = setup_db("ch8_vacuum_preserves").await;
     let t = make_default_test_outbox();
     t.outbox.register_queue(&db, "q", 1).await.unwrap();
     let pid = t.outbox.all_partition_ids()[0];
@@ -1715,7 +1729,7 @@ async fn reaper_preserves_unprocessed_rows() {
     assert_eq!(snap.processed_seq, 3);
 
     // Reap — should only delete seqs 1-3
-    run_reaper(&db, pid).await;
+    run_vacuum(&db, pid).await;
 
     let remaining = read_outgoing(&db, pid).await;
     assert_eq!(remaining.len(), 2);
@@ -1725,6 +1739,179 @@ async fn reaper_preserves_unprocessed_rows() {
         assert_eq!(row.partition_id, pid);
         assert!(row.id > 0);
         assert!(row.body_id > 0);
+    }
+}
+
+/// Read the vacuum counter for a partition.
+async fn read_vacuum_counter(db: &Db, partition_id: i64) -> i64 {
+    #[derive(Debug, FromQueryResult)]
+    struct Row {
+        counter: i64,
+    }
+    let conn = db.sea_internal();
+    Row::find_by_statement(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "SELECT counter FROM modkit_outbox_vacuum_counter WHERE partition_id = $1",
+        [partition_id.into()],
+    ))
+    .one(&conn)
+    .await
+    .expect("query")
+    .expect("vacuum counter row")
+    .counter
+}
+
+/// Set the vacuum counter to an arbitrary value (test helper).
+async fn set_vacuum_counter(db: &Db, partition_id: i64, value: i64) {
+    let conn = db.sea_internal();
+    conn.execute(Statement::from_sql_and_values(
+        DbBackend::Sqlite,
+        "UPDATE modkit_outbox_vacuum_counter SET counter = $1 WHERE partition_id = $2",
+        [value.into(), partition_id.into()],
+    ))
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn vacuum_counter_bumped_on_processed_seq_advance() {
+    let db = setup_db("ch8_counter_bump").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    // Counter starts at 0.
+    assert_eq!(read_vacuum_counter(&db, pid).await, 0);
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b"]).await;
+
+    // Process batch of 2 — counter should bump once (one ack).
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig {
+        msg_batch_size: 2,
+        ..Default::default()
+    };
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    assert_eq!(read_vacuum_counter(&db, pid).await, 1);
+
+    // Process again (no messages) — counter should not change.
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    assert_eq!(read_vacuum_counter(&db, pid).await, 1);
+}
+
+#[tokio::test]
+async fn vacuum_counter_preserves_concurrent_bumps() {
+    let db = setup_db("ch8_counter_concurrent").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    enqueue_and_sequence(&t, &db, "q", 0, &["a", "b", "c"]).await;
+
+    // Process all 3 — counter = 1 (one ack of batch=3).
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig {
+        msg_batch_size: 3,
+        ..Default::default()
+    };
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    assert_eq!(read_vacuum_counter(&db, pid).await, 1);
+
+    // Simulate a concurrent processor bump (as if more messages were processed
+    // while vacuum was running): manually set counter to 3.
+    set_vacuum_counter(&db, pid, 3).await;
+
+    // Vacuum with snapshot_counter=3 — deletes rows, decrements by 3.
+    // After decrement: counter = GREATEST(3 - 3, 0) = 0.
+    run_vacuum(&db, pid).await;
+
+    assert_eq!(count_rows(&db, "modkit_outbox_outgoing").await, 0);
+    assert_eq!(read_vacuum_counter(&db, pid).await, 0);
+}
+
+#[tokio::test]
+async fn vacuum_stale_counter_reset() {
+    let db = setup_db("ch8_stale_counter").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 1).await.unwrap();
+    let pid = t.outbox.all_partition_ids()[0];
+
+    // Create and process a message so processed_seq > 0.
+    enqueue_and_sequence(&t, &db, "q", 0, &["a"]).await;
+    let count = Arc::new(AtomicU32::new(0));
+    let config = QueueConfig::default();
+    run_decoupled(
+        &db,
+        pid,
+        CountingSuccessHandler {
+            count: count.clone(),
+        },
+        &config,
+    )
+    .await;
+
+    // Vacuum to clean up — counter goes to 0.
+    run_vacuum(&db, pid).await;
+    assert_eq!(read_vacuum_counter(&db, pid).await, 0);
+    assert_eq!(count_rows(&db, "modkit_outbox_outgoing").await, 0);
+
+    // Simulate stale counter (as if crash prevented decrement).
+    set_vacuum_counter(&db, pid, 5).await;
+
+    // Vacuum runs again: processed_seq > 0 but no outgoing rows → stale.
+    // The run_vacuum helper resets counter after cleanup (0 rows deleted).
+    run_vacuum(&db, pid).await;
+
+    assert_eq!(read_vacuum_counter(&db, pid).await, 0);
+}
+
+#[tokio::test]
+async fn vacuum_counter_row_created_on_register_queue() {
+    let db = setup_db("ch8_counter_register").await;
+    let t = make_default_test_outbox();
+    t.outbox.register_queue(&db, "q", 2).await.unwrap();
+
+    let pids = t.outbox.all_partition_ids();
+    assert_eq!(pids.len(), 2);
+
+    // Both partitions should have vacuum counter rows with counter = 0.
+    for &pid in &pids {
+        assert_eq!(read_vacuum_counter(&db, pid).await, 0);
+    }
+
+    // Re-register (idempotent) — should not fail.
+    t.outbox.register_queue(&db, "q", 2).await.unwrap();
+
+    // Counters still 0.
+    for &pid in &pids {
+        assert_eq!(read_vacuum_counter(&db, pid).await, 0);
     }
 }
 
@@ -2089,7 +2276,7 @@ async fn e2e_happy_path_enqueue_through_reap() {
         &config,
     )
     .await;
-    run_reaper(&db, pid).await;
+    run_vacuum(&db, pid).await;
 
     assert_eq!(count_rows(&db, "modkit_outbox_incoming").await, 0);
     assert_eq!(count_rows(&db, "modkit_outbox_outgoing").await, 0);

--- a/libs/modkit-db/src/outbox/manager.rs
+++ b/libs/modkit-db/src/outbox/manager.rs
@@ -10,7 +10,10 @@ use tokio_util::sync::CancellationToken;
 use super::builder::QueueBuilder;
 use super::core::Outbox;
 use super::sequencer::Sequencer;
-use super::types::{OutboxConfig, OutboxError, Partitions, QueueConfig, SequencerConfig};
+use super::types::{
+    MaintenanceConfig, OutboxConfig, OutboxError, Partitions, QueueConfig, SequencerConfig,
+};
+use super::vacuum::VacuumTask;
 use crate::Db;
 
 /// Type-erased spawn function captured by the builder.
@@ -49,6 +52,8 @@ pub struct OutboxBuilder {
     db: Db,
     sequencer_batch_size: u32,
     poll_interval: Duration,
+    maintenance_concurrency: Option<usize>,
+    vacuum_cooldown: Duration,
     pub(crate) queue_declarations: Vec<QueueDeclaration>,
 }
 
@@ -58,6 +63,8 @@ impl OutboxBuilder {
             db,
             sequencer_batch_size: super::types::DEFAULT_SEQUENCER_BATCH_SIZE,
             poll_interval: super::types::DEFAULT_POLL_INTERVAL,
+            maintenance_concurrency: None,
+            vacuum_cooldown: super::types::DEFAULT_VACUUM_COOLDOWN,
             queue_declarations: Vec::new(),
         }
     }
@@ -74,6 +81,28 @@ impl OutboxBuilder {
     #[must_use]
     pub fn poll_interval(mut self, d: Duration) -> Self {
         self.poll_interval = d;
+        self
+    }
+
+    /// Maintenance connection budget — total semaphore permits shared
+    /// by the sequencer and vacuum for DB operations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `permits == 0`.
+    ///
+    /// Default (if not called): derived from `max_concurrent_partitions`.
+    #[must_use]
+    pub fn maintenance(mut self, permits: usize) -> Self {
+        assert!(permits > 0, "maintenance permits must be > 0");
+        self.maintenance_concurrency = Some(permits);
+        self
+    }
+
+    /// Minimum interval between full vacuum sweeps. Default: 1h.
+    #[must_use]
+    pub fn vacuum_cooldown(mut self, d: Duration) -> Self {
+        self.vacuum_cooldown = d;
         self
     }
 
@@ -99,8 +128,17 @@ impl OutboxBuilder {
                 poll_interval: self.poll_interval,
             },
         };
-        let outbox = Arc::new(Outbox::new(config, Arc::clone(&sequencer_notify)));
+        #[allow(unused_mut)]
+        let mut outbox = Outbox::new(config, Arc::clone(&sequencer_notify));
 
+        #[cfg(feature = "outbox-profiler")]
+        let profiler = {
+            let p = super::profiler::QueryProfiler::new(std::time::Duration::from_secs(10));
+            outbox.set_profiler(Arc::clone(&p));
+            p
+        };
+
+        let outbox = Arc::new(outbox);
         let cancel = CancellationToken::new();
         let mut handles = Vec::new();
         let partition_notify: DashMap<i64, Arc<Notify>> = DashMap::new();
@@ -130,6 +168,24 @@ impl OutboxBuilder {
             }
         }
 
+        // Resolve maintenance config with defaults
+        let max_partitions = self
+            .queue_declarations
+            .iter()
+            .map(|d| d.config.max_concurrent_partitions)
+            .max()
+            .unwrap_or(1);
+        let maintenance_config = resolve_maintenance_config(
+            self.maintenance_concurrency,
+            self.vacuum_cooldown,
+            max_partitions,
+        );
+
+        // Create maintenance semaphore shared by sequencer and vacuum
+        let maintenance_sem = Arc::new(Semaphore::new(
+            maintenance_config.concurrency.min(Semaphore::MAX_PERMITS),
+        ));
+
         // Collect per-partition notify map for the sequencer
         let mut notify_map: HashMap<i64, Arc<Notify>> = HashMap::new();
         for entry in &partition_notify {
@@ -137,11 +193,12 @@ impl OutboxBuilder {
         }
         let notify_map = Arc::new(notify_map);
 
-        // Spawn sequencer
+        // Spawn sequencer (with admin semaphore)
         let sequencer = Sequencer::new(
             outbox.config().sequencer.clone(),
             Arc::clone(&outbox),
             Arc::clone(&sequencer_notify),
+            Arc::clone(&maintenance_sem),
         );
         sequencer.set_partition_notify(Arc::clone(&notify_map));
         let seq_cancel = cancel.clone();
@@ -153,6 +210,29 @@ impl OutboxBuilder {
             }
         });
         handles.push(seq_handle);
+
+        // Spawn vacuum task
+        #[allow(unused_mut)]
+        let mut vacuum = VacuumTask::new(Arc::clone(&maintenance_sem), maintenance_config);
+        #[cfg(feature = "outbox-profiler")]
+        if let Some(p) = outbox.profiler_arc() {
+            vacuum.set_profiler(p);
+        }
+        let vacuum_cancel = cancel.clone();
+        let vacuum_db = self.db.clone();
+        let vacuum_handle = tokio::spawn(async move {
+            if let Err(e) = vacuum.run(&vacuum_db, vacuum_cancel).await {
+                tracing::error!(error = %e, "vacuum exited with error");
+            }
+        });
+        handles.push(vacuum_handle);
+
+        // Spawn profiler reporter task
+        #[cfg(feature = "outbox-profiler")]
+        {
+            let profiler_handle = profiler.spawn_reporter(cancel.clone());
+            handles.push(profiler_handle);
+        }
 
         Ok(OutboxHandle {
             outbox,
@@ -191,5 +271,52 @@ impl OutboxHandle {
     #[must_use]
     pub fn cancel_token(&self) -> &CancellationToken {
         &self.cancel
+    }
+}
+
+/// Resolve maintenance config with defaults.
+///
+/// When `maintenance()` was called, the value is already validated by the
+/// builder. When it was not called, derive a safe default from `max_partitions`.
+///
+/// Extracted as a free function for unit-testability without requiring a DB.
+fn resolve_maintenance_config(
+    explicit_total: Option<usize>,
+    vacuum_cooldown: Duration,
+    max_partitions: usize,
+) -> MaintenanceConfig {
+    // .max(2) ensures room for at least 1 sequencer + 1 vacuum chunk.
+    #[allow(clippy::integer_division)]
+    let concurrency = explicit_total.unwrap_or_else(|| (max_partitions / 2).max(2));
+
+    MaintenanceConfig {
+        concurrency,
+        vacuum_cooldown,
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_concurrency_is_half_max_partitions() {
+        let cfg = resolve_maintenance_config(None, Duration::from_secs(30), 16);
+        assert_eq!(cfg.concurrency, 8);
+    }
+
+    #[test]
+    fn default_minimum_is_two() {
+        // 1 partition → max(1/2, 2) = 2
+        let cfg = resolve_maintenance_config(None, Duration::from_secs(30), 1);
+        assert_eq!(cfg.concurrency, 2);
+    }
+
+    #[test]
+    fn explicit_value_passes_through() {
+        let cfg = resolve_maintenance_config(Some(6), Duration::from_secs(10), 16);
+        assert_eq!(cfg.concurrency, 6);
+        assert_eq!(cfg.vacuum_cooldown, Duration::from_secs(10));
     }
 }

--- a/libs/modkit-db/src/outbox/migrations.rs
+++ b/libs/modkit-db/src/outbox/migrations.rs
@@ -38,6 +38,7 @@ impl MigrationTrait for CreateOutboxSchema {
         create_outgoing(conn, backend).await?;
         create_dead_letters(conn, backend).await?;
         create_processor(conn, backend).await?;
+        create_vacuum_counter(conn, backend).await?;
 
         Ok(())
     }
@@ -47,6 +48,7 @@ impl MigrationTrait for CreateOutboxSchema {
         let backend = conn.get_database_backend();
 
         for table in [
+            "modkit_outbox_vacuum_counter",
             "modkit_outbox_processor",
             "modkit_outbox_dead_letters",
             "modkit_outbox_outgoing",
@@ -185,6 +187,19 @@ async fn create_incoming(
         },
     ))
     .await?;
+
+    // Index on body_id to accelerate FK constraint checks during
+    // DELETE FROM modkit_outbox_body WHERE id IN (...).
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres | DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
+                "CREATE INDEX idx_modkit_outbox_incoming_body_id \
+             ON modkit_outbox_incoming (body_id)"
+            }
+        },
+    ))
+    .await?;
     Ok(())
 }
 
@@ -237,6 +252,19 @@ async fn create_outgoing(
             DatabaseBackend::Postgres | DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
                 "CREATE UNIQUE INDEX idx_modkit_outbox_outgoing_partition_seq \
              ON modkit_outbox_outgoing (partition_id, seq)"
+            }
+        },
+    ))
+    .await?;
+
+    // Index on body_id to accelerate FK constraint checks during
+    // DELETE FROM modkit_outbox_body WHERE id IN (...).
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres | DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
+                "CREATE INDEX idx_modkit_outbox_outgoing_body_id \
+             ON modkit_outbox_outgoing (body_id)"
             }
         },
     ))
@@ -374,6 +402,40 @@ async fn create_processor(
                 last_error    TEXT,
                 locked_by     TEXT,
                 locked_until  TIMESTAMP(6) NULL,
+                FOREIGN KEY (partition_id) REFERENCES modkit_outbox_partitions(id)
+            )"
+            }
+        },
+    ))
+    .await?;
+    Ok(())
+}
+
+async fn create_vacuum_counter(
+    conn: &dyn ConnectionTrait,
+    backend: DatabaseBackend,
+) -> Result<(), DbErr> {
+    conn.execute(Statement::from_string(
+        backend,
+        match backend {
+            DatabaseBackend::Postgres => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_vacuum_counter (
+                partition_id BIGINT PRIMARY KEY
+                    REFERENCES modkit_outbox_partitions(id),
+                counter      BIGINT NOT NULL DEFAULT 0
+            )"
+            }
+            DatabaseBackend::Sqlite => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_vacuum_counter (
+                partition_id INTEGER PRIMARY KEY
+                    REFERENCES modkit_outbox_partitions(id),
+                counter      INTEGER NOT NULL DEFAULT 0
+            )"
+            }
+            DatabaseBackend::MySql => {
+                "CREATE TABLE IF NOT EXISTS modkit_outbox_vacuum_counter (
+                partition_id BIGINT PRIMARY KEY,
+                counter      BIGINT NOT NULL DEFAULT 0,
                 FOREIGN KEY (partition_id) REFERENCES modkit_outbox_partitions(id)
             )"
             }

--- a/libs/modkit-db/src/outbox/mod.rs
+++ b/libs/modkit-db/src/outbox/mod.rs
@@ -11,8 +11,8 @@
 //! 3. **Processor** — one long-lived task per partition reads from `outgoing`,
 //!    dispatches to the registered handler, and acks via cursor advance
 //!    (append-only — no deletes on the hot path).
-//! 4. **Reaper** — when a partition is idle, the processor bulk-deletes
-//!    processed outgoing and body rows.
+//! 4. **Vacuum** — a standalone background task (peer of the sequencer) that
+//!    garbage-collects processed outgoing and body rows across dirty partitions.
 //!
 //! # Processing modes
 //!
@@ -95,6 +95,10 @@ mod processor;
 mod sequencer;
 mod strategy;
 mod types;
+mod vacuum;
+
+#[cfg(feature = "outbox-profiler")]
+pub mod profiler;
 
 #[cfg(test)]
 #[cfg(feature = "sqlite")]

--- a/libs/modkit-db/src/outbox/processor.rs
+++ b/libs/modkit-db/src/outbox/processor.rs
@@ -1,19 +1,15 @@
 use std::sync::Arc;
 
-use sea_orm::{ConnectionTrait, DbBackend, Statement, TransactionTrait};
+use sea_orm::ConnectionTrait;
 use tokio::sync::{Notify, Semaphore};
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
-use super::dialect::{Dialect, ReaperSql};
 use super::handler::HandlerResult;
 use super::strategy::{ProcessContext, ProcessingStrategy};
 use super::types::{OutboxError, QueueConfig};
 use crate::Db;
-
-/// Max body IDs per batched DELETE in the reaper.
-const REAPER_CHUNK_SIZE: usize = 100;
 
 /// Per-partition adaptive batch sizing state machine.
 ///
@@ -100,6 +96,8 @@ pub struct PartitionProcessor<S: ProcessingStrategy> {
     semaphore: Arc<Semaphore>,
     backoff_until: Option<Instant>,
     partition_mode: PartitionMode,
+    #[cfg(feature = "outbox-profiler")]
+    profiler: Option<std::sync::Arc<super::profiler::QueryProfiler>>,
 }
 
 impl<S: ProcessingStrategy> PartitionProcessor<S> {
@@ -118,15 +116,27 @@ impl<S: ProcessingStrategy> PartitionProcessor<S> {
             semaphore,
             backoff_until: None,
             partition_mode: PartitionMode::Normal,
+            #[cfg(feature = "outbox-profiler")]
+            profiler: None,
         }
     }
 
+    /// Attach a query profiler.
+    #[cfg(feature = "outbox-profiler")]
+    pub fn set_profiler(&mut self, profiler: std::sync::Arc<super::profiler::QueryProfiler>) {
+        self.profiler = Some(profiler);
+    }
+
     /// Main event loop. Runs until `cancel` fires.
+    ///
+    /// Pure delivery loop: read → handler → ack → wait. Vacuum logic has been
+    /// extracted into a separate `VacuumTask`.
     pub async fn run(mut self, db: &Db, cancel: CancellationToken) -> Result<(), OutboxError> {
-        let sea_conn = db.sea_internal();
-        let backend = sea_conn.get_database_backend();
-        let dialect = Dialect::from(backend);
-        drop(sea_conn);
+        let (backend, dialect) = {
+            let sea_conn = db.sea_internal();
+            let b = sea_conn.get_database_backend();
+            (b, super::dialect::Dialect::from(b))
+        };
 
         let mut has_more = false;
         loop {
@@ -163,15 +173,26 @@ impl<S: ProcessingStrategy> PartitionProcessor<S> {
                 .effective_batch_size(self.config.msg_batch_size);
 
             let result = {
+                #[cfg(feature = "outbox-profiler")]
+                let sem_guard = self
+                    .profiler
+                    .as_ref()
+                    .map(|p| p.measure(super::profiler::Op::SemaphoreWait));
+
                 let Ok(_permit) = self.semaphore.acquire().await else {
                     break; // semaphore closed — shut down
                 };
+
+                #[cfg(feature = "outbox-profiler")]
+                drop(sem_guard);
 
                 let ctx = ProcessContext {
                     db,
                     backend,
                     dialect,
                     partition_id: self.partition_id,
+                    #[cfg(feature = "outbox-profiler")]
+                    profiler: self.profiler.clone(),
                 };
 
                 // Use effective batch size from partition mode
@@ -179,9 +200,24 @@ impl<S: ProcessingStrategy> PartitionProcessor<S> {
                 effective_config.msg_batch_size = effective_size;
 
                 let child_cancel = cancel.child_token();
-                self.strategy
+
+                #[cfg(feature = "outbox-profiler")]
+                let mut proc_guard = self
+                    .profiler
+                    .as_ref()
+                    .map(|p| p.measure(super::profiler::Op::ProcessorReadMessages));
+
+                let result = self
+                    .strategy
                     .process(&ctx, &effective_config, child_cancel)
-                    .await?
+                    .await?;
+
+                #[cfg(feature = "outbox-profiler")]
+                if let (Some(g), Some(pr)) = (proc_guard.as_mut(), result.as_ref()) {
+                    g.set_rows(u64::from(pr.count));
+                }
+
+                result
             }; // permit dropped here
 
             if let Some(pr) = result {
@@ -204,87 +240,8 @@ impl<S: ProcessingStrategy> PartitionProcessor<S> {
                 }
             } else {
                 has_more = false;
-                // Reaper: clean up processed outgoing + body rows when idle
-                self.reap(db, backend, &dialect).await?;
             }
         }
-        Ok(())
-    }
-
-    /// Reaper: bulk-delete processed outgoing rows and their body rows.
-    async fn reap(
-        &self,
-        db: &Db,
-        backend: DbBackend,
-        dialect: &Dialect,
-    ) -> Result<(), OutboxError> {
-        let conn = db.sea_internal();
-        let row = conn
-            .query_one(Statement::from_sql_and_values(
-                backend,
-                dialect.read_processor(),
-                [self.partition_id.into()],
-            ))
-            .await?;
-        drop(conn);
-
-        let Some(row) = row else {
-            return Ok(());
-        };
-        let processed_seq: i64 = row.try_get_by_index(0).map_err(|e| {
-            OutboxError::Database(sea_orm::DbErr::Custom(format!("processed_seq column: {e}")))
-        })?;
-        if processed_seq == 0 {
-            return Ok(());
-        }
-
-        let sea_conn = db.sea_internal();
-        let txn = sea_conn.begin().await?;
-
-        match dialect.reaper_cleanup() {
-            ReaperSql::Cte(sql) => {
-                txn.execute(Statement::from_sql_and_values(
-                    backend,
-                    sql,
-                    [self.partition_id.into(), processed_seq.into()],
-                ))
-                .await?;
-            }
-            ReaperSql::TwoStep {
-                select_body_ids,
-                delete_outgoing,
-            } => {
-                let rows = txn
-                    .query_all(Statement::from_sql_and_values(
-                        backend,
-                        select_body_ids,
-                        [self.partition_id.into(), processed_seq.into()],
-                    ))
-                    .await?;
-
-                let body_ids: Vec<i64> = rows
-                    .iter()
-                    .filter_map(|r| r.try_get_by_index::<i64>(0).ok())
-                    .collect();
-
-                txn.execute(Statement::from_sql_and_values(
-                    backend,
-                    delete_outgoing,
-                    [self.partition_id.into(), processed_seq.into()],
-                ))
-                .await?;
-
-                // Batch body deletes — chunk to avoid exceeding DB parameter limits
-                for chunk in body_ids.chunks(REAPER_CHUNK_SIZE) {
-                    let delete_sql = dialect.build_delete_body_batch(chunk.len());
-                    let values: Vec<sea_orm::Value> = chunk.iter().map(|&id| id.into()).collect();
-                    txn.execute(Statement::from_sql_and_values(backend, &delete_sql, values))
-                        .await?;
-                }
-            }
-        }
-
-        txn.commit().await?;
         Ok(())
     }
 
@@ -360,6 +317,8 @@ mod tests {
             semaphore: Arc::new(Semaphore::new(1)),
             backoff_until: None,
             partition_mode: PartitionMode::Normal,
+            #[cfg(feature = "outbox-profiler")]
+            profiler: None,
         }
     }
 

--- a/libs/modkit-db/src/outbox/profiler.rs
+++ b/libs/modkit-db/src/outbox/profiler.rs
@@ -1,0 +1,380 @@
+//! Query profiler for the outbox pipeline.
+//!
+//! Enabled via the `outbox-profiler` feature flag.  Instruments all outbox
+//! SQL operations and periodically emits a structured summary via `tracing`.
+//!
+//! # Output format
+//!
+//! ```text
+//! Outbox Profile (window: 10.0s)
+//!   enqueue.insert_body            calls=1204   total=  842.3ms  avg=  0.70ms  max=  12.4ms  avg_batch=  1.0  max_batch=1
+//!   sequencer.claim_incoming       calls=96     total=  312.4ms  avg=  3.25ms  max=  24.8ms  avg_batch= 12.5  max_batch=50
+//!   processor.read_messages        calls=512    total=  448.6ms  avg=  0.88ms  max=   8.3ms  avg_batch=  2.4  max_batch=50
+//!   processor.sem_wait             calls=512    total=   42.1ms  avg=  0.08ms  max=   1.2ms  avg_batch=  0.0  max_batch=0
+//!   vacuum.delete                  calls=4      total=   89.2ms  avg= 22.30ms  max=  31.4ms  avg_batch=  0.0  max_batch=0
+//! ```
+
+use std::fmt::Write as _;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+/// Threshold above which a semaphore wait is considered "starvation" (50ms).
+const STARVATION_THRESHOLD_US: u64 = 50_000;
+
+/// All tracked outbox query operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Op {
+    EnqueueInsertBody,
+    EnqueueInsertIncoming,
+    SequencerLockPartition,
+    SequencerClaimIncoming,
+    SequencerAllocateSeq,
+    SequencerInsertOutgoing,
+    ProcessorLockState,
+    ProcessorReadMessages,
+    ProcessorAck,
+    VacuumDelete,
+    /// Semaphore wait time before a processor can start work.
+    /// High values indicate pool / concurrency starvation.
+    SemaphoreWait,
+}
+
+impl Op {
+    const ALL: [Op; 11] = [
+        Op::EnqueueInsertBody,
+        Op::EnqueueInsertIncoming,
+        Op::SequencerLockPartition,
+        Op::SequencerClaimIncoming,
+        Op::SequencerAllocateSeq,
+        Op::SequencerInsertOutgoing,
+        Op::ProcessorLockState,
+        Op::ProcessorReadMessages,
+        Op::ProcessorAck,
+        Op::VacuumDelete,
+        Op::SemaphoreWait,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Op::EnqueueInsertBody => "enqueue.insert_body",
+            Op::EnqueueInsertIncoming => "enqueue.insert_incoming",
+            Op::SequencerLockPartition => "sequencer.lock_partition",
+            Op::SequencerClaimIncoming => "sequencer.claim_incoming",
+            Op::SequencerAllocateSeq => "sequencer.allocate_seq",
+            Op::SequencerInsertOutgoing => "sequencer.insert_outgoing",
+            Op::ProcessorLockState => "processor.lock_state",
+            Op::ProcessorReadMessages => "processor.read_messages",
+            Op::ProcessorAck => "processor.ack",
+            Op::VacuumDelete => "vacuum.delete",
+            Op::SemaphoreWait => "processor.sem_wait",
+        }
+    }
+
+    fn index(self) -> usize {
+        self as usize
+    }
+}
+
+/// Atomic counters for a single operation.
+struct OpCounters {
+    calls: AtomicU64,
+    total_us: AtomicU64,
+    max_us: AtomicU64,
+    total_rows: AtomicU64,
+    max_rows: AtomicU64,
+}
+
+impl OpCounters {
+    const fn new() -> Self {
+        Self {
+            calls: AtomicU64::new(0),
+            total_us: AtomicU64::new(0),
+            max_us: AtomicU64::new(0),
+            total_rows: AtomicU64::new(0),
+            max_rows: AtomicU64::new(0),
+        }
+    }
+
+    fn record(&self, elapsed_us: u64, rows: u64) {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        self.total_us.fetch_add(elapsed_us, Ordering::Relaxed);
+        self.max_us.fetch_max(elapsed_us, Ordering::Relaxed);
+        self.total_rows.fetch_add(rows, Ordering::Relaxed);
+        self.max_rows.fetch_max(rows, Ordering::Relaxed);
+    }
+
+    fn snapshot_and_reset(&self) -> OpSnapshot {
+        let calls = self.calls.swap(0, Ordering::Relaxed);
+        let total_us = self.total_us.swap(0, Ordering::Relaxed);
+        let max_us = self.max_us.swap(0, Ordering::Relaxed);
+        let total_rows = self.total_rows.swap(0, Ordering::Relaxed);
+        let max_rows = self.max_rows.swap(0, Ordering::Relaxed);
+        OpSnapshot {
+            calls,
+            total_us,
+            max_us,
+            total_rows,
+            max_rows,
+        }
+    }
+}
+
+/// A point-in-time snapshot of a single operation's counters.
+#[derive(Debug, Clone, Copy)]
+struct OpSnapshot {
+    calls: u64,
+    total_us: u64,
+    max_us: u64,
+    total_rows: u64,
+    max_rows: u64,
+}
+
+impl OpSnapshot {
+    #[allow(clippy::cast_precision_loss)]
+    fn avg_ms(self) -> f64 {
+        if self.calls == 0 {
+            0.0
+        } else {
+            (self.total_us as f64 / self.calls as f64) / 1000.0
+        }
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn total_ms(self) -> f64 {
+        self.total_us as f64 / 1000.0
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn max_ms(self) -> f64 {
+        self.max_us as f64 / 1000.0
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn avg_rows(self) -> f64 {
+        if self.calls == 0 {
+            0.0
+        } else {
+            self.total_rows as f64 / self.calls as f64
+        }
+    }
+}
+
+/// Shared query profiler instance.
+///
+/// Create once when building the outbox pipeline. Calling [`record`](Self::record)
+/// is lock-free (atomic increments only).
+pub struct QueryProfiler {
+    counters: [OpCounters; 11],
+    /// Number of semaphore waits exceeding the starvation threshold.
+    starvation_events: AtomicU64,
+    window: Duration,
+    /// Guards against double final-report emission. The reporter task
+    /// (`spawn_reporter`) emits a final report on cancellation, then
+    /// sets this flag. The Drop impl checks it to avoid a duplicate
+    /// (which would always be empty since counters were already reset).
+    final_report_emitted: AtomicBool,
+}
+
+impl QueryProfiler {
+    /// Create a new profiler that emits a report every `window`.
+    #[must_use]
+    pub fn new(window: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            counters: [
+                OpCounters::new(),
+                OpCounters::new(),
+                OpCounters::new(),
+                OpCounters::new(),
+                OpCounters::new(),
+                OpCounters::new(),
+                OpCounters::new(),
+                OpCounters::new(),
+                OpCounters::new(),
+                OpCounters::new(),
+                OpCounters::new(),
+            ],
+            starvation_events: AtomicU64::new(0),
+            window,
+            final_report_emitted: AtomicBool::new(false),
+        })
+    }
+
+    /// Record a completed query with optional row count.
+    #[inline]
+    pub fn record(&self, op: Op, elapsed: Duration, rows: u64) {
+        #[allow(clippy::cast_possible_truncation)]
+        let us = elapsed.as_micros() as u64;
+        self.counters[op.index()].record(us, rows);
+        // Track starvation events for semaphore waits
+        if matches!(op, Op::SemaphoreWait) && us >= STARVATION_THRESHOLD_US {
+            self.starvation_events.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Start measuring an operation. Returns a guard that records elapsed
+    /// time on drop. Use `set_rows()` on the guard to record row count.
+    #[inline]
+    #[must_use]
+    pub fn measure(&self, op: Op) -> MeasureGuard<'_> {
+        MeasureGuard {
+            profiler: self,
+            op,
+            start: Instant::now(),
+            rows: 0,
+        }
+    }
+
+    /// Snapshot all counters and reset. Returns the formatted report.
+    ///
+    /// One line per operation:
+    /// `op_name  calls=N  total=Xms  avg=Yms  max=Zms  avg_batch=B  max_batch=M`
+    fn snapshot_and_format(&self, window_secs: f64) -> Option<String> {
+        let snapshots: Vec<(Op, OpSnapshot)> = Op::ALL
+            .iter()
+            .map(|&op| (op, self.counters[op.index()].snapshot_and_reset()))
+            .collect();
+        let starvation = self.starvation_events.swap(0, Ordering::Relaxed);
+
+        let total_calls: u64 = snapshots.iter().map(|(_, s)| s.calls).sum();
+        if total_calls == 0 {
+            return None;
+        }
+
+        let mut report = String::with_capacity(512);
+        #[allow(clippy::let_underscore_must_use)]
+        let _ = writeln!(report, "Outbox Profile (window: {window_secs:.1}s)");
+
+        for (op, snap) in &snapshots {
+            if snap.calls > 0 {
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = writeln!(
+                    report,
+                    "  {:<28} calls={:<6} total={:>9.1}ms  avg={:>6.2}ms  max={:>6.1}ms  avg_batch={:>5.1}  max_batch={}",
+                    op.label(),
+                    snap.calls,
+                    snap.total_ms(),
+                    snap.avg_ms(),
+                    snap.max_ms(),
+                    snap.avg_rows(),
+                    snap.max_rows,
+                );
+            }
+        }
+
+        if starvation > 0 {
+            #[allow(clippy::integer_division)]
+            let threshold_ms = STARVATION_THRESHOLD_US / 1000;
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = writeln!(
+                report,
+                "  *** POOL STARVATION: {starvation} semaphore wait(s) exceeded {threshold_ms}ms ***",
+            );
+        }
+
+        Some(report)
+    }
+
+    /// Spawn the background reporter task. Returns a `JoinHandle` that runs
+    /// until the `CancellationToken` is cancelled.
+    pub fn spawn_reporter(
+        self: &Arc<Self>,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> tokio::task::JoinHandle<()> {
+        let profiler = Arc::clone(self);
+        let window = profiler.window;
+        tokio::spawn(async move {
+            let window_secs = window.as_secs_f64();
+            loop {
+                tokio::select! {
+                    () = cancel.cancelled() => break,
+                    () = tokio::time::sleep(window) => {
+                        if let Some(report) = profiler.snapshot_and_format(window_secs) {
+                            tracing::info!(target: "outbox::profiler", "{report}");
+                        }
+                    }
+                }
+            }
+            // Emit final report on shutdown
+            if let Some(report) = profiler.snapshot_and_format(window_secs) {
+                tracing::info!(target: "outbox::profiler", "Final report:{report}");
+            }
+            // Signal that final report was already emitted by the reporter task,
+            // so the Drop impl doesn't emit a duplicate empty report.
+            profiler.final_report_emitted.store(true, Ordering::Release);
+        })
+    }
+}
+
+impl Drop for QueryProfiler {
+    fn drop(&mut self) {
+        // Reporter task already emitted the final report — skip.
+        if self.final_report_emitted.load(Ordering::Acquire) {
+            return;
+        }
+        let window_secs = self.window.as_secs_f64();
+        if let Some(report) = self.snapshot_and_format(window_secs) {
+            tracing::info!(target: "outbox::profiler", "Final report:{report}");
+        }
+    }
+}
+
+/// RAII guard that records elapsed time on drop.
+pub struct MeasureGuard<'a> {
+    profiler: &'a QueryProfiler,
+    op: Op,
+    start: Instant,
+    rows: u64,
+}
+
+impl MeasureGuard<'_> {
+    /// Set the number of rows processed by this operation.
+    #[inline]
+    pub fn set_rows(&mut self, rows: u64) {
+        self.rows = rows;
+    }
+}
+
+impl Drop for MeasureGuard<'_> {
+    fn drop(&mut self) {
+        self.profiler
+            .record(self.op, self.start.elapsed(), self.rows);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_and_snapshot() {
+        let p = QueryProfiler::new(Duration::from_secs(10));
+        p.record(Op::EnqueueInsertBody, Duration::from_micros(500), 1);
+        p.record(Op::EnqueueInsertBody, Duration::from_micros(1500), 5);
+        p.record(Op::SequencerClaimIncoming, Duration::from_millis(5), 100);
+
+        let report = p.snapshot_and_format(10.0);
+        assert!(report.is_some());
+        let text = report.expect("report should be Some after recording ops");
+        assert!(text.contains("enqueue.insert_body"));
+        assert!(text.contains("sequencer.claim_incoming"));
+        // Should not contain zero-call ops
+        assert!(!text.contains("vacuum.delete"));
+
+        // After snapshot, counters should be reset
+        let report2 = p.snapshot_and_format(10.0);
+        assert!(report2.is_none());
+    }
+
+    #[test]
+    fn measure_guard() {
+        let p = QueryProfiler::new(Duration::from_secs(10));
+        {
+            let _g = p.measure(Op::ProcessorAck);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        let snap = p.counters[Op::ProcessorAck.index()].snapshot_and_reset();
+        assert_eq!(snap.calls, 1);
+        assert!(snap.total_us >= 1000); // at least 1ms
+    }
+}

--- a/libs/modkit-db/src/outbox/sequencer.rs
+++ b/libs/modkit-db/src/outbox/sequencer.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use sea_orm::{ConnectionTrait, DbBackend, FromQueryResult, Statement, TransactionTrait};
-use tokio::sync::Notify;
+use tokio::sync::{Notify, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
@@ -24,6 +24,7 @@ pub struct Sequencer {
     config: SequencerConfig,
     outbox: Arc<Outbox>,
     notify: Arc<Notify>,
+    maintenance_sem: Arc<Semaphore>,
     /// Per-partition notify map for direct signaling.
     partition_notify: std::sync::RwLock<Option<PartitionNotifyMap>>,
 }
@@ -44,11 +45,17 @@ struct ClaimedIncoming {
 impl Sequencer {
     /// Create a new sequencer.
     #[must_use]
-    pub fn new(config: SequencerConfig, outbox: Arc<Outbox>, notify: Arc<Notify>) -> Self {
+    pub fn new(
+        config: SequencerConfig,
+        outbox: Arc<Outbox>,
+        notify: Arc<Notify>,
+        maintenance_sem: Arc<Semaphore>,
+    ) -> Self {
         Self {
             config,
             outbox,
             notify,
+            maintenance_sem,
             partition_notify: std::sync::RwLock::new(None),
         }
     }
@@ -99,6 +106,19 @@ impl Sequencer {
     ///
     /// Returns an error if a database operation fails.
     pub async fn sequence_batch(&self, db: &Db) -> Result<SequenceBatchResult, OutboxError> {
+        // Acquire maintenance semaphore permit before DB operations.
+        let Ok(_maint_permit) = self.maintenance_sem.acquire().await else {
+            return Ok(SequenceBatchResult {
+                any_partition_saturated: false,
+            });
+        };
+
+        #[cfg(feature = "outbox-profiler")]
+        let mut profiler_guard = self
+            .outbox
+            .profiler()
+            .map(|p| p.measure(super::profiler::Op::SequencerClaimIncoming));
+
         let partition_ids = self.outbox.all_partition_ids();
         if partition_ids.is_empty() {
             return Ok(SequenceBatchResult {
@@ -171,6 +191,11 @@ impl Sequencer {
         }
 
         txn.commit().await?;
+
+        #[cfg(feature = "outbox-profiler")]
+        if let Some(g) = profiler_guard.as_mut() {
+            g.set_rows(u64::from(total));
+        }
 
         // Notify per-partition processors after commit
         if let Some(map) = self

--- a/libs/modkit-db/src/outbox/strategy.rs
+++ b/libs/modkit-db/src/outbox/strategy.rs
@@ -14,6 +14,9 @@ pub struct ProcessContext<'a> {
     pub backend: DbBackend,
     pub dialect: Dialect,
     pub partition_id: i64,
+    #[cfg(feature = "outbox-profiler")]
+    #[allow(dead_code)] // available for strategies to instrument inner queries
+    pub profiler: Option<std::sync::Arc<super::profiler::QueryProfiler>>,
 }
 
 /// Sealed trait for compile-time processing mode dispatch.
@@ -128,7 +131,7 @@ async fn read_messages(
 }
 
 /// Append-only ack: only UPDATE `processed_seq`, no DELETEs.
-/// Reaper handles cleanup of processed outgoing + body rows.
+/// Vacuum handles cleanup of processed outgoing + body rows.
 async fn ack(
     txn: &impl ConnectionTrait,
     backend: DbBackend,
@@ -145,6 +148,12 @@ async fn ack(
                 backend,
                 dialect.advance_processed_seq(),
                 [last_seq.into(), partition_id.into()],
+            ))
+            .await?;
+            txn.execute(Statement::from_sql_and_values(
+                backend,
+                dialect.bump_vacuum_counter(),
+                [partition_id.into()],
             ))
             .await?;
         }
@@ -178,6 +187,12 @@ async fn ack(
                 backend,
                 dialect.advance_processed_seq(),
                 [last_seq.into(), partition_id.into()],
+            ))
+            .await?;
+            txn.execute(Statement::from_sql_and_values(
+                backend,
+                dialect.bump_vacuum_counter(),
+                [partition_id.into()],
             ))
             .await?;
         }
@@ -423,6 +438,13 @@ impl ProcessingStrategy for DecoupledStrategy {
                     ack_txn.commit().await?;
                     return Ok(None);
                 }
+                ack_txn
+                    .execute(Statement::from_sql_and_values(
+                        ctx.backend,
+                        ctx.dialect.bump_vacuum_counter(),
+                        [ctx.partition_id.into()],
+                    ))
+                    .await?;
             }
             HandlerResult::Retry { reason } => {
                 // Retry: cursor not advanced — the same batch will be re-read.
@@ -493,6 +515,13 @@ impl ProcessingStrategy for DecoupledStrategy {
                     ack_txn.commit().await?;
                     return Ok(None);
                 }
+                ack_txn
+                    .execute(Statement::from_sql_and_values(
+                        ctx.backend,
+                        ctx.dialect.bump_vacuum_counter(),
+                        [ctx.partition_id.into()],
+                    ))
+                    .await?;
             }
         }
 

--- a/libs/modkit-db/src/outbox/types.rs
+++ b/libs/modkit-db/src/outbox/types.rs
@@ -148,6 +148,21 @@ pub struct QueueConfig {
     pub backoff_max: Duration,
 }
 
+/// Default vacuum cooldown: 1 hour.
+pub const DEFAULT_VACUUM_COOLDOWN: Duration = Duration::from_secs(3600);
+
+/// Maintenance connection budget for the outbox pipeline.
+///
+/// The sequencer and vacuum share a semaphore pool of `concurrency`
+/// permits for DB operations.
+#[derive(Debug, Clone)]
+pub struct MaintenanceConfig {
+    /// Total shared maintenance semaphore permits.
+    pub concurrency: usize,
+    /// Minimum interval between full vacuum sweeps. Default: 1h.
+    pub vacuum_cooldown: Duration,
+}
+
 impl Default for QueueConfig {
     fn default() -> Self {
         Self {

--- a/libs/modkit-db/src/outbox/vacuum.rs
+++ b/libs/modkit-db/src/outbox/vacuum.rs
@@ -1,0 +1,373 @@
+use std::sync::Arc;
+
+use sea_orm::{ConnectionTrait, DbBackend, Statement, TransactionTrait};
+use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use super::dialect::Dialect;
+use super::types::{MaintenanceConfig, OutboxError};
+use crate::Db;
+
+/// Max rows per bounded vacuum chunk (SELECT + DELETE).
+const VACUUM_BATCH_SIZE: usize = 10_000;
+
+/// SQL LIMIT value for vacuum batch size.
+const VACUUM_BATCH_LIMIT: i64 = 10_000;
+
+/// Page size for the dirty-partition cursor.
+const DIRTY_PAGE_SIZE: usize = 64;
+
+/// SQL LIMIT value for dirty-partition page size.
+const DIRTY_PAGE_LIMIT: i64 = 64;
+
+/// Standalone vacuum background task that garbage-collects processed
+/// outgoing rows and their associated body rows.
+///
+/// Counter-driven: only visits partitions where the processor has
+/// bumped `modkit_outbox_vacuum_counter` since the last vacuum.
+///
+/// Each sweep snapshots all dirty partitions, drains each one
+/// (delete chunks until `deleted < VACUUM_BATCH_SIZE`), decrements
+/// the counter by the snapshot value, then sleeps for `vacuum_cooldown`.
+/// Partitions dirtied during the sweep are picked up in the next cycle.
+///
+/// Resilient to transient DB errors: a failed snapshot or per-partition
+/// error is logged and the sweep continues (or retries after cooldown).
+/// The vacuum never kills itself on a transient failure.
+pub struct VacuumTask {
+    maintenance_sem: Arc<Semaphore>,
+    config: MaintenanceConfig,
+    #[cfg(feature = "outbox-profiler")]
+    profiler: Option<Arc<super::profiler::QueryProfiler>>,
+}
+
+impl VacuumTask {
+    pub fn new(maintenance_sem: Arc<Semaphore>, config: MaintenanceConfig) -> Self {
+        Self {
+            maintenance_sem,
+            config,
+            #[cfg(feature = "outbox-profiler")]
+            profiler: None,
+        }
+    }
+
+    #[cfg(feature = "outbox-profiler")]
+    pub fn set_profiler(&mut self, profiler: Arc<super::profiler::QueryProfiler>) {
+        self.profiler = Some(profiler);
+    }
+
+    /// Run the vacuum loop until cancellation.
+    ///
+    /// Each cycle: snapshot dirty partitions → drain each → sleep cooldown.
+    /// Transient errors are logged and retried next cycle — the vacuum
+    /// never exits on a recoverable failure.
+    pub async fn run(self, db: &Db, cancel: CancellationToken) -> Result<(), OutboxError> {
+        let cooldown = self.config.vacuum_cooldown;
+
+        let (backend, dialect) = {
+            let sea_conn = db.sea_internal();
+            let b = sea_conn.get_database_backend();
+            (b, Dialect::from(b))
+        };
+
+        loop {
+            let sweep_start = tokio::time::Instant::now();
+
+            // Phase 1: Snapshot all dirty partitions via paginated cursor.
+            let dirty = match Self::snapshot_dirty(db, backend, &dialect, &cancel).await {
+                Ok(d) => d,
+                Err(e) => {
+                    if cancel.is_cancelled() {
+                        break;
+                    }
+                    warn!(error = %e, "vacuum: failed to snapshot dirty partitions, retrying after cooldown");
+                    Self::sleep_remaining(cooldown, sweep_start, &cancel).await;
+                    continue;
+                }
+            };
+
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            // Phase 2: Drain each partition, then decrement its counter.
+            let mut errors = 0u32;
+            for (partition_id, snapshot_counter) in &dirty {
+                if cancel.is_cancelled() {
+                    break;
+                }
+
+                if let Err(e) = self
+                    .drain_partition(
+                        db,
+                        backend,
+                        &dialect,
+                        *partition_id,
+                        *snapshot_counter,
+                        &cancel,
+                    )
+                    .await
+                {
+                    warn!(
+                        partition_id,
+                        error = %e,
+                        "vacuum: failed to drain partition, skipping",
+                    );
+                    errors += 1;
+                }
+            }
+
+            let elapsed = sweep_start.elapsed();
+            debug!(
+                partitions = dirty.len(),
+                errors,
+                elapsed_ms = u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
+                "vacuum: sweep complete",
+            );
+
+            // Phase 3: Sleep for remaining cooldown (cooldown minus sweep time).
+            Self::sleep_remaining(cooldown, sweep_start, &cancel).await;
+        }
+
+        Ok(())
+    }
+
+    /// Drain a single partition and decrement its counter.
+    /// Extracted so the caller can catch errors per-partition.
+    async fn drain_partition(
+        &self,
+        db: &Db,
+        backend: DbBackend,
+        dialect: &Dialect,
+        partition_id: i64,
+        snapshot_counter: i64,
+        cancel: &CancellationToken,
+    ) -> Result<(), OutboxError> {
+        self.vacuum_partition(db, backend, dialect, partition_id, cancel)
+            .await?;
+
+        // Decrement counter by snapshot value. GREATEST(counter - snapshot, 0)
+        // preserves any concurrent bumps from the processor.
+        let conn = db.sea_internal();
+        conn.execute(Statement::from_sql_and_values(
+            backend,
+            dialect.decrement_vacuum_counter(),
+            [snapshot_counter.into(), partition_id.into()],
+        ))
+        .await?;
+
+        Ok(())
+    }
+
+    /// Sleep for the remaining cooldown after a sweep, cancellation-aware.
+    async fn sleep_remaining(
+        cooldown: std::time::Duration,
+        sweep_start: tokio::time::Instant,
+        cancel: &CancellationToken,
+    ) {
+        let remaining = cooldown.saturating_sub(sweep_start.elapsed());
+        if !remaining.is_zero() {
+            tokio::select! {
+                () = cancel.cancelled() => {}
+                () = tokio::time::sleep(remaining) => {}
+            }
+        }
+    }
+
+    /// Collect all dirty partitions (counter > 0) via paginated cursor.
+    /// Returns `(partition_id, counter)` pairs, snapshot taken once per sweep.
+    async fn snapshot_dirty(
+        db: &Db,
+        backend: DbBackend,
+        dialect: &Dialect,
+        cancel: &CancellationToken,
+    ) -> Result<Vec<(i64, i64)>, OutboxError> {
+        let mut dirty = Vec::new();
+        let mut cursor: i64 = 0;
+
+        loop {
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            let conn = db.sea_internal();
+            let page = DIRTY_PAGE_LIMIT;
+            let rows = conn
+                .query_all(Statement::from_sql_and_values(
+                    backend,
+                    dialect.fetch_dirty_partitions(),
+                    [cursor.into(), page.into()],
+                ))
+                .await?;
+
+            if rows.is_empty() {
+                break;
+            }
+
+            for r in &rows {
+                let pid: i64 = r.try_get_by_index(0).map_err(|e| {
+                    OutboxError::Database(sea_orm::DbErr::Custom(format!(
+                        "partition_id column: {e}"
+                    )))
+                })?;
+                let counter: i64 = r.try_get_by_index(1).map_err(|e| {
+                    OutboxError::Database(sea_orm::DbErr::Custom(format!("counter column: {e}")))
+                })?;
+                dirty.push((pid, counter));
+            }
+
+            cursor = dirty.last().map_or(cursor, |&(pid, _)| pid);
+
+            if rows.len() < DIRTY_PAGE_SIZE {
+                break;
+            }
+        }
+
+        Ok(dirty)
+    }
+
+    /// Drain a single partition: read `processed_seq`, then delete all
+    /// outgoing + body rows with `seq <= processed_seq` in bounded chunks
+    /// until `deleted < VACUUM_BATCH_SIZE`.
+    async fn vacuum_partition(
+        &self,
+        db: &Db,
+        backend: DbBackend,
+        dialect: &Dialect,
+        partition_id: i64,
+        cancel: &CancellationToken,
+    ) -> Result<(), OutboxError> {
+        // Read processed_seq (PK lookup, cheap).
+        let row = {
+            let conn = db.sea_internal();
+            conn.query_one(Statement::from_sql_and_values(
+                backend,
+                dialect.read_processor(),
+                [partition_id.into()],
+            ))
+            .await?
+        };
+
+        let Some(row) = row else {
+            return Ok(());
+        };
+        let processed_seq: i64 = row.try_get_by_index(0).map_err(|e| {
+            OutboxError::Database(sea_orm::DbErr::Custom(format!(
+                "`processed_seq` column: {e}",
+            )))
+        })?;
+        if processed_seq == 0 {
+            return Ok(());
+        }
+
+        let vacuum_sql = dialect.vacuum_cleanup();
+
+        // Delete in bounded chunks until drained.
+        loop {
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            // Acquire maintenance permit, cancellation-aware.
+            let _maint_permit = tokio::select! {
+                () = cancel.cancelled() => break,
+                result = self.maintenance_sem.acquire() => match result {
+                    Ok(permit) => permit,
+                    Err(_) => break,
+                }
+            };
+
+            #[cfg(feature = "outbox-profiler")]
+            let mut delete_guard = self
+                .profiler
+                .as_ref()
+                .map(|p| p.measure(super::profiler::Op::VacuumDelete));
+
+            let deleted = Self::delete_chunk(
+                db,
+                backend,
+                dialect,
+                &vacuum_sql,
+                partition_id,
+                processed_seq,
+            )
+            .await?;
+
+            #[cfg(feature = "outbox-profiler")]
+            if let Some(g) = delete_guard.as_mut() {
+                g.set_rows(u64::try_from(deleted).unwrap_or(u64::MAX));
+            }
+
+            // _maint_permit drops here → permit released.
+
+            if deleted < VACUUM_BATCH_SIZE {
+                break; // Partition drained.
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Execute one bounded chunk of cleanup for a single partition.
+    /// Returns the number of outgoing rows deleted.
+    async fn delete_chunk(
+        db: &Db,
+        backend: DbBackend,
+        dialect: &Dialect,
+        vacuum_sql: &super::dialect::VacuumSql,
+        partition_id: i64,
+        processed_seq: i64,
+    ) -> Result<usize, OutboxError> {
+        let conn = db.sea_internal();
+        let txn = conn.begin().await?;
+
+        let limit = VACUUM_BATCH_LIMIT;
+
+        let rows = txn
+            .query_all(Statement::from_sql_and_values(
+                backend,
+                vacuum_sql.select_outgoing_chunk,
+                [partition_id.into(), processed_seq.into(), limit.into()],
+            ))
+            .await?;
+
+        if rows.is_empty() {
+            txn.rollback().await?;
+            return Ok(0);
+        }
+
+        let mut outgoing_ids: Vec<i64> = Vec::with_capacity(rows.len());
+        let mut body_ids: Vec<i64> = Vec::with_capacity(rows.len());
+        for r in &rows {
+            let oid: i64 = r.try_get_by_index(0).map_err(|e| {
+                OutboxError::Database(sea_orm::DbErr::Custom(format!("outgoing_id column: {e}")))
+            })?;
+            outgoing_ids.push(oid);
+            if let Ok(bid) = r.try_get_by_index::<i64>(1) {
+                body_ids.push(bid);
+            }
+        }
+
+        let count = outgoing_ids.len();
+
+        // DELETE outgoing rows by ID.
+        if !outgoing_ids.is_empty() {
+            let delete_sql = dialect.build_delete_outgoing_batch(outgoing_ids.len());
+            let values: Vec<sea_orm::Value> = outgoing_ids.iter().map(|&id| id.into()).collect();
+            txn.execute(Statement::from_sql_and_values(backend, &delete_sql, values))
+                .await?;
+        }
+
+        // DELETE body rows by ID.
+        if !body_ids.is_empty() {
+            let delete_sql = dialect.build_delete_body_batch(body_ids.len());
+            let values: Vec<sea_orm::Value> = body_ids.iter().map(|&id| id.into()).collect();
+            txn.execute(Statement::from_sql_and_values(backend, &delete_sql, values))
+                .await?;
+        }
+
+        txn.commit().await?;
+        Ok(count)
+    }
+}


### PR DESCRIPTION
feat(outbox): add two-tier semaphore, reaper, query profiler, and benchmarks

- Introduce admin/processor semaphore tiers to prevent DB pool starvation,
- add background reaper task for garbage-collecting processed messages,
- optional query profiler behind `outbox-profiler` feature flag, and
- comprehensive throughput benchmarks (1p–16p, single/batch, up to 1M messages).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive performance benchmarking suite for outbox operations across PostgreSQL, MySQL, MariaDB, and SQLite.
  * Introduced configurable maintenance scheduling with concurrency controls for background cleanup operations.

* **Improvements**
  * Enhanced background cleanup task for processed messages.
  * Added optional performance profiling and monitoring capabilities for outbox operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->