### PR TITLE
feat(mini-chat): add turn_started SSE event and persist cancelled messages.

### DIFF
--- a/modules/mini-chat/docs/DESIGN.md
+++ b/modules/mini-chat/docs/DESIGN.md
@@ -820,7 +820,7 @@ To support reconnect UX and reduce support reliance on direct DB inspection, the
 - `request_id`
 - `state`: `running|done|error|cancelled`
 - `error_code` (nullable string) — terminal error code when `state` is `error` (e.g. `provider_error`, `orphan_timeout`). Null for non-error states and while running. Mapped from `chat_turns.error_code`. Provider identifiers and billing outcome are not exposed.
-- `assistant_message_id` (nullable UUID) — persisted assistant message ID when `state` is `done`. Null while running, on error, or on cancellation. Allows clients to fetch the assistant message directly without listing all messages.
+- `assistant_message_id` (nullable UUID) — persisted assistant message ID. Present when `state` is `done`. Present when `state` is `cancelled` if partial content was persisted (non-empty accumulated text at cancellation point). Null while `running` or on `error`. Allows clients to fetch the assistant message directly without listing all messages.
 - `updated_at`
 
 Turn Status is authoritative for lifecycle state resolution after disconnect. `error_code` provides actionable terminal error categorization so clients can display an appropriate error message without further queries. `assistant_message_id` lets clients fetch the completed assistant message directly by ID without scanning full message history; retrieving the message content itself requires one follow-up request (`GET /v1/chats/{id}/messages?$filter=id eq '{assistant_message_id}'`). Billing outcome, internal settlement details, and provider internals are not exposed via this endpoint in P1.
@@ -868,7 +868,16 @@ UI guidance: if the SSE stream disconnects before a terminal event, the UI SHOUL
 
 #### SSE Event Definitions
 
-Six event types. The stream always ends with exactly one terminal event: `done` or `error`. Image-bearing turns use the same event types; no new SSE events are required for image support. The `citations` event MAY include items from both `file_search` (`source="file"`) and `web_search` (`source="web"`). Image inputs do not produce citations by themselves.
+Seven event types. The stream always begins with `turn_started` (carrying the server-generated `request_id`) and ends with exactly one terminal event: `done` or `error`. Image-bearing turns use the same event types; no new SSE events are required for image support. The `citations` event MAY include items from both `file_search` (`source="file"`) and `web_search` (`source="web"`). Image inputs do not produce citations by themselves.
+
+##### `event: turn_started`
+
+Emitted once at stream start, before any content events. Carries the server-generated `request_id` for this turn. Present on `POST /messages:stream`, `POST /turns/{id}/retry`, and `PATCH /turns/{id}`.
+
+```
+event: turn_started
+data: {"request_id": "550e8400-e29b-41d4-a716-446655440000"}
+```
 
 ##### `event: delta`
 
@@ -1008,7 +1017,7 @@ A well-formed stream follows this ordering:
 **P1 normative ordering**:
 
 ```text
-ping*  (delta | tool)*  citations?  (done | error)
+turn_started  ping*  (delta | tool)*  citations?  (done | error)
 ```
 
 - Zero or more `ping` events may appear at any point before terminal.
@@ -1910,7 +1919,7 @@ Tracks idempotency and in-progress generation state for `request_id`. This avoid
 | state | VARCHAR(16) | `running`, `completed`, `failed`, `cancelled` |
 | provider_name | VARCHAR(128) | Provider GTS identifier (nullable until request starts). Same GTS format as `messages.provider_name`. |
 | provider_response_id | VARCHAR(128) | Provider response ID (nullable) |
-| assistant_message_id | UUID | Persisted assistant message ID (nullable until completed) |
+| assistant_message_id | UUID | Persisted assistant message ID (nullable — set for `completed` and `cancelled`-with-content turns) |
 | error_code | VARCHAR(64) | Terminal error code (nullable) |
 | reserve_tokens | BIGINT | Preflight token reserve (`estimated_input_tokens + max_output_tokens_applied`). Persisted at preflight before any outbound provider call. Nullable - NULL only for turns that fail before a reserve is taken (pre-reserve failures). Immutable after insert. Used for deterministic reconciliation under ABORTED and post-provider-start FAILED outcomes (sections 5.7, 5.8, 5.9). |
 | max_output_tokens_applied | INTEGER | The `max_output_tokens` value used at preflight for this turn. Persisted at preflight (same time as `reserve_tokens`). Nullable — NULL only for pre-reserve failures. Immutable after insert. Required for deterministic derivation of `estimated_input_tokens` at settlement time: `estimated_input_tokens = reserve_tokens - max_output_tokens_applied` (sections 5.8, 5.9). |
