### PR TITLE
Add profiling capabilities with separate http server.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "aliri"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,7 +944,7 @@ dependencies = [
  "encoding_rs",
  "fast-float2",
  "log",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "zip 4.6.1",
 ]
@@ -1308,6 +1317,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
+ "backtrace",
  "cf-modkit-db",
  "cf-modkit-errors",
  "cf-modkit-macros",
@@ -1321,6 +1331,7 @@ dependencies = [
  "enable-ansi-support",
  "figment",
  "file-rotate",
+ "flate2",
  "futures-core",
  "futures-util",
  "gts",
@@ -1333,6 +1344,8 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
+ "pprof",
+ "prost",
  "schemars 1.2.1",
  "sea-orm-migration",
  "serde",
@@ -1358,6 +1371,7 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "uuid",
+ "windows-sys 0.59.0",
  "zip 2.4.2",
 ]
 
@@ -2615,6 +2629,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,6 +2987,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3189,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3182,7 +3237,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3678,7 +3733,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -4155,6 +4210,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash 0.8.12",
+ "indexmap 2.13.0",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml 0.26.0",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "inherent"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4344,7 +4417,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -4584,6 +4657,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4647,7 +4729,7 @@ dependencies = [
  "httparse",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -4705,6 +4787,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -4857,6 +4950,16 @@ name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
 
 [[package]]
 name = "num-integer"
@@ -5745,7 +5848,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -5808,6 +5911,28 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pprof"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "once_cell",
+ "smallvec 1.15.1",
+ "spin 0.10.0",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "pptx-to-md"
@@ -6040,6 +6165,15 @@ dependencies = [
  "wasi",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -6330,6 +6464,15 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -7265,6 +7408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7519,6 +7671,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "stringmetrics"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7599,6 +7757,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
 dependencies = [
  "is_ci",
+]
+
+[[package]]
+name = "symbolic-common"
+version = "12.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "751a2823d606b5d0a7616499e4130a516ebd01a44f39811be2b9600936509c23"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b237cfbe320601dd24b4ac817a5b68bb28f5508e33f08d42be0682cadc8ac9"
+dependencies = [
+ "rustc-demangle",
+ "symbolic-common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,10 @@ resolver = "3"
 [workspace.lints.rust]
 deprecated = "warn"
 non_ascii_idents = "forbid"
-unsafe_code = "forbid"
+# `deny` (not `forbid`) so that the Windows profiling sampler in modkit can
+# locally `#[allow(unsafe_code)]` for Win32 FFI.  Every other module remains
+# effectively forbidden because `deny` triggers the same compile error.
+unsafe_code = "deny"
 unused_mut = "warn"
 noop_method_call = "warn"
 unused_import_braces = "warn"
@@ -505,6 +508,10 @@ nanoid = "0.4"
 
 # Metrics
 tokio-metrics = { version = "0.4", features = ["rt"] }
+
+# Profiling (CPU sampling)
+pprof = { version = "0.15", default-features = false, features = ["flamegraph"] }
+backtrace = "0.3"
 
 # GTS dependencies
 jsonschema = "0.40"

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -20,6 +20,7 @@ static-authz = ["dep:static-authz-plugin"]
 static-credstore = ["dep:static-credstore-plugin"]
 mini-chat = ["dep:mini-chat", "dep:static-mini-chat-model-policy-plugin", "dep:static-mini-chat-audit-plugin"]
 otel = ["modkit/otel"]
+profiling = ["modkit/profiling"]
 
 [dependencies]
 mimalloc = { version = "0.1" }

--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -9,6 +9,14 @@
 server:
   home_dir: "~/.hyperspot"
 
+# # On-demand profiling endpoint (requires --features profiling)
+# profiling:
+#   enabled: true
+#   bind_addr: "127.0.0.1:6060"
+#   cpu_sample_duration_secs: 30
+#   cpu_sample_frequency_hz: 100
+#   # auth_token: "my-secret-token"
+
 database:
   servers:
     sqlite_mini_chat:

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -1,0 +1,164 @@
+# On-Demand Profiling Endpoint
+
+The profiling feature adds a **separate HTTP server** exposing pprof-compatible
+CPU and memory profiling endpoints.  It is designed for incident analysis in
+production and pre-production environments.
+
+## Quick start
+
+### 1. Build with the `profiling` feature
+
+```bash
+cargo build --release --features profiling
+```
+
+### 2. Enable in configuration
+
+Add a `profiling` section to your YAML config (or use environment variables):
+
+```yaml
+profiling:
+  enabled: true
+  bind_addr: "127.0.0.1:6060"
+  cpu_sample_duration_secs: 30
+  cpu_sample_frequency_hz: 100
+  # auth_token: "my-secret-token"   # optional
+```
+
+Or via environment:
+
+```bash
+export APP__PROFILING__ENABLED=true
+export APP__PROFILING__BIND_ADDR="127.0.0.1:6060"
+# export APP__PROFILING__AUTH_TOKEN="my-secret-token"
+```
+
+### 3. Collect a profile
+
+```bash
+# CPU profile (pprof protobuf, 30 seconds)
+curl -o profile.pb.gz "http://127.0.0.1:6060/debug/pprof/profile?seconds=30"
+
+# CPU flamegraph (SVG on Unix, folded stacks on Windows)
+curl -o flame.svg "http://127.0.0.1:6060/debug/pprof/profile?seconds=10&format=flamegraph"
+
+# Heap / process memory stats
+curl "http://127.0.0.1:6060/debug/pprof/heap"
+
+# With auth token
+curl -H "Authorization: Bearer my-secret-token" \
+     -o profile.pb.gz "http://127.0.0.1:6060/debug/pprof/profile?seconds=30"
+```
+
+### 4. Visualize
+
+```bash
+# Interactive web UI (requires Go toolchain)
+go tool pprof -http=:8080 profile.pb.gz
+
+# CLI top functions
+go tool pprof -top profile.pb.gz
+
+# Windows folded stacks → flamegraph (requires inferno)
+cargo install inferno
+curl "http://127.0.0.1:6060/debug/pprof/profile?seconds=10&format=flamegraph" \
+  | inferno-flamegraph > flame.svg
+```
+
+---
+
+## Endpoints
+
+| Method | Path                        | Description                              |
+|--------|-----------------------------|------------------------------------------|
+| GET    | `/debug/pprof/`             | Index — lists available profiles         |
+| GET    | `/debug/pprof/profile`      | CPU profile (pprof protobuf or SVG)      |
+| GET    | `/debug/pprof/heap`         | Heap / process memory statistics (JSON)  |
+
+### Query parameters for `/debug/pprof/profile`
+
+| Param     | Default    | Description                                          |
+|-----------|------------|------------------------------------------------------|
+| `seconds` | 30         | Profile duration (clamped to `cpu_sample_duration_secs`) |
+| `format`  | `protobuf` | Output format: `protobuf` or `flamegraph`            |
+
+---
+
+## Configuration reference
+
+| Field                       | Type     | Default            | Description                                    |
+|-----------------------------|----------|--------------------|------------------------------------------------|
+| `enabled`                   | bool     | `false`            | Enable the profiling endpoint                  |
+| `bind_addr`                 | string   | `127.0.0.1:6060`   | Socket address for the profiling server        |
+| `cpu_sample_duration_secs`  | u64      | `30`               | Maximum allowed CPU profile duration           |
+| `cpu_sample_frequency_hz`   | u32      | `100`              | Sampling frequency (samples per second)        |
+| `auth_token`                | string?  | `null`             | Optional bearer token for authentication       |
+
+---
+
+## Platform support
+
+| Platform       | CPU profiling backend                                       |
+|----------------|-------------------------------------------------------------|
+| Linux / macOS  | `pprof-rs` — signal-based sampling via `SIGPROF`            |
+| Windows        | Custom sampler thread — `SuspendThread` / `GetThreadContext` |
+
+Both backends produce **pprof protobuf** output compatible with `go tool pprof`,
+Grafana Pyroscope, and other standard pprof tooling.
+
+### Windows notes
+
+- The Windows sampler captures instruction pointers (single-frame samples).
+  Full stack walking may be added in a future iteration.
+- Flamegraph output on Windows returns folded-stack text format; pipe through
+  `inferno-flamegraph` to produce SVG.
+- Symbol resolution requires debug info.  Release builds with `debug = 1`
+  (the workspace default) provide function-level names.
+
+---
+
+## Security
+
+The profiling server is **separate** from the main api-gateway and is:
+
+- **Loopback-only** by default (`127.0.0.1:6060`) — not reachable from outside
+  the host.
+- **Disabled** by default — must be explicitly enabled in configuration.
+- **Optionally authenticated** via a bearer token.
+
+### Kubernetes recommendations
+
+- Do **not** expose the profiling port in Service or Ingress definitions.
+- Use `kubectl port-forward` to access the profiling endpoint:
+  ```bash
+  kubectl port-forward pod/my-pod 6060:6060
+  curl -o profile.pb.gz "http://127.0.0.1:6060/debug/pprof/profile?seconds=30"
+  ```
+- Consider a `NetworkPolicy` restricting egress/ingress on port 6060.
+
+---
+
+## Overhead
+
+Profiling is **on-demand only** — no overhead when idle.  During active
+collection:
+
+- **Unix**: `pprof-rs` uses `SIGPROF` at the configured frequency.  At 100 Hz
+  the overhead is typically < 1 % CPU.
+- **Windows**: The sampler thread briefly suspends each thread per sample.  At
+  100 Hz with a small number of threads, overhead is negligible.
+
+---
+
+## Cargo feature
+
+The feature is opt-in per binary:
+
+```toml
+# apps/hyperspot-server/Cargo.toml
+[features]
+profiling = ["modkit/profiling"]
+```
+
+Build without the feature to completely exclude all profiling code and
+dependencies from the binary.

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -51,6 +51,17 @@ bootstrap = [
     "dep:enable-ansi-support",
 ]
 
+# On-demand CPU profiling endpoint (pprof-compatible).
+# Linux/macOS: CPU sampling via pprof-rs (dep:pprof, Unix-only, signal-based).
+# Windows:     CPU sampling via custom SuspendThread/GetThreadContext sampler
+#              (windows-sys, declared in [target.'cfg(windows)'.dependencies]).
+profiling = [
+    "dep:prost",
+    "dep:backtrace",
+    "dep:flate2",
+    "dep:pprof",
+]
+
 [dependencies]
 # Project-local crates
 modkit-macros = { workspace = true }
@@ -95,6 +106,11 @@ gts = { workspace = true }
 gts-macros = { workspace = true }
 zip = { version = "2.3", default-features = false, features = ["deflate"] }
 
+# Profiling support (optional)
+prost = { workspace = true, optional = true }
+backtrace = { workspace = true, optional = true }
+flate2 = { workspace = true, optional = true }
+
 # Performance / lock-free structures
 parking_lot = { workspace = true }
 dashmap = { workspace = true }
@@ -120,6 +136,16 @@ tonic = { workspace = true, optional = true }
 # Unix-specific dependencies for graceful process termination
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", default-features = false, features = ["signal"] }
+pprof = { workspace = true, optional = true }
+
+# Windows-specific dependencies for CPU profiling (SuspendThread/GetThreadContext)
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", optional = true, features = [
+    "Win32_System_Threading",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_Foundation",
+] }
 
 [build-dependencies]
 zip = { version = "2.3", default-features = false, features = ["deflate"] }

