### PR TITLE
test(outbox): use tokio virtual time to fix flaky CI tests

### DIFF
--- a/libs/modkit-db/Cargo.toml
+++ b/libs/modkit-db/Cargo.toml
@@ -110,7 +110,7 @@ tempfile = { workspace = true }
 serde-saphyr = { workspace = true }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 anyhow = { workspace = true }
 temp-env = { workspace = true }
 trybuild = { workspace = true }

--- a/libs/modkit-db/src/outbox/integration_tests.rs
+++ b/libs/modkit-db/src/outbox/integration_tests.rs
@@ -3627,12 +3627,19 @@ async fn pipeline_single_enqueue_one_delivery() {
             .ok();
     }
 
-    // Brief window for any spurious duplicate deliveries
+    // Verify no duplicate delivery arrives. Wait 200ms and check the counter
+    // hasn't incremented beyond 1. We check the counter directly instead of
+    // notify.notified() because a stale permit from the first delivery's
+    // notify_one() would cause notified().await to resolve immediately.
+    let baseline = counter.load(Ordering::Relaxed);
     tokio::time::sleep(Duration::from_millis(200)).await;
-
     assert_eq!(
         counter.load(Ordering::Relaxed),
-        1,
+        baseline,
+        "no duplicate delivery should occur (counter changed during wait)"
+    );
+    assert_eq!(
+        baseline, 1,
         "single enqueue must produce exactly one delivery"
     );
 

