### PR TITLE
feat(mini-chat): use S2S client credentials for OAGW upstream provisioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1252,6 +1252,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
+ "cf-authn-resolver-sdk",
  "cf-authz-resolver-sdk",
  "cf-mini-chat-sdk",
  "cf-modkit",
@@ -1270,6 +1271,7 @@ dependencies = [
  "regex",
  "sea-orm",
  "sea-orm-migration",
+ "secrecy",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1626,6 +1628,7 @@ version = "0.5.2"
 dependencies = [
  "humantime",
  "regex",
+ "secrecy",
  "serde",
  "serde_json",
  "temp-env",

--- a/config/e2e-features.txt
+++ b/config/e2e-features.txt
@@ -1,1 +1,1 @@
-users-info-example,mini-chat,static-tenants,static-authz,static-credstore
+users-info-example,mini-chat,static-tenants,static-authn,static-authz,static-credstore

--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -216,6 +216,15 @@ modules:
   authz-resolver:
     config:
       vendor: "hyperspot"
+  
+  static-authn-plugin:
+    config:
+      vendor: "hyperspot"
+      priority: 100
+      mode: accept_all
+      s2s_credentials:
+        - client_id: "mini-chat"
+          client_secret: "mini-chat-dev-secret"
 
   static-authz-plugin:
     config:
@@ -227,6 +236,13 @@ modules:
     database:
       server: "sqlite_users"
       file: "mini_chat.db"
+    config:
+      # S2S credentials for obtaining SecurityContext
+      # that will be used for communication with other modules.
+      client_credentials:
+        client_id: "mini-chat"
+        client_secret: "mini-chat-dev-secret"
+
 
   simple-user-settings:
     # Module-specific database configuration

--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -77,6 +77,9 @@ modules:
       vendor: "hyperspot"
       priority: 100
       mode: accept_all
+      s2s_credentials:
+        - client_id: "mini-chat"
+          client_secret: "mini-chat-dev-secret"
 
   static-authz-plugin:
     config:
@@ -112,6 +115,11 @@ modules:
       server: "sqlite_mini_chat"
       file: "mini_chat.db"
     config:
+      # S2S credentials for obtaining SecurityContext
+      # that will be used for communication with other modules.
+      client_credentials:
+        client_id: "mini-chat"
+        client_secret: "mini-chat-dev-secret"
       # Provider registry. Key = provider_id (matches ModelCatalogEntry.provider_id).
       # `upstream_alias` is optional — defaults to `host` when omitted.
       providers:

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -132,6 +132,9 @@ modules:
       vendor: "hyperspot"
       priority: 100
       mode: accept_all
+      s2s_credentials:
+        - client_id: "mini-chat"
+          client_secret: "mini-chat-dev-secret"
 
   static-authz-plugin:
     config:
@@ -144,6 +147,11 @@ modules:
       server: "sqlite_users"
       file: "mini_chat.db"
     config:
+      # S2S credentials for obtaining SecurityContext
+      # that will be used for communication with other modules.
+      client_credentials:
+        client_id: "mini-chat"
+        client_secret: "mini-chat-dev-secret"
       # Provider registry. Key = provider_id (matches ModelCatalogEntry.provider_id).
       # `upstream_alias` is optional — defaults to `host` when omitted.
       providers:

--- a/libs/modkit-utils/Cargo.toml
+++ b/libs/modkit-utils/Cargo.toml
@@ -23,6 +23,7 @@ humantime-serde = ["dep:humantime", "dep:serde"]
 [dependencies]
 serde = { workspace = true, optional = true }
 humantime = { workspace = true, optional = true }
+secrecy = { workspace = true }
 regex = { workspace = true }
 zeroize = { workspace = true }
 

--- a/libs/modkit-utils/src/var_expand.rs
+++ b/libs/modkit-utils/src/var_expand.rs
@@ -129,6 +129,15 @@ impl<K, V: ExpandVars, S: std::hash::BuildHasher> ExpandVars
     }
 }
 
