### PR TITLE
fix(mini-chat): defer OAGW upstream registration to start() phase

### DIFF
--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -101,7 +101,7 @@ modules:
     config:
       secrets:
         - key: "azure-openai-key"
-          value: "AZURE_OPENAI_API_KEY_PLACEHOLDER"
+          value: "${AZURE_API_KEY}"
 
   file-parser:
     config:
@@ -123,7 +123,7 @@ modules:
           auth_config:
             header: "api-key"
             prefix: ""
-            secret_ref: "cred://${AZURE_API_KEY}"
+            secret_ref: "cred://azure-openai-key"
 
       # ── Azure OpenAI example (uncomment and set your endpoint) ──────────
       #   azure_openai:
@@ -135,7 +135,7 @@ modules:
       #     auth_config:
       #       header: "api-key"
       #       prefix: ""
-      #       secret_ref: "cred://${AZURE_API_KEY}"
+      #       secret_ref: "cred://azure-openai-key"
       #
       # ── Per-tenant Azure example (each tenant gets its own endpoint/auth) ─
       # Tenant overrides share the root provider's adapter kind and api_path.
@@ -150,7 +150,7 @@ modules:
       #     auth_config:
       #       header: "api-key"
       #       prefix: ""
-      #       secret_ref: "cred://${AZURE_API_KEY}"
+      #       secret_ref: "cred://azure-openai-key"
       #     tenant_overrides:
       #       "tenant-a-uuid":
       #         host: "tenant-a.openai.azure.com"

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -239,6 +239,12 @@ modules:
       priority: 20
       # Tenant tree configuration (example: company with 2 divisions, each with departments)
       tenants:
+        # Default tenant for auth-disabled mode (must match DEFAULT_TENANT_ID in modkit-security)
+        - id: "00000000-df51-5b42-9538-d2b56b7ee953"
+          name: "default"
+          parent_id: null
+          status: active
+
         # Root tenant (company level)
         - id: "00000000-0000-0000-0000-000000000001"
           name: "company-root"

