### PR TITLE
feat(skills): add modkit-pr-review skill with Rust and framework compliance checklists

### DIFF
--- a/.claude/skills/modkit-pr-review/SKILL.md
+++ b/.claude/skills/modkit-pr-review/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: modkit-pr-review
+description: "Review Rust PRs against idiomatic Rust guidelines and ModKit framework rules, post inline comments on GitHub"
+user-invocable: true
+allowed-tools: Bash, Read, Glob, Grep, Write
+---
+
+# Rust PR Review
+
+Review a GitHub pull request for Rust code quality and ModKit framework compliance.
+Posts findings as inline review comments directly on the PR.
+
+**Usage**: `/modkit-pr-review <PR_NUMBER>`
+
+---
+
+## Inputs
+
+- `<PR_NUMBER>` — required, the GitHub PR number (e.g. `123`)
+
+## Review guidelines
+
+Apply **Rust idioms and engineering** (`docs/pr-review/modkit-rust-review.md`) to every `.rs` file in the diff.
+
+Apply **ModKit framework compliance** (`docs/pr-review/modkit-framework-compliance-review.md`) **only** to `.rs` files that belong to ModKit-owned code. A file is ModKit-owned when **any** of these signals is present:
+
+1. **Cargo.toml signals** — the nearest `Cargo.toml` (same crate or workspace member) declares a `modkit` dependency/feature, or the crate name starts with `modkit`.
+2. **Path heuristics** — the file lives under a path that matches ModKit module conventions (e.g. `modules/*/src/`, `crates/modkit-*/`, or similar namespace).
+3. **Source-level symbols** — the file imports from ModKit crates (`use modkit_*`, `use crate::` inside a modkit crate) or references ModKit-specific types/traits such as `OperationBuilder`, `SecureConn`, `SecureORM`, `ClientHub`, or `ModuleLifecycle`.
+
+If none of these signals are detected, skip the framework compliance checklist for that file and apply only the general Rust idioms checklist.
+
+For non-Rust files in the diff (TOML, YAML, migrations, etc.) — apply only general correctness checks, do not force Rust-specific rules.
+
+## Coding guidelines reference
+
+When reviewing, also consult:
+- `guidelines/DNA/languages/RUST.md` — project Rust conventions
+- `guidelines/SECURITY.md` — security requirements
+
+---
+
+## Steps
+
+### Step 1: Fetch PR metadata and diff
+
+```bash
+gh pr view <PR_NUMBER> --json number,title,body,headRefOid,baseRefName,headRefName
+gh pr diff <PR_NUMBER>
+```
+
+Save the diff output for analysis. Extract the HEAD commit SHA — you need it for posting comments.
+
+### Step 2: Identify Rust files in diff
+
+Parse the diff to find all `.rs` files that were added or modified.
+For each file, note the changed line ranges (added lines only — you can only comment on lines present in the diff).
+
+### Step 3: Read review guidelines and classify files
+
+Read `docs/pr-review/modkit-rust-review.md` (always needed).
+
+For each `.rs` file from Step 2, determine whether it is ModKit-owned code:
+- Check the nearest `Cargo.toml` for modkit dependencies/features or a `modkit-` crate name.
+- Check whether the file path matches ModKit module conventions (`modules/*/src/`, `crates/modkit-*/`).
+- Scan the file for ModKit imports (`use modkit_*`) or ModKit types (`OperationBuilder`, `SecureConn`, `SecureORM`, `ClientHub`, `ModuleLifecycle`).
+
+If **any** file is classified as ModKit-owned, also read `docs/pr-review/modkit-framework-compliance-review.md`.
+
+### Step 4: Review each changed file
+
+For each `.rs` file in the diff:
+
+a. Read the full current file from the repo (not just the diff hunk) to understand context.
+b. Apply **modkit-rust-review.md** checklist items — idiomatic Rust, error handling, async safety, ownership, testing, etc.
+c. **Only if the file was classified as ModKit-owned in Step 3**, also apply **modkit-framework-compliance-review.md** checklist items — SDK pattern, OperationBuilder, SecureConn, module layout, error types, etc.
+d. Record each finding with: checklist ID, severity, file path, line number, issue description, fix.
+
+### Step 5: Filter and deduplicate
+
+- Drop findings that are not evidenced in the diff
+- Drop style issues that rustfmt/clippy should catch
+- Drop speculative or hypothetical issues
+- Merge overlapping findings on the same line
+- Keep only findings where you have concrete evidence
+
+### Step 6: Post inline review comments on GitHub
+
+Use `gh api` to create a pull request review with inline comments.
+
+Build the review payload:
+
+IMPORTANT: The `gh api` `-f` array syntax is limited. For multiple comments, build a JSON file and POST it.
+
+The review `body` MUST be empty string — no summary in the review itself. The summary goes to the terminal only (Step 7).
+
+```bash
+cat > /tmp/review-payload.json << 'REVIEW_EOF'
+{
+  "commit_id": "<HEAD_SHA>",
+  "event": "COMMENT",
+  "body": "",
+  "comments": [
+    {
+      "path": "modules/foo/src/domain/service.rs",
+      "line": 42,
+      "side": "RIGHT",
+      "body": "**HIGH**\n\nError context discarded by `map_err(|_| ...)`.\n\nPreserve the source error — wrap with `.context()` or map to a domain error that keeps the cause."
+    }
+  ]
+}
+REVIEW_EOF
+
+gh api repos/{owner}/{repo}/pulls/<PR_NUMBER>/reviews \
+  --method POST \
+  --input /tmp/review-payload.json
+```
+
+### Step 7: Print summary
+
+After posting, print a compact summary table to the terminal:
+
+```
+## Rust PR Review: #<PR_NUMBER>
+
+| # | ID | Sev | Location | Issue | Fix |
+|---|----|-----|----------|-------|-----|
+| 1 | RUST-ERR-001 | HIGH | service.rs:42 | Error context lost | Preserve source error |
+| 2 | MODKIT-SEC-001 | CRIT | handler.rs:18 | Raw DB connection | Use SecureConn |
+
+Posted <N> inline comments on PR #<PR_NUMBER>.
+```
+
+---
+
+## Comment formatting rules
+
+Each inline comment MUST follow this format:
+
+```
+**<SEVERITY>**
+
+<One-sentence issue description.>
+
+<One-sentence why it matters.>
+
+<Concrete fix — what to change, not a vague suggestion.>
+```
+
+Where `<SEVERITY>` is one of: `CRITICAL`, `HIGH`, `MEDIUM`, `LOW`.
+
+Do NOT include checklist IDs (e.g. RUST-ERR-001, MODKIT-SEC-001) in inline comments. IDs appear only in the terminal summary table (Step 7).
+
+Rules:
+- Engineering English. No filler, no praise, no hedging.
+- No "consider", "you might want to", "it would be nice if". State what is wrong and what to do.
+- One issue per comment. If a line has two problems, post two comments.
+- Line number must point to an added/modified line that exists in the diff. Do not comment on unchanged lines.
+- If you cannot determine the exact line, do not guess — skip that finding.
+
+---
+
+## What NOT to do
+
+- Do not approve or request changes — use `event: "COMMENT"` only
+- Do not post comments on lines outside the diff
+- Do not post generic praise or "LGTM" if there are no issues
+- Do not invent issues without evidence in the code
+- Do not complain about formatting that rustfmt handles
+- Do not suggest speculative abstractions or premature generalization
+- Do not post more than 30 comments per review (prioritize by severity)
+- If there are zero findings, post a single review comment: "No issues found."