+impl ExpandVars for secrecy::SecretString {
+    fn expand_vars(&mut self) -> Result<(), ExpandVarsError> {
+        use secrecy::ExposeSecret;
+        let expanded = expand_env_vars(self.expose_secret())?;
+        *self = secrecy::SecretString::from(expanded);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -21,6 +21,9 @@ workspace = true
 # Plugin SDK - policy plugin traits, models, and errors
 mini-chat-sdk = { workspace = true }
 
+# AuthN resolver for S2S client credentials exchange
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.2.7", path = "../../system/authn-resolver/authn-resolver-sdk" }
+
 # AuthZ resolver for authorization (PEP flow)
 authz-resolver-sdk = { workspace = true }
 
@@ -76,6 +79,7 @@ modkit-db-macros = { workspace = true }
 modkit-security = { workspace = true }
 modkit-macros = { workspace = true }
 modkit-odata = { workspace = true, features = ["with-utoipa"] }
+secrecy = { workspace = true }
 
 [dev-dependencies]
 chrono = { workspace = true }

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 
 use crate::infra::llm::ProviderKind;
@@ -22,6 +23,12 @@ pub struct MiniChatConfig {
     pub outbox: OutboxConfig,
     #[serde(default)]
     pub context: ContextConfig,
+    /// `OAuth2` client credentials for OAGW upstream provisioning.
+    /// Mini-chat exchanges these via the `AuthN` resolver to obtain
+    /// a `SecurityContext` for OAGW API calls.
+    #[expand_vars]
+    #[serde(skip_serializing)]
+    pub client_credentials: ClientCredentialsConfig,
     /// Provider registry. Key = `provider_id` (matches [`ModelCatalogEntry::provider_id`]).
     #[expand_vars]
     #[serde(default = "default_providers")]
@@ -190,6 +197,28 @@ fn default_providers() -> HashMap<String, ProviderEntry> {
     m
 }
 
+/// `OAuth2` client credentials for authenticating OAGW provisioning calls.
+#[derive(Clone, Deserialize, modkit_macros::ExpandVars)]
+#[serde(deny_unknown_fields)]
+pub struct ClientCredentialsConfig {
+    /// `OAuth2` client identifier. Supports `${VAR}` env expansion.
+    #[expand_vars]
+    pub client_id: String,
+    /// `OAuth2` client secret. Supports `${VAR}` env expansion.
+    /// Redacted in `Debug` output.
+    #[expand_vars]
+    pub client_secret: SecretString,
+}
+
+impl std::fmt::Debug for ClientCredentialsConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientCredentialsConfig")
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"[REDACTED]")
+            .finish()
+    }
+}
+
 /// SSE streaming tuning parameters.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -262,8 +291,31 @@ impl Default for MiniChatConfig {
             quota: QuotaConfig::default(),
             outbox: OutboxConfig::default(),
             context: ContextConfig::default(),
+            client_credentials: ClientCredentialsConfig::default(),
             providers: default_providers(),
         }
+    }
+}
+
+impl Default for ClientCredentialsConfig {
+    fn default() -> Self {
+        Self {
+            client_id: String::new(),
+            client_secret: SecretString::from(String::new()),
+        }
+    }
+}
+
+impl ClientCredentialsConfig {
+    /// Validate that S2S credentials are configured.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.client_id.trim().is_empty() {
+            return Err("client_credentials client_id must not be empty".to_owned());
+        }
+        if self.client_secret.expose_secret().trim().is_empty() {
+            return Err("client_credentials client_secret must not be empty".to_owned());
+        }
+        Ok(())
     }
 }
 

--- a/modules/mini-chat/mini-chat/src/infra/oagw_provisioning.rs
+++ b/modules/mini-chat/mini-chat/src/infra/oagw_provisioning.rs
@@ -22,28 +22,23 @@ use crate::config::ProviderEntry;
 /// [`ProviderEntry::upstream_alias`] (root) and
 /// [`ProviderTenantOverride::upstream_alias`] (per-tenant).
 ///