--- a/libs/modkit/src/bootstrap/config/mod.rs
+++ b/libs/modkit/src/bootstrap/config/mod.rs
@@ -88,6 +88,10 @@ pub struct AppConfig {
     /// Tracing configuration.
     #[serde(default)]
     pub tracing: TracingConfig,
+    /// On-demand CPU/memory profiling endpoint configuration.
+    /// When enabled, a separate HTTP server exposes pprof-compatible endpoints.
+    #[serde(default)]
+    pub profiling: Option<ProfilingConfig>,
     /// Directory containing per-module YAML files (optional).
     #[serde(default)]
     pub modules_dir: Option<String>,
@@ -104,6 +108,7 @@ impl Default for AppConfig {
             database: None,
             logging: default_logging_config(),
             tracing: TracingConfig::default(),
+            profiling: None,
             modules_dir: None,
             modules: HashMap::new(),
         }
@@ -142,6 +147,60 @@ impl ServerConfig {
         std::fs::create_dir_all(&self.home_dir).context("Failed to create home_dir")?;
 
         Ok(())
+    }
+}
+
+fn default_profiling_bind_addr() -> String {
+    "127.0.0.1:6060".to_owned()
+}
+
+fn default_cpu_sample_duration_secs() -> u64 {
+    30
+}
+
+fn default_cpu_sample_frequency_hz() -> u32 {
+    100
+}
+
+/// On-demand profiling endpoint configuration.
+///
+/// When enabled, a **separate** HTTP server (not part of the api-gateway) is
+/// started on `bind_addr` exposing pprof-compatible CPU and memory profiling
+/// endpoints.  Disabled by default.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProfilingConfig {
+    /// Enable the profiling endpoint.  Default: `false`.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Socket address for the profiling HTTP server.  Default: `127.0.0.1:6060`.
+    #[serde(default = "default_profiling_bind_addr")]
+    pub bind_addr: String,
+
+    /// Maximum CPU profile capture duration in seconds.  Default: `30`.
+    #[serde(default = "default_cpu_sample_duration_secs")]
+    pub cpu_sample_duration_secs: u64,
+
+    /// CPU sampling frequency in Hz (samples per second).  Default: `100` (10 ms).
+    #[serde(default = "default_cpu_sample_frequency_hz")]
+    pub cpu_sample_frequency_hz: u32,
+
+    /// Optional bearer token for endpoint authentication.
+    /// When set, requests must include `Authorization: Bearer <token>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_token: Option<String>,
+}
+
+impl Default for ProfilingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind_addr: default_profiling_bind_addr(),
+            cpu_sample_duration_secs: default_cpu_sample_duration_secs(),
+            cpu_sample_frequency_hz: default_cpu_sample_frequency_hz(),
+            auth_token: None,
+        }
     }
 }
 
@@ -2685,6 +2744,86 @@ logging:
         assert!(modules.contains_key("module_a"));
         assert!(modules.contains_key("module_b"));
         assert!(modules.contains_key("module_c"));
