### PR TITLE
feat(api-gateway): add HTTP server metrics middleware using OpenTelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,8 @@ dependencies = [
  "inventory",
  "matchit 0.9.1",
  "nanoid",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "parking_lot",
  "rust-embed",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,6 +310,7 @@ tower-http = { version = "0.6", features = [
     "decompression-br",
     "decompression-deflate",
     "follow-redirect",
+    "catch-panic",
 ] }
 uuid = { version = "1.19", features = ["serde"] }
 governor = "0.10"

--- a/modules/system/api-gateway/Cargo.toml
+++ b/modules/system/api-gateway/Cargo.toml
@@ -44,6 +44,7 @@ tower-http = { workspace = true }
 matchit = { workspace = true }
 governor = { workspace = true }
 
+opentelemetry = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 
@@ -53,6 +54,8 @@ rust-embed = { workspace = true }
 
 [dev-dependencies]
 futures-core = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 uuid = { workspace = true }
 
 [features]

--- a/modules/system/api-gateway/src/middleware/http_metrics.rs
+++ b/modules/system/api-gateway/src/middleware/http_metrics.rs
@@ -1,0 +1,146 @@
+//! HTTP server metrics middleware (OpenTelemetry Semantic Conventions).
+//!
+//! Records two instruments per request:
+//! - `http.server.request.duration` — histogram (seconds)
+//! - `http.server.active_requests` — up-down counter
+//!
+//! Attributes follow [OpenTelemetry HTTP semantic conventions][otel]:
+//! `http.request.method`, `http.route`, `http.response.status_code`.
+//!
+//! [otel]: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{MatchedPath, State},
+    middleware::Next,
+    response::Response,
+};
+use opentelemetry::{
+    KeyValue,
+    metrics::{Histogram, UpDownCounter},
+};
+
+/// Holds the two OpenTelemetry instruments for HTTP server metrics.
+pub struct HttpMetrics {
+    duration: Histogram<f64>,
+    active_requests: UpDownCounter<i64>,
+}
+
+impl HttpMetrics {
+    /// Create instruments on the global meter scoped to the given module name.
+    #[must_use]
+    pub fn new(module_name: &str) -> Self {
+        let scope = opentelemetry::InstrumentationScope::builder(module_name.to_owned()).build();
+        let meter = opentelemetry::global::meter_with_scope(scope);
+
+        let duration = meter
+            .f64_histogram("http.server.request.duration")
+            .with_description("Duration of HTTP server requests")
+            .with_unit("s")
+            .build();
+
+        let active_requests = meter
+            .i64_up_down_counter("http.server.active_requests")
+            .with_description("Number of active HTTP server requests")
+            .build();
+
+        Self {
+            duration,
+            active_requests,
+        }
+    }
+}
+
+/// Drop guard that decrements the active-requests counter, ensuring
+/// the counter is decremented even if downstream handlers panic.
+struct ActiveRequestGuard {
+    counter: UpDownCounter<i64>,
+    attrs: [KeyValue; 1],
+}
+
+impl Drop for ActiveRequestGuard {
+    fn drop(&mut self) {
+        self.counter.add(-1, &self.attrs);
+    }
+}
+
+/// Tiny `route_layer` that copies [`MatchedPath`] into **response** extensions
+/// so that outer `layer()` middleware (e.g. metrics) can read the route template.
+pub async fn propagate_matched_path(
+    matched_path: Option<MatchedPath>,
+    req: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let mut response = next.run(req).await;
+    if let Some(path) = matched_path {
+        response.extensions_mut().insert(path);
+    }
+    response
+}
+
+/// Normalize HTTP method per [OTel semantic conventions][semconv].
+///
+/// Unknown methods are mapped to `_OTHER` to bound attribute cardinality
+/// and prevent metric explosion from arbitrary method strings.
+///
+/// [semconv]: https://opentelemetry.io/docs/specs/semconv/http/http-metrics/
+fn normalize_method(method: &axum::http::Method) -> &'static str {
+    match *method {
+        axum::http::Method::GET => "GET",
+        axum::http::Method::POST => "POST",
+        axum::http::Method::PUT => "PUT",
+        axum::http::Method::DELETE => "DELETE",
+        axum::http::Method::PATCH => "PATCH",
+        axum::http::Method::HEAD => "HEAD",
+        axum::http::Method::OPTIONS => "OPTIONS",
+        axum::http::Method::CONNECT => "CONNECT",
+        axum::http::Method::TRACE => "TRACE",
+        _ => "_OTHER",
+    }
+}
+
+/// Axum middleware that records HTTP server metrics.
+///
+/// Use with `axum::middleware::from_fn_with_state` and add as a **`layer`**
+/// (not `route_layer`) so it captures responses from all middleware layers.
+/// The `http.route` attribute is read from response extensions, populated
+/// by [`propagate_matched_path`] which must be added as an inner `route_layer`.
+pub async fn http_metrics_middleware(
+    State(metrics): State<Arc<HttpMetrics>>,
+    req: axum::extract::Request,
+    next: Next,
+) -> Response {
+    let method_kv = KeyValue::new("http.request.method", normalize_method(req.method()));
+
+    metrics
+        .active_requests
+        .add(1, std::slice::from_ref(&method_kv));
+    let _guard = ActiveRequestGuard {
+        counter: metrics.active_requests.clone(),
+        attrs: [method_kv.clone()],
+    };
+
+    let start = std::time::Instant::now();
+    let response = next.run(req).await;
+    let elapsed = start.elapsed().as_secs_f64();
+
+    let route = response
+        .extensions()
+        .get::<MatchedPath>()
+        .map_or("unmatched", MatchedPath::as_str)
+        .to_owned();
+    let route_kv = KeyValue::new("http.route", route);
+    let status = i64::from(response.status().as_u16());
+
+    metrics.duration.record(
+        elapsed,
+        &[
+            method_kv,
+            route_kv,
+            KeyValue::new("http.response.status_code", status),
+        ],
+    );
+
+    response
+}

