### PR TITLE
feat(api-gateway): add configurable prefix for HTTP metrics instrument names

### DIFF
--- a/modules/system/api-gateway/Cargo.toml
+++ b/modules/system/api-gateway/Cargo.toml
@@ -54,9 +54,7 @@ rust-embed = { workspace = true }
 
 [dev-dependencies]
 futures-core = { workspace = true }
-opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
-uuid = { workspace = true }
 
 [features]
 grpc = []

--- a/modules/system/api-gateway/src/config.rs
+++ b/modules/system/api-gateway/src/config.rs
@@ -47,6 +47,10 @@ pub struct ApiGatewayConfig {
     /// Empty string (the default) means no prefix.
     #[serde(default)]
     pub prefix_path: String,
+
+    /// HTTP metrics settings.
+    #[serde(default)]
+    pub metrics: MetricsConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -117,6 +121,20 @@ impl Default for CorsConfig {
             max_age_seconds: 600,
         }
     }
+}
+
+/// HTTP metrics configuration.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct MetricsConfig {
+    /// Optional prefix for HTTP metrics instrument names.
+    ///
+    /// When set, metric names become `{prefix}.http.server.request.duration`
+    /// and `{prefix}.http.server.active_requests` instead of the default
+    /// OpenTelemetry semantic convention names.
+    ///
+    /// Empty string (the default) means no prefix — standard `OTel` names are used.
+    pub prefix: String,
 }
 
 /// `OpenAPI` document metadata configuration

--- a/modules/system/api-gateway/src/middleware/http_metrics.rs
+++ b/modules/system/api-gateway/src/middleware/http_metrics.rs
@@ -29,19 +29,37 @@ pub struct HttpMetrics {
 
 impl HttpMetrics {
     /// Create instruments on the global meter scoped to the given module name.
+    ///
+    /// When `prefix` is non-empty the metric names become
+    /// `{prefix}.http.server.request.duration` and
+    /// `{prefix}.http.server.active_requests`.
     #[must_use]
-    pub fn new(module_name: &str) -> Self {
+    pub fn new(module_name: &str, prefix: &str) -> Self {
+        let prefix = prefix.trim().trim_end_matches('.'); // Normalize prefix.
+
         let scope = opentelemetry::InstrumentationScope::builder(module_name.to_owned()).build();
         let meter = opentelemetry::global::meter_with_scope(scope);
 
+        let (duration_name, active_name) = if prefix.is_empty() {
+            (
+                "http.server.request.duration".to_owned(),
+                "http.server.active_requests".to_owned(),
+            )
+        } else {
+            (
+                format!("{prefix}.http.server.request.duration"),
+                format!("{prefix}.http.server.active_requests"),
+            )
+        };
+
         let duration = meter
-            .f64_histogram("http.server.request.duration")
+            .f64_histogram(duration_name)
             .with_description("Duration of HTTP server requests")
             .with_unit("s")
             .build();
 
         let active_requests = meter
-            .i64_up_down_counter("http.server.active_requests")
+            .i64_up_down_counter(active_name)
             .with_description("Number of active HTTP server requests")
             .build();
 

--- a/modules/system/api-gateway/src/module.rs
+++ b/modules/system/api-gateway/src/module.rs
@@ -337,6 +337,7 @@ impl ApiGateway {
         // 4) HTTP metrics (layer — captures all middleware responses including auth/rate-limit/timeout)
         let http_metrics = Arc::new(middleware::http_metrics::HttpMetrics::new(
             Self::MODULE_NAME,
+            &config.metrics.prefix,
         ));
         router = router.layer(from_fn_with_state(
             http_metrics,

--- a/modules/system/api-gateway/tests/http_metrics_tests.rs
+++ b/modules/system/api-gateway/tests/http_metrics_tests.rs
@@ -65,6 +65,15 @@ fn install_test_meter_provider() -> (SdkMeterProvider, InMemoryMetricExporter) {
     (provider, exporter)
 }
 
+/// Check whether a metric with the given name exists in the exported data (any type).
+fn metric_exists(exporter: &InMemoryMetricExporter, name: &str) -> bool {
+    let metrics = exporter.get_finished_metrics().unwrap();
+    metrics.iter().any(|rm| {
+        rm.scope_metrics()
+            .any(|sm| sm.metrics().any(|m| m.name() == name))
+    })
+}
+
 /// Extract the sum of all histogram data point counts for the named metric.
 fn histogram_count(exporter: &InMemoryMetricExporter, name: &str) -> u64 {
     let metrics = exporter.get_finished_metrics().unwrap();
@@ -409,6 +418,76 @@ async fn metrics_unmatched_route() -> Result<()> {
             ]
         ),
         "unmatched route should have http.route='unmatched' and status 404"
+    );
+
+    Ok(())
+}
+
+fn prefixed_config() -> serde_json::Value {
+    json!({
+        "api-gateway": {
+            "config": {
+                "bind_addr": "127.0.0.1:0",
+                "cors_enabled": false,
+                "auth_disabled": true,
+                "metrics": { "prefix": "myapp" },
+                "defaults": {
+                    "rate_limit": { "rps": 1000, "burst": 1000, "in_flight": 64 }
+                },
+            }
+        }
+    })
+}
+
+#[tokio::test]
+async fn metrics_prefix_applied_to_instrument_names() -> Result<()> {
+    let _lock = METER_LOCK.lock().await;
+    let (provider, exporter) = install_test_meter_provider();
+    let ctx = create_api_gateway_ctx(prefixed_config());
+    let api = api_gateway::ApiGateway::default();
+    api.init(&ctx).await?;
+
+    let router = OperationBuilder::get("/tests/v1/items")
+        .operation_id("test:list-items")
+        .summary("List items")
+        .public()
+        .json_response(StatusCode::OK, "OK")
+        .handler(axum::routing::get(ok_handler))
+        .register(Router::new(), &api);
+    let app = api.rest_finalize(&ctx, router)?;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/tests/v1/items")
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    provider.force_flush().unwrap();
+
+    let count = histogram_count(&exporter, "myapp.http.server.request.duration");
+    assert!(
+        count >= 1,
+        "expected at least 1 data point for prefixed metric name, got {count}"
+    );
+
+    // Verify active_requests counter is also prefixed
+    assert!(
+        metric_exists(&exporter, "myapp.http.server.active_requests"),
+        "active_requests counter should use the configured prefix"
+    );
+
+    // The unprefixed names should NOT exist when prefix is configured
+    assert!(
+        !metric_exists(&exporter, "http.server.request.duration"),
+        "unprefixed duration should not exist when prefix is configured"
+    );
+    assert!(
+        !metric_exists(&exporter, "http.server.active_requests"),
+        "unprefixed active_requests should not exist when prefix is configured"
     );
 
     Ok(())


### PR DESCRIPTION
- Add MetricsConfig with optional prefix field to ApiGatewayConfig
- Update HttpMetrics::new() to accept prefix and prepend it to metric names
- Wire prefix from config through to HttpMetrics construction in module.rs
- Remove unused dev-dependencies (opentelemetry, uuid)
- Add integration test verifying prefixed metric names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP metrics support a configurable prefix so metric names can be scoped/customized in observability systems.

* **Tests**
  * Added tests to verify that the configured metrics prefix is applied to emitted metric names and that unprefixed metrics remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->