+    }
+
+    #[test]
+    fn profiling_config_defaults() {
+        let cfg = ProfilingConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.bind_addr, "127.0.0.1:6060");
+        assert_eq!(cfg.cpu_sample_duration_secs, 30);
+        assert_eq!(cfg.cpu_sample_frequency_hz, 100);
+        assert!(cfg.auth_token.is_none());
+    }
+
+    #[test]
+    fn profiling_config_deserialize_minimal() {
+        let yaml = "enabled: true\n";
+        let cfg: ProfilingConfig =
+            serde_json::from_value(serde_json::json!({ "enabled": true })).unwrap();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.bind_addr, "127.0.0.1:6060");
+        assert_eq!(cfg.cpu_sample_duration_secs, 30);
+        assert_eq!(cfg.cpu_sample_frequency_hz, 100);
+        assert!(cfg.auth_token.is_none());
+        let _ = yaml;
+    }
+
+    #[test]
+    fn profiling_config_deserialize_full() {
+        let cfg: ProfilingConfig = serde_json::from_value(serde_json::json!({
+            "enabled": true,
+            "bind_addr": "0.0.0.0:9090",
+            "cpu_sample_duration_secs": 60,
+            "cpu_sample_frequency_hz": 250,
+            "auth_token": "my-secret"
+        }))
+        .unwrap();
+        assert!(cfg.enabled);
+        assert_eq!(cfg.bind_addr, "0.0.0.0:9090");
+        assert_eq!(cfg.cpu_sample_duration_secs, 60);
+        assert_eq!(cfg.cpu_sample_frequency_hz, 250);
+        assert_eq!(cfg.auth_token.as_deref(), Some("my-secret"));
+    }
+
+    #[test]
+    fn profiling_config_rejects_unknown_fields() {
+        let result: Result<ProfilingConfig, _> = serde_json::from_value(serde_json::json!({
+            "enabled": true,
+            "unknown_field": 42
+        }));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn profiling_config_roundtrip_serialize() {
+        let cfg = ProfilingConfig {
+            enabled: true,
+            bind_addr: "127.0.0.1:7070".to_owned(),
+            cpu_sample_duration_secs: 15,
+            cpu_sample_frequency_hz: 50,
+            auth_token: Some("token".to_owned()),
+        };
+        let json = serde_json::to_value(&cfg).unwrap();
+        let deserialized: ProfilingConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(deserialized.enabled, cfg.enabled);
+        assert_eq!(deserialized.bind_addr, cfg.bind_addr);
+        assert_eq!(
+            deserialized.cpu_sample_duration_secs,
+            cfg.cpu_sample_duration_secs
+        );
+        assert_eq!(
+            deserialized.cpu_sample_frequency_hz,
+            cfg.cpu_sample_frequency_hz
+        );
+        assert_eq!(deserialized.auth_token, cfg.auth_token);
+    }
+
+    #[test]
+    fn profiling_config_auth_token_omitted_from_serialization_when_none() {
+        let cfg = ProfilingConfig::default();
+        let json = serde_json::to_value(&cfg).unwrap();
+        assert!(!json.as_object().unwrap().contains_key("auth_token"));
     }
 }
 

--- a/libs/modkit/src/bootstrap/host/mod.rs
+++ b/libs/modkit/src/bootstrap/host/mod.rs
@@ -16,3 +16,6 @@ pub use metrics_provider::*;
 pub use panic::*;
 pub use paths::{HomeDirError, expand_tilde, normalize_path};
 pub use signals::*;
+
+#[cfg(feature = "profiling")]
+pub mod profiling;

--- a/libs/modkit/src/bootstrap/host/profiling/mod.rs
+++ b/libs/modkit/src/bootstrap/host/profiling/mod.rs
@@ -1,0 +1,26 @@
+//! On-demand CPU and memory profiling endpoint (pprof-compatible).
+//!
+//! When enabled via [`ProfilingConfig`], a **separate** HTTP server is started
+//! on a configurable address (default `127.0.0.1:6060`) exposing:
+//!
+//! - `GET /debug/pprof/profile` — CPU profile (pprof protobuf or flamegraph SVG)
+//! - `GET /debug/pprof/heap`    — Heap / allocator statistics (JSON)
+//! - `GET /debug/pprof/`        — Index page listing available profiles
+//!
+//! ## Platform support
+//!
+//! - **Linux / macOS**: CPU profiling via `pprof-rs` (signal-based sampling).
+//! - **Windows**: CPU profiling via a custom sampler thread
+//!   (`SuspendThread` / `GetThreadContext` / `ResumeThread`).
+
+mod server;
+
+#[cfg(unix)]
+mod sampler_unix;
+
+#[cfg(windows)]
+mod sampler_win;
+
+mod pprof_proto;
+
+pub use server::start_profiling_server;

