### PR TITLE
chore(versions):

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "cf-mini-chat"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "cf-oagw"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-mini-chat"
 description = "Mini-chat module: multi-tenant AI chat"
-version = "0.1.7"
+version = "0.1.8"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cf-oagw"
 description = "OAGW module - discovers and routes to plugins"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
 - bump oagw - v0.2.9
  - bump minichat - v0.1.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updates: mini-chat (0.1.7 → 0.1.8) and oagw (0.2.8 → 0.2.9) for maintenance and stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->