### PR TITLE
feat(api-gateway): add coarse grained access checks for scope enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "futures-core",
+ "glob",
  "governor",
  "http",
  "http-body",

--- a/config/e2e-scope-enforcement.yaml
+++ b/config/e2e-scope-enforcement.yaml
@@ -1,0 +1,159 @@
+# E2E Configuration for Gateway Scope Enforcement Testing
+#
+# This config enables authentication with static tokens that have specific scopes,
+# allowing us to test the gateway_scope_checks middleware.
+
+server:
+  home_dir: "~/.hyperspot"
+
+database:
+  servers:
+    sqlite_users:
+      engine: "sqlite"
+      params:
+        WAL: "true"
+        synchronous: "NORMAL"
+        busy_timeout: "5000"
+      pool:
+        max_conns: 5
+        acquire_timeout: "30s"
+
+logging:
+  default:
+    console_level: info
+    file: "logs/hyperspot-scope-e2e.log"
+    file_level: debug
+
+modules:
+  api-gateway:
+    config:
+      bind_addr: "0.0.0.0:8086"
+      enable_docs: true
+      cors_enabled: false
+
+      openapi:
+        title: "HyperSpot API - Scope Enforcement E2E"
+        version: "0.1.0"
+
+      defaults:
+        body_limit_bytes: 64000000
+        rate_limit:
+          rps: 1000
+          burst: 200
+          in_flight: 64
+
+      # Enable authentication (required for scope enforcement)
+      auth_disabled: false
+      require_auth_by_default: true
+
+      # Gateway Scope Enforcement configuration
+      gateway_scope_checks:
+        enabled: true
+        routes:
+          # Require 'users:read' scope for listing users
+          "/users-info/v1/users":
+            required_scopes: ["users:read", "users:admin"]
+          # Require 'users:read' or 'users:admin' for getting a specific user
+          "/users-info/v1/users/*":
+            required_scopes: ["users:read", "users:admin"]
+          # Require 'cities:admin' for cities endpoints
+          # Use both exact path and glob to cover list and nested paths
+          "/users-info/v1/cities":
+            required_scopes: ["cities:admin"]
+          "/users-info/v1/cities/*":
+            required_scopes: ["cities:admin"]
+
+  # AuthN pipeline - validates bearer tokens
+  authn-resolver:
+    config:
+      vendor: "hyperspot"
+
+  static-authn-plugin:
+    config:
+      vendor: "hyperspot"
+      priority: 100
+      mode: static_tokens
+      # Define tokens with specific scopes for testing
+      tokens:
+        # Token with full access (first-party app)
+        - token: "token-full-access"
+          identity:
+            subject_id: "11111111-1111-1111-1111-111111111111"
+            subject_tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
+            token_scopes: ["*"]
+        # Token with users:read scope only
+        - token: "token-users-read"
+          identity:
+            subject_id: "22222222-2222-2222-2222-222222222222"
+            subject_tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
+            token_scopes: ["users:read"]
+        # Token with users:admin scope
+        - token: "token-users-admin"
+          identity:
+            subject_id: "33333333-3333-3333-3333-333333333333"
+            subject_tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
+            token_scopes: ["users:admin"]
+        # Token with cities:admin scope (no users access)
+        - token: "token-cities-admin"
+          identity:
+            subject_id: "44444444-4444-4444-4444-444444444444"
+            subject_tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
+            token_scopes: ["cities:admin"]
+        # Token with no relevant scopes
+        - token: "token-no-scopes"
+          identity:
+            subject_id: "55555555-5555-5555-5555-555555555555"
+            subject_tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
+            token_scopes: ["unrelated:scope"]
+
+  # AuthZ pipeline
+  authz-resolver:
+    config:
+      vendor: "hyperspot"
+
+  static-authz-plugin:
+    config:
+      vendor: "hyperspot"
+      priority: 100
+
+  # Tenant resolver
+  tenant-resolver:
+    config:
+      vendor: "hyperspot"
+
+  static-tr-plugin:
+    config:
+      vendor: "hyperspot"
+      priority: 20
+      tenants:
+        - id: "00000000-df51-5b42-9538-d2b56b7ee953"
+          name: "e2e-root"
+          parent_id: null
+          status: active
+
+  types-registry:
+    config: {}
+
+  # File parser module (required by hyperspot-server)
+  file-parser:
+    config:
+      allowed_local_base_dir: /tmp
+
+  # Simple user settings module (required by hyperspot-server)
+  simple-user-settings:
+    database:
+      server: "sqlite_users"
+      file: "settings_scope_e2e.db"
+    config: {}
+
+  # Users-info module for testing
+  users-info:
+    database:
+      server: "sqlite_users"
+      file: "users_info_scope_e2e.db"
+    config:
+      default_page_size: 5
+      max_page_size: 100
+
+tracing:
+  enabled: false

--- a/config/e2e-scope-enforcement.yaml
+++ b/config/e2e-scope-enforcement.yaml
@@ -1,7 +1,7 @@
-# E2E Configuration for Gateway Scope Enforcement Testing
+# E2E Configuration for Route Policy Enforcement Testing
 #
 # This config enables authentication with static tokens that have specific scopes,
-# allowing us to test the gateway_scope_checks middleware.
+# allowing us to test the route_policies middleware.
 
 server:
   home_dir: "~/.hyperspot"
@@ -47,20 +47,20 @@ modules:
       require_auth_by_default: true
 
       # Gateway Scope Enforcement configuration
-      gateway_scope_checks:
+      route_policies:
         enabled: true
-        routes:
+        rules:
           # Require 'users:read' scope for listing users
-          "/users-info/v1/users":
+          - path: "/users-info/v1/users"
             required_scopes: ["users:read", "users:admin"]
           # Require 'users:read' or 'users:admin' for getting a specific user
-          "/users-info/v1/users/*":
+          - path: "/users-info/v1/users/*"
             required_scopes: ["users:read", "users:admin"]
           # Require 'cities:admin' for cities endpoints
           # Use both exact path and glob to cover list and nested paths
-          "/users-info/v1/cities":
+          - path: "/users-info/v1/cities"
             required_scopes: ["cities:admin"]
-          "/users-info/v1/cities/*":
+          - path: "/users-info/v1/cities/*"
             required_scopes: ["cities:admin"]
 
   # AuthN pipeline - validates bearer tokens

--- a/docs/arch/authorization/DESIGN.md
+++ b/docs/arch/authorization/DESIGN.md
@@ -339,19 +339,22 @@ scope mismatch without calling PDP.
 
 **Configuration:**
 ```yaml
-auth:
-  gateway_scope_checks:
-    enabled: true
-    routes:
-      "/admin/*":
-        required_scopes: ["admin"]
-      "/events/v1/*":
-        required_scopes: ["read:events", "write:events"]  # any of these
+api-gateway:
+  config:
+    route_policies:
+      enabled: true
+      rules:
+        - path: "/admin/**"
+          required_scopes: ["admin"]
+        - path: "/events/v1/*"
+          required_scopes: ["read:events", "write:events"]  # any of these
 ```
 
 **Behavior:**
-- If `token_scopes: ["*"]` → always pass
+- Rules are evaluated in declaration order (first match wins)
+- If `token_scopes: ["*"]` → always pass (first-party app)
 - If `token_scopes` contains any of `required_scopes` → pass
+- Empty `token_scopes` → 403 Forbidden (fail-closed)
 - Otherwise → 403 Forbidden (before PDP call)
 
 **Note:** This is coarse-grained optimization. Fine-grained permission checks still happen in PDP.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -86,11 +86,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors"
-<<<<<<< HEAD
-version = "0.5.0"
-=======
 version = "0.5.1"