--- a/libs/modkit/src/bootstrap/host/profiling/pprof_proto.rs
+++ b/libs/modkit/src/bootstrap/host/profiling/pprof_proto.rs
@@ -1,0 +1,412 @@
+//! Builds a pprof `profile.proto` from aggregated stack trace data.
+//!
+//! This module is used by the Windows sampler backend to produce output
+//! compatible with `go tool pprof` and other pprof-based tooling.
+
+use std::collections::HashMap;
+
+/// A collected stack sample: instruction pointer addresses (top-of-stack first)
+/// mapped to the number of times this exact stack was observed.
+pub(super) type StackSamples = HashMap<Vec<usize>, u64>;
+
+/// Encode aggregated stack samples into the pprof protobuf wire format.
+///
+/// The output is a raw (uncompressed) `perftools.profiles.Profile` message
+/// encoded via `prost`.  The caller is responsible for gzip-compressing
+/// if needed.
+pub(super) fn encode_pprof(
+    samples: &StackSamples,
+    duration_nanos: u64,
+    frequency_hz: u32,
+) -> anyhow::Result<Vec<u8>> {
+    // String table: index 0 is always the empty string.
+    let mut string_table: Vec<String> = vec![String::new()];
+    let mut string_index: HashMap<String, i64> = HashMap::new();
+    string_index.insert(String::new(), 0);
+
+    let mut intern = |s: &str| -> i64 {
+        if let Some(&idx) = string_index.get(s) {
+            return idx;
+        }
+        let idx = i64::try_from(string_table.len()).unwrap_or(0);
+        string_table.push(s.to_owned());
+        string_index.insert(s.to_owned(), idx);
+        idx
+    };
+
+    let sample_type_name = intern("samples");
+    let sample_type_unit = intern("count");
+    let cpu_type_name = intern("cpu");
+    let cpu_type_unit = intern("nanoseconds");
+
+    // Build locations and functions.
+    let mut locations: Vec<Location> = Vec::new();
+    let mut functions: Vec<Function> = Vec::new();
+    let mut location_index: HashMap<usize, u64> = HashMap::new();
+    let mut function_id_counter: u64 = 1;
+    let mut location_id_counter: u64 = 1;
+
+    for addrs in samples.keys() {
+        for &addr in addrs {
+            if location_index.contains_key(&addr) {
+                continue;
+            }
+
+            let loc_id = location_id_counter;
+            location_id_counter += 1;
+            location_index.insert(addr, loc_id);
+
+            // Resolve symbol name.
+            let mut func_name = format!("0x{addr:x}");
+            let mut file_name = String::new();
+            let mut line_no: i64 = 0;
+
+            backtrace::resolve(addr as *mut std::ffi::c_void, |symbol| {
+                if let Some(name) = symbol.name() {
+                    func_name = name.to_string();
+                }
+                if let Some(f) = symbol.filename() {
+                    file_name = f.display().to_string();
+                }
+                if let Some(l) = symbol.lineno() {
+                    line_no = i64::from(l);
+                }
+            });
+
+            let fn_name_idx = intern(&func_name);
+            let file_name_idx = intern(&file_name);
+
+            let func_id = function_id_counter;
+            function_id_counter += 1;
+
+            functions.push(Function {
+                id: func_id,
+                name: fn_name_idx,
+                system_name: fn_name_idx,
+                filename: file_name_idx,
+                start_line: 0,
+            });
+
+            locations.push(Location {
+                id: loc_id,
+                address: addr.try_into().unwrap_or(0),
+                line: vec![Line {
+                    function_id: func_id,
+                    line: line_no,
+                }],
+            });
+        }
+    }
+
+    // Build samples.
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    let period_ns = if frequency_hz > 0 {
+        (1_000_000_000_f64 / f64::from(frequency_hz)).round() as u64
+    } else {
+        10_000_000
+    };
+
+    let mut proto_samples: Vec<Sample> = Vec::with_capacity(samples.len());
+    for (addrs, &count) in samples {
+        let location_ids: Vec<u64> = addrs
+            .iter()
+            .filter_map(|a| location_index.get(a).copied())
+            .collect();
+
+        let cpu_nanos = i64::try_from(count.saturating_mul(period_ns)).unwrap_or(i64::MAX);
+
+        proto_samples.push(Sample {
+            location_id: location_ids,
+            value: vec![i64::try_from(count).unwrap_or(i64::MAX), cpu_nanos],
+            label: Vec::new(),
+        });
+    }
+
+    let period_type_name = intern("cpu");
+    let period_type_unit = intern("nanoseconds");
+
+    let profile = Profile {
+        sample_type: vec![
+            ValueType {
+                r#type: sample_type_name,
+                unit: sample_type_unit,
+            },
+            ValueType {
+                r#type: cpu_type_name,
+                unit: cpu_type_unit,
+            },
+        ],
+        sample: proto_samples,
+        location: locations,
+        function: functions,
+        string_table,
+        drop_frames: 0,
+        keep_frames: 0,
+        time_nanos: 0,
+        duration_nanos: i64::try_from(duration_nanos).unwrap_or(i64::MAX),
+        period_type: Some(ValueType {
+            r#type: period_type_name,
+            unit: period_type_unit,
+        }),
+        period: i64::try_from(period_ns).unwrap_or(0),
+        comment: Vec::new(),
+        default_sample_type: 0,
+    };
+
+    let mut buf = Vec::new();
+    prost::Message::encode(&profile, &mut buf)
+        .map_err(|e| anyhow::anyhow!("protobuf encoding failed: {e}"))?;
+    Ok(buf)
+}
+
+// ---------------------------------------------------------------------------
+// Minimal pprof protobuf message types (hand-rolled for prost::Message).
+//
+// These mirror `perftools.profiles.Profile` from
+// <https://github.com/google/pprof/blob/main/proto/profile.proto>.
+// We define them here to avoid depending on a full proto compilation step.
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, prost::Message)]
+struct Profile {
+    #[prost(message, repeated, tag = "1")]
+    sample_type: Vec<ValueType>,
+    #[prost(message, repeated, tag = "2")]
+    sample: Vec<Sample>,
+    // mapping omitted (tag 3)
+    #[prost(message, repeated, tag = "4")]
+    location: Vec<Location>,
+    #[prost(message, repeated, tag = "5")]
+    function: Vec<Function>,
+    #[prost(string, repeated, tag = "6")]
+    string_table: Vec<String>,
+    #[prost(int64, tag = "7")]
+    drop_frames: i64,
+    #[prost(int64, tag = "8")]
+    keep_frames: i64,
+    #[prost(int64, tag = "9")]
+    time_nanos: i64,
+    #[prost(int64, tag = "10")]
+    duration_nanos: i64,
+    #[prost(message, optional, tag = "11")]
+    period_type: Option<ValueType>,
+    #[prost(int64, tag = "12")]
+    period: i64,
+    #[prost(int64, repeated, tag = "13")]
+    comment: Vec<i64>,
+    #[prost(int64, tag = "14")]
+    default_sample_type: i64,
+}
+
+#[derive(Clone, prost::Message)]
+struct ValueType {
+    #[prost(int64, tag = "1")]
+    r#type: i64,
+    #[prost(int64, tag = "2")]
+    unit: i64,
+}
+
+#[derive(Clone, prost::Message)]
+struct Sample {
+    #[prost(uint64, repeated, tag = "1")]
+    location_id: Vec<u64>,
+    #[prost(int64, repeated, tag = "2")]
+    value: Vec<i64>,
+    #[prost(message, repeated, tag = "3")]
+    label: Vec<Label>,
+}
+
+#[derive(Clone, prost::Message)]
+struct Label {
+    #[prost(int64, tag = "1")]
+    key: i64,
+    #[prost(int64, tag = "2")]
+    str: i64,
+    #[prost(int64, tag = "3")]
+    num: i64,
+    #[prost(int64, tag = "4")]
+    num_unit: i64,
+}
+
+#[derive(Clone, prost::Message)]
+struct Location {
+    #[prost(uint64, tag = "1")]
+    id: u64,
+    // mapping_id omitted (tag 2)
+    #[prost(uint64, tag = "3")]
+    address: u64,
+    #[prost(message, repeated, tag = "4")]
+    line: Vec<Line>,
+}
+
+#[derive(Clone, prost::Message)]
+struct Line {
+    #[prost(uint64, tag = "1")]
+    function_id: u64,
+    #[prost(int64, tag = "2")]
+    line: i64,
+}
+
+#[derive(Clone, prost::Message)]
+struct Function {
+    #[prost(uint64, tag = "1")]
+    id: u64,
+    #[prost(int64, tag = "2")]
+    name: i64,
+    #[prost(int64, tag = "3")]
+    system_name: i64,
+    #[prost(int64, tag = "4")]
+    filename: i64,
+    #[prost(int64, tag = "5")]
+    start_line: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Decode the raw protobuf back into a `Profile` for assertions.
+    #[allow(clippy::useless_asref)]
+    fn decode_profile(buf: &[u8]) -> Profile {
+        <Profile as prost::Message>::decode(buf.as_ref()).expect("valid protobuf")
+    }
+
+    #[test]
+    fn encode_empty_samples() {
+        let samples = StackSamples::new();
+        let buf = encode_pprof(&samples, 1_000_000_000, 100).unwrap();
+        let profile = decode_profile(&buf);
+
+        assert!(profile.sample.is_empty());
+        assert!(profile.location.is_empty());
+        assert!(profile.function.is_empty());
+        // String table always has at least the empty string at index 0.
+        assert!(!profile.string_table.is_empty());
+        assert_eq!(profile.string_table[0], "");
+    }
+
+    #[test]
+    fn encode_single_sample() {
+        let mut samples = StackSamples::new();
+        samples.insert(vec![0x1000], 42);
+
+        let buf = encode_pprof(&samples, 5_000_000_000, 100).unwrap();
+        let profile = decode_profile(&buf);
+
+        assert_eq!(profile.sample.len(), 1);
+        assert_eq!(profile.location.len(), 1);
+        assert_eq!(profile.function.len(), 1);
+
+        // Two sample types: samples/count and cpu/nanoseconds.
+        assert_eq!(profile.sample_type.len(), 2);
+
+        // Value[0] = count, Value[1] = cpu_nanos.
+        let sample = &profile.sample[0];
+        assert_eq!(sample.value[0], 42);
+        // period_ns at 100 Hz = 10_000_000 ns; cpu_nanos = 42 * 10_000_000.
+        assert_eq!(sample.value[1], 42 * 10_000_000);
+
+        // Duration and period.
+        assert_eq!(profile.duration_nanos, 5_000_000_000);
+        assert_eq!(profile.period, 10_000_000);
+    }
+
+    #[test]
+    fn encode_multiple_samples_and_shared_addresses() {
+        let mut samples = StackSamples::new();
+        samples.insert(vec![0xA, 0xB], 10);
+        samples.insert(vec![0xA, 0xC], 20);
+
+        let buf = encode_pprof(&samples, 2_000_000_000, 50).unwrap();
+        let profile = decode_profile(&buf);
+
+        assert_eq!(profile.sample.len(), 2);
+        // Three unique addresses: 0xA, 0xB, 0xC.
+        assert_eq!(profile.location.len(), 3);
+        assert_eq!(profile.function.len(), 3);
+
+        // Each sample should reference exactly 2 locations.
+        for s in &profile.sample {
+            assert_eq!(s.location_id.len(), 2);
+        }
+    }
+
+    #[test]
+    fn zero_frequency_uses_default_period() {
+        let mut samples = StackSamples::new();
+        samples.insert(vec![0x1], 1);
+
+        let buf = encode_pprof(&samples, 1_000_000_000, 0).unwrap();
+        let profile = decode_profile(&buf);
+
+        // Default period when frequency_hz == 0 is 10_000_000 ns (100 Hz equivalent).
+        assert_eq!(profile.period, 10_000_000);
+    }
+
+    #[test]
+    fn period_precision_with_non_divisible_frequency() {
+        let mut samples = StackSamples::new();
+        samples.insert(vec![0x1], 1);
+
+        // 7 Hz → 1_000_000_000 / 7 = 142_857_142.857..., rounded to 142_857_143.
+        let buf = encode_pprof(&samples, 1_000_000_000, 7).unwrap();
+        let profile = decode_profile(&buf);
+        assert_eq!(profile.period, 142_857_143);
+
+        // 3 Hz → 1_000_000_000 / 3 = 333_333_333.333..., rounded to 333_333_333.
+        let buf = encode_pprof(&samples, 1_000_000_000, 3).unwrap();
+        let profile = decode_profile(&buf);
+        assert_eq!(profile.period, 333_333_333);
+    }
+
+    #[test]
+    fn string_table_contains_required_entries() {
+        let mut samples = StackSamples::new();
+        samples.insert(vec![0x1], 1);
+
+        let buf = encode_pprof(&samples, 1_000_000_000, 100).unwrap();
+        let profile = decode_profile(&buf);
+
+        // Must contain: "", "samples", "count", "cpu", "nanoseconds", and at
+        // least one function name (hex fallback or resolved symbol).
+        assert!(profile.string_table.contains(&String::new()));
+        assert!(profile.string_table.contains(&"samples".to_owned()));
+        assert!(profile.string_table.contains(&"count".to_owned()));
+        assert!(profile.string_table.contains(&"cpu".to_owned()));
+        assert!(profile.string_table.contains(&"nanoseconds".to_owned()));
+    }
+
+    #[test]
+    fn location_ids_are_unique_and_nonzero() {
+        let mut samples = StackSamples::new();
+        samples.insert(vec![0xA, 0xB, 0xC], 5);
+
+        let buf = encode_pprof(&samples, 1_000_000_000, 100).unwrap();
+        let profile = decode_profile(&buf);
+
+        let ids: Vec<u64> = profile.location.iter().map(|l| l.id).collect();
+        assert!(ids.iter().all(|&id| id > 0));
+
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), ids.len(), "location IDs must be unique");
+    }
+
+    #[test]
+    fn function_ids_are_unique_and_nonzero() {
+        let mut samples = StackSamples::new();
+        samples.insert(vec![0xA, 0xB], 1);
+
+        let buf = encode_pprof(&samples, 1_000_000_000, 100).unwrap();
+        let profile = decode_profile(&buf);
+
+        let ids: Vec<u64> = profile.function.iter().map(|f| f.id).collect();
+        assert!(ids.iter().all(|&id| id > 0));
+
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), ids.len(), "function IDs must be unique");
+    }
+}

