### PR TITLE
feat(mini-chat): add turn context assembly for multi-turn conversations

### DIFF
--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -177,6 +177,11 @@ modules:
           icon: ""
           tier: Premium
           enabled: true
+          # System prompt sent as `instructions` in every LLM request for this model.
+          # Omit or leave empty for no system instructions.
+          system_prompt: "You are a helpful, concise assistant. Answer clearly and directly."
+          # Prompt template for thread summary generation (future use).
+          # thread_summary_prompt: "Summarize the key points of this conversation."
           multimodal_capabilities: ["VISION_INPUT"]
           context_window: 1047576
           max_output_tokens: 32768
@@ -261,6 +266,7 @@ modules:
           icon: ""
           tier: Standard
           enabled: true
+          system_prompt: "You are a helpful, concise assistant. Answer clearly and directly."
           multimodal_capabilities: ["VISION_INPUT"]
           context_window: 1047576
           max_output_tokens: 32768

--- a/modules/mini-chat/mini-chat-sdk/src/models.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/models.rs
@@ -77,6 +77,14 @@ pub struct ModelCatalogEntry {
     pub general_config: ModelGeneralConfig,
     /// Tenant preference settings captured at snapshot time.
     pub preference: ModelPreference,
+    /// System prompt sent as `instructions` in every LLM request for this model.
+    /// Empty string = no system instructions.
+    #[serde(default)]
+    pub system_prompt: String,
+    /// Prompt template used when generating thread summaries for this model.
+    /// Plumbed through the stack for future use by the summary generation job.
+    #[serde(default)]
+    pub thread_summary_prompt: String,
 }
 
 /// Per-model token estimation budget parameters (API: `PolicyModelEstimationBudgets`).

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
@@ -203,6 +203,7 @@ async fn start_mutation_stream(
             mutation.new_turn_id,
             mutation.user_content,
             resolved,
+            mutation.snapshot_boundary,
             cancel.clone(),
             tx,
         )

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -20,6 +20,8 @@ pub struct MiniChatConfig {
     pub quota: QuotaConfig,
     #[serde(default)]
     pub outbox: OutboxConfig,
+    #[serde(default)]
+    pub context: ContextConfig,
     /// Provider registry. Key = `provider_id` (matches [`ModelCatalogEntry::provider_id`]).
     #[expand_vars]
     #[serde(default = "default_providers")]
@@ -172,6 +174,7 @@ impl Default for MiniChatConfig {
             estimation_budgets: EstimationBudgets::default(),
             quota: QuotaConfig::default(),
             outbox: OutboxConfig::default(),
+            context: ContextConfig::default(),
             providers: default_providers(),
         }
     }
@@ -322,6 +325,57 @@ fn default_overshoot_tolerance() -> f64 {
     1.10
 }
 
