### PR TITLE
fix(mini-chat): align AttachmentDetailDto with OpenAPI contract

### DIFF
--- a/modules/mini-chat/docs/openapi.json
+++ b/modules/mini-chat/docs/openapi.json
@@ -447,7 +447,7 @@
                   "$ref": "#/components/schemas/Attachment"
                 },
                 "example": {
-                  "attachment_id": "c3d4e5f6-7890-4abc-def1-234567890abc",
+                  "id": "c3d4e5f6-7890-4abc-def1-234567890abc",
                   "status": "pending",
                   "kind": "document",
                   "filename": "Q3_Report.pdf",
@@ -642,7 +642,7 @@
                   "document_attachment": {
                     "summary": "Document attachment (ready, with summary)",
                     "value": {
-                      "attachment_id": "c3d4e5f6-7890-4abc-def1-234567890abc",
+                      "id": "c3d4e5f6-7890-4abc-def1-234567890abc",
                       "status": "ready",
                       "kind": "document",
                       "filename": "Q3_Report.pdf",
@@ -658,7 +658,7 @@
                   "image_attachment": {
                     "summary": "Image attachment (ready, with thumbnail preview)",
                     "value": {
-                      "attachment_id": "d4e5f6a7-8901-4abc-def1-234567890abd",
+                      "id": "d4e5f6a7-8901-4abc-def1-234567890abd",
                       "status": "ready",
                       "kind": "image",
                       "filename": "architecture_diagram.png",
@@ -1488,12 +1488,13 @@
       },
       "Attachment": {
         "type": "object",
-        "required": ["attachment_id", "status", "kind", "filename", "content_type", "size_bytes", "created_at"],
+        "required": ["id", "status", "kind", "filename", "content_type", "size_bytes", "created_at"],
         "description": "File attachment (document or image) on a chat.",
         "properties": {
-          "attachment_id": {
+          "id": {
             "type": "string",
-            "format": "uuid"
+            "format": "uuid",
+            "description": "Attachment UUID."
           },
           "status": {
             "type": "string",

--- a/modules/mini-chat/mini-chat/src/api/rest/dto.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/dto.rs
@@ -161,23 +161,24 @@ impl From<ImgThumbnail> for ImgThumbnailDto {
 #[modkit_macros::api_dto(response)]
 pub struct AttachmentDetailDto {
     pub id: Uuid,
-    pub chat_id: Uuid,
     pub filename: String,
     pub content_type: String,
     pub size_bytes: i64,
-    pub storage_backend: String,
     pub status: String,
-    pub attachment_kind: String,
+    pub kind: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub doc_summary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub img_thumbnail: Option<ImgThumbnailDto>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        with = "time::serde::rfc3339::option"
+    )]
+    pub summary_updated_at: Option<OffsetDateTime>,
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
-    #[serde(with = "time::serde::rfc3339")]
-    pub updated_at: OffsetDateTime,
 }
 
 impl From<AttachmentModel> for AttachmentDetailDto {
@@ -195,18 +196,16 @@ impl From<AttachmentModel> for AttachmentDetailDto {
 
         Self {
             id: m.id,
-            chat_id: m.chat_id,
             filename: m.filename,
             content_type: m.content_type,
             size_bytes: m.size_bytes,
-            storage_backend: m.storage_backend,
             status: m.status.to_string(),
-            attachment_kind: m.attachment_kind.to_string(),
+            kind: m.attachment_kind.to_string(),
             error_code: m.error_code,
             doc_summary: m.doc_summary,
             img_thumbnail,
+            summary_updated_at: m.summary_updated_at,
             created_at: m.created_at,
-            updated_at: m.updated_at,
         }
     }
 }


### PR DESCRIPTION
- Rename attachment_kind -> kind, updated_at -> summary_updated_at (nullable)
- Remove chat_id and storage_backend from response (internal details)
- Update Attachment schema in openapi.json: attachment_id -> id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Renamed attachment identifier field from `attachment_id` to `id` in attachment responses across all endpoints.
  * Updated attachment response structure: removed internal tracking fields, added attachment summary timestamp information, and standardized attachment type field naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->