--- a/libs/modkit/src/bootstrap/host/profiling/sampler_unix.rs
+++ b/libs/modkit/src/bootstrap/host/profiling/sampler_unix.rs
@@ -1,0 +1,129 @@
+//! Unix CPU profiler backend using `pprof-rs` (signal-based sampling).
+//!
+//! Flamegraph SVG is generated directly by `pprof-rs`.  Protobuf output uses
+//! the shared [`pprof_proto`] encoder to avoid a `prost` version conflict
+//! (`pprof 0.15` depends on `prost 0.12`; the workspace uses `prost 0.14`).
+
+use std::collections::HashMap;
+
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+
+use super::pprof_proto;
+use super::server::ProfOutputFormat;
+
+/// Capture a CPU profile for `seconds` at the given `frequency` Hz.
+pub(super) async fn capture(seconds: u64, frequency: u32, format: ProfOutputFormat) -> Response {
+    let result =
+        tokio::task::spawn_blocking(move || capture_blocking(seconds, frequency, format)).await;
+
+    match result {
+        Ok(Ok(resp)) => resp,
+        Ok(Err(e)) => {
+            tracing::error!(error = %e, "CPU profile capture failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("profiling error: {e}"),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "CPU profile task panicked");
+            (StatusCode::INTERNAL_SERVER_ERROR, "profiling task panicked").into_response()
+        }
+    }
+}
+
+fn capture_blocking(
+    seconds: u64,
+    frequency: u32,
+    format: ProfOutputFormat,
+) -> anyhow::Result<Response> {
+    let frequency_i32 = i32::try_from(frequency).unwrap_or(100);
+
+    let guard = pprof::ProfilerGuardBuilder::default()
+        .frequency(frequency_i32)
+        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+        .build()
+        .map_err(|e| anyhow::anyhow!("failed to start profiler: {e}"))?;
+
+    std::thread::sleep(std::time::Duration::from_secs(seconds));
+
+    let report = guard
+        .report()
+        .build()
+        .map_err(|e| anyhow::anyhow!("failed to build report: {e}"))?;
+
+    match format {
+        ProfOutputFormat::Flamegraph => {
+            let mut svg = Vec::new();
+            report
+                .flamegraph(&mut svg)
+                .map_err(|e| anyhow::anyhow!("flamegraph generation failed: {e}"))?;
+
+            Ok((
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, "image/svg+xml")],
+                svg,
+            )
+                .into_response())
+        }
+        ProfOutputFormat::Protobuf => {
+            let samples = report_to_stack_samples(&report);
+            let duration_nanos = seconds * 1_000_000_000;
+            let raw = pprof_proto::encode_pprof(&samples, duration_nanos, frequency)?;
+            let compressed = gzip_compress(&raw)?;
+
+            Ok((
+                StatusCode::OK,
+                [
+                    (header::CONTENT_TYPE, "application/octet-stream"),
+                    (header::CONTENT_ENCODING, "gzip"),
+                    (
+                        header::CONTENT_DISPOSITION,
+                        "attachment; filename=\"profile.pb.gz\"",
+                    ),
+                ],
+                compressed,
+            )
+                .into_response())
+        }
+    }
+}
+
+/// Convert a `pprof::Report` into our generic `StackSamples` format.
+///
+/// Each `Frames` entry has resolved symbol addresses.  We extract the first
+/// symbol address from each frame level to build a flat address list.
+fn report_to_stack_samples(report: &pprof::Report) -> HashMap<Vec<usize>, u64> {
+    let mut samples: HashMap<Vec<usize>, u64> = HashMap::new();
+
+    for (frames, count) in &report.data {
+        let addrs: Vec<usize> = frames
+            .frames
+            .iter()
+            .filter_map(|syms| syms.first().and_then(|s| s.addr.map(|p| p as usize)))
+            .collect();
+
+        if !addrs.is_empty() {
+            let count_u64 = u64::try_from(*count).unwrap_or(0);
+            *samples.entry(addrs).or_insert(0) += count_u64;
+        }
+    }
+
+    samples
+}
+
+fn gzip_compress(data: &[u8]) -> anyhow::Result<Vec<u8>> {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use std::io::Write;
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(data)
+        .map_err(|e| anyhow::anyhow!("gzip write failed: {e}"))?;
+    encoder
+        .finish()
+        .map_err(|e| anyhow::anyhow!("gzip finish failed: {e}"))
+}