+/// Context assembly configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContextConfig {
+    /// Soft-guideline instruction appended to system prompt when `web_search` is enabled.
+    #[serde(default = "default_web_search_guard")]
+    pub web_search_guard: String,
+
+    /// Soft-guideline instruction appended to system prompt when `file_search` is enabled.
+    #[serde(default = "default_file_search_guard")]
+    pub file_search_guard: String,
+
+    /// Maximum number of recent messages to include in context. Range: 0–100.
+    #[serde(default = "default_recent_messages_limit")]
+    pub recent_messages_limit: u32,
+}
+
+impl Default for ContextConfig {
+    fn default() -> Self {
+        Self {
+            web_search_guard: default_web_search_guard(),
+            file_search_guard: default_file_search_guard(),
+            recent_messages_limit: default_recent_messages_limit(),
+        }
+    }
+}
+
+impl ContextConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.recent_messages_limit > 100 {
+            return Err(format!(
+                "context recent_messages_limit must be 0-100, got {}",
+                self.recent_messages_limit
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn default_web_search_guard() -> String {
+    "Use web_search only if the answer cannot be obtained from the provided context or your training data. Never use it for general knowledge questions. At most one web_search call per request.".to_owned()
+}
+
+fn default_file_search_guard() -> String {
+    "Use file_search to find relevant information in the user's uploaded documents. Prefer file_search over general knowledge when documents are available.".to_owned()
+}
+
+fn default_recent_messages_limit() -> u32 {
+    10
+}
+
 fn default_url_prefix() -> String {
     DEFAULT_URL_PREFIX.to_owned()
 }
@@ -340,6 +394,7 @@ mod tests {
         EstimationBudgets::default().validate().unwrap();
         QuotaConfig::default().validate().unwrap();
         OutboxConfig::default().validate().unwrap();
+        ContextConfig::default().validate().unwrap();
     }
 
     #[test]

--- a/modules/mini-chat/mini-chat/src/domain/llm.rs
+++ b/modules/mini-chat/mini-chat/src/domain/llm.rs
@@ -1,0 +1,113 @@
+//! Domain-level LLM value types.
+//!
+//! Provider-agnostic types for LLM request construction. These are pure data
+//! types with no infrastructure dependencies. Provider adapters in `infra::llm`
+//! consume these types and map them to wire formats.
+
+use modkit_macros::domain_model;
+use serde::Serialize;
+
+// ════════════════════════════════════════════════════════════════════════════
+// Message types
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A role in the conversation.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    User,
+    Assistant,
+    System,
+}
+
+/// A content part within a message.
+#[domain_model]
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum ContentPart {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "image")]
+    Image { file_id: String },
+}
+
+/// A single message in the conversation.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct LlmMessage {
+    pub role: Role,
+    pub content: Vec<ContentPart>,
+}
+
+impl LlmMessage {
+    /// Create a user message with text content.
+    #[must_use]
+    pub fn user(text: impl Into<String>) -> Self {
+        LlmMessage {
+            role: Role::User,
+            content: vec![ContentPart::Text { text: text.into() }],
+        }
+    }
+
+    /// Create an assistant message with text content.
+    #[must_use]
+    pub fn assistant(text: impl Into<String>) -> Self {
+        LlmMessage {
+            role: Role::Assistant,
+            content: vec![ContentPart::Text { text: text.into() }],
+        }
+    }
+
+    /// Create a user message with text and an image.
+    #[must_use]
+    pub fn user_with_image(text: impl Into<String>, file_id: impl Into<String>) -> Self {
+        LlmMessage {
+            role: Role::User,
+            content: vec![
+                ContentPart::Text { text: text.into() },
+                ContentPart::Image {
+                    file_id: file_id.into(),
+                },
+            ],
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Tool types
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A provider-agnostic tool descriptor.
+///
+/// Each adapter maps supported tools to its wire format and silently drops
+/// unsupported ones with a `debug!` log.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub enum LlmTool {
+    /// Server-side file search (provider manages execution).
+    FileSearch { vector_store_ids: Vec<String> },
+    /// Server-side web search (provider manages execution).
+    WebSearch,
+    /// Generic function tool (for providers supporting function calling).
+    Function {
+        name: String,
+        description: String,
+        parameters: serde_json::Value,
+    },
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Context assembly input types
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Minimal message representation for context assembly input.
+///
+/// Decouples context assembly from ORM entities — only carries the fields
+/// needed for LLM prompt construction.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct ContextMessage {
+    pub role: Role,
+    pub content: String,
+}

--- a/modules/mini-chat/mini-chat/src/domain/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/mod.rs
@@ -4,6 +4,7 @@
 #![allow(de0301_no_infra_in_domain)]
 
 pub mod error;
+pub mod llm;
 pub mod model;
 pub mod models;
 pub mod repos;

--- a/modules/mini-chat/mini-chat/src/domain/model/quota.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/quota.rs
@@ -14,6 +14,8 @@ pub enum PreflightDecision {
         reserved_credits_micro: i64,
         policy_version_applied: i64,
         minimal_generation_floor_applied: i32,
+        /// System prompt for the effective model (from `ModelCatalogEntry`).
+        system_prompt: String,
     },
     Downgrade {
         effective_model: String,
@@ -24,6 +26,8 @@ pub enum PreflightDecision {
         minimal_generation_floor_applied: i32,
         downgrade_from: String,
         downgrade_reason: DowngradeReason,
+        /// System prompt for the effective model (from `ModelCatalogEntry`).
+        system_prompt: String,
     },
     Reject {
         error_code: String,

--- a/modules/mini-chat/mini-chat/src/domain/models.rs
+++ b/modules/mini-chat/mini-chat/src/domain/models.rs
@@ -161,6 +161,9 @@ pub struct ResolvedModel {
     pub description: Option<String>,
     pub multimodal_capabilities: Vec<String>,
     pub context_window: u32,
+    /// System prompt sent as `instructions` in every LLM request for this model.
+    /// Sourced from `ModelCatalogEntry.system_prompt` (per-model, per-policy-version).
+    pub system_prompt: String,
 }
 
 impl From<&mini_chat_sdk::ModelCatalogEntry> for ResolvedModel {
@@ -182,6 +185,7 @@ impl From<&mini_chat_sdk::ModelCatalogEntry> for ResolvedModel {
             },
             multimodal_capabilities: e.multimodal_capabilities.clone(),
             context_window: e.context_window,
+            system_prompt: e.system_prompt.clone(),
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
@@ -4,11 +4,26 @@ use async_trait::async_trait;
 use modkit_db::secure::DBRunner;
 use modkit_macros::domain_model;
 use modkit_security::AccessScope;
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::domain::error::DomainError;
 use crate::domain::models::AttachmentSummary;
 use crate::infra::db::entity::message::Model as MessageModel;
+
+/// Snapshot boundary for deterministic context assembly.
+///
+/// Computed once before the current user message is persisted.
+/// Context queries MUST include only messages where
+/// `(created_at, id) <= (boundary_created_at, boundary_id)`.
+///
+/// See DESIGN.md `§ContextPlan` Determinism and Snapshot Boundary (P1).
+#[domain_model]
+#[derive(Debug, Clone, Copy)]
+pub struct SnapshotBoundary {
+    pub created_at: OffsetDateTime,
+    pub id: Uuid,
+}
 
 /// Parameters for inserting a user message.
 #[domain_model]
@@ -36,7 +51,7 @@ pub struct InsertAssistantMessageParams {
 
 /// Repository trait for message persistence operations.
 #[async_trait]
-#[allow(dead_code)]
+#[allow(dead_code, clippy::too_many_arguments)]
 pub trait MessageRepository: Send + Sync {
     /// INSERT a user message linked to a turn's `request_id`.
     async fn insert_user_message<C: DBRunner>(
@@ -102,4 +117,45 @@ pub trait MessageRepository: Send + Sync {
         chat_id: Uuid,
         message_ids: &[Uuid],
     ) -> Result<HashMap<Uuid, Vec<AttachmentSummary>>, DomainError>;
+
+    /// Fetch the snapshot boundary: the latest message's `(created_at, id)` in the chat.
+    ///
+    /// Returns `None` if the chat has no messages yet. Must be called BEFORE
+    /// persisting the current user message to establish the deterministic boundary.
+    async fn snapshot_boundary<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<SnapshotBoundary>, DomainError>;
+
+    /// Fetch the most recent K messages for context assembly.
+    ///
+    /// Returns messages where `(created_at, id) <= snapshot_boundary` (if provided),
+    /// `deleted_at IS NULL`, and `request_id IS NOT NULL`,
+    /// ordered chronologically (oldest first). The query fetches DESC then reverses.
+    async fn recent_for_context<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        limit: u32,
+        boundary: Option<SnapshotBoundary>,
+    ) -> Result<Vec<MessageModel>, DomainError>;
+
+    /// Fetch recent messages after a thread summary boundary for context assembly.
+    ///
+    /// Same as [`recent_for_context`] but only returns messages with
+    /// `(created_at, id) > (lower_created_at, lower_id)` AND
+    /// `(created_at, id) <= snapshot_boundary` (if provided).
+    async fn recent_after_boundary<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        lower_created_at: time::OffsetDateTime,
+        lower_id: Uuid,
+        limit: u32,
+        boundary: Option<SnapshotBoundary>,
+    ) -> Result<Vec<MessageModel>, DomainError>;
 }

--- a/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
@@ -6,7 +6,7 @@ mod outbox_enqueuer;
 mod policy_snapshot_provider;
 mod quota_usage_repo;
 mod reaction_repo;
-mod thread_summary_repo;
+pub(crate) mod thread_summary_repo;
 mod turn_repo;
 mod user_limits_provider;
 mod vector_store_repo;
@@ -14,14 +14,14 @@ mod vector_store_repo;
 pub(crate) use attachment_repo::AttachmentRepository;
 pub(crate) use chat_repo::ChatRepository;
 pub(crate) use message_repo::{
-    InsertAssistantMessageParams, InsertUserMessageParams, MessageRepository,
+    InsertAssistantMessageParams, InsertUserMessageParams, MessageRepository, SnapshotBoundary,
 };
 pub(crate) use model_resolver::ModelResolver;
 pub(crate) use outbox_enqueuer::OutboxEnqueuer;
 pub(crate) use policy_snapshot_provider::PolicySnapshotProvider;
 pub(crate) use quota_usage_repo::{IncrementReserveParams, QuotaUsageRepository, SettleParams};
 pub(crate) use reaction_repo::{ReactionRepository, UpsertReactionParams};
-pub(crate) use thread_summary_repo::ThreadSummaryRepository;
+pub(crate) use thread_summary_repo::{ThreadSummaryModel, ThreadSummaryRepository};
 pub(crate) use turn_repo::{
     CasCompleteParams, CasTerminalParams, CreateTurnParams, TurnRepository,
 };

--- a/modules/mini-chat/mini-chat/src/domain/repos/thread_summary_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/thread_summary_repo.rs
@@ -1,2 +1,31 @@
+use async_trait::async_trait;
+use modkit_db::secure::DBRunner;
+use modkit_macros::domain_model;
+use modkit_security::AccessScope;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+
+/// Domain model for a thread summary used in context assembly.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct ThreadSummaryModel {
+    pub content: String,
+    pub boundary_message_id: Uuid,
+    pub boundary_created_at: OffsetDateTime,
+}
+
 /// Repository trait for thread summary persistence operations.
-pub trait ThreadSummaryRepository: Send + Sync {}
+#[async_trait]
+pub trait ThreadSummaryRepository: Send + Sync {
+    /// Fetch the latest thread summary for a chat.
+    ///
+    /// Returns `None` if no summary exists (graceful degradation for P1).
+    async fn get_latest<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<ThreadSummaryModel>, DomainError>;
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
@@ -17,20 +17,20 @@ use super::{DbProvider, actions, resources};
 
 /// Service handling chat CRUD operations.
 #[domain_model]
-pub struct ChatService<CR: ChatRepository> {
+pub struct ChatService<CR: ChatRepository, TSR: ThreadSummaryRepository> {
     db: Arc<DbProvider>,
     chat_repo: Arc<CR>,
     #[allow(dead_code)]
-    thread_summary_repo: Arc<dyn ThreadSummaryRepository>,
+    thread_summary_repo: Arc<TSR>,
     enforcer: PolicyEnforcer,
     model_resolver: Arc<dyn ModelResolver>,
 }
 
-impl<CR: ChatRepository + 'static> ChatService<CR> {
+impl<CR: ChatRepository + 'static, TSR: ThreadSummaryRepository + 'static> ChatService<CR, TSR> {
     pub(crate) fn new(
         db: Arc<DbProvider>,
         chat_repo: Arc<CR>,
-        thread_summary_repo: Arc<dyn ThreadSummaryRepository>,
+        thread_summary_repo: Arc<TSR>,
         enforcer: PolicyEnforcer,
         model_resolver: Arc<dyn ModelResolver>,
     ) -> Self {

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
@@ -9,13 +9,13 @@ use crate::infra::db::repo::chat_repo::ChatRepository as OrmChatRepository;
 
 use super::ChatService;
 use crate::domain::service::test_helpers::{
-    inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver, mock_thread_summary_repo,
-    test_security_ctx, test_security_ctx_with_id,
+    MockThreadSummaryRepo, inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver,
+    mock_thread_summary_repo, test_security_ctx, test_security_ctx_with_id,
 };
 
 // ── Test Helpers ──
 
-fn build_service(db: modkit_db::Db) -> ChatService<OrmChatRepository> {
+fn build_service(db: modkit_db::Db) -> ChatService<OrmChatRepository, MockThreadSummaryRepo> {
     let db = mock_db_provider(db);
     let chat_repo = Arc::new(OrmChatRepository::new(modkit_db::odata::LimitCfg {
         default: 20,

--- a/modules/mini-chat/mini-chat/src/domain/service/context_assembly.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/context_assembly.rs
@@ -1,0 +1,365 @@
+//! Pure context assembly for LLM requests.
+//!
+//! Assembles system instructions, conversation messages, and tool definitions
+//! from domain inputs. No I/O, no async — all data is gathered beforehand.
+
+use modkit_macros::domain_model;
+
+use crate::domain::llm::{ContextMessage, LlmMessage, LlmTool, Role};
+
+/// All inputs needed to assemble the LLM request context.
+#[domain_model]
+pub struct ContextInput<'a> {
+    /// System prompt from the model catalog (via preflight).
+    pub system_prompt: &'a str,
+    /// Guard instruction appended when `web_search` is enabled.
+    pub web_search_guard: &'a str,
+    /// Guard instruction appended when `file_search` is enabled.
+    pub file_search_guard: &'a str,
+    /// Thread summary content (if exists).
+    pub thread_summary: Option<&'a str>,
+    /// Recent messages from DB, already in chronological order.
+    pub recent_messages: &'a [ContextMessage],
+    /// Current user message text.
+    pub user_message: &'a str,
+    /// Whether `web_search` tool is enabled for this request.
+    pub web_search_enabled: bool,
+    /// Whether `file_search` tool is enabled for this request.
+    pub file_search_enabled: bool,
+    /// Vector store IDs for `file_search` (empty = no `file_search` tool).
+    pub vector_store_ids: &'a [String],
+}
+
+/// Output of context assembly — ready to feed into `LlmRequestBuilder`.
+#[domain_model]
+pub struct AssembledContext {
+    /// System instructions (None if empty).
+    pub system_instructions: Option<String>,
+    /// Conversation messages in normative order.
+    pub messages: Vec<LlmMessage>,
+    /// Tool definitions to include in the request.
+    pub tools: Vec<LlmTool>,
+}
+
+/// Assemble the LLM request context from gathered domain inputs.
+///
+/// Normative order:
+/// 1. System prompt + tool guards → `system_instructions`
+/// 2. Thread summary (as user message with prefix) → first message
+/// 3. Recent messages (role-mapped) → middle messages
+/// 4. Current user message → last message
+#[must_use]
+pub fn assemble_context(input: &ContextInput<'_>) -> AssembledContext {
+    // ── System instructions ──
+    let system_instructions = build_system_instructions(
+        input.system_prompt,
+        input.web_search_enabled,
+        input.web_search_guard,
+        input.file_search_enabled,
+        input.file_search_guard,
+    );
+
+    // ── Messages ──
+    let mut messages = Vec::new();
+
+    // Thread summary as first message (if present)
+    if let Some(summary) = input.thread_summary {
+        messages.push(LlmMessage::user(format!("[Thread Summary]\n{summary}")));
+    }
+
+    // Recent messages (role-mapped)
+    for msg in input.recent_messages {
+        match msg.role {
+            Role::User => messages.push(LlmMessage::user(&msg.content)),
+            Role::Assistant => messages.push(LlmMessage::assistant(&msg.content)),
+            Role::System => {
+                // System messages are not included in context assembly.
+            }
+        }
+    }
+
+    // Current user message (always last)
+    messages.push(LlmMessage::user(input.user_message));
+
+    // ── Tools ──
+    let mut tools = Vec::new();
+    if input.file_search_enabled && !input.vector_store_ids.is_empty() {
+        tools.push(LlmTool::FileSearch {
+            vector_store_ids: input.vector_store_ids.to_vec(),
+        });
+    }
+    if input.web_search_enabled {
+        tools.push(LlmTool::WebSearch);
+    }
+
+    AssembledContext {
+        system_instructions,
+        messages,
+        tools,
+    }
+}
+
+/// Build system instructions from base prompt + conditional guard strings.
+/// Returns `None` if the result would be empty.
+fn build_system_instructions(
+    system_prompt: &str,
+    web_search_enabled: bool,
+    web_search_guard: &str,
+    file_search_enabled: bool,
+    file_search_guard: &str,
+) -> Option<String> {
+    let mut parts: Vec<&str> = Vec::new();
+
+    if !system_prompt.is_empty() {
+        parts.push(system_prompt);
+    }
+    if web_search_enabled && !web_search_guard.is_empty() {
+        parts.push(web_search_guard);
+    }
+    if file_search_enabled && !file_search_guard.is_empty() {
+        parts.push(file_search_guard);
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("\n\n"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_message(role: Role, content: &str) -> ContextMessage {
+        ContextMessage {
+            role,
+            content: content.to_owned(),
+        }
+    }
+
+    // 5.6: empty system prompt + no tools → system_instructions: None, tools: []
+    #[test]
+    fn empty_system_prompt_no_tools() {
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "hello",
+            web_search_enabled: false,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+        });
+        assert!(result.system_instructions.is_none());
+        assert!(result.tools.is_empty());
+        assert_eq!(result.messages.len(), 1);
+    }
+
+    // 5.7: system prompt + web_search enabled → guard appended
+    #[test]
+    fn system_prompt_with_web_search_guard() {
+        let result = assemble_context(&ContextInput {
+            system_prompt: "You are helpful.",
+            web_search_guard: "Use web_search only if needed.",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "hello",
+            web_search_enabled: true,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+        });
+        let instructions = result.system_instructions.unwrap();
+        assert!(instructions.contains("You are helpful."));
+        assert!(instructions.contains("Use web_search only if needed."));
+    }
+
+    // 5.8: system prompt + file_search enabled → guard appended
+    #[test]
+    fn system_prompt_with_file_search_guard() {
+        let result = assemble_context(&ContextInput {
+            system_prompt: "You are helpful.",
+            web_search_guard: "",
+            file_search_guard: "Use file_search for documents.",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "hello",
+            web_search_enabled: false,
+            file_search_enabled: true,
+            vector_store_ids: &["vs-1".to_owned()],
+        });
+        let instructions = result.system_instructions.unwrap();
+        assert!(instructions.contains("You are helpful."));
+        assert!(instructions.contains("Use file_search for documents."));
+    }
+
+    // 5.9: both guards appended when both tools enabled
+    #[test]
+    fn both_guards_appended() {
+        let result = assemble_context(&ContextInput {
+            system_prompt: "Base prompt.",
+            web_search_guard: "web guard",
+            file_search_guard: "file guard",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "hello",
+            web_search_enabled: true,
+            file_search_enabled: true,
+            vector_store_ids: &["vs-1".to_owned()],
+        });
+        let instructions = result.system_instructions.unwrap();
+        assert!(instructions.contains("Base prompt."));
+        assert!(instructions.contains("web guard"));
+        assert!(instructions.contains("file guard"));
+    }
+
+    // 5.10: thread summary present → included as first message with prefix
+    #[test]
+    fn thread_summary_included_as_first_message() {
+        let recent = vec![make_message(Role::User, "prior question")];
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: Some("Summary of prior conversation."),
+            recent_messages: &recent,
+            user_message: "new question",
+            web_search_enabled: false,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+        });
+        // First message should be the thread summary
+        assert_eq!(result.messages.len(), 3); // summary + recent + current
+        let first_content = &result.messages[0].content;
+        match &first_content[0] {
+            crate::domain::llm::ContentPart::Text { text } => {
+                assert!(text.contains("[Thread Summary]"));
+                assert!(text.contains("Summary of prior conversation."));
+            }
+            crate::domain::llm::ContentPart::Image { .. } => {
+                panic!("Expected text content")
+            }
+        }
+    }
+
+    // 5.11: no thread summary → messages start with recent history
+    #[test]
+    fn no_thread_summary_starts_with_recent() {
+        let recent = vec![
+            make_message(Role::User, "first"),
+            make_message(Role::Assistant, "response"),
+        ];
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &recent,
+            user_message: "second",
+            web_search_enabled: false,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+        });
+        assert_eq!(result.messages.len(), 3); // 2 recent + current
+    }
+
+    // 5.12: recent messages mapped by role (user/assistant), system role skipped
+    #[test]
+    fn system_role_skipped() {
+        let recent = vec![
+            make_message(Role::User, "hello"),
+            make_message(Role::System, "system msg"),
+            make_message(Role::Assistant, "hi"),
+        ];
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &recent,
+            user_message: "bye",
+            web_search_enabled: false,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+        });
+        // system message skipped: 2 recent (user+assistant) + 1 current = 3
+        assert_eq!(result.messages.len(), 3);
+    }
+
+    // 5.13: current user message always last
+    #[test]
+    fn current_user_message_is_last() {
+        let recent = vec![make_message(Role::Assistant, "prior")];
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &recent,
+            user_message: "current input",
+            web_search_enabled: false,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+        });
+        let last = result.messages.last().unwrap();
+        match &last.content[0] {
+            crate::domain::llm::ContentPart::Text { text } => {
+                assert_eq!(text, "current input");
+            }
+            crate::domain::llm::ContentPart::Image { .. } => {
+                panic!("Expected text content")
+            }
+        }
+    }
+
+    // 5.14: tools vec populated correctly for file_search + web_search combinations
+    #[test]
+    fn tools_populated_correctly() {
+        // Both enabled with vector store
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "hello",
+            web_search_enabled: true,
+            file_search_enabled: true,
+            vector_store_ids: &["vs-123".to_owned()],
+        });
+        assert_eq!(result.tools.len(), 2);
+        assert!(matches!(&result.tools[0], LlmTool::FileSearch { .. }));
+        assert!(matches!(&result.tools[1], LlmTool::WebSearch));
+
+        // file_search enabled but no vector store IDs → no file_search tool
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "hello",
+            web_search_enabled: false,
+            file_search_enabled: true,
+            vector_store_ids: &[],
+        });
+        assert!(result.tools.is_empty());
+
+        // Only web_search
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "hello",
+            web_search_enabled: true,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+        });
+        assert_eq!(result.tools.len(), 1);
+        assert!(matches!(&result.tools[0], LlmTool::WebSearch));
+    }
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/message_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/message_service_test.rs
@@ -14,8 +14,8 @@ use crate::domain::repos::{
     InsertAssistantMessageParams, InsertUserMessageParams, MessageRepository as MessageRepoTrait,
 };
 use crate::domain::service::test_helpers::{
-    inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver, mock_thread_summary_repo,
-    test_security_ctx,
+    MockThreadSummaryRepo, inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver,
+    mock_thread_summary_repo, test_security_ctx,
 };
 use crate::infra::db::entity::attachment::{ActiveModel as AttAm, Entity as AttEntity};
 use crate::infra::db::entity::message_attachment::{ActiveModel as MaAm, Entity as MaEntity};
