### PR TITLE
feat(mini-chat): wire web search kill switch, daily quota, and per-message call limit

### DIFF
--- a/modules/mini-chat/mini-chat/src/api/rest/error.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/error.rs
@@ -77,6 +77,20 @@ impl From<DomainError> for Problem {
                 )
                 .with_trace_id(trace_id.unwrap_or_default())
             }
+
+            DomainError::WebSearchDisabled => Problem::new(
+                StatusCode::BAD_REQUEST,
+                "web_search_disabled",
+                "Web search is currently disabled",
+            )
+            .with_trace_id(trace_id.unwrap_or_default()),
+
+            DomainError::WebSearchCallsExceeded => Problem::new(
+                StatusCode::BAD_REQUEST,
+                "web_search_calls_exceeded",
+                "Web search calls exceeded for this message",
+            )
+            .with_trace_id(trace_id.unwrap_or_default()),
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
@@ -93,6 +93,9 @@ pub(crate) async fn stream_message(
         }
     };
 
+    // ── Extract web search flag from DTO ───────────────────────────────
+    let web_search_enabled = body.web_search.as_ref().is_some_and(|c| c.enabled);
+
     // ── Wire up streaming pipeline ─────────────────────────────────────
     let capacity = svc.stream.channel_capacity();
     let ping_secs = svc.stream.ping_interval_secs();
@@ -110,6 +113,7 @@ pub(crate) async fn stream_message(
             request_id,
             body.content,
             resolved,
+            web_search_enabled,
             cancel.clone(),
             tx,
         )