-/// Uses a default-tenant `SecurityContext`. If the upstream already exists
-/// (e.g. re-init), the error is logged and skipped.
+/// The caller is responsible for obtaining a valid `SecurityContext`
+/// (typically via S2S client credentials exchange).
 pub async fn register_oagw_upstreams(
     gateway: &Arc<dyn ServiceGatewayClientV1>,
+    ctx: &modkit_security::SecurityContext,
     providers: &mut HashMap<String, ProviderEntry>,
 ) -> anyhow::Result<()> {
-    let ctx = modkit_security::SecurityContext::builder()
-        .subject_tenant_id(modkit_security::constants::DEFAULT_TENANT_ID)
-        .subject_id(modkit_security::constants::DEFAULT_SUBJECT_ID)
-        .build()
-        .map_err(|e| anyhow::anyhow!("failed to build security context: {e}"))?;
-
     for (provider_id, entry) in providers.iter_mut() {
         // Register root upstream + route. Fail hard — without upstreams the
         // module cannot proxy LLM requests.
-        let upstream = create_upstream(gateway, &ctx, provider_id, entry)
+        let upstream = create_upstream(gateway, ctx, provider_id, entry)
             .await
             .ok_or_else(|| {
                 anyhow::anyhow!("OAGW upstream registration failed for provider '{provider_id}'")
             })?;
         entry.upstream_alias = Some(upstream.alias.clone());
-        register_route(gateway, &ctx, provider_id, entry, &upstream)
+        register_route(gateway, ctx, provider_id, entry, &upstream)
             .await
             .map_err(|e| {
                 anyhow::anyhow!("OAGW route registration failed for provider '{provider_id}': {e}")
@@ -63,7 +58,7 @@ pub async fn register_oagw_upstreams(
 
             let label = format!("{provider_id}[tenant={tenant_id}]");
             if let Some(alias) =
-                create_tenant_upstream(gateway, &ctx, &label, entry, tenant_id).await
+                create_tenant_upstream(gateway, ctx, &label, entry, tenant_id).await
                 && let Some(tenant_override) = entry.tenant_overrides.get_mut(tenant_id)
             {
                 tenant_override.upstream_alias = Some(alias);

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex, OnceLock};
 
 use async_trait::async_trait;
+use authn_resolver_sdk::{AuthNResolverClient, ClientCredentialsRequest};
 use authz_resolver_sdk::AuthZResolverClient;
 use mini_chat_sdk::{MiniChatAuditPluginSpecV1, MiniChatModelPolicyPluginSpecV1};
 use modkit::api::OpenApiRegistry;
@@ -9,6 +10,7 @@ use modkit::{DatabaseCapability, Module, ModuleCtx, RestApiCapability};
 use modkit_db::outbox::{Outbox, OutboxHandle, Partitions};
 use oagw_sdk::ServiceGatewayClientV1;
 use sea_orm_migration::MigrationTrait;
+use secrecy::ExposeSecret;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use types_registry_sdk::{RegisterResult, TypesRegistryClient};
@@ -43,7 +45,7 @@ pub const DEFAULT_URL_PREFIX: &str = "/mini-chat";
 /// The mini-chat module: multi-tenant AI chat with SSE streaming.
 #[modkit::module(
     name = "mini-chat",
-    deps = ["types-registry", "authz-resolver", "oagw"],
+    deps = ["types-registry", "authn-resolver", "authz-resolver", "oagw"],
     capabilities = [db, rest, stateful],
 )]
 pub struct MiniChatModule {
@@ -57,6 +59,8 @@ pub struct MiniChatModule {
 /// State needed to register OAGW upstreams in `start()` (after GTS is ready).
 struct OagwDeferred {
     gateway: Arc<dyn ServiceGatewayClientV1>,
+    authn: Arc<dyn AuthNResolverClient>,
+    client_credentials: crate::config::ClientCredentialsConfig,
     providers: std::collections::HashMap<String, ProviderEntry>,
 }
 
@@ -92,6 +96,9 @@ impl Module for MiniChatModule {
         cfg.context
             .validate()
             .map_err(|e| anyhow::anyhow!("context config: {e}"))?;
+        cfg.client_credentials
+            .validate()
+            .map_err(|e| anyhow::anyhow!("client_credentials config: {e}"))?;
         for (id, entry) in &cfg.providers {
             entry
                 .validate(id)
@@ -187,6 +194,11 @@ impl Module for MiniChatModule {
             .get::<dyn AuthZResolverClient>()
             .map_err(|e| anyhow::anyhow!("failed to get AuthZ resolver: {e}"))?;
 
+        let authn_client = ctx
+            .client_hub()
+            .get::<dyn AuthNResolverClient>()
+            .map_err(|e| anyhow::anyhow!("failed to get AuthN resolver: {e}"))?;
+
         let gateway = ctx
             .client_hub()
             .get::<dyn ServiceGatewayClientV1>()
@@ -213,6 +225,8 @@ impl Module for MiniChatModule {
         // Ignore the result: if already set, we keep the first value.
         drop(self.oagw_deferred.set(OagwDeferred {
             gateway: Arc::clone(&gateway),
+            authn: Arc::clone(&authn_client),
+            client_credentials: cfg.client_credentials.clone(),
             providers: cfg.providers.clone(),
         }));
 
@@ -301,9 +315,12 @@ impl RunnableCapability for MiniChatModule {
         // list() only queries the persistent store which is empty until
         // switch_to_ready().
         if let Some(deferred) = self.oagw_deferred.get() {
+            let ctx =
+                exchange_client_credentials(&deferred.authn, &deferred.client_credentials).await?;
             let mut providers = deferred.providers.clone();
             crate::infra::oagw_provisioning::register_oagw_upstreams(
                 &deferred.gateway,
+                &ctx,
                 &mut providers,
             )
             .await?;
@@ -330,6 +347,26 @@ impl RunnableCapability for MiniChatModule {
         }
         Ok(())
     }
+}
+
+/// Exchange `OAuth2` client credentials via the `AuthN` resolver to obtain
+/// a `SecurityContext` for OAGW upstream provisioning.
+async fn exchange_client_credentials(
+    authn: &Arc<dyn AuthNResolverClient>,
+    creds: &crate::config::ClientCredentialsConfig,
+) -> anyhow::Result<modkit_security::SecurityContext> {
+    info!("Exchanging client credentials for OAGW provisioning context");
+    let request = ClientCredentialsRequest {
+        client_id: creds.client_id.clone(),
+        client_secret: secrecy::SecretString::from(creds.client_secret.expose_secret().to_owned()),
+        scopes: Vec::new(),
+    };
+    let result = authn
+        .exchange_client_credentials(&request)
+        .await
+        .map_err(|e| anyhow::anyhow!("client credentials exchange failed: {e}"))?;
+    info!("Security context obtained for OAGW provisioning");
+    Ok(result.security_context)
 }
 
 async fn register_plugin_schemas(

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/src/config.rs
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/src/config.rs
@@ -102,6 +102,8 @@ pub struct S2sCredentialMapping {
     /// Client secret (redacted in `Debug` output).
     pub client_secret: SecretString,
     /// The identity to return when these credentials are presented.
+    /// When omitted, uses the default identity (`DEFAULT_SUBJECT_ID` / `DEFAULT_TENANT_ID`).
+    #[serde(default)]
     pub identity: IdentityConfig,
 }
 


### PR DESCRIPTION
Replace the hardcoded default-tenant SecurityContext with a proper S2S flow: mini-chat now exchanges OAuth2 client credentials via the AuthN resolver to obtain an authenticated SecurityContext for OAGW API calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service-to-service (S2S) authentication: configurable client credentials for inter-service OAuth2 exchanges.
  * Module-level credential support and runtime credential exchange to obtain security contexts.

* **Refactor**
  * Security context propagation moved to be provided externally during provisioning.
  * Identity mapping now defaults when omitted.

* **Chores**
  * Added secret-handling support and related dependency updates.
* **Tests/Config**
  * Updated local and quickstart configs and e2e feature ordering to include the new authn module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->