### PR TITLE
chore(release): increase publish timeout to 10m

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -19,7 +19,7 @@ changelog_path = "CHANGELOG.md"
 semver_check = true
 
 # To prevent crates.io throttling
-publish_timeout = "7m"
+publish_timeout = "10m"
 
 [changelog]
 body = """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the maximum publish timeout duration to accommodate longer deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->