### PR TITLE
feat(config): add vendor configuration section to AppConfig

### DIFF
--- a/libs/modkit/src/bootstrap/config/mod.rs
+++ b/libs/modkit/src/bootstrap/config/mod.rs
@@ -7,6 +7,7 @@ mod dump;
 use anyhow::{Context, Result, ensure};
 // Use DB config types from modkit-db
 pub use modkit_db::{DbConnConfig, GlobalDatabaseConfig, PoolCfg};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -15,6 +16,19 @@ use tracing::Level;
 use crate::ConfigProvider;
 use crate::telemetry::TracingConfig;
 use url::Url;
+
+/// Error type for vendor configuration access.
+#[derive(thiserror::Error, Debug)]
+pub enum VendorConfigError {
+    #[error("vendor '{vendor}' not found in configuration")]
+    NotFound { vendor: String },
+    #[error("invalid config for vendor '{vendor}': {source}")]
+    InvalidConfig {
+        vendor: String,
+        #[source]
+        source: serde_json::Error,
+    },
+}
 
 // Re-export dump functions
 pub use dump::{
@@ -94,6 +108,10 @@ pub struct AppConfig {
     /// Per-module configuration bag: `module_name` → arbitrary JSON/YAML value.
     #[serde(default)]
     pub modules: HashMap<String, serde_json::Value>,
+    /// Per-vendor configuration bag: `vendor_name` → arbitrary JSON/YAML value.
+    /// Allows vendors to add their own typed configuration sections.
+    #[serde(default)]
+    pub vendor: VendorConfig,
 }
 
 impl Default for AppConfig {
@@ -106,6 +124,7 @@ impl Default for AppConfig {
             tracing: TracingConfig::default(),
             modules_dir: None,
             modules: HashMap::new(),
+            vendor: VendorConfig::new(),
         }
     }
 }