--- a/docs/pr-review/modkit-framework-compliance-review.md
+++ b/docs/pr-review/modkit-framework-compliance-review.md
@@ -1,0 +1,384 @@
+---
+cypilot: true
+type: requirement
+name: ModKit Framework Compliance Review
+version: 1.0
+purpose: Verify that code changes follow ModKit architectural rules and invariants
+---
+
+# ModKit Framework Compliance Review
+
+This review verifies that the pull request follows **ModKit architectural invariants and patterns**.
+
+It runs **in addition to the Rust PR review guidelines**.
+
+Focus only on **framework-specific compliance**, not generic Rust style.
+
+## Authoritative reference
+
+When a change touches module layout, `@/lib/modkit`*, plugins, REST wiring, ClientHub, OpenAPI, lifecycle/stateful tasks, SSE, or standardized HTTP errors, consult `docs/modkit_unified_system/README.md` — the canonical ModKit architecture document. Findings that contradict it take priority.
+
+---
+
+# Output Contract
+
+Produce an **issues-only report**.
+
+For each issue include:
+
+- Checklist ID
+- Severity
+- Location
+- Issue
+- Why it matters
+- Fix
+
+Do not repeat generic Rust findings.
+
+---
+
+# Severity
+
+CRITICAL – breaks framework security model or architecture invariants  
+HIGH – breaks module architecture or integration contracts  
+MEDIUM – deviation from recommended ModKit patterns  
+LOW – minor style / best practice
+
+---
+
+# Core Framework Invariants
+
+These rules apply to all modules.
+
+---
+
+## MODKIT-CORE-001: SDK Pattern Enforcement
+
+Public module APIs MUST be defined in `<module>-sdk` crates.
+
+Check:
+
+- Traits used for inter-module communication are defined in the SDK crate
+- Public models live in the SDK crate
+- Public error types live in the SDK crate
+- Consumers depend only on `<module>-sdk`
+
+Violation examples:
+
+- Modules importing internal domain types from another module
+- SDK leaking REST DTOs or database entities
+- Consumers depending on module implementation crate
+
+Why it matters:
+
+ModKit enforces transport-agnostic APIs and module isolation.
+
+---
+
+## MODKIT-CORE-002: Module Layout Compliance
+
+Modules must follow the canonical structure.
+
+Required structure:
+
+```
+
+modules/<module>/ <module>-sdk/ <module>/
+api/rest
+domain
+infra
+
+```
+
+Check:
+
+- REST DTOs exist only under `api/rest/dto.rs`
+- Business logic lives in `domain/`
+- Storage adapters live in `infra/storage`
+- SDK types are not duplicated in the module crate
+
+Why it matters:
+
+Ensures separation of API, domain, and infrastructure.
+
+---
+
+## MODKIT-CORE-003: Module Naming Convention
+
+Module names must be **kebab-case**.
+
+Check:
+
+- Folder names
+- `#[modkit::module(name = "...")]`
+
+Why it matters:
+
+Naming consistency is enforced by CI and macros.
+
+---
+
+# REST Layer Rules
+
+---
+
+## MODKIT-REST-001: OperationBuilder Usage
+
+All REST endpoints must be defined via `OperationBuilder`.
+
+Check:
+
+- No direct Axum router manipulation
+- Routes registered via `.register(router, openapi)`
+- `.operation_id()` is defined
+- `.standard_errors()` is included
+
+Why it matters:
+
+OperationBuilder guarantees compile-time completeness and OpenAPI correctness.
+
+---
+
+## MODKIT-REST-002: Authentication Declaration
+
+Every endpoint must declare its auth posture.
+
+Check:
+
+- `.authenticated()` for protected routes
+- `.public()` for open routes
+
+Why it matters:
+
+Gateway middleware depends on this metadata.
+
+---
+
+## MODKIT-REST-003: SecurityContext Extraction
+
+Handlers must receive `SecurityContext` via Axum extension.
+
+Correct pattern:
+
+```
+
+Extension(ctx): Extension<SecurityContext>
+
+```
+
+Check:
+
+- SecurityContext not manually constructed
+- Handlers do not bypass gateway injection
+
+Why it matters:
+
+AuthN is gateway responsibility.
+
+---
+
+# Error Handling
+
+---
+
+## MODKIT-ERR-001: RFC 9457 Problem Usage
+
+All REST errors must use `Problem`.
+
+Check:
+
+- Handler return type is `ApiResult<T>`
+- `Problem` is returned for errors
+- No custom HTTP error structs
+
+Why it matters:
+
+ModKit standardizes error handling with RFC-9457.
+
+---
+
+## MODKIT-ERR-002: Domain Error Separation
+
+Domain errors must not contain transport logic.
+
+Check:
+
+- Domain errors defined in `domain/error.rs`
+- SDK errors transport-agnostic
+- Conversion chain:
+
+```
+
+DomainError → SDK Error → Problem
+
+```
+
+---
+
+# Security Model
+
+---
+
+## MODKIT-SEC-001: SecureConn Enforcement
+
+All database access must go through `SecureConn`.
+
+Check:
+
+- No raw database connections
+- No direct `DatabaseConnection`
+- Use `db.sea_secure()`
+
+Why it matters:
+
+SecureConn enforces authorization constraints.
+
+---
+
+## MODKIT-SEC-002: PolicyEnforcer Usage
+
+Authorization must be handled through `PolicyEnforcer`.
+
+Check:
+
+- No manual `AccessScope` construction
+- AccessScope obtained from PolicyEnforcer
+
+Why it matters:
+
+Authorization decisions must come from PDP.
+
+---
+
+# Database Layer
+
+---
+
+## MODKIT-DB-001: Repository Pattern
+
+Repository methods must accept `&impl DBRunner`.
+
+Check:
+
+- No direct use of `SecureConn` in repository APIs
+- Repository methods work both with transactions and normal queries
+
+---
+
+## MODKIT-DB-002: SQL Restrictions
+
+Raw SQL must only exist in migrations.
+
+Check:
+
+- No SQL in handlers/services
+- No SQL in repositories unless generated via ORM
+
+Why it matters:
+
+Database safety and migration discipline.
+
+---
+
+# ClientHub and Modules
+
+---
+
+## MODKIT-CLIENT-001: ClientHub Resolution
+
+Modules must communicate via ClientHub.
+
+Check:
+
+- No direct module dependency calls
+- Clients resolved via:
+
+```
+
+ctx.client_hub().get::<dyn MyModuleApi>()
+
+```
+
+---
+
+## MODKIT-CLIENT-002: Plugin Isolation
+
+Regular modules must not depend on plugin modules.
+
+Check:
+
+- Plugins accessed only via main module API
+- Scoped clients used for plugin resolution
+
+---
+
+# OData Integration
+
+---
+
+## MODKIT-ODATA-001: ODataFilterable Usage
+
+DTO filtering must use `ODataFilterable`.
+
+Check:
+
+- DTOs derive `ODataFilterable`
+- `.with_odata_filter()` used in OperationBuilder
+
+---
+
+# Lifecycle and Background Tasks
+
+---
+
+## MODKIT-LIFE-001: CancellationToken Usage
+
+Background tasks must respect cancellation.
+
+Check:
+
+- CancellationToken passed to tasks
+- Tasks stop on token cancellation
+
+---
+
+# Out-of-Process Modules
+
+---
+
+## MODKIT-OOP-001: SDK Pattern for gRPC
+
+Out-of-process modules must expose API via SDK crate.
+
+Check:
+
+- gRPC client defined in SDK
+- server implementation in module crate
+
+---
+
+# Additional Heuristics
+
+Be suspicious of:
+
+- modules accessing DB directly without SecureConn
+- modules calling other modules directly instead of ClientHub
+- REST handlers performing domain logic instead of delegating to services
+- DTO types leaking into SDK
+- entities leaking into REST
+
+---
+
+# Review Philosophy
+
+ModKit prioritizes:
+
+- module isolation
+- transport-agnostic APIs
+- secure data access
+- explicit authorization
+- compile-time safe REST wiring
+
+Framework rules override convenience.
+
+If a change violates these invariants, it should be flagged even if the Rust code itself is correct.