@@ -37,7 +37,7 @@ fn limit_cfg() -> modkit_db::odata::LimitCfg {
 fn build_chat_service(
     db_provider: Arc<crate::domain::service::DbProvider>,
     chat_repo: Arc<OrmChatRepository>,
-) -> ChatService<OrmChatRepository> {
+) -> ChatService<OrmChatRepository, MockThreadSummaryRepo> {
     ChatService::new(
         db_provider,
         chat_repo,

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -5,7 +5,7 @@ use authz_resolver_sdk::{AuthZResolverClient, PolicyEnforcer};
 use modkit_db::DBProvider;
 use modkit_macros::domain_model;
 
-use crate::config::{EstimationBudgets, QuotaConfig, StreamingConfig};
+use crate::config::{ContextConfig, EstimationBudgets, QuotaConfig, StreamingConfig};
 use crate::domain::repos::{
     AttachmentRepository, ChatRepository, MessageRepository, ModelResolver, OutboxEnqueuer,
     PolicySnapshotProvider, QuotaUsageRepository, ReactionRepository, ThreadSummaryRepository,
@@ -16,6 +16,7 @@ use crate::infra::llm::provider_resolver::ProviderResolver;
 
 mod attachment_service;
 mod chat_service;
+pub(crate) mod context_assembly;
 pub(crate) mod credit_arithmetic;
 pub(crate) mod finalization_service;
 mod message_service;
@@ -94,6 +95,7 @@ pub(crate) struct Repositories<
     QR: QuotaUsageRepository,
     RR: ReactionRepository,
     CR: ChatRepository,
+    TSR: ThreadSummaryRepository,
 > {
     pub(crate) chat: Arc<CR>,
     pub(crate) attachment: Arc<dyn AttachmentRepository>,
@@ -101,7 +103,7 @@ pub(crate) struct Repositories<
     pub(crate) quota: Arc<QR>,
     pub(crate) turn: Arc<TR>,
     pub(crate) reaction: Arc<RR>,
-    pub(crate) thread_summary: Arc<dyn ThreadSummaryRepository>,
+    pub(crate) thread_summary: Arc<TSR>,
     pub(crate) vector_store: Arc<dyn VectorStoreRepository>,
 }
 
@@ -118,10 +120,11 @@ pub(crate) struct AppServices<
     QR: QuotaUsageRepository + 'static,
     RR: ReactionRepository + 'static,
     CR: ChatRepository + 'static,
+    TSR: ThreadSummaryRepository + 'static,
 > {
-    pub(crate) chats: ChatService<CR>,
+    pub(crate) chats: ChatService<CR, TSR>,
     pub(crate) messages: MessageService<MR, CR>,
-    pub(crate) stream: StreamService<TR, MR, QR, CR>,
+    pub(crate) stream: StreamService<TR, MR, QR, CR, TSR>,
     pub(crate) turns: TurnService<TR, MR, CR>,
     pub(crate) reactions: ReactionService<RR, MR, CR>,
     pub(crate) attachments: AttachmentService<CR>,
@@ -140,11 +143,12 @@ impl<
     QR: QuotaUsageRepository + 'static,
     RR: ReactionRepository + 'static,
     CR: ChatRepository + 'static,
-> AppServices<TR, MR, QR, RR, CR>
+    TSR: ThreadSummaryRepository + 'static,
+> AppServices<TR, MR, QR, RR, CR, TSR>
 {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        repos: &Repositories<TR, MR, QR, RR, CR>,
+        repos: &Repositories<TR, MR, QR, RR, CR, TSR>,
         db: Arc<DbProvider>,
         authz: Arc<dyn AuthZResolverClient>,
         model_resolver: &Arc<dyn ModelResolver>,
@@ -155,6 +159,7 @@ impl<
         estimation_budgets: EstimationBudgets,
         quota_config: QuotaConfig,
         outbox_enqueuer: Arc<dyn OutboxEnqueuer>,
+        context_config: ContextConfig,
     ) -> Self {
         let enforcer = PolicyEnforcer::new(authz);
 
@@ -209,6 +214,8 @@ impl<
                 streaming_config,
                 Arc::clone(&finalization),
                 Arc::clone(&quota_svc),
+                Arc::clone(&repos.thread_summary),
+                context_config,
             ),
             turns,
             reactions: ReactionService::new(

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
@@ -427,6 +427,8 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                             let minimal_generation_floor_applied =
                                 estimation_budgets.minimal_generation_floor as i32;
 
+                            let system_prompt = eff_entry.system_prompt.clone();
+
                             let preflight_decision = match decision {
                                 CascadeDecision::Allow { .. } => PreflightDecision::Allow {
                                     effective_model,
@@ -435,6 +437,7 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                                     reserved_credits_micro: final_reserved,
                                     policy_version_applied,
                                     minimal_generation_floor_applied,
+                                    system_prompt,
                                 },
                                 CascadeDecision::Downgrade {
                                     downgrade_from,
@@ -449,6 +452,7 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                                     minimal_generation_floor_applied,
                                     downgrade_from,
                                     downgrade_reason: reason,
+                                    system_prompt,
                                 },
                                 CascadeDecision::Reject => unreachable!(),
                             };
@@ -1543,6 +1547,7 @@ mod tests {
                 reserved_credits_micro,
                 policy_version_applied,
                 minimal_generation_floor_applied,
+                ..
             } => {
                 assert_eq!(effective_model, "gpt-5");
                 assert!(reserve_tokens > 0);
@@ -1887,6 +1892,7 @@ mod tests {
                 policy_version_applied,
                 max_output_tokens_applied,
                 minimal_generation_floor_applied,
+                ..
             } => (
                 effective_model,
                 reserve_tokens,

--- a/modules/mini-chat/mini-chat/src/domain/service/reaction_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/reaction_service_test.rs
@@ -10,8 +10,8 @@ use crate::domain::repos::{
     InsertAssistantMessageParams, InsertUserMessageParams, MessageRepository as MessageRepoTrait,
 };
 use crate::domain::service::test_helpers::{
-    inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver, mock_thread_summary_repo,
-    test_security_ctx,
+    MockThreadSummaryRepo, inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver,
+    mock_thread_summary_repo, test_security_ctx,
 };
 use crate::infra::db::repo::chat_repo::ChatRepository as OrmChatRepository;
 use crate::infra::db::repo::message_repo::MessageRepository as OrmMessageRepository;
@@ -32,7 +32,7 @@ fn limit_cfg() -> modkit_db::odata::LimitCfg {
 fn build_chat_service(
     db_provider: Arc<crate::domain::service::DbProvider>,
     chat_repo: Arc<OrmChatRepository>,
-) -> ChatService<OrmChatRepository> {
+) -> ChatService<OrmChatRepository, MockThreadSummaryRepo> {
     ChatService::new(
         db_provider,
         chat_repo,

--- a/modules/mini-chat/mini-chat/src/domain/service/replay.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/replay.rs
@@ -204,6 +204,39 @@ mod tests {
         {
             unimplemented!()
         }
+
+        async fn snapshot_boundary<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+        ) -> Result<Option<crate::domain::repos::SnapshotBoundary>, DomainError> {
+            Ok(None)
+        }
+
+        async fn recent_for_context<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+            _: u32,
+            _: Option<crate::domain::repos::SnapshotBoundary>,
+        ) -> Result<Vec<MessageModel>, DomainError> {
+            unimplemented!()
+        }
+
+        async fn recent_after_boundary<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+            _: time::OffsetDateTime,
+            _: Uuid,
+            _: u32,
+            _: Option<crate::domain::repos::SnapshotBoundary>,
+        ) -> Result<Vec<MessageModel>, DomainError> {
+            unimplemented!()
+        }
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -9,18 +9,18 @@ use tokio_util::sync::CancellationToken;
 use tracing::{Instrument, debug, info, warn};
 use uuid::Uuid;
 
-use crate::config::StreamingConfig;
+use crate::config::{ContextConfig, StreamingConfig};
 use crate::domain::error::DomainError;
 use crate::domain::models::ResolvedModel;
 use crate::domain::repos::{
     ChatRepository, CreateTurnParams, InsertUserMessageParams, MessageRepository,
-    QuotaUsageRepository, TurnRepository,
+    QuotaUsageRepository, SnapshotBoundary, ThreadSummaryRepository, TurnRepository,
 };
 use crate::domain::stream_events::{DoneData, ErrorData, StreamEvent};
 use crate::infra::db::entity::chat_turn::{Model as TurnModel, TurnState};
 use crate::infra::llm::{
-    ClientSseEvent, LlmMessage, LlmProvider, LlmProviderError, LlmRequestBuilder, TerminalOutcome,
-    Usage, provider_resolver::ProviderResolver,
+    ClientSseEvent, LlmMessage, LlmProvider, LlmProviderError, LlmRequestBuilder, LlmTool,
+    TerminalOutcome, Usage, provider_resolver::ProviderResolver,
 };
 
 use super::{DbProvider, actions, resources};
@@ -242,6 +242,7 @@ struct PreflightResult {
     quota_decision: String,
     downgrade_from: Option<String>,
     downgrade_reason: Option<String>,
+    system_prompt: String,
 }
 
 /// Convert a `PreflightDecision` into a flat `PreflightResult` or a `StreamError`.
@@ -257,6 +258,7 @@ fn flatten_preflight(
             reserved_credits_micro,
             policy_version_applied,
             minimal_generation_floor_applied,
+            system_prompt,
         } => Ok(PreflightResult {
             effective_model,
             reserve_tokens,
@@ -267,6 +269,7 @@ fn flatten_preflight(
             quota_decision: "allow".to_owned(),
             downgrade_from: None,
             downgrade_reason: None,
+            system_prompt,
         }),
         PreflightDecision::Downgrade {
             effective_model,
@@ -277,6 +280,7 @@ fn flatten_preflight(
             minimal_generation_floor_applied,
             downgrade_from,
             downgrade_reason,
+            system_prompt,
         } => Ok(PreflightResult {
             effective_model,
             reserve_tokens,
@@ -287,6 +291,7 @@ fn flatten_preflight(
             quota_decision: "downgrade".to_owned(),
             downgrade_from: Some(downgrade_from),
             downgrade_reason: Some(downgrade_reason.as_str().to_owned()),
+            system_prompt,
         }),
         PreflightDecision::Reject {
             error_code,
@@ -315,6 +320,7 @@ pub struct StreamService<
     MR: MessageRepository + 'static,
     QR: QuotaUsageRepository + 'static,
     CR: ChatRepository,
+    TSR: ThreadSummaryRepository + 'static,
 > {
     db: Arc<DbProvider>,
     turn_repo: Arc<TR>,
@@ -325,6 +331,8 @@ pub struct StreamService<
     streaming_config: StreamingConfig,
     finalization: Arc<crate::domain::service::finalization_service::FinalizationService<TR, MR>>,
     quota: Arc<crate::domain::service::QuotaService<QR>>,
+    thread_summary_repo: Arc<TSR>,
+    context_config: ContextConfig,
 }
 
 impl<
@@ -332,7 +340,8 @@ impl<
     MR: MessageRepository + 'static,
     QR: QuotaUsageRepository + 'static,
     CR: ChatRepository,
-> StreamService<TR, MR, QR, CR>
+    TSR: ThreadSummaryRepository + 'static,
+> StreamService<TR, MR, QR, CR, TSR>
 {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
@@ -347,6 +356,8 @@ impl<
             crate::domain::service::finalization_service::FinalizationService<TR, MR>,
         >,
         quota: Arc<crate::domain::service::QuotaService<QR>>,
+        thread_summary_repo: Arc<TSR>,
+        context_config: ContextConfig,
     ) -> Self {
         Self {
             db,
@@ -358,6 +369,8 @@ impl<
             streaming_config,
             finalization,
             quota,
+            thread_summary_repo,
+            context_config,
         }
     }
 
@@ -453,6 +466,15 @@ impl<
             });
         }
 
+        // ── Snapshot boundary (DESIGN §ContextPlan Determinism P1) ──
+        // Must be computed BEFORE persisting the user message so the boundary
+        // excludes the current user message from context queries.
+        let snapshot_boundary = self
+            .message_repo
+            .snapshot_boundary(&conn, &scope, chat_id)
+            .await
+            .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
+
         // ── Preflight quota evaluate (external I/O, no DB writes) ──
         let selected_model = model.clone();
         let computed = self
@@ -515,6 +537,17 @@ impl<
             period_starts,
         };
 
+        // ── Context assembly ──
+        let assembled = self
+            .gather_context(
+                tenant_id,
+                chat_id,
+                snapshot_boundary,
+                &pf.system_prompt,
+                &content,
+            )
+            .await?;
+
         let resolved_provider = self.provider_resolver.resolve(&provider_id).map_err(|e| {
             StreamError::TurnCreationFailed {
                 source: DomainError::internal(format!("provider resolution: {e}")),
@@ -531,7 +564,9 @@ impl<
             resolved_provider.adapter,
             proxy_path,
             ctx,
-            content,
+            assembled.messages,
+            assembled.system_instructions,
+            assembled.tools,
             model,
             provider_model_id,
             pf.max_output_tokens_applied.cast_unsigned(),
@@ -658,6 +693,92 @@ impl<
         Ok(turn_id)
     }
 
+    /// Shared context assembly: thread summary lookup, recent-message fetch
+    /// (bounded by snapshot boundary), and `assemble_context` call.
+    async fn gather_context(
+        &self,
+        tenant_id: Uuid,
+        chat_id: Uuid,
+        snapshot_boundary: Option<SnapshotBoundary>,
+        system_prompt: &str,
+        user_message: &str,
+    ) -> Result<super::context_assembly::AssembledContext, StreamError> {
+        let conn = self
+            .db
+            .conn()
+            .map_err(|e| StreamError::TurnCreationFailed {
+                source: DomainError::from(e),
+            })?;
+        let scope = AccessScope::for_tenant(tenant_id);
+
+        let thread_summary = self
+            .thread_summary_repo
+            .get_latest(&conn, &scope, chat_id)
+            .await
+            .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
+
+        let recent_messages = match &thread_summary {
+            Some(ts) => {
+                self.message_repo
+                    .recent_after_boundary(
+                        &conn,
+                        &scope,
+                        chat_id,
+                        ts.boundary_created_at,
+                        ts.boundary_message_id,
+                        self.context_config.recent_messages_limit,
+                        snapshot_boundary,
+                    )
+                    .await
+            }
+            None => {
+                self.message_repo
+                    .recent_for_context(
+                        &conn,
+                        &scope,
+                        chat_id,
+                        self.context_config.recent_messages_limit,
+                        snapshot_boundary,
+                    )
+                    .await
+            }
+        }
+        .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
+
+        // Map ORM models → domain ContextMessage (decouples context assembly from infra).
+        let context_messages: Vec<crate::domain::llm::ContextMessage> = recent_messages
+            .iter()
+            .map(|m| crate::domain::llm::ContextMessage {
+                role: match m.role {
+                    crate::infra::db::entity::message::MessageRole::User => {
+                        crate::domain::llm::Role::User
+                    }
+                    crate::infra::db::entity::message::MessageRole::Assistant => {
+                        crate::domain::llm::Role::Assistant
+                    }
+                    crate::infra::db::entity::message::MessageRole::System => {
+                        crate::domain::llm::Role::System
+                    }
+                },
+                content: m.content.clone(),
+            })
+            .collect();
+
+        Ok(super::context_assembly::assemble_context(
+            &super::context_assembly::ContextInput {
+                system_prompt,
+                web_search_guard: &self.context_config.web_search_guard,
+                file_search_guard: &self.context_config.file_search_guard,
+                thread_summary: thread_summary.as_ref().map(|ts| ts.content.as_str()),
+                recent_messages: &context_messages,
+                user_message,
+                web_search_enabled: false, // P1: not yet wired from request
+                file_search_enabled: false, // P1: not yet wired from request
+                vector_store_ids: &[],
+            },
+        ))
+    }
+
     /// Run streaming for an already-created turn (used by retry/edit mutations).
     ///
     /// The mutation transaction has already created the turn (state=running) and
@@ -674,6 +795,7 @@ impl<
         turn_id: Uuid,
         content: String,
         resolved_model: ResolvedModel,
+        snapshot_boundary: Option<SnapshotBoundary>,
         cancel: CancellationToken,
         tx: mpsc::Sender<StreamEvent>,
     ) -> Result<tokio::task::JoinHandle<StreamOutcome>, StreamError> {
@@ -749,7 +871,7 @@ impl<
 
         let finalization_ctx = FinalizationCtx {
             finalization_svc: Arc::clone(&self.finalization),
-            scope,
+            scope: scope.clone(),
             turn_id,
             tenant_id,
             chat_id,
@@ -769,6 +891,17 @@ impl<
             period_starts,
         };
 
+        // ── Context assembly ──
+        let assembled = self
+            .gather_context(
+                tenant_id,
+                chat_id,
+                snapshot_boundary,
+                &pf.system_prompt,
+                &content,
+            )
+            .await?;
+
         let resolved_provider = self.provider_resolver.resolve(&provider_id).map_err(|e| {
             StreamError::TurnCreationFailed {
                 source: DomainError::internal(format!("provider resolution: {e}")),
@@ -783,7 +916,9 @@ impl<
             resolved_provider.adapter,
             proxy_path,
             ctx,
-            content,
+            assembled.messages,
+            assembled.system_instructions,
+            assembled.tools,
             pf.effective_model,
             provider_model_id,
             pf.max_output_tokens_applied.cast_unsigned(),
@@ -813,7 +948,9 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
     llm: Arc<dyn LlmProvider>,
     upstream_alias: String,
     ctx: SecurityContext,
-    content: String,
+    messages: Vec<LlmMessage>,
+    system_instructions: Option<String>,
+    tools: Vec<LlmTool>,
     model: String,
     provider_model_id: String,
     max_output_tokens: u32,
@@ -839,10 +976,16 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
         let msg_id_str = fin_ctx.as_ref().map(|p| p.message_id.to_string());
 
         // Build the LLM request using provider_model_id (the actual provider-facing name)
-        let request = LlmRequestBuilder::new(&provider_model_id)
-            .message(LlmMessage::user(&content))
-            .max_output_tokens(u64::from(max_output_tokens))
-            .build_streaming();
+        let mut builder = LlmRequestBuilder::new(&provider_model_id)
+            .messages(messages)
+            .max_output_tokens(u64::from(max_output_tokens));
+        if let Some(instructions) = system_instructions {
+            builder = builder.system_instructions(instructions);
+        }
+        for tool in tools {
+            builder = builder.tool(tool);
+        }
+        let request = builder.build_streaming();
 
         // Call the provider to start streaming
         let stream_result = llm
@@ -1479,7 +1622,9 @@ mod tests {
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
-            "hi".into(),
+            vec![LlmMessage::user("hi")],
+            None,
+            vec![],
             "test-model".into(),
             "test-model".into(),
             4096,
@@ -1525,7 +1670,9 @@ mod tests {
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
-            "hi".into(),
+            vec![LlmMessage::user("hi")],
+            None,
+            vec![],
             "test-model".into(),
             "test-model".into(),
             4096,
@@ -1564,7 +1711,9 @@ mod tests {
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
-            "hi".into(),
+            vec![LlmMessage::user("hi")],
+            None,
+            vec![],
             "test-model".into(),
             "test-model".into(),
             4096,
@@ -1652,7 +1801,9 @@ mod tests {
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
-            "hi".into(),
+            vec![LlmMessage::user("hi")],
+            None,
+            vec![],
             "test-model".into(),
             "test-model".into(),
             4096,
@@ -1677,8 +1828,9 @@ mod tests {
     // ── Pre-stream check tests (7.6) ──
 
     use crate::domain::service::test_helpers::{
-        MockPolicySnapshotProvider, MockUserLimitsProvider, TestCatalogEntryParams, inmem_db,
-        mock_db_provider, mock_enforcer, test_catalog_entry, test_security_ctx_with_id,
+        MockPolicySnapshotProvider, MockThreadSummaryRepo, MockUserLimitsProvider,
+        TestCatalogEntryParams, inmem_db, mock_db_provider, mock_enforcer,
+        mock_thread_summary_repo, test_catalog_entry, test_security_ctx_with_id,
     };
     use crate::infra::db::repo::quota_usage_repo::QuotaUsageRepository as OrmQuotaUsageRepo;
 
@@ -1686,7 +1838,8 @@ mod tests {
     fn build_stream_service(
         db: Arc<DbProvider>,
         provider: Arc<dyn LlmProvider>,
-    ) -> StreamService<TurnRepo, MsgRepo, OrmQuotaUsageRepo, OrmChatRepo> {
+    ) -> StreamService<TurnRepo, MsgRepo, OrmQuotaUsageRepo, OrmChatRepo, MockThreadSummaryRepo>
+    {
         use crate::domain::service::finalization_service::FinalizationService;
         use crate::domain::service::quota_settler::QuotaSettler;
 
@@ -1787,6 +1940,8 @@ mod tests {
             crate::config::StreamingConfig::default(),
             finalization,
             quota_svc,
+            mock_thread_summary_repo(),
+            crate::config::ContextConfig::default(),
         )
     }
 
@@ -1826,6 +1981,7 @@ mod tests {
             description: None,
             multimodal_capabilities: vec![],
             context_window: 128_000,
+            system_prompt: String::new(),
         }
     }
 
@@ -2562,7 +2718,9 @@ mod tests {
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
-            "hi".into(),
+            vec![LlmMessage::user("hi")],
+            None,
+            vec![],
             "gpt-4o-mini".into(), // effective_model passed as the model param
             "gpt-4o-mini".into(),
             4096,
@@ -2635,7 +2793,8 @@ mod tests {
         provider: Arc<dyn LlmProvider>,
         catalog: Vec<mini_chat_sdk::ModelCatalogEntry>,
         limits: mini_chat_sdk::UserLimits,
-    ) -> StreamService<TurnRepo, MsgRepo, OrmQuotaUsageRepo, OrmChatRepo> {
+    ) -> StreamService<TurnRepo, MsgRepo, OrmQuotaUsageRepo, OrmChatRepo, MockThreadSummaryRepo>
+    {
         use crate::domain::service::finalization_service::FinalizationService;
         use crate::domain::service::quota_settler::QuotaSettler;
 
@@ -2706,6 +2865,8 @@ mod tests {
             crate::config::StreamingConfig::default(),
             finalization,
             quota_svc,
+            mock_thread_summary_repo(),
+            crate::config::ContextConfig::default(),
         )
     }
 
@@ -2912,6 +3073,7 @@ mod tests {
                     description: None,
                     multimodal_capabilities: vec![],
                     context_window: 128_000,
+                    system_prompt: String::new(),
                 },
                 cancel,
                 tx,

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -298,9 +298,21 @@ pub fn mock_model_resolver() -> Arc<dyn ModelResolver> {
     Arc::new(MockModelResolver::default())
 }
 
-pub fn mock_thread_summary_repo() -> Arc<dyn ThreadSummaryRepository> {
-    struct MockThreadSummaryRepo;
-    impl ThreadSummaryRepository for MockThreadSummaryRepo {}
+pub struct MockThreadSummaryRepo;
+#[async_trait::async_trait]
+impl ThreadSummaryRepository for MockThreadSummaryRepo {
+    async fn get_latest<C: modkit_db::secure::DBRunner>(
+        &self,
+        _runner: &C,
+        _scope: &modkit_security::AccessScope,
+        _chat_id: uuid::Uuid,
+    ) -> Result<Option<crate::domain::repos::ThreadSummaryModel>, crate::domain::error::DomainError>
+    {
+        Ok(None)
+    }
+}
+
+pub fn mock_thread_summary_repo() -> Arc<MockThreadSummaryRepo> {
     Arc::new(MockThreadSummaryRepo)
 }
 
@@ -433,6 +445,8 @@ pub fn test_catalog_entry(params: TestCatalogEntryParams) -> ModelCatalogEntry {
             is_default: params.is_default,
             sort_order: 0,
         },
+        system_prompt: String::new(),
+        thread_summary_prompt: String::new(),
     }
 }
 

--- a/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
@@ -96,6 +96,9 @@ pub struct MutationResult {
     pub new_request_id: Uuid,
     pub new_turn_id: Uuid,
     pub user_content: String,
+    /// Snapshot boundary computed before the new user message was persisted.
+    /// Ensures deterministic context assembly (DESIGN `§ContextPlan` Determinism P1).
+    pub snapshot_boundary: Option<crate::domain::repos::SnapshotBoundary>,
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -275,7 +278,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
         let scope_tx = chat_scope.clone();
         let ctx_clone = ctx.clone();
 
-        let user_content = self
+        let (user_content, snapshot_boundary) = self
             .db
             .transaction(|tx| {
                 Box::pin(async move {
@@ -342,6 +345,13 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
                             modkit_db::DbError::Other(anyhow::Error::new(e))
                         })?;
 
+                    // Snapshot boundary: must be computed BEFORE inserting the new
+                    // user message so context queries exclude it (DESIGN §ContextPlan P1).
+                    let boundary = message_repo
+                        .snapshot_boundary(tx, &scope, chat_id)
+                        .await
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
+
                     // Insert user message for the new turn
                     message_repo
                         .insert_user_message(
@@ -358,7 +368,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
                         .await
                         .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
 
-                    Ok(user_content)
+                    Ok((user_content, boundary))
                 })
             })
             .await
@@ -368,6 +378,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static, CR: ChatRepo
             new_request_id,
             new_turn_id,
             user_content,
+            snapshot_boundary,
         })
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
@@ -16,7 +16,9 @@ use uuid::Uuid;
 
 use crate::domain::error::DomainError;
 use crate::domain::models::{AttachmentSummary, ImgThumbnail};
-use crate::domain::repos::{InsertAssistantMessageParams, InsertUserMessageParams};
+use crate::domain::repos::{
+    InsertAssistantMessageParams, InsertUserMessageParams, SnapshotBoundary,
+};
 use crate::infra::db::entity::attachment::Column as AttCol;
 use crate::infra::db::entity::message::{
     ActiveModel, Column, Entity as MessageEntity, MessageRole, Model as MessageModel,
@@ -271,6 +273,113 @@ impl crate::domain::repos::MessageRepository for MessageRepository {
         }
         Ok(map)
     }
+    async fn snapshot_boundary<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<SnapshotBoundary>, DomainError> {
+        let row = MessageEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::RequestId.is_not_null())
+                    .add(Column::DeletedAt.is_null()),
+            )
+            .secure()
+            .scope_with(scope)
+            .order_by(Column::CreatedAt, Order::Desc)
+            .order_by(Column::Id, Order::Desc)
+            .one(runner)
+            .await?;
+        Ok(row.map(|m| SnapshotBoundary {
+            created_at: m.created_at,
+            id: m.id,
+        }))
+    }
+
+    async fn recent_for_context<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        limit: u32,
+        boundary: Option<SnapshotBoundary>,
+    ) -> Result<Vec<MessageModel>, DomainError> {
+        let mut cond = Condition::all()
+            .add(Column::ChatId.eq(chat_id))
+            .add(Column::RequestId.is_not_null())
+            .add(Column::DeletedAt.is_null());
+
+        if let Some(b) = boundary {
+            cond = cond.add(upper_bound_filter(b));
+        }
+
+        let mut rows = MessageEntity::find()
+            .filter(cond)
+            .secure()
+            .scope_with(scope)
+            .order_by(Column::CreatedAt, Order::Desc)
+            .order_by(Column::Id, Order::Desc)
+            .limit(u64::from(limit))
+            .all(runner)
+            .await?;
+        rows.reverse();
+        Ok(rows)
+    }
+
+    async fn recent_after_boundary<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        lower_created_at: OffsetDateTime,
+        lower_id: Uuid,
+        limit: u32,
+        boundary: Option<SnapshotBoundary>,
+    ) -> Result<Vec<MessageModel>, DomainError> {
+        // Composite cursor: (created_at, id) > (lower_created_at, lower_id)
+        let lower_filter = Condition::any()
+            .add(Column::CreatedAt.gt(lower_created_at))
+            .add(
+                Condition::all()
+                    .add(Column::CreatedAt.eq(lower_created_at))
+                    .add(Column::Id.gt(lower_id)),
+            );
+
+        let mut cond = Condition::all()
+            .add(Column::ChatId.eq(chat_id))
+            .add(Column::RequestId.is_not_null())
+            .add(Column::DeletedAt.is_null())
+            .add(lower_filter);
+
+        if let Some(b) = boundary {
+            cond = cond.add(upper_bound_filter(b));
+        }
+
+        let mut rows = MessageEntity::find()
+            .filter(cond)
+            .secure()
+            .scope_with(scope)
+            .order_by(Column::CreatedAt, Order::Desc)
+            .order_by(Column::Id, Order::Desc)
+            .limit(u64::from(limit))
+            .all(runner)
+            .await?;
+        rows.reverse();
+        Ok(rows)
+    }
+}
+
+/// Composite upper-bound filter: `(created_at, id) <= (b.created_at, b.id)`.
+fn upper_bound_filter(b: SnapshotBoundary) -> Condition {
+    Condition::any()
+        .add(Column::CreatedAt.lt(b.created_at))
+        .add(
+            Condition::all()
+                .add(Column::CreatedAt.eq(b.created_at))
+                .add(Column::Id.lte(b.id)),
+        )
 }
 
 #[cfg(test)]

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/thread_summary_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/thread_summary_repo.rs
@@ -1,4 +1,26 @@
+use async_trait::async_trait;
+use modkit_db::secure::DBRunner;
+use modkit_security::AccessScope;
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::domain::repos::ThreadSummaryModel;
+
 /// Repository for thread summary persistence operations.
+///
+/// P1: No `thread_summaries` table exists yet — always returns `None`.
+/// When the summarization job is implemented (P2+), this will query the DB.
 pub struct ThreadSummaryRepository;
 
-impl crate::domain::repos::ThreadSummaryRepository for ThreadSummaryRepository {}
+#[async_trait]
+impl crate::domain::repos::ThreadSummaryRepository for ThreadSummaryRepository {
+    async fn get_latest<C: DBRunner>(
+        &self,
+        _runner: &C,
+        _scope: &AccessScope,
+        _chat_id: Uuid,
+    ) -> Result<Option<ThreadSummaryModel>, DomainError> {
+        // Graceful degradation: no summary table in P1.
+        Ok(None)
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
@@ -495,10 +495,15 @@ fn build_request_body<M>(request: &LlmRequest<M>, stream: bool) -> serde_json::V
                 // System messages are handled via the `instructions` field above.
                 crate::infra::llm::request::Role::System => unreachable!(),
             };
+            let is_assistant = role == "assistant";
             let content: Vec<serde_json::Value> = msg
                 .content
                 .iter()
                 .map(|part| match part {
+                    MessageContentPart::Text { text } if is_assistant => serde_json::json!({
+                        "type": "output_text",
+                        "text": text
+                    }),
                     MessageContentPart::Text { text } => serde_json::json!({
                         "type": "input_text",
                         "text": text

--- a/modules/mini-chat/mini-chat/src/infra/llm/request.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/request.rs
@@ -2,6 +2,10 @@
 //!
 //! [`LlmRequest`] is the common input for all provider adapters. Each adapter
 //! converts it to its provider-specific wire format.
+//!
+//! Core message and tool types (`Role`, `ContentPart`, `LlmMessage`, `LlmTool`)
+//! are defined in [`crate::domain::llm`] and re-exported here for backward
+//! compatibility with existing infra consumers.
 
 use std::marker::PhantomData;
 
@@ -9,91 +13,9 @@ use serde::Serialize;
 
 use super::{NonStreaming, Streaming};
 
-// ════════════════════════════════════════════════════════════════════════════
-// Message types
-// ════════════════════════════════════════════════════════════════════════════
-
-/// A role in the conversation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Role {
-    User,
-    Assistant,
-    System,
-}
-
-/// A content part within a message.
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type")]
-pub enum ContentPart {
-    #[serde(rename = "text")]
-    Text { text: String },
-    #[serde(rename = "image")]
-    Image { file_id: String },
-}
-
-/// A single message in the conversation.
-#[derive(Debug, Clone)]
-pub struct LlmMessage {
-    pub role: Role,
-    pub content: Vec<ContentPart>,
-}
-
-impl LlmMessage {
-    /// Create a user message with text content.
-    #[must_use]
-    pub fn user(text: impl Into<String>) -> Self {
-        LlmMessage {
-            role: Role::User,
-            content: vec![ContentPart::Text { text: text.into() }],
-        }
-    }
-
-    /// Create an assistant message with text content.
-    #[must_use]
-    pub fn assistant(text: impl Into<String>) -> Self {
-        LlmMessage {
-            role: Role::Assistant,
-            content: vec![ContentPart::Text { text: text.into() }],
-        }
-    }
-
-    /// Create a user message with text and an image.
-    #[must_use]
-    pub fn user_with_image(text: impl Into<String>, file_id: impl Into<String>) -> Self {
-        LlmMessage {
-            role: Role::User,
-            content: vec![
-                ContentPart::Text { text: text.into() },
-                ContentPart::Image {
-                    file_id: file_id.into(),
-                },
-            ],
-        }
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// Tool types
-// ════════════════════════════════════════════════════════════════════════════
-
-/// A provider-agnostic tool descriptor.
-///
-/// Each adapter maps supported tools to its wire format and silently drops
-/// unsupported ones with a `debug!` log.
-#[derive(Debug, Clone)]
-pub enum LlmTool {
-    /// Server-side file search (provider manages execution).
-    FileSearch { vector_store_ids: Vec<String> },
-    /// Server-side web search (provider manages execution).
-    WebSearch,
-    /// Generic function tool (for providers supporting function calling).
-    Function {
-        name: String,
-        description: String,
-        parameters: serde_json::Value,
-    },
-}
+// Re-export domain-level LLM types so existing `crate::infra::llm::request::*`
+// imports continue to work.
+pub use crate::domain::llm::{ContentPart, LlmMessage, LlmTool, Role};
 
 // ════════════════════════════════════════════════════════════════════════════
 // User identity and metadata

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -23,6 +23,7 @@ pub(crate) type AppServices = GenericAppServices<
     QuotaUsageRepository,
     ReactionRepository,
     ChatRepository,
+    ThreadSummaryRepository,
 >;
 use crate::infra::db::repo::attachment_repo::AttachmentRepository;
 use crate::infra::db::repo::chat_repo::ChatRepository;
@@ -78,6 +79,9 @@ impl Module for MiniChatModule {
         cfg.outbox
             .validate()
             .map_err(|e| anyhow::anyhow!("outbox config: {e}"))?;
+        cfg.context
+            .validate()
+            .map_err(|e| anyhow::anyhow!("context config: {e}"))?;
         for (id, entry) in &cfg.providers {
             entry
                 .validate(id)
@@ -208,6 +212,7 @@ impl Module for MiniChatModule {
             cfg.estimation_budgets,
             cfg.quota,
             outbox_enqueuer,
+            cfg.context,
         ));
 
         self.service

--- a/modules/mini-chat/plugins/static-model-policy-plugin/src/domain/client.rs
+++ b/modules/mini-chat/plugins/static-model-policy-plugin/src/domain/client.rs
@@ -169,6 +169,8 @@ mod tests {
                 is_default: false,
                 sort_order: 0,
             },
+            system_prompt: String::new(),
+            thread_summary_prompt: String::new(),
         }
     }
 


### PR DESCRIPTION
feat(mini-chat): add turn context assembly for multi-turn conversations

Introduce a pure context assembly function that gathers system prompt, tool guards, thread summary, and recent message history into a complete LLM request context. Wire it into StreamService so each turn sends full conversation history. Fix OpenAI Responses API content type for assistant messages (input_text → output_text). Add ContextConfig for guard strings and message limits. Extend repos with recent-messages and thread-summary queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-model system prompts and thread-summary prompts are included in LLM requests.
  * Thread summaries supported and surfaced for on-demand context use.
  * New chat context controls: web/file search guards and recent-message limits.
  * Enhanced context assembly and tools ordering (system instructions, thread summary, recent messages, user message, enabled tools).
  * Deterministic context retrieval (snapshot boundaries) for more reliable, relevant message selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->