@@ -159,6 +178,11 @@ pub enum ConsoleFormat {
 /// Logging configuration - maps subsystem names to their logging settings.
 /// Key "default" is the catch-all for logs that don't match explicit subsystems.
 pub type LoggingConfig = HashMap<String, Section>;
+
+/// Per-vendor configuration bag: vendor name → arbitrary JSON/YAML value.
+/// Each vendor's section can be deserialized into a typed struct via
+/// [`AppConfig::vendor_config`] or [`AppConfig::vendor_config_or_default`].
+pub type VendorConfig = HashMap<String, serde_json::Value>;
 
 // ================= Custom serde module for optional Level (supports "off") =================
 mod optional_level_serde {
@@ -329,6 +353,45 @@ impl AppConfig {
     /// Returns an error if serialization fails.
     pub fn to_yaml(&self) -> Result<String> {
         serde_saphyr::to_string(self).context("Failed to serialize config to YAML")
+    }
+
+    /// Deserialize a vendor configuration section into a typed struct.
+    ///
+    /// # Errors
+    /// Returns `VendorConfigError::NotFound` if the vendor is not present,
+    /// or `VendorConfigError::InvalidConfig` if deserialization fails.
+    pub fn vendor_config<T: DeserializeOwned>(
+        &self,
+        vendor_name: &str,
+    ) -> Result<T, VendorConfigError> {
+        let raw = self
+            .vendor
+            .get(vendor_name)
+            .ok_or_else(|| VendorConfigError::NotFound {
+                vendor: vendor_name.to_owned(),
+            })?;
+        serde_json::from_value(raw.clone()).map_err(|e| VendorConfigError::InvalidConfig {
+            vendor: vendor_name.to_owned(),
+            source: e,
+        })
+    }
+
+    /// Deserialize a vendor configuration section, returning `T::default()` if absent.
+    ///
+    /// # Errors
+    /// Returns `VendorConfigError::InvalidConfig` if the section exists but cannot be
+    /// deserialized into `T`.
+    pub fn vendor_config_or_default<T: DeserializeOwned + Default>(
+        &self,
+        vendor_name: &str,
+    ) -> Result<T, VendorConfigError> {
+        let Some(raw) = self.vendor.get(vendor_name) else {
+            return Ok(T::default());
+        };
+        serde_json::from_value(raw.clone()).map_err(|e| VendorConfigError::InvalidConfig {
+            vendor: vendor_name.to_owned(),
+            source: e,
+        })
     }
 
     /// Apply overrides from command line arguments.
@@ -2685,6 +2748,261 @@ logging:
         assert!(modules.contains_key("module_a"));
         assert!(modules.contains_key("module_b"));
         assert!(modules.contains_key("module_c"));
+    }
+
+    // ========== Vendor configuration tests ==========
+
+    #[derive(Debug, Deserialize, Default, PartialEq)]
+    struct TestVendorConfig {
+        #[serde(default)]
+        api_token: String,
+        #[serde(default)]
+        api_url: String,
+    }
+
+    #[test]
+    fn test_vendor_section_parses_from_yaml() {
+        let yaml = r#"
+server:
+  home_dir: "~/.test_vendor"
+vendor:
+  acme:
+    api_token: "acme-token-123"
+    api_url: "https://acme.example.com"
+  other_corp:
+    api_token: "other-token-789"
+    api_url: "https://other.example.com"
+"#;
+        let config: AppConfig = serde_saphyr::from_str(yaml).unwrap();
+        assert_eq!(config.vendor.len(), 2);
+        assert!(config.vendor.contains_key("acme"));
+        assert!(config.vendor.contains_key("other_corp"));
+
+        let acme: TestVendorConfig = config.vendor_config("acme").unwrap();
+        assert_eq!(acme.api_token, "acme-token-123");
+        assert_eq!(acme.api_url, "https://acme.example.com");
+
+        let other: TestVendorConfig = config.vendor_config("other_corp").unwrap();
+        assert_eq!(other.api_token, "other-token-789");
+        assert_eq!(other.api_url, "https://other.example.com");
+    }
+
+    #[test]
+    fn test_vendor_section_defaults_to_empty() {
+        let config = AppConfig::default();
+        assert!(config.vendor.is_empty());
+    }
+
+    #[test]
+    fn test_vendor_config_typed_access() {
+        let mut config = AppConfig::default();
+        config.vendor.insert(
+            "acme".to_owned(),
+            serde_json::json!({
+                "api_token": "acme-token-123",
+                "api_url": "https://acme.example.com"
+            }),
+        );
+
+        let acme: TestVendorConfig = config.vendor_config("acme").unwrap();
+        assert_eq!(acme.api_token, "acme-token-123");
+        assert_eq!(acme.api_url, "https://acme.example.com");
+    }
+
+    #[test]
+    fn test_vendor_config_not_found() {
+        let config = AppConfig::default();
+        let result: Result<TestVendorConfig, _> = config.vendor_config("nonexistent");
+        assert!(matches!(
+            result,
+            Err(VendorConfigError::NotFound { ref vendor }) if vendor == "nonexistent"
+        ));
+    }
+
+    #[test]
+    fn test_vendor_config_invalid_structure() {
+        let mut config = AppConfig::default();
+        config
+            .vendor
+            .insert("bad".to_owned(), serde_json::json!("not an object"));
+
+        let result: Result<TestVendorConfig, _> = config.vendor_config("bad");
+        assert!(matches!(
+            result,
+            Err(VendorConfigError::InvalidConfig { ref vendor, .. }) if vendor == "bad"
+        ));
+    }
+
+    #[test]
+    fn test_vendor_config_or_default_missing() {
+        let config = AppConfig::default();
+        let acme: TestVendorConfig = config.vendor_config_or_default("acme").unwrap();
+        assert_eq!(acme, TestVendorConfig::default());
+    }
+
+    #[test]
+    fn test_vendor_config_or_default_present() {
+        let mut config = AppConfig::default();
+        config.vendor.insert(
+            "acme".to_owned(),
+            serde_json::json!({ "api_token": "acme-token-123" }),
+        );
+
+        let acme: TestVendorConfig = config.vendor_config_or_default("acme").unwrap();
+        assert_eq!(acme.api_token, "acme-token-123");
+    }
+
+    #[test]
+    fn test_vendor_config_env_override() {
+        let tmp = tempdir().unwrap();
+        let cfg_path = tmp.path().join("cfg.yaml");
+        let yaml = r#"
+server:
+  home_dir: "~/.test_vendor"
+vendor:
+  env_test_vendor:
+    api_token: "from_yaml"
+"#;
+        fs::write(&cfg_path, yaml).unwrap();
+
+        with_var(
+            "APP__VENDOR__ENV_TEST_VENDOR__API_TOKEN",
+            Some("from_env"),
+            || {
+                let config = AppConfig::load_layered(&cfg_path).unwrap();
+                let v: TestVendorConfig = config.vendor_config("env_test_vendor").unwrap();
+                assert_eq!(v.api_token, "from_env");
+            },
+        );
+    }
+
+    #[test]
+    fn test_vendor_multiple_vendors_typed_access() {
+        let mut config = AppConfig::default();
+        config.vendor.insert(
+            "acme".to_owned(),
+            serde_json::json!({ "api_token": "acme-token", "api_url": "https://acme.com" }),
+        );
+        config.vendor.insert(
+            "other_corp".to_owned(),
+            serde_json::json!({ "api_token": "other-token", "api_url": "https://other.com" }),
+        );
+
+        let acme: TestVendorConfig = config.vendor_config("acme").unwrap();
+        let other: TestVendorConfig = config.vendor_config("other_corp").unwrap();
+
+        assert_eq!(acme.api_token, "acme-token");
+        assert_eq!(other.api_token, "other-token");
+        assert_eq!(acme.api_url, "https://acme.com");
+        assert_eq!(other.api_url, "https://other.com");
+    }
+
+    #[test]
+    fn test_vendor_nested_config() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct NestedVendorConfig {
+            api_url: String,
+            feature_flags: FeatureFlags,
+        }
+
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct FeatureFlags {
+            beta_mode: bool,
+            max_retries: u32,
+        }
+
+        let mut config = AppConfig::default();
+        config.vendor.insert(
+            "acme".to_owned(),
+            serde_json::json!({
+                "api_url": "https://acme.com",
+                "feature_flags": {
+                    "beta_mode": true,
+                    "max_retries": 3
+                }
+            }),
+        );
+
+        let acme: NestedVendorConfig = config.vendor_config("acme").unwrap();
+        assert_eq!(acme.api_url, "https://acme.com");
+        assert!(acme.feature_flags.beta_mode);
+        assert_eq!(acme.feature_flags.max_retries, 3);
+    }
+
+    #[test]
+    fn test_vendor_config_or_default_invalid_returns_error() {
+        let mut config = AppConfig::default();
+        config
+            .vendor
+            .insert("bad".to_owned(), serde_json::json!("not an object"));
+
+        let result: Result<TestVendorConfig, _> = config.vendor_config_or_default("bad");
+        assert!(matches!(
+            result,
+            Err(VendorConfigError::InvalidConfig { ref vendor, .. }) if vendor == "bad"
+        ));
+    }
+
+    #[test]
+    fn test_vendor_config_yaml_roundtrip() {
+        let mut config = AppConfig::default();
+        config.vendor.insert(
+            "acme".to_owned(),
+            serde_json::json!({ "api_token": "acme-token-123" }),
+        );
+
+        let yaml = config.to_yaml().unwrap();
+        assert!(yaml.contains("vendor"));
+        assert!(yaml.contains("acme"));
+        assert!(yaml.contains("acme-token-123"));
+    }
+
+    #[test]
+    fn test_vendor_coexists_with_modules() {
+        let mut config = AppConfig::default();
+        config.modules.insert(
+            "my_module".to_owned(),
+            serde_json::json!({ "config": { "some_setting": true } }),
+        );
+        config.vendor.insert(
+            "acme".to_owned(),
+            serde_json::json!({ "api_token": "acme-token-123" }),
+        );
+
+        assert!(config.modules.contains_key("my_module"));
+        assert!(config.vendor.contains_key("acme"));
+
+        let acme: TestVendorConfig = config.vendor_config("acme").unwrap();
+        assert_eq!(acme.api_token, "acme-token-123");
+    }
+
+    #[test]
+    fn test_vendor_error_display_messages() {
+        let not_found = VendorConfigError::NotFound {
+            vendor: "acme".to_owned(),
+        };
+        assert_eq!(
+            not_found.to_string(),
+            "vendor 'acme' not found in configuration"
+        );
+
+        let invalid = VendorConfigError::InvalidConfig {
+            vendor: "bad".to_owned(),
+            source: serde_json::from_str::<TestVendorConfig>("invalid").unwrap_err(),
+        };
+        let msg = invalid.to_string();
+        assert!(msg.starts_with("invalid config for vendor 'bad':"));
+    }
+
+    #[test]
+    fn test_vendor_empty_object_in_yaml() {
+        let yaml = r#"
+server:
+  home_dir: "~/.test_vendor"
+vendor: {}
+"#;
+        let config: AppConfig = serde_saphyr::from_str(yaml).unwrap();
+        assert!(config.vendor.is_empty());
     }
 }
 