@@ -176,11 +180,26 @@ fn stream_error_response(err: &StreamError) -> Response {
         StreamError::QuotaExhausted {
             error_code,
             http_status,
+            quota_scope,
         } => {
-            info!(error_code = %error_code, http_status = *http_status, "quota exhausted, request rejected");
+            info!(error_code = %error_code, http_status = *http_status, quota_scope = %quota_scope, "quota exhausted, request rejected");
             let status =
                 StatusCode::from_u16(*http_status).unwrap_or(StatusCode::TOO_MANY_REQUESTS);
-            Problem::new(status, "Quota Exhausted", error_code).into_response()
+            // TODO(P2): include `quota_scope` in the response body so clients can
+            // distinguish token vs web_search quota exhaustion (DESIGN.md §5.2).
+            Problem::new(status, error_code, error_code).into_response()
+        }
+        StreamError::WebSearchDisabled => {
+            info!(
+                reason = "kill_switch",
+                "web search disabled via kill switch, request rejected"
+            );
+            Problem::new(
+                StatusCode::BAD_REQUEST,
+                "web_search_disabled",
+                "Web search is currently disabled",
+            )
+            .into_response()
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/turns.rs
@@ -203,6 +203,7 @@ async fn start_mutation_stream(
             mutation.new_turn_id,
             mutation.user_content,
             resolved,
+            false, // web_search_enabled: retry/edit defaults to disabled
             mutation.snapshot_boundary,
             cancel.clone(),
             tx,
@@ -273,16 +274,32 @@ fn mutation_error_to_problem(err: &MutationError) -> Problem {
 
 /// Caller is expected to be within an instrumented span that carries
 /// `chat_id` and `turn_request_id` fields.
+#[allow(clippy::cognitive_complexity)]
 fn stream_error_to_response(err: &StreamError) -> Response {
     match err {
         StreamError::QuotaExhausted {
             error_code,
             http_status,
+            quota_scope,
         } => {
-            info!(error_code = %error_code, http_status = *http_status, "quota exhausted, mutation rejected");
+            info!(error_code = %error_code, http_status = *http_status, quota_scope = %quota_scope, "quota exhausted, mutation rejected");
             let status =
                 StatusCode::from_u16(*http_status).unwrap_or(StatusCode::TOO_MANY_REQUESTS);
-            Problem::new(status, "Quota Exhausted", error_code).into_response()
+            // TODO(P2): include `quota_scope` in the response body so clients can
+            // distinguish token vs web_search quota exhaustion (DESIGN.md §5.2).
+            Problem::new(status, error_code, error_code).into_response()
+        }
+        StreamError::WebSearchDisabled => {
+            info!(
+                reason = "kill_switch",
+                "web search disabled via kill switch, mutation rejected"
+            );
+            Problem::new(
+                StatusCode::BAD_REQUEST,
+                "web_search_disabled",
+                "Web search is currently disabled",
+            )
+            .into_response()
         }
         other => {
             warn!(error = ?other, "post-mutation stream error");

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -334,6 +334,12 @@ fn default_web_surcharge() -> u32 {
 fn default_min_gen_floor() -> u32 {
     50
 }
+fn default_web_search_max_calls() -> u32 {
+    2
+}
+fn default_web_search_daily_quota() -> u32 {
+    75
+}
 
 /// Quota enforcement configuration.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -341,12 +347,18 @@ fn default_min_gen_floor() -> u32 {
 pub struct QuotaConfig {
     #[serde(default = "default_overshoot_tolerance")]
     pub overshoot_tolerance_factor: f64,
+    #[serde(default = "default_web_search_max_calls")]
+    pub web_search_max_calls_per_message: u32,
+    #[serde(default = "default_web_search_daily_quota")]
+    pub web_search_daily_quota: u32,
 }
 
 impl Default for QuotaConfig {
     fn default() -> Self {
         Self {
             overshoot_tolerance_factor: default_overshoot_tolerance(),
+            web_search_max_calls_per_message: default_web_search_max_calls(),
+            web_search_daily_quota: default_web_search_daily_quota(),
         }
     }
 }
@@ -358,6 +370,12 @@ impl QuotaConfig {
                 "overshoot_tolerance_factor must be 1.0-1.5, got {}",
                 self.overshoot_tolerance_factor
             ));
+        }
+        if self.web_search_max_calls_per_message == 0 {
+            return Err("web_search_max_calls_per_message must be > 0".to_owned());
+        }
+        if self.web_search_daily_quota == 0 {
+            return Err("web_search_daily_quota must be > 0".to_owned());
         }
         Ok(())
     }
@@ -510,28 +528,48 @@ mod tests {
     fn quota_config_validation() {
         assert!(
             (QuotaConfig {
-                overshoot_tolerance_factor: 0.99
+                overshoot_tolerance_factor: 0.99,
+                ..QuotaConfig::default()
             })
             .validate()
             .is_err()
         );
         assert!(
             (QuotaConfig {
-                overshoot_tolerance_factor: 1.0
+                overshoot_tolerance_factor: 1.0,
+                ..QuotaConfig::default()
             })
             .validate()
             .is_ok()
         );
         assert!(
             (QuotaConfig {
-                overshoot_tolerance_factor: 1.5
+                overshoot_tolerance_factor: 1.5,
+                ..QuotaConfig::default()
             })
             .validate()
             .is_ok()
         );
         assert!(
             (QuotaConfig {
-                overshoot_tolerance_factor: 1.51
+                overshoot_tolerance_factor: 1.51,
+                ..QuotaConfig::default()
+            })
+            .validate()
+            .is_err()
+        );
+        assert!(
+            (QuotaConfig {
+                web_search_max_calls_per_message: 0,
+                ..QuotaConfig::default()
+            })
+            .validate()
+            .is_err()
+        );
+        assert!(
+            (QuotaConfig {
+                web_search_daily_quota: 0,
+                ..QuotaConfig::default()
             })
             .validate()
             .is_err()

--- a/modules/mini-chat/mini-chat/src/domain/error.rs
+++ b/modules/mini-chat/mini-chat/src/domain/error.rs
@@ -41,6 +41,12 @@ pub enum DomainError {
 
     #[error("Internal error: {message}")]
     InternalError { message: String },
+
+    #[error("Web search is currently disabled")]
+    WebSearchDisabled,
+
+    #[error("Web search calls exceeded for this message")]
+    WebSearchCallsExceeded,
 }
 
 impl DomainError {

--- a/modules/mini-chat/mini-chat/src/domain/model/finalization.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/finalization.rs
@@ -45,6 +45,10 @@ pub struct FinalizationInput {
     pub downgrade_from: Option<String>,
     pub downgrade_reason: Option<String>,
     pub period_starts: Vec<(PeriodType, time::Date)>,
+
+    // ── Web search telemetry ──
+    /// Number of completed web search calls during this turn.
+    pub web_search_calls: u32,
 }
 
 /// Result of `finalize_turn_cas()`.

--- a/modules/mini-chat/mini-chat/src/domain/model/quota.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/quota.rs
@@ -103,6 +103,8 @@ pub struct SettlementInput {
     pub minimal_generation_floor_applied: i32,
     pub settlement_path: SettlementPath,
     pub period_starts: Vec<(PeriodType, time::Date)>,
+    /// Completed web search calls to settle.
+    pub web_search_calls: u32,
 }
 
 /// Classification of the settlement path to take.

--- a/modules/mini-chat/mini-chat/src/domain/repos/quota_usage_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/quota_usage_repo.rs
@@ -33,6 +33,8 @@ pub struct SettleParams {
     /// Token telemetry — only applied on `total` bucket.
     pub input_tokens: Option<i64>,
     pub output_tokens: Option<i64>,
+    /// Web search calls to increment — only applied on `total` bucket.
+    pub web_search_calls: u32,
 }
 
 /// Repository trait for quota usage persistence operations.
@@ -75,4 +77,15 @@ pub trait QuotaUsageRepository: Send + Sync {
         period_types: &[PeriodType],
         period_starts: &[time::Date],
     ) -> Result<Vec<QuotaUsageModel>, DomainError>;
+
+    /// Sum `web_search_calls` for a user's daily `total` bucket on the given date.
+    /// Returns 0 if no row exists.
+    async fn get_daily_web_search_calls<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        tenant_id: Uuid,
+        user_id: Uuid,
+        period_start: time::Date,
+    ) -> Result<u32, DomainError>;
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
@@ -189,6 +189,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
                         minimal_generation_floor_applied: input.minimal_generation_floor_applied,
                         settlement_path,
                         period_starts: input.period_starts.clone(),
+                        web_search_calls: input.web_search_calls,
                     };
                     let settlement_outcome = quota_settler
                         .settle_in_tx(tx, &scope, settlement_input)
@@ -535,6 +536,7 @@ mod tests {
                 (PeriodType::Daily, today),
                 (PeriodType::Monthly, month_start),
             ],
+            web_search_calls: 3,
         }
     }
 

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
@@ -62,6 +62,10 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
             quota_config,
         }
     }
+
+    pub(crate) fn web_search_max_calls_per_message(&self) -> u32 {
+        self.quota_config.web_search_max_calls_per_message
+    }
 }
 
 // ── Cascade types ──
@@ -259,6 +263,7 @@ pub struct PreflightComputed {
 impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
     /// Evaluate preflight: external I/O, token estimation, cascade decision.
     /// Does NOT write reserves — call `preflight_write_reserve` in the caller's transaction.
+    #[allow(clippy::too_many_lines)]
     pub async fn preflight_evaluate(
         &self,
         input: PreflightInput,
@@ -276,6 +281,11 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
             .limits_provider
             .get_limits(input.user_id, policy_version)
             .await?;
+
+        // 1b. Web search kill switch check (before any estimation or DB reads)
+        if input.web_search_enabled && snapshot.kill_switches.disable_web_search {
+            return Err(DomainError::WebSearchDisabled);
+        }
 
         // 2. Estimate tokens
         let estimation = token_estimator::estimate_tokens(
@@ -320,13 +330,15 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
             .map_err(|e| DomainError::internal(e.to_string()))?;
         let periods = vec![(PeriodType::Daily, now), (PeriodType::Monthly, month_start)];
 
-        // 6. Read-only transaction: lock rows, run cascade
+        // 6. Transaction: lock rows, check web search quota, run cascade
         let repo = Arc::clone(&self.repo);
         let tenant_id = input.tenant_id;
         let user_id = input.user_id;
         let selected_model = input.selected_model.clone();
         let max_output_tokens_cap = input.max_output_tokens_cap;
         let estimation_budgets = self.estimation_budgets;
+        let web_search_enabled = input.web_search_enabled;
+        let web_search_daily_quota = self.quota_config.web_search_daily_quota;
 
         let tx_result = self
             .db
@@ -354,6 +366,29 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                         )
                         .await
                         .map_err(to_db)?;
+
+                    // 6a. Daily web search quota check (inside tx to prevent TOCTOU)
+                    if web_search_enabled {
+                        let today = period_starts[0]; // Daily period start
+                        let daily_web_search_calls = repo
+                            .get_daily_web_search_calls(tx, &scope, tenant_id, user_id, today)
+                            .await
+                            .map_err(to_db)?;
+                        if daily_web_search_calls >= web_search_daily_quota {
+                            return Ok(PreflightComputed {
+                                decision: PreflightDecision::Reject {
+                                    error_code: "quota_exceeded".to_owned(),
+                                    http_status: 429,
+                                    quota_scope: "web_search".to_owned(),
+                                },
+                                buckets: vec![],
+                                reserved_credits_micro: 0,
+                                periods: periods.clone(),
+                                tenant_id,
+                                user_id,
+                            });
+                        }
+                    }
 
                     let cascade_ctx = CascadeContext {
                         snapshot: &snapshot,
@@ -717,6 +752,7 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
                             actual_credits_micro: committed_credits,
                             input_tokens: if is_total { Some(actual_input) } else { None },
                             output_tokens: if is_total { Some(actual_output) } else { None },
+                            web_search_calls: input.web_search_calls,
                         },
                     )
                     .await?;
@@ -773,6 +809,7 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
                             actual_credits_micro: actual_credits,
                             input_tokens: None,
                             output_tokens: None,
+                            web_search_calls: input.web_search_calls,
                         },
                     )
                     .await?;
@@ -811,6 +848,7 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
                             actual_credits_micro: 0,
                             input_tokens: None,
                             output_tokens: None,
+                            web_search_calls: 0,
                         },
                     )
                     .await?;
