### PR TITLE
docs(mini-chat): update RAG retrieval model, attachment deletion, and…

### DIFF
--- a/modules/mini-chat/docs/DESIGN.md
+++ b/modules/mini-chat/docs/DESIGN.md
@@ -23,7 +23,7 @@ Long conversations are managed via thread summaries - a Level 1 compression stra
 | `cpt-cf-mini-chat-fr-file-upload` | `p1` | Upload via OAGW -> Files API (OpenAI: `POST /v1/files`; Azure OpenAI: `POST /openai/files`); metadata persisted via infra/storage repositories; file added to the chat's vector store. P1 uses `purpose="assistants"` for both providers (OpenAI also supports `purpose="user_data"`, but we use `assistants` to keep parity and because the files are used with Vector Stores / File Search). |
 | `cpt-cf-mini-chat-fr-image-upload` | `p1` | Image upload via OAGW -> Files API; metadata persisted via infra/storage repositories; NOT added to vector store. Images referenced as multimodal input (file ID) in Responses API calls. Model capability checked before outbound call; defensive `unsupported_media` error if model lacks image support (unreachable under P1 catalog invariant where all models include `VISION_INPUT`). |
 | `cpt-cf-mini-chat-fr-file-search` | `p1` | File Search tool call scoped to the chat's dedicated vector store (identical `file_search` tool on both OpenAI and Azure OpenAI Responses API) |
-| `cpt-cf-mini-chat-fr-web-search` | `p1` | Web Search tool included in Responses API request when explicitly enabled via `web_search.enabled` parameter; provider decides invocation; per-message and per-day call limits enforced; global `disable_web_search` kill switch |
+| `cpt-cf-mini-chat-fr-web-search` | `p1` | Web Search tool included in Responses API request when explicitly enabled via `web_search.enabled` parameter; provider decides invocation; per-turn and per-day call limits enforced; global `disable_web_search` kill switch |
 | `cpt-cf-mini-chat-fr-doc-summary` | `p1` | See **File Upload** sequence ("Generate doc summary" background variant) and `attachments.doc_summary` schema field. `doc_summary` is server-generated asynchronously; never provided by the client. Status polled via `GET /v1/chats/{id}/attachments/{attachment_id}`. |
 | `cpt-cf-mini-chat-fr-thread-summary` | `p1` | Periodic LLM-driven summarization of old messages; summary replaces history in context |
 | `cpt-cf-mini-chat-fr-chat-crud` | `p1` | REST endpoints for create/list/get/update title/delete chats. Get returns metadata + message_count (no embedded messages). |
@@ -300,13 +300,13 @@ Hard caps: token budgets (`max_input_tokens`, `max_output_tokens`) MUST remain c
 | AuditEvent | Structured event emitted to platform `audit_service`: prompt, response, user/tenant, timestamps, policy decisions, usage. Not stored locally.                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | QuotaUsage | Per-user usage counters for rate limiting and budget enforcement. Tracks daily and monthly periods per tier in credits. Credits are computed from provider-reported token usage using the model credit multipliers in the policy snapshot. Premium models have stricter limits; standard-tier models have separate, higher limits.                                                                                                                                                                                                                                                  |
 | MessageReaction | A binary like or dislike reaction on an assistant message. One reaction per user per message. Stored for analytics and feedback collection.                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ContextPlan | Transient object assembled per request: system prompt, summary, doc summaries, recent messages, user message, retrieval excerpts. Retrieval scope is determined by the Retrieval Scope Precedence rule: `rag_attachment_ids` > document `attachment_ids` > chat-wide (see File Search Retrieval Scope).                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ContextPlan | Transient object assembled per request: system prompt, summary, doc summaries, recent messages, user message, retrieval excerpts. Retrieval always operates over the entire chat vector store (see File Search Retrieval Scope). |
 
 **Relationships**:
 - Chat -> Message: 1..\*
 - Chat -> Attachment: 0..\*
 - Chat -> ThreadSummary: 0..1
-- Message -> Attachment: 0..\* (M:N via `message_attachments` join table; user messages reference attachments from `attachment_ids` — not from `rag_attachment_ids`, which are retrieval-only and do not create `message_attachments` rows)
+- Message -> Attachment: 0..\* (M:N via `message_attachments` join table; user messages reference attachments from `attachment_ids`)
 - Attachment -> ChatVectorStore: belongs to (via chat_id; documents only — images are not indexed)
 - Message -> AuditEvent: 1..1 (each turn emits an audit event to platform `audit_service`)
 - Message -> MessageReaction: 0..1 (per user)
@@ -527,8 +527,9 @@ Covers public API from PRD: `cpt-cf-mini-chat-interface-public-api`
 | `POST` | `/v1/chats/{id}/messages:stream` | Send message, receive SSE stream | stable |
 | `POST` | `/v1/chats/{id}/attachments` | Upload file attachment | stable |
 | `GET` | `/v1/chats/{id}/attachments/{attachment_id}` | Get attachment status and metadata (polling) | stable |
+| `DELETE` | `/v1/chats/{id}/attachments/{attachment_id}` | Delete attachment from chat and retrieval corpus | stable |
 | `GET` | `/v1/chats/{id}/turns/{request_id}` | Get authoritative turn status (read-only) | stable |
-| `POST` | `/v1/chats/{id}/turns/{request_id}:retry` | Retry last turn (new generation) | stable |
+| `POST` | `/v1/chats/{id}/turns/{request_id}/retry` | Retry last turn (new generation) | stable |
 | `PATCH` | `/v1/chats/{id}/turns/{request_id}` | Edit last turn (replace content + regenerate) | stable |
 | `DELETE` | `/v1/chats/{id}/turns/{request_id}` | Delete last turn (soft-delete) | stable |
 | `GET` | `/v1/models` | List models visible to the current user | stable |
@@ -678,7 +679,6 @@ Request body:
   "content": "string",
   "request_id": "uuid (optional — client MAY provide for idempotency; server generates UUID v4 if omitted)",
   "attachment_ids": ["uuid (optional)"],
-  "rag_attachment_ids": ["uuid (optional)"],
   "web_search": { "enabled": false }
 }
 ```
@@ -725,25 +725,24 @@ impl MessageEntity {
 
 `web_search` is an optional object controlling web search for this turn. Defaults to `{ "enabled": false }` when omitted (backward compatible). When `web_search.enabled=true`, the backend includes the `web_search` tool in the provider Responses API request. The provider decides whether to invoke the tool. If the global `disable_web_search` kill switch is active, the request is rejected with HTTP 400 and error code `web_search_disabled` before opening an SSE stream.
 
-`attachment_ids` is an optional list of **attachment IDs** (documents or images) explicitly attached/referenced on the current user message. When the user message is persisted, the association between the message and each referenced attachment is recorded in the `message_attachments` join table (see section 3.7). This is the **single source of truth** for the `attachments` array returned in `GET /v1/chats/{id}/messages` (each entry is an `AttachmentSummary` with `attachment_id`, `kind`, `filename`, `status`, `img_thumbnail`). Images from `attachment_ids` are included in multimodal model input for the current turn only. Documents from `attachment_ids` serve as both message-level UI associations and explicit retrieval scope for the turn when `rag_attachment_ids` is empty (see Retrieval Scope Precedence below). Previously uploaded image attachments MAY be re-attached on later turns via `attachment_ids`; only explicit re-attachment includes them in multimodal input — images from previous turns are never implicitly reused.
+`attachment_ids` is an optional list of **attachment IDs** (documents or images) explicitly attached/referenced on the current user message. When the user message is persisted, the association between the message and each referenced attachment is recorded in the `message_attachments` join table (see section 3.7). This is the **single source of truth** for the `attachments` array returned in `GET /v1/chats/{id}/messages` (each entry is an `AttachmentSummary` with `attachment_id`, `kind`, `filename`, `status`, `img_thumbnail`). Images from `attachment_ids` are included in multimodal model input for the current turn only. Previously uploaded image attachments MAY be re-attached on later turns via `attachment_ids`; only explicit re-attachment includes them in multimodal input — images from previous turns are never implicitly reused. `attachment_ids` records the association between messages and attachments for UI/audit/history purposes. In P1, `attachment_ids` does **not** scope or filter retrieval — retrieval always operates over the entire chat vector store when document attachments exist in the chat (see Retrieval Model below).
 
-`rag_attachment_ids` is an optional list of **document attachment IDs** that constrain file-search scope for the current turn only. These are request-local retrieval controls and MUST NOT create `message_attachments` rows. They MUST NOT appear in the message `attachments` array in API responses. They MUST NOT imply that the attachment was uploaded on the current turn. Every entry MUST reference an attachment with `attachment_kind=document`; image attachments MUST be rejected. Omitted `rag_attachment_ids` and empty `rag_attachment_ids: []` are semantically equivalent.
+**Retrieval Model (normative)**:
 
-**Retrieval Scope Precedence (normative, deterministic)**:
+Retrieval behavior depends on the attachment state of the chat and the current message:
 
-1. If `rag_attachment_ids` is non-empty, it MUST define the retrieval scope for the turn.
-2. Else, if `attachment_ids` contains document attachments, those document attachments MUST define the retrieval scope for the turn.
-3. Else, retrieval scope defaults to all ready document attachments in the chat.
+1. **No attachments in the chat** — The backend does NOT include `file_search` in Responses API calls. No vector store exists for the chat, so retrieval is unavailable.
 
-The backend MAY include the provider `file_search` tool only when the chat has at least one ready document attachment. When included, the retrieval scope follows the precedence above. The provider/model decides whether to actually invoke the tool.
+2. **Chat has ready document attachments** — The backend includes `file_search` referencing the chat vector store without metadata filtering. Retrieval always operates over all documents currently present in the chat vector store. The LLM decides whether to invoke `file_search`. The `attachment_ids` field on the message does not affect retrieval scope in P1.
 
-**Image input scope invariant (P1)**: Image attachments affect model input only on the turn where they are explicitly included in `attachment_ids`. Uploading an image to the chat does not make it part of future model context by default. Previously uploaded images MAY be reused on later turns only via explicit re-attachment in `attachment_ids`. Images are never allowed in `rag_attachment_ids`.
+> **P2 (deferred)**: Attachment-scoped retrieval — when `attachment_ids` includes document attachments, retrieval is restricted to those documents via metadata filtering on `attachment_id`.
+
+**Image input scope invariant (P1)**: Image attachments affect model input only on the turn where they are explicitly included in `attachment_ids`. Uploading an image to the chat does not make it part of future model context by default. Previously uploaded images MAY be reused on later turns only via explicit re-attachment in `attachment_ids`. Images are never indexed into the vector store.
 
 **P1 attachment scenarios**:
 
-- **Scenario A — upload + attach on this turn**: User uploads a file via `POST /v1/chats/{id}/attachments`, then sends the attachment ID in `attachment_ids`. Result: `message_attachments` row created; file appears in the message `attachments` array; if image, included in multimodal input; if document, defines retrieval scope for the turn (when `rag_attachment_ids` is empty).
-- **Scenario B — explicit retrieval-only reference**: User references previously uploaded document(s) (e.g., via a UI `@file` picker). UI resolves selections to chat-local `attachment_id` values and sends them in `rag_attachment_ids`. Result: NO `message_attachments` rows; NO UI attachment association; file_search scope is restricted to those document attachments only.
-- **Scenario C — implicit retrieval over the chat**: User sends a message without `rag_attachment_ids` and without documents in `attachment_ids`. If the chat has ready document attachments, the backend MAY include the `file_search` tool for the chat's vector store. Retrieval scope defaults to all ready document attachments in the chat.
+- **Scenario A — upload + attach on this turn**: User uploads a file via `POST /v1/chats/{id}/attachments`, then sends the attachment ID in `attachment_ids`. Result: `message_attachments` row created; file appears in the message `attachments` array; if image, included in multimodal input; if document, already indexed in the chat vector store and retrieval operates over the entire chat vector store (no per-document filtering in P1).
+- **Scenario B — retrieval over the chat**: User sends a message (with or without document attachments in `attachment_ids`). If the chat has ready document attachments, the backend includes the `file_search` tool with the chat vector store. Retrieval covers all documents in the chat. If the chat has no document attachments at all, `file_search` is not included.
 
 **P1 intentionally NOT supported** (out of scope):
 - Resolving filename references from free-form user text (e.g., "that contract PDF")
@@ -751,7 +750,7 @@ The backend MAY include the provider `file_search` tool only when the chat has a
 - Multilingual filename or entity resolution
 - Hidden helper LLM call to infer intended file(s) from message text
 
-Validation MUST ensure all of the following for each `attachment_id` in **both** `attachment_ids` and `rag_attachment_ids`:
+Validation MUST ensure all of the following for each `attachment_id` in `attachment_ids`:
 
 - `attachments.tenant_id` matches the request security context tenant
 - `attachments.uploaded_by_user_id` matches the user who uploads attachment
@@ -760,21 +759,17 @@ Validation MUST ensure all of the following for each `attachment_id` in **both**
 - `attachments.status == ready`
 
 Additionally:
-- For each `attachment_id` in `rag_attachment_ids`: `attachments.attachment_kind` MUST equal `document`. Image attachments MUST be rejected.
-- Each array MUST contain unique attachment IDs. Duplicate IDs within `attachment_ids` or within `rag_attachment_ids` MUST be rejected with HTTP 400 (`invalid_request`) before quota reserve and before any provider call.
-- The same attachment ID MUST NOT appear in both `attachment_ids` and `rag_attachment_ids` in the same request. Such requests MUST be rejected with HTTP 400 (`invalid_request`) before quota reserve and before any provider call.
+- Each array MUST contain unique attachment IDs. Duplicate IDs within `attachment_ids` MUST be rejected with HTTP 400 (`invalid_request`) before quota reserve and before any provider call.
 
 ##### Attachment Preflight Validation Invariant (P1)
 
-Attachment validation MUST occur before any provider request is issued and before any quota reserve is taken. For each `attachment_id` in **both** `attachment_ids` and `rag_attachment_ids`:
+Attachment validation MUST occur before any provider request is issued and before any quota reserve is taken. For each `attachment_id` in `attachment_ids`:
 
 - It MUST belong to the same `tenant_id` as the request security context.
 - It MUST belong to the same `user_id` as the request security context.
 - It MUST belong to the same `chat_id` as the requested chat.
 - `status` MUST equal `ready`.
-- For `rag_attachment_ids` only: `attachment_kind` MUST equal `document`.
 - Each array MUST contain unique attachment IDs (no duplicates within a single array).
-- No attachment ID may appear in both arrays simultaneously.
 
 If any of the above validations fail, the request MUST be rejected with an appropriate error before any provider call or quota reserve. No `attachment_id` validation may rely on provider-side failure.
 
@@ -972,7 +967,7 @@ data: {"code": "quota_exceeded", "message": "Daily limit reached", "quota_scope"
 |-------|------|-------------|
 | `code` | string | Canonical error code (see table below). |
 | `message` | string | Human-readable description. |
-| `quota_scope` | `"tokens"` \| `"uploads"` \| `"web_search"` | **Required** when `code = "quota_exceeded"`; MUST be absent otherwise. Clients MUST use this field, not `message` parsing, to determine quota scope. |
+| `quota_scope` | `"tokens"` \| `"uploads"` \| `"web_search"` \| `"image_inputs"` | **Required** when `code = "quota_exceeded"`; MUST be absent otherwise. Clients MUST use this field, not `message` parsing, to determine quota scope. |
 
 ##### `event: ping`
 
@@ -1006,7 +1001,7 @@ A well-formed stream follows this ordering:
 **P1 normative ordering**:
 
 ```text