--- a/libs/modkit-db/src/outbox/prioritizer.rs
+++ b/libs/modkit-db/src/outbox/prioritizer.rs
@@ -326,11 +326,23 @@ impl SharedPrioritizer {
     /// Lock-contention is minimal: only the inbox mutex is held, for a
     /// single `push_back`.
     pub fn push_dirty(&self, pid: i64) {
+        self.push_dirty_impl(pid, Instant::now());
+    }
+
+    /// Test-only variant that accepts an explicit timestamp instead of
+    /// `Instant::now()`, allowing tests to bypass coalesce/cooldown
+    /// windows without real sleeps.
+    #[cfg(test)]
+    fn push_dirty_at(&self, pid: i64, dirty_since: Instant) {
+        self.push_dirty_impl(pid, dirty_since);
+    }
+
+    fn push_dirty_impl(&self, pid: i64, dirty_since: Instant) {
         let mut inbox = self
             .inbox
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if !inbox.try_push(pid, Instant::now()) {
+        if !inbox.try_push(pid, dirty_since) {
             // Duplicate within coalesce window — skip notification
             return;
         }
@@ -474,7 +486,6 @@ impl Drop for PartitionGuard {
 mod tests {
     use super::*;
     use std::collections::HashSet;
-    use std::thread;
 
     fn make_shared() -> Arc<SharedPrioritizer> {
         Arc::new(SharedPrioritizer::new())
@@ -691,9 +702,16 @@ mod tests {
         let g = sp.take().unwrap();
         g.error(); // error_count = 1
 
-        // Wait for cooldown
-        thread::sleep(Duration::from_millis(250));
-        sp.push_dirty(10);
+        // Move the cooldown-delayed entry to the past so take() can pop it
+        {
+            let mut sched = sp.scheduler.lock().unwrap();
+            let entry = *sched.pending.iter().find(|(_, pid)| *pid == 10).unwrap();
+            sched.pending.remove(&entry);
+            sched.pending.insert((
+                Instant::now().checked_sub(Duration::from_secs(1)).unwrap(),
+                10,
+            ));
+        }
         let g2 = sp.take().unwrap();
         g2.processed(); // should reset error_count
 
@@ -720,9 +738,10 @@ mod tests {
     #[test]
     fn skipped_retains_original_priority() {
         let sp = make_shared();
-        sp.push_dirty(10);
-        thread::sleep(Duration::from_millis(2));
-        sp.push_dirty(20);
+        let now = Instant::now();
+        let t0 = now.checked_sub(Duration::from_secs(2)).unwrap();
+        sp.push_dirty_at(10, t0);
+        sp.push_dirty_at(20, t0 + Duration::from_secs(1));
 
         // Take partition 10, skip it
         let g1 = sp.take().unwrap();
@@ -926,11 +945,11 @@ mod tests {
     #[test]
     fn oldest_dirty_served_first() {
         let sp = make_shared();
-        sp.push_dirty(30);
-        thread::sleep(Duration::from_millis(2));
-        sp.push_dirty(10);
-        thread::sleep(Duration::from_millis(2));
-        sp.push_dirty(20);
+        let now = Instant::now();
+        let t0 = now.checked_sub(Duration::from_secs(3)).unwrap();
+        sp.push_dirty_at(30, t0);
+        sp.push_dirty_at(10, t0 + Duration::from_secs(1));
+        sp.push_dirty_at(20, t0 + Duration::from_secs(2));
 
         let g1 = sp.take().unwrap();
         assert_eq!(g1.partition_id(), 30, "oldest dirty should be first");

--- a/libs/modkit-db/src/outbox/taskward/bulkhead.rs
+++ b/libs/modkit-db/src/outbox/taskward/bulkhead.rs
@@ -615,7 +615,7 @@ mod tests {
         assert_eq!(shared.available_permits(), 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn priority_cancel_during_wait() {
         let guaranteed = Arc::new(Semaphore::new(0));
         let shared = Arc::new(Semaphore::new(0));
@@ -630,7 +630,7 @@ mod tests {
         assert!(bh.acquire(&cancel).await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn priority_blocks_when_neither_available() {
         let guaranteed = Arc::new(Semaphore::new(0));
         let shared = Arc::new(Semaphore::new(0));

--- a/libs/modkit-db/src/outbox/taskward/poker.rs
+++ b/libs/modkit-db/src/outbox/taskward/poker.rs
@@ -91,7 +91,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn stored_permit_semantics() {
         // Prove: a poke that fires while nobody is awaiting creates a
         // stored permit that the next notified() consumes immediately.

--- a/libs/modkit-db/src/outbox/taskward/showcase.rs
+++ b/libs/modkit-db/src/outbox/taskward/showcase.rs
@@ -2,13 +2,14 @@
 //! realistic settings. Each test tells a story — the name describes the
 //! situation, the body shows how the worker handles it.
 //!
-//! Durations are scaled down (hours → milliseconds) so tests complete fast.
+//! All tests use `start_paused = true` (tokio virtual time) so durations
+//! are realistic (hours, seconds) yet tests complete instantly.
 
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering};
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use tokio::sync::Notify;
     use tokio_util::sync::CancellationToken;
@@ -28,8 +29,6 @@ mod tests {
     // But one day the batch is huge — work takes 5 h, overshooting the
     // 4 h window. The action returns `Proceed` so the worker retries
     // immediately instead of waiting for the next poke.
-    //
-    // Scaled: 4h → 80ms, 2h → 40ms, 5h → 100ms, 1h → 20ms.
 
     struct BatchProcessor {
         /// Durations of simulated work per call.
@@ -64,10 +63,9 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn long_interval_worker_reschedules_when_work_exceeds_window() {
-        // Scale: 1h = 20ms, so 4h = 80ms, 2h = 40ms, 5h = 100ms.
-        let h = Duration::from_millis(20); // 1 "hour"
+        let h = Duration::from_secs(3600); // 1 hour (virtual time, runs instantly)
 
         let cancel = CancellationToken::new();
         let call_count = Arc::new(AtomicU32::new(0));
@@ -86,14 +84,14 @@ mod tests {
             .with_poker(h * 4) // 4h poker
             .build(action);
 
-        // Cancel after 16h scaled — enough for 3 calls + some idle.
+        // Cancel after 16h — enough for 3 calls + some idle.
         let cancel_c = cancel.clone();
         tokio::spawn(async move {
             tokio::time::sleep(h * 16).await;
             cancel_c.cancel();
         });
 
-        let start = Instant::now();
+        let start = tokio::time::Instant::now();
         worker.run().await;
 
         // At least 3 calls happened. Call 3 was the immediate retry after
@@ -136,8 +134,10 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn event_driven_worker_ignores_long_poker_when_notified() {
+        let h = Duration::from_secs(3600);
+
         let cancel = CancellationToken::new();
         let notify = Arc::new(Notify::new());
         let call_count = Arc::new(AtomicU32::new(0));
@@ -146,39 +146,39 @@ mod tests {
             call_count: call_count.clone(),
         };
 
-        // Poker fires every 5s (safety net) — but notifiers fire much sooner.
+        // Poker fires every 5h (safety net) — but notifiers fire much sooner.
         let worker = WorkerBuilder::new("event-worker", cancel.clone())
             .notifier(notify.clone())
-            .with_poker(Duration::from_secs(5))
+            .with_poker(h * 5)
             .build(action);
 
         // Stored permit → initial Idle resolves immediately.
         notify.notify_one();
         let notify_c = notify.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(30)).await;
+            tokio::time::sleep(h).await;
             notify_c.notify_one(); // call 2
-            tokio::time::sleep(Duration::from_millis(30)).await;
+            tokio::time::sleep(h).await;
             notify_c.notify_one(); // call 3
         });
 
         let cancel_c = cancel.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(200)).await;
+            tokio::time::sleep(h * 4).await;
             cancel_c.cancel();
         });
 
-        let start = Instant::now();
+        let start = tokio::time::Instant::now();
         worker.run().await;
 
         assert_eq!(
             call_count.load(Ordering::SeqCst),
             3,
-            "expected 3 event-driven calls, not waiting for 5s poker",
+            "expected 3 event-driven calls, not waiting for 5h poker",
         );
-        // All 3 calls happen within 200ms — well before the 5s poker.
+        // All 3 calls happen within 4h — well before the 5h poker.
         assert!(
-            start.elapsed() < Duration::from_secs(1),
+            start.elapsed() < h * 5,
             "should complete fast via notifiers, not wait for poker",
         );
     }
@@ -199,27 +199,27 @@ mod tests {
             self.results
                 .get(idx)
                 .cloned()
-                .unwrap_or(Ok(Directive::sleep(Duration::from_secs(60))))
+                .unwrap_or(Ok(Directive::sleep(Duration::from_secs(3600))))
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn transient_errors_backoff_then_recover() {
-        // 3 consecutive errors → escalating backoff (10ms, 20ms, 40ms = 70ms)
+        // 3 consecutive errors → escalating backoff (1s, 2s, 4s = 7s)
         // Then success → backoff resets.
-        // Then another error → backoff starts from 10ms again (not 80ms).
+        // Then another error → backoff starts from 1s again (not 8s).
 
         let cancel = CancellationToken::new();
         let call_count = Arc::new(AtomicU32::new(0));
 
         let action = FlakyAction {
             results: vec![
-                Err("db timeout".into()), // backoff → 10ms
-                Err("db timeout".into()), // backoff → 20ms
-                Err("db timeout".into()), // backoff → 40ms
+                Err("db timeout".into()), // backoff → 1s
+                Err("db timeout".into()), // backoff → 2s
+                Err("db timeout".into()), // backoff → 4s
                 Ok(Directive::proceed()), // reset backoff
-                Err("db timeout".into()), // backoff → 10ms (reset!)
-                Ok(Directive::sleep(Duration::from_secs(60))),
+                Err("db timeout".into()), // backoff → 1s (reset!)
+                Ok(Directive::sleep(Duration::from_secs(3600))),
             ],
             call_count: call_count.clone(),
         };
@@ -229,8 +229,8 @@ mod tests {
             BulkheadConfig {
                 semaphore: ConcurrencyLimit::Unlimited,
                 backoff: BackoffConfig {
-                    initial: Duration::from_millis(10),
-                    max: Duration::from_secs(60),
+                    initial: Duration::from_secs(1),
+                    max: Duration::from_secs(3600),
                     multiplier: 2.0,
                     jitter: 0.0,
                 },
@@ -246,11 +246,11 @@ mod tests {
 
         let cancel_c = cancel.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_secs(5)).await;
+            tokio::time::sleep(Duration::from_secs(3600)).await;
             cancel_c.cancel();
         });
 
-        let start = Instant::now();
+        let start = tokio::time::Instant::now();
         worker.run().await;
 
         assert_eq!(
@@ -258,8 +258,8 @@ mod tests {
             6,
             "all 6 calls should complete -- errors absorbed by bulkhead",
         );
-        // Total backoff: 10 + 20 + 40 + 0 (Proceed) + 10 = 80ms minimum.
-        assert!(start.elapsed() >= Duration::from_millis(80));
+        // Total backoff: 1 + 2 + 4 + 0 (Proceed) + 1 = 8s minimum.
+        assert!(start.elapsed() >= Duration::from_secs(8));
     }
 
     // ---- Scenario: Multiple wake sources compose naturally ----
@@ -278,8 +278,10 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn multiple_notifiers_any_source_wakes_worker() {
+        let h = Duration::from_secs(3600);
+
         // 3 independent event sources — worker wakes on whichever fires first.
         let cancel = CancellationToken::new();
         let source_a = Arc::new(Notify::new());
@@ -302,19 +304,19 @@ mod tests {
 
         let (b, c, a) = (source_b.clone(), source_c.clone(), source_a.clone());
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            tokio::time::sleep(h).await;
             b.notify_one(); // source B → call 2
 
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            tokio::time::sleep(h).await;
             c.notify_one(); // source C → call 3
 
-            tokio::time::sleep(Duration::from_millis(20)).await;
+            tokio::time::sleep(h).await;
             a.notify_one(); // source A → call 4
         });
 
         let cancel_c = cancel.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(200)).await;
+            tokio::time::sleep(h * 6).await;
             cancel_c.cancel();
         });
 
@@ -365,7 +367,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn parallel_workers_share_semaphore_and_notifier() {
         let cancel = CancellationToken::new();
         let notify = Arc::new(Notify::new());
@@ -381,7 +383,7 @@ mod tests {
         for id in 0..4 {
             let action = ParallelAction {
                 _worker_id: id,
-                work_duration: Duration::from_millis(50),
+                work_duration: Duration::from_secs(30),
                 total_calls: total_calls.clone(),
                 max_concurrent: max_concurrent.clone(),
                 current_concurrent: current_concurrent.clone(),
@@ -393,8 +395,8 @@ mod tests {
                 BulkheadConfig {
                     semaphore: ConcurrencyLimit::Fixed(sem.clone()),
                     backoff: BackoffConfig {
-                        initial: Duration::from_millis(10),
-                        max: Duration::from_secs(10),
+                        initial: Duration::from_secs(1),
+                        max: Duration::from_secs(600),
                         multiplier: 2.0,
                         jitter: 0.0,
                     },
@@ -416,12 +418,12 @@ mod tests {
         tokio::spawn(async move {
             for _ in 0..8 {
                 notify_c.notify_one();
-                tokio::time::sleep(Duration::from_millis(10)).await;
+                tokio::time::sleep(Duration::from_secs(5)).await;
             }
         });
 
         // Let them work, then shut down.
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(Duration::from_secs(300)).await;
         task_set.shutdown().await;
 
         let calls = total_calls.load(Ordering::SeqCst);
@@ -455,8 +457,10 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn vacuum_worker_self_schedules_via_sleep() {
+        let h = Duration::from_secs(3600);
+
         // A vacuum worker has no external notifiers — it runs on its own
         // cadence using Sleep directives. A poker breaks the initial Idle.
 
@@ -465,17 +469,17 @@ mod tests {
 
         let action = VacuumAction {
             call_count: call_count.clone(),
-            cooldown: Duration::from_millis(30),
+            cooldown: h, // 1h cooldown between sweeps
         };
 
         let worker = WorkerBuilder::new("vacuum", cancel.clone())
-            .with_poker(Duration::from_millis(10)) // just to break initial Idle
+            .with_poker(Duration::from_secs(600)) // 10min poker to break initial Idle
             .build(action);
 
         let cancel_c = cancel.clone();
         tokio::spawn(async move {
-            // 10ms (initial poke) + 3 × 30ms (cooldowns) = 100ms for 3 calls.
-            tokio::time::sleep(Duration::from_millis(120)).await;
+            // 10min (initial poke) + 3 × 1h (cooldowns) = 3h 10m for 3 calls.
+            tokio::time::sleep(h * 4).await;
             cancel_c.cancel();
         });
 
@@ -524,7 +528,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn panicking_worker_recovers_and_keeps_running() {
         // The "bad" worker panics on call 0, but the worker loop catches
         // the panic and retries with backoff. It continues executing on
@@ -541,14 +545,14 @@ mod tests {
 
         let bad_worker = WorkerBuilder::new("bad", cancel.clone())
             .notifier(notify.clone())
-            .with_poker(Duration::from_millis(10))
+            .with_poker(Duration::from_secs(1))
             .on_panic(PanicPolicy::CatchAndRetry)
             .build(bad_action);
 
         let handle = tokio::spawn(bad_worker.run());
 
         // Let it run — first call panics, subsequent calls succeed.
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        tokio::time::sleep(Duration::from_secs(10)).await;
         cancel.cancel();
         handle.await.unwrap();
 
@@ -560,7 +564,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn panicking_worker_does_not_kill_siblings() {
         // 2 workers in the same TaskSet — "bad" panics on first execute,
         // "good" keeps running. Both survive.
@@ -581,13 +585,13 @@ mod tests {
 
         let bad_worker = WorkerBuilder::new("bad", cancel.clone())
             .notifier(notify.clone())
-            .with_poker(Duration::from_millis(10))
+            .with_poker(Duration::from_secs(1))
             .on_panic(PanicPolicy::CatchAndRetry)
             .build(bad_action);
 
         let good_worker = WorkerBuilder::new("good", cancel.clone())
             .notifier(notify.clone())
-            .with_poker(Duration::from_millis(10))
+            .with_poker(Duration::from_secs(1))
             .build(good_action);
 
         let mut task_set = crate::outbox::taskward::task_set::TaskSet::new(cancel.clone());
@@ -595,7 +599,7 @@ mod tests {
         task_set.spawn("good", good_worker.run());
 
         // Let them run.
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        tokio::time::sleep(Duration::from_secs(10)).await;
         task_set.shutdown().await;
 
         // "bad" survived the panic — it executed more than once.

--- a/libs/modkit-db/src/outbox/taskward/task.rs
+++ b/libs/modkit-db/src/outbox/taskward/task.rs
@@ -301,7 +301,7 @@ impl<A: WorkerAction> WorkerTask<A> {
 mod tests {
     use std::collections::VecDeque;
     use std::sync::atomic::{AtomicU32, Ordering};
-    use std::time::Instant;
+    use tokio::time::Instant;
 
     use std::sync::Mutex;
 
@@ -430,7 +430,7 @@ mod tests {
         assert_eq!(worker.notifiers.len(), 3);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn builder_with_poker_adds_notifier() {
         let cancel = CancellationToken::new();
         let action = MockAction::new(vec![]);
@@ -440,7 +440,7 @@ mod tests {
         assert_eq!(worker.notifiers.len(), 1);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn builder_notifier_plus_poker() {
         let cancel = CancellationToken::new();
         let notify = Arc::new(Notify::new());
@@ -479,7 +479,7 @@ mod tests {
 
     // ---- Scheduling Tests ----
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn continue_executes_immediately() {
         let cancel = CancellationToken::new();
         let action = MockAction::new(vec![
@@ -501,7 +501,7 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 4);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn sleep_respects_duration() {
         let cancel = CancellationToken::new();
         let action = MockAction::new(vec![
@@ -523,7 +523,7 @@ mod tests {
         assert!(start.elapsed() >= Duration::from_millis(100));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn sleep_zero_is_immediate() {
         let cancel = CancellationToken::new();
         let action = MockAction::new(vec![
@@ -543,7 +543,7 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 2);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn idle_wakes_on_notify() {
         let cancel = CancellationToken::new();
         let notify = Arc::new(Notify::new());
@@ -577,7 +577,7 @@ mod tests {
         assert!(start.elapsed() < Duration::from_secs(1));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn idle_with_no_notifiers_blocks_until_cancel() {
         let cancel = CancellationToken::new();
         let action = MockAction::new(vec![]);
@@ -597,7 +597,7 @@ mod tests {
         assert!(start.elapsed() < Duration::from_millis(200));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn sleep_ignores_notify() {
         let cancel = CancellationToken::new();
         let notify = Arc::new(Notify::new());
@@ -631,7 +631,7 @@ mod tests {
 
     // ---- Multi-Notifier Tests ----
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn single_notifier_wakes() {
         let cancel = CancellationToken::new();
         let notify = Arc::new(Notify::new());
@@ -659,7 +659,7 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 2);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn multiple_notifiers_first_one_wakes() {
         let cancel = CancellationToken::new();
         let n1 = Arc::new(Notify::new());
@@ -697,7 +697,7 @@ mod tests {
         assert!(start.elapsed() < Duration::from_secs(1));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn zero_notifiers_blocks_until_cancel() {
         let cancel = CancellationToken::new();
         let action = MockAction::new(vec![]);
@@ -714,7 +714,7 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn stored_permit_consumed_immediately() {
         let cancel = CancellationToken::new();
         let notify = Arc::new(Notify::new());
@@ -740,7 +740,7 @@ mod tests {
 
     // ---- Cancellation Tests ----
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn cancel_during_idle() {
         let cancel = CancellationToken::new();
         let notify = Arc::new(Notify::new());
@@ -761,7 +761,7 @@ mod tests {
         assert!(start.elapsed() < Duration::from_millis(150));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn cancel_during_sleep() {
         let cancel = CancellationToken::new();
         let action = MockAction::new(vec![Ok(Directive::sleep(Duration::from_secs(10)))]);
@@ -798,7 +798,7 @@ mod tests {
         assert!(count.load(Ordering::SeqCst) > 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn cancel_visible_in_execute() {
         let cancel = CancellationToken::new();
         let worker = WorkerBuilder::new("test", cancel.clone())
@@ -816,7 +816,7 @@ mod tests {
         worker.run().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn already_cancelled() {
         let cancel = CancellationToken::new();
         cancel.cancel();
@@ -830,7 +830,7 @@ mod tests {
 
     // ---- Error Absorption Tests ----
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn error_triggers_escalation_and_retry() {
         let cancel = CancellationToken::new();
         let action = MockAction::new(vec![
@@ -851,7 +851,7 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 3);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn error_on_first_call_retries() {
         let cancel = CancellationToken::new();
         let action = MockAction::new(vec![
@@ -871,7 +871,7 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 2);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn error_applies_backoff_floor() {
         use crate::outbox::taskward::bulkhead::{
             BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit,
@@ -912,7 +912,7 @@ mod tests {
         assert!(start.elapsed() >= Duration::from_millis(100));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn consecutive_errors_escalate() {
         use crate::outbox::taskward::bulkhead::{
             BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit,
@@ -956,7 +956,7 @@ mod tests {
         assert!(start.elapsed() >= Duration::from_millis(70));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn success_resets_bulkhead() {
         use crate::outbox::taskward::bulkhead::{
             BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit,
@@ -998,7 +998,7 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 5);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn error_sets_directive_to_idle() {
         use crate::outbox::taskward::bulkhead::{
             BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit,
@@ -1051,7 +1051,7 @@ mod tests {
 
     // ---- Bulkhead Floor Tests ----
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn floor_applied_to_continue() {
         use crate::outbox::taskward::bulkhead::{
             BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit,
@@ -1093,7 +1093,7 @@ mod tests {
         assert!(start.elapsed() >= Duration::from_millis(100));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn floor_applied_to_idle() {
         use crate::outbox::taskward::bulkhead::{
             BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit,
@@ -1150,7 +1150,7 @@ mod tests {
         assert!(start.elapsed() >= Duration::from_millis(200));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn floor_applied_to_sleep() {
         use crate::outbox::taskward::bulkhead::{
             BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit,
@@ -1192,7 +1192,7 @@ mod tests {
         assert!(start.elapsed() >= Duration::from_millis(200));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn floor_does_not_reduce() {
         use crate::outbox::taskward::bulkhead::{
             BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit,
@@ -1234,7 +1234,7 @@ mod tests {
         assert!(start.elapsed() >= Duration::from_millis(500));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn zero_floor_no_effect() {
         let cancel = CancellationToken::new();
         let action = MockAction::new(vec![
@@ -1259,7 +1259,7 @@ mod tests {
 
     // ---- Semaphore Integration Tests ----
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn semaphore_acquired_before_execute() {
         use crate::outbox::taskward::bulkhead::{
             BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit,
@@ -1296,7 +1296,7 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 1);
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn semaphore_blocks_until_released() {
         use crate::outbox::taskward::bulkhead::{
             BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit,
@@ -1341,7 +1341,7 @@ mod tests {
         assert!(start.elapsed() >= Duration::from_millis(50));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn cancel_during_semaphore_wait() {
         use crate::outbox::taskward::bulkhead::{
             BackoffConfig, Bulkhead, BulkheadConfig, ConcurrencyLimit,
@@ -1382,7 +1382,7 @@ mod tests {
 
     // ---- Notify Semantics Tests ----
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn stored_permit() {
         let cancel = CancellationToken::new();
         let notify = Arc::new(Notify::new());
@@ -1405,7 +1405,7 @@ mod tests {
         assert!(start.elapsed() < Duration::from_secs(1));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn multiple_coalesce() {
         let cancel = CancellationToken::new();
         let notify = Arc::new(Notify::new());
@@ -1467,7 +1467,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn listener_called_on_start_stop() {
         let cancel = CancellationToken::new();
         cancel.cancel();
@@ -1484,7 +1484,7 @@ mod tests {
         assert_eq!(events.last(), Some(&"stop".to_owned()));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn listener_called_on_complete() {
         let cancel = CancellationToken::new();
         let listener = RecordingListener::default();
@@ -1506,7 +1506,7 @@ mod tests {
         assert!(events.contains(&"complete".to_owned()));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn listener_called_on_error_with_context() {
         let cancel = CancellationToken::new();
         let listener = RecordingListener::default();
@@ -1531,7 +1531,7 @@ mod tests {
         assert!(events.contains(&"error".to_owned()));
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn multiple_listeners_called_in_order() {
         let cancel = CancellationToken::new();
         cancel.cancel();


### PR DESCRIPTION
Replace wall-clock sleeps with `start_paused = true` across taskward tests. Add `push_dirty_at()` for deterministic prioritizer ordering. Replace sleep-then-assert with notify timeout in pipeline test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored tests to use virtual/paused runtime and virtual-time instants, replacing real sleeps.
  * Added helpers and explicit timestamping so tests simulate timing deterministically.
  * Improved assertions to check baselines directly and avoid timing assumptions.

* **Chores**
  * Enabled deterministic testing features in development dependencies to support virtual-time testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->