@@ -1169,6 +1207,7 @@ mod tests {
             crate::config::EstimationBudgets::default(),
             QuotaConfig {
                 overshoot_tolerance_factor: overshoot_tolerance,
+                ..QuotaConfig::default()
             },
         )
     }
@@ -1192,6 +1231,7 @@ mod tests {
             minimal_generation_floor_applied: 50,
             settlement_path: path,
             period_starts: default_periods(today),
+            web_search_calls: 0,
         }
     }
 
@@ -1686,6 +1726,7 @@ mod tests {
             crate::config::EstimationBudgets::default(),
             QuotaConfig {
                 overshoot_tolerance_factor: 1.10,
+                ..QuotaConfig::default()
             },
         );
 
@@ -1861,6 +1902,94 @@ mod tests {
         );
     }
 
+    // ── Web search preflight tests ──
+
+    #[tokio::test]
+    async fn preflight_web_search_kill_switch_rejects() {
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let mut snapshot = default_snapshot();
+        snapshot.kill_switches.disable_web_search = true;
+        let svc = make_test_service(Arc::clone(&db), snapshot, 1.10);
+
+        let mut input = preflight_input("gpt-5");
+        input.web_search_enabled = true;
+
+        let result = svc.preflight_evaluate(input).await;
+        assert!(
+            matches!(result, Err(DomainError::WebSearchDisabled)),
+            "expected WebSearchDisabled, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn preflight_web_search_daily_quota_rejects() {
+        let db_raw = inmem_db().await;
+        let db = mock_db_provider(db_raw);
+        let snapshot = default_snapshot();
+        let svc = make_test_service(Arc::clone(&db), snapshot, 1.10);
+
+        // Seed daily web search usage at the quota limit
+        let today = OffsetDateTime::now_utc().date();
+        let scope = AccessScope::for_tenant(Uuid::nil());
+        let repo = QuotaUsageRepo;
+        let conn = db.conn().unwrap();
+
+        // First create the row via increment_reserve, then settle with web_search_calls
+        use crate::domain::repos::IncrementReserveParams;
+        repo.increment_reserve(
+            &conn,
+            &scope,
+            IncrementReserveParams {
+                tenant_id: Uuid::nil(),
+                user_id: Uuid::nil(),
+                period_type: PeriodType::Daily,
+                period_start: today,
+                bucket: "total".to_owned(),
+                amount_micro: 1000,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Settle with web_search_calls = daily quota (default 75)
+        use crate::domain::repos::SettleParams;
+        repo.settle(
+            &conn,
+            &scope,
+            SettleParams {
+                tenant_id: Uuid::nil(),
+                user_id: Uuid::nil(),
+                period_type: PeriodType::Daily,
+                period_start: today,
+                bucket: "total".to_owned(),
+                reserved_credits_micro: 1000,
+                actual_credits_micro: 1000,
+                input_tokens: Some(10),
+                output_tokens: Some(5),
+                web_search_calls: QuotaConfig::default().web_search_daily_quota,
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut input = preflight_input("gpt-5");
+        input.web_search_enabled = true;
+
+        let computed = svc.preflight_evaluate(input).await.unwrap();
+        match computed.decision {
+            PreflightDecision::Reject {
+                quota_scope,
+                http_status,
+                ..
+            } => {
+                assert_eq!(quota_scope, "web_search");
+                assert_eq!(http_status, 429);
+            }
+            other => panic!("expected Reject with web_search scope, got {other:?}"),
+        }
+    }
+
     // ── 10: Integration tests ──
 
     // 10.2: Full preflight → settle round-trip
@@ -1921,6 +2050,7 @@ mod tests {
                 output_tokens: 200,
             },
             period_starts: default_periods(today),
+            web_search_calls: 0,
         };
 
         let outcome = svc.settle(&conn, &scope, settle_input).await.unwrap();
@@ -2015,6 +2145,7 @@ mod tests {
                 output_tokens: 200,
             },
             period_starts: default_periods(today),
+            web_search_calls: 0,
         };
 
         let outcome = svc.settle(&conn, &scope, settle_input).await.unwrap();

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -20,7 +20,7 @@ use crate::domain::stream_events::{DoneData, ErrorData, StreamEvent};
 use crate::infra::db::entity::chat_turn::{Model as TurnModel, TurnState};
 use crate::infra::llm::{
     ClientSseEvent, LlmMessage, LlmProvider, LlmProviderError, LlmRequestBuilder, LlmTool,
-    TerminalOutcome, Usage, provider_resolver::ProviderResolver,
+    TerminalOutcome, ToolPhase, Usage, provider_resolver::ProviderResolver,
 };
 
 use super::{DbProvider, actions, resources};
@@ -97,7 +97,10 @@ pub enum StreamError {
     QuotaExhausted {
         error_code: String,
         http_status: u16,
+        quota_scope: String,
     },
+    /// Web search is disabled via kill switch but was requested.
+    WebSearchDisabled,
 }
 
 impl From<authz_resolver_sdk::EnforcerError> for StreamError {
@@ -154,6 +157,7 @@ struct FinalizationCtx<TR: TurnRepository + 'static, MR: MessageRepository + 'st
 
 impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> FinalizationCtx<TR, MR> {
     /// Build a [`FinalizationInput`] from this context and stream outcome data.
+    #[allow(clippy::too_many_arguments)]
     fn to_finalization_input(
         &self,
         terminal_state: TurnState,
@@ -162,6 +166,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
         error_code: Option<String>,
         error_detail: Option<String>,
         provider_response_id: Option<String>,
+        web_search_calls: u32,
     ) -> crate::domain::model::finalization::FinalizationInput {
         crate::domain::model::finalization::FinalizationInput {
             turn_id: self.turn_id,
@@ -188,6 +193,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
             downgrade_from: self.downgrade_from.clone(),
             downgrade_reason: self.downgrade_reason.clone(),
             period_starts: self.period_starts.clone(),
+            web_search_calls,
         }
     }
 }
@@ -296,10 +302,11 @@ fn flatten_preflight(
         PreflightDecision::Reject {
             error_code,
             http_status,
-            ..
+            quota_scope,
         } => Err(StreamError::QuotaExhausted {
             error_code,
             http_status,
+            quota_scope,
         }),
     }
 }
@@ -397,6 +404,7 @@ impl<
         request_id: Uuid,
         content: String,
         resolved_model: ResolvedModel,
+        web_search_enabled: bool,
         cancel: CancellationToken,
         tx: mpsc::Sender<StreamEvent>,
     ) -> Result<tokio::task::JoinHandle<StreamOutcome>, StreamError> {
@@ -486,11 +494,14 @@ impl<
                 utf8_bytes: content.len() as u64,
                 num_images: 0,
                 tools_enabled: false,
-                web_search_enabled: false,
+                web_search_enabled,
                 max_output_tokens_cap: self.streaming_config.max_output_tokens,
             })
             .await
-            .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
+            .map_err(|e| match e {
+                DomainError::WebSearchDisabled => StreamError::WebSearchDisabled,
+                other => StreamError::TurnCreationFailed { source: other },
+            })?;
 
         let pf = flatten_preflight(computed.decision.clone())?;
         // Period boundaries from the computed preflight (used by finalization for settlement)
@@ -545,6 +556,7 @@ impl<
                 snapshot_boundary,
                 &pf.system_prompt,
                 &content,
+                web_search_enabled,
             )
             .await?;
 
