### PR TITLE
feat(authn-resolver): add S2S authentication via OAuth2 client credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,6 +1105,7 @@ dependencies = [
  "gts",
  "gts-macros",
  "schemars 1.2.1",
+ "secrecy",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/docs/arch/authorization/AUTHN_JWT_OIDC_PLUGIN.md
+++ b/docs/arch/authorization/AUTHN_JWT_OIDC_PLUGIN.md
@@ -704,9 +704,89 @@ For systems with strict security requirements (PCI-DSS, HIPAA, SOC2), set `ttl: 
 
 ---
 
+## S2S Authentication (Client Credentials)
+
+The JWT/OIDC plugin implements `exchange_client_credentials()` for service-to-service authentication using the [OAuth 2.0 Client Credentials Grant (RFC 6749 §4.4)](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4).
+
+See [DESIGN.md — S2S Authentication](./DESIGN.md#s2s-authentication-service-to-service) for the overall S2S design and contract.
+
+### Flow
+
+```mermaid
+sequenceDiagram
+    participant Module as Calling Module
+    participant Plugin as JWT/OIDC Plugin
+    participant IdP as Vendor's IdP
+
+    Module->>Plugin: exchange_client_credentials(client_id, client_secret, scopes)
+    Plugin->>IdP: POST {token_endpoint}<br/>grant_type=client_credentials<br/>&client_id=...&client_secret=...&scope=...
+    IdP-->>Plugin: { access_token, token_type, expires_in, scope }
+    Plugin->>Plugin: Map token claims → SecurityContext
+    Plugin-->>Module: AuthenticationResult
+```
+
+### Token Endpoint Configuration
+
+The plugin uses the token endpoint from OIDC Discovery or explicit configuration:
+
+```yaml
+auth:
+  s2s:
+    # Token endpoint for client_credentials grant (required for S2S).
+    # Can be configured explicitly or resolved via OIDC Discovery from s2s.issuer.
+    token_endpoint: "https://idp.corp.example.com/oauth2/token"
+
+    # Alternatively, reference a trusted issuer for OIDC Discovery.
+    # The plugin discovers token_endpoint from {discovery_url}/.well-known/openid-configuration.
+    # Exactly one of token_endpoint or issuer must be configured.
+    # issuer: "my-corp-idp"  # must match a key in jwt.trusted_issuers
+
+    # Claim mapping for the issued token (if different from jwt.claim_mapping).
+    # Falls back to jwt.claim_mapping if not specified.
+    claim_mapping:
+      subject_id: "sub"
+      subject_type: "sub_type"
+      subject_tenant_id: "tenant_id"
+      token_scopes: "scope"
+```
+
+**Endpoint resolution:**
+- If `s2s.token_endpoint` is configured → use it directly
+- If `s2s.issuer` is configured → look up the issuer in `jwt.trusted_issuers`, discover `token_endpoint` from its OIDC configuration
+- If neither is configured → `exchange_client_credentials()` returns `TokenAcquisitionFailed`
+
+### SecurityContext Construction
+
+After obtaining the access token from the IdP:
+
+1. **If token is JWT** — extract claims directly (same as bearer token authentication)
+2. **If token is opaque** — introspect using the same introspection configuration
+3. **Map claims** to `SecurityContext` using `s2s.claim_mapping` (or `jwt.claim_mapping` fallback)
+4. **Set `bearer_token`** — the obtained access token, for PDP forwarding
+5. **Set `subject_type`** — from token claims via claim mapping (e.g., IdP may set `sub_type: "service"` for client_credentials grants)
+
+### Token Caching
+
+The plugin internally reuses `modkit-auth::oauth2::Token` handles with automatic refresh:
+
+- Repeated `exchange_client_credentials()` calls with the same `client_id` reuse the cached token
+- Token is automatically refreshed when it expires (using `expires_in` from the IdP response)
+- No cache configuration needed at the plugin level — caching is transparent to callers
+
+### Error Handling
+
+| Error | When |
+|-------|------|
+| `TokenAcquisitionFailed` | IdP returns error (invalid credentials, unauthorized client, network failure) |
+| `TokenAcquisitionFailed` | Token endpoint not configured and cannot be discovered |
+| `Internal` | Unexpected errors (response parsing failure, claim mapping errors) |
+
+---
+
 ## References
 
 - [DESIGN.md](./DESIGN.md) — Main authentication and authorization design
+- [RFC 6749: OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749) (§4.4 Client Credentials Grant)
 - [RFC 7519: JSON Web Token (JWT)](https://datatracker.ietf.org/doc/html/rfc7519)
 - [RFC 7662: OAuth 2.0 Token Introspection](https://datatracker.ietf.org/doc/html/rfc7662)
 - [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)

--- a/docs/arch/authorization/DESIGN.md
+++ b/docs/arch/authorization/DESIGN.md
@@ -15,6 +15,7 @@
   - [Capabilities -> Predicate Matrix](#capabilities---predicate-matrix)
   - [Table Schemas (Local Projections)](#table-schemas-local-projections)
   - [Usage Scenarios](#usage-scenarios)
+- [S2S Authentication (Service-to-Service)](#s2s-authentication-service-to-service)
 - [Open Questions](#open-questions)
 - [References](#references)
 
@@ -388,17 +389,12 @@ Authentication is handled by the **AuthN Resolver** — a module with plugins an
 #[async_trait]
 pub trait AuthNResolverClient: Send + Sync {
     /// Authenticate a bearer token and return the authentication result.
-    ///
-    /// # Errors
-    ///
-    /// - `Unauthorized` if the token is malformed/invalid/expired or authentication fails
-    /// - `ServiceUnavailable` if the IdP is unreachable
-    /// - `NoPluginAvailable` if no plugin is configured
-    ///
-    /// # Arguments
-    ///
-    /// * `bearer_token` - The bearer token from the Authorization header
     async fn authenticate(&self, bearer_token: &str) -> Result<AuthenticationResult, AuthNResolverError>;
+
+    /// Exchange OAuth2 client credentials for a SecurityContext (S2S authentication).
+    /// See [S2S Authentication](#s2s-authentication-service-to-service) for details.
+    async fn exchange_client_credentials(&self, request: &ClientCredentialsRequest)
+        -> Result<AuthenticationResult, AuthNResolverError>;
 }
 ```
 
@@ -408,14 +404,12 @@ pub trait AuthNResolverClient: Send + Sync {
 #[async_trait]
 pub trait AuthNResolverPluginClient: Send + Sync {
     /// Authenticate a bearer token using vendor-specific validation logic.
-    ///
-    /// Plugins implement this method with their validation strategy
-    /// (JWT local validation, token introspection, custom protocols, etc.).
-    ///
-    /// # Arguments
-    ///
-    /// * `bearer_token` - The bearer token to validate
     async fn authenticate(&self, bearer_token: &str) -> Result<AuthenticationResult, AuthNResolverError>;
+
+    /// Exchange client credentials for a SecurityContext (S2S authentication).
+    /// See [S2S Authentication](#s2s-authentication-service-to-service) for details.
+    async fn exchange_client_credentials(&self, request: &ClientCredentialsRequest)
+        -> Result<AuthenticationResult, AuthNResolverError>;
 }
 ```
 
@@ -504,6 +498,7 @@ The AuthN Resolver plugin bridges Cyber Fabric to the vendor's IdP. Plugin respo
 3. **Claim Enrichment** — If IdP doesn't include required claims (`subject_type`, `subject_tenant_id`), fetch from vendor services
 4. **Token Scope Detection** — Determine first-party vs third-party apps and set `token_scopes` accordingly (see [Token Scopes](#token-scopes))
 5. **Response Mapping** — Convert vendor-specific responses to `AuthenticationResult` (containing `SecurityContext`)
+6. **S2S Credential Exchange** — Implement `exchange_client_credentials()` for service-to-service authentication (see [S2S Authentication](#s2s-authentication-service-to-service))
 
 ### Rationale: Minimalist Interface
 
@@ -1367,6 +1362,54 @@ For concrete examples demonstrating the authorization model in practice, see [AU
 
 ---
 
+## S2S Authentication (Service-to-Service)
+
+### Overview
+
+Platform modules communicate with each other outside the context of an HTTP request — inter-module calls, background processing, scheduled tasks. These interactions require a `SecurityContext` to pass through AuthZ. AuthN Resolver provides S2S authentication via the [OAuth 2.0 Client Credentials Grant (RFC 6749 §4.4)](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) pattern.
+
+A module presents its OAuth2 credentials (`client_id`, `client_secret`, optional `scopes`) to AuthN Resolver. The AuthN plugin exchanges them with the vendor's IdP and returns a validated `SecurityContext` — the same `AuthenticationResult` that `authenticate()` returns for bearer tokens.
+
+### How It Works
+
+```mermaid
+sequenceDiagram
+    participant Module as Calling Module
+    participant AuthN as AuthN Resolver
+    participant Plugin as AuthN Plugin
+    participant IdP as Vendor's IdP
+
+    Module->>AuthN: exchange_client_credentials(client_id, client_secret, scopes)
+    AuthN->>Plugin: exchange_client_credentials(request)
+    Plugin->>IdP: POST /token (client_credentials grant)
+    IdP-->>Plugin: access_token + claims
+    Plugin->>Plugin: Map IdP response → SecurityContext
+    Plugin-->>AuthN: AuthenticationResult
+    AuthN-->>Module: SecurityContext
+    Module->>Module: Use SecurityContext for inter-module calls
+```
+
+The calling module knows only its credentials. The plugin owns the token endpoint URL, OAuth2 flow, and identity mapping — analogous to how `authenticate()` accepts only the bearer token while JWKS URL is configured in the plugin or obtained from the IdP's `.well-known` endpoint for the issuer (it's up to the plugin to determine the correct endpoint).
+
+The returned `SecurityContext` contains the same fields as for bearer token authentication.
+
+### Relationship to AuthZ
+
+S2S `SecurityContext` flows through the standard AuthZ pipeline unchanged. The target module's PEP evaluates authorization with the S2S subject, PDP applies policies (potentially using `subject_type` for service-specific rules), and constraints are compiled to `AccessScope` as usual. No changes to AuthZ Resolver or PEP are required.
+
+### Key Principles
+
+- **AuthN Resolver is the single owner of `SecurityContext`.** Modules do not construct `SecurityContext` directly. All identity mapping and OAuth2 logic is encapsulated in the plugin.
+- **The platform does not issue tokens.** The plugin delegates to an external IdP and maps the response.
+- **Credentials and endpoints are separated.** Module configuration contains credentials; plugin configuration contains token endpoint / issuer URL.
+
+### Future Extensions
+
+- **Token lifetime propagation** — Plugin communicates token expiry to enable caller-side caching with proper TTL
+- **Cached SecurityContext provider** — A wrapper that caches the `SecurityContext` and automatically refreshes it on expiry, so modules don't need to manage token lifecycle themselves
+
+---
+
 ## Open Questions
 
 These questions require further design work.
@@ -1390,10 +1433,7 @@ These questions require further design work.
    - **Migration protocol** — When closure table schema changes, how do PEPs discover and adapt? Is there a capabilities negotiation mechanism?
    - **Backward compatibility** — Can old PEPs work with new schema, or is coordinated upgrade required? What's the compatibility matrix?
 
-9. **S2S token issuance** — Should AuthN Resolver support token issuance for service-to-service communication, or is it sufficient to rely on standard [OAuth 2.0 Client Credentials Grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4)? Open questions:
-   - **Scope** — Is token issuance AuthN Resolver's responsibility, or should services obtain tokens directly from the IdP?
-   - **Use cases** — What S2S scenarios require Cyber Fabric involvement vs. direct IdP integration?
-   - **Token types** — Should S2S tokens differ from user tokens (e.g., different scopes, shorter TTL)?
+9. ~~**S2S token issuance**~~ — **Resolved.** See [S2S Authentication (Service-to-Service)](#s2s-authentication-service-to-service).
 
 10. **Multi-Factor Authentication (MFA) support** — How should Cyber Fabric handle MFA across both AuthN and AuthZ layers? Industry standards and best practices to study:
     - **AuthN side:**
@@ -1410,12 +1450,20 @@ These questions require further design work.
       - How do industry multi-tenant platforms (Azure AD Conditional Access, AWS IAM, Google Cloud IAP) handle MFA in the context of delegated authorization?
       - What is the interaction between MFA and token scopes? Should third-party apps be able to request MFA-elevated scopes?
 
+11. **S2S SecurityContext caching** — Modules may call `exchange_client_credentials()` frequently (on every background task iteration, on every inter-module call). Open questions:
+    - **TTL strategy** — What default TTL for cached `SecurityContext`? Static plugin has no token expiry (effectively infinite), production plugins depend on OAuth2 token TTL. Proposal: default 5 min, configurable.
+    - **`AuthenticationResult.expires_at`** — Should `AuthenticationResult` include an `expires_at: Option<DateTime>` field so the plugin can communicate token lifetime to the caller? This enables smart caller-side caching without hardcoded TTLs.
+    - **`S2sSecurityContextProvider`** — Should there be a standard cached wrapper in the SDK (`authn-resolver-sdk`) that modules use instead of calling `exchange_client_credentials()` directly? Design: ArcSwap-based cache with TTL from `expires_at`, automatic refresh on expiry.
+    - **Plugin-level caching** — Production plugins can reuse `modkit-auth::oauth2::Token` handles with auto-refresh internally. Should this be a requirement or recommendation for plugin implementors?
+    - **Cache invalidation** — When credentials are rotated, how does the cached `SecurityContext` get invalidated? Is TTL-based expiry sufficient, or do we need explicit invalidation?
+
 ---
 
 ## References
 
 ### Authentication
 - [AUTHN_JWT_OIDC_PLUGIN.md](./AUTHN_JWT_OIDC_PLUGIN.md) — JWT + OIDC plugin reference implementation
+- [RFC 6749: OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749) (§4.4 Client Credentials Grant — S2S authentication)
 - [RFC 7519: JSON Web Token (JWT)](https://datatracker.ietf.org/doc/html/rfc7519)
 - [RFC 7662: OAuth 2.0 Token Introspection](https://datatracker.ietf.org/doc/html/rfc7662)
 - [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)

--- a/modules/system/api-gateway/src/middleware/auth.rs
+++ b/modules/system/api-gateway/src/middleware/auth.rs
@@ -255,7 +255,7 @@ fn authn_error_to_response(err: &AuthNResolverError) -> axum::response::Response
             "Service Unavailable",
             "Authentication service unavailable",
         ),
-        AuthNResolverError::Internal(_) => (
+        AuthNResolverError::TokenAcquisitionFailed(_) | AuthNResolverError::Internal(_) => (
             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
             "Internal Server Error",
             "Internal authentication error",
@@ -274,6 +274,9 @@ fn log_authn_error(err: &AuthNResolverError) {
         AuthNResolverError::NoPluginAvailable => tracing::error!("No AuthN plugin available"),
         AuthNResolverError::ServiceUnavailable(msg) => {
             tracing::error!("AuthN service unavailable: {msg}");
+        }
+        AuthNResolverError::TokenAcquisitionFailed(msg) => {
+            tracing::error!("AuthN token acquisition failed: {msg}");
         }
         AuthNResolverError::Internal(msg) => tracing::error!("AuthN internal error: {msg}"),
     }

--- a/modules/system/api-gateway/tests/auth_middleware.rs
+++ b/modules/system/api-gateway/tests/auth_middleware.rs
@@ -10,7 +10,9 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use authn_resolver_sdk::{AuthNResolverClient, AuthNResolverError, AuthenticationResult};
+use authn_resolver_sdk::{
+    AuthNResolverClient, AuthNResolverError, AuthenticationResult, ClientCredentialsRequest,
+};
 use axum::{
     Extension, Json, Router,
     body::Body,
@@ -653,6 +655,15 @@ impl AuthNResolverClient for MockAuthNResolverClient {
         bearer_token: &str,
     ) -> Result<AuthenticationResult, AuthNResolverError> {
         (self.handler)(bearer_token)
+    }
+
+    async fn exchange_client_credentials(
+        &self,
+        _request: &ClientCredentialsRequest,
+    ) -> Result<AuthenticationResult, AuthNResolverError> {
+        Err(AuthNResolverError::Internal(
+            "not implemented in mock".to_owned(),
+        ))
     }
 }
 

--- a/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
+++ b/modules/system/authn-resolver/authn-resolver-sdk/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+secrecy = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 serde = { workspace = true }

--- a/modules/system/authn-resolver/authn-resolver-sdk/README.md
+++ b/modules/system/authn-resolver/authn-resolver-sdk/README.md
@@ -66,7 +66,10 @@ Implement `AuthNResolverPluginClient` and register with a GTS instance ID:
 
 ```rust
 use async_trait::async_trait;
-use authn_resolver_sdk::{AuthNResolverPluginClient, AuthenticationResult, AuthNResolverError};
+use authn_resolver_sdk::{
+    AuthNResolverPluginClient, AuthenticationResult, AuthNResolverError,
+    ClientCredentialsRequest,
+};
 
 struct MyOidcPlugin { /* ... */ }
 
@@ -75,6 +78,11 @@ impl AuthNResolverPluginClient for MyOidcPlugin {
     async fn authenticate(&self, bearer_token: &str)
         -> Result<AuthenticationResult, AuthNResolverError> {
         // Validate token, extract claims, build SecurityContext
+    }
+
+    async fn exchange_client_credentials(&self, request: &ClientCredentialsRequest)
+        -> Result<AuthenticationResult, AuthNResolverError> {
+        // OAuth2 client_credentials flow → SecurityContext
     }
 }
 ```

--- a/modules/system/authn-resolver/authn-resolver-sdk/src/api.rs
+++ b/modules/system/authn-resolver/authn-resolver-sdk/src/api.rs
@@ -7,7 +7,7 @@
 use async_trait::async_trait;
 
 use crate::error::AuthNResolverError;
-use crate::models::AuthenticationResult;
+use crate::models::{AuthenticationResult, ClientCredentialsRequest};
 
 /// Public API trait for the `AuthN` resolver.
 ///
@@ -43,5 +43,31 @@ pub trait AuthNResolverClient: Send + Sync {
     async fn authenticate(
         &self,
         bearer_token: &str,
+    ) -> Result<AuthenticationResult, AuthNResolverError>;
+
+    /// Exchange `OAuth2` client credentials for a validated `SecurityContext`.
+    ///
+    /// Used for service-to-service (S2S) communication when there is no
+    /// incoming HTTP request with a bearer token.
+    ///
+    /// The caller provides its credentials; the `AuthN` plugin knows the
+    /// token endpoint / issuer URL from its own configuration.
+    ///
+    /// # Scopes
+    ///
+    /// The `scopes` field is passed to the `IdP` as-is in the `OAuth2`
+    /// `client_credentials` grant `scope` parameter. The `IdP` determines
+    /// the final granted scopes. Plugins that do not interact with an
+    /// `IdP` (e.g., static dev plugins) may ignore this field.
+    ///
+    /// # Errors
+    ///
+    /// - `TokenAcquisitionFailed` if credentials are invalid or the `IdP` is unreachable
+    /// - `NoPluginAvailable` if no `AuthN` plugin is registered
+    /// - `ServiceUnavailable` if the plugin is not ready
+    /// - `Internal` for unexpected errors
+    async fn exchange_client_credentials(
+        &self,
+        request: &ClientCredentialsRequest,
     ) -> Result<AuthenticationResult, AuthNResolverError>;
 }

--- a/modules/system/authn-resolver/authn-resolver-sdk/src/error.rs
+++ b/modules/system/authn-resolver/authn-resolver-sdk/src/error.rs
@@ -17,6 +17,11 @@ pub enum AuthNResolverError {
     #[error("service unavailable: {0}")]
     ServiceUnavailable(String),
 
+    /// Client credentials exchange failed (e.g., invalid credentials,
+    /// `IdP` unreachable, token endpoint error).
+    #[error("token acquisition failed: {0}")]
+    TokenAcquisitionFailed(String),
+
     /// An internal error occurred.
     #[error("internal error: {0}")]
     Internal(String),

--- a/modules/system/authn-resolver/authn-resolver-sdk/src/lib.rs
+++ b/modules/system/authn-resolver/authn-resolver-sdk/src/lib.rs
@@ -33,5 +33,5 @@ pub mod plugin_api;
 pub use api::AuthNResolverClient;
 pub use error::AuthNResolverError;
 pub use gts::AuthNResolverPluginSpecV1;
-pub use models::AuthenticationResult;
+pub use models::{AuthenticationResult, ClientCredentialsRequest};
 pub use plugin_api::AuthNResolverPluginClient;

--- a/modules/system/authn-resolver/authn-resolver-sdk/src/models.rs
+++ b/modules/system/authn-resolver/authn-resolver-sdk/src/models.rs
@@ -1,5 +1,7 @@
 //! Domain models for the `AuthN` resolver module.
 
+use secrecy::SecretString;
+
 use modkit_security::SecurityContext;
 
 /// Result of a successful authentication.
@@ -17,4 +19,21 @@ pub struct AuthenticationResult {
     /// - `bearer_token` — Original token for PDP forwarding
     /// - `tenant_id` — Context tenant (may be set by `AuthN` or later by middleware)
     pub security_context: SecurityContext,
+}
+
+/// Request to exchange `OAuth2` client credentials for a `SecurityContext`.
+///
+/// The caller provides its credentials; the `AuthN` plugin knows the token
+/// endpoint / issuer URL from its own configuration.
+pub struct ClientCredentialsRequest {
+    /// `OAuth2` client identifier.
+    pub client_id: String,
+
+    /// `OAuth2` client secret.
+    pub client_secret: SecretString,
+
+    /// Optional scopes to request from the `IdP`.
+    /// Passed as `scope` parameter in the `OAuth2` `client_credentials` grant.
+    /// When empty, the `IdP` returns its default scopes.
+    pub scopes: Vec<String>,
 }

--- a/modules/system/authn-resolver/authn-resolver-sdk/src/plugin_api.rs
+++ b/modules/system/authn-resolver/authn-resolver-sdk/src/plugin_api.rs
@@ -7,7 +7,7 @@
 use async_trait::async_trait;
 
 use crate::error::AuthNResolverError;
-use crate::models::AuthenticationResult;
+use crate::models::{AuthenticationResult, ClientCredentialsRequest};
 
 /// Plugin API trait for `AuthN` resolver implementations.
 ///
@@ -31,5 +31,26 @@ pub trait AuthNResolverPluginClient: Send + Sync {
     async fn authenticate(
         &self,
         bearer_token: &str,
+    ) -> Result<AuthenticationResult, AuthNResolverError>;
+
+    /// Exchange client credentials for an `AuthenticationResult`.
+    ///
+    /// The plugin performs the actual `OAuth2` `client_credentials` flow
+    /// (or static credential lookup) and returns an `AuthenticationResult`
+    /// containing the validated `SecurityContext`.
+    ///
+    /// # Scopes
+    ///
+    /// Production plugins forward `scopes` to the `IdP` as-is in the
+    /// `OAuth2` `scope` parameter. Plugins that do not interact with an
+    /// `IdP` (e.g., static dev plugins) may ignore this field.
+    ///
+    /// # Errors
+    ///
+    /// - `TokenAcquisitionFailed` if credentials are invalid or `IdP` is unreachable
+    /// - `Internal` for unexpected errors
+    async fn exchange_client_credentials(
+        &self,
+        request: &ClientCredentialsRequest,
     ) -> Result<AuthenticationResult, AuthNResolverError>;
 }

--- a/modules/system/authn-resolver/authn-resolver/src/domain/error.rs
+++ b/modules/system/authn-resolver/authn-resolver/src/domain/error.rs
@@ -22,6 +22,9 @@ pub enum DomainError {
     #[error("unauthorized: {0}")]
     Unauthorized(String),
 
+    #[error("token acquisition failed: {0}")]
+    TokenAcquisitionFailed(String),
+
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -68,6 +71,7 @@ impl From<AuthNResolverError> for DomainError {
                 gts_id: "unknown".to_owned(),
                 reason: msg,
             },
+            AuthNResolverError::TokenAcquisitionFailed(msg) => Self::TokenAcquisitionFailed(msg),
             AuthNResolverError::Internal(msg) => Self::Internal(msg),
         }
     }
@@ -84,6 +88,7 @@ impl From<DomainError> for AuthNResolverError {
                 Self::ServiceUnavailable(format!("plugin not available for '{gts_id}': {reason}"))
             }
             DomainError::Unauthorized(msg) => Self::Unauthorized(msg),
+            DomainError::TokenAcquisitionFailed(msg) => Self::TokenAcquisitionFailed(msg),
             DomainError::TypesRegistryUnavailable(reason) | DomainError::Internal(reason) => {
                 Self::Internal(reason)
             }

--- a/modules/system/authn-resolver/authn-resolver/src/domain/local_client.rs
+++ b/modules/system/authn-resolver/authn-resolver/src/domain/local_client.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use authn_resolver_sdk::{AuthNResolverClient, AuthNResolverError, AuthenticationResult};
+use authn_resolver_sdk::{
+    AuthNResolverClient, AuthNResolverError, AuthenticationResult, ClientCredentialsRequest,
+};
 use modkit_macros::domain_model;
 
 use super::{DomainError, Service};
@@ -38,5 +40,15 @@ impl AuthNResolverClient for AuthNResolverLocalClient {
             .authenticate(bearer_token)
             .await
             .map_err(|e| log_and_convert("authenticate", e))
+    }
+
+    async fn exchange_client_credentials(
+        &self,
+        request: &ClientCredentialsRequest,
+    ) -> Result<AuthenticationResult, AuthNResolverError> {
+        self.svc
+            .exchange_client_credentials(request)
+            .await
+            .map_err(|e| log_and_convert("exchange_client_credentials", e))
     }
 }

--- a/modules/system/authn-resolver/authn-resolver/src/domain/service.rs
+++ b/modules/system/authn-resolver/authn-resolver/src/domain/service.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use authn_resolver_sdk::{
     AuthNResolverPluginClient, AuthNResolverPluginSpecV1, AuthenticationResult,
+    ClientCredentialsRequest,
 };
 use modkit::client_hub::{ClientHub, ClientScope};
 use modkit::plugins::{GtsPluginSelector, choose_plugin_instance};
@@ -112,6 +113,24 @@ impl Service {
         let plugin = self.get_plugin().await?;
         plugin
             .authenticate(bearer_token)
+            .await
+            .map_err(DomainError::from)
+    }
+
+    /// Exchange client credentials for a `SecurityContext` via the selected plugin.
+    ///
+    /// # Errors
+    ///
+    /// - `TokenAcquisitionFailed` if credentials are invalid
+    /// - Plugin resolution errors
+    #[tracing::instrument(skip_all, fields(client_id = %request.client_id))]
+    pub async fn exchange_client_credentials(
+        &self,
+        request: &ClientCredentialsRequest,
+    ) -> Result<AuthenticationResult, DomainError> {
+        let plugin = self.get_plugin().await?;
+        plugin
+            .exchange_client_credentials(request)
             .await
             .map_err(DomainError::from)
     }

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/Cargo.toml
@@ -42,6 +42,9 @@ serde_json = { workspace = true }
 # Logging
 tracing = { workspace = true }
 
+# Secrets
+secrecy = { workspace = true }
+
 # Required by modkit::module macro
 inventory = { workspace = true }
 

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/src/config.rs
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/src/config.rs
@@ -1,5 +1,6 @@
 //! Configuration for the static `AuthN` resolver plugin.
 
+use secrecy::SecretString;
 use serde::Deserialize;
 use uuid::Uuid;
 
@@ -23,6 +24,9 @@ pub struct StaticAuthNPluginConfig {
 
     /// Static token-to-identity mappings for `static_tokens` mode.
     pub tokens: Vec<TokenMapping>,
+
+    /// S2S credential-to-identity mappings for `exchange_client_credentials`.
+    pub s2s_credentials: Vec<S2sCredentialMapping>,
 }
 
 impl Default for StaticAuthNPluginConfig {
@@ -33,6 +37,7 @@ impl Default for StaticAuthNPluginConfig {
             mode: AuthNMode::AcceptAll,
             default_identity: IdentityConfig::default(),
             tokens: Vec::new(),
+            s2s_credentials: Vec::new(),
         }
     }
 }
@@ -60,6 +65,11 @@ pub struct IdentityConfig {
 
     /// Token scopes. `["*"]` means first-party / unrestricted.
     pub token_scopes: Vec<String>,
+
+    /// Subject type — opaque metadata passed through to PDP via `EvaluationRequest.Subject`.
+    /// Recommended format: GTS type identifier (e.g. `"gts.x.core.security.subject_user.v1~"`).
+    /// The platform does not interpret this value; PDP policies may use it for role/permission mapping.
+    pub subject_type: Option<String>,
 }
 
 impl Default for IdentityConfig {
@@ -68,6 +78,7 @@ impl Default for IdentityConfig {
             subject_id: DEFAULT_SUBJECT_ID,
             subject_tenant_id: DEFAULT_TENANT_ID,
             token_scopes: vec!["*".to_owned()],
+            subject_type: None,
         }
     }
 }
@@ -80,4 +91,26 @@ pub struct TokenMapping {
     pub token: String,
     /// The identity to return when this token is presented.
     pub identity: IdentityConfig,
+}
+
+/// Maps S2S client credentials to a specific identity.
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct S2sCredentialMapping {
+    /// `OAuth2` client identifier.
+    pub client_id: String,
+    /// Client secret (redacted in `Debug` output).
+    pub client_secret: SecretString,
+    /// The identity to return when these credentials are presented.
+    pub identity: IdentityConfig,
+}
+
+impl std::fmt::Debug for S2sCredentialMapping {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S2sCredentialMapping")
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"[REDACTED]")
+            .field("identity", &self.identity)
+            .finish()
+    }
 }

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/src/domain/client.rs
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/src/domain/client.rs
@@ -3,7 +3,9 @@
 //! Implements `AuthNResolverPluginClient` using the domain service.
 
 use async_trait::async_trait;
-use authn_resolver_sdk::{AuthNResolverError, AuthNResolverPluginClient, AuthenticationResult};
+use authn_resolver_sdk::{
+    AuthNResolverError, AuthNResolverPluginClient, AuthenticationResult, ClientCredentialsRequest,
+};
 
 use super::service::Service;
 
@@ -16,13 +18,24 @@ impl AuthNResolverPluginClient for Service {
         self.authenticate(bearer_token)
             .ok_or_else(|| AuthNResolverError::Unauthorized("invalid token".to_owned()))
     }
+
+    async fn exchange_client_credentials(
+        &self,
+        request: &ClientCredentialsRequest,
+    ) -> Result<AuthenticationResult, AuthNResolverError> {
+        self.exchange_client_credentials(request).ok_or_else(|| {
+            AuthNResolverError::TokenAcquisitionFailed("invalid client credentials".to_owned())
+        })
+    }
 }
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use secrecy::SecretString;
+
     use super::*;
-    use crate::config::StaticAuthNPluginConfig;
+    use crate::config::{IdentityConfig, S2sCredentialMapping, StaticAuthNPluginConfig};
 
     #[tokio::test]
     async fn plugin_trait_accept_all_succeeds() {
@@ -43,6 +56,46 @@ mod tests {
         match result.unwrap_err() {
             AuthNResolverError::Unauthorized(_) => {}
             other => panic!("Expected Unauthorized, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn plugin_trait_s2s_valid_credentials() {
+        let cfg = StaticAuthNPluginConfig {
+            s2s_credentials: vec![S2sCredentialMapping {
+                client_id: "svc".to_owned(),
+                client_secret: SecretString::from("secret"),
+                identity: IdentityConfig::default(),
+            }],
+            ..StaticAuthNPluginConfig::default()
+        };
+        let service = Service::from_config(&cfg);
+        let plugin: &dyn AuthNResolverPluginClient = &service;
+
+        let request = ClientCredentialsRequest {
+            client_id: "svc".to_owned(),
+            client_secret: SecretString::from("secret"),
+            scopes: vec![],
+        };
+        let result = plugin.exchange_client_credentials(&request).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn plugin_trait_s2s_invalid_credentials() {
+        let service = Service::from_config(&StaticAuthNPluginConfig::default());
+        let plugin: &dyn AuthNResolverPluginClient = &service;
+
+        let request = ClientCredentialsRequest {
+            client_id: "unknown".to_owned(),
+            client_secret: SecretString::from("bad"),
+            scopes: vec![],
+        };
+        let result = plugin.exchange_client_credentials(&request).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            AuthNResolverError::TokenAcquisitionFailed(_) => {}
+            other => panic!("Expected TokenAcquisitionFailed, got: {other:?}"),
         }
     }
 }

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/src/domain/service.rs
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/src/domain/service.rs
@@ -4,9 +4,10 @@ use std::collections::HashMap;
 
 use modkit_macros::domain_model;
 use modkit_security::SecurityContext;
+use secrecy::{ExposeSecret, SecretString};
 
 use crate::config::{AuthNMode, IdentityConfig, StaticAuthNPluginConfig};
-use authn_resolver_sdk::AuthenticationResult;
+use authn_resolver_sdk::{AuthenticationResult, ClientCredentialsRequest};
 
 /// Static `AuthN` resolver service.
 ///
@@ -18,6 +19,14 @@ pub struct Service {
     mode: AuthNMode,
     default_identity: IdentityConfig,
     token_map: HashMap<String, IdentityConfig>,
+    s2s_credentials: HashMap<String, S2sEntry>,
+}
+
+/// Internal entry for S2S credential lookup.
+#[domain_model]
+struct S2sEntry {
+    client_secret: SecretString,
+    identity: IdentityConfig,
 }
 
 impl Service {
@@ -30,10 +39,27 @@ impl Service {
             .map(|m| (m.token.clone(), m.identity.clone()))
             .collect();
 
+        let s2s_credentials: HashMap<String, S2sEntry> = cfg
+            .s2s_credentials
+            .iter()
+            .map(|m| {
+                (
+                    m.client_id.clone(),
+                    S2sEntry {
+                        client_secret: SecretString::from(
+                            m.client_secret.expose_secret().to_owned(),
+                        ),
+                        identity: m.identity.clone(),
+                    },
+                )
+            })
+            .collect();
+
         Self {
             mode: cfg.mode.clone(),
             default_identity: cfg.default_identity.clone(),
             token_map,
+            s2s_credentials,
         }
     }
 
@@ -52,16 +78,44 @@ impl Service {
             AuthNMode::StaticTokens => self.token_map.get(bearer_token)?,
         };
 
-        build_result(identity, bearer_token)
+        build_result(identity, Some(bearer_token))
+    }
+
+    /// Exchange client credentials for a `SecurityContext`.
+    ///
+    /// Looks up `client_id` in the configured S2S credentials and verifies
+    /// the `client_secret`. Returns `None` if credentials are not found or
+    /// do not match.
+    #[must_use]
+    pub fn exchange_client_credentials(
+        &self,
+        request: &ClientCredentialsRequest,
+    ) -> Option<AuthenticationResult> {
+        let entry = self.s2s_credentials.get(&request.client_id)?;
+        if entry.client_secret.expose_secret() != request.client_secret.expose_secret() {
+            return None;
+        }
+        build_result(&entry.identity, None)
     }
 }
 
-fn build_result(identity: &IdentityConfig, bearer_token: &str) -> Option<AuthenticationResult> {
-    let ctx = SecurityContext::builder()
+fn build_result(
+    identity: &IdentityConfig,
+    bearer_token: Option<&str>,
+) -> Option<AuthenticationResult> {
+    let mut builder = SecurityContext::builder()
         .subject_id(identity.subject_id)
         .subject_tenant_id(identity.subject_tenant_id)
-        .token_scopes(identity.token_scopes.clone())
-        .bearer_token(bearer_token.to_owned())
+        .token_scopes(identity.token_scopes.clone());
+
+    if let Some(st) = &identity.subject_type {
+        builder = builder.subject_type(st);
+    }
+    if let Some(token) = bearer_token {
+        builder = builder.bearer_token(token.to_owned());
+    }
+
+    let ctx = builder
         .build()
         .map_err(|e| tracing::error!("Failed to build SecurityContext from config: {e}"))
         .ok()?;
@@ -74,10 +128,10 @@ fn build_result(identity: &IdentityConfig, bearer_token: &str) -> Option<Authent
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
-    use secrecy::ExposeSecret;
+    use secrecy::{ExposeSecret, SecretString};
 
     use super::*;
-    use crate::config::TokenMapping;
+    use crate::config::{S2sCredentialMapping, TokenMapping};
     use uuid::Uuid;
 
     fn default_config() -> StaticAuthNPluginConfig {
@@ -129,6 +183,7 @@ mod tests {
                     subject_id: user_a_id,
                     subject_tenant_id: tenant_a,
                     token_scopes: vec!["read:data".to_owned()],
+                    subject_type: None,
                 },
             }],
             ..default_config()
@@ -178,6 +233,118 @@ mod tests {
         let service = Service::from_config(&cfg);
 
         let result = service.authenticate("");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn subject_type_propagated_in_security_context() {
+        let cfg = StaticAuthNPluginConfig {
+            default_identity: IdentityConfig {
+                subject_type: Some("user".to_owned()),
+                ..IdentityConfig::default()
+            },
+            ..default_config()
+        };
+
+        let service = Service::from_config(&cfg);
+        let result = service.authenticate("any-token").unwrap();
+        assert_eq!(result.security_context.subject_type(), Some("user"));
+    }
+
+    #[test]
+    fn subject_type_none_when_not_configured() {
+        let service = Service::from_config(&default_config());
+        let result = service.authenticate("any-token").unwrap();
+        assert_eq!(result.security_context.subject_type(), None);
+    }
+
+    fn s2s_config() -> StaticAuthNPluginConfig {
+        let svc_id = Uuid::parse_str("cccccccc-cccc-cccc-cccc-cccccccccccc").unwrap();
+        let svc_tenant = Uuid::parse_str("dddddddd-dddd-dddd-dddd-dddddddddddd").unwrap();
+
+        StaticAuthNPluginConfig {
+            s2s_credentials: vec![S2sCredentialMapping {
+                client_id: "my-service".to_owned(),
+                client_secret: SecretString::from("my-secret"),
+                identity: IdentityConfig {
+                    subject_id: svc_id,
+                    subject_tenant_id: svc_tenant,
+                    token_scopes: vec!["platform.internal".to_owned()],
+                    subject_type: Some("service".to_owned()),
+                },
+            }],
+            ..default_config()
+        }
+    }
+
+    #[test]
+    fn s2s_exchange_returns_identity_for_valid_credentials() {
+        let service = Service::from_config(&s2s_config());
+
+        let request = ClientCredentialsRequest {
+            client_id: "my-service".to_owned(),
+            client_secret: SecretString::from("my-secret"),
+            scopes: vec![],
+        };
+
+        let result = service.exchange_client_credentials(&request);
+        assert!(result.is_some());
+
+        let auth = result.unwrap();
+        let ctx = &auth.security_context;
+        assert_eq!(
+            ctx.subject_id(),
+            Uuid::parse_str("cccccccc-cccc-cccc-cccc-cccccccccccc").unwrap()
+        );
+        assert_eq!(
+            ctx.subject_tenant_id(),
+            Uuid::parse_str("dddddddd-dddd-dddd-dddd-dddddddddddd").unwrap()
+        );
+        assert_eq!(ctx.token_scopes(), &["platform.internal"]);
+        assert_eq!(ctx.subject_type(), Some("service"));
+        // S2S exchange does not set bearer_token (no real token issued)
+        assert!(ctx.bearer_token().is_none());
+    }
+
+    #[test]
+    fn s2s_exchange_rejects_wrong_secret() {
+        let service = Service::from_config(&s2s_config());
+
+        let request = ClientCredentialsRequest {
+            client_id: "my-service".to_owned(),
+            client_secret: SecretString::from("wrong-secret"),
+            scopes: vec![],
+        };
+
+        let result = service.exchange_client_credentials(&request);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn s2s_exchange_rejects_unknown_client_id() {
+        let service = Service::from_config(&s2s_config());
+
+        let request = ClientCredentialsRequest {
+            client_id: "unknown-service".to_owned(),
+            client_secret: SecretString::from("my-secret"),
+            scopes: vec![],
+        };
+
+        let result = service.exchange_client_credentials(&request);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn s2s_exchange_returns_none_with_no_credentials_configured() {
+        let service = Service::from_config(&default_config());
+
+        let request = ClientCredentialsRequest {
+            client_id: "any-service".to_owned(),
+            client_secret: SecretString::from("any-secret"),
+            scopes: vec![],
+        };
+
+        let result = service.exchange_client_credentials(&request);
         assert!(result.is_none());
     }
 }


### PR DESCRIPTION
- Add `exchange_client_credentials()` to `AuthNResolverClient` and plugin traits
- Introduce `ClientCredentialsRequest` model with `SecretString` for secure credential handling
- Add `TokenAcquisitionFailed` error variant across SDK, domain, and API gateway
- Implement S2S credential lookup in static-authn-plugin with config-based mappings
- Add `subject_type` field to `IdentityConfig` for service vs user distinction
- Update DESIGN.md and AUTHN_JWT_OIDC_PLUGIN.md with S2S authentication design

closes #454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service-to-Service (S2S) authentication via OAuth2 Client Credentials; resolvers and plugins can perform client-credentials token exchange
  * Static authentication plugin supports S2S credential mappings and subject type for identity construction

* **Error Handling**
  * Added TokenAcquisitionFailed error to surface token exchange failures

* **Configuration**
  * New S2S credential mappings and sensible defaults for plugin configuration

* **Documentation**
  * Expanded architecture/design docs describing S2S flows, examples, and references

* **Tests**
  * Added tests covering S2S success and failure scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->