-ping*  delta*  tool*  citations?  (done | error)
+ping*  (delta | tool)*  citations?  (done | error)
 ```
 
 - Zero or more `ping` events may appear at any point before terminal.
@@ -1073,7 +1068,7 @@ For streaming endpoints, failures before any streaming begins MUST be returned a
 | `chat_not_found` | 404 | Chat does not exist or not accessible under current authorization constraints |
 | `generation_in_progress` | 409 | A generation is already running for this chat (one running turn per chat policy). Always pre-stream JSON. |
 | `request_id_conflict` | 409 | The same `(chat_id, request_id)` is already in a non-replayable state (`running`, `failed`, or `cancelled`). Always pre-stream JSON. |
-| `quota_exceeded` | 429 | Quota exhaustion. Always accompanied by a `quota_scope` field: `"tokens"` (token rate limits across all tiers exhausted, emergency flags, or all models disabled), `"uploads"` (daily upload quota exceeded for the attachment endpoint), or `"web_search"` (per-user daily web search call quota exhausted). |
+| `quota_exceeded` | 429 | Quota exhaustion. Always accompanied by a `quota_scope` field: `"tokens"` (token rate limits across all tiers exhausted, emergency flags, or all models disabled), `"uploads"` (daily upload quota exceeded for the attachment endpoint), `"web_search"` (per-user daily web search call quota exhausted), or `"image_inputs"` (per-turn or per-day image input limit exceeded). |
 | `web_search_disabled` | 400 | Request includes `web_search.enabled=true` but the global `disable_web_search` kill switch is active |
 | `rate_limited` | 429 | Provider upstream throttling (provider 429 after OAGW retry exhaustion) |
 | `file_too_large` | 413 | Uploaded file exceeds size limit |
@@ -1084,13 +1079,14 @@ For streaming endpoints, failures before any streaming begins MUST be returned a
 | `model_not_found` | 404 | Model does not exist in the catalog or is globally disabled. Used by `GET /v1/models/{model_id}`. |
 | `provider_error` | 502 | LLM provider returned an error |
 | `provider_timeout` | 504 | LLM provider request timed out |
-| `web_search_calls_exceeded` | — (SSE only) | Per-message web search tool call limit exceeded mid-turn. Emitted as terminal `event: error` payload only; no HTTP error status is used because the stream is already open. The turn is finalized as `failed` with `settlement_method="actual"\|"estimated"`. |
+| `web_search_calls_exceeded` | — (SSE only) | Per-turn web search tool call limit exceeded mid-turn. Emitted as terminal `event: error` payload only; no HTTP error status is used because the stream is already open. The turn is finalized as `failed` with `settlement_method="actual"\|"estimated"`. |
 | `invalid_turn_state` | 400 | Retry, edit, or delete attempted on a turn that is not in a terminal state (turn is `running`). Always pre-stream JSON. |
 | `not_latest_turn` | 409 | Retry, edit, or delete targeted a turn that is not the most recent non-deleted turn for the chat. Always pre-stream JSON. |
+| `attachment_locked` | 409 | Attachment is referenced by a submitted message and cannot be deleted. Always pre-stream JSON. |
 | `message_not_found` | 404 | Target message does not exist or is not accessible. Used by reaction endpoints. Always pre-stream JSON. |
 | `invalid_reaction_target` | 400 | Reaction attempted on a message type that does not support reactions (e.g., system messages). Always pre-stream JSON. |
 
-**Quota error disambiguation invariant**: token quota exhaustion, upload quota exhaustion, and web search quota exhaustion MUST be distinguishable to clients via the stable, machine-readable `quota_scope` field on every `quota_exceeded` error response. Clients MUST NOT parse the `message` string to determine quota scope. The `quota_scope` field is REQUIRED when `code` is `quota_exceeded` and MUST be one of: `"tokens"` (token-based rate limit exhaustion), `"uploads"` (per-user daily upload limit exhaustion), or `"web_search"` (per-user daily web search call limit exhaustion).
+**Quota error disambiguation invariant**: token quota exhaustion, upload quota exhaustion, web search quota exhaustion, and image input quota exhaustion MUST be distinguishable to clients via the stable, machine-readable `quota_scope` field on every `quota_exceeded` error response. Clients MUST NOT parse the `message` string to determine quota scope. The `quota_scope` field is REQUIRED when `code` is `quota_exceeded` and MUST be one of: `"tokens"` (token-based rate limit exhaustion), `"uploads"` (per-user daily upload limit exhaustion), `"web_search"` (per-user daily web search call limit exhaustion), or `"image_inputs"` (per-turn or per-day image input limit exhaustion).
 
 #### Models API — **ID**: `cpt-cf-mini-chat-interface-models-api`
 
@@ -1319,13 +1315,13 @@ sequenceDiagram
         AG-->>UI: 400
     end
 
-    Note over CS, DB: Preflight transaction (must commit before provider call): validate attachment_ids + rag_attachment_ids (incl. no duplicates across arrays), persist `messages` (role='user'), persist `message_attachments` (from attachment_ids only; rag_attachment_ids do NOT create message_attachments), insert `chat_turns` (state='running') + quota reserve.
+    Note over CS, DB: Preflight transaction (must commit before provider call): validate attachment_ids, persist `messages` (role='user'), persist `message_attachments` (from attachment_ids), insert `chat_turns` (state='running') + quota reserve.
 
-    Note over CS, OAI: Single provider call per user turn. file_search tool included only if chat has ready document attachments; retrieval scope per precedence rule (rag_attachment_ids > document attachment_ids > chat-wide). web_search included when web_search.enabled=true.
+    Note over CS, OAI: Single provider call per user turn. file_search tool always included when chat has ready document attachments; retrieval scope = entire chat vector store. web_search included when web_search.enabled=true.
 
     CS->>DB: Preflight commit: Persist user msg + message_attachments (attachment_ids only) + chat_turns(running) + quota reserve
 
-    CS->>OG: POST /outbound/llm/responses:stream (tools: file_search if chat has ready docs + optionally web_search; retrieval scope per precedence rule)
+    CS->>OG: POST /outbound/llm/responses:stream (tools: file_search if chat has ready docs + optionally web_search; retrieval scope = entire chat vector store)
     OG->>OAI: Responses API (streaming, tool calling enabled)
     OAI-->>OG: SSE tokens
     OG-->>CS: Token stream
@@ -1734,7 +1730,7 @@ Soft-delete rules:
 
 - [ ] `p1` - **ID**: `cpt-cf-mini-chat-dbtable-message-attachments`
 
-M:N join table linking messages to the attachments explicitly referenced on that message. Populated **only** from `attachment_ids` in the `SendMessage` request body (and when a turn is retried or edited, where attachment associations are copied to the new user message). `rag_attachment_ids` MUST NOT create rows in this table — they are retrieval-only and do not represent message-level associations. This table is the **single source of truth** for the `attachments` array (`AttachmentSummary` objects) returned in `GET /v1/chats/{id}/messages` responses.
+M:N join table linking messages to the attachments explicitly referenced on that message. Populated **only** from `attachment_ids` in the `SendMessage` request body (and when a turn is retried or edited, where attachment associations are copied to the new user message). This table is the **single source of truth** for the `attachments` array (`AttachmentSummary` objects) returned in `GET /v1/chats/{id}/messages` responses.
 
 Writers MUST populate `chat_id` from the parent message's `messages.chat_id` (not from user input), and the composite foreign keys enforce that both referenced rows belong to the same chat.
 
@@ -1957,18 +1953,25 @@ Alternative naming (NOT in P1):
 | Column | Type | Description |
 |--------|------|-------------|
 | id | UUID | Reaction identifier |
+| chat_id | UUID | Owning chat (denormalized for integrity; MUST match the parent message's `messages.chat_id`) |
 | message_id | UUID | Parent message (FK → messages.id) |
 | user_id | UUID | Reacting user |
+| tenant_id | UUID | Owning tenant (denormalized for tenant isolation; MUST match the parent chat's `chats.tenant_id`) |
 | reaction | VARCHAR(16) | `like` or `dislike` |
 | created_at | TIMESTAMPTZ | Reaction creation time |
 
 **PK**: `id`
 
-**Constraints**: UNIQUE on `(message_id, user_id)`. NOT NULL on `message_id`, `user_id`, `reaction`, `created_at`. FK `message_id` → `messages.id` ON DELETE CASCADE. CHECK `reaction IN ('like', 'dislike')`.
+**Constraints**:
+- UNIQUE on `(message_id, user_id)`
+- NOT NULL on `chat_id`, `message_id`, `user_id`, `tenant_id`, `reaction`, `created_at`
+- Composite FK `(message_id, chat_id)` → `messages(id, chat_id)` ON DELETE CASCADE (enforces the message belongs to the same chat)
+  - **Implementation note**: this requires `messages` to expose a UNIQUE key on `(id, chat_id)` (in addition to the primary key on `id`) so the composite FK is valid in Postgres/SQLite.
+- CHECK `reaction IN ('like', 'dislike')`
 
-**Indexes**: `(message_id)` for lookups by message
+**Indexes**: `(message_id)` for lookups by message; `(chat_id)` for chat-scoped cleanup
 
-**Secure ORM**: No independent `#[secure]` — accessed through parent chat. The reaction endpoints require the message's parent chat to be loaded via a scoped query first (same pattern as messages, attachments, and chat_turns).
+**Secure ORM**: No independent `#[secure]` — accessed through parent chat. The reaction endpoints require the message's parent chat to be loaded via a scoped query first (same pattern as messages, attachments, and chat_turns). Writers MUST populate `chat_id` and `tenant_id` from the parent message's resolved chat (not from user input).
 
 #### Projection Table: tenant_closure
 
@@ -2047,8 +2050,9 @@ The authorized resource for the Models API is **Model**. This is a read-only, ca
 | `POST /v1/chats/{id}/messages:stream` | `send_message` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `POST /v1/chats/{id}/attachments` | `upload_attachment` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `GET /v1/chats/{id}/attachments/{attachment_id}` | `read_attachment` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
+| `DELETE /v1/chats/{id}/attachments/{attachment_id}` | `delete_attachment` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `GET /v1/chats/{id}/turns/{request_id}` | `read_turn` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
-| `POST /v1/chats/{id}/turns/{request_id}:retry` | `retry_turn` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
+| `POST /v1/chats/{id}/turns/{request_id}/retry` | `retry_turn` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `PATCH /v1/chats/{id}/turns/{request_id}` | `edit_turn` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `DELETE /v1/chats/{id}/turns/{request_id}` | `delete_turn` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
 | `PUT /v1/chats/{id}/messages/{msg_id}/reaction` | `set_reaction` | present (chat_id) | `true` | `eq(owner_tenant_id)` + `eq(user_id)` |
@@ -2057,7 +2061,7 @@ The authorized resource for the Models API is **Model**. This is a read-only, ca
 | `GET /v1/models/{model_id}` | `read` | absent | `false` | decision only (no constraints) |
 
 **Notes**:
-- `list_messages`, `send_message`, `upload_attachment`, `read_attachment`, `retry_turn`, `edit_turn`, `delete_turn`, `set_reaction`, and `delete_reaction` are actions on the Chat resource, not on Message or Turn sub-resources. The `resource.id` is the chat's ID.
+- `list_messages`, `send_message`, `upload_attachment`, `read_attachment`, `delete_attachment`, `retry_turn`, `edit_turn`, `delete_turn`, `set_reaction`, and `delete_reaction` are actions on the Chat resource, not on Message or Turn sub-resources. The `resource.id` is always the chat's ID (`chat_id`). Sub-resource identifiers (`request_id`, `attachment_id`, `msg_id`) are child identifiers used for lookups within the chat but are **not independently protected** — authorization is anchored to the parent chat resource.
 - For streaming (`send_message`, `retry_turn`, `edit_turn`), authorization is evaluated once at SSE connection establishment. The entire streaming session operates under the initial authorization decision. No per-message re-authorization.
 - For `create`, the PEP passes `resource.properties.owner_tenant_id` and `resource.properties.user_id` from the SecurityContext. The PDP validates permission without returning constraints.
 - Turn mutation endpoints (`retry_turn`, `edit_turn`, `delete_turn`) additionally enforce latest-turn and terminal-state checks in the domain service after authorization succeeds (see section 3.9).
@@ -2252,7 +2256,7 @@ Mini Chat recognizes the following token scopes for third-party application narr
 |-------|---------|
 | `ai:mini_chat` | All mini-chat operations (umbrella scope) |
 | `ai:mini_chat:read` | `list`, `read`, `list_messages`, `read_attachment`, `read_turn` actions only |
-| `ai:mini_chat:write` | `create`, `update`, `delete`, `send_message`, `upload_attachment`, `retry_turn`, `edit_turn`, `delete_turn`, `set_reaction`, `delete_reaction` actions |
+| `ai:mini_chat:write` | `create`, `update`, `delete`, `send_message`, `upload_attachment`, `delete_attachment`, `retry_turn`, `edit_turn`, `delete_turn`, `set_reaction`, `delete_reaction` actions |
 
 First-party applications (UI) use `token_scopes: ["*"]`. Third-party integrations receive narrowed scopes. Scope enforcement is handled by the PDP - the PEP includes `token_scopes` in the evaluation request context.
 
@@ -2281,8 +2285,8 @@ A turn is a user-message + assistant-response pair identified by `request_id` in
 
 | Operation | Effect |
 |-----------|--------|