@@ -572,6 +584,7 @@ impl<
             model,
             provider_model_id,
             pf.max_output_tokens_applied.cast_unsigned(),
+            self.quota.web_search_max_calls_per_message(),
             cancel,
             tx,
             Some(finalization_ctx),
@@ -704,6 +717,7 @@ impl<
         snapshot_boundary: Option<SnapshotBoundary>,
         system_prompt: &str,
         user_message: &str,
+        web_search_enabled: bool,
     ) -> Result<super::context_assembly::AssembledContext, StreamError> {
         let conn = self
             .db
@@ -774,7 +788,7 @@ impl<
                 thread_summary: thread_summary.as_ref().map(|ts| ts.content.as_str()),
                 recent_messages: &context_messages,
                 user_message,
-                web_search_enabled: false, // P1: not yet wired from request
+                web_search_enabled,
                 file_search_enabled: false, // P1: not yet wired from request
                 vector_store_ids: &[],
             },
@@ -797,6 +811,7 @@ impl<
         turn_id: Uuid,
         content: String,
         resolved_model: ResolvedModel,
+        web_search_enabled: bool,
         snapshot_boundary: Option<SnapshotBoundary>,
         cancel: CancellationToken,
         tx: mpsc::Sender<StreamEvent>,
@@ -819,11 +834,14 @@ impl<
                 utf8_bytes: content.len() as u64,
                 num_images: 0,
                 tools_enabled: false,
-                web_search_enabled: false,
+                web_search_enabled,
                 max_output_tokens_cap: self.streaming_config.max_output_tokens,
             })
             .await
-            .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
+            .map_err(|e| match e {
+                DomainError::WebSearchDisabled => StreamError::WebSearchDisabled,
+                other => StreamError::TurnCreationFailed { source: other },
+            })?;
 
         let pf = flatten_preflight(computed.decision.clone())?;
         let period_starts = computed.periods.clone();
@@ -901,6 +919,7 @@ impl<
                 snapshot_boundary,
                 &pf.system_prompt,
                 &content,
+                web_search_enabled,
             )
             .await?;
 
@@ -926,6 +945,7 @@ impl<
             pf.effective_model,
             provider_model_id,
             pf.max_output_tokens_applied.cast_unsigned(),
+            self.quota.web_search_max_calls_per_message(),
             cancel,
             tx,
             Some(finalization_ctx),
@@ -958,6 +978,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
     model: String,
     provider_model_id: String,
     max_output_tokens: u32,
+    web_search_max_calls: u32,
     cancel: CancellationToken,
     tx: mpsc::Sender<StreamEvent>,
     fin_ctx: Option<FinalizationCtx<TR, MR>>,
@@ -1015,6 +1036,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                         Some(code.clone()),
                         None,
                         None,