@@ -3944,7 +3953,7 @@ Orphan watchdog timeout MUST be bounded to prevent indefinite user-visible lock 
 
 The following are explicitly out of scope for P1 crash recovery:
 
-- **No partial delta persistence**: streamed deltas are not persisted incrementally during normal streaming operation. If the pod crashes mid-stream, partial text is lost. On user-initiated cancellation, the accumulated in-memory content up to the cancel point MAY be persisted as a single final partial message (see cancellation sequence above); this is a one-time snapshot, not incremental delta persistence. No replay or resume from partial content is supported.
+- **No partial delta persistence**: streamed deltas are not persisted incrementally during normal streaming operation. If the pod crashes mid-stream, partial text is lost. On user-initiated cancellation, the accumulated in-memory content up to the cancel point is persisted as a single final partial message when non-empty (see cancellation sequence above); this is a one-time snapshot, not incremental delta persistence. The persisted partial message participates in conversation history and context assembly for subsequent turns. No replay or resume from partial content is supported.
 - **No resume-from-delta**: the system does not resume generation from the last streamed token after a crash.
 - **No event sourcing**: turn state is a simple row update, not an append-only event log.
 - **No cross-pod streaming recovery**: a stream cannot be handed off from a crashed pod to a surviving pod. Recovery is client-driven via the turn status API.
@@ -5330,7 +5339,8 @@ Deterministic reconciliation for `ABORTED` and post-provider-start `FAILED` outc
 
 **Clarification (normative):** “Single shared function” does NOT require a single DB update shape. The function MAY branch internally by terminal outcome:
 - For `completed` (including provider `response.incomplete`): finalize via the “completed” CAS path that sets `assistant_message_id` and MUST keep `chat_turns.error_code = NULL`. Any incomplete/truncation reason MUST be recorded only as `completion_signal` in audit/outbox payloads and the `mini_chat_stream_incomplete_total{reason}` metric.
-- For `failed` / `cancelled`: finalize via the “terminal state” CAS path that may set `error_code` / `error_detail` as specified elsewhere in this section.
+- For `cancelled` with non-empty accumulated text: persist the partial assistant message and set `assistant_message_id` (same INSERT + SET sequence as completed), but do NOT retry-as-failed on persistence failure — best-effort only, log at `warn` and finalize as `cancelled` with `assistant_message_id = NULL`.
+- For `failed` / `cancelled` with empty text: finalize via the “terminal state” CAS path that may set `error_code` / `error_detail` as specified elsewhere in this section.
 
 #### Dedupe Key Requirement for Quota-Bearing Events (Normative)
 

--- a/modules/mini-chat/mini-chat/src/api/rest/sse.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/sse.rs
@@ -3,7 +3,7 @@
 //! - `into_sse_event()`: converts domain `StreamEvent` to Axum SSE `Event`
 //! - `From<ClientSseEvent>`: translates provider events to domain events
 //! - `StreamPhase`: state machine enforcing the ordering grammar
-//!   `ping* (delta | tool)* citations? (done | error)`
+//!   `turn_started ping* (delta | tool)* citations? (done | error)`
 
 use axum::response::sse::Event;
 