--- a/modules/credstore/plugins/static-credstore-plugin/src/config.rs
+++ b/modules/credstore/plugins/static-credstore-plugin/src/config.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use credstore_sdk::SharingMode;
 
 /// Plugin configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, modkit_macros::ExpandVars)]
 #[serde(default, deny_unknown_fields)]
 pub struct StaticCredStorePluginConfig {
     /// Vendor name for GTS instance registration.
@@ -14,6 +14,7 @@ pub struct StaticCredStorePluginConfig {
     pub priority: i16,
 
     /// Static secrets served by this plugin.
+    #[expand_vars]
     pub secrets: Vec<SecretConfig>,
 }
 
@@ -28,7 +29,7 @@ impl Default for StaticCredStorePluginConfig {
 }
 
 /// A single secret entry in the plugin configuration.
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, modkit_macros::ExpandVars)]
 #[serde(deny_unknown_fields)]
 pub struct SecretConfig {
     /// Tenant that owns this secret.
@@ -62,6 +63,7 @@ pub struct SecretConfig {
     pub key: String,
 
     /// Secret value (plaintext string, converted to bytes at init).
+    #[expand_vars]
     pub value: String,
 
     /// Sharing mode for this secret.

--- a/modules/credstore/plugins/static-credstore-plugin/src/module.rs
+++ b/modules/credstore/plugins/static-credstore-plugin/src/module.rs
@@ -35,7 +35,7 @@ impl Default for StaticCredStorePlugin {
 impl Module for StaticCredStorePlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         // Load configuration
-        let cfg: StaticCredStorePluginConfig = ctx.config()?;
+        let cfg: StaticCredStorePluginConfig = ctx.config_expanded()?;
 
         info!(
             vendor = %cfg.vendor,

--- a/modules/mini-chat/mini-chat/src/infra/oagw_provisioning.rs
+++ b/modules/mini-chat/mini-chat/src/infra/oagw_provisioning.rs
@@ -35,10 +35,13 @@ pub async fn register_oagw_upstreams(
         .map_err(|e| anyhow::anyhow!("failed to build security context: {e}"))?;
 
     for (provider_id, entry) in providers.iter_mut() {
-        // Register root upstream + route.
-        let Some(upstream) = create_upstream(gateway, &ctx, provider_id, entry).await else {
-            continue;
-        };
+        // Register root upstream + route. Fail hard — without upstreams the
+        // module cannot proxy LLM requests.
+        let upstream = create_upstream(gateway, &ctx, provider_id, entry)
+            .await
+            .ok_or_else(|| {
+                anyhow::anyhow!("OAGW upstream registration failed for provider '{provider_id}'")
+            })?;
         entry.upstream_alias = Some(upstream.alias.clone());
         register_route(gateway, &ctx, provider_id, entry, &upstream).await;
 

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -49,6 +49,14 @@ pub struct MiniChatModule {
     service: OnceLock<Arc<AppServices>>,
     url_prefix: OnceLock<String>,
     outbox_handle: Mutex<Option<OutboxHandle>>,
+    /// OAGW gateway + provider config for deferred upstream registration in `start()`.
+    oagw_deferred: OnceLock<OagwDeferred>,
+}
+
+/// State needed to register OAGW upstreams in `start()` (after GTS is ready).
+struct OagwDeferred {
+    gateway: Arc<dyn ServiceGatewayClientV1>,
+    providers: std::collections::HashMap<String, crate::config::ProviderEntry>,
 }
 
 impl Default for MiniChatModule {
@@ -57,6 +65,7 @@ impl Default for MiniChatModule {
             service: OnceLock::new(),
             url_prefix: OnceLock::new(),
             outbox_handle: Mutex::new(None),
+            oagw_deferred: OnceLock::new(),
         }
     }
 }
@@ -178,10 +187,29 @@ impl Module for MiniChatModule {
             .get::<dyn ServiceGatewayClientV1>()
             .map_err(|e| anyhow::anyhow!("failed to get OAGW gateway: {e}"))?;
 
-        // Register OAGW upstreams for each configured provider.
-        // This stamps `upstream_alias` on each ProviderEntry / ProviderTenantOverride.
-        crate::infra::oagw_provisioning::register_oagw_upstreams(&gateway, &mut cfg.providers)
-            .await?;
+        // Pre-fill upstream_alias with host as fallback so ProviderResolver
+        // works immediately. The actual OAGW registration is deferred to
+        // start() because GTS instances are not visible via list() until
+        // post_init (types-registry switches to ready mode there).
+        for entry in cfg.providers.values_mut() {
+            if entry.upstream_alias.is_none() {
+                entry.upstream_alias = Some(entry.host.clone());
+            }
+            for ovr in entry.tenant_overrides.values_mut() {
+                if ovr.upstream_alias.is_none()
+                    && let Some(ref h) = ovr.host
+                {
+                    ovr.upstream_alias = Some(h.clone());
+                }
+            }
+        }
+
+        // Save a copy for deferred OAGW registration in start().
+        // Ignore the result: if already set, we keep the first value.
+        drop(self.oagw_deferred.set(OagwDeferred {
+            gateway: Arc::clone(&gateway),
+            providers: cfg.providers.clone(),
+        }));
 
         let provider_resolver = Arc::new(ProviderResolver::new(&gateway, cfg.providers));
 
@@ -263,7 +291,18 @@ impl RestApiCapability for MiniChatModule {
 #[async_trait]
 impl RunnableCapability for MiniChatModule {
     async fn start(&self, _cancel: CancellationToken) -> anyhow::Result<()> {
-        // Outbox pipeline already started in init().
+        // Register OAGW upstreams now that GTS is in ready mode (post_init
+        // has completed). During init() this fails because types-registry
+        // list() only queries the persistent store which is empty until
+        // switch_to_ready().
+        if let Some(deferred) = self.oagw_deferred.get() {
+            let mut providers = deferred.providers.clone();
+            crate::infra::oagw_provisioning::register_oagw_upstreams(
+                &deferred.gateway,
+                &mut providers,
+            )
+            .await?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
During init(), types-registry list() only queries the persistent store which is empty until switch_to_ready() in post_init. Move upstream registration to start() where GTS instances are visible.

- Store gateway + provider config in OagwDeferred for use in start()
- Pre-fill upstream_alias with host as fallback so ProviderResolver works
- Make upstream registration fail hard instead of silently skipping
- Fix secret_ref / env var config in mini-chat.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated Azure API key references to use a concrete local secret name and environment variable placeholder.
  * Added a default tenant entry for auth-disabled quickstart scenarios.

* **New Features**
  * Static credential store now supports environment-variable expansion for configured secrets.

* **Bug Fixes**
  * Provider upstream registration now fails fast with clear error reporting instead of being silently skipped.

* **Refactor**
  * Upstream registration deferred to startup to ensure readiness before registering providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->