--- a/modules/system/api-gateway/src/middleware/mod.rs
+++ b/modules/system/api-gateway/src/middleware/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod common;
+pub mod http_metrics;
 pub mod license_validation;
 pub mod mime_validation;
 pub mod rate_limit;

--- a/modules/system/api-gateway/src/module.rs
+++ b/modules/system/api-gateway/src/module.rs
@@ -19,6 +19,7 @@ use std::net::SocketAddr;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tower_http::{
+    catch_panic::CatchPanicLayer,
     limit::RequestBodyLimitLayer,
     request_id::{PropagateRequestIdLayer, SetRequestIdLayer},
     timeout::TimeoutLayer,
@@ -225,11 +226,18 @@ impl ApiGateway {
         // becomes the **outermost** layer and therefore runs **first** on the request path.
         //
         // Desired request execution order (outermost -> innermost):
-        // SetRequestId -> PropagateRequestId -> Trace -> push_req_id_to_extensions
-        // -> Timeout -> BodyLimit -> CORS -> MIME validation -> RateLimit -> ErrorMapping -> Auth -> Router
+        // SetRequestId -> PropagateRequestId -> Trace -> push_req_id
+        // -> HttpMetrics -> CatchPanic
+        // -> Timeout -> BodyLimit -> CORS -> MIME validation -> RateLimit -> ErrorMapping -> Auth -> License
+        // -> [Route matching] -> PropagateMatchedPath -> Handler
         //
         // Therefore we must add layers in the reverse order (innermost -> outermost) below.
         // Due future refactoring, this order must be maintained.
+
+        // 14) Propagate MatchedPath to response extensions (route_layer — innermost).
+        // This copies MatchedPath from the request (populated by Axum route matching)
+        // into the response so outer layer() middleware (metrics) can read it.
+        router = router.route_layer(from_fn(middleware::http_metrics::propagate_matched_path));
 
         let config = self.get_cached_config();
 
@@ -241,7 +249,7 @@ impl ApiGateway {
             .map(|e| e.value().clone())
             .collect();
 
-        // 11) License validation
+        // 13) License validation
         let license_map = middleware::license_validation::LicenseRequirementMap::from_specs(&specs);
 
         router = router.layer(from_fn(
@@ -251,7 +259,7 @@ impl ApiGateway {
             },
         ));
 
-        // 10) Auth
+        // 12) Auth
         if config.auth_disabled {
             // Build security contexts for compatibility during migration
             let default_security_context = SecurityContext::builder()
@@ -286,10 +294,10 @@ impl ApiGateway {
             ));
         }
 
-        // 9) Error mapping (outer to auth so it can translate auth/handler errors)
+        // 11) Error mapping (outer to auth so it can translate auth/handler errors)
         router = router.layer(from_fn(modkit::api::error_layer::error_mapping_middleware));
 
-        // 8) Per-route rate limiting & in-flight limits
+        // 10) Per-route rate limiting & in-flight limits
         let rate_map = middleware::rate_limit::RateLimiterMap::from_specs(&specs, &config)?;
 
         router = router.layer(from_fn(
@@ -299,7 +307,7 @@ impl ApiGateway {
             },
         ));
 
-        // 7) MIME type validation
+        // 9) MIME type validation
         let mime_map = middleware::mime_validation::build_mime_validation_map(&specs);
         router = router.layer(from_fn(
             move |req: axum::extract::Request, next: axum::middleware::Next| {
@@ -308,19 +316,31 @@ impl ApiGateway {
             },
         ));
 
-        // 6) CORS (must be outer to auth/limits so OPTIONS preflight short-circuits)
+        // 8) CORS (must be outer to auth/limits so OPTIONS preflight short-circuits)
         if config.cors_enabled {
             router = router.layer(crate::cors::build_cors_layer(&config));
         }
 
-        // 5) Body limit
+        // 7) Body limit
         router = router.layer(RequestBodyLimitLayer::new(config.defaults.body_limit_bytes));
         router = router.layer(DefaultBodyLimit::max(config.defaults.body_limit_bytes));
 
-        // 4) Timeout
+        // 6) Timeout
         router = router.layer(TimeoutLayer::with_status_code(
             axum::http::StatusCode::GATEWAY_TIMEOUT,
             Duration::from_secs(30),
+        ));
+
+        // 5) CatchPanic (converts panics to 500 before metrics sees them)
+        router = router.layer(CatchPanicLayer::new());
+
+        // 4) HTTP metrics (layer — captures all middleware responses including auth/rate-limit/timeout)
+        let http_metrics = Arc::new(middleware::http_metrics::HttpMetrics::new(
+            Self::MODULE_NAME,
+        ));
+        router = router.layer(from_fn_with_state(
+            http_metrics,
+            middleware::http_metrics::http_metrics_middleware,
         ));
 
         // 3) Record request_id into span + extensions (requires span to exist first => must be inner to Trace)
@@ -383,7 +403,7 @@ impl ApiGateway {
                 )
         });
 
-        // 1) Request ID handling
+        // 1) Request ID handling (outermost)
         let x_request_id = crate::middleware::request_id::header();
         // If missing, generate x-request-id first; then propagate it to the response.
         router = router.layer(PropagateRequestIdLayer::new(x_request_id.clone()));

--- a/modules/system/api-gateway/tests/http_metrics_tests.rs
+++ b/modules/system/api-gateway/tests/http_metrics_tests.rs
@@ -1,0 +1,415 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+//! Integration tests for HTTP metrics middleware.
+//!
+//! Verifies that the metrics middleware (now a `layer()` instead of `route_layer()`)
+//! captures responses from all middleware layers — including auth, rate-limit, MIME,
+//! and timeout — and that `http.route` uses the route template (not raw path).
+
+use anyhow::Result;
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    response::IntoResponse,
+};
+use modkit::{
+    Module, api::OperationBuilder, config::ConfigProvider, context::ModuleCtx,
+    contracts::ApiGatewayCapability,
+};
+use opentelemetry_sdk::metrics::{
+    InMemoryMetricExporter, Instrument, PeriodicReader, SdkMeterProvider, Stream,
+    data::{AggregatedMetrics, MetricData},
+};
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+/// Global lock to serialize tests that mutate the OpenTelemetry global meter provider.
+static METER_LOCK: Mutex<()> = Mutex::const_new(());
+
+struct TestConfigProvider {
+    config: serde_json::Value,
+}
+
+impl ConfigProvider for TestConfigProvider {
+    fn get_module_config(&self, module: &str) -> Option<&serde_json::Value> {
+        self.config.get(module)
+    }
+}
+
+fn create_api_gateway_ctx(config: serde_json::Value) -> ModuleCtx {
+    let hub = Arc::new(modkit::ClientHub::new());
+    ModuleCtx::new(
+        "api-gateway",
+        Uuid::new_v4(),
+        Arc::new(TestConfigProvider { config }),
+        hub,
+        tokio_util::sync::CancellationToken::new(),
+        None,
+    )
+}
+
+/// Install an in-memory meter provider as the OpenTelemetry global so that
+/// `HttpMetrics::new` (which uses `opentelemetry::global::meter_with_scope`)
+/// records into our exporter.
+fn install_test_meter_provider() -> (SdkMeterProvider, InMemoryMetricExporter) {
+    let exporter = InMemoryMetricExporter::default();
+    let provider = SdkMeterProvider::builder()
+        .with_reader(PeriodicReader::builder(exporter.clone()).build())
+        .with_view(|_: &Instrument| Stream::builder().with_cardinality_limit(2000).build().ok())
+        .build();
+    opentelemetry::global::set_meter_provider(provider.clone());
+    (provider, exporter)
+}
+
+/// Extract the sum of all histogram data point counts for the named metric.
+fn histogram_count(exporter: &InMemoryMetricExporter, name: &str) -> u64 {
+    let metrics = exporter.get_finished_metrics().unwrap();
+    let mut total = 0u64;
+    for resource_metrics in &metrics {
+        for scope_metrics in resource_metrics.scope_metrics() {
+            for metric in scope_metrics.metrics() {
+                if metric.name() == name
+                    && let AggregatedMetrics::F64(MetricData::Histogram(hist)) = metric.data()
+                {
+                    for dp in hist.data_points() {
+                        total += dp.count();
+                    }
+                }
+            }
+        }
+    }
+    total
+}
+
+/// Check whether a histogram data point exists with the given attribute values.
+fn histogram_has_attributes(
+    exporter: &InMemoryMetricExporter,
+    name: &str,
+    expected_attrs: &[(&str, &str)],
+) -> bool {
+    let metrics = exporter.get_finished_metrics().unwrap();
+    for resource_metrics in &metrics {
+        for scope_metrics in resource_metrics.scope_metrics() {
+            for metric in scope_metrics.metrics() {
+                if metric.name() == name
+                    && let AggregatedMetrics::F64(MetricData::Histogram(hist)) = metric.data()
+                {
+                    for dp in hist.data_points() {
+                        let attrs: Vec<_> = dp.attributes().collect();
+                        let all_match = expected_attrs.iter().all(|(key, val)| {
+                            attrs
+                                .iter()
+                                .any(|kv| kv.key.as_str() == *key && kv.value.as_str() == *val)
+                        });
+                        if all_match {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+async fn ok_handler() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+fn base_config() -> serde_json::Value {
+    json!({
+        "api-gateway": {
+            "config": {
+                "bind_addr": "127.0.0.1:0",
+                "cors_enabled": false,
+                "auth_disabled": true,
+                "defaults": {
+                    "rate_limit": { "rps": 1000, "burst": 1000, "in_flight": 64 }
+                },
+            }
+        }
+    })
+}
+
+#[tokio::test]
+async fn metrics_capture_successful_request() -> Result<()> {
+    let _lock = METER_LOCK.lock().await;
+    let (provider, exporter) = install_test_meter_provider();
+    let ctx = create_api_gateway_ctx(base_config());
+    let api = api_gateway::ApiGateway::default();
+    api.init(&ctx).await?;
+
+    let router = OperationBuilder::get("/tests/v1/items")
+        .operation_id("test:list-items")
+        .summary("List items")
+        .public()
+        .json_response(StatusCode::OK, "OK")
+        .handler(axum::routing::get(ok_handler))
+        .register(Router::new(), &api);
+    let app = api.rest_finalize(&ctx, router)?;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/tests/v1/items")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    provider.force_flush().unwrap();
+
+    let count = histogram_count(&exporter, "http.server.request.duration");
+    assert!(
+        count >= 1,
+        "expected at least 1 duration data point, got {count}"
+    );
+
+    assert!(
+        histogram_has_attributes(
+            &exporter,
+            "http.server.request.duration",
+            &[
+                ("http.request.method", "GET"),
+                ("http.route", "/tests/v1/items"),
+                ("http.response.status_code", "200"),
+            ]
+        ),
+        "duration histogram should have correct method/route/status attributes"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn metrics_capture_mime_rejection() -> Result<()> {
+    let _lock = METER_LOCK.lock().await;
+    let (provider, exporter) = install_test_meter_provider();
+    let ctx = create_api_gateway_ctx(base_config());
+    let api = api_gateway::ApiGateway::default();
+    api.init(&ctx).await?;
+
+    let mut builder = OperationBuilder::post("/tests/v1/items");
+    builder.require_rate_limit(1000, 1000, 64);
+    let router = builder
+        .operation_id("test:create-item")
+        .summary("Create item")
+        .public()
+        .allow_content_types(&["application/json"])
+        .json_response(StatusCode::OK, "OK")
+        .handler(axum::routing::post(ok_handler))
+        .register(Router::new(), &api);
+    let app = api.rest_finalize(&ctx, router)?;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tests/v1/items")
+                .header("content-type", "text/plain")
+                .body(Body::from("hi"))?,
+        )
+        .await?;
+    assert_eq!(res.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+    provider.force_flush().unwrap();
+
+    let count = histogram_count(&exporter, "http.server.request.duration");
+    assert!(
+        count >= 1,
+        "MIME rejection (415) must be captured by metrics, got {count} data points"
+    );
+
+    assert!(
+        histogram_has_attributes(
+            &exporter,
+            "http.server.request.duration",
+            &[("http.response.status_code", "415"),]
+        ),
+        "duration histogram should record 415 status from MIME rejection"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn metrics_capture_rate_limit() -> Result<()> {
+    let _lock = METER_LOCK.lock().await;
+    let cfg = json!({
+        "api-gateway": {
+            "config": {
+                "bind_addr": "127.0.0.1:0",
+                "cors_enabled": false,
+                "auth_disabled": true,
+                "defaults": {
+                    "rate_limit": { "rps": 1, "burst": 1, "in_flight": 64 }
+                },
+            }
+        }
+    });
+
+    let (provider, exporter) = install_test_meter_provider();
+    let ctx = create_api_gateway_ctx(cfg);
+    let api = api_gateway::ApiGateway::default();
+    api.init(&ctx).await?;
+
+    let mut builder = OperationBuilder::get("/tests/v1/limited");
+    builder.require_rate_limit(1, 1, 64);
+    let router = builder
+        .operation_id("test:limited")
+        .summary("Rate-limited endpoint")
+        .public()
+        .json_response(StatusCode::OK, "OK")
+        .handler(axum::routing::get(ok_handler))
+        .register(Router::new(), &api);
+    let app = api.rest_finalize(&ctx, router)?;
+
+    // First request — succeeds and consumes the token
+    let res1 = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/tests/v1/limited")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(res1.status(), StatusCode::OK);
+
+    // Second request immediately — rate-limited
+    let res2 = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/tests/v1/limited")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(res2.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    provider.force_flush().unwrap();
+
+    let count = histogram_count(&exporter, "http.server.request.duration");
+    assert!(
+        count >= 2,
+        "both 200 and 429 must be captured by metrics, got {count} data points"
+    );
+
+    assert!(
+        histogram_has_attributes(
+            &exporter,
+            "http.server.request.duration",
+            &[("http.response.status_code", "429"),]
+        ),
+        "duration histogram should record 429 from rate limiting"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn metrics_route_attribute_uses_template() -> Result<()> {
+    let _lock = METER_LOCK.lock().await;
+    let (provider, exporter) = install_test_meter_provider();
+    let ctx = create_api_gateway_ctx(base_config());
+    let api = api_gateway::ApiGateway::default();
+    api.init(&ctx).await?;
+
+    let router = OperationBuilder::get("/tests/v1/items/{id}")
+        .operation_id("test:get-item")
+        .summary("Get item")
+        .public()
+        .json_response(StatusCode::OK, "OK")
+        .handler(axum::routing::get(ok_handler))
+        .register(Router::new(), &api);
+    let app = api.rest_finalize(&ctx, router)?;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/tests/v1/items/42")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    provider.force_flush().unwrap();
+
+    // Must use the template "/tests/v1/items/{id}", NOT the raw path "/tests/v1/items/42"
+    assert!(
+        histogram_has_attributes(
+            &exporter,
+            "http.server.request.duration",
+            &[("http.route", "/tests/v1/items/{id}"),]
+        ),
+        "http.route must be the template, not the concrete path"
+    );
+
+    // Verify it does NOT record the raw path
+    assert!(
+        !histogram_has_attributes(
+            &exporter,
+            "http.server.request.duration",
+            &[("http.route", "/tests/v1/items/42"),]
+        ),
+        "http.route must NOT contain the concrete path (cardinality explosion)"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn metrics_unmatched_route() -> Result<()> {
+    let _lock = METER_LOCK.lock().await;
+    let (provider, exporter) = install_test_meter_provider();
+    let ctx = create_api_gateway_ctx(base_config());
+    let api = api_gateway::ApiGateway::default();
+    api.init(&ctx).await?;
+
+    let router = OperationBuilder::get("/tests/v1/items")
+        .operation_id("test:list-items")
+        .summary("List items")
+        .public()
+        .json_response(StatusCode::OK, "OK")
+        .handler(axum::routing::get(ok_handler))
+        .register(Router::new(), &api);
+    let app = api.rest_finalize(&ctx, router)?;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/no/such/route")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+
+    provider.force_flush().unwrap();
+
+    let count = histogram_count(&exporter, "http.server.request.duration");
+    assert!(
+        count >= 1,
+        "unmatched route 404 must be captured by metrics, got {count} data points"
+    );
+
+    assert!(
+        histogram_has_attributes(
+            &exporter,
+            "http.server.request.duration",
+            &[
+                ("http.route", "unmatched"),
+                ("http.response.status_code", "404"),
+            ]
+        ),
+        "unmatched route should have http.route='unmatched' and status 404"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Introduce http_metrics middleware that records request duration histogram and active request count following OpenTelemetry HTTP semantic conventions. Instruments are scoped to the api-gateway meter and attached as an innermost route_layer so MatchedPath is available for the http.route attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry-based HTTP metrics middleware to capture request duration, active concurrent requests, HTTP method, route template and response status; integrated earlier in the middleware chain so metrics include panic/timeout/limit outcomes.

* **Tests**
  * Added integration tests validating metric collection for success, rejections (MIME/rate), templated routes, unmatched routes, and panic/timeout scenarios.

* **Chores**
  * Added OpenTelemetry dependencies and enabled panic-capture support in HTTP tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->