-| **Retry** | Soft-deletes the last turn (sets `deleted_at`, sets `replaced_by_request_id` to the new turn's `request_id`). Creates a new turn. The original user message content and attachment associations are re-submitted to the LLM for a new assistant response. Attachment associations are **copied** from the old user message to the new user message via new `message_attachments` rows (the old rows remain on the soft-deleted message for audit). `rag_attachment_ids` are request-local retrieval controls that are NOT persisted and NOT copied; the retry endpoint does not accept `rag_attachment_ids`. Retrieval scope for the retried turn follows the normal precedence rule: if the copied `message_attachments` include documents, those documents define retrieval scope; else, scope defaults to all ready documents in the chat. |
-| **Edit** | Soft-deletes the last turn (sets `deleted_at`, sets `replaced_by_request_id` to the new turn's `request_id`). Creates a new turn with the updated user message content and generates a new assistant response. Attachment associations are **copied** from the old user message to the new user message via new `message_attachments` rows (preserving the same attachments). `rag_attachment_ids` are request-local retrieval controls that are NOT persisted and NOT copied; the edit endpoint does not accept `rag_attachment_ids`. Retrieval scope for the edited turn follows the normal precedence rule based on the copied `message_attachments`. |
+| **Retry** | Soft-deletes the last turn (sets `deleted_at`, sets `replaced_by_request_id` to the new turn's `request_id`). Creates a new turn. The original user message content and attachment associations are re-submitted to the LLM for a new assistant response. Attachment associations are **copied** from the old user message to the new user message via new `message_attachments` rows (the old rows remain on the soft-deleted message for audit). **Deleted attachment handling**: attachments that have been deleted since the original turn are silently excluded from the copy — only non-deleted (`deleted_at IS NULL`) attachments are copied to the new message. Retrieval operates over the entire chat vector store (P1). |
+| **Edit** | Soft-deletes the last turn (sets `deleted_at`, sets `replaced_by_request_id` to the new turn's `request_id`). Creates a new turn with the updated user message content and generates a new assistant response. Attachment associations are **copied** from the old user message to the new user message via new `message_attachments` rows (preserving the same attachments). **Deleted attachment handling**: same as retry — deleted attachments are silently excluded from the copy. |
 | **Delete** | Soft-deletes the last turn (sets `deleted_at`). No new turn is created. |
 
 #### Rules
@@ -2292,13 +2296,14 @@ A turn is a user-message + assistant-response pair identified by `request_id` in
 3. Retry, edit, and delete are allowed only if the target turn is in a terminal state (`completed`, `failed`, or `cancelled`). If the turn is `running`, reject with `400 Bad Request` — the client must wait for completion or cancel by disconnecting the SSE stream (see `cpt-cf-mini-chat-seq-cancellation`).
 4. Retry and edit soft-delete the previous turn (set `deleted_at`) and set `replaced_by_request_id` on the old turn pointing to the new turn's `request_id`. Delete sets `deleted_at` only (no replacement turn). Mutation eligibility considers only non-deleted turns, so delete cannot target an already replaced (soft-deleted) turn.
 5. Soft-deleted turns (`deleted_at IS NOT NULL`) are excluded from active conversation history and context assembly but retained in storage for audit traceability.
-6. **Atomicity invariant (normative)**: The "latest turn" identity check (rule 1), the terminal state check (rule 3), the soft-delete of the old turn, and the INSERT of the new `running` turn MUST all execute within a single DB transaction using `SELECT FOR UPDATE` or equivalent serializable isolation. Without this, two concurrent retry/edit requests for the same turn can both pass the validation checks simultaneously, both soft-delete the old turn (the second soft-delete is a no-op since `deleted_at` is already set), and both attempt to INSERT a new running turn — which violates the `UNIQUE(chat_id) WHERE state = 'running' AND deleted_at IS NULL` index. If the new running turn INSERT fails due to this unique constraint (concurrent race condition), the mutation MUST return `409 Conflict` with `code = "generation_in_progress"` (not HTTP 500).
+6. **New request_id invariant (normative)**: Both retry and edit create a new turn with a **new `request_id`** generated by the **server** (`Uuid::new_v4()`). The client does not provide the new `request_id` — the retry endpoint has no request body, and the edit endpoint body contains only `content`. The server-generated `request_id` is returned to the client via the SSE `event: turn_started` event (same contract as `sendMessage`). The old turn's `replaced_by_request_id` is set to the new `request_id` for audit traceability. The old `request_id` is no longer valid for idempotent replay — the soft-deleted turn is excluded from the replay path (replay requires `deleted_at IS NULL`). Audit events include both `original_request_id` and `new_request_id` (see audit event payloads for `turn_retry` and `turn_edit`).
+7. **Atomicity invariant (normative)**: The "latest turn" identity check (rule 1), the terminal state check (rule 3), the soft-delete of the old turn, and the INSERT of the new `running` turn MUST all execute within a single DB transaction using `SELECT FOR UPDATE` or equivalent serializable isolation. Without this, two concurrent retry/edit requests for the same turn can both pass the validation checks simultaneously, both soft-delete the old turn (the second soft-delete is a no-op since `deleted_at` is already set), and both attempt to INSERT a new running turn — which violates the `UNIQUE(chat_id) WHERE state = 'running' AND deleted_at IS NULL` index. If the new running turn INSERT fails due to this unique constraint (concurrent race condition), the mutation MUST return `409 Conflict` with `code = "generation_in_progress"` (not HTTP 500).
 
 #### Turn Mutation API Contracts
 
 ##### Retry Last Turn
 
-**Endpoint**: `POST /v1/chats/{id}/turns/{request_id}:retry`
+**Endpoint**: `POST /v1/chats/{id}/turns/{request_id}/retry`
 
 **Request body**: none
 
@@ -2309,6 +2314,7 @@ A turn is a user-message + assistant-response pair identified by `request_id` in
 | Code | HTTP Status | Condition |
 |------|-------------|-----------|
 | `not_latest_turn` | 409 | Target `request_id` is not the most recent turn |
+| `generation_in_progress` | 409 | Another turn is already running for this chat (including concurrent retry/edit race — see rule 7) |
 | `invalid_turn_state` | 400 | Turn is not in a terminal state |
 | `insufficient_permissions` | 403 | Turn does not belong to the requesting user |
 | `chat_not_found` | 404 | Chat does not exist or not accessible |
@@ -2369,8 +2375,8 @@ These events are emitted to platform `audit_service` following the same emission
 - Image upload and image-aware chat via multimodal Responses API input (PNG/JPEG/WebP); images stored via Files API, not indexed in vector stores
 - Retry, edit, and delete for the last turn only (tail-only mutation; see section 3.9)
 - Quota enforcement: daily + monthly per user; credit-based rate limits per tier tracked in real-time; credits are computed from provider-reported token usage using model credit multipliers; premium models have stricter limits, standard models have separate, higher limits; when all tiers are exhausted, reject with `quota_exceeded`; image counters enforced separately
-- File Search per-message call limit is configurable per deployment (default: 2 tool calls per message)
-- Web search via provider tooling (Azure Foundry), explicitly enabled per request via `web_search.enabled` parameter; per-message call limit (default: 2) and per-user daily quota (default: 75); global `disable_web_search` kill switch
+- File Search per-turn call limit is configurable per deployment (default: 2 tool calls per turn)
+- Web search via provider tooling (Azure Foundry), explicitly enabled per request via `web_search.enabled` parameter; per-turn call limit (default: 2) and per-user daily quota (default: 75); global `disable_web_search` kill switch
 - Public Models API (`GET /v1/models`, `GET /v1/models/{model_id}`): read-only; returns only globally enabled models from the policy catalog. Catalog sourced from `mini-chat-model-policy-plugin`.
 
 **Deferred to P2+**:
@@ -2382,7 +2388,7 @@ These events are emitted to platform `audit_service` following the same emission
 - Per-workspace vector store aggregation
 - Full conversation history editing (editing/deleting arbitrary historical messages)
 - Thread branching or multi-version conversations
-- Automatic filename/document-reference resolution from free-form user text (P1 requires explicit `rag_attachment_ids` or `attachment_ids` resolved by the UI)
+- Automatic filename/document-reference resolution from free-form user text (P1 requires explicit `attachment_ids` resolved by the UI)
 
 ### Data Classification and Retention (P1)
 
@@ -2430,9 +2436,9 @@ On each user message, the domain service assembles a `ContextPlan` in this norma
 3. **Thread summary** — if exists, replaces older history.
 4. **Document summaries** — short descriptions of attached documents.
 5. **Recent messages** — last N messages not covered by summary (N configurable, default 6-10).
-6. **Retrieval excerpts** — file_search results from the chat's vector store (top-k chunks), scoped by the Retrieval Scope Precedence rule: if `rag_attachment_ids` is non-empty, retrieval is restricted to those documents; else if `attachment_ids` includes documents, retrieval is restricted to those documents; else retrieval covers all ready documents in the chat. Metadata filtering on `attachment_id` is applied when scope is restricted.
+6. **Retrieval excerpts** — file_search results from the chat's vector store (top-k chunks). Retrieval always covers all documents in the chat vector store (no per-document filtering in P1). `file_search` is only included when the chat has at least one ready document attachment.
 7. **User message** — current turn.
-8. **Image attachments** — if the current request includes `attachment_ids` with image entries, include up to N images (configurable, default: 4) in the Responses API input content array. Images are appended to the user message content as `input_image` items with internal `provider_file_id` references (resolved from the `attachments` table; never exposed to clients). Images from previous turns are never implicitly reused; previously uploaded image attachments MAY be re-attached on later turns via `attachment_ids`, and only explicit re-attachment includes them in multimodal input. Images are never allowed in `rag_attachment_ids`.
+8. **Image attachments** — if the current request includes `attachment_ids` with image entries, include up to N images (configurable, default: 4) in the Responses API input content array. Images are appended to the user message content as `input_image` items with internal `provider_file_id` references (resolved from the `attachments` table; never exposed to clients). Images from previous turns are never implicitly reused; previously uploaded image attachments MAY be re-attached on later turns via `attachment_ids`, and only explicit re-attachment includes them in multimodal input. Images are never indexed into the vector store.
 
 **Truncation priority** (when total exceeds `token_budget` — see Context Window Budget constraint): items are dropped in reverse order of priority. Lowest priority is truncated first:
 
@@ -2445,11 +2451,11 @@ On each user message, the domain service assembles a `ContextPlan` in this norma
 | 5 | Document summaries |
 | 6 (truncated first) | Retrieval excerpts |
 
-Image attachments on the current turn are not truncated (they are subject to per-message count limits enforced at upload/preflight, not at context assembly).
+Image attachments on the current turn are not truncated (they are subject to per-turn count limits enforced at upload/preflight, not at context assembly).
 
 **Image context rules** (unchanged): images are referenced by provider file ID, not summarized at P1, not indexed in vector stores. If the effective model does not support image input, the domain service rejects before context assembly (see `cpt-cf-mini-chat-constraint-model-image-capability`).
 
-**Web search tool inclusion**: When `web_search.enabled=true` on the request, the domain service includes the `web_search` tool in the Responses API request alongside `file_search`. The provider decides whether to invoke the tool based on the query. Web search tool inclusion does not affect context assembly order or truncation priority. Web search call limits (per-message and per-day) are enforced by `quota_service` at preflight and committed on turn completion. When the per-user daily web search call quota (`web_search.daily_quota`) is exhausted, `quota_service` MUST reject the request at preflight (before any provider call) with `quota_exceeded` and `quota_scope = "web_search"`. This MUST NOT be reported as `quota_scope = "tokens"`.
+**Web search tool inclusion**: When `web_search.enabled=true` on the request, the domain service includes the `web_search` tool in the Responses API request alongside `file_search`. The provider decides whether to invoke the tool based on the query. Web search tool inclusion does not affect context assembly order or truncation priority. Web search call limits (per-turn and per-day) are enforced by `quota_service` at preflight and committed on turn completion. When the per-user daily web search call quota (`web_search.daily_quota`) is exhausted, `quota_service` MUST reject the request at preflight (before any provider call) with `quota_exceeded` and `quota_scope = "web_search"`. This MUST NOT be reported as `quota_scope = "tokens"`.
 
 #### Context Plan Truncation Algorithm
 
@@ -2516,19 +2522,15 @@ SELECT * FROM messages
 
 The result is reversed to chronological order for ContextPlan assembly. K is a server-side configurable cap (default 6-10) and is not exposed to clients.
 
-### File Search Trigger Heuristics
+### File Search Tool Availability
 
-The backend MAY include the provider `file_search` tool only when the chat has at least one ready document attachment. When included, the Retrieval Scope Precedence rule (see Streaming Contract) determines the candidate document set:
+The `file_search` tool is only provided to the LLM after at least one document attachment has been uploaded and reached `ready` status in the chat. Before any attachments exist, the backend MUST NOT include `file_search` in Responses API calls because no vector store exists for the chat.
 
-1. If `rag_attachment_ids` is non-empty → scope restricted to those documents (metadata filtered).
-2. Else if `attachment_ids` includes documents → scope restricted to those documents (metadata filtered).
-3. Else → scope is the full chat vector store.
+Once document attachments exist, the backend includes the `file_search` tool on every model request with the chat vector store ID attached via `tool_resources.file_search.vector_store_ids`. The provider/model decides whether to actually invoke the tool.
 
-The provider/model decides whether to actually invoke the tool. The explicit scope (cases 1 and 2) deterministically restricts the candidate set; it does not force invocation.
+**P1 constraint**: the backend MUST NOT infer document references from free-form user text. All attachment association is via `attachment_ids`, resolved to `attachment_id` values by the UI before the request is sent.
 
-**P1 constraint**: the backend MUST NOT infer document references from free-form user text. All explicit retrieval scoping is via `rag_attachment_ids` or document entries in `attachment_ids`, resolved to `attachment_id` values by the UI before the request is sent.
-
-Limits: per-message file_search tool call limit is configurable per deployment (default: 2); max calls per day/user tracked in `quota_usage`.
+Limits: per-turn file_search tool call limit is configurable per deployment (default: 2); max calls per day/user tracked in `quota_usage`.
 
 ### Web Search Configuration
 
@@ -2540,13 +2542,13 @@ Web search is an explicitly-enabled tool available when `web_search.enabled=true
 
 ```yaml
 web_search:
-  max_calls_per_message: 2          # hard limit on web_search tool calls per user turn
+  max_calls_per_turn: 2             # hard limit on web_search tool calls per user turn
   daily_quota: 75                    # per-user daily web search call limit
 ```
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `max_calls_per_message` | integer | `2` | Hard limit on web_search tool calls the provider may make per user turn. Enforced by `quota_service` at preflight. |
+| `max_calls_per_turn` | integer | `2` | Hard limit on web_search tool calls the provider may make per user turn. Enforced by `quota_service` at preflight. |
 | `daily_quota` | integer | `75` | Per-user daily web search call limit. Tracked in `quota_usage.web_search_calls`. |
 
 **Deferred to P2+**: `web_search.provider_parameters` (search_depth, max_results, include_answer, include_raw_content, include_images, auto_parameters). P1 uses provider defaults. When implemented, provider_parameters are passed through opaquely to the web search provider on every search tool call.
@@ -2559,7 +2561,7 @@ web_search:
 
 > Use web_search only if the answer cannot be obtained from the provided context or your training data. Never use it for general knowledge questions. At most one web_search call per request.
 
-This instruction is a **soft guideline** appended to the system prompt only when `web_search.enabled=true`. It is not included when web search is disabled. The model MAY exceed the "at most one" suggestion; the system does not enforce it. The **hard limit** is `max_calls_per_message` (default: 2) enforced by `quota_service` at preflight — this is the enforceable backstop that prevents runaway tool calls regardless of model behavior.
+This instruction is a **soft guideline** appended to the system prompt only when `web_search.enabled=true`. It is not included when web search is disabled. The model MAY exceed the "at most one" suggestion; the system does not enforce it. The **hard limit** is `max_calls_per_turn` (default: 2) enforced by `quota_service` at preflight — this is the enforceable backstop that prevents runaway tool calls regardless of model behavior.
 
 **Citations**: Web search results are mapped to `event: citations` items with `source: "web"`, `url`, `title`, and `snippet` fields via the same provider event translation layer used for file_search.
 
@@ -2585,8 +2587,8 @@ Web search quota enforcement follows deterministic preflight checks with no retr
 
 **Mid-Turn Hard Limit Enforcement**:
 
-3. **Per-Message Tool Call Limit**: During turn execution, track web_search tool calls made by the provider.
-   - Hard limit: `max_calls_per_message` (configurable, default: 2)
+3. **Per-Turn Tool Call Limit**: During turn execution, track web_search tool calls made by the provider.
+   - Hard limit: `max_calls_per_turn` (configurable, default: 2)
    - If exceeded mid-turn:
      - Finalize turn as `failed` with `error_code = "web_search_calls_exceeded"` (not `quota_exceeded`)
      - Settle tokens based on actual/estimated usage at that point
@@ -2598,26 +2600,30 @@ Web search quota enforcement follows deterministic preflight checks with no retr
 **Error Codes Summary**:
 - `web_search_disabled` → HTTP 400 (kill switch active)
 - `quota_exceeded` with quota_scope=`"web_search"` → HTTP 429 (daily quota exhausted)
-- `web_search_calls_exceeded` → HTTP 200 + SSE `event: error` (per-message tool call limit breached mid-turn; not HTTP 429; turn finalized as `failed`)
+- `web_search_calls_exceeded` → HTTP 200 + SSE `event: error` (per-turn tool call limit breached mid-turn; not HTTP 429; turn finalized as `failed`)
 
 ### File Search Retrieval Scope
 
 **Physical store**: one dedicated vector store per chat (see `chat_vector_stores` table). Created on first document upload to the chat. All document attachments in a chat are indexed in the same physical vector store. The backend MUST resolve the provider vector store from `(tenant_id, chat_id)` internally. The client MUST NOT send provider `vector_store_id` values; the public API accepts only internal `attachment_id` UUIDs.
 
-**Retrieval scope (P1)**: file search is inherently scoped to the current chat because each chat has its own vector store. No cross-chat document leakage by design. Within a chat, retrieval scope is determined by the Retrieval Scope Precedence rule (normative, deterministic):
+**Retrieval scope**: file search is inherently scoped to the current chat because each chat has its own vector store. No cross-chat document leakage by design. Within a chat, retrieval always covers all documents currently present in the chat vector store (no per-document metadata filtering in P1). Attachment-scoped retrieval via metadata filtering on `attachment_id` is deferred to P2.
 
-1. **Explicit turn-local scope via `rag_attachment_ids`**: If the request includes a non-empty `rag_attachment_ids`, file search MUST be restricted to those document attachments only. The backend applies provider-side metadata filtering using stable `attachment_id` values (indexed as metadata on each chunk — see Vector Store Scope below). Filename text MUST NOT be used as the authoritative retrieval key; `attachment_id` is the stable identity for filtering.
-2. **Explicit document attachments via `attachment_ids`**: Else, if `attachment_ids` includes document attachments, those documents MUST define the retrieval scope for the turn (same metadata filtering mechanism).
-3. **Chat-wide default scope**: Else, retrieval scope defaults to all ready document attachments in the chat (the entire chat vector store).
+### Retrieval Invariants
 
-**P1 constraint**: the backend MUST NOT attempt filename or document-reference resolution from free-form user text. All explicit retrieval scoping is via `rag_attachment_ids` or document entries in `attachment_ids`, resolved by the UI to chat-local `attachment_id` values before the request is sent.
+1. `file_search` MUST NOT be included in Responses API calls before the first document attachment reaches `ready` status in the chat (no vector store exists).
+2. All document attachments are indexed into the chat vector store after upload processing completes.
+3. In P1, `file_search` is always provided without metadata filtering when the chat has ready document attachments. The decision to invoke `file_search` is delegated to the LLM; retrieval searches across all documents in the chat vector store.
+4. Deleting an attachment removes it from both chat metadata and the retrieval corpus.
+5. Image attachments are never indexed into the vector store.
+6. The `attachments` array of a submitted message MUST NOT be modified. An attachment referenced by any submitted message MUST NOT be deleted (see Attachment Mutability and Deletion).
+
+> **P2 (deferred)**: When `attachment_ids` in a user message includes document attachments, retrieval MAY be restricted to those documents via metadata filter on `attachment_id`.
 
 This means:
-- Chat A with documents D1, D2, no explicit scope → file_search queries D1, D2 (Chat A's full vector store)
-- Chat A with `rag_attachment_ids=[D1]` → file_search queries only D1 (metadata-filtered within Chat A's vector store)
-- Chat A with `attachment_ids=[D1]` (document), no `rag_attachment_ids` → file_search queries only D1
-- Chat B with documents D3 → file_search queries only D3 (Chat B's vector store)
-- No metadata filtering needed for cross-chat isolation; metadata filtering is used only for intra-chat turn-local scope restriction
+- Chat with no attachments → `file_search` is NOT included in the Responses API call
+- Chat A with documents D1, D2; any message → `file_search` queries D1, D2 (full chat vector store)
+- Chat B with documents D3 → `file_search` queries only D3 (Chat B's vector store)
+- Cross-chat isolation: each chat has its own dedicated vector store; no metadata filtering needed for tenant/chat isolation
 
 #### Vector Store Scope (P1)
 
@@ -2627,10 +2633,10 @@ One provider-hosted vector store per chat (see `chat_vector_stores` table). Crea
 
 | Metadata field | Source | Purpose |
 |---------------|--------|---------|
-| `attachment_id` | `attachments.id` | Turn-local retrieval filtering (via `rag_attachment_ids` / document `attachment_ids`), cleanup, and deduplication |
+| `attachment_id` | `attachments.id` | Cleanup and deduplication |
 | `uploaded_at` | `attachments.created_at` | Recency bias in retrieval |
 
-Physical and logical isolation are both per chat. No metadata filtering needed for cross-chat isolation. Metadata filtering on `attachment_id` is used only for intra-chat turn-local scope restriction when `rag_attachment_ids` or document `attachment_ids` are present on the request.
+Physical and logical isolation are both per chat. No metadata filtering is needed — each chat has its own dedicated vector store.
 
 **Tenant isolation invariants (normative)**:
 
@@ -2642,14 +2648,88 @@ Physical and logical isolation are both per chat. No metadata filtering needed f
 
 Retrieved file search excerpts are integrated into the prompt as follows:
 
-1. The domain service determines retrieval scope per the Retrieval Scope Precedence rule: if `rag_attachment_ids` is non-empty, restrict to those documents; else if `attachment_ids` includes documents, restrict to those documents; else use the full chat vector store.
-2. The domain service invokes the provider `file_search` tool on the chat's vector store (top-k similarity search), applying `attachment_id` metadata filtering when retrieval scope is restricted.
+1. The domain service uses the chat vector store for retrieval without metadata filtering (P1). All documents in the chat vector store are searchable on every turn.
+2. The domain service invokes the provider `file_search` tool on the chat's vector store (top-k similarity search).
 3. Only the returned chunks are included in the prompt — full file contents are **never** injected by default.
 4. If retrieval returns no relevant chunks, the system proceeds without file context.
 5. Retrieved chunks are subject to the token budget truncation rules in Context Plan Assembly: thread summary and system prompt always have higher priority; retrieval excerpts are truncated first when the budget is exceeded.
 6. Maximum retrieved chunks per turn and maximum retrieved tokens per turn are configurable (see RAG defaults below).
 
-Provider-side retrieval filtering MUST be based on stable `attachment_id` metadata (indexed per chunk), not on filename text. Filename may exist for UI display only.
+#### Citation File ID Resolution
+
+File citations returned by the provider include a provider-specific file identifier (`provider_file_id`) in the annotation payload. Before constructing the client-visible citation object, the backend MUST resolve this provider identifier to the internal `attachment_id` used by the Mini Chat system.
+
+Resolution is performed by a lookup in the `attachments` table:
+
+```
+(chat_id, provider_file_id) → attachment_id
+```
+
+The lookup MUST be restricted to the current `chat_id` to preserve tenant and chat isolation. Raw `provider_file_id` values MUST NOT be exposed in API responses. The citation payload returned to the client MUST contain the internal `attachment_id` only.
+
+**Citation resolution rules**:
+
+1. If a matching attachment row is found and the attachment is not soft-deleted (`deleted_at IS NULL`), the citation MUST include the corresponding `attachment_id`.
+2. If no matching attachment is found (e.g., provider returns an unknown file ID), the citation MUST be omitted from the `citations` event. The backend MUST NOT expose the raw `provider_file_id` to the client.
+3. If the attachment exists but is soft-deleted (`deleted_at IS NOT NULL`), the citation MUST be omitted. The raw provider identifier MUST NOT be returned.
+4. The `attachments` table MUST maintain an index on `(chat_id, provider_file_id)` to ensure deterministic and efficient lookup.
+
+**Provider identifier non-exposure invariant**: provider-specific identifiers (such as `provider_file_id`, `vector_store_id`) are internal integration details and MUST NOT appear in any public API payloads, SSE event payloads, or error messages. See also the normative non-exposure invariant in section 3.3 (SSE Events).
+
+#### Attachment Mutability and Deletion
+
+Attachments may be removed while the message they belong to has not yet been submitted.
+
+Once a message is submitted, its `attachments` array and corresponding `message_attachments` associations become immutable and MUST NOT be modified.
+
+An attachment referenced by any submitted message MUST NOT be deleted.
+
+An attachment that is not referenced by any submitted message MAY be deleted via `DELETE /v1/chats/{chat_id}/attachments/{attachment_id}`.
+
+The deletion guard is based on whether the attachment is referenced by any submitted `message_attachments` association, not merely on whether the attachment exists in the chat.
+
+**Attachment Deletion Invariants**:
+
+1. The `attachments` array of a submitted message MUST NOT be modified.
+2. An attachment referenced by any submitted message MUST NOT be deleted.
+3. An attachment not referenced by any submitted message MAY be deleted.
+4. `DELETE /v1/chats/{chat_id}/attachments/{attachment_id}` MUST return HTTP 409 with `error.code = "attachment_locked"` if the attachment is referenced by any submitted message.
+
+**P1 Limitation**: Attachments referenced by submitted messages are immutable and cannot be deleted. This avoids breaking historical message rendering, attachment references, citations, and replay semantics. Corpus-level deletion of attachments referenced by submitted messages is out of scope for P1.
+
+#### Attachment Deletion
+
+`DELETE /v1/chats/{chat_id}/attachments/{attachment_id}`
+
+This operation deletes the attachment only if it is not referenced by any submitted message.
+
+If the attachment is referenced by one or more submitted messages, the operation MUST be rejected with HTTP 409 Conflict and `error.code = "attachment_locked"`.
+
+If the attachment is not referenced by any submitted message, the attachment is soft-deleted locally and immediately excluded from future retrieval and chat metadata. Provider-side cleanup (file deletion via the Files API and document removal from the vector store) is performed asynchronously via the transactional outbox mechanism. The API response MUST NOT wait for external cleanup to complete.
+
+Deletion follows a two-phase approach using the transactional outbox pattern (see section 5.7):
+
+**Phase 1 — Transactional commit (synchronous, within the HTTP request)**:
+
+1. Soft-delete the `attachments` row (`deleted_at = now()`).
+2. Insert a `modkit_outbox_events` row with `event_type = "attachment_cleanup"` containing `provider_file_id` and `vector_store_id` in the payload.
+3. Both writes execute in a single DB transaction. The endpoint returns `204 No Content` once the transaction commits.
+
+After Phase 1 commits, the attachment is **immediately invisible** to retrieval: the `file_search` tool inclusion check counts only `status = 'ready' AND deleted_at IS NULL` attachments, and vector store queries are scoped to attachments present in `chat_vector_stores` metadata — the soft-deleted attachment is excluded from both paths.
+
+**Phase 2 — Asynchronous cleanup (outbox relay)**:
+
+The outbox relay picks up the `attachment_cleanup` event and performs provider-side cleanup:
+
+1. Remove the document from the chat vector store (provider Vector Stores API).
+2. Delete the file from the provider Files API.
+
+If either provider call fails, the outbox relay retries with exponential backoff (standard outbox retry policy). Partial failure is safe: the attachment is already soft-deleted and excluded from retrieval. Provider-side orphans are eventually cleaned up by retries or by the chat deletion cleanup worker.
+
+**Invariants**:
+
+- After Phase 1, the attachment MUST NOT appear in `file_search` tool resources or retrieval scope.
+- Deleting an already-deleted attachment is idempotent: returns `204 No Content` without inserting a duplicate outbox event.
 
 #### RAG Quality & Scale Controls (P1)
 
@@ -2670,17 +2750,17 @@ All values are configurable per deployment. The domain service enforces `max_doc
 
 Since each chat has a dedicated vector store, these limits directly bound the size of each vector store. The `max_chunks_per_chat` limit (default: 10,000) serves as both a RAG quality control and a vector store growth guardrail. No additional per-user aggregate limit is enforced at P1; operators can monitor total vector store count per user via metrics (`mini_chat_vector_stores_per_user` gauge).
 
-#### File Search Per-Message Call Limit Enforcement (P1)
+#### File Search Per-Turn Call Limit Enforcement (P1)
 
-The file search per-message call limit (`max_calls_per_message`, default: 2) is enforced at **preflight only** in P1.
+The file search per-turn call limit (`max_calls_per_turn`, default: 2) is enforced at **preflight only** in P1.
 
-**Preflight enforcement**: The `file_search_surcharge_tokens` budget included in the reserve estimate covers up to `max_calls_per_message` invocations. No mid-stream monitoring or hard stop is implemented for file_search calls in P1. There is no `file_search_calls_exceeded` error code or mid-turn finalization path for file_search at P1 scope.
+**Preflight enforcement**: The `file_search_surcharge_tokens` budget included in the reserve estimate covers up to `max_calls_per_turn` invocations. No mid-stream monitoring or hard stop is implemented for file_search calls in P1. There is no `file_search_calls_exceeded` error code or mid-turn finalization path for file_search at P1 scope.
 
-**Post-hoc accounting**: After the provider reports actual token usage, the system applies standard commit-vs-reserve settlement regardless of how many file_search calls the provider actually made. If the provider makes fewer calls than budgeted, actual token usage is lower and any underspend is released. If the provider makes more calls than `max_calls_per_message`, the additional token cost is subject to the standard `overshoot_tolerance_factor` cap — overruns beyond tolerance are capped at `reserve_tokens` per §5.4.5. No separate mid-stream enforcement, error_code, or settlement exception applies.
+**Post-hoc accounting**: After the provider reports actual token usage, the system applies standard commit-vs-reserve settlement regardless of how many file_search calls the provider actually made. If the provider makes fewer calls than budgeted, actual token usage is lower and any underspend is released. If the provider makes more calls than `max_calls_per_turn`, the additional token cost is subject to the standard `overshoot_tolerance_factor` cap — overruns beyond tolerance are capped at `reserve_tokens` per §5.4.5. No separate mid-stream enforcement, error_code, or settlement exception applies.
 
-**Rationale**: Unlike web search (which incurs discrete per-call surcharges tracked in a daily quota bucket requiring mid-turn enforcement), file_search surcharge tokens are a fixed per-turn budget estimate baked into the reserve. Enforcement at preflight by sizing the reserve to cover `max_calls_per_message` calls provides sufficient cost bounding without requiring SSE event monitoring. Mid-stream abort on file_search call count exceed (analogous to web search's Mid-Turn Hard Limit Enforcement) is deferred to P2+.
+**Rationale**: Unlike web search (which incurs discrete per-call surcharges tracked in a daily quota bucket requiring mid-turn enforcement), file_search surcharge tokens are a fixed per-turn budget estimate baked into the reserve. Enforcement at preflight by sizing the reserve to cover `max_calls_per_turn` calls provides sufficient cost bounding without requiring SSE event monitoring. Mid-stream abort on file_search call count exceed (analogous to web search's Mid-Turn Hard Limit Enforcement) is deferred to P2+.
 
-**Scope note**: Operators can detect excessive file_search call usage via audit logs. Per-message mid-stream file_search call count enforcement is explicitly out of P1 scope.
+**Scope note**: Operators can detect excessive file_search call usage via audit logs. Per-turn mid-stream file_search call count enforcement is explicitly out of P1 scope.
 
 ### Model Catalog Configuration
 
@@ -2764,7 +2844,7 @@ Operational configuration of rate limits, quota allocations, and model catalog i
 | Credit limit (per tier per period) | Positive integer > 0 |
 | `period_type` | One of: `daily`, `monthly` (P2+: `4h`, `weekly`) |
 | Period status | `enabled` or `disabled` (disabled periods are skipped during tier availability check) |
-| `web_search.max_calls_per_message` | Positive integer > 0 |
+| `web_search.max_calls_per_turn` | Positive integer > 0 |
 | `web_search.daily_quota` | Positive integer > 0 |
 
 Invalid configuration MUST be rejected at startup with a descriptive error. Runtime config reloads that fail validation MUST be rejected without affecting the running configuration.
@@ -2995,7 +3075,7 @@ When image attachments are included in a chat turn, `llm_provider` constructs th
 }
 ```
 
-Multiple images are appended as additional `input_image` items (up to the per-message limit). The `file_id` in this payload is the provider-issued `provider_file_id` resolved internally from the `attachments` table. This identifier is used only in internal provider API calls and MUST NOT be exposed to clients.
+Multiple images are appended as additional `input_image` items (up to the per-turn limit). The `file_id` in this payload is the provider-issued `provider_file_id` resolved internally from the `attachments` table. This identifier is used only in internal provider API calls and MUST NOT be exposed to clients.
 
 This is the normalized internal representation; provider-specific request shaping (if any) is handled by `llm_provider` / OAGW.
 
@@ -3427,7 +3507,7 @@ When a `POST /v1/chats/{id}/messages:stream` request arrives with a `(chat_id, r
 | `failed` | Reject with `409 Conflict` — client MUST use a new `request_id` to retry |
 | `cancelled` | Reject with `409 Conflict` — client MUST use a new `request_id` to retry |
 
-A new `request_id` is required for every retry attempt. The system never overwrites or reuses a turn record.
+A new `request_id` is required for every retry or edit attempt. The client MUST NOT reuse the `request_id` of an existing completed turn — a completed `(chat_id, request_id)` pair is replay-only and will return the previously generated result instead of starting a new generation. The system never overwrites or reuses a turn record.
 
 **Replay Side-Effect-Free Invariant (P1)**:
 
@@ -5132,7 +5212,7 @@ The following patterns are explicitly prohibited. Any implementation that matche
 
 **INVARIANT: user message MUST be durably persisted before the `chat_turns` row enters `running` state and before any outbound provider call.**
 
-The user message (`messages` row with `role = 'user'`) and the `message_attachments` associations (from `attachment_ids` only; `rag_attachment_ids` MUST NOT create `message_attachments` rows) MUST be committed to the database as part of the preflight transaction — the same transaction that inserts the `chat_turns` row with `state = 'running'` and records the quota reserve. This ordering guarantees:
+The user message (`messages` row with `role = 'user'`) and the `message_attachments` associations (from `attachment_ids`) MUST be committed to the database as part of the preflight transaction — the same transaction that inserts the `chat_turns` row with `state = 'running'` and records the quota reserve. This ordering guarantees:
 
 - The user message is always available for ContextPlan assembly and replay, even after crash recovery.
 - If the preflight transaction fails (e.g. DB write error), neither the user message nor the turn record exists — the system is in a clean state and the client can retry with a new `request_id`.
@@ -5370,7 +5450,7 @@ impl TurnErrorCode {
 |------------------------------|-----------------|------------------|---------------------------|-------|
 | `state = 'completed'` | `COMPLETED` | `"completed"` | `"actual"` | Normal success; provider reported full usage |
 | `state = 'failed'` AND `error_code IN ('provider_error', 'provider_timeout', 'rate_limited')` | `FAILED` | `"failed"` | `"actual"` (if provider reported partial usage) OR `"estimated"` (if no usage available) | Provider terminal error after streaming started |
-| `state = 'failed'` AND `error_code = 'web_search_calls_exceeded'` | `FAILED` | `"failed"` | `"actual"` (if provider reported partial usage) OR `"estimated"` (if no usage available) | Per-message tool call limit breached mid-turn; turn was post-provider-start; mirrors `provider_error` settlement. MUST NOT use `"released"` even if partial usage is unavailable — the provider was already called. |
+| `state = 'failed'` AND `error_code = 'web_search_calls_exceeded'` | `FAILED` | `"failed"` | `"actual"` (if provider reported partial usage) OR `"estimated"` (if no usage available) | Per-turn tool call limit breached mid-turn; turn was post-provider-start; mirrors `provider_error` settlement. MUST NOT use `"released"` even if partial usage is unavailable — the provider was already called. |
 | `state = 'failed'` AND `error_code IN ('context_length_exceeded', 'validation_error')` AND reserve was taken | `FAILED` | `"failed"` | `"released"` | Pre-provider failure after reserve; zero charge |
 | `state = 'cancelled'` (client disconnect) | `ABORTED` | `"aborted"` | `"actual"` (if provider reported partial usage) OR `"estimated"` (use deterministic formula) | Stream ended without provider terminal event |
 | `state = 'failed'` AND `error_code = 'orphan_timeout'` (watchdog) | `ABORTED` | `"aborted"` | `"estimated"` (MUST use deterministic formula from section 5.8) | Watchdog cleanup; no provider terminal event received |
@@ -6255,7 +6335,7 @@ Estimation budgets are embedded **per-model** in the policy snapshot catalog. Ea
 | Parameter | Type | Default | Source | Notes |
 |-----------|------|---------|--------|-------|
 | `web_search.enabled` | `bool` | `false` | **Request** | Per-request body field |
-| `web_search.max_calls_per_message` | `integer` | `2` | **ConfigMap** | n/a in CCM API |
+| `web_search.max_calls_per_turn` | `integer` | `2` | **ConfigMap** | n/a in CCM API |
 | `web_search.daily_quota` | `integer` | `75` | **ConfigMap** | n/a in CCM API |
 | `disable_web_search` (kill switch) | `bool` | — | **CCM API**: `GET /policies/{v}` | `snapshot.kill_switches.disable_web_search` |
 
@@ -6263,7 +6343,7 @@ Estimation budgets are embedded **per-model** in the policy snapshot catalog. Ea
 
 | Parameter | Type | Default | Source |
 |-----------|------|---------|--------|
-| `file_search.max_calls_per_message` | `integer` | `2` | **ConfigMap** |
+| `file_search.max_calls_per_turn` | `integer` | `2` | **ConfigMap** |
 | `max_documents_per_chat` | `integer` | `50` | **ConfigMap** |
 | `max_total_upload_mb_per_chat` | `integer` | `100` | **ConfigMap** |
 | `max_chunks_per_chat` | `integer` | `10_000` | **ConfigMap** |
@@ -6279,9 +6359,9 @@ Estimation budgets are embedded **per-model** in the policy snapshot catalog. Ea
 | `uploaded_file_max_size_kb` | `integer` | — | **ConfigMap** |
 | `uploaded_image_max_size_kb` | `integer` | — | **ConfigMap** |
 | Max image size | — | `16 MiB` (target `25 MiB`) | **ConfigMap** |
-| `max_image_inputs_per_message` | `integer` | `4` | **ConfigMap** |
+| `max_images_per_message` | `integer` | `4` | **ConfigMap** |
 | `max_image_inputs_per_user_per_day` | `integer` | `50` | **ConfigMap** |
-| `max_total_image_bytes_per_message` | — | uncapped | **ConfigMap** |
+| `max_total_image_bytes_per_turn` | — | uncapped | **ConfigMap** |
 | `thumbnail_width` | `integer` | `128` | **ConfigMap** |
 | `thumbnail_height` | `integer` | `128` | **ConfigMap** |
 | `thumbnail_max_bytes` | `integer` | `131072` | **ConfigMap** |

--- a/modules/mini-chat/docs/PRD.md
+++ b/modules/mini-chat/docs/PRD.md
@@ -18,7 +18,6 @@ Mini Chat is a lightweight, self-contained chat module designed for rapid delive
 | File storage | External only (provider-hosted: Azure / OpenAI Files API) | Pluggable storage providers via plugins |
 | Search / retrieval | External only (provider-hosted vector stores, web search via Azure Foundry) | Pluggable search providers via plugins |
 | Model orchestration | Single model per chat, locked at creation | Multi-model orchestration, dynamic routing |
-| DB table prefix | `mini_` (co-exists with main chat tables) | TBD |
 
 Mini Chat is NOT a stepping stone to Main Chat — it is a separate, simpler product. P2+ items in this PRD are design considerations only; feature parity with Main Chat is explicitly out of scope.
 
@@ -57,7 +56,7 @@ Current gaps: no native chat experience within the platform; no way to query upl
 | Web Search | An LLM tool call that retrieves information from the public web during a chat turn; explicitly enabled per request via API parameter |
 | Selected Model | The model chosen by the user (or resolved via the `is_default` premium model algorithm) at chat creation and stored in `chat.model`. Immutable for the chat lifetime. |
 | Effective Model | The model actually used for a specific turn after quota and policy evaluation. Equals the selected model unless a quota-driven downgrade or kill switch overrides it. Recorded per assistant message. |
-| RAG Attachment IDs | An optional list of chat-local document attachment IDs (`rag_attachment_ids`) sent with a message to constrain file-search scope for that turn only. Provides retrieval-only explicit scope — does not create message-attachment associations or appear in message history. When empty or omitted, document attachments in `attachment_ids` define explicit retrieval scope instead (see Retrieval Scope Precedence). |
+| Chat Knowledge Base | The set of all document attachments currently present in a chat's vector store. Documents are added on upload and removed on deletion. The assistant may reference any document in the chat knowledge base when generating answers. |
 
 ## 2. Actors
 
@@ -94,14 +93,14 @@ This PRD uses **P1/P2** to describe phased scope. The `p1`/`p2` tags on requirem
 - Real-time streamed AI responses (SSE)
 - Persistent conversation history
 - Document upload and document-aware question answering via file search
-- Explicit per-turn retrieval scoping via `rag_attachment_ids` (retrieval-only scope) or document attachments included in `attachment_ids` (message-associated scope); deterministic precedence rule governs which mechanism takes effect
+- Chat-scoped document retrieval: all uploaded documents are searchable in all future turns via `file_search` over the chat vector store
 - Document summary on upload
 - Thread summary compression for long conversations
 - Per-user credit-based rate limits across multiple periods (daily, monthly) tracked in real-time; credits are computed from provider-reported tokens using model credit multipliers from the active policy snapshot; premium models have stricter limits, standard-tier models have separate, higher limits; two-tier downgrade cascade (premium → standard); when all tiers are exhausted, the system rejects with `quota_exceeded`
 - Model selection per chat at creation time (locked for conversation lifetime)
 - Binary like/dislike reactions on assistant messages (persisted, API-accessible)
 - File search call limits per message and per user/day
-- Web search via provider tooling (Azure Foundry), explicitly enabled per request via API parameter, with per-message and per-day call limits and a global kill switch
+- Web search via provider tooling (Azure Foundry), explicitly enabled per request via API parameter, with per-turn and per-day call limits and a global kill switch
 - Token budget enforcement and context truncation
 - License feature gate (`ai_chat`)
 - Emit audit events to platform `audit_service` (append-only semantics owned by `audit_service`)
@@ -127,7 +126,7 @@ This PRD uses **P1/P2** to describe phased scope. The `p1`/`p2` tags on requirem
 - Thread versioning / branching (multi-branch conversations, history forks)
 - Multi-branch recovery or resume-from-middle editing
 - Web search auto-triggering (P1 requires explicit API parameter; implicit query-based triggering is deferred)
-- Automatic filename or document-reference resolution from free-form user text (P1 requires explicit `rag_attachment_ids` or `attachment_ids` resolved by the UI)
+- Automatic filename or document-reference resolution from free-form user text (P1 requires explicit `attachment_ids` resolved by the UI)
 - URL content extraction
 - Admin configuration UI for AI policies, model selection, or provider settings (P1 uses deployment configuration; see DESIGN.md Section 2.2 constraints and emergency flags)
 - Additional quota periods beyond the P1 set (4-hourly rolling windows, weekly periods, 12h rolling windows)
@@ -172,9 +171,9 @@ The system MUST deliver AI responses as a real-time SSE stream. The user sends a
 
 **Error model (Option A)**: If request validation, authorization, or quota preflight fails before any streaming begins, the system MUST return a normal JSON error response with the appropriate HTTP status and MUST NOT open an SSE stream. If a failure occurs after streaming has started, the system MUST terminate the stream with a terminal `event: error`.
 
-The request body MAY include a client-generated `request_id` used as an idempotency key (if omitted, the server MUST generate a UUID v4); MAY include `attachment_ids` for attachments (documents or images) explicitly associated with the current message; MAY include `rag_attachment_ids` for document-only retrieval scope restriction (see `cpt-cf-mini-chat-fr-file-search`); and MAY include `web_search` to explicitly enable web search for the turn (see `cpt-cf-mini-chat-fr-web-search`). In every Message response DTO, `request_id` is always present and non-null (a required UUID). Within a normal turn, the user message and assistant response share the same `request_id` (the turn correlation key). System/background messages (e.g. `doc_summary`) carry an independently server-generated UUID v4. P1 enforces **at most one running turn per chat**: if any turn in the chat is currently `running`, the system MUST reject the new request with `409 Conflict`, regardless of the `request_id` value. Additionally, if a `chat_turns` record with `state=running` exists for the same `(chat_id, request_id)`, the system MUST reject with `409 Conflict`. If a completed generation exists for the same `(chat_id, request_id)`, the system MUST replay the completed assistant response rather than starting a new provider request. Replay MUST be side-effect-free: no new quota reserve, no quota settlement, no billing/outbox event emission.
+The request body MAY include a client-generated `request_id` used as an idempotency key (if omitted, the server MUST generate a UUID v4); MAY include `attachment_ids` for attachments (documents or images) explicitly associated with the current message; and MAY include `web_search` to explicitly enable web search for the turn (see `cpt-cf-mini-chat-fr-web-search`). In every Message response DTO, `request_id` is always present and non-null (a required UUID). Within a normal turn, the user message and assistant response share the same `request_id` (the turn correlation key). System/background messages (e.g. `doc_summary`) carry an independently server-generated UUID v4. P1 enforces **at most one running turn per chat**: if any turn in the chat is currently `running`, the system MUST reject the new request with `409 Conflict`, regardless of the `request_id` value. Additionally, if a `chat_turns` record with `state=running` exists for the same `(chat_id, request_id)`, the system MUST reject with `409 Conflict`. If a completed generation exists for the same `(chat_id, request_id)`, the system MUST replay the completed assistant response rather than starting a new provider request. Replay MUST be side-effect-free: no new quota reserve, no quota settlement, no billing/outbox event emission.
 
-Clients must not auto-retry with the same `request_id` after disconnect; recovery is via the Turn Status API (`GET /v1/chats/{chat_id}/turns/{request_id}`). A new `request_id` MUST be generated for every new user-initiated retry.
+Clients must not auto-retry with the same `request_id` after disconnect; recovery is via the Turn Status API (`GET /v1/chats/{chat_id}/turns/{request_id}`). Retry and edit operations both create a new turn and therefore require a new `request_id`. A completed `(chat_id, request_id)` pair is replay-only — reusing it will return the previously generated result instead of starting a new generation.
 
 **Rationale**: Streaming provides perceived low latency and matches user expectations from consumer AI chat products.
 **Actors**: `cpt-cf-mini-chat-actor-chat-user`
@@ -185,7 +184,7 @@ Clients must not auto-retry with the same `request_id` after disconnect; recover
 
 The system MUST persist all user and assistant messages. Conversation history access MUST be limited to the owning user within their tenant. On each new user message, the system MUST include relevant conversation history in the LLM context to maintain conversational coherence.
 
-The system MUST expose conversation history via `GET /v1/chats/{id}/messages` with cursor-based pagination (Page + PageInfo pattern) and OData v4 query support (`$orderby`, `$filter`, `$select`). Each message MUST include: a required `request_id` (UUID, always present and non-null — within a normal turn, user and assistant messages share the same value; system/background messages use an independently server-generated UUID v4) and a required `attachments` field (always-present array of associated attachment summaries, empty array when none). The `attachments` array MUST be derived only from `message_attachments` (populated from `attachment_ids` at send time); retrieval-only references via `rag_attachment_ids` MUST NOT appear in this array. Attachment details are not embedded; the UI fetches them individually via `GET /v1/chats/{id}/attachments/{attachment_id}` if needed.
+The system MUST expose conversation history via `GET /v1/chats/{id}/messages` with cursor-based pagination (Page + PageInfo pattern) and OData v4 query support (`$orderby`, `$filter`, `$select`). Each message MUST include: a required `request_id` (UUID, always present and non-null — within a normal turn, user and assistant messages share the same value; system/background messages use an independently server-generated UUID v4) and a required `attachments` field (always-present array of associated attachment summaries, empty array when none). The `attachments` array MUST be derived only from `message_attachments` (populated from `attachment_ids` at send time). Attachment details are not embedded; the UI fetches them individually via `GET /v1/chats/{id}/attachments/{attachment_id}` if needed.
 
 **Rationale**: Multi-turn conversations require the AI to remember prior context within the same chat. Cursor pagination ensures efficient history loading for long conversations.
 **Actors**: `cpt-cf-mini-chat-actor-chat-user`
@@ -235,15 +234,17 @@ The system MUST allow users to upload image files (PNG, JPEG/JPG, WebP) to a cha
 **Rationale**: Users need to share visual content (screenshots, diagrams, photos) with the AI assistant and ask questions about what they see.
 **Actors**: `cpt-cf-mini-chat-actor-chat-user`
 
-All `attachment_ids` and `rag_attachment_ids` submitted with a message are strictly scoped to `(tenant_id, user_id, chat_id)` and validated before LLM invocation. Every entry in `rag_attachment_ids` MUST reference an attachment with `attachment_kind=document`. Each array MUST contain unique attachment IDs; duplicate IDs within `attachment_ids` or within `rag_attachment_ids` MUST be rejected with HTTP 400 before quota reserve and before any provider call. No attachment validation may rely on provider-side failure; all checks MUST complete before any quota reserve or provider request is issued. `rag_attachment_ids` MUST NOT create `message_attachments` rows and MUST NOT appear in the message `attachments` array in API responses.
+All `attachment_ids` submitted with a message are strictly scoped to `(tenant_id, user_id, chat_id)` and validated before LLM invocation. Each array MUST contain unique attachment IDs; duplicate IDs within `attachment_ids` MUST be rejected with HTTP 400 before quota reserve and before any provider call. No attachment validation may rely on provider-side failure; all checks MUST complete before any quota reserve or provider request is issued.
 
 #### Document Question Answering (File Search)
 
 - [ ] `p1` - **ID**: `cpt-cf-mini-chat-fr-file-search`
 
-The system MUST support answering questions about uploaded documents by retrieving relevant excerpts during chat. On each turn, retrieval MUST be scoped to the current chat's dedicated vector store. The system MUST NOT inject full file contents into the prompt; only top-k retrieved chunks are included. File search MUST be scoped to the user's tenant. Retrieved excerpts and citations MUST be returned only to the owning user within their tenant. The system MUST enforce a configurable per-message file search call limit (default: 2 retrieval calls per message).
+The system MUST support answering questions about uploaded documents by retrieving relevant excerpts during chat. In P1, retrieval always covers all documents currently present in the chat vector store — `attachment_ids` does not scope or filter retrieval. The system MUST NOT inject full file contents into the prompt; only top-k retrieved chunks are included. File search MUST be scoped to the user's tenant. Retrieved excerpts and citations MUST be returned only to the owning user within their tenant. The system MUST enforce a configurable per-turn file search call limit (default: 2 retrieval calls per turn).
 
-The public API MUST distinguish between attachments explicitly attached to a message (`attachment_ids`) and attachments used only to constrain file-search scope for the current turn (`rag_attachment_ids`). Retrieval scope MUST follow this deterministic precedence: (1) if `rag_attachment_ids` is non-empty, file search MUST be restricted to those document attachments; (2) else, if document attachments are present in `attachment_ids`, those documents MUST define the retrieval scope; (3) else, retrieval scope defaults to all ready document attachments in the chat. The backend MAY include the provider `file_search` tool only when the chat has at least one ready document attachment. The backend MUST resolve the provider vector store internally from `(tenant_id, chat_id)` and MUST NOT require or accept provider vector store identifiers from clients. Provider-side retrieval filtering MUST be based on stable internal attachment identity (`attachment_id`), not on filename text. The same attachment ID MUST NOT appear in both `attachment_ids` and `rag_attachment_ids`; such requests MUST be rejected before any provider call. Omitted and empty `rag_attachment_ids` are semantically equivalent.
+The backend MUST NOT include the `file_search` tool before the first document attachment reaches `ready` status in the chat (no vector store exists). Once document attachments exist, the backend includes `file_search` on every model request with the chat vector store ID attached via `tool_resources`, without metadata filtering (P1). The backend MUST resolve the provider vector store internally from `(tenant_id, chat_id)` and MUST NOT require or accept provider vector store identifiers from clients. Attachment-scoped retrieval (narrowing to documents referenced in `attachment_ids`) is deferred to P2.
+
+When users upload files to a chat, those files become part of the chat's knowledge base. The assistant may reference any uploaded file during future responses. Deleting a file removes it from the assistant's knowledge.
 
 In P1, the backend MUST NOT attempt filename or document-reference resolution from free-form user text. Fuzzy filename matching, multilingual entity resolution, and hidden helper LLM calls to infer intended files from message text are explicitly out of scope for P1.
 
@@ -256,7 +257,7 @@ In P1, the backend MUST NOT attempt filename or document-reference resolution fr
 
 The system MUST support web search as an LLM tool, explicitly enabled per request via an API parameter (`web_search.enabled`). When enabled, the backend includes the `web_search` tool in the provider request (Azure Foundry API tooling). The provider decides whether to invoke the tool based on the query; explicit enablement means "tool is available and allowed", not "force a call every time". Web search MUST be disabled by default (safe default for backward compatibility).
 
-**Rate limits**: The system MUST enforce configurable per-message web search call limits (default: 2 calls per message) and per-user daily web search quota (default: 75 calls per day), tracked in `quota_usage.web_search_calls`. When the daily web search quota is exhausted, the system MUST reject with `quota_exceeded` and `quota_scope = "web_search"` at preflight (before any provider call). This is part of cost control / quotas and MUST NOT be reported as `quota_scope = "tokens"`.
+**Rate limits**: The system MUST enforce configurable per-turn web search call limits (default: 2 calls per turn) and per-user daily web search quota (default: 75 calls per day), tracked in `quota_usage.web_search_calls`. When the daily web search quota is exhausted, the system MUST reject with `quota_exceeded` and `quota_scope = "web_search"` at preflight (before any provider call). This is part of cost control / quotas and MUST NOT be reported as `quota_scope = "tokens"`.
 
 **Kill switch**: A global `disable_web_search` flag MUST allow operators to disable web search at runtime. When the kill switch is active and a request includes `web_search.enabled=true`, the system MUST reject with HTTP 400 and error code `web_search_disabled` before opening an SSE stream. The system MUST NOT silently ignore the parameter.
 
@@ -295,6 +296,24 @@ The system MUST reject upload requests that would exceed any per-chat limit with
 **Rationale**: Prevents RAG retrieval degradation from overly large document sets and bounds vector store size per chat.
 **Actors**: `cpt-cf-mini-chat-actor-chat-user`
 
+#### Attachment Deletion
+
+- [ ] `p1` - **ID**: `cpt-cf-mini-chat-fr-attachment-deletion`
+
+The system MUST allow users to delete individual attachments from a chat via `DELETE /v1/chats/{id}/attachments/{attachment_id}`. Deleting an attachment MUST:
+
+1. Soft-delete the attachment record locally and immediately exclude it from future retrieval and active chat metadata.
+2. Return `204 No Content` after the local transaction commits.
+3. Perform provider-side cleanup asynchronously — file deletion via the provider Files API and document removal from the chat vector store are executed via transactional outbox workers and MUST NOT block the API response.
+4. Re-deleting an already soft-deleted attachment is idempotent and returns `204 No Content`.
+
+Historical messages that reference deleted attachments MUST NOT be modified. Messages may still reference deleted attachments in their `attachments` array, but the file will no longer be available for retrieval or download.
+
+**Attachment Removal Rules**: Users may remove attachments while composing a message. After a message is sent, its attachment references become immutable. An attachment cannot be deleted if it is referenced by any submitted message. An attachment that is not referenced by any submitted message may still be deleted.
+
+**Rationale**: Users need the ability to remove documents from a chat's knowledge base without deleting the entire chat.
+**Actors**: `cpt-cf-mini-chat-actor-chat-user`
+
 ### 5.3 Conversation Management
 
 #### Thread Summary Compression
@@ -327,8 +346,8 @@ P1 supports retry, edit, and delete for the **last turn only**. Full message his
 
 **Supported actions (P1)**:
 
-- **Retry last turn**: Re-submit the last user message to generate a new assistant response. Original attachment associations from `attachment_ids` (images and documents) are preserved — copied to the new user message via `message_attachments`. `rag_attachment_ids` are NOT preserved (they are ephemeral per-turn); retrieval scope for the retried turn follows the normal precedence rule based on the copied `message_attachments`. The previous turn is soft-deleted and a new turn is created with a fresh assistant response.
-- **Edit last user turn**: Replace the content of the last user message and regenerate the assistant response. Original attachment associations from `attachment_ids` (images and documents) are preserved — copied to the new user message via `message_attachments`. `rag_attachment_ids` are NOT preserved (they are ephemeral per-turn); retrieval scope for the edited turn follows the normal precedence rule based on the copied `message_attachments`. The previous turn is soft-deleted and a new turn is created with the updated content.
+- **Retry last turn**: Re-submit the last user message to generate a new assistant response. Original attachment associations from `attachment_ids` (images and documents) are preserved — copied to the new user message via `message_attachments` (deleted attachments are silently excluded). Retrieval operates over the entire chat vector store (P1). The previous turn is soft-deleted and a new turn is created with a fresh assistant response.
+- **Edit last user turn**: Replace the content of the last user message and regenerate the assistant response. Original attachment associations from `attachment_ids` (images and documents) are preserved — copied to the new user message via `message_attachments` (deleted attachments are silently excluded). Retrieval operates over the entire chat vector store (P1). The previous turn is soft-deleted and a new turn is created with the updated content.
 - **Delete last turn**: Remove the most recent turn (user message + assistant response) from the active conversation. The turn is soft-deleted.
 
 **Functional constraints**:
@@ -385,7 +404,7 @@ If quota preflight rejects a send-message request, the system MUST return a norm
 **Image-specific quota limits** (configurable per deployment):
 
 - Maximum image inputs per message: default 4.
-- Maximum image inputs per user per day: default 50.
+- Maximum image inputs per user per day: default 50. **Whole-request rejection policy**: if the number of images in the request would cause the daily quota to be exceeded (e.g., remaining daily quota is 2 but request contains 4 images), the entire request MUST be rejected with `quota_exceeded` (`quota_scope = "image_inputs"`) before any provider call. No partial acceptance of images within a single request.
 - Optional: maximum total image bytes per message (default: uncapped; operator may configure).
 - Token accounting: `usage.input_tokens` / `usage.output_tokens` from the provider already includes image token costs as the provider defines them. The system enforces these via the same preflight/commit mechanism. Additionally, the system MUST track and enforce explicit image counters (`image_inputs` per day, `image_upload_bytes` per day/month, counted on upload) independent of token quotas to prevent abuse via large or frequent image uploads.
 
@@ -554,7 +573,7 @@ Authorization MUST follow the platform PDP/PEP model, including query-level cons
 
 - [ ] `p1` - **ID**: `cpt-cf-mini-chat-nfr-cost-control`
 
-Per-user LLM costs MUST be bounded by configurable token-based rate limits across multiple periods (daily, monthly), tracked in real-time. Premium models have stricter limits; standard-tier models have separate, higher limits. File search and web search costs MUST be bounded by per-message and per-day call limits. The system MUST track actual costs with tenant aggregation and per-user attribution for quota enforcement. Administrator visibility is limited to aggregated usage and operational metrics.
+Per-user LLM costs MUST be bounded by configurable token-based rate limits across multiple periods (daily, monthly), tracked in real-time. Premium models have stricter limits; standard-tier models have separate, higher limits. File search and web search costs MUST be bounded by per-turn and per-day call limits. The system MUST track actual costs with tenant aggregation and per-user attribution for quota enforcement. Administrator visibility is limited to aggregated usage and operational metrics.
 
 **Threshold**: No user exceeds configured quota; estimated cost available for 100% of requests
 **Rationale**: Unbounded LLM usage can generate unexpected costs; tenants need cost predictability.
@@ -739,7 +758,7 @@ After a disconnect, the client MUST call `GET /v1/chats/{chat_id}/turns/{request
 | `running` | Wait and poll again, or inform the user that generation is still in progress |
 | `failed` or `cancelled` | Resend with a **new** `request_id` |
 
-The client MUST NOT automatically resend `POST /messages:stream` with the same `request_id` after a disconnect. A new `request_id` MUST be generated for every retry.
+The client MUST NOT automatically resend `POST /messages:stream` with the same `request_id` after a disconnect. Retry and edit operations both create a new turn and MUST use a new server-generated `request_id`. Reusing a previously completed `request_id` will result in replay of the existing result.
 
 #### Orphan turn handling
 
@@ -815,7 +834,8 @@ Support and UX recovery flows MUST be able to query authoritative turn state bac
 | `chat_not_found` | 404 | Chat does not exist or not accessible under current authorization constraints |
 | `generation_in_progress` | 409 | A generation is already running for this chat (one running turn per chat policy) |
 | `request_id_conflict` | 409 | The same `(chat_id, request_id)` is already in a non-replayable state (`running`, `failed`, or `cancelled`) |
-| `quota_exceeded` | 429 | Quota exhaustion. Always accompanied by `quota_scope`: `"tokens"` (token rate limits across all tiers exhausted, emergency flags, or all models disabled), `"uploads"` (daily upload quota exceeded), or `"web_search"` (per-user daily web search call quota exhausted) |
+| `not_latest_turn` | 409 | Target `request_id` is not the most recent non-deleted turn; retry/edit/delete mutations apply only to the latest turn |
+| `quota_exceeded` | 429 | Quota exhaustion. Always accompanied by `quota_scope`: `"tokens"` (token rate limits across all tiers exhausted, emergency flags, or all models disabled), `"uploads"` (daily upload quota exceeded), `"web_search"` (per-user daily web search call quota exhausted), or `"image_inputs"` (per-turn or per-day image input limit exceeded) |
 | `rate_limited` | 429 | Provider upstream throttling (provider 429 after OAGW retry exhaustion) |
 | `file_too_large` | 413 | Uploaded file exceeds size limit |
 | `unsupported_file_type` | 415 | File type not supported for upload |
@@ -890,16 +910,15 @@ Provider identifiers (`provider_file_id`, `provider_response_id`, `vector_store_
 - At least one document is attached to the chat and has `ready` status
 
 **Main Flow**:
-1. User sends a message that references document content. The UI MAY include `rag_attachment_ids` (resolved to chat-local document `attachment_id` values via a UI file picker) to explicitly restrict retrieval scope.
-2. System determines retrieval scope using the deterministic precedence rule: if `rag_attachment_ids` is non-empty, restrict to those documents; else if `attachment_ids` includes documents, those documents define the retrieval scope; else scope defaults to all ready documents in the chat vector store.
-3. System retrieves relevant excerpts from the scoped document set within the chat's vector store
+1. User sends a message that references document content.
+2. System searches across all documents currently present in the chat vector store.
+3. System retrieves relevant excerpts from the chat's vector store
 4. System includes excerpts in the LLM context alongside conversation history
 5. System streams AI response grounded in document content
 
 **Postconditions**:
-- Response incorporates information from uploaded documents (scoped by `rag_attachment_ids` if provided)
+- Response incorporates information from uploaded documents in the chat knowledge base
 - File search call counted against user quota
-- `rag_attachment_ids` does not create `message_attachments` rows; the message `attachments` array reflects only `attachment_ids`
 
 **Alternative Flows**:
 - **File search limit reached**: System proceeds without retrieval; response based on conversation context and document summaries only
@@ -1098,14 +1117,21 @@ Provider identifiers (`provider_file_id`, `provider_response_id`, `vector_store_
 - [ ] User can like or dislike an assistant message; reaction is persisted and retrievable via API; changing reaction replaces the previous one; removing reaction deletes it
 - [ ] Deleted chat resources are removed from the external provider (best-effort target: within 1 hour under normal conditions; eventual with retry/backoff; not a guaranteed SLA)
 - [ ] Every completed chat turn emits a structured audit event to platform `audit_service` (one event per completed turn) including usage metrics
-- [ ] Long conversations (50+ turns) remain functional via thread summary compression
+- [ ] Long conversations (50+ turns) remain functional via thread summary compression; compression triggers when message count exceeds 20, token count exceeds budget, or every 15 user turns (see DESIGN.md `cpt-cf-mini-chat-seq-thread-summary` for threshold details)
 - [ ] User can retry, edit, or delete the last turn; operations on non-latest turns are rejected with `409 Conflict`
 - [ ] User can upload an image attachment (PNG/JPEG/WebP) and ask "what is in this image" and receive a relevant answer
 - [ ] Image attachments do not appear in file_search citations
-- [ ] Quota limits for images are enforced: per-message image input limit and per-day image input limit reject requests that exceed configured caps
+- [ ] Quota limits for images are enforced: per-turn image input limit and per-day image input limit reject requests that exceed configured caps
 - [ ] Audit events for turns with image input do not include raw image bytes; only attachment metadata (attachment_id, content_type, size_bytes, filename) is included
 - [ ] Submitting an image to a model that does not support multimodal input returns `unsupported_media` error (HTTP 415) — defensive check; not expected under the P1 catalog invariant (all enabled models include `VISION_INPUT`)
 - [ ] If a future catalog introduces a non-vision model, the downgrade cascade selecting that model for an image-bearing turn MUST reject with `unsupported_media` (HTTP 415) before any outbound provider call; images are never silently dropped. Under the P1 catalog invariant this path is unreachable.
+- [ ] User can delete an attachment via `DELETE /v1/chats/{id}/attachments/{attachment_id}`; after deletion the attachment is immediately excluded from future `file_search` retrieval on subsequent turns
+- [ ] Deleting an attachment does not modify historical messages that reference it; the `attachments` array on past messages still includes the deleted attachment's metadata
+- [ ] Re-deleting an already-deleted attachment is idempotent (returns 204 No Content)
+- [ ] Given a message that has not yet been sent, when the user removes an attachment from the draft, then the attachment is removed successfully
+- [ ] Given an attachment that is not referenced by any submitted message, when the user calls `DELETE /v1/chats/{id}/attachments/{attachment_id}`, then the attachment is deleted successfully and the API returns 204 No Content
+- [ ] Given an attachment that is referenced by a submitted message, when the user calls `DELETE /v1/chats/{id}/attachments/{attachment_id}`, then the API returns HTTP 409 Conflict with error code `attachment_locked`
+- [ ] Provider-side cleanup (file deletion, vector store removal) is performed asynchronously via transactional outbox; partial provider failure does not block the API response or leave the attachment visible to retrieval
 - [ ] File search retrieval only considers documents attached to the current chat (each chat has its own dedicated vector store; no cross-chat leakage by design)
 - [ ] Full file text is not injected into the prompt; only top-k retrieved chunks are included
 - [ ] Per-chat document count and total file size limits are enforced; uploads exceeding limits are rejected
@@ -1167,12 +1193,12 @@ These defaults are used for P1 planning and MUST be configurable per tenant/oper
 - Downgrade cascade: premium → standard; when all tiers exhausted → reject with `quota_exceeded`
 - Default premium-tier token rate limits: daily `50_000`, monthly `1_000_000`
 - Default standard-tier token rate limits: daily `200_000`, monthly `5_000_000` (configurable per deployment)
-- Web search per-message call limit: 2 (deployment config: `web_search.max_calls_per_message: 2`)
+- Web search per-turn call limit: 2 (deployment config: `web_search.max_calls_per_turn: 2`)
 - Web search per-user daily quota: 75 (deployment config: `web_search.daily_quota: 75`)
 - Web search provider parameters: **Deferred to P2+**. P1 uses provider defaults. When implemented, configurable via `web_search.provider_parameters` (search_depth, max_results, include_answer, include_raw_content, include_images, auto_parameters).
 - Upload size limit: 16 MiB (deployment config example: `uploaded_file_max_size_kb: 16384`); PM target: 25 MiB (configurable)
 - Image upload size limit: same as above unless overridden (deployment config example: `uploaded_image_max_size_kb: 16384`)
-- Max image inputs per message: 4 (deployment config example: `max_images_per_message: 4`)
+- Max image inputs per message: 1 (deployment config example: `max_images_per_message: 1`)
 - Max image inputs per user per day: 50 (deployment config example: `max_images_per_user_daily: 50`)
 - Temporary chat retention window: 24 hours (P2; deployment config example: `temporary_chat_retention_hours: 24`)
 

--- a/modules/mini-chat/docs/openapi.json
+++ b/modules/mini-chat/docs/openapi.json
@@ -88,6 +88,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           }
@@ -116,6 +119,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -154,6 +160,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
@@ -170,6 +179,9 @@
         "responses": {
           "204": {
             "description": "Chat deleted. Cleanup of external resources is asynchronous."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -227,6 +239,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
@@ -246,7 +261,7 @@
         "operationId": "sendMessage",
         "tags": ["messages"],
         "summary": "Send message and receive streamed AI response",
-        "description": "Sends a user message and opens an SSE stream for the assistant response. If `request_id` matches an active generation, returns 409 Conflict (JSON, no SSE). If `request_id` matches a completed generation, replays the response as SSE (side-effect-free: no new quota reserve, no billing events).\n\nThe optional `web_search` parameter enables web search for this turn (disabled by default, backward compatible).\n\n**Attachment fields**: `attachment_ids` identifies attachments explicitly attached to this message (persisted into `message_attachments`, returned in message `attachments[]`; images included in multimodal input; documents define retrieval scope per the deterministic precedence rule when `rag_attachment_ids` is empty). `rag_attachment_ids` identifies document-only retrieval scope restriction for this turn (NOT persisted into `message_attachments`, NOT returned in message `attachments[]`; every entry MUST be `attachment_kind=document`). The same attachment ID MUST NOT appear in both arrays (rejected with 400). Omitted and empty `rag_attachment_ids` are semantically equivalent.\n\n**SSE event ordering (P1)**: `ping* delta* tool* citations? (done | error)`. `delta` and `tool` may interleave; at most one `citations` event, emitted after all `delta` events and before the terminal event.\n\nExactly one terminal event (`done` or `error`) ends the stream.\n\n**SSE event types and payloads**:\n- `event: ping` — keepalive, payload: `{}`. Clients MUST ignore.\n- `event: delta` — incremental text. Payload: `SseDeltaEvent`.\n- `event: tool` — tool activity (file_search, web_search at P1). Payload: `SseToolEvent`.\n- `event: citations` — source references (file and web). Payload: `SseCitationsEvent`.\n- `event: done` — terminal success with usage and quota_decision. Emitted for both full completions and truncated-but-successful completions (provider `response.incomplete`). Payload: `SseDoneEvent`.\n- `event: error` — terminal failure. Payload: `SseErrorEvent`.\n\nSee component schemas for payload definitions.\n\n**Pre-stream errors**: If validation, authorization, or quota preflight fails before streaming, a JSON error response with the appropriate HTTP status is returned and no SSE stream is opened.\n\n**Cancellation**: If the client disconnects mid-stream, the server cancels the in-flight provider request and applies a bounded best-effort debit for quota. No SSE error event is emitted (the stream is already broken). The Turn Status API is authoritative for final state after disconnect.",
+        "description": "Sends a user message and opens an SSE stream for the assistant response. If `request_id` matches an active generation, returns 409 Conflict (JSON, no SSE). If `request_id` matches a completed generation, replays the response as SSE (side-effect-free: no new quota reserve, no billing events).\n\nThe optional `web_search` parameter enables web search for this turn (disabled by default, backward compatible).\n\n**Attachment fields**: `attachment_ids` identifies attachments explicitly attached to this message (persisted into `message_attachments`, returned in message `attachments[]`; images included in multimodal input for the current turn). In P1, retrieval always covers all documents in the chat vector store — `attachment_ids` does not scope or filter retrieval. `file_search` is only included when the chat has at least one ready document attachment.\n\n**SSE event ordering (P1)**: `ping* (delta | tool)* citations? (done | error)`. `delta` and `tool` may interleave; at most one `citations` event, emitted after all `delta` events and before the terminal event.\n\nExactly one terminal event (`done` or `error`) ends the stream.\n\n**SSE event types and payloads**:\n- `event: ping` — keepalive, payload: `{}`. Clients MUST ignore.\n- `event: delta` — incremental text. Payload: `SseDeltaEvent`.\n- `event: tool` — tool activity (file_search, web_search at P1). Payload: `SseToolEvent`.\n- `event: citations` — source references (file and web). Payload: `SseCitationsEvent`.\n- `event: done` — terminal success with usage and quota_decision. Emitted for both full completions and truncated-but-successful completions (provider `response.incomplete`). Payload: `SseDoneEvent`.\n- `event: error` — terminal failure. Payload: `SseErrorEvent`.\n\nSee component schemas for payload definitions.\n\n**Pre-stream errors**: If validation, authorization, or quota preflight fails before streaming, a JSON error response with the appropriate HTTP status is returned and no SSE stream is opened.\n\n**Cancellation**: If the client disconnects mid-stream, the server cancels the in-flight provider request and applies a bounded best-effort debit for quota. No SSE error event is emitted (the stream is already broken). The Turn Status API is authoritative for final state after disconnect.",
         "requestBody": {
           "required": true,
           "content": {
@@ -255,16 +270,15 @@
                 "$ref": "#/components/schemas/SendMessageRequest"
               },
               "examples": {
-                "document_scoped_retrieval": {
-                  "summary": "Retrieval scoped to specific documents via rag_attachment_ids",
+                "document_question": {
+                  "summary": "Question answered via chat-scoped document retrieval",
                   "value": {
                     "content": "What does the document say about Q3 revenue?",
-                    "request_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-                    "rag_attachment_ids": ["c3d4e5f6-7890-4abc-def1-234567890abc"]
+                    "request_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
                   }
                 },
                 "image_with_document_attachment": {
-                  "summary": "Image in multimodal input + document attached to message (retrieval scoped to attached document)",
+                  "summary": "Image in multimodal input + document attached to message",
                   "value": {
                     "content": "Compare this chart with the annual report highlights.",
                     "request_id": "a1b2c3d4-5678-4def-9012-abcdef345678",
@@ -284,8 +298,14 @@
             "content": {
               "text/event-stream": {
                 "schema": {
-                  "type": "string",
-                  "description": "Server-Sent Events stream. Each event has `event:` type and `data:` JSON payload. See SseDeltaEvent, SseToolEvent, SseCitationsEvent, SseDoneEvent, SseErrorEvent schemas."
+                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering (P1): `ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
+                  "oneOf": [
+                    { "$ref": "#/components/schemas/SseDeltaEvent" },
+                    { "$ref": "#/components/schemas/SseToolEvent" },
+                    { "$ref": "#/components/schemas/SseCitationsEvent" },
+                    { "$ref": "#/components/schemas/SseDoneEvent" },
+                    { "$ref": "#/components/schemas/SseErrorEvent" }
+                  ]
                 }
               }
             },
@@ -313,6 +333,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -351,11 +374,14 @@
             }
           },
           "429": {
-            "description": "Quota or rate limit exceeded. Code: `quota_exceeded` (with `quota_scope`: `tokens` or `web_search`) for user quota exhaustion (always pre-stream), or `rate_limited` for upstream provider throttling after OAGW retry exhaustion. `rate_limited` may also appear as a terminal SSE `event: error` if the provider returns 429 mid-stream (HTTP status remains 200 in that case). Clients MUST use the `code` field to distinguish the two.",
+            "description": "Quota or rate limit exceeded. Code: `quota_exceeded` (with mandatory `quota_scope`: `tokens`, `web_search`, or `image_inputs`) for user quota exhaustion (always pre-stream), or `rate_limited` for upstream provider throttling after OAGW retry exhaustion. `rate_limited` may also appear as a terminal SSE `event: error` if the provider returns 429 mid-stream (HTTP status remains 200 in that case). Clients MUST use the `code` field to distinguish the two.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "oneOf": [
+                    { "$ref": "#/components/schemas/QuotaExceededError" },
+                    { "$ref": "#/components/schemas/GenericError" }
+                  ]
                 }
               }
             }