--- a/docs/pr-review/modkit-rust-review.md
+++ b/docs/pr-review/modkit-rust-review.md
@@ -1,0 +1,451 @@
+---
+cypilot: true
+type: requirement
+name: Rust PR Review Guidelines
+version: 1.0
+purpose: Idiomatic, engineering-grade checklist for reviewing Rust pull requests
+---
+
+# Rust PR Review Guidelines
+
+## Overview
+
+Use this guideline to review Rust pull requests for correctness, idiomatic style, maintainability, safety, and operational quality.
+
+This is a **PR review checklist**, not a language tutorial and not a generic architecture manifesto.  
+Focus on **real merge risk**, **idiomatic Rust**, and **actionable findings**.
+
+## Review Goals
+
+Review the PR as a senior Rust engineer. Prioritize:
+
+1. Correctness and invariant preservation
+2. Idiomatic Rust usage
+3. Error handling and panic safety
+4. Async and concurrency correctness
+5. API and type design
+6. Security and data handling
+7. Performance footguns
+8. Test adequacy
+9. Observability and operability
+
+---
+
+## Output Contract
+
+Produce an **issues-only** report.
+
+For each issue include:
+
+- **Checklist ID**
+- **Severity**: CRITICAL | HIGH | MEDIUM | LOW
+- **Location**: file path and line(s)
+- **Issue**: what is wrong
+- **Why it matters**: concrete impact
+- **Fix**: specific recommendation
+
+### Rules for reporting
+
+- Report only problems, not praise
+- Do not invent issues without evidence
+- Do not complain about style that `rustfmt` should handle
+- Do not demand speculative abstractions
+- Prefer concrete Rust-specific guidance over generic OO theory
+- If something cannot be verified from the diff or context, do not state it as fact
+- Prefer fewer, higher-signal findings over many weak ones
+
+---
+
+## Severity Dictionary
+
+- **CRITICAL**: can cause data corruption, security issue, undefined behavior, deadlock, production outage, or incorrect behavior in core paths
+- **HIGH**: significant correctness, maintainability, or operability risk; should usually be fixed before merge
+- **MEDIUM**: meaningful improvement; fix if practical in this PR
+- **LOW**: minor issue or polish
+
+---
+
+# MUST HAVE
+
+## RUST-API-001: Idiomatic Public API Design
+**Severity**: HIGH
+
+Check that public APIs follow idiomatic Rust conventions.
+
+- Function, type, trait, and module names are clear and conventional
+- Types express meaning better than raw `bool`, `String`, or loosely structured maps
+- Arguments are hard to misuse
+- Builders are used where construction is complex
+- Trait boundaries are purposeful and not overly broad
+- Public APIs expose the minimum necessary surface
+- Return types are ergonomic and predictable
+- Visibility is minimal (`pub` only where necessary)
+
+**Review guidance**:
+- Prefer domain types over primitive obsession
+- Prefer explicit enums/newtypes where they encode invariants
+- Avoid exposing implementation details in public signatures
+
+---
+
+## RUST-TYPE-001: Type Safety and Invariants
+**Severity**: HIGH
+
+- Important invariants are enforced by types where practical
+- Invalid states are made unrepresentable when reasonable
+- `Option` and `Result` are used intentionally, not as vague escape hatches
+- Newtypes are used when they improve safety or readability
+- Distinct concepts are not mixed through aliases of the same primitive type
+- Lifetimes and ownership model are used to prevent misuse, not bypassed with clones or shared mutability
+
+**Review guidance**:
+- Prefer compile-time guarantees over comments
+- Flag APIs that rely on caller discipline when the type system could help
+
+---
+
+## RUST-ERR-001: Error Handling Is Explicit and Useful
+**Severity**: CRITICAL
+
+- Fallible operations return `Result` where failure is expected
+- Error context is preserved
+- Errors are not swallowed or silently downgraded
+- Error messages are actionable
+- Domain errors are distinguishable where that matters
+- The code does not rely on logs alone instead of returning errors
+
+**Review guidance**:
+- Flag `map_err(|_| ...)` if it destroys useful context
+- Flag generic error wrapping that hides root cause without reason
+- Prefer propagation with context over ad hoc stringification
+
+---
+
+## RUST-PANIC-001: Panic Safety
+**Severity**: HIGH
+
+- No `unwrap()`, `expect()`, or `panic!()` in production paths without strong justification
+- `unreachable!()` is only used where the invariant is truly guaranteed
+- Assertions are not used as normal runtime validation in production code
+- Panics are reserved for impossible states, tests, examples, or process-fatal initialization where justified
+
+**Review guidance**:
+- In library code, panic is usually a much stronger smell
+- In service code, `expect()` may be acceptable only for startup invariants with a very clear message
+- Flag panic-prone code in request paths, workers, retries, background tasks, and data pipelines
+
+---
+
+## RUST-OWN-001: Ownership and Borrowing Are Used Idiomatically
+**Severity**: MEDIUM
+
+- The code does not clone data unnecessarily
+- References are preferred when ownership transfer is not needed
+- `Arc`, `Rc`, `Mutex`, `RwLock`, and interior mutability are used only when justified
+- Large values are not copied or moved unnecessarily
+- Borrowing structure keeps APIs ergonomic and efficient
+
+**Review guidance**:
+- Flag defensive cloning without evidence
+- Flag ownership patterns that make APIs awkward or expensive
+- Flag unnecessary heap allocation or conversion churn
+
+---
+
+## RUST-ASYNC-001: Async Code Is Runtime-Safe
+**Severity**: CRITICAL
+
+- No blocking I/O or long CPU-bound work on async executor threads without proper offloading
+- `.await` is not performed while holding a lock unless the design explicitly requires and justifies it
+- Task cancellation is handled where required
+- Timeouts are present where the operation can hang indefinitely
+- Retries are bounded and observable
+- Background tasks have lifecycle control and error handling
+
+**Review guidance**:
+- Flag blocking calls inside async paths
+- Flag `.await` inside critical sections
+- Flag detached tasks with no supervision or shutdown behavior
+- Flag loops that can retry forever without jitter, cap, or logging
+
+---
+
+## RUST-CONC-001: Shared State and Concurrency Are Well Designed
+**Severity**: HIGH
+
+- Shared mutable state is minimized
+- Lock scope is small and intentional
+- The chosen primitive matches the workload: channels, atomics, `Mutex`, `RwLock`, etc.
+- There is no obvious deadlock or starvation risk
+- Concurrency assumptions are visible in the code
+- Synchronization is not broader than necessary
+
+**Review guidance**:
+- Prefer ownership transfer and message passing over pervasive shared state
+- Flag `Arc<Mutex<_>>` used as a default design habit
+- Flag nested locking or lock ordering hazards
+
+---
+
+## RUST-SEC-001: Security and Boundary Validation
+**Severity**: CRITICAL
+
+- External input is validated at boundaries
+- Authorization and tenant/resource scoping are enforced where applicable
+- Secrets, tokens, and sensitive identifiers are not logged
+- Path, command, SQL, serialization, and deserialization boundaries are treated as hostile
+- Dangerous defaults are not silently accepted
+
+**Review guidance**:
+- Flag missing validation on request or config boundaries
+- Flag security checks implemented too deep or too late
+- Flag implicit trust in upstream data without validation
+
+---
+
+## RUST-DATA-001: Serialization and Data Contracts Are Stable
+**Severity**: HIGH
+
+- `serde` attributes are intentional and correct
+- Field renames, defaults, enum formats, and optionality are safe for the intended contract
+- Backward/forward compatibility is considered where relevant
+- Deserialization failures remain diagnosable
+- Time, UUID, and numeric formats are handled consistently
+
+**Review guidance**:
+- Flag accidental wire-format changes
+- Flag fragile enum/string handling
+- Flag implicit defaults that can hide contract bugs
+
+---
+
+## RUST-PERF-001: No Obvious Performance Footguns
+**Severity**: MEDIUM
+
+- No obvious N+1 queries or repeated expensive work in hot paths
+- Allocations are not excessive without reason
+- Data structures fit the access pattern
+- Work is not repeated unnecessarily
+- Expensive formatting/logging is not done eagerly in hot paths
+
+**Review guidance**:
+- Do not micro-optimize blindly
+- Report only clear, likely-relevant footguns
+- Prefer evidence-based performance comments
+
+---
+
+## RUST-OBS-001: Logging, Tracing, and Metrics Are Operationally Useful
+**Severity**: MEDIUM
+
+- Important failures are logged at the right boundary
+- Logs contain enough context to debug production issues
+- Sensitive data is not emitted
+- Request/task/job identifiers are propagated where relevant
+- Metrics or tracing exist for critical operational paths when the service is long-running
+
+**Review guidance**:
+- Flag duplicate logging of the same error at multiple layers unless intentional
+- Flag logs with no identifiers or context
+- Flag missing observability in background workers, retries, queue processing, and external calls
+
+---
+
+## RUST-TEST-001: Tests Cover Behavior, Not Just Syntax
+**Severity**: HIGH
+
+- New behavior is covered by tests
+- Core happy path is tested
+- Important error paths are tested
+- Edge cases and regressions are tested where risk justifies it
+- Tests verify observable behavior, not internal implementation details
+- Tests are deterministic and readable
+
+**Review guidance**:
+- Do not require exhaustive testing for trivial refactors
+- Do flag missing tests for bug fixes, parsing, state transitions, retries, concurrency-sensitive code, and boundary conditions
+
+---
+
+## RUST-MOD-001: Module Boundaries and Code Organization Are Clean
+**Severity**: HIGH
+
+- Responsibilities are separated clearly
+- Business logic is not tangled with transport, persistence, or framework glue
+- Helpers are not used to hide poor structure
+- Modules are cohesive
+- Visibility and dependency direction are intentional
+- The PR does not introduce avoidable architectural drift
+
+**Review guidance**:
+- Flag "god modules"
+- Flag handlers/controllers doing domain work directly
+- Flag infrastructure details leaking into domain logic without need
+
+---
+
+# MUST NOT HAVE
+
+## RUST-NO-001: No Placeholder Production Logic
+**Severity**: CRITICAL
+
+- No `todo!()`, `unimplemented!()`, stub returns, fake success, or empty implementations in production paths
+- No placeholder branches that silently discard work
+- No fake adapters presented as complete behavior unless clearly test-only
+
+---
+
+## RUST-NO-002: No Silent Failure
+**Severity**: CRITICAL
+
+- No ignored `Result` for fallible operations without justification
+- No `let _ = ...` on meaningful failures unless explicitly intentional and documented
+- No empty error handlers
+- No failure paths that only log and continue when correctness requires propagation or state change
+
+---
+
+## RUST-NO-003: No Panic-Driven Control Flow
+**Severity**: HIGH
+
+- No `unwrap()` / `expect()` used as ordinary control flow
+- No panic used instead of validation or typed error handling
+- No assumptions about "this can never fail" unless invariant is obvious and local
+
+---
+
+## RUST-NO-004: No Async Blocking Footguns
+**Severity**: CRITICAL
+
+- No blocking file, network, database, sleep, or CPU-heavy work directly inside async tasks without appropriate handling
+- No `.await` while holding broad or long-lived locks unless explicitly justified
+- No unbounded fan-out of tasks without backpressure
+
+---
+
+## RUST-NO-005: No Unjustified Shared Mutability
+**Severity**: HIGH
+
+- No `Arc<Mutex<_>>` as a default convenience pattern
+- No pervasive interior mutability where plain ownership would work
+- No overly broad lock-protected state blobs
+
+---
+
+## RUST-NO-006: No Unsafe Without Tight Justification
+**Severity**: CRITICAL
+
+- No `unsafe` unless it is necessary
+- Unsafe blocks must have local justification and clear invariants
+- No casual assumptions around aliasing, lifetimes, initialization, or FFI contracts
+- No undocumented transmute-like behavior
+
+---
+
+## RUST-NO-007: No Contract Drift by Accident
+**Severity**: HIGH
+
+- No accidental API breakage
+- No accidental serde/wire/schema changes
+- No accidental visibility expansion
+- No accidental behavior changes hidden inside refactoring
+
+---
+
+# Review Heuristics
+
+## Prefer This
+
+- Small, explicit types
+- Meaningful enums and newtypes
+- `Result` with preserved context
+- Narrow visibility
+- Clear module boundaries
+- Structured async flows
+- Bounded retries and timeouts
+- Tests for behavior and regressions
+- Standard library and ecosystem conventions
+- Simplicity over abstraction
+
+## Be Suspicious Of
+
+- Generic abstractions with no current need
+- Excessive trait layering
+- Broad `pub` exposure
+- Clone-heavy code
+- `Arc<Mutex<HashMap<...>>>` growing into a hidden subsystem
+- Lossy error conversion
+- Detached background tasks
+- Hidden wire-format changes
+- Logging without identifiers
+- Refactors mixed with behavioral change and no tests
+
+---
+
+# What "Idiomatic Rust" Means in Review
+
+Treat code as more idiomatic when it is:
+
+- Clear without being verbose
+- Safe by construction
+- Explicit about ownership and failure
+- Conservative with shared mutability
+- Consistent with standard Rust ecosystem conventions
+- Easy to test
+- Hard to misuse
+- Minimal in API surface
+- Honest about runtime behavior
+
+Do **not** equate "idiomatic" with:
+- maximum cleverness
+- maximum abstraction
+- macro-heavy design by default
+- avoiding all cloning at any cost
+- forcing functional style where it hurts readability
+
+---
+
+# Reporting Format
+
+## Compact Format
+
+```markdown
+## Rust PR Review
+
+| # | ID | Sev | Location | Issue | Why it matters | Fix |
+|---|----|-----|----------|-------|----------------|-----|
+| 1 | RUST-ERR-001 | CRITICAL | src/service.rs:84-96 | Error context is discarded by `map_err(|_| ...)` | Production failures become undiagnosable without the original cause | Preserve source error and add context |
+| 2 | RUST-ASYNC-001 | CRITICAL | src/worker.rs:41-58 | Blocking operation in async task | Starves the async runtime and causes latency spikes | Move to `spawn_blocking` or dedicated worker |
+````
+
+## Full Format
+
+```markdown
+### 1. Error context is lost
+
+**Checklist ID**: `RUST-ERR-001`  
+**Severity**: CRITICAL
+**Location**: `src/service.rs:84-96`
+
+**Issue**  
+The code converts a specific repository error into a generic string/error variant and drops the original cause.
+
+**Why it matters**  
+This makes production failures harder to diagnose and may prevent correct retry or classification logic.
+
+**Fix**  
+Preserve the original error as source/context and map only at the service boundary if needed.
+```
+
+---
+
+# Final Review Discipline
+
+Before finalizing the review:
+
+* Report only real, evidence-based issues
+* Prefer Rust-specific findings over generic OO criticism
+* Do not request speculative abstractions
+* Do not nitpick formatting that tooling should handle
+* Escalate correctness, panic, async, concurrency, contract, and security problems first
+* Keep the report concise and engineering-focused


### PR DESCRIPTION
- Add Claude Code skill for reviewing Rust PRs against idiomatic Rust guidelines and ModKit framework compliance rules, with inline GitHub comment posting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new PR review skill guide describing workflow, inputs, review checklists, and comment formatting for automated Rust PR reviews.
  * Added comprehensive Rust PR review guidelines covering correctness, idioms, error handling, async, API design, security, performance, testing, and reporting formats.
  * Added ModKit framework compliance checklist with core invariants and validation rules across subsystems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->