--- a/libs/modkit/src/bootstrap/host/profiling/sampler_win.rs
+++ b/libs/modkit/src/bootstrap/host/profiling/sampler_win.rs
@@ -1,0 +1,254 @@
+//! Windows CPU profiler backend using `SuspendThread` / `GetThreadContext` /
+//! `ResumeThread` — the same approach used by Go's runtime (`os_windows.go:profileLoop`).
+//!
+//! A dedicated high-priority sampler thread periodically suspends every other
+//! thread in the process, captures the instruction pointer from its context,
+//! resolves symbols via `backtrace::resolve`, and aggregates the results into
+//! pprof-compatible protobuf output.
+
+use std::collections::HashMap;
+
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+
+use super::pprof_proto;
+use super::server::ProfOutputFormat;
+
+/// Capture a CPU profile for `seconds` at the given `frequency` Hz.
+pub(super) async fn capture(seconds: u64, frequency: u32, format: ProfOutputFormat) -> Response {
+    let result =
+        tokio::task::spawn_blocking(move || capture_blocking(seconds, frequency, format)).await;
+
+    match result {
+        Ok(Ok(resp)) => resp,
+        Ok(Err(e)) => {
+            tracing::error!(error = %e, "Windows CPU profile capture failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("profiling error: {e}"),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Windows CPU profile task panicked");
+            (StatusCode::INTERNAL_SERVER_ERROR, "profiling task panicked").into_response()
+        }
+    }
+}
+
+fn capture_blocking(
+    seconds: u64,
+    frequency: u32,
+    format: ProfOutputFormat,
+) -> anyhow::Result<Response> {
+    let freq = if frequency == 0 { 100 } else { frequency };
+
+    let samples = ffi::sample_threads(seconds, freq);
+
+    let duration_nanos = seconds * 1_000_000_000;
+
+    match format {
+        ProfOutputFormat::Protobuf => {
+            let raw = pprof_proto::encode_pprof(&samples, duration_nanos, freq)?;
+            let compressed = gzip_compress(&raw)?;
+
+            Ok((
+                StatusCode::OK,
+                [
+                    (header::CONTENT_TYPE, "application/octet-stream"),
+                    (header::CONTENT_ENCODING, "gzip"),
+                    (
+                        header::CONTENT_DISPOSITION,
+                        "attachment; filename=\"profile.pb.gz\"",
+                    ),
+                ],
+                compressed,
+            )
+                .into_response())
+        }
+        ProfOutputFormat::Flamegraph => {
+            let folded = build_folded_stacks(&samples);
+            Ok((
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+                format!(
+                    "# Folded stack format (pipe through `inferno-flamegraph` to produce SVG)\n\
+                     # Install: cargo install inferno\n\
+                     # Usage:   curl ... | inferno-flamegraph > flame.svg\n\n\
+                     {folded}"
+                ),
+            )
+                .into_response())
+        }
+    }
+}
+
+/// Build folded-stack text (compatible with `inferno-flamegraph`).
+fn build_folded_stacks(samples: &HashMap<Vec<usize>, u64>) -> String {
+    let mut lines = Vec::with_capacity(samples.len());
+    for (addrs, &count) in samples {
+        let names: Vec<String> = addrs
+            .iter()
+            .rev()
+            .map(|&addr| resolve_symbol(addr))
+            .collect();
+        lines.push(format!("{} {count}", names.join(";")));
+    }
+    lines.sort();
+    lines.join("\n")
+}
+
+fn resolve_symbol(addr: usize) -> String {
+    let mut name = format!("0x{addr:x}");
+    backtrace::resolve(addr as *mut std::ffi::c_void, |symbol| {
+        if let Some(n) = symbol.name() {
+            name = n.to_string();
+        }
+    });
+    name
+}
+
+fn gzip_compress(data: &[u8]) -> anyhow::Result<Vec<u8>> {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use std::io::Write;
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder
+        .write_all(data)
+        .map_err(|e| anyhow::anyhow!("gzip write failed: {e}"))?;
+    encoder
+        .finish()
+        .map_err(|e| anyhow::anyhow!("gzip finish failed: {e}"))
+}
+
+// ---------------------------------------------------------------------------
+// Win32 FFI — all `unsafe` code is confined to this inner module.
+// ---------------------------------------------------------------------------
+
+#[allow(unsafe_code)]
+mod ffi {
+    use std::collections::HashMap;
+
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::Debug::{
+        CONTEXT, CONTEXT_CONTROL, GetThreadContext,
+    };
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, TH32CS_SNAPTHREAD, THREADENTRY32, Thread32First, Thread32Next,
+    };
+    use windows_sys::Win32::System::Threading::{
+        GetCurrentProcessId, GetCurrentThreadId, OpenThread, ResumeThread, SuspendThread,
+        THREAD_GET_CONTEXT, THREAD_SUSPEND_RESUME,
+    };
+
+    /// Sample all threads in the current process for `seconds` at `frequency_hz`.
+    pub(super) fn sample_threads(seconds: u64, frequency_hz: u32) -> HashMap<Vec<usize>, u64> {
+        let freq = if frequency_hz == 0 { 100 } else { frequency_hz };
+        let interval = std::time::Duration::from_nanos(1_000_000_000 / u64::from(freq));
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(seconds);
+
+        let my_tid = unsafe { GetCurrentThreadId() };
+        let my_pid = unsafe { GetCurrentProcessId() };
+
+        // Elevate sampler thread priority for timing accuracy (non-fatal on failure).
+        unsafe {
+            windows_sys::Win32::System::Threading::SetThreadPriority(
+                windows_sys::Win32::System::Threading::GetCurrentThread(),
+                windows_sys::Win32::System::Threading::THREAD_PRIORITY_HIGHEST,
+            );
+        }
+
+        let mut samples: HashMap<Vec<usize>, u64> = HashMap::new();
+
+        while std::time::Instant::now() < deadline {
+            sample_all_threads(my_pid, my_tid, &mut samples);
+            std::thread::sleep(interval);
+        }
+
+        samples
+    }
+
+    fn sample_all_threads(pid: u32, self_tid: u32, samples: &mut HashMap<Vec<usize>, u64>) {
+        let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+        if snapshot == INVALID_HANDLE_VALUE {
+            return;
+        }
+
+        let mut entry = THREADENTRY32 {
+            dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+            cntUsage: 0,
+            th32ThreadID: 0,
+            th32OwnerProcessID: 0,
+            tpBasePri: 0,
+            tpDeltaPri: 0,
+            dwFlags: 0,
+        };
+
+        if unsafe { Thread32First(snapshot, &mut entry) } == 0 {
+            unsafe { CloseHandle(snapshot) };
+            return;
+        }
+
+        loop {
+            if entry.th32OwnerProcessID == pid && entry.th32ThreadID != self_tid {
+                sample_thread(entry.th32ThreadID, samples);
+            }
+
+            if unsafe { Thread32Next(snapshot, &mut entry) } == 0 {
+                break;
+            }
+        }
+
+        unsafe { CloseHandle(snapshot) };
+    }
+
+    fn sample_thread(tid: u32, samples: &mut HashMap<Vec<usize>, u64>) {
+        let handle: HANDLE =
+            unsafe { OpenThread(THREAD_SUSPEND_RESUME | THREAD_GET_CONTEXT, 0, tid) };
+        if handle == 0 {
+            return;
+        }
+
+        // SuspendThread returns previous suspend count, or u32::MAX on error.
+        if unsafe { SuspendThread(handle) } == u32::MAX {
+            unsafe { CloseHandle(handle) };
+            return;
+        }
+
+        // CONTEXT must be 16-byte aligned on x86-64.
+        #[repr(align(16))]
+        struct AlignedContext {
+            ctx: CONTEXT,
+        }
+
+        let mut aligned = AlignedContext {
+            ctx: unsafe { std::mem::zeroed() },
+        };
+        aligned.ctx.ContextFlags = CONTEXT_CONTROL;
+
+        let got_ctx = unsafe { GetThreadContext(handle, &mut aligned.ctx) };
+
+        // Always resume, even if GetThreadContext failed.
+        unsafe { ResumeThread(handle) };
+        unsafe { CloseHandle(handle) };
+
+        if got_ctx == 0 {
+            return;
+        }
+
+        // Extract instruction pointer (architecture-specific).
+        #[cfg(target_arch = "x86_64")]
+        let ip = aligned.ctx.Rip as usize;
+
+        #[cfg(target_arch = "x86")]
+        let ip = aligned.ctx.Eip as usize;
+
+        #[cfg(target_arch = "aarch64")]
+        let ip = aligned.ctx.Pc as usize;
+
+        if ip != 0 {
+            *samples.entry(vec![ip]).or_insert(0) += 1;
+        }
+    }
+}