+                        0,
                     );
                     match fctx.finalization_svc.finalize_turn_cas(input).await {
                         Ok(outcome) if outcome.won_cas => {
@@ -1061,6 +1083,13 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
         // Read events from provider, translate and forward through channel
         let mut accumulated_text = String::new();
         let mut cancelled = false;
+        let mut web_search_call_count: u32 = 0;
+        // TODO(P2): web_search_call_count (Start) is used for enforcement,
+        // web_search_completed_count (Done) is used for settlement. If a search
+        // starts but never completes (provider error between Start/Done), the
+        // daily quota under-counts by one. Acceptable for P1 since OpenAI always
+        // pairs searching→completed; revisit if we add providers that don't.
+        let mut web_search_completed_count: u32 = 0;
 
         loop {
             tokio::select! {
@@ -1087,6 +1116,76 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                 }
                                 accumulated_text.push_str(content);
                             }
+
+                            // Track web search tool calls for per-message limit
+                            if let ClientSseEvent::Tool { ref phase, name, .. } = client_event
+                                && name == "web_search"
+                            {
+                                match phase {
+                                    ToolPhase::Start => {
+                                        web_search_call_count += 1;
+                                        if web_search_call_count > web_search_max_calls {
+                                            warn!(
+                                                web_search_call_count,
+                                                limit = web_search_max_calls,
+                                                "web search per-message limit exceeded"
+                                            );
+                                            let code = "web_search_calls_exceeded".to_owned();
+                                            let message = "Web search calls exceeded for this message".to_owned();
+
+                                            // Finalize as failed, then emit error (D3)
+                                            if let Some(ref fctx) = fin_ctx {
+                                                let input = fctx.to_finalization_input(
+                                                    TurnState::Failed,
+                                                    &accumulated_text,
+                                                    None,
+                                                    Some(code.clone()),
+                                                    None,
+                                                    None,
+                                                    web_search_completed_count,
+                                                );
+                                                match fctx.finalization_svc.finalize_turn_cas(input).await {
+                                                    Ok(outcome) if outcome.won_cas => {
+                                                        let _ = tx.send(StreamEvent::Error(ErrorData {
+                                                            code: code.clone(),
+                                                            message,
+                                                        })).await;
+                                                    }
+                                                    Ok(_) => {}
+                                                    Err(fe) => {
+                                                        warn!(error = %fe, "finalization failed on ws limit exceeded");
+                                                        let _ = tx.send(StreamEvent::Error(ErrorData {
+                                                            code: code.clone(),
+                                                            message,
+                                                        })).await;
+                                                    }
+                                                }
+                                            } else {
+                                                let _ = tx.send(StreamEvent::Error(ErrorData {
+                                                    code: code.clone(),
+                                                    message,
+                                                })).await;
+                                            }
+
+                                            provider_stream.cancel();
+                                            let has_partial = !accumulated_text.is_empty();
+                                            return StreamOutcome {
+                                                terminal: StreamTerminal::Failed,
+                                                accumulated_text,
+                                                usage: None,
+                                                effective_model: model,
+                                                error_code: Some(code),
+                                                provider_response_id: None,
+                                                provider_partial_usage: has_partial,
+                                            };
+                                        }
+                                    }
+                                    ToolPhase::Done => {
+                                        web_search_completed_count += 1;
+                                    }
+                                }
+                            }
+
                             let stream_event = StreamEvent::from(client_event);
                             if tx.send(stream_event).await.is_err() {
                                 // Receiver dropped (client disconnect handled by relay)
@@ -1108,6 +1207,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                     Some(code.clone()),
                                     None,
                                     None,
+                                    web_search_completed_count,
                                 );
                                 match fctx.finalization_svc.finalize_turn_cas(input).await {
                                     Ok(outcome) if outcome.won_cas => {
@@ -1138,6 +1238,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                     .await;
                             }
 
+                            provider_stream.cancel();
                             let has_partial = !accumulated_text.is_empty();
                             return StreamOutcome {
                                 terminal: StreamTerminal::Failed,
@@ -1175,6 +1276,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                     None,
                     None,
                     None,
+                    web_search_completed_count,
                 );
                 if let Err(e) = fctx.finalization_svc.finalize_turn_cas(input).await {
                     warn!(error = %e, "finalization failed on cancelled stream");
@@ -1221,6 +1323,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                         None,
                         None,
                         Some(response_id.clone()),
+                        web_search_completed_count,
                     );
                     match fctx.finalization_svc.finalize_turn_cas(input).await {
                         Ok(outcome) if outcome.won_cas => {
@@ -1314,6 +1417,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                         None,
                         None,
                         None,
+                        web_search_completed_count,
                     );
                     match fctx.finalization_svc.finalize_turn_cas(input).await {
                         Ok(outcome) if outcome.won_cas => {
@@ -1390,6 +1494,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                         Some(code.clone()),
                         None,
                         None,
+                        web_search_completed_count,
                     );
                     match fctx.finalization_svc.finalize_turn_cas(input).await {
                         Ok(outcome) if outcome.won_cas => {
@@ -1582,6 +1687,85 @@ mod tests {
                 events: std::sync::Mutex::new(events),
             }
         }
+
+        /// Provider that emits `web_search` tool start/done pairs, then completes.
+        fn with_web_search_calls(web_search_count: usize) -> Self {
+            let mut events: Vec<Result<TranslatedEvent, StreamingError>> = Vec::new();
+
+            // Emit a delta first so we have content
+            events.push(Ok(TranslatedEvent::Sse(ClientSseEvent::Delta {
+                r#type: "text",
+                content: "Hello".to_owned(),
+            })));
+
+            for _ in 0..web_search_count {
+                events.push(Ok(TranslatedEvent::Sse(ClientSseEvent::Tool {
+                    phase: ToolPhase::Start,
+                    name: "web_search",
+                    details: serde_json::json!({}),
+                })));
+                events.push(Ok(TranslatedEvent::Sse(ClientSseEvent::Tool {
+                    phase: ToolPhase::Done,
+                    name: "web_search",
+                    details: serde_json::json!({}),
+                })));
+            }
+
+            events.push(Ok(TranslatedEvent::Terminal(TerminalOutcome::Completed {
+                usage: Usage {
+                    input_tokens: 10,
+                    output_tokens: 5,
+                },
+                response_id: "resp-test".to_owned(),
+                content: "Hello".to_owned(),
+                citations: vec![],
+                raw_response: serde_json::Value::Null,
+            })));
+
+            Self {
+                events: std::sync::Mutex::new(events),
+            }
+        }
+
+        /// Provider that emits tool start/done pairs for arbitrary tool names, then completes.
+        fn with_tool_calls(calls: &[(&'static str, usize)]) -> Self {
+            let mut events: Vec<Result<TranslatedEvent, StreamingError>> = Vec::new();
+
+            events.push(Ok(TranslatedEvent::Sse(ClientSseEvent::Delta {
+                r#type: "text",
+                content: "Hello".to_owned(),
+            })));
+
+            for &(name, count) in calls {
+                for _ in 0..count {
+                    events.push(Ok(TranslatedEvent::Sse(ClientSseEvent::Tool {
+                        phase: ToolPhase::Start,
+                        name,
+                        details: serde_json::json!({}),
+                    })));
+                    events.push(Ok(TranslatedEvent::Sse(ClientSseEvent::Tool {
+                        phase: ToolPhase::Done,
+                        name,
+                        details: serde_json::json!({}),
+                    })));
+                }
+            }
+
+            events.push(Ok(TranslatedEvent::Terminal(TerminalOutcome::Completed {
+                usage: Usage {
+                    input_tokens: 10,
+                    output_tokens: 5,
+                },
+                response_id: "resp-test".to_owned(),
+                content: "Hello".to_owned(),
+                citations: vec![],
+                raw_response: serde_json::Value::Null,
+            })));
+
+            Self {
+                events: std::sync::Mutex::new(events),
+            }
+        }
     }
 
     #[async_trait::async_trait]
@@ -1632,6 +1816,7 @@ mod tests {
             "test-model".into(),
             "test-model".into(),
             4096,
+            2, // web_search_max_calls
             cancel,
             tx,
             None,
@@ -1680,6 +1865,7 @@ mod tests {
             "test-model".into(),
             "test-model".into(),
             4096,
+            2, // web_search_max_calls
             cancel,
             tx,
             None,
@@ -1721,6 +1907,7 @@ mod tests {
             "test-model".into(),
             "test-model".into(),
             4096,
+            2, // web_search_max_calls
             cancel,
             tx,
             None,
@@ -1811,6 +1998,7 @@ mod tests {
             "test-model".into(),
             "test-model".into(),
             4096,
+            2, // web_search_max_calls
             cancel.clone(),
             tx,
             None,
@@ -1928,6 +2116,7 @@ mod tests {
             crate::config::EstimationBudgets::default(),
             crate::config::QuotaConfig {
                 overshoot_tolerance_factor: 1.10,
+                ..crate::config::QuotaConfig::default()
             },
         ));
 
@@ -2056,6 +2245,7 @@ mod tests {
                 request_id,
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel,
                 tx,
             )
@@ -2118,6 +2308,7 @@ mod tests {
                 request_id,
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel,
                 tx,
             )
@@ -2197,6 +2388,7 @@ mod tests {
                 request_id,
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel,
                 tx,
             )
@@ -2276,6 +2468,7 @@ mod tests {
                 request_id,
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel,
                 tx,
             )
@@ -2340,6 +2533,7 @@ mod tests {
                 Uuid::new_v4(),
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel,
                 tx,
             )
@@ -2375,6 +2569,7 @@ mod tests {
                 Uuid::new_v4(),
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel,
                 tx,
             )
@@ -2426,6 +2621,7 @@ mod tests {
                 request_id,
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel1,
                 tx1,
             )
@@ -2451,6 +2647,7 @@ mod tests {
                 request_id,
                 "hello again".into(),
                 test_resolved_model(),
+                false,
                 cancel2,
                 tx2,
             )
@@ -2534,6 +2731,7 @@ mod tests {
                 request_id,
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel.clone(),
                 tx,
             )
@@ -2599,6 +2797,7 @@ mod tests {
                 Uuid::new_v4(),
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel,
                 tx,
             )
@@ -2728,6 +2927,7 @@ mod tests {
             "gpt-4o-mini".into(), // effective_model passed as the model param
             "gpt-4o-mini".into(),
             4096,
+            2, // web_search_max_calls
             cancel,
             tx,
             Some(fctx),
@@ -2853,6 +3053,7 @@ mod tests {
             crate::config::EstimationBudgets::default(),
             crate::config::QuotaConfig {
                 overshoot_tolerance_factor: 1.10,
+                ..crate::config::QuotaConfig::default()
             },
         ));
 
@@ -2917,6 +3118,7 @@ mod tests {
                 Uuid::new_v4(),
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel,
                 tx,
             )
@@ -3009,6 +3211,7 @@ mod tests {
                 Uuid::new_v4(),
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel,
                 tx,
             )
@@ -3019,6 +3222,7 @@ mod tests {
             StreamError::QuotaExhausted {
                 error_code,
                 http_status,
+                ..
             } => {
                 assert_eq!(http_status, 429);
                 assert!(!error_code.is_empty());
@@ -3079,6 +3283,7 @@ mod tests {
                     context_window: 128_000,
                     system_prompt: String::new(),
                 },
+                false,
                 cancel,
                 tx,
             )
@@ -3141,6 +3346,7 @@ mod tests {
                 Uuid::new_v4(),
                 "hello".into(),
                 test_resolved_model(),
+                false,
                 cancel,
                 tx,
             )
@@ -3153,5 +3359,141 @@ mod tests {
             }
             other => panic!("expected ChatNotFound, got: {other:?}"),
         }
+    }
+
+    // ── Per-message web search call limit tests ──
+
+    /// 6.5: Web search calls within limit — stream completes normally.
+    #[tokio::test]
+    async fn test_per_message_limit_not_exceeded() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::with_web_search_calls(2)); // 2 calls, limit is 2
+        let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
+        let cancel = CancellationToken::new();
+
+        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+            provider,
+            "test-alias".to_owned(),
+            mock_ctx(),
+            vec![LlmMessage::user("hi")],
+            None,
+            vec![],
+            "test-model".into(),
+            "test-model".into(),
+            4096,
+            2, // web_search_max_calls
+            cancel,
+            tx,
+            None,
+        );
+
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            let is_term = ev.is_terminal();
+            events.push(ev);
+            if is_term {
+                break;
+            }
+        }
+
+        let outcome = handle.await.expect("task should not panic");
+        assert_eq!(outcome.terminal, StreamTerminal::Completed);
+
+        // Expect: 1 delta + 2*(start+done) tool events + 1 done = 6 events
+        assert_eq!(events.len(), 6);
+        assert!(matches!(events.last(), Some(StreamEvent::Done(_))));
+        // No error events
+        assert!(!events.iter().any(|e| matches!(e, StreamEvent::Error(_))));
+    }
+
+    /// 6.6: Web search calls exceed limit — stream terminates with error.
+    #[tokio::test]
+    async fn test_per_message_limit_exceeded() {
+        // 3 web search calls but limit is 2 — the 3rd start should trigger error
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::with_web_search_calls(3));
+        let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
+        let cancel = CancellationToken::new();
+
+        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+            provider,
+            "test-alias".to_owned(),
+            mock_ctx(),
+            vec![LlmMessage::user("hi")],
+            None,
+            vec![],
+            "test-model".into(),
+            "test-model".into(),
+            4096,
+            2, // web_search_max_calls
+            cancel,
+            tx,
+            None,
+        );
+
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            let is_term = ev.is_terminal();
+            events.push(ev);
+            if is_term {
+                break;
+            }
+        }
+
+        let outcome = handle.await.expect("task should not panic");
+        assert_eq!(outcome.terminal, StreamTerminal::Failed);
+        assert_eq!(
+            outcome.error_code.as_deref(),
+            Some("web_search_calls_exceeded")
+        );
+
+        // Last event should be an error
+        let last = events.last().expect("should have events");
+        match last {
+            StreamEvent::Error(data) => {
+                assert_eq!(data.code, "web_search_calls_exceeded");
+            }
+            other => panic!("expected Error event, got: {other:?}"),
+        }
+    }
+
+    /// 6.7: Other tool calls don't count toward web search limit.
+    #[tokio::test]
+    async fn test_per_message_counter_ignores_other_tools() {
+        // 5 file_search calls + 1 web_search call, limit is 2 — should complete
+        let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::with_tool_calls(&[
+            ("file_search", 5),
+            ("web_search", 1),
+        ]));
+        let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
+        let cancel = CancellationToken::new();
+
+        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+            provider,
+            "test-alias".to_owned(),
+            mock_ctx(),
+            vec![LlmMessage::user("hi")],
+            None,
+            vec![],
+            "test-model".into(),
+            "test-model".into(),
+            4096,
+            2, // web_search_max_calls
+            cancel,
+            tx,
+            None,
+        );
+
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            let is_term = ev.is_terminal();
+            events.push(ev);
+            if is_term {
+                break;
+            }
+        }
+
+        let outcome = handle.await.expect("task should not panic");
+        assert_eq!(outcome.terminal, StreamTerminal::Completed);
+        // No error events
+        assert!(!events.iter().any(|e| matches!(e, StreamEvent::Error(_))));
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/quota_usage_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/quota_usage_repo.rs
@@ -79,7 +79,7 @@ impl crate::domain::repos::QuotaUsageRepository for QuotaUsageRepository {
     ) -> Result<(), DomainError> {
         let now = OffsetDateTime::now_utc();
 
-        // Determine if token telemetry should be updated (only for `total` bucket).
+        // Determine if token/web-search telemetry should be updated (only for `total` bucket).
         let is_total = params.bucket == "total";
         let (input_delta, output_delta) = if is_total {
             (
@@ -89,8 +89,9 @@ impl crate::domain::repos::QuotaUsageRepository for QuotaUsageRepository {
         } else {
             (0, 0)
         };
+        let web_search_delta = if is_total { params.web_search_calls } else { 0 };
 
-        QuotaUsageEntity::update_many()
+        let mut update = QuotaUsageEntity::update_many()
             .col_expr(
                 Column::ReservedCreditsMicro,
                 Expr::col(Column::ReservedCreditsMicro)
@@ -112,7 +113,16 @@ impl crate::domain::repos::QuotaUsageRepository for QuotaUsageRepository {
                 Column::OutputTokens,
                 Expr::col(Column::OutputTokens).add(Expr::value(output_delta)),
             )
-            .col_expr(Column::UpdatedAt, Expr::value(now))
+            .col_expr(Column::UpdatedAt, Expr::value(now));
+
+        if web_search_delta > 0 {
+            update = update.col_expr(
+                Column::WebSearchCalls,
+                Expr::col(Column::WebSearchCalls).add(Expr::value(web_search_delta.cast_signed())),
+            );
+        }
+
+        update
             .filter(
                 Condition::all()
                     .add(Column::TenantId.eq(params.tenant_id))
@@ -176,5 +186,42 @@ impl crate::domain::repos::QuotaUsageRepository for QuotaUsageRepository {
         let query = base_query.lock(sea_orm::sea_query::LockType::Update);
 
         Ok(query.secure().scope_with(scope).all(runner).await?)
+    }
+
+    async fn get_daily_web_search_calls<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        tenant_id: Uuid,
+        user_id: Uuid,
+        period_start: time::Date,
+    ) -> Result<u32, DomainError> {
+        let row = QuotaUsageEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::TenantId.eq(tenant_id))
+                    .add(Column::UserId.eq(user_id))
+                    .add(Column::PeriodType.eq(PeriodType::Daily.into_value()))
+                    .add(Column::PeriodStart.eq(period_start))
+                    .add(Column::Bucket.eq("total")),
+            )
+            .secure()
+            .scope_with(scope)
+            .one(runner)
+            .await?;
+
+        Ok(row.map_or(0, |r| {
+            if r.web_search_calls < 0 {
+                tracing::warn!(
+                    tenant_id = %tenant_id,
+                    user_id = %user_id,
+                    web_search_calls = r.web_search_calls,
+                    "negative web_search_calls detected, clamping to 0"
+                );
+                0
+            } else {
+                r.web_search_calls.cast_unsigned()
+            }
+        }))
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/repo_test.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/repo_test.rs
@@ -864,6 +864,7 @@ async fn settle_decrements_reserved_increments_spent() {
             actual_credits_micro: 1500,
             input_tokens: Some(100),
             output_tokens: Some(50),
+            web_search_calls: 0,
         },
     )
     .await
@@ -920,6 +921,7 @@ async fn settle_non_total_bucket_skips_token_telemetry() {
             actual_credits_micro: 800,
             input_tokens: Some(999),
             output_tokens: Some(999),
+            web_search_calls: 0,
         },
     )
     .await
@@ -938,6 +940,112 @@ async fn settle_non_total_bucket_skips_token_telemetry() {
         rows[0].output_tokens, 0,
         "non-total bucket: tokens not updated"
     );
+}
+
+#[tokio::test]
+async fn settle_increments_web_search_calls_on_total_bucket() {
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+
+    let repo = QuotaUsageRepository;
+    let conn = db.conn().unwrap();
+    let period_start = time::Date::from_calendar_date(2026, time::Month::March, 5).unwrap();
+
+    repo.increment_reserve(
+        &conn,
+        &scope(),
+        IncrementReserveParams {
+            tenant_id,
+            user_id,
+            period_type: PeriodType::Daily,
+            period_start,
+            bucket: "total".to_owned(),
+            amount_micro: 2000,
+        },
+    )
+    .await
+    .expect("reserve");
+
+    // Settle with 2 web search calls
+    repo.settle(
+        &conn,
+        &scope(),
+        SettleParams {
+            tenant_id,
+            user_id,
+            period_type: PeriodType::Daily,
+            period_start,
+            bucket: "total".to_owned(),
+            reserved_credits_micro: 2000,
+            actual_credits_micro: 1500,
+            input_tokens: Some(100),
+            output_tokens: Some(50),
+            web_search_calls: 2,
+        },
+    )
+    .await
+    .expect("settle");
+
+    let rows = repo
+        .find_bucket_rows(&conn, &scope(), tenant_id, user_id)
+        .await
+        .expect("find");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].web_search_calls, 2);
+}
+
+#[tokio::test]
+async fn settle_zero_web_search_calls_unchanged() {
+    let db = test_db().await;
+    let tenant_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+
+    let repo = QuotaUsageRepository;
+    let conn = db.conn().unwrap();
+    let period_start = time::Date::from_calendar_date(2026, time::Month::March, 5).unwrap();
+
+    repo.increment_reserve(
+        &conn,
+        &scope(),
+        IncrementReserveParams {
+            tenant_id,
+            user_id,
+            period_type: PeriodType::Daily,
+            period_start,
+            bucket: "total".to_owned(),
+            amount_micro: 2000,
+        },
+    )
+    .await
+    .expect("reserve");
+
+    // Settle with 0 web search calls — column should stay at 0
+    repo.settle(
+        &conn,
+        &scope(),
+        SettleParams {
+            tenant_id,
+            user_id,
+            period_type: PeriodType::Daily,
+            period_start,
+            bucket: "total".to_owned(),
+            reserved_credits_micro: 2000,
+            actual_credits_micro: 1000,
+            input_tokens: Some(50),
+            output_tokens: Some(25),
+            web_search_calls: 0,
+        },
+    )
+    .await
+    .expect("settle");
+
+    let rows = repo
+        .find_bucket_rows(&conn, &scope(), tenant_id, user_id)
+        .await
+        .expect("find");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].web_search_calls, 0);
 }
 
 #[tokio::test]

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
@@ -385,7 +385,7 @@ fn translate_provider_event(event: &ProviderEvent, accumulated_text: &str) -> Tr
         }
 
         ProviderEvent::ResponseCompleted { response } => {
-            let citations = extract_citations(response);
+            let citations = extract_citations(response, accumulated_text);
             let usage = Usage {
                 input_tokens: response.usage.input_tokens,
                 output_tokens: response.usage.output_tokens,
@@ -427,37 +427,53 @@ fn translate_provider_event(event: &ProviderEvent, accumulated_text: &str) -> Tr
 }
 
 /// Extract citations from a `ResponseCompleted`'s output annotations.
-fn extract_citations(response: &ResponseObject) -> Vec<Citation> {
+fn extract_citations(response: &ResponseObject, accumulated_text: &str) -> Vec<Citation> {
     let mut citations = Vec::new();
 
     for output_item in &response.output {
         for content_part in &output_item.content {
             for annotation in &content_part.annotations {
                 let citation = match annotation.r#type.as_str() {
-                    "file_citation" => Citation {
-                        source: CitationSource::File,
-                        title: annotation.title.clone(),
-                        url: None,
-                        attachment_id: annotation.file_id.clone(),
-                        snippet: annotation.text.clone().unwrap_or_default(),
-                        score: None,
-                        span: match (annotation.start_index, annotation.end_index) {
+                    "file_citation" | "url_citation" => {
+                        let snippet = annotation
+                            .text
+                            .clone()
+                            .or_else(|| {
+                                annotation.start_index.zip(annotation.end_index).and_then(
+                                    |(start, end)| {
+                                        accumulated_text.get(start..end).map(ToOwned::to_owned)
+                                    },
+                                )
+                            })
+                            .unwrap_or_default();
+                        let span = match (annotation.start_index, annotation.end_index) {
                             (Some(start), Some(end)) => Some(TextSpan { start, end }),
                             _ => None,
-                        },
-                    },
-                    "url_citation" => Citation {
-                        source: CitationSource::Web,
-                        title: annotation.title.clone(),
-                        url: annotation.url.clone(),
-                        attachment_id: None,
-                        snippet: annotation.text.clone().unwrap_or_default(),
-                        score: None,
-                        span: match (annotation.start_index, annotation.end_index) {
-                            (Some(start), Some(end)) => Some(TextSpan { start, end }),
-                            _ => None,
-                        },
-                    },
+                        };
+
+                        let is_file = annotation.r#type == "file_citation";
+                        Citation {
+                            source: if is_file {
+                                CitationSource::File
+                            } else {
+                                CitationSource::Web
+                            },
+                            title: annotation.title.clone(),
+                            url: if is_file {
+                                None
+                            } else {
+                                annotation.url.clone()
+                            },
+                            attachment_id: if is_file {
+                                annotation.file_id.clone()
+                            } else {
+                                None
+                            },
+                            snippet,
+                            score: None,
+                            span,
+                        }
+                    }
                     _ => continue,
                 };
                 citations.push(citation);
@@ -551,6 +567,7 @@ fn build_request_body<M>(request: &LlmRequest<M>, stream: bool) -> serde_json::V
                 "type": "file_search",
                 "vector_store_ids": vector_store_ids
             })),
+            // TODO(P2): Update "web_search_preview" to "web_search" when adding provider parameter pass-through
             LlmTool::WebSearch => Some(serde_json::json!({
                 "type": "web_search_preview"
             })),
@@ -718,8 +735,6 @@ impl crate::infra::llm::LlmProvider for OpenAiResponsesProvider {
         let response_obj: ResponseObject =
             serde_json::from_slice(&bytes).map_err(|_| parse_error_response(&bytes))?;
 
-        let citations = extract_citations(&response_obj);
-
         // Extract text content from output
         let content = response_obj
             .output
@@ -729,6 +744,8 @@ impl crate::infra::llm::LlmProvider for OpenAiResponsesProvider {
             .map(|part| part.text.as_str())
             .collect::<Vec<_>>()
             .join("");
+
+        let citations = extract_citations(&response_obj, &content);
 
         let usage = Usage {
             input_tokens: response_obj.usage.input_tokens,
@@ -1479,7 +1496,7 @@ mod tests {
                 output_tokens: 0,
             },
         };
-        let citations = extract_citations(&response);
+        let citations = extract_citations(&response, "");
         assert_eq!(citations.len(), 1);
         assert!(matches!(citations[0].source, CitationSource::File));
         assert_eq!(citations[0].title, "Report.pdf");
@@ -1513,7 +1530,7 @@ mod tests {
                 output_tokens: 0,
             },
         };
-        let citations = extract_citations(&response);
+        let citations = extract_citations(&response, "");
         assert_eq!(citations.len(), 1);
         assert!(matches!(citations[0].source, CitationSource::Web));
         assert_eq!(citations[0].url.as_deref(), Some("https://example.com"));
@@ -1537,8 +1554,99 @@ mod tests {
                 output_tokens: 0,
             },
         };
-        let citations = extract_citations(&response);
+        let citations = extract_citations(&response, "");
         assert!(citations.is_empty());
+    }
+
+    #[test]
+    fn extract_citations_url_citation_snippet_from_text_range() {
+        let accumulated = "0123456789The capital of France is Paris.";
+        let response = ResponseObject {
+            id: "resp-1".into(),
+            output: vec![OutputItem {
+                r#type: "message".into(),
+                content: vec![ResponseContentPart {
+                    r#type: "output_text".into(),
+                    text: accumulated.into(),
+                    annotations: vec![Annotation {
+                        r#type: "url_citation".into(),
+                        title: "Wikipedia".into(),
+                        url: Some("https://en.wikipedia.org/wiki/France".into()),
+                        file_id: None,
+                        start_index: Some(10),
+                        end_index: Some(31),
+                        text: None,
+                    }],
+                }],
+            }],
+            usage: RawUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+            },
+        };
+        let citations = extract_citations(&response, accumulated);
+        assert_eq!(citations.len(), 1);
+        assert_eq!(citations[0].snippet, "The capital of France");
+    }
+
+    #[test]
+    fn extract_citations_url_citation_snippet_from_annotation_text() {
+        let response = ResponseObject {
+            id: "resp-1".into(),
+            output: vec![OutputItem {
+                r#type: "message".into(),
+                content: vec![ResponseContentPart {
+                    r#type: "output_text".into(),
+                    text: "Hello world".into(),
+                    annotations: vec![Annotation {
+                        r#type: "url_citation".into(),
+                        title: "Example".into(),
+                        url: Some("https://example.com".into()),
+                        file_id: None,
+                        start_index: Some(0),
+                        end_index: Some(5),
+                        text: Some("explicit snippet".into()),
+                    }],
+                }],
+            }],
+            usage: RawUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+            },
+        };
+        let citations = extract_citations(&response, "Hello world");
+        assert_eq!(citations.len(), 1);
+        assert_eq!(citations[0].snippet, "explicit snippet");
+    }
+
+    #[test]
+    fn extract_citations_url_citation_no_text_no_indices() {
+        let response = ResponseObject {
+            id: "resp-1".into(),
+            output: vec![OutputItem {
+                r#type: "message".into(),
+                content: vec![ResponseContentPart {
+                    r#type: "output_text".into(),
+                    text: "Hello".into(),
+                    annotations: vec![Annotation {
+                        r#type: "url_citation".into(),
+                        title: "Example".into(),
+                        url: Some("https://example.com".into()),
+                        file_id: None,
+                        start_index: None,
+                        end_index: None,
+                        text: None,
+                    }],
+                }],
+            }],
+            usage: RawUsage {
+                input_tokens: 0,
+                output_tokens: 0,
+            },
+        };
+        let citations = extract_citations(&response, "Hello");
+        assert_eq!(citations.len(), 1);
+        assert_eq!(citations[0].snippet, "");
     }
 
     // ── Integration tests: streaming ───────────────────────────────────────


### PR DESCRIPTION
feat(mini-chat): wire web search kill switch, daily quota, and per-message call limit

Enforces disable_web_search kill switch and daily web_search_calls quota at preflight, tracks per-message web search tool calls mid-stream with configurable max_calls_per_message, settles web_search_calls telemetry to quota_usage, and fixes citation snippet fallback to extract from accumulated text when annotation.text is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable web-search quotas and kill-switch: per-message limits, daily caps, and per-request enable/disable.
  * Per-message enforcement and telemetry: web-search call counts are tracked and carried through finalization/settlement.
  * Improved citation extraction: prefers annotation text and derives snippets from accumulated context when needed.

* **Bug Fixes**
  * Clearer error responses when web search is disabled or calls exceed quota (client-visible 400/429 with descriptive codes and traceable IDs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->