--- a/libs/modkit/src/bootstrap/mod.rs
+++ b/libs/modkit/src/bootstrap/mod.rs
@@ -22,9 +22,9 @@ pub mod oop;
 // Re-export commonly used config types at crate root for convenience
 pub use config::{
     AppConfig, CliArgs, ConsoleFormat, LoggingConfig, MODKIT_MODULE_CONFIG_ENV, ModuleConfig,
-    ModuleRuntime, RenderedModuleConfig, RuntimeKind, Section, ServerConfig,
-    dump_effective_modules_config_json, dump_effective_modules_config_yaml, list_module_names,
-    render_effective_modules_config,
+    ModuleRuntime, RenderedModuleConfig, RuntimeKind, Section, ServerConfig, VendorConfig,
+    VendorConfigError, dump_effective_modules_config_json, dump_effective_modules_config_yaml,
+    list_module_names, render_effective_modules_config,
 };
 
 // Re-export host types for convenience


### PR DESCRIPTION
Allow vendors to define typed configuration under a `vendor` key in the YAML config. Supports multiple vendors and typed deserialization via `vendor_config::<T>()` / `vendor_config_or_default::<T>()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vendor configuration support with error handling for missing or invalid vendor settings.
  * Added methods to retrieve vendor-specific configuration values with optional fallback to defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->