### PR TITLE
fix(modkit): resolve dangling $ref in OpenAPI for generic Page<T> schema

### DIFF
--- a/libs/modkit-odata/src/page.rs
+++ b/libs/modkit-odata/src/page.rs
@@ -8,11 +8,77 @@ pub struct PageInfo {
     pub limit: u64,
 }
 
-#[cfg_attr(feature = "with-utoipa", derive(utoipa::ToSchema))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Page<T> {
     pub items: Vec<T>,
     pub page_info: PageInfo,
+}
+
+/// Manual [`utoipa::PartialSchema`] impl for `Page<T>`.
+///
+/// utoipa's derive macro for generic structs omits the generic parameter `T`
+/// from the `schemas()` dependency list, producing a dangling `$ref`.
+/// This hand-written impl ensures `T`'s schema is always registered.
+#[cfg(feature = "with-utoipa")]
+impl<T> utoipa::PartialSchema for Page<T>
+where
+    T: utoipa::ToSchema + utoipa::PartialSchema,
+{
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        use utoipa::openapi::schema::{ArrayBuilder, ObjectBuilder};
+
+        ObjectBuilder::new()
+            .property(
+                "items",
+                ArrayBuilder::new().items(
+                    utoipa::openapi::RefOr::<utoipa::openapi::schema::Schema>::Ref(
+                        utoipa::openapi::Ref::from_schema_name(T::name().to_string()),
+                    ),
+                ),
+            )
+            .required("items")
+            .property(
+                "page_info",
+                utoipa::openapi::RefOr::<utoipa::openapi::schema::Schema>::Ref(
+                    utoipa::openapi::Ref::from_schema_name(
+                        <PageInfo as utoipa::ToSchema>::name().to_string(),
+                    ),
+                ),
+            )
+            .required("page_info")
+            .into()
+    }
+}
+
+#[cfg(feature = "with-utoipa")]
+impl<T> utoipa::ToSchema for Page<T>
+where
+    T: utoipa::ToSchema + utoipa::PartialSchema,
+{
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Owned(format!("Page_{}", T::name()))
+    }
+
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        // PageInfo (same as derive)
+        schemas.push((
+            <PageInfo as utoipa::ToSchema>::name().to_string(),
+            <PageInfo as utoipa::PartialSchema>::schema(),
+        ));
+        <PageInfo as utoipa::ToSchema>::schemas(schemas);
+
+        // T — the generic parameter (this is what the derive omits)
+        schemas.push((
+            <T as utoipa::ToSchema>::name().to_string(),
+            <T as utoipa::PartialSchema>::schema(),
+        ));
+        <T as utoipa::ToSchema>::schemas(schemas);
+    }
 }
 
 impl<T> Page<T> {
@@ -41,5 +107,42 @@ impl<T> Page<T> {
             items: self.items.into_iter().map(&mut f).collect(),
             page_info: self.page_info,
         }
+    }
+}
+
+#[cfg(all(test, feature = "with-utoipa"))]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    /// Dummy type to verify `Page<T>::schemas()` includes `T`'s schema.
+    #[derive(utoipa::ToSchema)]
+    struct DummyItem {
+        #[allow(dead_code)]
+        pub value: String,
+    }
+
+    #[test]
+    fn test_page_name_includes_generic() {
+        use utoipa::ToSchema;
+        let name = <Page<DummyItem> as ToSchema>::name();
+        assert_eq!(name.as_ref(), "Page_DummyItem");
+    }
+
+    #[test]
+    fn test_page_schemas_includes_inner_type() {
+        use utoipa::ToSchema;
+        let mut schemas = Vec::new();
+        <Page<DummyItem> as ToSchema>::schemas(&mut schemas);
+
+        let names: Vec<&str> = schemas.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(
+            names.contains(&"DummyItem"),
+            "Expected DummyItem in schemas, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"PageInfo"),
+            "Expected PageInfo in schemas, got: {names:?}"
+        );
     }
 }