--- a/libs/modkit/src/bootstrap/host/profiling/server.rs
+++ b/libs/modkit/src/bootstrap/host/profiling/server.rs
@@ -1,0 +1,429 @@
+//! Profiling HTTP server: routes, auth middleware, and graceful shutdown.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::{Query, State};
+use axum::http::{StatusCode, header};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use tokio_util::sync::CancellationToken;
+
+use crate::bootstrap::config::ProfilingConfig;
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Spawn the profiling HTTP server as a background tokio task.
+///
+/// The server binds to `config.bind_addr` and shuts down gracefully when
+/// `cancel` is triggered.
+pub fn start_profiling_server(config: ProfilingConfig, cancel: CancellationToken) {
+    tokio::spawn(async move {
+        if let Err(e) = run_server(config, cancel).await {
+            tracing::error!(error = %e, "profiling server failed");
+        }
+    });
+}
+
+async fn run_server(config: ProfilingConfig, cancel: CancellationToken) -> anyhow::Result<()> {
+    let addr: SocketAddr = config
+        .bind_addr
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid profiling bind_addr '{}': {e}", config.bind_addr))?;
+
+    let state = Arc::new(ProfileState {
+        config: config.clone(),
+    });
+
+    let mut app = Router::new()
+        .route("/debug/pprof/", get(index_handler))
+        .route("/debug/pprof/profile", get(cpu_profile_handler))
+        .route("/debug/pprof/heap", get(heap_handler))
+        .with_state(Arc::clone(&state));
+
+    // Optional bearer-token auth middleware
+    if config.auth_token.is_some() {
+        app = app.layer(middleware::from_fn_with_state(
+            Arc::clone(&state),
+            auth_middleware,
+        ));
+    }
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!(%addr, "profiling server started");
+
+    let shutdown = {
+        let cancel = cancel.clone();
+        async move {
+            cancel.cancelled().await;
+            tracing::info!("profiling server shutting down");
+        }
+    };
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await
+        .map_err(|e| anyhow::anyhow!(e))
+}
+
+// ---------------------------------------------------------------------------
+// Shared state
+// ---------------------------------------------------------------------------
+
+struct ProfileState {
+    config: ProfilingConfig,
+}
+
+// ---------------------------------------------------------------------------
+// Auth middleware
+// ---------------------------------------------------------------------------
+
+async fn auth_middleware(
+    State(state): State<Arc<ProfileState>>,
+    req: axum::extract::Request,
+    next: Next,
+) -> Response {
+    if let Some(ref expected) = state.config.auth_token {
+        let provided = req
+            .headers()
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "));
+
+        match provided {
+            Some(token) if token == expected.as_str() => {}
+            _ => {
+                return (StatusCode::UNAUTHORIZED, "missing or invalid bearer token")
+                    .into_response();
+            }
+        }
+    }
+    next.run(req).await
+}
+
+// ---------------------------------------------------------------------------
+// Query params
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Deserialize)]
+struct CpuProfileParams {
+    /// Duration in seconds (clamped to `cpu_sample_duration_secs`).
+    #[serde(default = "default_seconds")]
+    seconds: u64,
+    /// Output format: `protobuf` (default) or `flamegraph`.
+    #[serde(default)]
+    format: OutputFormat,
+}
+
+fn default_seconds() -> u64 {
+    30
+}
+
+#[derive(Default, serde::Deserialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+pub(in crate::bootstrap::host::profiling) enum OutputFormat {
+    #[default]
+    Protobuf,
+    Flamegraph,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn index_handler() -> impl IntoResponse {
+    let platform = if cfg!(unix) {
+        "unix (pprof-rs, signal-based)"
+    } else if cfg!(windows) {
+        "windows (SuspendThread sampler)"
+    } else {
+        "unsupported"
+    };
+
+    let body = format!(
+        "pprof profiling endpoint\n\n\
+         Platform: {platform}\n\n\
+         Available profiles:\n\
+         - /debug/pprof/profile?seconds=30&format=protobuf  CPU profile\n\
+         - /debug/pprof/profile?seconds=10&format=flamegraph CPU flamegraph SVG\n\
+         - /debug/pprof/heap                                 Heap / process memory stats\n"
+    );
+
+    (StatusCode::OK, [(header::CONTENT_TYPE, "text/plain")], body)
+}
+
+async fn cpu_profile_handler(
+    State(state): State<Arc<ProfileState>>,
+    Query(params): Query<CpuProfileParams>,
+) -> Response {
+    let seconds = params.seconds.min(state.config.cpu_sample_duration_secs);
+    if seconds == 0 {
+        return (StatusCode::BAD_REQUEST, "seconds must be > 0").into_response();
+    }
+    let frequency = state.config.cpu_sample_frequency_hz;
+
+    #[cfg(unix)]
+    {
+        super::sampler_unix::capture(seconds, frequency, params.format).await
+    }
+
+    #[cfg(windows)]
+    {
+        super::sampler_win::capture(seconds, frequency, params.format).await
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (seconds, frequency);
+        (
+            StatusCode::NOT_IMPLEMENTED,
+            "CPU profiling is not supported on this platform",
+        )
+            .into_response()
+    }
+}
+
+async fn heap_handler() -> impl IntoResponse {
+    let info = gather_memory_info();
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        serde_json::to_string_pretty(&info).unwrap_or_else(|_| "{}".to_owned()),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Memory info (cross-platform)
+// ---------------------------------------------------------------------------
+
+fn gather_memory_info() -> serde_json::Value {
+    // Use /proc/self/status on Linux, basic process info elsewhere.
+    #[cfg(target_os = "linux")]
+    {
+        gather_linux_memory()
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        serde_json::json!({
+            "note": "detailed memory stats are only available on Linux; consider /proc/self/status",
+            "platform": std::env::consts::OS,
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn gather_linux_memory() -> serde_json::Value {
+    match std::fs::read_to_string("/proc/self/status") {
+        Ok(contents) => {
+            let mut info = serde_json::Map::new();
+            for line in contents.lines() {
+                if let Some((key, val)) = line.split_once(':') {
+                    let key = key.trim();
+                    let val = val.trim();
+                    if key.starts_with("Vm") || key.starts_with("Rss") || key == "Threads" {
+                        info.insert(key.to_owned(), serde_json::Value::String(val.to_owned()));
+                    }
+                }
+            }
+            serde_json::Value::Object(info)
+        }
+        Err(e) => serde_json::json!({ "error": e.to_string() }),
+    }
+}
+
+// Re-export OutputFormat so samplers can use it.
+pub(super) use self::OutputFormat as ProfOutputFormat;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn test_config(auth_token: Option<&str>) -> ProfilingConfig {
+        ProfilingConfig {
+            enabled: true,
+            bind_addr: "127.0.0.1:0".to_owned(),
+            cpu_sample_duration_secs: 5,
+            cpu_sample_frequency_hz: 100,
+            auth_token: auth_token.map(ToOwned::to_owned),
+        }
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    fn build_app(config: ProfilingConfig) -> Router {
+        let state = Arc::new(ProfileState {
+            config: config.clone(),
+        });
+
+        let mut app = Router::new()
+            .route("/debug/pprof/", get(index_handler))
+            .route("/debug/pprof/profile", get(cpu_profile_handler))
+            .route("/debug/pprof/heap", get(heap_handler))
+            .with_state(Arc::clone(&state));
+
+        if config.auth_token.is_some() {
+            app = app.layer(middleware::from_fn_with_state(
+                Arc::clone(&state),
+                auth_middleware,
+            ));
+        }
+        app
+    }
+
+    #[tokio::test]
+    async fn index_returns_200_and_text() {
+        let app = build_app(test_config(None));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/debug/pprof/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8_lossy(&body);
+        assert!(text.contains("pprof profiling endpoint"));
+        assert!(text.contains("/debug/pprof/profile"));
+        assert!(text.contains("/debug/pprof/heap"));
+    }
+
+    #[tokio::test]
+    async fn heap_returns_200_json() {
+        let app = build_app(test_config(None));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/debug/pprof/heap")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(ct.contains("application/json"));
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        // Must be valid JSON.
+        let _: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    }
+
+    #[tokio::test]
+    async fn auth_rejects_missing_token() {
+        let app = build_app(test_config(Some("secret")));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/debug/pprof/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn auth_rejects_wrong_token() {
+        let app = build_app(test_config(Some("secret")));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/debug/pprof/")
+                    .header(header::AUTHORIZATION, "Bearer wrong")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn auth_accepts_valid_token() {
+        let app = build_app(test_config(Some("secret")));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/debug/pprof/")
+                    .header(header::AUTHORIZATION, "Bearer secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn no_auth_config_passes_through() {
+        let app = build_app(test_config(None));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/debug/pprof/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn cpu_profile_rejects_zero_seconds() {
+        let app = build_app(test_config(None));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/debug/pprof/profile?seconds=0")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn unknown_route_returns_404() {
+        let app = build_app(test_config(None));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/debug/pprof/nonexistent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/libs/modkit/src/bootstrap/mod.rs
+++ b/libs/modkit/src/bootstrap/mod.rs
@@ -22,7 +22,7 @@ pub mod oop;
 // Re-export commonly used config types at crate root for convenience
 pub use config::{
     AppConfig, CliArgs, ConsoleFormat, LoggingConfig, MODKIT_MODULE_CONFIG_ENV, ModuleConfig,
-    ModuleRuntime, RenderedModuleConfig, RuntimeKind, Section, ServerConfig,
+    ModuleRuntime, ProfilingConfig, RenderedModuleConfig, RuntimeKind, Section, ServerConfig,
     dump_effective_modules_config_json, dump_effective_modules_config_yaml, list_module_names,
     render_effective_modules_config,
 };

--- a/libs/modkit/src/bootstrap/run.rs
+++ b/libs/modkit/src/bootstrap/run.rs
@@ -58,6 +58,14 @@ pub async fn run_server(config: AppConfig) -> anyhow::Result<()> {
     // This replaces the use of ShutdownOptions::Signals inside the runtime.
     spawn_signal_handler(cancel.clone(), "server");
 
+    // Start the profiling HTTP server if enabled.
+    #[cfg(feature = "profiling")]
+    if let Some(ref prof_cfg) = config.profiling
+        && prof_cfg.enabled
+    {
+        super::host::profiling::start_profiling_server(prof_cfg.clone(), cancel.clone());
+    }
+
     // Build config provider and resolve database options
     let db_options = resolve_db_options(&config)?;
 


### PR DESCRIPTION
Add profiling capabilities with separate http server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added on-demand CPU and heap profiling via HTTP endpoints when enabled in configuration.
  * Profiling server binds to configurable address (default: 127.0.0.1:6060) with optional bearer token authentication.
  * Supports multiple output formats: pprof protobuf and flamegraph visualization.

* **Documentation**
  * Added comprehensive profiling guide covering configuration, endpoints, security, and platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->