### PR TITLE
fix(mini-chat): table-qualify column in ON CONFLICT to fix PostgreSQL ambiguity

### DIFF
--- a/modules/mini-chat/mini-chat/src/infra/db/repo/quota_usage_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/quota_usage_repo.rs
@@ -57,7 +57,8 @@ impl crate::domain::repos::QuotaUsageRepository for QuotaUsageRepository {
         ])
         .value(
             Column::ReservedCreditsMicro,
-            Expr::col(Column::ReservedCreditsMicro).add(Expr::value(params.amount_micro)),
+            Expr::col((QuotaUsageEntity, Column::ReservedCreditsMicro))
+                .add(Expr::value(params.amount_micro)),
         )?
         .value(Column::UpdatedAt, Expr::value(now))?;
 


### PR DESCRIPTION
Unqualified reserved_credits_micro in the upsert's DO UPDATE SET was ambiguous on PostgreSQL because it could refer to either the existing row or EXCLUDED. Use (QuotaUsageEntity, Column) tuple so SeaORM emits "quota_usage"."reserved_credits_micro".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reserved credit tracking in quota management to ensure accurate updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->