@@ -21,6 +21,7 @@ impl StreamEvent {
     /// and `data:` JSON payload.
     pub fn into_sse_event(self) -> Result<Event, axum::Error> {
         match self {
+            StreamEvent::TurnStarted(d) => Event::default().event("turn_started").json_data(&d),
             StreamEvent::Ping => Ok(Event::default().event("ping").data("{}")),
             StreamEvent::Delta(d) => Event::default().event("delta").json_data(&d),
             StreamEvent::Tool(t) => Event::default().event("tool").json_data(&t),
@@ -64,6 +65,7 @@ impl From<ClientSseEvent> for StreamEvent {
 impl std::fmt::Display for StreamEventKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::TurnStarted => f.write_str("TurnStarted"),
             Self::Ping => f.write_str("Ping"),
             Self::Delta => f.write_str("Delta"),
             Self::Tool => f.write_str("Tool"),
@@ -77,15 +79,18 @@ impl std::fmt::Display for StreamEventKind {
 // StreamPhase — event ordering state machine
 // ════════════════════════════════════════════════════════════════════════════
 
-/// Enforces the SSE ordering grammar: `ping* (delta | tool)* citations? (done | error)`.
+/// Enforces the SSE ordering grammar:
+/// `turn_started ping* (delta | tool)* citations? (done | error)`.
 ///
 /// Delta and tool events may interleave freely within the `Streaming` phase.
 /// Only forward transitions are allowed. Out-of-order events produce an
 /// [`OrderingViolation`] error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamPhase {
-    /// Before any events. Accepts ping, delta, tool, citations, terminal.
+    /// Before any events. Accepts `turn_started`, ping, delta, tool, citations, terminal.
     Idle,
+    /// After `turn_started`. Same transitions as `Idle` except `turn_started` (exactly-once).
+    Started,
     /// After one or more pings. Accepts ping, delta, tool, citations, terminal.
     Pinging,
     /// After first delta or tool. Accepts delta, tool, citations, terminal.
@@ -117,6 +122,7 @@ impl std::fmt::Display for StreamPhase {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Idle => f.write_str("Idle"),
+            Self::Started => f.write_str("Started"),
             Self::Pinging => f.write_str("Pinging"),
             Self::Streaming => f.write_str("Streaming"),
             Self::Citations => f.write_str("Citations"),
@@ -147,20 +153,30 @@ impl StreamPhase {
             // Terminal events are always accepted from non-terminal phases
             (_, StreamEventKind::Terminal) => Ok(StreamPhase::Terminal),
 
-            // Ping: only from Idle or Pinging
-            (StreamPhase::Idle | StreamPhase::Pinging, StreamEventKind::Ping) => {
-                Ok(StreamPhase::Pinging)
-            }
+            // TurnStarted: only from Idle (exactly-once)
+            (StreamPhase::Idle, StreamEventKind::TurnStarted) => Ok(StreamPhase::Started),
 
-            // Delta or Tool: from Idle, Pinging, or Streaming
+            // Ping: from Idle, Started, or Pinging
             (
-                StreamPhase::Idle | StreamPhase::Pinging | StreamPhase::Streaming,
+                StreamPhase::Idle | StreamPhase::Started | StreamPhase::Pinging,
+                StreamEventKind::Ping,
+            ) => Ok(StreamPhase::Pinging),
+
+            // Delta or Tool: from Idle, Started, Pinging, or Streaming
+            (
+                StreamPhase::Idle
+                | StreamPhase::Started
+                | StreamPhase::Pinging
+                | StreamPhase::Streaming,
                 StreamEventKind::Delta | StreamEventKind::Tool,
             ) => Ok(StreamPhase::Streaming),
 
-            // Citations: from Idle, Pinging, or Streaming (at most once)
+            // Citations: from Idle, Started, Pinging, or Streaming (at most once)
             (
-                StreamPhase::Idle | StreamPhase::Pinging | StreamPhase::Streaming,
+                StreamPhase::Idle
+                | StreamPhase::Started
+                | StreamPhase::Pinging
+                | StreamPhase::Streaming,
                 StreamEventKind::Citations,
             ) => Ok(StreamPhase::Citations),
 
@@ -449,5 +465,109 @@ mod tests {
         let mut phase = StreamPhase::Idle;
         phase = phase.try_advance(StreamEventKind::Tool).unwrap();
         assert!(phase.try_advance(StreamEventKind::Ping).is_err());
+    }
+
+    // ── TurnStarted / Started phase tests ──
+
+    #[test]
+    fn phase_idle_accepts_turn_started() {
+        assert_eq!(
+            StreamPhase::Idle
+                .try_advance(StreamEventKind::TurnStarted)
+                .unwrap(),
+            StreamPhase::Started
+        );
+    }
+
+    #[test]
+    fn phase_started_accepts_all_content_kinds() {
+        assert_eq!(
+            StreamPhase::Started
+                .try_advance(StreamEventKind::Ping)
+                .unwrap(),
+            StreamPhase::Pinging
+        );
+        assert_eq!(
+            StreamPhase::Started
+                .try_advance(StreamEventKind::Delta)
+                .unwrap(),
+            StreamPhase::Streaming
+        );
+        assert_eq!(
+            StreamPhase::Started
+                .try_advance(StreamEventKind::Tool)
+                .unwrap(),
+            StreamPhase::Streaming
+        );
+        assert_eq!(
+            StreamPhase::Started
+                .try_advance(StreamEventKind::Citations)
+                .unwrap(),
+            StreamPhase::Citations
+        );
+        assert_eq!(
+            StreamPhase::Started
+                .try_advance(StreamEventKind::Terminal)
+                .unwrap(),
+            StreamPhase::Terminal
+        );
+    }
+
+    #[test]
+    fn phase_started_rejects_turn_started() {
+        assert!(
+            StreamPhase::Started
+                .try_advance(StreamEventKind::TurnStarted)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn turn_started_then_ping_then_deltas_then_done() {
+        let mut phase = StreamPhase::Idle;
+        phase = phase.try_advance(StreamEventKind::TurnStarted).unwrap();
+        assert_eq!(phase, StreamPhase::Started);
+        phase = phase.try_advance(StreamEventKind::Ping).unwrap();
+        assert_eq!(phase, StreamPhase::Pinging);
+        phase = phase.try_advance(StreamEventKind::Delta).unwrap();
+        assert_eq!(phase, StreamPhase::Streaming);
+        phase = phase.try_advance(StreamEventKind::Delta).unwrap();
+        assert_eq!(phase, StreamPhase::Streaming);
+        phase = phase.try_advance(StreamEventKind::Terminal).unwrap();
+        assert_eq!(phase, StreamPhase::Terminal);
+    }
+
+    #[test]
+    fn turn_started_then_tool_delta_citations_done() {
+        let mut phase = StreamPhase::Idle;
+        phase = phase.try_advance(StreamEventKind::TurnStarted).unwrap();
+        assert_eq!(phase, StreamPhase::Started);
+        phase = phase.try_advance(StreamEventKind::Tool).unwrap();
+        assert_eq!(phase, StreamPhase::Streaming);
+        phase = phase.try_advance(StreamEventKind::Delta).unwrap();
+        assert_eq!(phase, StreamPhase::Streaming);
+        phase = phase.try_advance(StreamEventKind::Citations).unwrap();
+        assert_eq!(phase, StreamPhase::Citations);
+        phase = phase.try_advance(StreamEventKind::Terminal).unwrap();
+        assert_eq!(phase, StreamPhase::Terminal);
+    }
+
+    #[test]
+    fn idle_still_accepts_delta_directly_backwards_compat() {
+        let mut phase = StreamPhase::Idle;
+        phase = phase.try_advance(StreamEventKind::Delta).unwrap();
+        assert_eq!(phase, StreamPhase::Streaming);
+        phase = phase.try_advance(StreamEventKind::Terminal).unwrap();
+        assert_eq!(phase, StreamPhase::Terminal);
+    }
+
+    #[test]
+    fn turn_started_converts_to_sse_event() {
+        use crate::domain::stream_events::TurnStartedData;
+        let event = StreamEvent::TurnStarted(TurnStartedData {
+            request_id: uuid::Uuid::new_v4(),
+        });
+        let sse = event.into_sse_event();
+        assert!(sse.is_ok());
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
@@ -77,6 +77,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
     /// If message persistence fails on a completed turn, rolls back and
     /// retries as `Failed` with `error_code = "message_persistence_failed"`
     /// (content durability invariant).
+    #[allow(clippy::cognitive_complexity)]
     pub(crate) async fn finalize_turn_cas(
         &self,
         input: FinalizationInput,
@@ -97,35 +98,77 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
                 Ok(outcome)
             }
             Err(FinalizationError::MessagePersistenceFailed(e)) => {
-                // Content durability invariant: downgrade completed → failed.
-                // The transaction rolled back, so the turn is still 'running'.
-                // Retry with Failed state.
-                error!(
-                    error = %e,
-                    turn_id = %input.turn_id,
-                    "message persistence failed, downgrading completed to failed"
-                );
-                let mut retry_input = input;
-                retry_input.terminal_state = TurnState::Failed;
-                retry_input.error_code = Some("message_persistence_failed".to_owned());
-                let retry_outcome =
-                    self.try_finalize(&retry_input)
-                        .await
-                        .map_err(|fe| match fe {
-                            FinalizationError::Domain(de) => de,
-                            FinalizationError::MessagePersistenceFailed(e2) => {
-                                // Should not happen on Failed path (no message INSERT).
-                                DomainError::internal(format!("unexpected retry failure: {e2}"))
-                            }
-                        })?;
-                if retry_outcome.won_cas {
-                    self.outbox_enqueuer.flush();
+                if input.terminal_state == TurnState::Completed {
+                    // Content durability invariant: downgrade completed → failed.
+                    // The transaction rolled back, so the turn is still 'running'.
+                    // Retry with Failed state.
+                    error!(
+                        error = %e,
+                        turn_id = %input.turn_id,
+                        "message persistence failed, downgrading completed to failed"
+                    );
+                    let mut retry_input = input;
+                    retry_input.terminal_state = TurnState::Failed;
+                    retry_input.error_code = Some("message_persistence_failed".to_owned());
+                    let retry_outcome =
+                        self.try_finalize(&retry_input)
+                            .await
+                            .map_err(|fe| match fe {
+                                FinalizationError::Domain(de) => de,
+                                FinalizationError::MessagePersistenceFailed(e2) => {
+                                    DomainError::internal(format!("unexpected retry failure: {e2}"))
+                                }
+                            })?;
+                    if retry_outcome.won_cas {
+                        self.outbox_enqueuer.flush();
+                    }
+                    if let Some(billing) = retry_outcome.billing_outcome {
+                        let ms = start.elapsed().as_secs_f64() * 1000.0;
+                        Self::emit_post_commit_side_effects(
+                            &retry_input,
+                            billing,
+                            ms,
+                            &*self.metrics,
+                        );
+                    }
+                    Ok(retry_outcome)
+                } else {
+                    // Best-effort path (cancelled turns): log and finalize
+                    // without message by clearing accumulated_text (D4).
+                    warn!(
+                        error = %e,
+                        turn_id = %input.turn_id,
+                        terminal_state = ?input.terminal_state,
+                        "message persistence failed on non-completed turn, \
+                         finalizing without message"
+                    );
+                    let mut retry_input = input;
+                    retry_input.accumulated_text = String::new();
+                    let retry_outcome =
+                        self.try_finalize(&retry_input)
+                            .await
+                            .map_err(|fe| match fe {
+                                FinalizationError::Domain(de) => de,
+                                FinalizationError::MessagePersistenceFailed(e2) => {
+                                    DomainError::internal(format!(
+                                        "unexpected message persist on empty text: {e2}"
+                                    ))
+                                }
+                            })?;
+                    if retry_outcome.won_cas {
+                        self.outbox_enqueuer.flush();
+                    }
+                    if let Some(billing) = retry_outcome.billing_outcome {
+                        let ms = start.elapsed().as_secs_f64() * 1000.0;
+                        Self::emit_post_commit_side_effects(
+                            &retry_input,
+                            billing,
+                            ms,
+                            &*self.metrics,
+                        );
+                    }
+                    Ok(retry_outcome)
                 }
-                if let Some(billing) = retry_outcome.billing_outcome {
-                    let ms = start.elapsed().as_secs_f64() * 1000.0;
-                    Self::emit_post_commit_side_effects(&retry_input, billing, ms, &*self.metrics);
-                }
-                Ok(retry_outcome)
             }
             Err(FinalizationError::Domain(e)) => Err(e),
         }
@@ -205,10 +248,14 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
                         .await
                         .map_err(to_db)?;
 
-                    // 4. Persist assistant message (completed turns only)
-                    //    Content durability invariant:
-                    //    "completed ⟹ full assistant content is durably persisted"
-                    if input.terminal_state == TurnState::Completed {
+                    // 4. Persist assistant message
+                    //    Completed: full content, required (retry-as-failed on failure)
+                    //    Cancelled with non-empty text: partial content, best-effort
+                    let should_persist_message = input.terminal_state == TurnState::Completed
+                        || (input.terminal_state == TurnState::Cancelled
+                            && !input.accumulated_text.is_empty());
+
+                    if should_persist_message {
                         message_repo
                             .insert_assistant_message(
                                 tx,
@@ -859,5 +906,145 @@ mod tests {
             1,
             "should record quota_actual_tokens"
         );
+    }
+
+    // ── Cancelled message persistence tests (D4) ──
+
+    #[tokio::test]
+    async fn cancelled_with_text_persists_message() {
+        let db = mock_db_provider(inmem_db().await);
+        let (svc, _outbox) = build_finalization_service(Arc::clone(&db));
+
+        let tenant_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        insert_test_chat(&db, tenant_id, chat_id, user_id).await;
+        insert_running_turn(&db, tenant_id, chat_id, turn_id, request_id).await;
+
+        let mut input = make_input(
+            tenant_id,
+            chat_id,
+            turn_id,
+            request_id,
+            user_id,
+            TurnState::Cancelled,
+        );
+        input.accumulated_text = "partial response content".to_owned();
+        input.usage = None;
+
+        let outcome = svc
+            .finalize_turn_cas(input)
+            .await
+            .expect("finalization should succeed");
+
+        assert!(outcome.won_cas);
+
+        // Verify turn is cancelled with assistant_message_id set
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let turn_repo = TurnRepo;
+        let turn = turn_repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .expect("find turn")
+            .expect("turn should exist");
+        assert_eq!(turn.state, TurnState::Cancelled);
+        assert!(
+            turn.assistant_message_id.is_some(),
+            "cancelled turn with text should have assistant_message_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_without_text_does_not_persist_message() {
+        let db = mock_db_provider(inmem_db().await);
+        let (svc, _outbox) = build_finalization_service(Arc::clone(&db));
+
+        let tenant_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        insert_test_chat(&db, tenant_id, chat_id, user_id).await;
+        insert_running_turn(&db, tenant_id, chat_id, turn_id, request_id).await;
+
+        let mut input = make_input(
+            tenant_id,
+            chat_id,
+            turn_id,
+            request_id,
+            user_id,
+            TurnState::Cancelled,
+        );
+        input.accumulated_text = String::new();
+        input.usage = None;
+
+        let outcome = svc
+            .finalize_turn_cas(input)
+            .await
+            .expect("finalization should succeed");
+
+        assert!(outcome.won_cas);
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let turn_repo = TurnRepo;
+        let turn = turn_repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .expect("find turn")
+            .expect("turn should exist");
+        assert_eq!(turn.state, TurnState::Cancelled);
+        assert!(
+            turn.assistant_message_id.is_none(),
+            "cancelled turn without text should have no assistant_message_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn completed_message_persist_failure_retries_as_failed() {
+        // Existing behavior unchanged — verify the guard doesn't break it.
+        // We test by finalizing as Completed, then finalizing again (CAS loser
+        // path), confirming the first finalization worked correctly.
+        let db = mock_db_provider(inmem_db().await);
+        let (svc, _outbox) = build_finalization_service(Arc::clone(&db));
+
+        let tenant_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        insert_test_chat(&db, tenant_id, chat_id, user_id).await;
+        insert_running_turn(&db, tenant_id, chat_id, turn_id, request_id).await;
+
+        let input = make_input(
+            tenant_id,
+            chat_id,
+            turn_id,
+            request_id,
+            user_id,
+            TurnState::Completed,
+        );
+        let outcome = svc
+            .finalize_turn_cas(input)
+            .await
+            .expect("finalization should succeed");
+        assert!(outcome.won_cas);
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let turn_repo = TurnRepo;
+        let turn = turn_repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .expect("find turn")
+            .expect("turn should exist");
+        assert_eq!(turn.state, TurnState::Completed);
+        assert!(turn.assistant_message_id.is_some());
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -20,7 +20,7 @@ use crate::domain::repos::{
     MessageAttachmentRepository, MessageRepository, QuotaUsageRepository, SnapshotBoundary,
     ThreadSummaryRepository, TurnRepository, VectorStoreRepository,
 };
-use crate::domain::stream_events::{DoneData, ErrorData, StreamEvent};
+use crate::domain::stream_events::{DoneData, ErrorData, StreamEvent, TurnStartedData};
 use crate::infra::db::entity::chat_turn::{Model as TurnModel, TurnState};
 use crate::infra::llm::{
     ClientSseEvent, LlmMessage, LlmProvider, LlmProviderError, LlmRequestBuilder, LlmTool,
@@ -767,6 +767,15 @@ impl<
             .replace("{model}", &provider_model_id);
         let proxy_path = format!("{}{api_path}", resolved_provider.upstream_alias);
 
+        // Emit turn_started before handing tx to the provider task (D3).
+        if tx
+            .send(StreamEvent::TurnStarted(TurnStartedData { request_id }))
+            .await
+            .is_err()
+        {
+            warn!(%request_id, "turn_started send failed (client disconnected before first event)");
+        }
+
         Ok(spawn_provider_task(
             resolved_provider.adapter,
             proxy_path,
@@ -1335,6 +1344,15 @@ impl<
             .api_path
             .replace("{model}", &provider_model_id);
         let proxy_path = format!("{}{api_path}", resolved_provider.upstream_alias);
+
+        // Emit turn_started before handing tx to the provider task (D3).
+        if tx
+            .send(StreamEvent::TurnStarted(TurnStartedData { request_id }))
+            .await
+            .is_err()
+        {
+            warn!(%request_id, "turn_started send failed (client disconnected before first event)");
+        }
 
         Ok(spawn_provider_task(
             resolved_provider.adapter,
@@ -3339,7 +3357,9 @@ mod tests {
             .await
             .expect("should start stream");
 
-        // Read the first delta
+        // Read the turn_started event, then the first delta
+        let started = rx.recv().await.expect("should get turn_started");
+        assert!(matches!(started, StreamEvent::TurnStarted(_)));
         let first = rx.recv().await.expect("should get delta");
         assert!(matches!(first, StreamEvent::Delta(_)));
 
@@ -3367,6 +3387,11 @@ mod tests {
         assert!(
             turn.completed_at.is_some(),
             "completed_at should be set after CAS finalization"
+        );
+        // D4: cancelled turn with accumulated text should have assistant_message_id
+        assert!(
+            turn.assistant_message_id.is_some(),
+            "cancelled turn with partial text should have assistant_message_id"
         );
     }
 
@@ -5381,11 +5406,13 @@ mod tests {
             .await
             .expect("should succeed");
 
-        // Wait for the first delta to arrive, then cancel
-        let ev = rx.recv().await.expect("should receive at least one event");
+        // Wait for turn_started and first delta to arrive, then cancel
+        let started = rx.recv().await.expect("should get turn_started");
+        assert!(matches!(started, StreamEvent::TurnStarted(_)));
+        let ev = rx.recv().await.expect("should receive delta");
         assert!(
             matches!(ev, StreamEvent::Delta(_)),
-            "first event should be a delta"
+            "second event should be a delta"
         );
         cancel.cancel();
 

--- a/modules/mini-chat/mini-chat/src/domain/stream_events.rs
+++ b/modules/mini-chat/mini-chat/src/domain/stream_events.rs
@@ -8,6 +8,8 @@ use modkit_macros::domain_model;
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use uuid::Uuid;
+
 use crate::domain::llm::{Citation, ToolPhase, Usage};
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -17,10 +19,11 @@ use crate::domain::llm::{Citation, ToolPhase, Usage};
 /// Stream event envelope for the `messages:stream` pipeline.
 ///
 /// Each variant maps to a distinct SSE `event:` name and `data:` JSON payload.
-/// Ordering grammar: `ping* (delta | tool)* citations? (done | error)`.
+/// Ordering grammar: `turn_started ping* (delta | tool)* citations? (done | error)`.
 #[domain_model]
 #[derive(Debug, Clone, ToSchema)]
 pub enum StreamEvent {
+    TurnStarted(TurnStartedData),
     Ping,
     Delta(DeltaData),
     Tool(ToolData),
@@ -76,6 +79,13 @@ pub struct ErrorData {
     pub message: String,
 }
 
+/// Initial lifecycle event carrying the server-generated request ID.
+#[domain_model]
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct TurnStartedData {
+    pub request_id: Uuid,
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 // StreamEventKind — coarse classification for ordering enforcement
 // ════════════════════════════════════════════════════════════════════════════
@@ -84,6 +94,7 @@ pub struct ErrorData {
 #[domain_model]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamEventKind {
+    TurnStarted,
     Ping,
     Delta,
     Tool,
@@ -97,6 +108,7 @@ impl StreamEvent {
     #[must_use]
     pub fn event_kind(&self) -> StreamEventKind {
         match self {
+            StreamEvent::TurnStarted(_) => StreamEventKind::TurnStarted,
             StreamEvent::Ping => StreamEventKind::Ping,
             StreamEvent::Delta(_) => StreamEventKind::Delta,
             StreamEvent::Tool(_) => StreamEventKind::Tool,


### PR DESCRIPTION
feat(mini-chat): add turn_started SSE event and persist cancelled messages.

Refs #1147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added `turn_started` streaming event emitted at the beginning of each turn, providing a server-generated request identifier for improved turn tracking.

**Bug Fixes**
* Enhanced error handling and recovery mechanisms for cancellations and message persistence failures.
* Improved turn state tracking and visibility of assistant message availability across different operational scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->