->>>>>>> baadf109 (feat(api_gateway): add coarse grained access checks for scope enforcement)
 dependencies = [
  "http",
  "serde",
@@ -98,11 +94,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
-<<<<<<< HEAD
-version = "0.5.0"
-=======
 version = "0.5.1"
->>>>>>> baadf109 (feat(api_gateway): add coarse grained access checks for scope enforcement)
 dependencies = [
  "proc-macro2",
  "quote",
@@ -113,11 +105,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-<<<<<<< HEAD
-version = "0.5.0"
-=======
 version = "0.5.1"
->>>>>>> baadf109 (feat(api_gateway): add coarse grained access checks for scope enforcement)
 dependencies = [
  "base64",
  "bigdecimal",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -86,7 +86,11 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors"
+<<<<<<< HEAD
 version = "0.5.0"
+=======
+version = "0.5.1"
+>>>>>>> baadf109 (feat(api_gateway): add coarse grained access checks for scope enforcement)
 dependencies = [
  "http",
  "serde",
@@ -94,7 +98,11 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-errors-macro"
+<<<<<<< HEAD
 version = "0.5.0"
+=======
+version = "0.5.1"
+>>>>>>> baadf109 (feat(api_gateway): add coarse grained access checks for scope enforcement)
 dependencies = [
  "proc-macro2",
  "quote",
@@ -105,7 +113,11 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
+<<<<<<< HEAD
 version = "0.5.0"
+=======
+version = "0.5.1"
+>>>>>>> baadf109 (feat(api_gateway): add coarse grained access checks for scope enforcement)
 dependencies = [
  "base64",
  "bigdecimal",

--- a/modules/system/api-gateway/Cargo.toml
+++ b/modules/system/api-gateway/Cargo.toml
@@ -43,6 +43,7 @@ tower = { workspace = true }
 tower-http = { workspace = true }
 matchit = { workspace = true }
 governor = { workspace = true }
+glob = { workspace = true }
 
 opentelemetry = { workspace = true }
 chrono = { workspace = true }

--- a/modules/system/api-gateway/src/config.rs
+++ b/modules/system/api-gateway/src/config.rs
@@ -174,7 +174,7 @@ impl Default for OpenApiConfig {
 /// # Example YAML
 ///
 /// ```yaml
-/// gateway_scope_checks:
+/// route_policies:
 ///   enabled: true
 ///   rules:
 ///     - path: "/admin/**"
@@ -205,6 +205,10 @@ pub struct RoutePoliciesConfig {
 pub struct RoutePolicyRule {
     /// Path pattern to match. Supports glob syntax (`*` = one segment, `**` = any depth).
     pub path: String,
+    /// HTTP method to match (GET, POST, PUT, PATCH, DELETE, etc.).
+    /// If not specified, matches any method.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
     /// Required scopes for this route. Request passes if token has ANY of these scopes.
     /// Must not be empty.
     pub required_scopes: Vec<String>,

--- a/modules/system/api-gateway/src/config.rs
+++ b/modules/system/api-gateway/src/config.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 fn default_require_auth_by_default() -> bool {
@@ -48,9 +50,16 @@ pub struct ApiGatewayConfig {
     #[serde(default)]
     pub prefix_path: String,
 
+<<<<<<< HEAD
     /// HTTP metrics settings.
     #[serde(default)]
     pub metrics: MetricsConfig,
+=======
+    /// Gateway-level scope enforcement configuration.
+    /// Allows early rejection of requests based on token scopes without calling the PDP.
+    #[serde(default)]
+    pub gateway_scope_checks: GatewayScopeChecksConfig,
+>>>>>>> f24cc0d7 (feat(api_gateway): add coarse grained access checks for scope enforcement)
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -158,4 +167,44 @@ impl Default for OpenApiConfig {
             description: None,
         }
     }
+}
+
+/// Gateway-level scope enforcement configuration.
+///
+/// Enables coarse-grained early rejection of requests based on token scopes
+/// without calling the PDP. This is an optimization for performance-critical routes.
+///
+/// # Example YAML
+///
+/// ```yaml
+/// gateway_scope_checks:
+///   enabled: true
+///   routes:
+///     "/admin/*":
+///       required_scopes: ["admin"]
+///     "/events/v1/*":
+///       required_scopes: ["read:events", "write:events"]  # any of these
+/// ```
+///
+/// # Behavior
+///
+/// - If `token_scopes: ["*"]` → always pass (first-party app)
+/// - If `token_scopes` contains any of `required_scopes` → pass
+/// - Otherwise → 403 Forbidden (before PDP call)
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct GatewayScopeChecksConfig {
+    /// Whether gateway scope enforcement is enabled.
+    pub enabled: bool,
+    /// Route patterns mapped to their scope requirements.
+    /// Patterns support glob syntax (e.g., `/admin/*`, `/events/v1/**`).
+    pub routes: HashMap<String, RouteScopeRequirement>,
+}
+
+/// Scope requirements for a specific route pattern.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RouteScopeRequirement {
+    /// Required scopes for this route. Request passes if token has ANY of these scopes.
+    pub required_scopes: Vec<String>,
 }

--- a/modules/system/api-gateway/src/config.rs
+++ b/modules/system/api-gateway/src/config.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 fn default_require_auth_by_default() -> bool {
@@ -50,16 +48,15 @@ pub struct ApiGatewayConfig {
     #[serde(default)]
     pub prefix_path: String,
 
-<<<<<<< HEAD
-    /// HTTP metrics settings.
+    /// Route-level policy configuration.
+    /// Allows early rejection of requests based on token scopes without calling the PDP.
+    /// Rules are evaluated in declaration order (first match wins).
+    #[serde(default)]
+    pub route_policies: RoutePoliciesConfig,
+
+    /// HTTP metrics configuration.
     #[serde(default)]
     pub metrics: MetricsConfig,
-=======
-    /// Gateway-level scope enforcement configuration.
-    /// Allows early rejection of requests based on token scopes without calling the PDP.
-    #[serde(default)]
-    pub gateway_scope_checks: GatewayScopeChecksConfig,
->>>>>>> f24cc0d7 (feat(api_gateway): add coarse grained access checks for scope enforcement)
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -169,7 +166,7 @@ impl Default for OpenApiConfig {
     }
 }
 
-/// Gateway-level scope enforcement configuration.
+/// Route-level policy configuration.
 ///
 /// Enables coarse-grained early rejection of requests based on token scopes
 /// without calling the PDP. This is an optimization for performance-critical routes.
@@ -179,32 +176,37 @@ impl Default for OpenApiConfig {
 /// ```yaml
 /// gateway_scope_checks:
 ///   enabled: true
-///   routes:
-///     "/admin/*":
+///   rules:
+///     - path: "/admin/**"
 ///       required_scopes: ["admin"]
-///     "/events/v1/*":
+///     - path: "/events/v1/*"
 ///       required_scopes: ["read:events", "write:events"]  # any of these
 /// ```
 ///
 /// # Behavior
 ///
+/// - Rules are evaluated in declaration order (first match wins)
 /// - If `token_scopes: ["*"]` → always pass (first-party app)
 /// - If `token_scopes` contains any of `required_scopes` → pass
 /// - Otherwise → 403 Forbidden (before PDP call)
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
-pub struct GatewayScopeChecksConfig {
-    /// Whether gateway scope enforcement is enabled.
+pub struct RoutePoliciesConfig {
+    /// Whether route policy enforcement is enabled.
     pub enabled: bool,
-    /// Route patterns mapped to their scope requirements.
+    /// Route policy rules evaluated in declaration order.
     /// Patterns support glob syntax (e.g., `/admin/*`, `/events/v1/**`).
-    pub routes: HashMap<String, RouteScopeRequirement>,
+    pub rules: Vec<RoutePolicyRule>,
 }
 
-/// Scope requirements for a specific route pattern.
+/// A single route policy rule.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct RouteScopeRequirement {
+pub struct RoutePolicyRule {
+    /// Path pattern to match. Supports glob syntax (`*` = one segment, `**` = any depth).
+    pub path: String,
     /// Required scopes for this route. Request passes if token has ANY of these scopes.
+    /// Must not be empty.
     pub required_scopes: Vec<String>,
+    // Future fields: rate_limit, timeout, operation_id, etc.
 }

--- a/modules/system/api-gateway/src/middleware/mod.rs
+++ b/modules/system/api-gateway/src/middleware/mod.rs
@@ -6,3 +6,4 @@ pub mod license_validation;
 pub mod mime_validation;
 pub mod rate_limit;
 pub mod request_id;
+pub mod scope_enforcement;

--- a/modules/system/api-gateway/src/middleware/scope_enforcement.rs
+++ b/modules/system/api-gateway/src/middleware/scope_enforcement.rs
@@ -24,10 +24,12 @@ pub struct ScopeEnforcementRules {
     enabled: bool,
 }
 
-/// A single compiled rule: glob pattern + required scopes.
+/// A single compiled rule: glob pattern + optional method + required scopes.
 #[derive(Clone, Debug)]
 struct CompiledRule {
     pattern: Pattern,
+    /// HTTP method to match (uppercase). None means match any method.
+    method: Option<String>,
     required_scopes: Vec<String>,
 }
 
@@ -66,6 +68,7 @@ impl ScopeEnforcementRules {
 
             rules.push(CompiledRule {
                 pattern,
+                method: rule.method.as_ref().map(|m| m.to_uppercase()),
                 required_scopes: rule.required_scopes.clone(),
             });
         }
@@ -82,10 +85,10 @@ impl ScopeEnforcementRules {
         })
     }
 
-    /// Check if the given path matches any protected route.
+    /// Check if the given path and method match any protected route.
     ///
-    /// Returns `true` if the path matches at least one scope enforcement rule.
-    fn matches_protected_route(&self, path: &str) -> bool {
+    /// Returns `true` if the path/method matches at least one scope enforcement rule.
+    fn matches_protected_route(&self, path: &str, method: &str) -> bool {
         if !self.enabled {
             return false;
         }
@@ -95,16 +98,21 @@ impl ScopeEnforcementRules {
             ..MatchOptions::default()
         };
 
-        self.rules
-            .iter()
-            .any(|rule| rule.pattern.matches_with(path, match_opts))
+        self.rules.iter().any(|rule| {
+            let path_matches = rule.pattern.matches_with(path, match_opts);
+            let method_matches = rule
+                .method
+                .as_ref()
+                .is_none_or(|m| m.eq_ignore_ascii_case(method));
+            path_matches && method_matches
+        })
     }
 
-    /// Check if the given path and token scopes satisfy the scope requirements.
+    /// Check if the given path, method, and token scopes satisfy the scope requirements.
     ///
     /// Returns `Ok(())` if access is allowed, or `Err(problem)` if denied.
     #[allow(clippy::result_large_err)]
-    fn check(&self, path: &str, token_scopes: &[String]) -> Result<(), Problem> {
+    fn check(&self, path: &str, method: &str, token_scopes: &[String]) -> Result<(), Problem> {
         if !self.enabled {
             return Ok(());
         }
@@ -121,33 +129,45 @@ impl ScopeEnforcementRules {
             ..MatchOptions::default()
         };
 
-        // Find matching rules and check scopes
+        // First match wins: find the first matching rule and check scopes against it only.
+        // This allows more specific rules to override broader ones when declared first.
         for rule in self.rules.iter() {
-            if rule.pattern.matches_with(path, match_opts) {
+            let path_matches = rule.pattern.matches_with(path, match_opts);
+            let method_matches = rule
+                .method
+                .as_ref()
+                .is_none_or(|m| m.eq_ignore_ascii_case(method));
+
+            if path_matches && method_matches {
                 // Check if token has ANY of the required scopes
                 let has_required_scope = rule
                     .required_scopes
                     .iter()
                     .any(|required| token_scopes.contains(required));
 
-                if !has_required_scope {
-                    tracing::warn!(
-                        path = %path,
-                        pattern = %rule.pattern,
-                        required_scopes = ?rule.required_scopes,
-                        token_scopes = ?token_scopes,
-                        "Route policy enforcement denied: insufficient scopes"
-                    );
-
-                    return Err(Problem::new(
-                        axum::http::StatusCode::FORBIDDEN,
-                        "Forbidden",
-                        "Insufficient token scopes for this resource",
-                    ));
+                if has_required_scope {
+                    return Ok(());
                 }
+
+                tracing::warn!(
+                    path = %path,
+                    method = %method,
+                    pattern = %rule.pattern,
+                    rule_method = ?rule.method,
+                    required_scopes = ?rule.required_scopes,
+                    token_scopes = ?token_scopes,
+                    "Route policy enforcement denied: insufficient scopes"
+                );
+
+                return Err(Problem::new(
+                    axum::http::StatusCode::FORBIDDEN,
+                    "Forbidden",
+                    "Insufficient token scopes for this resource",
+                ));
             }
         }
 
+        // No rule matched — allow (unprotected route)
         Ok(())
     }
 }
@@ -178,15 +198,17 @@ pub async fn scope_enforcement_middleware(
     // returns the route template like "/{*path}" for catch-all routes).
     let path = req.uri().path();
     let path = common::resolve_path(&req, path);
+    let method = req.method().as_str();
 
     // Get SecurityContext from request extensions (populated by auth middleware)
     let Some(security_context) = req.extensions().get::<SecurityContext>() else {
         // No SecurityContext means auth middleware didn't run or request is unauthenticated.
         // If the path matches a protected route, reject with 401 Unauthorized.
         // Otherwise, let it pass through for public/unprotected routes.
-        if state.rules.matches_protected_route(&path) {
+        if state.rules.matches_protected_route(&path, method) {
             tracing::warn!(
                 path = %path,
+                method = %method,
                 "Route policy enforcement denied: no SecurityContext for protected route"
             );
             return Problem::new(
@@ -200,7 +222,10 @@ pub async fn scope_enforcement_middleware(
     };
 
     // Check scopes
-    if let Err(problem) = state.rules.check(&path, security_context.token_scopes()) {
+    if let Err(problem) = state
+        .rules
+        .check(&path, method, security_context.token_scopes())
+    {
         return problem.into_response();
     }
 
@@ -214,10 +239,20 @@ mod tests {
     use crate::config::RoutePolicyRule;
 
     fn build_config(enabled: bool, routes: Vec<(&str, Vec<&str>)>) -> RoutePoliciesConfig {
+        build_config_with_methods(
+            enabled,
+            routes.into_iter().map(|(p, s)| (p, None, s)).collect(),
+        )
+    }
+
+    type TestRoute<'a> = (&'a str, Option<&'a str>, Vec<&'a str>);
+
+    fn build_config_with_methods(enabled: bool, routes: Vec<TestRoute<'_>>) -> RoutePoliciesConfig {
         let rules = routes
             .into_iter()
-            .map(|(path, scopes)| RoutePolicyRule {
+            .map(|(path, method, scopes)| RoutePolicyRule {
                 path: path.to_owned(),
+                method: method.map(String::from),
                 required_scopes: scopes.into_iter().map(String::from).collect(),
             })
             .collect();
@@ -231,7 +266,7 @@ mod tests {
         let rules = ScopeEnforcementRules::from_config(&config).unwrap();
 
         // Even with no scopes, should pass when disabled
-        assert!(rules.check("/admin/users", &[]).is_ok());
+        assert!(rules.check("/admin/users", "GET", &[]).is_ok());
     }
 
     #[test]
@@ -241,7 +276,7 @@ mod tests {
 
         // First-party apps have ["*"] scope
         let scopes = vec!["*".to_owned()];
-        assert!(rules.check("/admin/users", &scopes).is_ok());
+        assert!(rules.check("/admin/users", "GET", &scopes).is_ok());
     }
 
     #[test]
@@ -250,7 +285,7 @@ mod tests {
         let rules = ScopeEnforcementRules::from_config(&config).unwrap();
 
         let scopes = vec!["admin".to_owned()];
-        assert!(rules.check("/admin/users", &scopes).is_ok());
+        assert!(rules.check("/admin/users", "GET", &scopes).is_ok());
     }
 
     #[test]
@@ -263,10 +298,10 @@ mod tests {
 
         // Having just one of the required scopes should pass
         let scopes = vec!["read:events".to_owned()];
-        assert!(rules.check("/events/v1/list", &scopes).is_ok());
+        assert!(rules.check("/events/v1/list", "GET", &scopes).is_ok());
 
         let scopes = vec!["write:events".to_owned()];
-        assert!(rules.check("/events/v1/create", &scopes).is_ok());
+        assert!(rules.check("/events/v1/create", "POST", &scopes).is_ok());
     }
 
     #[test]
@@ -276,7 +311,7 @@ mod tests {
 
         // No matching scope
         let scopes = vec!["read:events".to_owned()];
-        let result = rules.check("/admin/users", &scopes);
+        let result = rules.check("/admin/users", "GET", &scopes);
         assert!(result.is_err());
 
         let problem = result.unwrap_err();
@@ -289,7 +324,7 @@ mod tests {
         let rules = ScopeEnforcementRules::from_config(&config).unwrap();
 
         // Empty scopes = no permissions (fail-closed)
-        let result = rules.check("/admin/users", &[]);
+        let result = rules.check("/admin/users", "GET", &[]);
         assert!(result.is_err());
 
         let problem = result.unwrap_err();
@@ -303,7 +338,7 @@ mod tests {
 
         // Route doesn't match any pattern, should pass even with unrelated scope
         let scopes = vec!["unrelated:scope".to_owned()];
-        assert!(rules.check("/public/health", &scopes).is_ok());
+        assert!(rules.check("/public/health", "GET", &scopes).is_ok());
     }
 
     #[test]
@@ -314,14 +349,14 @@ mod tests {
         let scopes = vec!["api:read".to_owned()];
 
         // Single * matches exactly one path segment (doesn't cross `/`)
-        assert!(rules.check("/api/v1/items", &scopes).is_ok());
-        assert!(rules.check("/api/v2/items", &scopes).is_ok());
+        assert!(rules.check("/api/v1/items", "GET", &scopes).is_ok());
+        assert!(rules.check("/api/v2/items", "GET", &scopes).is_ok());
 
         // Multiple segments do NOT match single * pattern (no scope check triggered)
         let unrelated_scopes = vec!["unrelated:scope".to_owned()];
         assert!(
             rules
-                .check("/api/v1/nested/items", &unrelated_scopes)
+                .check("/api/v1/nested/items", "GET", &unrelated_scopes)
                 .is_ok()
         ); // doesn't match pattern
     }
@@ -334,9 +369,13 @@ mod tests {
         let scopes = vec!["api:access".to_owned()];
 
         // ** matches any number of path segments
-        assert!(rules.check("/api/v1", &scopes).is_ok());
-        assert!(rules.check("/api/v1/items", &scopes).is_ok());
-        assert!(rules.check("/api/v1/items/123/details", &scopes).is_ok());
+        assert!(rules.check("/api/v1", "GET", &scopes).is_ok());
+        assert!(rules.check("/api/v1/items", "GET", &scopes).is_ok());
+        assert!(
+            rules
+                .check("/api/v1/items/123/details", "GET", &scopes)
+                .is_ok()
+        );
     }
 
     #[test]
@@ -358,7 +397,8 @@ mod tests {
     }
 
     #[test]
-    fn multiple_rules_all_checked() {
+    fn multiple_non_overlapping_rules() {
+        // Non-overlapping patterns: each path matches exactly one rule
         let config = build_config(
             true,
             vec![
@@ -370,17 +410,61 @@ mod tests {
 
         // Admin route needs admin scope
         let admin_scopes = vec!["admin".to_owned()];
-        assert!(rules.check("/admin/users", &admin_scopes).is_ok());
+        assert!(rules.check("/admin/users", "GET", &admin_scopes).is_ok());
 
         // Events route needs events:read scope
         let events_scopes = vec!["events:read".to_owned()];
-        assert!(rules.check("/events/v1/list", &events_scopes).is_ok());
+        assert!(
+            rules
+                .check("/events/v1/list", "GET", &events_scopes)
+                .is_ok()
+        );
 
         // Wrong scope for admin route
-        assert!(rules.check("/admin/users", &events_scopes).is_err());
+        assert!(rules.check("/admin/users", "GET", &events_scopes).is_err());
 
         // Wrong scope for events route
-        assert!(rules.check("/events/v1/list", &admin_scopes).is_err());
+        assert!(
+            rules
+                .check("/events/v1/list", "GET", &admin_scopes)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn overlapping_rules_first_match_wins() {
+        // Path /api/admin/users matches BOTH rules with DIFFERENT scope requirements.
+        // First-match-wins: only the first matching rule is evaluated.
+        let config = build_config(
+            true,
+            vec![
+                ("/api/**", vec!["basic"]), // Matches /api/admin/users, requires "basic"
+                ("/api/admin/**", vec!["admin"]), // Also matches, requires "admin" (never evaluated)
+            ],
+        );
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        // /api/admin/users matches both rules, but first rule wins
+        let basic_scopes = vec!["basic".to_owned()];
+        let admin_scopes = vec!["admin".to_owned()];
+
+        // "basic" scope passes because first rule (/api/**) is evaluated
+        assert!(
+            rules
+                .check("/api/admin/users", "GET", &basic_scopes)
+                .is_ok()
+        );
+
+        // "admin" scope also passes (it satisfies the first rule too? No - let's check)
+        // Actually "admin" does NOT satisfy ["basic"], so it should fail
+        assert!(
+            rules
+                .check("/api/admin/users", "GET", &admin_scopes)
+                .is_err()
+        );
+
+        // This demonstrates first-match-wins: even though second rule requires "admin",
+        // the first rule requiring "basic" takes precedence for /api/admin/users
     }
 
     #[test]
@@ -388,8 +472,8 @@ mod tests {
         let config = build_config(true, vec![("/admin/*", vec!["admin"])]);
         let rules = ScopeEnforcementRules::from_config(&config).unwrap();
 
-        assert!(rules.matches_protected_route("/admin/users"));
-        assert!(rules.matches_protected_route("/admin/settings"));
+        assert!(rules.matches_protected_route("/admin/users", "GET"));
+        assert!(rules.matches_protected_route("/admin/settings", "POST"));
     }
 
     #[test]
@@ -397,8 +481,8 @@ mod tests {
         let config = build_config(true, vec![("/admin/*", vec!["admin"])]);
         let rules = ScopeEnforcementRules::from_config(&config).unwrap();
 
-        assert!(!rules.matches_protected_route("/public/health"));
-        assert!(!rules.matches_protected_route("/api/v1/users"));
+        assert!(!rules.matches_protected_route("/public/health", "GET"));
+        assert!(!rules.matches_protected_route("/api/v1/users", "GET"));
     }
 
     #[test]
@@ -407,6 +491,121 @@ mod tests {
         let rules = ScopeEnforcementRules::from_config(&config).unwrap();
 
         // Even matching paths return false when enforcement is disabled
-        assert!(!rules.matches_protected_route("/admin/users"));
+        assert!(!rules.matches_protected_route("/admin/users", "GET"));
+    }
+
+    #[test]
+    fn first_match_wins_more_specific_rule_first() {
+        // More specific rule declared first should take precedence
+        let config = build_config(
+            true,
+            vec![
+                ("/api/admin/**", vec!["admin"]), // More specific, declared first
+                ("/api/**", vec!["basic"]),       // Broader, declared second
+            ],
+        );
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        // /api/admin/users matches first rule, requires "admin"
+        let admin_scopes = vec!["admin".to_owned()];
+        let basic_scopes = vec!["basic".to_owned()];
+
+        // Admin scope passes (matches first rule)
+        assert!(
+            rules
+                .check("/api/admin/users", "GET", &admin_scopes)
+                .is_ok()
+        );
+
+        // Basic scope fails for /api/admin/users (first rule requires admin)
+        assert!(
+            rules
+                .check("/api/admin/users", "GET", &basic_scopes)
+                .is_err()
+        );
+
+        // Basic scope passes for /api/other (matches second rule)
+        assert!(rules.check("/api/other", "GET", &basic_scopes).is_ok());
+    }
+
+    #[test]
+    fn first_match_wins_broader_rule_first() {
+        // If broader rule is declared first, it takes precedence
+        let config = build_config(
+            true,
+            vec![
+                ("/api/**", vec!["basic"]),       // Broader, declared first
+                ("/api/admin/**", vec!["admin"]), // More specific, declared second (never reached)
+            ],
+        );
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        let basic_scopes = vec!["basic".to_owned()];
+
+        // /api/admin/users matches first rule (/api/**), so "basic" is sufficient
+        assert!(
+            rules
+                .check("/api/admin/users", "GET", &basic_scopes)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn method_matching_specific_method() {
+        // Rule with specific method only matches that method
+        let config = build_config_with_methods(
+            true,
+            vec![
+                ("/users/*", Some("POST"), vec!["users:write"]),
+                ("/users/*", Some("GET"), vec!["users:read"]),
+            ],
+        );
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        let read_scopes = vec!["users:read".to_owned()];
+        let write_scopes = vec!["users:write".to_owned()];
+
+        // GET with read scope passes
+        assert!(rules.check("/users/123", "GET", &read_scopes).is_ok());
+
+        // POST with write scope passes
+        assert!(rules.check("/users/123", "POST", &write_scopes).is_ok());
+
+        // GET with write scope fails (first matching rule requires users:write for POST)
+        // Actually GET matches second rule which requires users:read
+        assert!(rules.check("/users/123", "GET", &write_scopes).is_err());
+
+        // POST with read scope fails (POST rule requires users:write)
+        assert!(rules.check("/users/123", "POST", &read_scopes).is_err());
+    }
+
+    #[test]
+    fn method_matching_any_method() {
+        // Rule without method matches any method
+        let config = build_config_with_methods(true, vec![("/api/**", None, vec!["api:access"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        let scopes = vec!["api:access".to_owned()];
+
+        // All methods should match
+        assert!(rules.check("/api/users", "GET", &scopes).is_ok());
+        assert!(rules.check("/api/users", "POST", &scopes).is_ok());
+        assert!(rules.check("/api/users", "PUT", &scopes).is_ok());
+        assert!(rules.check("/api/users", "DELETE", &scopes).is_ok());
+    }
+
+    #[test]
+    fn method_matching_case_insensitive() {
+        // Method matching should be case-insensitive
+        let config =
+            build_config_with_methods(true, vec![("/api/**", Some("get"), vec!["api:read"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        let scopes = vec!["api:read".to_owned()];
+
+        // Should match regardless of case
+        assert!(rules.check("/api/users", "GET", &scopes).is_ok());
+        assert!(rules.check("/api/users", "get", &scopes).is_ok());
+        assert!(rules.check("/api/users", "Get", &scopes).is_ok());
     }
 }

--- a/modules/system/api-gateway/src/middleware/scope_enforcement.rs
+++ b/modules/system/api-gateway/src/middleware/scope_enforcement.rs
@@ -1,0 +1,334 @@
+//! Gateway Scope Enforcement Middleware
+//!
+//! Performs coarse-grained early rejection of requests based on token scopes
+//! without calling the PDP. This is an optimization for performance-critical routes.
+//!
+//! See `docs/arch/authorization/DESIGN.md` section "Gateway Scope Enforcement" for details.
+
+use std::sync::Arc;
+
+use axum::response::IntoResponse;
+use glob::{MatchOptions, Pattern};
+
+use crate::config::GatewayScopeChecksConfig;
+use crate::middleware::common;
+use modkit::api::Problem;
+use modkit_security::SecurityContext;
+
+/// Compiled scope enforcement rules for efficient runtime matching.
+#[derive(Clone)]
+pub struct ScopeEnforcementRules {
+    /// Compiled glob patterns with their required scopes.
+    rules: Arc<[CompiledRule]>,
+    /// Whether scope enforcement is enabled.
+    enabled: bool,
+}
+
+/// A single compiled rule: glob pattern + required scopes.
+#[derive(Clone)]
+struct CompiledRule {
+    pattern: Pattern,
+    required_scopes: Vec<String>,
+}
+
+impl ScopeEnforcementRules {
+    /// Build scope enforcement rules from configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any glob pattern is invalid.
+    pub fn from_config(config: &GatewayScopeChecksConfig) -> Result<Self, anyhow::Error> {
+        if !config.enabled {
+            return Ok(Self {
+                rules: Arc::from([]),
+                enabled: false,
+            });
+        }
+
+        let mut rules = Vec::with_capacity(config.routes.len());
+
+        for (pattern_str, requirement) in &config.routes {
+            let pattern = Pattern::new(pattern_str).map_err(|e| {
+                anyhow::anyhow!("Invalid glob pattern '{pattern_str}' in gateway_scope_checks: {e}")
+            })?;
+
+            rules.push(CompiledRule {
+                pattern,
+                required_scopes: requirement.required_scopes.clone(),
+            });
+        }
+
+        tracing::info!(
+            rules_count = rules.len(),
+            "Gateway scope enforcement enabled with {} route rules",
+            rules.len()
+        );
+
+        Ok(Self {
+            rules: Arc::from(rules),
+            enabled: true,
+        })
+    }
+
+    /// Check if the given path and token scopes satisfy the scope requirements.
+    ///
+    /// Returns `Ok(())` if access is allowed, or `Err(problem)` if denied.
+    #[allow(clippy::result_large_err)]
+    fn check(&self, path: &str, token_scopes: &[String]) -> Result<(), Problem> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        // `["*"]` and legacy empty scopes are both unrestricted.
+        if token_scopes.is_empty() || token_scopes.iter().any(|s| s == "*") {
+            return Ok(());
+        }
+
+        // Match options: require `/` to be matched literally so `*` doesn't cross path segments
+        let match_opts = MatchOptions {
+            require_literal_separator: true,
+            ..MatchOptions::default()
+        };
+
+        // Find matching rules and check scopes
+        for rule in self.rules.iter() {
+            if rule.pattern.matches_with(path, match_opts) {
+                // Check if token has ANY of the required scopes
+                let has_required_scope = rule
+                    .required_scopes
+                    .iter()
+                    .any(|required| token_scopes.contains(required));
+
+                if !has_required_scope {
+                    tracing::debug!(
+                        path = %path,
+                        pattern = %rule.pattern,
+                        required_scopes = ?rule.required_scopes,
+                        token_scopes = ?token_scopes,
+                        "Gateway scope check failed: insufficient scopes"
+                    );
+
+                    return Err(Problem::new(
+                        axum::http::StatusCode::FORBIDDEN,
+                        "Forbidden",
+                        "Insufficient token scopes for this resource",
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Scope enforcement middleware state.
+#[derive(Clone)]
+pub struct ScopeEnforcementState {
+    pub rules: ScopeEnforcementRules,
+}
+
+/// Scope enforcement middleware.
+///
+/// Checks if the request's token scopes satisfy the configured requirements
+/// for the matched route pattern. Returns 403 Forbidden if scopes are insufficient.
+///
+/// This middleware MUST run AFTER the auth middleware (which populates `SecurityContext`).
+pub async fn scope_enforcement_middleware(
+    axum::extract::State(state): axum::extract::State<ScopeEnforcementState>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    // Skip if enforcement is disabled
+    if !state.rules.enabled {
+        return next.run(req).await;
+    }
+
+    // Get the matched path (use MatchedPath if available, otherwise URI path)
+    let path = req
+        .extensions()
+        .get::<axum::extract::MatchedPath>()
+        .map_or_else(|| req.uri().path().to_owned(), |p| p.as_str().to_owned());
+
+    let path = common::resolve_path(&req, path.as_str());
+
+    // Get SecurityContext from request extensions (populated by auth middleware)
+    let Some(security_context) = req.extensions().get::<SecurityContext>() else {
+        // No SecurityContext means auth middleware didn't run or request is unauthenticated
+        // Let it pass through - the handler will deal with missing auth
+        return next.run(req).await;
+    };
+
+    // Check scopes
+    if let Err(problem) = state.rules.check(&path, security_context.token_scopes()) {
+        return problem.into_response();
+    }
+
+    next.run(req).await
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::config::RouteScopeRequirement;
+    use std::collections::HashMap;
+
+    fn build_config(enabled: bool, routes: Vec<(&str, Vec<&str>)>) -> GatewayScopeChecksConfig {
+        let routes_map: HashMap<String, RouteScopeRequirement> = routes
+            .into_iter()
+            .map(|(pattern, scopes)| {
+                (
+                    pattern.to_owned(),
+                    RouteScopeRequirement {
+                        required_scopes: scopes.into_iter().map(String::from).collect(),
+                    },
+                )
+            })
+            .collect();
+
+        GatewayScopeChecksConfig {
+            enabled,
+            routes: routes_map,
+        }
+    }
+
+    #[test]
+    fn disabled_enforcement_always_passes() {
+        let config = build_config(false, vec![("/admin/*", vec!["admin"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        // Even with no scopes, should pass when disabled
+        assert!(rules.check("/admin/users", &[]).is_ok());
+    }
+
+    #[test]
+    fn first_party_app_always_passes() {
+        let config = build_config(true, vec![("/admin/*", vec!["admin"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        // First-party apps have ["*"] scope
+        let scopes = vec!["*".to_owned()];
+        assert!(rules.check("/admin/users", &scopes).is_ok());
+    }
+
+    #[test]
+    fn matching_scope_passes() {
+        let config = build_config(true, vec![("/admin/*", vec!["admin"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        let scopes = vec!["admin".to_owned()];
+        assert!(rules.check("/admin/users", &scopes).is_ok());
+    }
+
+    #[test]
+    fn any_of_required_scopes_passes() {
+        let config = build_config(
+            true,
+            vec![("/events/v1/*", vec!["read:events", "write:events"])],
+        );
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        // Having just one of the required scopes should pass
+        let scopes = vec!["read:events".to_owned()];
+        assert!(rules.check("/events/v1/list", &scopes).is_ok());
+
+        let scopes = vec!["write:events".to_owned()];
+        assert!(rules.check("/events/v1/create", &scopes).is_ok());
+    }
+
+    #[test]
+    fn missing_scope_returns_forbidden() {
+        let config = build_config(true, vec![("/admin/*", vec!["admin"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        // No matching scope
+        let scopes = vec!["read:events".to_owned()];
+        let result = rules.check("/admin/users", &scopes);
+        assert!(result.is_err());
+
+        let problem = result.unwrap_err();
+        assert_eq!(problem.status, axum::http::StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn empty_scopes_passes_for_legacy_compatibility() {
+        let config = build_config(true, vec![("/admin/*", vec!["admin"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        // Empty scopes are treated as unrestricted (legacy first-party behavior)
+        let result = rules.check("/admin/users", &[]);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn unmatched_route_passes() {
+        let config = build_config(true, vec![("/admin/*", vec!["admin"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        // Route doesn't match any pattern, should pass
+        let scopes: Vec<String> = vec![];
+        assert!(rules.check("/public/health", &scopes).is_ok());
+    }
+
+    #[test]
+    fn glob_single_star_matches_single_segment_only() {
+        let config = build_config(true, vec![("/api/*/items", vec!["api:read"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        let scopes = vec!["api:read".to_owned()];
+
+        // Single * matches exactly one path segment (doesn't cross `/`)
+        assert!(rules.check("/api/v1/items", &scopes).is_ok());
+        assert!(rules.check("/api/v2/items", &scopes).is_ok());
+
+        // Multiple segments do NOT match single * pattern (no scope check triggered)
+        let no_scopes: Vec<String> = vec![];
+        assert!(rules.check("/api/v1/nested/items", &no_scopes).is_ok()); // doesn't match pattern
+    }
+
+    #[test]
+    fn glob_double_star_matches_multiple_segments() {
+        let config = build_config(true, vec![("/api/**", vec!["api:access"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        let scopes = vec!["api:access".to_owned()];
+
+        // ** matches any number of path segments
+        assert!(rules.check("/api/v1", &scopes).is_ok());
+        assert!(rules.check("/api/v1/items", &scopes).is_ok());
+        assert!(rules.check("/api/v1/items/123/details", &scopes).is_ok());
+    }
+
+    #[test]
+    fn invalid_glob_pattern_returns_error() {
+        let config = build_config(true, vec![("/admin/[invalid", vec!["admin"])]);
+        let result = ScopeEnforcementRules::from_config(&config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn multiple_rules_all_checked() {
+        let config = build_config(
+            true,
+            vec![
+                ("/admin/*", vec!["admin"]),
+                ("/events/**", vec!["events:read"]),
+            ],
+        );
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        // Admin route needs admin scope
+        let admin_scopes = vec!["admin".to_owned()];
+        assert!(rules.check("/admin/users", &admin_scopes).is_ok());
+
+        // Events route needs events:read scope
+        let events_scopes = vec!["events:read".to_owned()];
+        assert!(rules.check("/events/v1/list", &events_scopes).is_ok());
+
+        // Wrong scope for admin route
+        assert!(rules.check("/admin/users", &events_scopes).is_err());
+
+        // Wrong scope for events route
+        assert!(rules.check("/events/v1/list", &admin_scopes).is_err());
+    }
+}

--- a/modules/system/api-gateway/src/middleware/scope_enforcement.rs
+++ b/modules/system/api-gateway/src/middleware/scope_enforcement.rs
@@ -70,6 +70,24 @@ impl ScopeEnforcementRules {
         })
     }
 
+    /// Check if the given path matches any protected route.
+    ///
+    /// Returns `true` if the path matches at least one scope enforcement rule.
+    fn matches_protected_route(&self, path: &str) -> bool {
+        if !self.enabled {
+            return false;
+        }
+
+        let match_opts = MatchOptions {
+            require_literal_separator: true,
+            ..MatchOptions::default()
+        };
+
+        self.rules
+            .iter()
+            .any(|rule| rule.pattern.matches_with(path, match_opts))
+    }
+
     /// Check if the given path and token scopes satisfy the scope requirements.
     ///
     /// Returns `Ok(())` if access is allowed, or `Err(problem)` if denied.
@@ -143,18 +161,28 @@ pub async fn scope_enforcement_middleware(
         return next.run(req).await;
     }
 
-    // Get the matched path (use MatchedPath if available, otherwise URI path)
-    let path = req
-        .extensions()
-        .get::<axum::extract::MatchedPath>()
-        .map_or_else(|| req.uri().path().to_owned(), |p| p.as_str().to_owned());
-
-    let path = common::resolve_path(&req, path.as_str());
+    // Use the concrete URI path for glob pattern matching (not MatchedPath which
+    // returns the route template like "/{*path}" for catch-all routes).
+    let path = req.uri().path();
+    let path = common::resolve_path(&req, path);
 
     // Get SecurityContext from request extensions (populated by auth middleware)
     let Some(security_context) = req.extensions().get::<SecurityContext>() else {
-        // No SecurityContext means auth middleware didn't run or request is unauthenticated
-        // Let it pass through - the handler will deal with missing auth
+        // No SecurityContext means auth middleware didn't run or request is unauthenticated.
+        // If the path matches a protected route, reject with 401 Unauthorized.
+        // Otherwise, let it pass through for public/unprotected routes.
+        if state.rules.matches_protected_route(&path) {
+            tracing::debug!(
+                path = %path,
+                "Gateway scope check failed: no SecurityContext for protected route"
+            );
+            return Problem::new(
+                axum::http::StatusCode::UNAUTHORIZED,
+                "Unauthorized",
+                "Authentication required for this resource",
+            )
+            .into_response();
+        }
         return next.run(req).await;
     };
 
@@ -265,8 +293,8 @@ mod tests {
         let config = build_config(true, vec![("/admin/*", vec!["admin"])]);
         let rules = ScopeEnforcementRules::from_config(&config).unwrap();
 
-        // Route doesn't match any pattern, should pass
-        let scopes: Vec<String> = vec![];
+        // Route doesn't match any pattern, should pass even with unrelated scope
+        let scopes = vec!["unrelated:scope".to_owned()];
         assert!(rules.check("/public/health", &scopes).is_ok());
     }
 
@@ -282,8 +310,12 @@ mod tests {
         assert!(rules.check("/api/v2/items", &scopes).is_ok());
 
         // Multiple segments do NOT match single * pattern (no scope check triggered)
-        let no_scopes: Vec<String> = vec![];
-        assert!(rules.check("/api/v1/nested/items", &no_scopes).is_ok()); // doesn't match pattern
+        let unrelated_scopes = vec!["unrelated:scope".to_owned()];
+        assert!(
+            rules
+                .check("/api/v1/nested/items", &unrelated_scopes)
+                .is_ok()
+        ); // doesn't match pattern
     }
 
     #[test]
@@ -330,5 +362,32 @@ mod tests {
 
         // Wrong scope for events route
         assert!(rules.check("/events/v1/list", &admin_scopes).is_err());
+    }
+
+    #[test]
+    fn matches_protected_route_returns_true_for_matching_path() {
+        let config = build_config(true, vec![("/admin/*", vec!["admin"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        assert!(rules.matches_protected_route("/admin/users"));
+        assert!(rules.matches_protected_route("/admin/settings"));
+    }
+
+    #[test]
+    fn matches_protected_route_returns_false_for_non_matching_path() {
+        let config = build_config(true, vec![("/admin/*", vec!["admin"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        assert!(!rules.matches_protected_route("/public/health"));
+        assert!(!rules.matches_protected_route("/api/v1/users"));
+    }
+
+    #[test]
+    fn matches_protected_route_returns_false_when_disabled() {
+        let config = build_config(false, vec![("/admin/*", vec!["admin"])]);
+        let rules = ScopeEnforcementRules::from_config(&config).unwrap();
+
+        // Even matching paths return false when enforcement is disabled
+        assert!(!rules.matches_protected_route("/admin/users"));
     }
 }

--- a/modules/system/api-gateway/src/middleware/scope_enforcement.rs
+++ b/modules/system/api-gateway/src/middleware/scope_enforcement.rs
@@ -10,13 +10,13 @@ use std::sync::Arc;
 use axum::response::IntoResponse;
 use glob::{MatchOptions, Pattern};
 
-use crate::config::GatewayScopeChecksConfig;
+use crate::config::RoutePoliciesConfig;
 use crate::middleware::common;
 use modkit::api::Problem;
 use modkit_security::SecurityContext;
 
 /// Compiled scope enforcement rules for efficient runtime matching.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ScopeEnforcementRules {
     /// Compiled glob patterns with their required scopes.
     rules: Arc<[CompiledRule]>,
@@ -25,7 +25,7 @@ pub struct ScopeEnforcementRules {
 }
 
 /// A single compiled rule: glob pattern + required scopes.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct CompiledRule {
     pattern: Pattern,
     required_scopes: Vec<String>,
@@ -36,8 +36,8 @@ impl ScopeEnforcementRules {
     ///
     /// # Errors
     ///
-    /// Returns an error if any glob pattern is invalid.
-    pub fn from_config(config: &GatewayScopeChecksConfig) -> Result<Self, anyhow::Error> {
+    /// Returns an error if any glob pattern is invalid or if any rule has empty `required_scopes`.
+    pub fn from_config(config: &RoutePoliciesConfig) -> Result<Self, anyhow::Error> {
         if !config.enabled {
             return Ok(Self {
                 rules: Arc::from([]),
@@ -45,22 +45,34 @@ impl ScopeEnforcementRules {
             });
         }
 
-        let mut rules = Vec::with_capacity(config.routes.len());
+        let mut rules = Vec::with_capacity(config.rules.len());
 
-        for (pattern_str, requirement) in &config.routes {
-            let pattern = Pattern::new(pattern_str).map_err(|e| {
-                anyhow::anyhow!("Invalid glob pattern '{pattern_str}' in gateway_scope_checks: {e}")
+        for rule in &config.rules {
+            // Validate: empty required_scopes is likely a config mistake
+            if rule.required_scopes.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Route policy rule for path '{}' has empty required_scopes. \
+                     This would match all tokens and is likely a config mistake.",
+                    rule.path
+                ));
+            }
+
+            let pattern = Pattern::new(&rule.path).map_err(|e| {
+                anyhow::anyhow!(
+                    "Invalid glob pattern '{}' in route_policies: {e}",
+                    rule.path
+                )
             })?;
 
             rules.push(CompiledRule {
                 pattern,
-                required_scopes: requirement.required_scopes.clone(),
+                required_scopes: rule.required_scopes.clone(),
             });
         }
 
         tracing::info!(
             rules_count = rules.len(),
-            "Gateway scope enforcement enabled with {} route rules",
+            "Route policy enforcement enabled with {} rules",
             rules.len()
         );
 
@@ -97,8 +109,9 @@ impl ScopeEnforcementRules {
             return Ok(());
         }
 
-        // `["*"]` and legacy empty scopes are both unrestricted.
-        if token_scopes.is_empty() || token_scopes.iter().any(|s| s == "*") {
+        // Only wildcard scope `["*"]` is unrestricted (first-party apps).
+        // Empty scopes = no permissions (fail-closed).
+        if token_scopes.iter().any(|s| s == "*") {
             return Ok(());
         }
 
@@ -118,12 +131,12 @@ impl ScopeEnforcementRules {
                     .any(|required| token_scopes.contains(required));
 
                 if !has_required_scope {
-                    tracing::debug!(
+                    tracing::warn!(
                         path = %path,
                         pattern = %rule.pattern,
                         required_scopes = ?rule.required_scopes,
                         token_scopes = ?token_scopes,
-                        "Gateway scope check failed: insufficient scopes"
+                        "Route policy enforcement denied: insufficient scopes"
                     );
 
                     return Err(Problem::new(
@@ -172,9 +185,9 @@ pub async fn scope_enforcement_middleware(
         // If the path matches a protected route, reject with 401 Unauthorized.
         // Otherwise, let it pass through for public/unprotected routes.
         if state.rules.matches_protected_route(&path) {
-            tracing::debug!(
+            tracing::warn!(
                 path = %path,
-                "Gateway scope check failed: no SecurityContext for protected route"
+                "Route policy enforcement denied: no SecurityContext for protected route"
             );
             return Problem::new(
                 axum::http::StatusCode::UNAUTHORIZED,
@@ -198,26 +211,18 @@ pub async fn scope_enforcement_middleware(
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
-    use crate::config::RouteScopeRequirement;
-    use std::collections::HashMap;
+    use crate::config::RoutePolicyRule;
 
-    fn build_config(enabled: bool, routes: Vec<(&str, Vec<&str>)>) -> GatewayScopeChecksConfig {
-        let routes_map: HashMap<String, RouteScopeRequirement> = routes
+    fn build_config(enabled: bool, routes: Vec<(&str, Vec<&str>)>) -> RoutePoliciesConfig {
+        let rules = routes
             .into_iter()
-            .map(|(pattern, scopes)| {
-                (
-                    pattern.to_owned(),
-                    RouteScopeRequirement {
-                        required_scopes: scopes.into_iter().map(String::from).collect(),
-                    },
-                )
+            .map(|(path, scopes)| RoutePolicyRule {
+                path: path.to_owned(),
+                required_scopes: scopes.into_iter().map(String::from).collect(),
             })
             .collect();
 
-        GatewayScopeChecksConfig {
-            enabled,
-            routes: routes_map,
-        }
+        RoutePoliciesConfig { enabled, rules }
     }
 
     #[test]
@@ -279,13 +284,16 @@ mod tests {
     }
 
     #[test]
-    fn empty_scopes_passes_for_legacy_compatibility() {
+    fn empty_scopes_returns_forbidden() {
         let config = build_config(true, vec![("/admin/*", vec!["admin"])]);
         let rules = ScopeEnforcementRules::from_config(&config).unwrap();
 
-        // Empty scopes are treated as unrestricted (legacy first-party behavior)
+        // Empty scopes = no permissions (fail-closed)
         let result = rules.check("/admin/users", &[]);
-        assert!(result.is_ok());
+        assert!(result.is_err());
+
+        let problem = result.unwrap_err();
+        assert_eq!(problem.status, axum::http::StatusCode::FORBIDDEN);
     }
 
     #[test]
@@ -336,6 +344,17 @@ mod tests {
         let config = build_config(true, vec![("/admin/[invalid", vec!["admin"])]);
         let result = ScopeEnforcementRules::from_config(&config);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_required_scopes_returns_error() {
+        let config = build_config(true, vec![("/admin/*", vec![])]);
+        let result = ScopeEnforcementRules::from_config(&config);
+        let err = result.expect_err("should fail with empty required_scopes");
+        assert!(
+            err.to_string().contains("empty required_scopes"),
+            "error should mention empty required_scopes: {err}"
+        );
     }
 
     #[test]

--- a/modules/system/api-gateway/src/module.rs
+++ b/modules/system/api-gateway/src/module.rs
@@ -259,6 +259,14 @@ impl ApiGateway {
 
         // 11) Route Policy Enforcement (runs after auth, checks token_scopes against route requirements)
         if config.route_policies.enabled {
+            // Reject invalid combination: route_policies requires authentication to work
+            if config.auth_disabled {
+                return Err(anyhow::anyhow!(
+                    "Invalid configuration: route_policies.enabled=true requires authentication. \
+                     Set auth_disabled=false or disable route_policies."
+                ));
+            }
+
             let scope_rules = middleware::scope_enforcement::ScopeEnforcementRules::from_config(
                 &config.route_policies,
             )?;

--- a/modules/system/api-gateway/src/module.rs
+++ b/modules/system/api-gateway/src/module.rs
@@ -226,10 +226,8 @@ impl ApiGateway {
         // becomes the **outermost** layer and therefore runs **first** on the request path.
         //
         // Desired request execution order (outermost -> innermost):
-        // SetRequestId -> PropagateRequestId -> Trace -> push_req_id
-        // -> HttpMetrics -> CatchPanic
-        // -> Timeout -> BodyLimit -> CORS -> MIME validation -> RateLimit -> ErrorMapping -> Auth -> License
-        // -> [Route matching] -> PropagateMatchedPath -> Handler
+        // SetRequestId -> PropagateRequestId -> Trace -> push_req_id_to_extensions
+        // -> Timeout -> BodyLimit -> CORS -> MIME validation -> RateLimit -> ErrorMapping -> Auth -> ScopeEnforcement -> License -> Router
         //
         // Therefore we must add layers in the reverse order (innermost -> outermost) below.
         // Due future refactoring, this order must be maintained.
@@ -249,7 +247,7 @@ impl ApiGateway {
             .map(|e| e.value().clone())
             .collect();
 
-        // 13) License validation
+        // 12) License validation
         let license_map = middleware::license_validation::LicenseRequirementMap::from_specs(&specs);
 
         router = router.layer(from_fn(
@@ -259,7 +257,20 @@ impl ApiGateway {
             },
         ));
 
-        // 12) Auth
+        // 11) Gateway Scope Enforcement (runs after auth, checks token_scopes against route requirements)
+        if config.gateway_scope_checks.enabled {
+            let scope_rules = middleware::scope_enforcement::ScopeEnforcementRules::from_config(
+                &config.gateway_scope_checks,
+            )?;
+            let scope_state =
+                middleware::scope_enforcement::ScopeEnforcementState { rules: scope_rules };
+            router = router.layer(from_fn_with_state(
+                scope_state,
+                middleware::scope_enforcement::scope_enforcement_middleware,
+            ));
+        }
+
+        // 10) Auth
         if config.auth_disabled {
             // Build security contexts for compatibility during migration
             let default_security_context = SecurityContext::builder()

--- a/modules/system/api-gateway/src/module.rs
+++ b/modules/system/api-gateway/src/module.rs
@@ -257,10 +257,10 @@ impl ApiGateway {
             },
         ));
 
-        // 11) Gateway Scope Enforcement (runs after auth, checks token_scopes against route requirements)
-        if config.gateway_scope_checks.enabled {
+        // 11) Route Policy Enforcement (runs after auth, checks token_scopes against route requirements)
+        if config.route_policies.enabled {
             let scope_rules = middleware::scope_enforcement::ScopeEnforcementRules::from_config(
-                &config.gateway_scope_checks,
+                &config.route_policies,
             )?;
             let scope_state =
                 middleware::scope_enforcement::ScopeEnforcementState { rules: scope_rules };

--- a/testing/e2e/modules/oagw/test_oagw_types_registered.py
+++ b/testing/e2e/modules/oagw/test_oagw_types_registered.py
@@ -104,8 +104,12 @@ async def test_gts_ids_have_valid_format(oagw_base_url, oagw_headers):
                 assert len(schema_segments) == 5, (
                     f"Schema portion should have 5 segments: {gts_id}"
                 )
-                # Instance portion: 5 segments
+                # Instance portion: either 5 segments (builtin) or bare UUID (dynamic)
+                # Builtin instances: x.core.oagw.<name>.v1
+                # Dynamic instances: <uuid> (e.g., routes, upstreams created at runtime)
                 instance_segments = instance_part.split(".")
-                assert len(instance_segments) == 5, (
-                    f"Instance portion should have 5 segments: {gts_id}"
+                is_builtin_format = len(instance_segments) == 5
+                is_uuid_format = len(instance_segments) == 1 and len(instance_part) >= 32
+                assert is_builtin_format or is_uuid_format, (
+                    f"Instance portion should be 5 segments (builtin) or UUID (dynamic): {gts_id}"
                 )

--- a/testing/e2e/modules/scope_enforcement/README.md
+++ b/testing/e2e/modules/scope_enforcement/README.md
@@ -1,0 +1,66 @@
+# Gateway Scope Enforcement E2E Tests
+
+Tests for the Gateway Scope Enforcement middleware, which performs coarse-grained
+early rejection of requests based on token scopes without calling the PDP.
+
+## Prerequisites
+
+1. Build the server with required features:
+   ```bash
+   cargo build --release --bin hyperspot-server --features users-info-example,static-authn,static-authz,static-tenants
+   ```
+
+2. Start the server with the scope enforcement config:
+   ```bash
+   cargo run --release --bin hyperspot-server --features users-info-example,static-authn,static-authz,static-tenants \
+     -- --config config/e2e-scope-enforcement.yaml
+   ```
+
+3. Install Python dependencies:
+   ```bash
+   pip3 install -r testing/e2e/requirements.txt
+   ```
+
+## Running Tests
+
+These tests require the scope enforcement config and are **not** part of the standard CI e2e suite.
+
+```bash
+# Set the environment variable to enable scope enforcement tests
+export E2E_SCOPE_ENFORCEMENT=1
+
+# Run all scope enforcement tests
+python3 -m pytest testing/e2e/modules/scope_enforcement -v
+
+# Run specific test class
+python3 -m pytest testing/e2e/modules/scope_enforcement/test_scope_enforcement.py::TestScopeEnforcementDenied -v
+```
+
+## Test Tokens
+
+The config defines these test tokens:
+
+| Token | Scopes | Expected Access |
+|-------|--------|-----------------|
+| `token-full-access` | `["*"]` | All routes (first-party) |
+| `token-users-read` | `["users:read"]` | `/users-info/v1/users*` |
+| `token-users-admin` | `["users:admin"]` | `/users-info/v1/users*` |
+| `token-cities-admin` | `["cities:admin"]` | `/users-info/v1/cities/**` |
+| `token-no-scopes` | `["unrelated:scope"]` | Only unconfigured routes |
+
+## Route Configuration
+
+The config enforces these scope requirements:
+
+| Route Pattern | Required Scopes |
+|---------------|-----------------|
+| `/users-info/v1/users` | `users:read` OR `users:admin` |
+| `/users-info/v1/users/*` | `users:read` OR `users:admin` |
+| `/users-info/v1/cities` | `cities:admin` |
+| `/users-info/v1/cities/*` | `cities:admin` |
+
+## Expected Behavior
+
+- **403 Forbidden**: Returned immediately when token scopes don't match required scopes
+- **401 Unauthorized**: Returned when no token or invalid token is provided
+- **Pass-through**: Routes not in the config are not subject to scope enforcement

--- a/testing/e2e/modules/scope_enforcement/README.md
+++ b/testing/e2e/modules/scope_enforcement/README.md
@@ -1,6 +1,6 @@
-# Gateway Scope Enforcement E2E Tests
+# Route Policy Enforcement E2E Tests
 
-Tests for the Gateway Scope Enforcement middleware, which performs coarse-grained
+Tests for the Route Policy Enforcement middleware, which performs coarse-grained
 early rejection of requests based on token scopes without calling the PDP.
 
 ## Prerequisites

--- a/testing/e2e/modules/scope_enforcement/__init__.py
+++ b/testing/e2e/modules/scope_enforcement/__init__.py
@@ -1,0 +1,1 @@
+# Scope enforcement e2e tests

--- a/testing/e2e/modules/scope_enforcement/conftest.py
+++ b/testing/e2e/modules/scope_enforcement/conftest.py
@@ -1,0 +1,76 @@
+"""Pytest configuration and fixtures for Gateway Scope Enforcement E2E tests."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def base_url():
+    """API Gateway base URL."""
+    return os.getenv("E2E_BASE_URL", "http://localhost:8086")
+
+
+@pytest.fixture
+def tenant_id():
+    """Fixed tenant UUID for test isolation."""
+    return "00000000-df51-5b42-9538-d2b56b7ee953"
+
+
+# Token fixtures for different scope scenarios
+@pytest.fixture
+def token_full_access():
+    """Token with full access (first-party app with '*' scope)."""
+    return "token-full-access"
+
+
+@pytest.fixture
+def token_users_read():
+    """Token with users:read scope only."""
+    return "token-users-read"
+
+
+@pytest.fixture
+def token_users_admin():
+    """Token with users:admin scope."""
+    return "token-users-admin"
+
+
+@pytest.fixture
+def token_cities_admin():
+    """Token with cities:admin scope (no users access)."""
+    return "token-cities-admin"
+
+
+@pytest.fixture
+def token_no_scopes():
+    """Token with no relevant scopes."""
+    return "token-no-scopes"
+
+
+def make_headers(tenant_id: str, token: str | None = None) -> dict:
+    """Build request headers with tenant and optional auth token."""
+    headers = {"x-tenant-id": tenant_id}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _check_scope_enforcement_enabled():
+    """Skip all tests if scope enforcement is not enabled.
+    
+    These tests require a server running with the scope enforcement config:
+    config/e2e-scope-enforcement.yaml
+    
+    Set E2E_SCOPE_ENFORCEMENT=1 to run these tests.
+    """
+    if not os.getenv("E2E_SCOPE_ENFORCEMENT"):
+        pytest.skip(
+            "Scope enforcement tests require E2E_SCOPE_ENFORCEMENT=1 and "
+            "server running with config/e2e-scope-enforcement.yaml",
+            allow_module_level=True,
+        )

--- a/testing/e2e/modules/scope_enforcement/test_scope_enforcement.py
+++ b/testing/e2e/modules/scope_enforcement/test_scope_enforcement.py
@@ -1,0 +1,235 @@
+"""E2E tests for Gateway Scope Enforcement middleware.
+
+These tests verify that the API Gateway correctly enforces token scope requirements
+at the gateway level, rejecting requests early with 403 Forbidden when scopes are
+insufficient.
+
+Prerequisites:
+- Start the server with: cargo run -- --config config/e2e-scope-enforcement.yaml
+- The config defines tokens with specific scopes for testing
+
+Test scenarios:
+1. First-party apps (token_scopes: ["*"]) always pass
+2. Tokens with matching scopes pass
+3. Tokens without required scopes get 403 Forbidden
+4. Glob patterns work correctly for route matching
+"""
+import httpx
+import pytest
+
+from .conftest import make_headers
+
+
+class TestScopeEnforcementBasic:
+    """Basic scope enforcement tests."""
+
+    @pytest.mark.asyncio
+    async def test_full_access_token_passes(
+        self, base_url, tenant_id, token_full_access
+    ):
+        """First-party app with '*' scope should always pass scope checks."""
+        headers = make_headers(tenant_id, token_full_access)
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/users-info/v1/users",
+                headers=headers,
+            )
+            # Should pass scope check (may fail later for other reasons, but not 403 from scope)
+            assert resp.status_code != 403 or "scope" not in resp.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_matching_scope_passes(
+        self, base_url, tenant_id, token_users_read
+    ):
+        """Token with 'users:read' scope should access /users-info/v1/users."""
+        headers = make_headers(tenant_id, token_users_read)
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/users-info/v1/users",
+                headers=headers,
+            )
+            # Should pass scope check - 200 OK or other non-403 status
+            assert resp.status_code != 403 or "scope" not in resp.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_admin_scope_passes(
+        self, base_url, tenant_id, token_users_admin
+    ):
+        """Token with 'users:admin' scope should access /users-info/v1/users."""
+        headers = make_headers(tenant_id, token_users_admin)
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/users-info/v1/users",
+                headers=headers,
+            )
+            # Should pass scope check
+            assert resp.status_code != 403 or "scope" not in resp.text.lower()
+
+
+class TestScopeEnforcementDenied:
+    """Tests for scope enforcement denial (403 Forbidden)."""
+
+    @pytest.mark.asyncio
+    async def test_wrong_scope_returns_403(
+        self, base_url, tenant_id, token_cities_admin
+    ):
+        """Token with 'cities:admin' scope should be denied access to /users-info/v1/users."""
+        headers = make_headers(tenant_id, token_cities_admin)
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/users-info/v1/users",
+                headers=headers,
+            )
+            assert resp.status_code == 403
+            body = resp.json()
+            assert body["status"] == 403
+            assert body["title"] == "Forbidden"
+            assert "scope" in body["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unrelated_scope_returns_403(
+        self, base_url, tenant_id, token_no_scopes
+    ):
+        """Token with unrelated scopes should be denied access to /users-info/v1/users."""
+        headers = make_headers(tenant_id, token_no_scopes)
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/users-info/v1/users",
+                headers=headers,
+            )
+            assert resp.status_code == 403
+            body = resp.json()
+            assert body["status"] == 403
+            assert body["title"] == "Forbidden"
+            assert "scope" in body["detail"].lower()
+
+
+class TestScopeEnforcementGlobPatterns:
+    """Tests for glob pattern matching in scope enforcement."""
+
+    @pytest.mark.asyncio
+    async def test_single_star_matches_path_segment(
+        self, base_url, tenant_id, token_users_read
+    ):
+        """Single * pattern should match single path segment.
+        
+        Route config: /users-info/v1/users/* requires users:read or users:admin
+        """
+        headers = make_headers(tenant_id, token_users_read)
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            # Should match /users-info/v1/users/{id}
+            resp = await client.get(
+                f"{base_url}/users-info/v1/users/11111111-1111-1111-1111-111111111111",
+                headers=headers,
+            )
+            # Should pass scope check (may get 404 for non-existent user, but not 403)
+            assert resp.status_code != 403 or "scope" not in resp.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_single_star_denied_wrong_scope(
+        self, base_url, tenant_id, token_cities_admin
+    ):
+        """Single * pattern should deny access with wrong scope."""
+        headers = make_headers(tenant_id, token_cities_admin)
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/users-info/v1/users/11111111-1111-1111-1111-111111111111",
+                headers=headers,
+            )
+            assert resp.status_code == 403
+            body = resp.json()
+            assert body["status"] == 403
+            assert body["title"] == "Forbidden"
+            assert "scope" in body["detail"].lower()
+
+    @pytest.mark.asyncio
+    async def test_cities_exact_path_with_correct_scope(
+        self, base_url, tenant_id, token_cities_admin
+    ):
+        """Exact path match should pass with correct scope.
+        
+        Route config: /users-info/v1/cities requires cities:admin
+        """
+        headers = make_headers(tenant_id, token_cities_admin)
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/users-info/v1/cities",
+                headers=headers,
+            )
+            # Should pass scope check
+            assert resp.status_code != 403 or "scope" not in resp.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_cities_exact_path_denied_wrong_scope(
+        self, base_url, tenant_id, token_users_read
+    ):
+        """Exact path match should deny access with wrong scope."""
+        headers = make_headers(tenant_id, token_users_read)
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/users-info/v1/cities",
+                headers=headers,
+            )
+            assert resp.status_code == 403
+            body = resp.json()
+            assert body["status"] == 403
+            assert body["title"] == "Forbidden"
+            assert "scope" in body["detail"].lower()
+
+
+class TestScopeEnforcementEdgeCases:
+    """Edge case tests for scope enforcement."""
+
+    @pytest.mark.asyncio
+    async def test_no_auth_header_returns_401(self, base_url, tenant_id):
+        """Request without Authorization header should get 401, not 403."""
+        headers = {"x-tenant-id": tenant_id}
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/users-info/v1/users",
+                headers=headers,
+            )
+            # Should be 401 Unauthorized (auth middleware), not 403 (scope enforcement)
+            assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_returns_401(self, base_url, tenant_id):
+        """Request with invalid token should get 401, not 403."""
+        headers = make_headers(tenant_id, "invalid-token-xyz")
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{base_url}/users-info/v1/users",
+                headers=headers,
+            )
+            # Should be 401 Unauthorized (auth middleware), not 403 (scope enforcement)
+            assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_route_passes(
+        self, base_url, tenant_id, token_no_scopes
+    ):
+        """Routes not configured in gateway_scope_checks should pass scope enforcement.
+        
+        The /docs endpoint is not configured, so any authenticated request should pass.
+        """
+        headers = make_headers(tenant_id, token_no_scopes)
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            # /docs is typically public and not in scope config
+            resp = await client.get(
+                f"{base_url}/docs",
+                headers=headers,
+            )
+            # Should not be 403 from scope enforcement
+            assert resp.status_code != 403


### PR DESCRIPTION
## Summary

Implements Gateway Scope Enforcement as described in [docs/arch/authorization/DESIGN.md](https://github.com/cyberfabric/cyberfabric-core/blob/main/docs/arch/authorization/DESIGN.md).

The API Gateway now performs coarse-grained early rejection of requests based on token scope mismatch, without calling the PDP. This is an optimization for performance-critical routes.

## Changes

- **Configuration schema**: Added `gateway_scope_checks` to [ApiGatewayConfig](https://github.com/cyberfabric/cyberfabric-core/blob/main/modules/system/api-gateway/src/config.rs) with route-level scope requirements
- **Scope enforcement middleware**: New middleware that intersects `SecurityContext.token_scopes` with configured `required_scopes`
- **Glob pattern support**: Route patterns support glob syntax (`/admin/*`, `/events/v1/**`)
- **Early 403 rejection**: Returns 403 Forbidden immediately if scopes are insufficient

## Example Configuration

```yaml
gateway_scope_checks:
  enabled: true
  routes:
    "/admin/*":
      required_scopes: ["admin"]
    "/events/v1/*":
      required_scopes: ["read:events", "write:events"]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway-level per-route scope enforcement middleware (configurable) that can return 401/403 based on token scopes and route patterns.

* **Documentation**
  * Added end-to-end README describing scope enforcement tests and run instructions.

* **Tests**
  * New e2e config and pytest suite covering scope rules, glob-style path matching, auth interactions, and expected 401/403 behaviors.

* **Chores**
  * Added workspace dependency to support glob-style route patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->