### PR TITLE
feat(mini-chat): add system_prompt field and check_user_license to plugin API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,6 +1281,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "time",
+ "tokio-util",
  "uuid",
 ]
 
@@ -1919,6 +1920,7 @@ dependencies = [
  "serde_json",
  "time",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
 ]

--- a/modules/mini-chat/mini-chat-sdk/Cargo.toml
+++ b/modules/mini-chat/mini-chat-sdk/Cargo.toml
@@ -29,3 +29,4 @@ schemars = { workspace = true }
 gts = { workspace = true }
 gts-macros = { workspace = true }
 modkit = { workspace = true }
+tokio-util = { workspace = true }

--- a/modules/mini-chat/mini-chat-sdk/src/lib.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/lib.rs
@@ -14,6 +14,7 @@ pub use error::{MiniChatAuditPluginError, MiniChatModelPolicyPluginError, Publis
 pub use gts::{MiniChatAuditPluginSpecV1, MiniChatModelPolicyPluginSpecV1};
 pub use models::{
     EstimationBudgets, KillSwitches, ModelCatalogEntry, ModelGeneralConfig, ModelPreference,
-    ModelTier, PolicySnapshot, PolicyVersionInfo, TierLimits, UsageEvent, UsageTokens, UserLimits,
+    ModelTier, PolicySnapshot, PolicyVersionInfo, TierLimits, UsageEvent, UsageTokens,
+    UserLicenseStatus, UserLimits,
 };
 pub use plugin_api::{MiniChatAuditPluginClientV1, MiniChatModelPolicyPluginClientV1};

--- a/modules/mini-chat/mini-chat-sdk/src/models.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/models.rs
@@ -54,6 +54,9 @@ pub struct ModelCatalogEntry {
     pub icon: String,
     /// Model tier (standard or premium).
     pub tier: ModelTier,
+    /// System prompt applied to this model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_prompt: Option<String>,
     pub enabled: bool,
     /// Multimodal capability flags, e.g. `VISION_INPUT`, `IMAGE_GENERATION`.
     pub multimodal_capabilities: Vec<String>,
@@ -233,6 +236,14 @@ pub enum ModelTier {
     Premium,
 }
 
+/// Whether a user holds an active `CyberChat` license (API: `CheckUserLicenseResponse`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserLicenseStatus {
+    /// `true` if the user's status is `active` in the `active_users` table for this tenant.
+    /// `false` if the user is not found, or has status `invited`, `deactivated`, or `deleted`.
+    pub active: bool,
+}
+
 /// Per-user credit allocations for a specific policy version.
 /// NOT part of the immutable shared `PolicySnapshot` (DESIGN.md §5.2.6).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -319,6 +330,36 @@ mod tests {
     // The upstream API sends `"type"` not `"config_type"`. If the rename
     // attribute is removed, deserialization from the real API breaks.
 
+    fn sample_catalog_entry() -> ModelCatalogEntry {
+        ModelCatalogEntry {
+            model_id: "test-model".to_owned(),
+            provider_model_id: "test-model-v1".to_owned(),
+            display_name: "Test Model".to_owned(),
+            description: String::new(),
+            version: String::new(),
+            provider_id: "default".to_owned(),
+            provider_display_name: "Default".to_owned(),
+            icon: String::new(),
+            tier: ModelTier::Standard,
+            system_prompt: None,
+            enabled: true,
+            multimodal_capabilities: vec![],
+            context_window: 128_000,
+            max_output_tokens: 16_384,
+            max_input_tokens: 128_000,
+            input_tokens_credit_multiplier_micro: 1_000_000,
+            output_tokens_credit_multiplier_micro: 3_000_000,
+            multiplier_display: "1x".to_owned(),
+            estimation_budgets: EstimationBudgets::default(),
+            max_retrieved_chunks_per_turn: 5,
+            general_config: sample_general_config(),
+            preference: ModelPreference {
+                is_default: false,
+                sort_order: 0,
+            },
+        }
+    }
+
     fn sample_general_config() -> ModelGeneralConfig {
         ModelGeneralConfig {
             config_type: "model.general.v1".to_owned(),
@@ -404,6 +445,50 @@ mod tests {
 
         assert_eq!(deserialized.config_type, original.config_type);
         assert_eq!(deserialized.tier, original.tier);
+    }
+
+    // ── ModelCatalogEntry: system_prompt serde contract ──
+    // `system_prompt` is optional: omitted from JSON when `None`, defaults
+    // to `None` when absent in input. Removing the `#[serde(default,
+    // skip_serializing_if)]` attributes would break the API contract.
+
+    #[test]
+    fn system_prompt_none_omitted_from_json() {
+        let mut entry = sample_catalog_entry();
+        entry.system_prompt = None;
+        let json = serde_json::to_value(&entry).unwrap();
+
+        assert!(
+            json.get("system_prompt").is_none(),
+            "system_prompt must be omitted when None"
+        );
+    }
+
+    #[test]
+    fn system_prompt_absent_in_json_deserializes_to_none() {
+        let mut json = serde_json::to_value(sample_catalog_entry()).unwrap();
+        json.as_object_mut().unwrap().remove("system_prompt");
+
+        let entry: ModelCatalogEntry = serde_json::from_value(json).unwrap();
+        assert!(
+            entry.system_prompt.is_none(),
+            "missing system_prompt must deserialize to None"
+        );
+    }
+
+    #[test]
+    fn system_prompt_some_roundtrips() {
+        let mut entry = sample_catalog_entry();
+        entry.system_prompt = Some("You are a helpful assistant.".to_owned());
+
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["system_prompt"], "You are a helpful assistant.");
+
+        let deserialized: ModelCatalogEntry = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            deserialized.system_prompt.as_deref(),
+            Some("You are a helpful assistant.")
+        );
     }
 
     // ── ModelTier serde representation ──

--- a/modules/mini-chat/mini-chat-sdk/src/plugin_api.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/plugin_api.rs
@@ -1,23 +1,28 @@
 use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::audit_models::{
     TurnAuditEvent, TurnDeleteAuditEvent, TurnEditAuditEvent, TurnRetryAuditEvent,
 };
 use crate::error::{MiniChatAuditPluginError, MiniChatModelPolicyPluginError, PublishError};
-use crate::models::{PolicySnapshot, PolicyVersionInfo, UsageEvent, UserLimits};
+use crate::models::{PolicySnapshot, PolicyVersionInfo, UsageEvent, UserLicenseStatus, UserLimits};
 
 /// Plugin API trait for mini-chat model policy implementations.
 ///
 /// Plugins implement this trait to provide model catalog and policy data.
 /// The mini-chat module discovers plugins via GTS types-registry and
 /// delegates policy queries to the selected plugin.
+///
+/// Every method accepts a [`CancellationToken`] so callers can abort
+/// in-flight HTTP requests on shutdown or request cancellation.
 #[async_trait]
 pub trait MiniChatModelPolicyPluginClientV1: Send + Sync {
     /// Get the current policy version for a user.
     async fn get_current_policy_version(
         &self,
         user_id: Uuid,
+        cancel: CancellationToken,
     ) -> Result<PolicyVersionInfo, MiniChatModelPolicyPluginError>;
 
     /// Get the full policy snapshot for a given version, including
@@ -26,6 +31,7 @@ pub trait MiniChatModelPolicyPluginClientV1: Send + Sync {
         &self,
         user_id: Uuid,
         policy_version: u64,
+        cancel: CancellationToken,
     ) -> Result<PolicySnapshot, MiniChatModelPolicyPluginError>;
 
     /// Get per-user credit limits for a specific policy version.
@@ -33,13 +39,34 @@ pub trait MiniChatModelPolicyPluginClientV1: Send + Sync {
         &self,
         user_id: Uuid,
         policy_version: u64,
+        cancel: CancellationToken,
     ) -> Result<UserLimits, MiniChatModelPolicyPluginError>;
+
+    /// Check whether a user holds an active `CyberChat` license in the caller's tenant.
+    ///
+    /// Returns `active: true` when the user's status is `active`.
+    /// Returns `active: false` for any other status (`invited`, `deactivated`,
+    /// `deleted`) or when the user is not found — this is not an error condition.
+    ///
+    /// The default implementation returns `active: false` so that existing
+    /// out-of-tree V1 plugins remain compatible without code changes.
+    async fn check_user_license(
+        &self,
+        _user_id: Uuid,
+        _cancel: CancellationToken,
+    ) -> Result<UserLicenseStatus, MiniChatModelPolicyPluginError> {
+        Ok(UserLicenseStatus { active: false })
+    }
 
     /// Publish a usage event after turn finalization.
     ///
     /// Called by the outbox processor after the finalization transaction
     /// commits. Plugins can forward the event to external billing systems.
-    async fn publish_usage(&self, payload: UsageEvent) -> Result<(), PublishError>;
+    async fn publish_usage(
+        &self,
+        payload: UsageEvent,
+        cancel: CancellationToken,
+    ) -> Result<(), PublishError>;
 }
 
 /// Plugin API trait for mini-chat audit event publishing.

--- a/modules/mini-chat/mini-chat/src/domain/service/message_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/message_service_test.rs
@@ -135,6 +135,9 @@ async fn list_messages_returns_messages_chronologically() {
         .await
         .expect("insert_user_message failed");
 
+    // Ensure distinct created_at timestamps (insert_*_message uses now_utc()).
+    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+
     message_repo
         .insert_assistant_message(
             &conn,

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -358,6 +358,7 @@ pub fn test_catalog_entry(params: TestCatalogEntryParams) -> ModelCatalogEntry {
         provider_display_name: params.provider_display_name,
         icon: String::new(),
         tier: params.tier,
+        system_prompt: None,
         enabled: params.enabled,
         multimodal_capabilities: params.multimodal_capabilities,
         context_window: params.context_window,

--- a/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
@@ -6,6 +6,7 @@ use mini_chat_sdk::{
 };
 use modkit::client_hub::{ClientHub, ClientScope};
 use modkit::plugins::{GtsPluginSelector, choose_plugin_instance};
+use tokio_util::sync::CancellationToken;
 use types_registry_sdk::{ListQuery, TypesRegistryClient};
 use uuid::Uuid;
 
@@ -20,14 +21,16 @@ pub struct ModelPolicyGateway {
     hub: Arc<ClientHub>,
     vendor: String,
     policy_selector: GtsPluginSelector,
+    cancel: CancellationToken,
 }
 
 impl ModelPolicyGateway {
-    pub(crate) fn new(hub: Arc<ClientHub>, vendor: String) -> Self {
+    pub(crate) fn new(hub: Arc<ClientHub>, vendor: String, cancel: CancellationToken) -> Self {
         Self {
             hub,
             vendor,
             policy_selector: GtsPluginSelector::new(),
+            cancel,
         }
     }
 
@@ -55,11 +58,11 @@ impl ModelPolicyGateway {
     async fn current_snapshot(&self, user_id: Uuid) -> Result<PolicySnapshot, DomainError> {
         let plugin = self.get_policy_plugin().await?;
         let version_info = plugin
-            .get_current_policy_version(user_id)
+            .get_current_policy_version(user_id, self.cancel.clone())
             .await
             .map_err(|e| DomainError::internal(e.to_string()))?;
         plugin
-            .get_policy_snapshot(user_id, version_info.policy_version)
+            .get_policy_snapshot(user_id, version_info.policy_version, self.cancel.clone())
             .await
             .map_err(|e| DomainError::internal(e.to_string()))
     }
@@ -161,7 +164,7 @@ impl PolicySnapshotProvider for ModelPolicyGateway {
     ) -> Result<PolicySnapshot, DomainError> {
         let plugin = self.get_policy_plugin().await?;
         plugin
-            .get_policy_snapshot(user_id, policy_version)
+            .get_policy_snapshot(user_id, policy_version, self.cancel.clone())
             .await
             .map_err(|e| DomainError::internal(e.to_string()))
     }
@@ -169,7 +172,7 @@ impl PolicySnapshotProvider for ModelPolicyGateway {
     async fn get_current_version(&self, user_id: Uuid) -> Result<u64, DomainError> {
         let plugin = self.get_policy_plugin().await?;
         let info = plugin
-            .get_current_policy_version(user_id)
+            .get_current_policy_version(user_id, self.cancel.clone())
             .await
             .map_err(|e| DomainError::internal(e.to_string()))?;
         Ok(info.policy_version)
@@ -185,7 +188,7 @@ impl UserLimitsProvider for ModelPolicyGateway {
     ) -> Result<UserLimits, DomainError> {
         let plugin = self.get_policy_plugin().await?;
         plugin
-            .get_user_limits(user_id, policy_version)
+            .get_user_limits(user_id, policy_version, self.cancel.clone())
             .await
             .map_err(|e| DomainError::internal(e.to_string()))
     }

--- a/modules/mini-chat/mini-chat/src/infra/outbox.rs
+++ b/modules/mini-chat/mini-chat/src/infra/outbox.rs
@@ -123,7 +123,7 @@ impl modkit_db::outbox::MessageHandler for UsageEventHandler {
     async fn handle(
         &self,
         msg: &modkit_db::outbox::OutboxMessage,
-        _cancel: tokio_util::sync::CancellationToken,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> modkit_db::outbox::HandlerResult {
         let event = match serde_json::from_slice::<UsageEvent>(&msg.payload) {
             Ok(e) => e,
@@ -169,7 +169,7 @@ impl modkit_db::outbox::MessageHandler for UsageEventHandler {
             }
         };
 
-        match plugin.publish_usage(event).await {
+        match plugin.publish_usage(event, cancel).await {
             Ok(()) => modkit_db::outbox::HandlerResult::Success,
             Err(PublishError::Transient(reason)) => {
                 warn!(
@@ -278,6 +278,7 @@ mod tests {
         async fn get_current_policy_version(
             &self,
             _user_id: Uuid,
+            _cancel: CancellationToken,
         ) -> Result<PolicyVersionInfo, MiniChatModelPolicyPluginError> {
             unimplemented!("not needed in outbox tests")
         }
@@ -286,6 +287,7 @@ mod tests {
             &self,
             _user_id: Uuid,
             _policy_version: u64,
+            _cancel: CancellationToken,
         ) -> Result<PolicySnapshot, MiniChatModelPolicyPluginError> {
             unimplemented!("not needed in outbox tests")
         }
@@ -294,11 +296,24 @@ mod tests {
             &self,
             _user_id: Uuid,
             _policy_version: u64,
+            _cancel: CancellationToken,
         ) -> Result<UserLimits, MiniChatModelPolicyPluginError> {
             unimplemented!("not needed in outbox tests")
         }
 
-        async fn publish_usage(&self, _payload: UsageEvent) -> Result<(), PublishError> {
+        async fn check_user_license(
+            &self,
+            _user_id: Uuid,
+            _cancel: CancellationToken,
+        ) -> Result<mini_chat_sdk::UserLicenseStatus, MiniChatModelPolicyPluginError> {
+            unimplemented!("not needed in outbox tests")
+        }
+
+        async fn publish_usage(
+            &self,
+            _payload: UsageEvent,
+            _cancel: CancellationToken,
+        ) -> Result<(), PublishError> {
             self.call_count.fetch_add(1, Ordering::SeqCst);
             let result = {
                 let guard = self.result.lock().unwrap();

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -118,7 +118,11 @@ impl Module for MiniChatModule {
         let db = Arc::new(db_provider);
 
         // Create the model-policy gateway early for both outbox handler and services.
-        let model_policy_gw = Arc::new(ModelPolicyGateway::new(ctx.client_hub(), vendor));
+        let model_policy_gw = Arc::new(ModelPolicyGateway::new(
+            ctx.client_hub(),
+            vendor,
+            ctx.cancellation_token().clone(),
+        ));
 
         // Start the outbox pipeline eagerly in init() (migrations ran in phase 2, DB is ready).
         // The framework guarantees stop() is called on init failure, so the pipeline

--- a/modules/mini-chat/plugins/static-model-policy-plugin/Cargo.toml
+++ b/modules/mini-chat/plugins/static-model-policy-plugin/Cargo.toml
@@ -24,6 +24,7 @@ modkit-macros = { workspace = true }
 
 # Async runtime
 async-trait = { workspace = true }
+tokio-util = { workspace = true }
 
 # Data structures
 uuid = { workspace = true }

--- a/modules/mini-chat/plugins/static-model-policy-plugin/src/domain/client.rs
+++ b/modules/mini-chat/plugins/static-model-policy-plugin/src/domain/client.rs
@@ -1,9 +1,10 @@
 use async_trait::async_trait;
 use mini_chat_sdk::{
     MiniChatModelPolicyPluginClientV1, MiniChatModelPolicyPluginError, PolicySnapshot,
-    PolicyVersionInfo, PublishError, UsageEvent, UserLimits,
+    PolicyVersionInfo, PublishError, UsageEvent, UserLicenseStatus, UserLimits,
 };
 use time::OffsetDateTime;
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use uuid::Uuid;
 
@@ -14,6 +15,7 @@ impl MiniChatModelPolicyPluginClientV1 for Service {
     async fn get_current_policy_version(
         &self,
         user_id: Uuid,
+        _cancel: CancellationToken,
     ) -> Result<PolicyVersionInfo, MiniChatModelPolicyPluginError> {
         Ok(PolicyVersionInfo {
             user_id,
@@ -26,6 +28,7 @@ impl MiniChatModelPolicyPluginClientV1 for Service {
         &self,
         user_id: Uuid,
         policy_version: u64,
+        _cancel: CancellationToken,
     ) -> Result<PolicySnapshot, MiniChatModelPolicyPluginError> {
         if policy_version != 1 {
             return Err(MiniChatModelPolicyPluginError::NotFound);
@@ -42,6 +45,7 @@ impl MiniChatModelPolicyPluginClientV1 for Service {
         &self,
         user_id: Uuid,
         policy_version: u64,
+        _cancel: CancellationToken,
     ) -> Result<UserLimits, MiniChatModelPolicyPluginError> {
         if policy_version != 1 {
             return Err(MiniChatModelPolicyPluginError::NotFound);
@@ -55,7 +59,20 @@ impl MiniChatModelPolicyPluginClientV1 for Service {
         })
     }
 
-    async fn publish_usage(&self, payload: UsageEvent) -> Result<(), PublishError> {
+    async fn check_user_license(
+        &self,
+        _user_id: Uuid,
+        _cancel: CancellationToken,
+    ) -> Result<UserLicenseStatus, MiniChatModelPolicyPluginError> {
+        // Static plugin assumes all users are licensed.
+        Ok(UserLicenseStatus { active: true })
+    }
+
+    async fn publish_usage(
+        &self,
+        payload: UsageEvent,
+        _cancel: CancellationToken,
+    ) -> Result<(), PublishError> {
         debug!(
             turn_id = %payload.turn_id,
             tenant_id = %payload.tenant_id,
@@ -94,6 +111,7 @@ mod tests {
             provider_display_name: "Default".to_owned(),
             icon: String::new(),
             tier,
+            system_prompt: None,
             enabled: true,
             multimodal_capabilities: vec![],
             context_window: 128_000,
@@ -185,13 +203,20 @@ mod tests {
         )
     }
 
+    fn token() -> CancellationToken {
+        CancellationToken::new()
+    }
+
     // ── get_current_policy_version ──
 
     #[tokio::test]
     async fn policy_version_echoes_user_id() {
         let svc = test_service();
         let user_id = Uuid::new_v4();
-        let info = svc.get_current_policy_version(user_id).await.unwrap();
+        let info = svc
+            .get_current_policy_version(user_id, token())
+            .await
+            .unwrap();
 
         assert_eq!(info.user_id, user_id);
         assert_eq!(info.policy_version, 1);
@@ -202,7 +227,7 @@ mod tests {
         let before = OffsetDateTime::now_utc();
         let svc = test_service();
         let info = svc
-            .get_current_policy_version(Uuid::new_v4())
+            .get_current_policy_version(Uuid::new_v4(), token())
             .await
             .unwrap();
         let after = OffsetDateTime::now_utc();
@@ -217,7 +242,7 @@ mod tests {
     async fn snapshot_version_1_returns_catalog() {
         let svc = test_service();
         let user_id = Uuid::new_v4();
-        let snap = svc.get_policy_snapshot(user_id, 1).await.unwrap();
+        let snap = svc.get_policy_snapshot(user_id, 1, token()).await.unwrap();
 
         assert_eq!(snap.user_id, user_id);
         assert_eq!(snap.policy_version, 1);
@@ -228,7 +253,9 @@ mod tests {
     async fn snapshot_wrong_version_returns_not_found() {
         let svc = test_service();
         for version in [0, 2, 100, u64::MAX] {
-            let result = svc.get_policy_snapshot(Uuid::new_v4(), version).await;
+            let result = svc
+                .get_policy_snapshot(Uuid::new_v4(), version, token())
+                .await;
             assert!(
                 matches!(result, Err(MiniChatModelPolicyPluginError::NotFound)),
                 "version {version} should return NotFound"
@@ -248,7 +275,10 @@ mod tests {
             cfg.default_standard_limits,
             cfg.default_premium_limits,
         );
-        let snap = svc.get_policy_snapshot(Uuid::new_v4(), 1).await.unwrap();
+        let snap = svc
+            .get_policy_snapshot(Uuid::new_v4(), 1, token())
+            .await
+            .unwrap();
 
         assert!(snap.kill_switches.disable_premium_tier);
         assert!(snap.kill_switches.disable_web_search);
@@ -258,7 +288,10 @@ mod tests {
     #[tokio::test]
     async fn snapshot_contains_both_tiers() {
         let svc = test_service();
-        let snap = svc.get_policy_snapshot(Uuid::new_v4(), 1).await.unwrap();
+        let snap = svc
+            .get_policy_snapshot(Uuid::new_v4(), 1, token())
+            .await
+            .unwrap();
 
         let has_premium = snap
             .model_catalog
@@ -273,13 +306,26 @@ mod tests {
         assert!(has_standard, "catalog must include a standard model");
     }
 
+    // ── check_user_license ──
+
+    #[tokio::test]
+    async fn check_user_license_returns_active() {
+        let svc = test_service();
+        let status = svc
+            .check_user_license(Uuid::new_v4(), token())
+            .await
+            .unwrap();
+
+        assert!(status.active, "static plugin should always return active");
+    }
+
     // ── get_user_limits: version gating ──
 
     #[tokio::test]
     async fn user_limits_version_1_returns_configured_limits() {
         let svc = test_service();
         let user_id = Uuid::new_v4();
-        let limits = svc.get_user_limits(user_id, 1).await.unwrap();
+        let limits = svc.get_user_limits(user_id, 1, token()).await.unwrap();
 
         assert_eq!(limits.user_id, user_id);
         assert_eq!(limits.policy_version, 1);
@@ -294,7 +340,7 @@ mod tests {
     async fn user_limits_wrong_version_returns_not_found() {
         let svc = test_service();
         for version in [0, 2, 100, u64::MAX] {
-            let result = svc.get_user_limits(Uuid::new_v4(), version).await;
+            let result = svc.get_user_limits(Uuid::new_v4(), version, token()).await;
             assert!(
                 matches!(result, Err(MiniChatModelPolicyPluginError::NotFound)),
                 "version {version} should return NotFound"
@@ -314,7 +360,10 @@ mod tests {
             cfg.default_standard_limits,
             cfg.default_premium_limits,
         );
-        let limits = svc.get_user_limits(Uuid::new_v4(), 1).await.unwrap();
+        let limits = svc
+            .get_user_limits(Uuid::new_v4(), 1, token())
+            .await
+            .unwrap();
 
         assert_eq!(limits.standard.limit_daily_credits_micro, 42);
         assert_eq!(limits.premium.limit_monthly_credits_micro, 99);


### PR DESCRIPTION
Add optional system_prompt to ModelCatalogEntry and introduce check_user_license method on MiniChatModelPolicyPluginClientV1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added user license status checking capability to verify user access eligibility.
  * Added system prompt support to model catalog entries for customized model behavior configuration.
  * Enhanced policy plugin API with cancellation support for improved operation responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->