### PR TITLE
fix(mini-chat): reject tenant overrides that cannot produce a distinct OAGW upstream

### DIFF
--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -164,6 +164,8 @@ modules:
       #           header: "api-key"
       #           prefix: ""
       #           secret_ref: "cred://azure-openai-key-tenant-b"
+      #     # NOTE: tenant secret_ref values need matching entries under
+      #     # modules.static-credstore-plugin.config.secrets
 
   static-mini-chat-audit-plugin:
     config:

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -134,12 +134,25 @@ impl ProviderEntry {
         if self.host.trim().is_empty() {
             return Err(format!("provider '{provider_id}': host must not be empty"));
         }
-        for (tid, ovr) in &self.tenant_overrides {
-            if let Some(h) = &ovr.host
+        for (tid, tenant_override) in &self.tenant_overrides {
+            if let Some(h) = &tenant_override.host
                 && h.trim().is_empty()
             {
                 return Err(format!(
                     "provider '{provider_id}': tenant override '{tid}' host must not be empty"
+                ));
+            }
+
+            let overrides_auth =
+                tenant_override.auth_plugin_type.is_some() || tenant_override.auth_config.is_some();
+            let has_distinct_upstream =
+                tenant_override.host.is_some() || tenant_override.upstream_alias.is_some();
+
+            if overrides_auth && !has_distinct_upstream {
+                return Err(format!(
+                    "provider '{provider_id}': tenant override '{tid}' overrides auth \
+                     without host or upstream_alias - \
+                     set one to create a distinct upstream"
                 ));
             }
         }
@@ -814,5 +827,117 @@ mod tests {
         let err = entry.validate("azure_openai").unwrap_err();
         assert!(err.contains("bad-tenant"));
         assert!(err.contains("host must not be empty"));
+    }
+
+    #[test]
+    fn validate_rejects_auth_only_override_without_alias() {
+        let entry = ProviderEntry {
+            kind: crate::infra::llm::ProviderKind::OpenAiResponses,
+            upstream_alias: None,
+            host: "default.openai.azure.com".to_owned(),
+            api_path: "/v1/responses".to_owned(),
+            auth_plugin_type: None,
+            auth_config: None,
+            tenant_overrides: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "tenant-a".to_owned(),
+                    ProviderTenantOverride {
+                        host: None,
+                        upstream_alias: None,
+                        auth_plugin_type: Some("custom-plugin".to_owned()),
+                        auth_config: Some({
+                            let mut c = HashMap::new();
+                            c.insert("secret_ref".to_owned(), "tenant-a-key".to_owned());
+                            c
+                        }),
+                    },
+                );
+                m
+            },
+        };
+        let err = entry.validate("azure_openai").unwrap_err();
+        assert!(err.contains("tenant-a"));
+        assert!(err.contains("overrides auth"));
+    }
+
+    #[test]
+    fn validate_rejects_auth_plugin_type_only_override_without_alias() {
+        let entry = ProviderEntry {
+            kind: crate::infra::llm::ProviderKind::OpenAiResponses,
+            upstream_alias: None,
+            host: "default.openai.azure.com".to_owned(),
+            api_path: "/v1/responses".to_owned(),
+            auth_plugin_type: None,
+            auth_config: None,
+            tenant_overrides: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "tenant-b".to_owned(),
+                    ProviderTenantOverride {
+                        host: None,
+                        upstream_alias: None,
+                        auth_plugin_type: Some("different-plugin".to_owned()),
+                        auth_config: None,
+                    },
+                );
+                m
+            },
+        };
+        let err = entry.validate("azure_openai").unwrap_err();
+        assert!(err.contains("tenant-b"));
+        assert!(err.contains("overrides auth"));
+    }
+
+    #[test]
+    fn validate_accepts_auth_only_override_with_explicit_alias() {
+        let entry = ProviderEntry {
+            kind: crate::infra::llm::ProviderKind::OpenAiResponses,
+            upstream_alias: None,
+            host: "default.openai.azure.com".to_owned(),
+            api_path: "/v1/responses".to_owned(),
+            auth_plugin_type: None,
+            auth_config: None,
+            tenant_overrides: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "tenant-a".to_owned(),
+                    ProviderTenantOverride {
+                        host: None,
+                        upstream_alias: Some("azure-tenant-a".to_owned()),
+                        auth_plugin_type: Some("custom-plugin".to_owned()),
+                        auth_config: None,
+                    },
+                );
+                m
+            },
+        };
+        assert!(entry.validate("azure_openai").is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_host_differing_override_with_auth() {
+        let entry = ProviderEntry {
+            kind: crate::infra::llm::ProviderKind::OpenAiResponses,
+            upstream_alias: None,
+            host: "default.openai.azure.com".to_owned(),
+            api_path: "/v1/responses".to_owned(),
+            auth_plugin_type: None,
+            auth_config: None,
+            tenant_overrides: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "tenant-a".to_owned(),
+                    ProviderTenantOverride {
+                        host: Some("tenant-a.openai.azure.com".to_owned()),
+                        upstream_alias: None,
+                        auth_plugin_type: Some("custom-plugin".to_owned()),
+                        auth_config: None,
+                    },
+                );
+                m
+            },
+        };
+        assert!(entry.validate("azure_openai").is_ok());
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/oagw_provisioning.rs
+++ b/modules/mini-chat/mini-chat/src/infra/oagw_provisioning.rs
@@ -45,12 +45,21 @@ pub async fn register_oagw_upstreams(
         // Register tenant-specific upstreams (share the same route/api_path).
         let tenant_ids: Vec<String> = entry.tenant_overrides.keys().cloned().collect();
         for tenant_id in &tenant_ids {
+            let tenant_override = &entry.tenant_overrides[tenant_id];
+            if tenant_override.host.is_none() && tenant_override.upstream_alias.is_none() {
+                anyhow::bail!(
+                    "provider '{provider_id}': tenant override '{tenant_id}' \
+                     has no host and no upstream_alias - \
+                     cannot create distinct upstream"
+                );
+            }
+
             let label = format!("{provider_id}[tenant={tenant_id}]");
             if let Some(alias) =
                 create_tenant_upstream(gateway, &ctx, &label, entry, tenant_id).await
-                && let Some(ovr) = entry.tenant_overrides.get_mut(tenant_id)
+                && let Some(tenant_override) = entry.tenant_overrides.get_mut(tenant_id)
             {
-                ovr.upstream_alias = Some(alias);
+                tenant_override.upstream_alias = Some(alias);
             }
         }
     }


### PR DESCRIPTION
fix(mini-chat): reject tenant overrides that cannot produce a distinct OAGW upstream

Auth-only tenant overrides (no host, no upstream_alias) silently created duplicate upstreams with the parent's alias, so the tenant's auth config never took effect. Reject these at config validation and bail at the service level as defense-in-depth.

- config.rs: validate() rejects overrides that set auth_plugin_type or auth_config without host or upstream_alias
- oagw_provisioning.rs: bail before create_tenant_upstream when both host and upstream_alias are None
- config/mini-chat.yaml: add credstore note to tenant_overrides example
- 4 unit tests for the new validation scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for tenant configuration overrides to ensure authentication changes include a distinct upstream endpoint specification.
  * Added error handling to prevent incomplete tenant override configurations.

* **Documentation**
  * Added clarification notes about tenant secret reference requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->