### PR TITLE
feat(oagw,mini-chat): upgrade GTS to 0.8.4, register all providers via types-registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3464,9 +3464,9 @@ dependencies = [
 
 [[package]]
 name = "gts"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0a15e08f030e746de66a3636d9d70df408afeaf7233dfa4ac885a26a54072f"
+checksum = "3cf70de49935aad158ecc91b335a5e1361757a7048417a26e19bd72b2d5bb44d"
 dependencies = [
  "gts-id",
  "jsonschema",
@@ -3491,18 +3491,18 @@ dependencies = [
 
 [[package]]
 name = "gts-id"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ec93e3bdbb302735a7b163a353791eadece2059a8b2d326c94d4b62523b8e2"
+checksum = "b2d137decd946d1034f918cb972069ca22928fe8416348dbbb142b9d4a5eb922"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gts-macros"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cbd92c6de37e030a107d7064ebb0611f6a85c5098be343496f79726e025b16"
+checksum = "d9140ff93e4f92f38ce91c47a3b7b27df6d581d05d94e435cb31ce91ee4fb391"
 dependencies = [
  "gts-id",
  "proc-macro2",
@@ -3513,11 +3513,12 @@ dependencies = [
 
 [[package]]
 name = "gts-validator"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804d00b8e69478d520e526514075ea76fea98e902ee667f64b68ebbb7ea576eb"
+checksum = "69aba10fcc6ce1d91152d4e86d177a017652ddfcc66b7461e6ad9b28b0b11122"
 dependencies = [
  "anyhow",
+ "clap",
  "glob",
  "gts",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -512,9 +512,9 @@ walkdir = "2.5"
 shellexpand = "3.1"
 
 # GTS library
-gts-id = "0.8.2"
-gts = "0.8.2"
-gts-macros = "0.8.2"
+gts-id = "0.8.4"
+gts = "0.8.4"
+gts-macros = "0.8.4"
 
 # GTS validator
-gts-validator = "0.8.2"
+gts-validator = "0.8.4"

--- a/modules/mini-chat/mini-chat/src/infra/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/mod.rs
@@ -3,3 +3,4 @@ pub mod llm;
 pub(crate) mod model_policy;
 pub(crate) mod oagw_provisioning;
 pub(crate) mod outbox;
+pub(crate) mod type_catalog;

--- a/modules/mini-chat/mini-chat/src/infra/oagw_provisioning.rs
+++ b/modules/mini-chat/mini-chat/src/infra/oagw_provisioning.rs
@@ -1,338 +1,35 @@
 //! OAGW upstream and route registration for configured LLM providers.
 //!
-//! Called once during `Module::init()` to ensure every provider entry
-//! has a corresponding OAGW upstream (with auth config) and route.
-//!
-//! After each successful `create_upstream`, the OAGW-assigned alias is
-//! stamped onto [`ProviderEntry::upstream_alias`] (or
-//! [`ProviderTenantOverride::upstream_alias`]) so the rest of mini-chat uses
-//! the authoritative alias from OAGW rather than deriving one locally.
+//! All provider upstreams, routes, and tenant-override upstreams are registered
+//! as GTS entities in the types-registry during `init()`. OAGW materialises
+//! them in `post_init()` via its type-provisioning pipeline.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
-use oagw_sdk::ServiceGatewayClientV1;
-use tracing::{info, warn};
+use tracing::info;
+use types_registry_sdk::{RegisterResult, TypesRegistryClient};
 
 use crate::config::ProviderEntry;
+use crate::infra::type_catalog;
 
-/// Register OAGW upstreams and routes for each configured provider.
+/// Register provider upstream, route, and tenant-override GTS entities in the types-registry.
 ///
-/// On success the **OAGW-assigned alias** is written into
-/// [`ProviderEntry::upstream_alias`] (root) and
-/// [`ProviderTenantOverride::upstream_alias`] (per-tenant).
-///
-/// Uses a default-tenant `SecurityContext`. If the upstream already exists
-/// (e.g. re-init), the error is logged and skipped.
-pub async fn register_oagw_upstreams(
-    gateway: &Arc<dyn ServiceGatewayClientV1>,
-    providers: &mut HashMap<String, ProviderEntry>,
+/// Called during `init()`. OAGW will materialise these in `post_init()`.
+pub async fn register_provider_entities(
+    registry: &dyn TypesRegistryClient,
+    providers: &HashMap<String, ProviderEntry>,
 ) -> anyhow::Result<()> {
-    let ctx = modkit_security::SecurityContext::builder()
-        .subject_tenant_id(modkit_security::constants::DEFAULT_TENANT_ID)
-        .subject_id(modkit_security::constants::DEFAULT_SUBJECT_ID)
-        .build()
-        .map_err(|e| anyhow::anyhow!("failed to build security context: {e}"))?;
+    let tenant_id = modkit_security::constants::DEFAULT_TENANT_ID;
+    let entities = type_catalog::build_provider_entities(providers, tenant_id);
+    let count = entities.len();
 
-    for (provider_id, entry) in providers.iter_mut() {
-        // Register root upstream + route. Fail hard — without upstreams the
-        // module cannot proxy LLM requests.
-        let upstream = create_upstream(gateway, &ctx, provider_id, entry)
-            .await
-            .ok_or_else(|| {
-                anyhow::anyhow!("OAGW upstream registration failed for provider '{provider_id}'")
-            })?;
-        entry.upstream_alias = Some(upstream.alias.clone());
-        register_route(gateway, &ctx, provider_id, entry, &upstream).await;
+    let results = registry.register(entities).await?;
+    RegisterResult::ensure_all_ok(&results)
+        .map_err(|e| anyhow::anyhow!("mini-chat provider type registration failed: {e}"))?;
 
-        // Register tenant-specific upstreams (share the same route/api_path).
-        let tenant_ids: Vec<String> = entry.tenant_overrides.keys().cloned().collect();
-        for tenant_id in &tenant_ids {
-            let tenant_override = &entry.tenant_overrides[tenant_id];
-            if tenant_override.host.is_none() && tenant_override.upstream_alias.is_none() {
-                anyhow::bail!(
-                    "provider '{provider_id}': tenant override '{tenant_id}' \
-                     has no host and no upstream_alias - \
-                     cannot create distinct upstream"
-                );
-            }
-
-            let label = format!("{provider_id}[tenant={tenant_id}]");
-            if let Some(alias) =
-                create_tenant_upstream(gateway, &ctx, &label, entry, tenant_id).await
-                && let Some(tenant_override) = entry.tenant_overrides.get_mut(tenant_id)
-            {
-                tenant_override.upstream_alias = Some(alias);
-            }
-        }
-    }
-
+    info!(
+        count,
+        "Registered mini-chat provider GTS entities in types-registry"
+    );
     Ok(())
-}
-
-/// Create an OAGW upstream for a single provider entry.
-///
-/// Only passes `upstream_alias` to OAGW when explicitly configured
-/// (required for IP-based hosts). For hostname-based hosts OAGW
-/// auto-derives the alias.
-///
-/// Returns `None` (with a warning log) if registration fails.
-async fn create_upstream(
-    gateway: &Arc<dyn ServiceGatewayClientV1>,
-    ctx: &modkit_security::SecurityContext,
-    provider_id: &str,
-    entry: &ProviderEntry,
-) -> Option<oagw_sdk::Upstream> {
-    use oagw_sdk::{AuthConfig, CreateUpstreamRequest, Endpoint, Scheme, Server};
-
-    let server = Server {
-        endpoints: vec![Endpoint {
-            scheme: Scheme::Https,
-            host: entry.host.clone(),
-            port: 443,
-        }],
-    };
-
-    let mut builder =
-        CreateUpstreamRequest::builder(server, "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1")
-            .enabled(true);
-
-    // Only pass alias when explicitly configured (IP-based hosts).
-    if let Some(alias) = &entry.upstream_alias {
-        builder = builder.alias(alias);
-    }
-
-    if let (Some(plugin_type), Some(config)) = (&entry.auth_plugin_type, &entry.auth_config) {
-        builder = builder.auth(AuthConfig {
-            plugin_type: plugin_type.clone(),
-            sharing: oagw_sdk::SharingMode::Inherit,
-            config: Some(config.clone()),
-        });
-    }
-
-    match gateway.create_upstream(ctx.clone(), builder.build()).await {
-        Ok(u) => {
-            info!(
-                provider_id,
-                alias = %u.alias,
-                upstream_id = %u.id,
-                "OAGW upstream registered"
-            );
-            Some(u)
-        }
-        Err(e) => {
-            warn!(
-                provider_id,
-                error = %e,
-                "OAGW upstream registration failed (may already exist)"
-            );
-            None
-        }
-    }
-}
-
-/// Create an OAGW upstream for a tenant-specific override.
-///
-/// Uses [`ProviderEntry::effective_host_for_tenant`] and the tenant's auth
-/// config. Only passes `upstream_alias` when the tenant override explicitly
-/// sets one (required for IP-based hosts). For hostname-based hosts OAGW
-/// auto-derives the alias.
-///
-/// Returns the OAGW-assigned alias on success, `None` on failure.
-async fn create_tenant_upstream(
-    gateway: &Arc<dyn ServiceGatewayClientV1>,
-    ctx: &modkit_security::SecurityContext,
-    label: &str,
-    entry: &ProviderEntry,
-    tenant_id: &str,
-) -> Option<String> {
-    use oagw_sdk::{AuthConfig, CreateUpstreamRequest, Endpoint, Scheme, Server};
-
-    let host = entry.effective_host_for_tenant(tenant_id);
-
-    let server = Server {
-        endpoints: vec![Endpoint {
-            scheme: Scheme::Https,
-            host: host.to_owned(),
-            port: 443,
-        }],
-    };
-
-    let mut builder =
-        CreateUpstreamRequest::builder(server, "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1")
-            .enabled(true);
-
-    // Only pass alias when the tenant override explicitly sets one (IP-based hosts).
-    if let Some(alias) = entry
-        .tenant_overrides
-        .get(tenant_id)
-        .and_then(|o| o.upstream_alias.as_deref())
-    {
-        builder = builder.alias(alias);
-    }
-
-    if let (Some(plugin_type), Some(config)) = (
-        entry.effective_auth_plugin_type_for_tenant(tenant_id),
-        entry.effective_auth_config_for_tenant(tenant_id),
-    ) {
-        builder = builder.auth(AuthConfig {
-            plugin_type: plugin_type.to_owned(),
-            sharing: oagw_sdk::SharingMode::Inherit,
-            config: Some(config.clone()),
-        });
-    }
-
-    match gateway.create_upstream(ctx.clone(), builder.build()).await {
-        Ok(u) => {
-            info!(
-                label,
-                alias = %u.alias,
-                upstream_id = %u.id,
-                "OAGW tenant upstream registered"
-            );
-            Some(u.alias)
-        }
-        Err(e) => {
-            warn!(
-                label,
-                error = %e,
-                "OAGW tenant upstream registration failed (may already exist)"
-            );
-            None
-        }
-    }
-}
-
-/// Derive route match rules from `api_path` and register the OAGW route.
-async fn register_route(
-    gateway: &Arc<dyn ServiceGatewayClientV1>,
-    ctx: &modkit_security::SecurityContext,
-    provider_id: &str,
-    entry: &ProviderEntry,
-    upstream: &oagw_sdk::Upstream,
-) {
-    use oagw_sdk::{CreateRouteRequest, HttpMatch, HttpMethod, MatchRules};
-
-    let (route_prefix, suffix_mode) = derive_route_match(&entry.api_path);
-    let query_allowlist = extract_query_allowlist(&entry.api_path);
-
-    let match_rules = MatchRules {
-        http: Some(HttpMatch {
-            methods: vec![HttpMethod::Post],
-            path: route_prefix.clone(),
-            query_allowlist,
-            path_suffix_mode: suffix_mode,
-        }),
-        grpc: None,
-    };
-
-    match gateway
-        .create_route(
-            ctx.clone(),
-            CreateRouteRequest::builder(upstream.id, match_rules)
-                .enabled(true)
-                .build(),
-        )
-        .await
-    {
-        Ok(route) => {
-            info!(
-                provider_id,
-                route_id = %route.id,
-                route_path = %route_prefix,
-                "OAGW route registered"
-            );
-        }
-        Err(e) => {
-            warn!(
-                provider_id,
-                error = %e,
-                "OAGW route registration failed"
-            );
-        }
-    }
-}
-
-/// Derive route prefix and suffix mode from an `api_path` template.
-///
-/// Strips query string, replaces `{model}` with `*`, and returns
-/// `(prefix, suffix_mode)` for OAGW route matching.
-fn derive_route_match(api_path: &str) -> (String, oagw_sdk::PathSuffixMode) {
-    let route_path = api_path
-        .split('?')
-        .next()
-        .unwrap_or(api_path)
-        .replace("{model}", "*");
-
-    let route_prefix = if let Some(pos) = route_path.find('*') {
-        route_path[..pos].trim_end_matches('/').to_owned()
-    } else {
-        route_path.clone()
-    };
-
-    let suffix_mode = if route_path.contains('*') {
-        oagw_sdk::PathSuffixMode::Append
-    } else {
-        oagw_sdk::PathSuffixMode::Disabled
-    };
-
-    (route_prefix, suffix_mode)
-}
-
-/// Extract query parameter names from an `api_path` template's query string.
-fn extract_query_allowlist(api_path: &str) -> Vec<String> {
-    api_path
-        .split('?')
-        .nth(1)
-        .map(|qs| {
-            qs.split('&')
-                .filter_map(|pair| pair.split('=').next().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn derive_simple_path() {
-        let (prefix, mode) = derive_route_match("/v1/responses");
-        assert_eq!(prefix, "/v1/responses");
-        assert!(matches!(mode, oagw_sdk::PathSuffixMode::Disabled));
-    }
-
-    #[test]
-    fn derive_path_with_model_placeholder() {
-        let (prefix, mode) =
-            derive_route_match("/openai/deployments/{model}/responses?api-version=2025-03-01");
-        assert_eq!(prefix, "/openai/deployments");
-        assert!(matches!(mode, oagw_sdk::PathSuffixMode::Append));
-    }
-
-    #[test]
-    fn derive_azure_openai_path() {
-        let (prefix, mode) = derive_route_match("/openai/v1/responses");
-        assert_eq!(prefix, "/openai/v1/responses");
-        assert!(matches!(mode, oagw_sdk::PathSuffixMode::Disabled));
-    }
-
-    #[test]
-    fn extract_empty_query() {
-        assert!(extract_query_allowlist("/v1/responses").is_empty());
-    }
-
-    #[test]
-    fn extract_single_query_param() {
-        let params =
-            extract_query_allowlist("/openai/deployments/{model}/responses?api-version=2025-03-01");
-        assert_eq!(params, vec!["api-version"]);
-    }
-
-    #[test]
-    fn extract_multiple_query_params() {
-        let params = extract_query_allowlist("/path?foo=1&bar=2&baz=3");
-        assert_eq!(params, vec!["foo", "bar", "baz"]);
-    }
 }

--- a/modules/mini-chat/mini-chat/src/infra/type_catalog.rs
+++ b/modules/mini-chat/mini-chat/src/infra/type_catalog.rs
@@ -1,0 +1,365 @@
+//! GTS entity builders for registering mini-chat provider upstreams and routes
+//! in the types-registry.
+//!
+//! Entities follow the format expected by OAGW's `TypeProvisioningServiceImpl`
+//! so that OAGW materialises them during `post_init()`.
+
+use std::collections::HashMap;
+
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::config::ProviderEntry;
+
+/// UUID v5 namespace for mini-chat deterministic IDs.
+const MINI_CHAT_NS: Uuid = Uuid::from_bytes([
+    0x6d, 0x69, 0x6e, 0x69, // "mini"
+    0x2d, 0x63, // "-c"
+    0x68, 0x61, // "ha"
+    0x74, 0x2d, // "t-"
+    0x6f, 0x61, 0x67, 0x77, // "oagw"
+    0x2d, 0x76, // "-v"
+]);
+
+/// Build upstream and route GTS entities for all configured providers,
+/// including tenant-override upstreams.
+///
+/// Each provider produces:
+/// - one `gts.x.core.oagw.upstream.v1~<uuid>` instance (root upstream)
+/// - one `gts.x.core.oagw.route.v1~<uuid>` instance (route match rules)
+/// - one upstream per tenant override (with tenant-specific host/auth)
+pub fn build_provider_entities(
+    providers: &HashMap<String, ProviderEntry>,
+    default_tenant_id: Uuid,
+) -> Vec<Value> {
+    let mut entities = Vec::new();
+    for (provider_id, entry) in providers {
+        entities.push(build_upstream_entity(provider_id, entry, default_tenant_id));
+        entities.push(build_route_entity(provider_id, entry, default_tenant_id));
+
+        // Tenant-override upstreams.
+        for tid_str in entry.tenant_overrides.keys() {
+            let tenant_id = Uuid::parse_str(tid_str).unwrap_or(default_tenant_id);
+            let label = format!("{provider_id}@{tid_str}");
+            entities.push(build_tenant_upstream_entity(
+                &label, entry, tid_str, tenant_id,
+            ));
+        }
+    }
+    entities
+}
+
+/// Deterministic UUID for a provider's upstream GTS entity.
+#[must_use]
+pub fn upstream_uuid(provider_id: &str, tenant_id: Uuid) -> Uuid {
+    Uuid::new_v5(
+        &MINI_CHAT_NS,
+        format!("upstream:{tenant_id}:{provider_id}").as_bytes(),
+    )
+}
+
+/// Deterministic UUID for a provider's route GTS entity.
+#[must_use]
+pub fn route_uuid(provider_id: &str, tenant_id: Uuid) -> Uuid {
+    Uuid::new_v5(
+        &MINI_CHAT_NS,
+        format!("route:{tenant_id}:{provider_id}").as_bytes(),
+    )
+}
+
+fn build_upstream_entity(provider_id: &str, entry: &ProviderEntry, tenant_id: Uuid) -> Value {
+    let id = upstream_uuid(provider_id, tenant_id);
+    let gts_id = format!("gts.x.core.oagw.upstream.v1~{}", id.hyphenated());
+
+    let mut content = json!({
+        "$id": gts_id,
+        "tenant_id": tenant_id,
+        "server": {
+            "endpoints": [{
+                "scheme": "https",
+                "host": entry.host,
+                "port": 443
+            }]
+        },
+        "protocol": "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+        "enabled": true,
+        "tags": []
+    });
+
+    // Only pass alias when explicitly configured (IP-based hosts).
+    if let Some(alias) = &entry.upstream_alias {
+        content["alias"] = json!(alias);
+    }
+
+    if let (Some(plugin_type), Some(config)) = (&entry.auth_plugin_type, &entry.auth_config) {
+        content["auth"] = json!({
+            "type": plugin_type,
+            "sharing": "inherit",
+            "config": config
+        });
+    }
+
+    content
+}
+
+fn build_tenant_upstream_entity(
+    label: &str,
+    entry: &ProviderEntry,
+    tenant_id_str: &str,
+    tenant_id: Uuid,
+) -> Value {
+    let id = upstream_uuid(label, tenant_id);
+    let gts_id = format!("gts.x.core.oagw.upstream.v1~{}", id.hyphenated());
+
+    let host = entry.effective_host_for_tenant(tenant_id_str);
+
+    let mut content = json!({
+        "$id": gts_id,
+        "tenant_id": tenant_id,
+        "server": {
+            "endpoints": [{
+                "scheme": "https",
+                "host": host,
+                "port": 443
+            }]
+        },
+        "protocol": "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+        "enabled": true,
+        "tags": []
+    });
+
+    // Only pass alias when the tenant override explicitly sets one.
+    if let Some(alias) = entry
+        .tenant_overrides
+        .get(tenant_id_str)
+        .and_then(|o| o.upstream_alias.as_deref())
+    {
+        content["alias"] = json!(alias);
+    }
+
+    if let (Some(plugin_type), Some(config)) = (
+        entry.effective_auth_plugin_type_for_tenant(tenant_id_str),
+        entry.effective_auth_config_for_tenant(tenant_id_str),
+    ) {
+        content["auth"] = json!({
+            "type": plugin_type,
+            "sharing": "inherit",
+            "config": config
+        });
+    }
+
+    content
+}
+
+fn build_route_entity(provider_id: &str, entry: &ProviderEntry, tenant_id: Uuid) -> Value {
+    let route_id = route_uuid(provider_id, tenant_id);
+    let upstream_id = upstream_uuid(provider_id, tenant_id);
+    let gts_id = format!("gts.x.core.oagw.route.v1~{}", route_id.hyphenated());
+
+    let (route_prefix, suffix_mode) = derive_route_match(&entry.api_path);
+    let query_allowlist = extract_query_allowlist(&entry.api_path);
+
+    let suffix_mode_str = match suffix_mode {
+        SuffixMode::Disabled => "disabled",
+        SuffixMode::Append => "append",
+    };
+
+    json!({
+        "$id": gts_id,
+        "tenant_id": tenant_id,
+        "upstream_id": upstream_id,
+        "match": {
+            "http": {
+                "methods": ["POST"],
+                "path": route_prefix,
+                "query_allowlist": query_allowlist,
+                "path_suffix_mode": suffix_mode_str
+            }
+        },
+        "enabled": true,
+        "tags": [],
+        "priority": 0
+    })
+}
+
+// -- Route-match helpers (shared with oagw_provisioning) --
+
+enum SuffixMode {
+    Disabled,
+    Append,
+}
+
+/// Derive route prefix and suffix mode from an `api_path` template.
+fn derive_route_match(api_path: &str) -> (String, SuffixMode) {
+    let route_path = api_path
+        .split('?')
+        .next()
+        .unwrap_or(api_path)
+        .replace("{model}", "*");
+
+    let route_prefix = if let Some(pos) = route_path.find('*') {
+        route_path[..pos].trim_end_matches('/').to_owned()
+    } else {
+        route_path.clone()
+    };
+
+    let suffix_mode = if route_path.contains('*') {
+        SuffixMode::Append
+    } else {
+        SuffixMode::Disabled
+    };
+
+    (route_prefix, suffix_mode)
+}
+
+/// Extract query parameter names from an `api_path` template's query string.
+fn extract_query_allowlist(api_path: &str) -> Vec<String> {
+    api_path
+        .split('?')
+        .nth(1)
+        .map(|qs| {
+            qs.split('&')
+                .filter_map(|pair| pair.split('=').next().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::infra::llm::ProviderKind;
+
+    fn test_entry() -> ProviderEntry {
+        ProviderEntry {
+            kind: ProviderKind::OpenAiResponses,
+            upstream_alias: None,
+            host: "api.openai.com".to_owned(),
+            api_path: "/v1/responses".to_owned(),
+            auth_plugin_type: Some(
+                "gts.x.core.oagw.auth_plugin.v1~x.core.oagw.apikey.v1".to_owned(),
+            ),
+            auth_config: Some({
+                let mut c = HashMap::new();
+                c.insert("header".to_owned(), "Authorization".to_owned());
+                c.insert("prefix".to_owned(), "Bearer ".to_owned());
+                c.insert("secret_ref".to_owned(), "openai-key".to_owned());
+                c
+            }),
+            tenant_overrides: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn upstream_uuid_is_deterministic() {
+        assert_eq!(
+            upstream_uuid("openai", Uuid::nil()),
+            upstream_uuid("openai", Uuid::nil())
+        );
+    }
+
+    #[test]
+    fn upstream_uuid_differs_per_provider() {
+        assert_ne!(
+            upstream_uuid("openai", Uuid::nil()),
+            upstream_uuid("azure_openai", Uuid::nil())
+        );
+    }
+
+    #[test]
+    fn route_uuid_is_deterministic() {
+        assert_eq!(
+            route_uuid("openai", Uuid::nil()),
+            route_uuid("openai", Uuid::nil())
+        );
+    }
+
+    #[test]
+    fn route_uuid_differs_from_upstream() {
+        assert_ne!(
+            upstream_uuid("openai", Uuid::nil()),
+            route_uuid("openai", Uuid::nil())
+        );
+    }
+
+    #[test]
+    fn build_upstream_entity_has_correct_gts_id() {
+        let entity = build_upstream_entity("openai", &test_entry(), Uuid::nil());
+        let id = entity["$id"].as_str().unwrap();
+        assert!(id.starts_with("gts.x.core.oagw.upstream.v1~"));
+    }
+
+    #[test]
+    fn build_upstream_entity_has_auth() {
+        let entity = build_upstream_entity("openai", &test_entry(), Uuid::nil());
+        assert!(entity["auth"].is_object());
+        assert_eq!(
+            entity["auth"]["type"],
+            "gts.x.core.oagw.auth_plugin.v1~x.core.oagw.apikey.v1"
+        );
+        assert_eq!(entity["auth"]["sharing"], "inherit");
+    }
+
+    #[test]
+    fn build_upstream_entity_omits_alias_when_none() {
+        let entity = build_upstream_entity("openai", &test_entry(), Uuid::nil());
+        assert!(entity.get("alias").is_none());
+    }
+
+    #[test]
+    fn build_upstream_entity_includes_alias_when_set() {
+        let mut entry = test_entry();
+        entry.upstream_alias = Some("my-alias".to_owned());
+        let entity = build_upstream_entity("openai", &entry, Uuid::nil());
+        assert_eq!(entity["alias"], "my-alias");
+    }
+
+    #[test]
+    fn build_route_entity_has_correct_gts_id() {
+        let entity = build_route_entity("openai", &test_entry(), Uuid::nil());
+        let id = entity["$id"].as_str().unwrap();
+        assert!(id.starts_with("gts.x.core.oagw.route.v1~"));
+    }
+
+    #[test]
+    fn build_route_entity_references_upstream_uuid() {
+        let entity = build_route_entity("openai", &test_entry(), Uuid::nil());
+        let upstream_id: Uuid = serde_json::from_value(entity["upstream_id"].clone()).unwrap();
+        assert_eq!(upstream_id, upstream_uuid("openai", Uuid::nil()));
+    }
+
+    #[test]
+    fn build_route_entity_simple_path() {
+        let entity = build_route_entity("openai", &test_entry(), Uuid::nil());
+        assert_eq!(entity["match"]["http"]["path"], "/v1/responses");
+        assert_eq!(entity["match"]["http"]["path_suffix_mode"], "disabled");
+    }
+
+    #[test]
+    fn build_route_entity_azure_path() {
+        let mut entry = test_entry();
+        entry.api_path = "/openai/deployments/{model}/responses?api-version=2025-03-01".to_owned();
+        let entity = build_route_entity("azure", &entry, Uuid::nil());
+        assert_eq!(entity["match"]["http"]["path"], "/openai/deployments");
+        assert_eq!(entity["match"]["http"]["path_suffix_mode"], "append");
+        assert_eq!(entity["match"]["http"]["query_allowlist"][0], "api-version");
+    }
+
+    #[test]
+    fn build_provider_entities_returns_two_per_provider() {
+        let mut providers = HashMap::new();
+        providers.insert("openai".to_owned(), test_entry());
+
+        let entities = build_provider_entities(&providers, Uuid::nil());
+        assert_eq!(entities.len(), 2);
+    }
+
+    #[test]
+    fn build_upstream_entity_no_auth_when_not_configured() {
+        let mut entry = test_entry();
+        entry.auth_plugin_type = None;
+        entry.auth_config = None;
+        let entity = build_upstream_entity("openai", &entry, Uuid::nil());
+        assert!(entity.get("auth").is_none());
+    }
+}

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -49,14 +49,6 @@ pub struct MiniChatModule {
     service: OnceLock<Arc<AppServices>>,
     url_prefix: OnceLock<String>,
     outbox_handle: Mutex<Option<OutboxHandle>>,
-    /// OAGW gateway + provider config for deferred upstream registration in `start()`.
-    oagw_deferred: OnceLock<OagwDeferred>,
-}
-
-/// State needed to register OAGW upstreams in `start()` (after GTS is ready).
-struct OagwDeferred {
-    gateway: Arc<dyn ServiceGatewayClientV1>,
-    providers: std::collections::HashMap<String, crate::config::ProviderEntry>,
 }
 
 impl Default for MiniChatModule {
@@ -65,7 +57,6 @@ impl Default for MiniChatModule {
             service: OnceLock::new(),
             url_prefix: OnceLock::new(),
             outbox_handle: Mutex::new(None),
-            oagw_deferred: OnceLock::new(),
         }
     }
 }
@@ -122,6 +113,11 @@ impl Module for MiniChatModule {
             ],
         )
         .await?;
+
+        // Register provider upstream + route GTS entities in types-registry.
+        // OAGW will materialise these in post_init() via type provisioning.
+        crate::infra::oagw_provisioning::register_provider_entities(&*registry, &cfg.providers)
+            .await?;
 
         self.url_prefix
             .set(cfg.url_prefix)
@@ -188,9 +184,7 @@ impl Module for MiniChatModule {
             .map_err(|e| anyhow::anyhow!("failed to get OAGW gateway: {e}"))?;
 
         // Pre-fill upstream_alias with host as fallback so ProviderResolver
-        // works immediately. The actual OAGW registration is deferred to
-        // start() because GTS instances are not visible via list() until
-        // post_init (types-registry switches to ready mode there).
+        // works immediately. OAGW materialises the real upstreams in post_init().
         for entry in cfg.providers.values_mut() {
             if entry.upstream_alias.is_none() {
                 entry.upstream_alias = Some(entry.host.clone());
@@ -203,13 +197,6 @@ impl Module for MiniChatModule {
                 }
             }
         }
-
-        // Save a copy for deferred OAGW registration in start().
-        // Ignore the result: if already set, we keep the first value.
-        drop(self.oagw_deferred.set(OagwDeferred {
-            gateway: Arc::clone(&gateway),
-            providers: cfg.providers.clone(),
-        }));
 
         let provider_resolver = Arc::new(ProviderResolver::new(&gateway, cfg.providers));
 
@@ -291,18 +278,6 @@ impl RestApiCapability for MiniChatModule {
 #[async_trait]
 impl RunnableCapability for MiniChatModule {
     async fn start(&self, _cancel: CancellationToken) -> anyhow::Result<()> {
-        // Register OAGW upstreams now that GTS is in ready mode (post_init
-        // has completed). During init() this fails because types-registry
-        // list() only queries the persistent store which is empty until
-        // switch_to_ready().
-        if let Some(deferred) = self.oagw_deferred.get() {
-            let mut providers = deferred.providers.clone();
-            crate::infra::oagw_provisioning::register_oagw_upstreams(
-                &deferred.gateway,
-                &mut providers,
-            )
-            .await?;
-        }
         Ok(())
     }
 

--- a/modules/system/oagw/oagw/src/domain/gts_helpers.rs
+++ b/modules/system/oagw/oagw/src/domain/gts_helpers.rs
@@ -44,38 +44,33 @@ pub const REQUEST_ID_TRANSFORM_PLUGIN_ID: &str =
 /// Format an upstream resource as a GTS identifier.
 #[must_use]
 pub fn format_upstream_gts(id: Uuid) -> String {
-    format!("{UPSTREAM_SCHEMA}{}", id.simple())
+    format!("{UPSTREAM_SCHEMA}{}", id.hyphenated())
 }
 
 /// Format a route resource as a GTS identifier.
 #[must_use]
 pub fn format_route_gts(id: Uuid) -> String {
-    format!("{ROUTE_SCHEMA}{}", id.simple())
+    format!("{ROUTE_SCHEMA}{}", id.hyphenated())
 }
 
 /// Parse a resource GTS identifier, extracting the schema and UUID instance.
 ///
-/// Validates the schema portion using the `gts` crate and parses the instance
-/// portion as a UUID. OAGW resource identifiers use bare UUIDs as instances
-/// (e.g. `gts.x.core.oagw.upstream.v1~<hex-uuid>`), which the `gts` crate does
-/// not accept as a full identifier, so we validate schema and instance separately.
+/// Validates the full identifier using the `gts` crate (0.8.4+ supports
+/// anonymous UUID instance segments) and then splits at `~` to extract the
+/// schema prefix and UUID.
 pub fn parse_resource_gts(s: &str) -> Result<(String, Uuid), DomainError> {
-    // Split at '~' to separate schema from instance.
+    // Validate the full GTS identifier (anonymous UUID segments supported since 0.8.4).
+    gts::GtsID::new(s).map_err(|e| DomainError::Validation {
+        detail: format!("invalid GTS identifier: {e}"),
+        instance: s.to_string(),
+    })?;
+
     let tilde_pos = s.rfind('~').ok_or_else(|| DomainError::Validation {
         detail: "missing '~' separator in GTS identifier".into(),
         instance: s.to_string(),
     })?;
 
-    let schema_with_tilde = &s[..=tilde_pos]; // e.g. "gts.x.core.oagw.upstream.v1~"
     let instance = &s[tilde_pos + 1..];
-
-    // Validate schema portion as a GTS type (ends with ~).
-    gts::GtsID::new(schema_with_tilde).map_err(|e| DomainError::Validation {
-        detail: format!("invalid GTS schema: {e}"),
-        instance: s.to_string(),
-    })?;
-
-    // Parse the instance portion as a UUID.
     let uuid = Uuid::parse_str(instance).map_err(|e| DomainError::Validation {
         detail: format!("invalid UUID in GTS instance: {e}"),
         instance: s.to_string(),

--- a/modules/system/oagw/oagw/src/domain/type_provisioning.rs
+++ b/modules/system/oagw/oagw/src/domain/type_provisioning.rs
@@ -11,11 +11,17 @@ use super::model::{CreateRouteRequest, CreateUpstreamRequest};
 use uuid::Uuid;
 
 /// An upstream definition read from the types-registry.
+///
+/// `gts_instance_id` is the UUID parsed from the GTS entity identifier
+/// (e.g. the `<uuid>` part of `gts.x.core.oagw.upstream.v1~<uuid>`).
+/// Used by `post_init()` to map GTS-level references in route entities
+/// to OAGW-assigned upstream UUIDs.
 #[domain_model]
 #[derive(Debug, Clone)]
 pub struct ProvisionedUpstream {
     pub tenant_id: Uuid,
     pub request: CreateUpstreamRequest,
+    pub gts_instance_id: Option<Uuid>,
 }
 
 /// A route definition read from the types-registry.

--- a/modules/system/oagw/oagw/src/infra/type_provisioning.rs
+++ b/modules/system/oagw/oagw/src/infra/type_provisioning.rs
@@ -508,21 +508,22 @@ impl From<MatchRules> for domain::MatchRules {
     }
 }
 
-impl From<UpstreamPayload> for ProvisionedUpstream {
-    fn from(p: UpstreamPayload) -> Self {
-        Self {
-            tenant_id: p.tenant_id,
+impl UpstreamPayload {
+    fn into_provisioned(self, gts_instance_id: Option<Uuid>) -> ProvisionedUpstream {
+        ProvisionedUpstream {
+            tenant_id: self.tenant_id,
             request: domain::CreateUpstreamRequest {
-                server: p.server.into(),
-                protocol: p.protocol,
-                alias: p.alias,
-                auth: p.auth.map(Into::into),
-                headers: p.headers.map(Into::into),
-                plugins: p.plugins.map(Into::into),
-                rate_limit: p.rate_limit.map(Into::into),
-                tags: p.tags,
-                enabled: p.enabled,
+                server: self.server.into(),
+                protocol: self.protocol,
+                alias: self.alias,
+                auth: self.auth.map(Into::into),
+                headers: self.headers.map(Into::into),
+                plugins: self.plugins.map(Into::into),
+                rate_limit: self.rate_limit.map(Into::into),
+                tags: self.tags,
+                enabled: self.enabled,
             },
+            gts_instance_id,
         }
     }
 }
@@ -542,6 +543,14 @@ impl From<RoutePayload> for ProvisionedRoute {
             },
         }
     }
+}
+
+/// Extract the instance UUID from a GTS identifier string.
+///
+/// Given `gts.x.core.oagw.upstream.v1~<hex-uuid>`, returns `Some(<Uuid>)`.
+fn extract_gts_instance_uuid(gts_id: &str) -> Option<Uuid> {
+    let instance = gts_id.rsplit('~').next()?;
+    Uuid::parse_str(instance).ok()
 }
 
 /// `TypeProvisioningService` implementation that delegates to `TypesRegistryClient`.
@@ -572,7 +581,8 @@ impl TypeProvisioningService for TypeProvisioningServiceImpl {
         for entity in entities {
             match serde_json::from_value::<UpstreamPayload>(entity.content.clone()) {
                 Ok(payload) => {
-                    result.push(payload.into());
+                    let gts_instance_id = extract_gts_instance_uuid(&entity.gts_id);
+                    result.push(payload.into_provisioned(gts_instance_id));
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -859,7 +869,7 @@ mod tests {
         });
 
         let payload: UpstreamPayload = serde_json::from_value(json).unwrap();
-        let provisioned: ProvisionedUpstream = payload.into();
+        let provisioned = payload.into_provisioned(None);
 
         assert_eq!(provisioned.tenant_id, tenant);
         let req = &provisioned.request;

--- a/modules/system/oagw/oagw/src/module.rs
+++ b/modules/system/oagw/oagw/src/module.rs
@@ -194,10 +194,17 @@ impl SystemCapability for OutboundApiGatewayModule {
             .as_ref()
             .clone();
 
+        // -- Materialise upstreams, building a GTS-instance-UUID -> OAGW-UUID map --
+        // Routes registered via types-registry reference upstreams by the
+        // deterministic GTS instance UUID. OAGW assigns random UUIDs, so we
+        // need to rewrite route upstream_ids before creating them.
         let upstreams = provisioning.list_upstreams().await?;
+        let mut gts_to_oagw: std::collections::HashMap<uuid::Uuid, uuid::Uuid> =
+            std::collections::HashMap::new();
         for u in &upstreams {
             let ctx = SecurityContext::builder()
                 .subject_tenant_id(u.tenant_id)
+                .subject_id(modkit_security::constants::DEFAULT_SUBJECT_ID)
                 .build()?;
             let created = app_state
                 .cp
@@ -206,6 +213,9 @@ impl SystemCapability for OutboundApiGatewayModule {
                 .map_err(|e| {
                     anyhow::anyhow!("Failed to provision upstream (tenant={}): {e}", u.tenant_id)
                 })?;
+            if let Some(gts_id) = u.gts_instance_id {
+                gts_to_oagw.insert(gts_id, created.id);
+            }
             info!(
                 id = %created.id,
                 tenant_id = %u.tenant_id,
@@ -218,14 +228,16 @@ impl SystemCapability for OutboundApiGatewayModule {
         for r in &routes {
             let ctx = SecurityContext::builder()
                 .subject_tenant_id(r.tenant_id)
+                .subject_id(modkit_security::constants::DEFAULT_SUBJECT_ID)
                 .build()?;
-            let created = app_state
-                .cp
-                .create_route(&ctx, r.request.clone())
-                .await
-                .map_err(|e| {
-                    anyhow::anyhow!("Failed to provision route (tenant={}): {e}", r.tenant_id)
-                })?;
+            // Rewrite upstream_id if it references a GTS instance UUID.
+            let mut req = r.request.clone();
+            if let Some(&oagw_id) = gts_to_oagw.get(&req.upstream_id) {
+                req.upstream_id = oagw_id;
+            }
+            let created = app_state.cp.create_route(&ctx, req).await.map_err(|e| {
+                anyhow::anyhow!("Failed to provision route (tenant={}): {e}", r.tenant_id)
+            })?;
             info!(
                 id = %created.id,
                 tenant_id = %r.tenant_id,


### PR DESCRIPTION
feat(oagw,mini-chat): upgrade GTS to 0.8.4, register all providers via types-registry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GTS-related dependencies to version 0.8.4.

* **Improvements**
  * Refactored provider provisioning to use registry-based registration for better initialization handling.
  * Updated UUID identifier format for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->