@@ -433,6 +459,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -573,6 +602,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
@@ -646,11 +678,44 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteAttachment",
+        "tags": ["attachments"],
+        "summary": "Delete an attachment from the chat",
+        "description": "Deletes an attachment if it is not referenced by any submitted message. If the attachment is referenced by a submitted message, the operation is rejected with 409 Conflict (attachment_locked). For eligible attachments, the attachment is soft-deleted locally and immediately removed from future retrieval and chat metadata. Provider-side file deletion and vector-store cleanup are performed asynchronously via background workers and are not required to complete before the API returns 204 No Content. Re-deleting an already-deleted attachment is idempotent and returns 204.",
+        "responses": {
+          "204": {
+            "description": "Attachment deleted successfully. No content returned."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "description": "Attachment cannot be deleted because it is referenced by a submitted message. Code: `attachment_locked`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -687,6 +752,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
@@ -699,7 +767,7 @@
         "operationId": "editTurn",
         "tags": ["turns"],
         "summary": "Edit the last user turn and regenerate response",
-        "description": "Replaces the content of the last user message and generates a new assistant response via SSE. The previous turn is soft-deleted with `replaced_by_request_id` set. Original attachment associations from `attachment_ids` are preserved (copied to the new user message via `message_attachments`). `rag_attachment_ids` are NOT preserved — they are ephemeral per-turn and the edit endpoint does not accept them. Retrieval scope for the edited turn follows the normal deterministic precedence rule: if the copied `message_attachments` include documents, those documents define retrieval scope; otherwise scope defaults to all ready documents in the chat. Only the most recent non-deleted turn in a terminal state may be edited.",
+        "description": "Replaces the content of the last user message and generates a new assistant response via SSE. The previous turn is soft-deleted with `replaced_by_request_id` set. The server generates a new `request_id` for the new turn; the old `request_id` becomes replay-only (a completed `request_id` always returns the previously stored result). Original attachment associations from `attachment_ids` are preserved (copied to the new user message via `message_attachments`). Retrieval for the edited turn operates over the entire chat vector store (P1). Only the most recent non-deleted turn in a terminal state may be edited.",
         "requestBody": {
           "required": true,
           "content": {
@@ -719,8 +787,14 @@
             "content": {
               "text/event-stream": {
                 "schema": {
-                  "type": "string",
-                  "description": "Server-Sent Events stream. See sendMessage operation for event types."
+                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering (P1): `ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
+                  "oneOf": [
+                    { "$ref": "#/components/schemas/SseDeltaEvent" },
+                    { "$ref": "#/components/schemas/SseToolEvent" },
+                    { "$ref": "#/components/schemas/SseCitationsEvent" },
+                    { "$ref": "#/components/schemas/SseDoneEvent" },
+                    { "$ref": "#/components/schemas/SseErrorEvent" }
+                  ]
                 }
               }
             }
@@ -735,6 +809,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
@@ -742,7 +819,7 @@
             "$ref": "#/components/responses/NotFound"
           },
           "409": {
-            "description": "Target is not the most recent turn. Code: `not_latest_turn`.",
+            "description": "Conflict. Codes: `not_latest_turn` (target request_id is not the most recent turn) or `generation_in_progress` (another turn is already running for this chat, including concurrent edit race).",
             "content": {
               "application/json": {
                 "schema": {
@@ -752,11 +829,14 @@
             }
           },
           "429": {
-            "description": "Quota or rate limit exceeded for regeneration. Code: `quota_exceeded` (`quota_scope`: `tokens`) for user quota exhaustion (always pre-stream), or `rate_limited` for upstream provider throttling. `rate_limited` may also appear as a terminal SSE `event: error` mid-stream (HTTP 200). Same semantics as sendMessage.",
+            "description": "Quota or rate limit exceeded for regeneration. Code: `quota_exceeded` (with mandatory `quota_scope`: `tokens` or `image_inputs`) for user quota exhaustion (always pre-stream), or `rate_limited` for upstream provider throttling. `rate_limited` may also appear as a terminal SSE `event: error` mid-stream (HTTP 200). Same semantics as sendMessage.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "oneOf": [
+                    { "$ref": "#/components/schemas/QuotaExceededError" },
+                    { "$ref": "#/components/schemas/GenericError" }
+                  ]
                 }
               }
             }
@@ -822,6 +902,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
@@ -829,7 +912,7 @@
             "$ref": "#/components/responses/NotFound"
           },
           "409": {
-            "description": "Target is not the most recent turn. Code: `not_latest_turn`.",
+            "description": "Conflict. Codes: `not_latest_turn` (target request_id is not the most recent turn) or `generation_in_progress` (another turn is already running for this chat).",
             "content": {
               "application/json": {
                 "schema": {
@@ -854,15 +937,25 @@
         "operationId": "retryTurn",
         "tags": ["turns"],
         "summary": "Retry the last turn",
-        "description": "Soft-deletes the previous turn and re-submits the original user message (including any attachment associations from `attachment_ids`, copied to the new user message via `message_attachments`) for a new assistant response via SSE. `rag_attachment_ids` are NOT preserved — they are ephemeral per-turn and the retry endpoint does not accept them. Retrieval scope for the retried turn follows the normal deterministic precedence rule: if the copied `message_attachments` include documents, those documents define retrieval scope; otherwise scope defaults to all ready documents in the chat. Only the most recent non-deleted turn in a terminal state may be retried.",
+        "description": "Soft-deletes the previous turn and re-submits the original user message (including any attachment associations from `attachment_ids`, copied to the new user message via `message_attachments`) for a new assistant response via SSE. The server generates a new `request_id` for the new turn; the old `request_id` becomes replay-only (a completed `request_id` always returns the previously stored result). Retrieval for the retried turn operates over the entire chat vector store (P1). Only the most recent non-deleted turn in a terminal state may be retried. No request body is required; the original user message content and attachment associations are reused automatically.",
+        "requestBody": {
+          "description": "No request body. The server automatically reuses the original user message content and attachment associations.",
+          "required": false
+        },
         "responses": {
           "200": {
             "description": "SSE stream with new assistant response. Same event contract as sendMessage.",
             "content": {
               "text/event-stream": {
                 "schema": {
-                  "type": "string",
-                  "description": "Server-Sent Events stream. See sendMessage operation for event types."
+                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering (P1): `ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
+                  "oneOf": [
+                    { "$ref": "#/components/schemas/SseDeltaEvent" },
+                    { "$ref": "#/components/schemas/SseToolEvent" },
+                    { "$ref": "#/components/schemas/SseCitationsEvent" },
+                    { "$ref": "#/components/schemas/SseDoneEvent" },
+                    { "$ref": "#/components/schemas/SseErrorEvent" }
+                  ]
                 }
               }
             }
@@ -877,6 +970,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
@@ -884,7 +980,7 @@
             "$ref": "#/components/responses/NotFound"
           },
           "409": {
-            "description": "Target is not the most recent turn. Code: `not_latest_turn`.",
+            "description": "Conflict. Codes: `not_latest_turn` (target request_id is not the most recent turn) or `generation_in_progress` (another turn is already running for this chat, including concurrent retry race).",
             "content": {
               "application/json": {
                 "schema": {
@@ -894,11 +990,14 @@
             }
           },
           "429": {
-            "description": "Quota or rate limit exceeded for regeneration. Code: `quota_exceeded` (`quota_scope`: `tokens`) for user quota exhaustion (always pre-stream), or `rate_limited` for upstream provider throttling. `rate_limited` may also appear as a terminal SSE `event: error` mid-stream (HTTP 200). Same semantics as sendMessage.",
+            "description": "Quota or rate limit exceeded for regeneration. Code: `quota_exceeded` (with mandatory `quota_scope`: `tokens` or `image_inputs`) for user quota exhaustion (always pre-stream), or `rate_limited` for upstream provider throttling. `rate_limited` may also appear as a terminal SSE `event: error` mid-stream (HTTP 200). Same semantics as sendMessage.",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
+                  "oneOf": [
+                    { "$ref": "#/components/schemas/QuotaExceededError" },
+                    { "$ref": "#/components/schemas/GenericError" }
+                  ]
                 }
               }
             }
@@ -959,6 +1058,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
@@ -982,6 +1084,9 @@
         "responses": {
           "204": {
             "description": "Reaction removed (or was already absent)."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -1246,7 +1351,9 @@
               "provider_timeout",
               "not_latest_turn",
               "invalid_turn_state",
-              "invalid_reaction_target"
+              "invalid_reaction_target",
+              "attachment_locked",
+              "web_search_calls_exceeded"
             ]
           },
           "message": {
@@ -1258,7 +1365,7 @@
       "QuotaExceededError": {
         "type": "object",
         "required": ["code", "message", "quota_scope"],
-        "description": "Error response for quota exhaustion. The quota_scope field is REQUIRED and distinguishes token quota exhaustion, upload quota exhaustion, and web search quota exhaustion. No provider identifiers in any field.",
+        "description": "Error response for quota exhaustion. The quota_scope field is REQUIRED and distinguishes token quota exhaustion, upload quota exhaustion, web search quota exhaustion, and image input quota exhaustion. No provider identifiers in any field.",
         "properties": {
           "code": {
             "type": "string",
@@ -1270,8 +1377,8 @@
           },
           "quota_scope": {
             "type": "string",
-            "enum": ["tokens", "uploads", "web_search"],
-            "description": "Distinguishes token quota exhaustion (tokens), upload quota exhaustion (uploads), and web search quota exhaustion (web_search). Clients MUST use this field, not message parsing, to determine quota scope."
+            "enum": ["tokens", "uploads", "web_search", "image_inputs"],
+            "description": "Distinguishes token quota exhaustion (tokens), upload quota exhaustion (uploads), web search quota exhaustion (web_search), and image input quota exhaustion (image_inputs). Clients MUST use this field, not message parsing, to determine quota scope."
           }
         }
       },
@@ -1509,7 +1616,7 @@
       "SendMessageRequest": {
         "type": "object",
         "required": ["content"],
-        "description": "Request body for sending a message. Opens an SSE stream on success. `attachment_ids` identifies attachments explicitly attached to this message (persisted, returned in message attachments array). `rag_attachment_ids` identifies document-only retrieval scope restriction (not persisted, not returned in message attachments array).",
+        "description": "Request body for sending a message. Opens an SSE stream on success. `attachment_ids` identifies attachments explicitly attached to this message (persisted, returned in message attachments array). In P1, retrieval always covers all documents in the chat vector store — `attachment_ids` does not scope or filter retrieval.",
         "properties": {
           "content": {
             "type": "string",
@@ -1526,15 +1633,9 @@
               "type": "string",
               "format": "uuid"
             },
-            "description": "Attachment IDs (images or documents) explicitly attached/referenced on the current user message. Persisted into `message_attachments` and returned in the message `attachments` array. Images are turn-local multimodal input only; uploaded images are not implicitly reused on later turns. Documents define retrieval scope per the deterministic precedence rule when `rag_attachment_ids` is empty. IDs MUST be unique within the array; duplicates are rejected with 400. Attachments must belong to this chat, must have status=ready, and are validated before any provider call or quota reserve."
-          },
-          "rag_attachment_ids": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "Document-only attachment IDs that constrain file-search scope for this turn. Retrieval-only: MUST NOT create message_attachments rows, MUST NOT appear in the message attachments array. Every entry MUST reference an attachment with attachment_kind=document (images rejected). IDs MUST be unique within the array; duplicates are rejected with 400. The same attachment ID MUST NOT appear in both `attachment_ids` and `rag_attachment_ids` (rejected with 400 invalid_request). Omitted and empty `rag_attachment_ids` are semantically equivalent. Attachments must belong to this chat, must have status=ready, and are validated before any provider call or quota reserve."
+            "uniqueItems": true,
+            "maxItems": 20,
+            "description": "Attachment IDs (images or documents) explicitly attached/referenced on the current user message. Persisted into `message_attachments` and returned in the message `attachments` array. Images are turn-local multimodal input only; uploaded images are not implicitly reused on later turns. In P1, `attachment_ids` does not scope or filter retrieval — retrieval always covers all documents in the chat vector store. IDs MUST be unique within the array; duplicates are rejected with 400. Attachments must belong to this chat, must have status=ready, and are validated before any provider call or quota reserve. Per-turn image input limit: configurable (default: 4); per-user daily image input limit: configurable (default: 50). Requests exceeding either limit are rejected as a whole."
           },
           "web_search": {
             "$ref": "#/components/schemas/WebSearchOption"
@@ -1544,7 +1645,7 @@
       "EditTurnRequest": {
         "type": "object",
         "required": ["content"],
-        "description": "Request body for editing the last user turn. Original attachment associations from `attachment_ids` are preserved automatically (copied via message_attachments). `rag_attachment_ids` are NOT preserved — they are ephemeral per-turn and the edit endpoint does not accept them. Retrieval scope for the edited turn follows the normal deterministic precedence rule based on the copied `message_attachments`.",
+        "description": "Request body for editing the last user turn. Original attachment associations from `attachment_ids` are preserved automatically (copied via message_attachments). Retrieval for the edited turn operates over the entire chat vector store (P1).",
         "properties": {
           "content": {
             "type": "string",
@@ -1620,7 +1721,7 @@
       "CitationItem": {
         "type": "object",
         "required": ["source", "title", "snippet"],
-        "description": "A single citation reference.",
+        "description": "A single citation reference. When source=\"file\", attachment_id is required. When source=\"web\", url is required.",
         "properties": {
           "source": {
             "type": "string",
@@ -1633,23 +1734,19 @@
           "url": {
             "type": "string",
             "format": "uri",
-            "description": "URL for web sources. Present when source=\"web\"."
+            "description": "URL for web sources. Required when source=\"web\"."
           },
           "attachment_id": {
             "type": "string",
             "format": "uuid",
-            "description": "Internal attachment ID. The only file identifier exposed to clients."
+            "description": "Internal attachment ID. Required when source=\"file\". The only file identifier exposed to clients."
           },
           "span": {
             "type": "object",
             "description": "Reserved for mapping citations to character positions in final assistant text.",
             "properties": {
-              "start": {
-                "type": "integer"
-              },
-              "end": {
-                "type": "integer"
-              }
+              "start": { "type": "integer" },
+              "end": { "type": "integer" }
             }
           },
           "snippet": {
@@ -1662,6 +1759,15 @@
             "maximum": 1,
             "description": "Relevance score."
           }
+        },
+        "if": {
+          "properties": { "source": { "const": "file" } }
+        },
+        "then": {
+          "required": ["attachment_id"]
+        },
+        "else": {
+          "required": ["url"]
         }
       },
       "SseDoneEvent": {
@@ -1698,7 +1804,28 @@
             "type": "string",
             "enum": ["premium_quota_exhausted", "force_standard_tier", "disable_premium_tier", "model_disabled"],
             "description": "Why downgrade occurred. Present only when quota_decision=\"downgrade\". Values: premium_quota_exhausted (user quota exhausted); force_standard_tier (operator kill switch: premium tier forcibly disabled for this tenant); disable_premium_tier (operator kill switch: premium tier globally disabled); model_disabled (operator kill switch: selected model global_enabled=false)."
+          },
+          "completion_signal": {
+            "type": ["object", "null"],
+            "description": "Non-fatal completion signal. Null for normal completion. For truncated responses (provider `response.incomplete`) contains the truncation reason. Not an error indicator — the turn outcome is still `completed`.",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["incomplete"]
+              },
+              "reason": {
+                "type": "string",
+                "description": "Truncation reason from the canonical CompletionSignalReason enum (e.g. \"max_tokens\", \"content_filter\")."
+              }
+            },
+            "required": ["kind"]
           }
+        },
+        "if": {
+          "properties": { "quota_decision": { "const": "downgrade" } }
+        },
+        "then": {
+          "required": ["downgrade_from", "downgrade_reason"]
         }
       },
       "SseUsage": {


### PR DESCRIPTION
… API semantics

- Replace "always full vector store" retrieval with three-state conditional model: no attachments → no file_search; message attaches docs → scoped filter; later turns → unfiltered, LLM decides
- Add DELETE /v1/chats/{id}/attachments/{attachment_id} with transactional outbox (soft-delete + async provider cleanup)
- Add quota_scope "image_inputs" with whole-request rejection policy
- Unify per-message → per-turn terminology across config keys and prose
- Add 401/403 responses to all authenticated OpenAPI endpoints
- Fix SSE schema: remove invalid discriminator, use oneOf union of 5 events
- Add CitationItem and SseDoneEvent conditional schemas (if/then/else)
- Add request_id invariant for retry/edit (new turn = new request_id)
- Add attachment deletion acceptance criteria and retry/edit handling
- Cross-document consistency fixes across DESIGN.md, PRD.md, openapi.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete attachment endpoint added (removes file from future retrieval).
  * Retry endpoint path standardized for retrying last turns.

* **Improvements**
  * Retrieval now uses a chat-wide knowledge base; per-turn attachment scoping removed.
  * Quotas unified to per-turn for web search and image inputs; image inputs limited per turn.
  * SSE events include citation payloads and clearer error/quota signals; authorization responses tightened.

* **Documentation**
  * Updated guidance on attachment lifecycle, retrieval rules, quotas, and retry/edit semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->