--- a/libs/modkit/src/api/openapi_registry.rs
+++ b/libs/modkit/src/api/openapi_registry.rs
@@ -6,7 +6,7 @@
 use anyhow::Result;
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use utoipa::openapi::{
     OpenApi, OpenApiBuilder, Ref, RefOr, Required,
@@ -315,8 +315,9 @@ impl OpenApiRegistryImpl {
         }
 
         // 2) Components (from our registry)
+        let reg = self.components_registry.load();
         let mut components = ComponentsBuilder::new();
-        for (name, schema) in self.components_registry.load().iter() {
+        for (name, schema) in reg.iter() {
             components = components.schema(name.clone(), schema.clone());
         }
 
@@ -343,6 +344,8 @@ impl OpenApiRegistryImpl {
             .paths(paths.build())
             .components(Some(components.build()))
             .build();
+
+        warn_dangling_refs_in_openapi(&openapi);
 
         Ok(openapi)
     }
@@ -394,6 +397,71 @@ impl OpenApiRegistry for OpenApiRegistryImpl {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+/// Walk the finalized `OpenAPI` document and warn about dangling `$ref` targets.
+///
+/// Scans the entire document (operations, request bodies, responses, and schemas)
+/// so that `$ref`s emitted outside `components.schemas` are also caught.
+fn warn_dangling_refs_in_openapi(openapi: &OpenApi) {
+    for ref_name in &collect_all_dangling_refs_in_openapi(openapi) {
+        tracing::warn!(
+            schema = %ref_name,
+            "Dangling $ref: schema '{}' is referenced but not registered. \
+             Add an explicit `ensure_schema::<T>(registry)` call.",
+            ref_name,
+        );
+    }
+}
+
+/// Serialize the full `OpenAPI` document to JSON, collect every
+/// `#/components/schemas/{name}` reference, and return those not defined
+/// in `components.schemas`.
+fn collect_all_dangling_refs_in_openapi(openapi: &OpenApi) -> Vec<String> {
+    let value = match serde_json::to_value(openapi) {
+        Ok(v) => v,
+        Err(err) => {
+            tracing::debug!(error = %err, "Failed to serialize OpenAPI doc for dangling $ref check");
+            return Vec::new();
+        }
+    };
+
+    let mut all_refs = HashSet::new();
+    collect_refs_from_json(&value, &mut all_refs);
+
+    // Defined schema names live under components.schemas keys
+    let defined: HashSet<&str> = value
+        .pointer("/components/schemas")
+        .and_then(|v| v.as_object())
+        .map(|obj| obj.keys().map(String::as_str).collect())
+        .unwrap_or_default();
+
+    all_refs
+        .into_iter()
+        .filter(|name| !defined.contains(name.as_str()))
+        .collect()
+}
+
+/// Recursively extract `#/components/schemas/{name}` targets from a JSON value.
+fn collect_refs_from_json(value: &serde_json::Value, refs: &mut HashSet<String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(serde_json::Value::String(ref_str)) = map.get("$ref")
+                && let Some(name) = ref_str.strip_prefix("#/components/schemas/")
+            {
+                refs.insert(name.to_owned());
+            }
+            for v in map.values() {
+                collect_refs_from_json(v, refs);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr {
+                collect_refs_from_json(v, refs);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -667,5 +735,91 @@ mod tests {
         let allowed_order = order_ext.get("allowedFields").unwrap().as_array().unwrap();
         assert!(allowed_order.iter().any(|v| v.as_str() == Some("name asc")));
         assert!(allowed_order.iter().any(|v| v.as_str() == Some("age desc")));
+    }
+
+    /// Helper: build a minimal `OpenAPI` doc with the given component schemas.
+    fn build_test_openapi(schemas: HashMap<String, RefOr<Schema>>) -> OpenApi {
+        let mut components = ComponentsBuilder::new();
+        for (name, schema) in schemas {
+            components = components.schema(name, schema);
+        }
+        OpenApiBuilder::new()
+            .components(Some(components.build()))
+            .build()
+    }
+
+    #[test]
+    fn test_dangling_refs_detects_missing_in_components() {
+        let mut schemas: HashMap<String, RefOr<Schema>> = HashMap::new();
+        // Register "Foo" with a $ref to "Bar" which is NOT registered
+        let foo_schema = serde_json::from_value::<Schema>(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "bar": { "$ref": "#/components/schemas/Bar" }
+            }
+        }))
+        .unwrap();
+        schemas.insert("Foo".to_owned(), RefOr::T(foo_schema));
+
+        let openapi = build_test_openapi(schemas);
+        let dangling = collect_all_dangling_refs_in_openapi(&openapi);
+        assert_eq!(dangling, vec!["Bar".to_owned()]);
+    }
+
+    #[test]
+    fn test_dangling_refs_no_false_positives() {
+        let mut schemas: HashMap<String, RefOr<Schema>> = HashMap::new();
+        // Register "Bar"
+        let bar_schema = Schema::Object(ObjectBuilder::new().build());
+        schemas.insert("Bar".to_owned(), RefOr::T(bar_schema));
+
+        // Register "Foo" referencing "Bar"
+        let foo_schema = serde_json::from_value::<Schema>(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "bar": { "$ref": "#/components/schemas/Bar" }
+            }
+        }))
+        .unwrap();
+        schemas.insert("Foo".to_owned(), RefOr::T(foo_schema));
+
+        let openapi = build_test_openapi(schemas);
+        let dangling = collect_all_dangling_refs_in_openapi(&openapi);
+        assert!(
+            dangling.is_empty(),
+            "Expected no dangling refs but got: {dangling:?}"
+        );
+    }
+
+    #[test]
+    fn test_dangling_refs_detects_missing_in_operations() {
+        // Build an OpenAPI doc with a response $ref to "MissingDto" but no
+        // matching component schema — simulates the scenario CodeRabbit flagged.
+        let openapi_json = serde_json::json!({
+            "openapi": "3.1.0",
+            "info": { "title": "test", "version": "0.1.0" },
+            "paths": {
+                "/items": {
+                    "get": {
+                        "responses": {
+                            "200": {
+                                "description": "OK",
+                                "content": {
+                                    "application/json": {
+                                        "schema": { "$ref": "#/components/schemas/MissingDto" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "components": {
+                "schemas": {}
+            }
+        });
+        let openapi: OpenApi = serde_json::from_value(openapi_json).unwrap();
+        let dangling = collect_all_dangling_refs_in_openapi(&openapi);
+        assert_eq!(dangling, vec!["MissingDto".to_owned()]);
     }
 }

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/messages.rs
@@ -1,6 +1,5 @@
 use axum::Router;
 use modkit::api::OpenApiRegistry;
-use modkit::api::ensure_schema;
 use modkit::api::operation_builder::OperationBuilder;
 
 use super::AiChatLicense;
@@ -13,14 +12,6 @@ pub(super) fn register_message_routes(
     openapi: &dyn OpenApiRegistry,
     prefix: &str,
 ) -> Router {
-    // TODO(modkit): `ensure_schema` should resolve dangling `$ref` targets
-    //  automatically. utoipa's derived `Page<T>::schemas()` omits `T` from
-    //  its dependency list, so `Page<MessageDto>` creates a `$ref` to
-    //  `MessageDto` without registering it.  Remove this workaround once
-    //  `ensure_schema_raw` learns to walk `$ref` pointers and pull missing
-    //  schemas into the registry.
-    ensure_schema::<dto::MessageDto>(openapi);
-
     // GET {prefix}/v1/chats/{id}/messages
     router = OperationBuilder::get(format!("{prefix}/v1/chats/{{id}}/messages"))
         .operation_id("mini_chat.list_messages")


### PR DESCRIPTION
utoipa's derive macro for generic structs omits the type parameter T from the schemas() dependency list, producing dangling $ref entries.

Fix this by:
- Replacing the derived ToSchema on Page<T> with a manual impl that registers T's schema in the schemas() method
- Adding dangling $ref detection in OpenApiRegistry to warn about missing schemas
- Removing the now-unnecessary ensure_schema::<MessageDto>() workaround in mini-chat

closes #989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated API docs for paged responses so generic item types are correctly represented.
  * Added detection and warnings for missing schema references in generated OpenAPI docs to highlight invalid/missing component schemas.

* **Chores**
  * Removed an unnecessary workaround in message route registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->