### PR TITLE
fix(mini-chat): support env var expansion in provider host config

### DIFF
--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -101,7 +101,7 @@ modules:
     config:
       secrets:
         - key: "azure-openai-key"
-          value: "${AZURE_API_KEY}"
+          value: "${AZURE_OPENAI_API_KEY}"
 
   file-parser:
     config:
@@ -117,7 +117,7 @@ modules:
       providers:
         azure_openai:
           kind: openai_responses
-          host: "AZURE_OPENAI_API_HOST_PLACEHOLDER"
+          host: "${AZURE_OPENAI_API_HOST}"
           api_path: "/openai/v1/responses"
           auth_plugin_type: "gts.x.core.oagw.auth_plugin.v1~x.core.oagw.apikey.v1"
           auth_config:

--- a/modules/mini-chat/README.md
+++ b/modules/mini-chat/README.md
@@ -31,33 +31,20 @@ This starts the server at `http://127.0.0.1:8087` with SQLite, mock auth, and si
 
 Config file: **`config/mini-chat.yaml`**
 
-#### Setting the LLM API key
+#### Setting up Azure OpenAI credentials
 
-Find the `static-credstore-plugin` section and set your key:
+Export two environment variables before starting the server:
 
-```yaml
-static-credstore-plugin:
-  config:
-    secrets:
-      - key: "azure-openai-key"
-        value: "<YOUR_API_KEY>"
+```bash
+export AZURE_OPENAI_API_KEY="<your-api-key>"
+export AZURE_OPENAI_API_HOST="<your-resource>.openai.azure.com"
 ```
 
-#### Setting the LLM provider endpoint
+The config references these via `${AZURE_OPENAI_API_KEY}` and `${AZURE_OPENAI_API_HOST}` — no need to edit the YAML for basic setup.
 
-Find the `mini-chat` -> `config` -> `providers` section:
+#### Per-tenant provider overrides (optional)
 
-```yaml
-mini-chat:
-  config:
-    providers:
-      azure_openai:
-        kind: openai_responses
-        host: "<your-resource>.openai.azure.com"
-        api_path: "/openai/v1/responses"
-        auth_config:
-          secret_ref: "cred://azure-openai-key"
-```
+Each provider entry in `mini-chat.config.providers` can include a `tenant_overrides` map to give specific tenants their own host and/or auth. See the commented examples in `config/mini-chat.yaml`.
 
 ## API
 
@@ -72,7 +59,7 @@ Base URL: `http://127.0.0.1:8087/mini-chat/v1`
 | GET | `/mini-chat/v1/chats/{id}` | Get a chat |
 | PATCH | `/mini-chat/v1/chats/{id}` | Update a chat |
 | DELETE | `/mini-chat/v1/chats/{id}` | Delete a chat |
-| POST | `/mini-chat/v1/chats/{id}/messages/stream` | Send message (SSE) |
+| POST | `/mini-chat/v1/chats/{id}/messages:stream` | Send message (SSE) |
 | GET | `/mini-chat/v1/chats/{id}/messages` | List messages |
 | PUT | `/mini-chat/v1/chats/{id}/messages/{mid}/reaction` | Set reaction |
 | DELETE | `/mini-chat/v1/chats/{id}/messages/{mid}/reaction` | Remove reaction |

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -45,6 +45,7 @@ pub struct ProviderEntry {
     pub upstream_alias: Option<String>,
     /// Upstream hostname (e.g., `api.openai.com`). Used for OAGW upstream
     /// registration during module init.
+    #[expand_vars]
     pub host: String,
     /// API path template for the responses endpoint.
     /// Use `{model}` as placeholder for the deployment/model name.


### PR DESCRIPTION
- Add #[expand_vars] to ProviderEntry.host so ${AZURE_OPENAI_API_HOST} is resolved from the environment at startup
- Replace hardcoded placeholder with ${AZURE_OPENAI_API_HOST} in config/mini-chat.yaml
- Rename env var ${AZURE_API_KEY} → ${AZURE_OPENAI_API_KEY} for consistency
- Update README: document env-var-based setup, fix SSE endpoint path (messages:stream)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration now supports environment variable expansion for Azure OpenAI credentials.

* **Documentation**
  * Updated setup instructions to use environment variables instead of static configuration for Azure OpenAI integration.

* **Bug Fixes**
  * Corrected SSE endpoint path for message streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->