### PR TITLE
fix(mini-chat): enforce user isolation with ensure_owner defence-in-depth

### DIFF
--- a/libs/modkit-security/src/access_scope.rs
+++ b/libs/modkit-security/src/access_scope.rs
@@ -907,4 +907,39 @@ mod tests {
             "Must narrow to single Eq for the matching owner"
         );
     }
+
+    #[test]
+    fn ensure_owner_multi_constraint_keeps_only_matching() {
+        let alice = uid(T1);
+        let bob = uid(T2);
+        let tenant = uid(T1);
+
+        // Constraint 1: tenant + alice → matches alice
+        let c1 = ScopeConstraint::new(vec![
+            ScopeFilter::eq(pep_properties::OWNER_TENANT_ID, tenant),
+            ScopeFilter::eq(pep_properties::OWNER_ID, alice),
+        ]);
+        // Constraint 2: tenant + bob → does NOT match alice
+        let c2 = ScopeConstraint::new(vec![
+            ScopeFilter::eq(pep_properties::OWNER_TENANT_ID, tenant),
+            ScopeFilter::eq(pep_properties::OWNER_ID, bob),
+        ]);
+
+        let scope = AccessScope::from_constraints(vec![c1, c2]);
+        let scoped = scope.ensure_owner(alice);
+
+        assert!(
+            !scoped.is_deny_all(),
+            "Must not be deny-all - one constraint matches"
+        );
+        assert_eq!(
+            scoped.all_uuid_values_for(pep_properties::OWNER_ID),
+            &[alice],
+            "Must keep only the constraint matching alice"
+        );
+        assert!(
+            scoped.contains_uuid(pep_properties::OWNER_TENANT_ID, tenant),
+            "Tenant filter must be preserved"
+        );
+    }
 }

--- a/libs/modkit-security/src/access_scope.rs
+++ b/libs/modkit-security/src/access_scope.rs
@@ -545,7 +545,7 @@ impl AccessScope {
     /// where `owner_id` constraints cannot be resolved and would cause fail-closed
     /// deny-all behaviour.
     ///
-    /// - Unconstrained scopes are returned as-is.
+    /// - Unconstrained scopes become deny-all (fail-closed).
     /// - Constraints that contain no `owner_tenant_id` filter are dropped entirely.
     /// - If all constraints are dropped, the result is deny-all.
     #[must_use]
@@ -558,7 +558,7 @@ impl AccessScope {
     /// Useful for entities that have both tenant and owner columns but no
     /// resource-level constraints (e.g., reactions scoped to the acting user).
     ///
-    /// - Unconstrained scopes are returned as-is.
+    /// - Unconstrained scopes become deny-all (fail-closed).
     /// - Constraints that contain none of the retained properties are dropped.
     /// - If all constraints are dropped, the result is deny-all.
     #[must_use]
@@ -566,11 +566,87 @@ impl AccessScope {
         self.retain_properties(&[pep_properties::OWNER_TENANT_ID, pep_properties::OWNER_ID])
     }
 
+    /// Create a new scope that guarantees an `owner_id` equality filter
+    /// matching exactly the supplied `owner_id` is present in every constraint.
+    ///
+    /// **Intersection semantics**: if a constraint already contains an
+    /// `owner_id` filter, the supplied value must be among its values —
+    /// otherwise the constraint is dropped. When it matches, the filter is
+    /// narrowed to exactly that single value.
+    ///
+    /// - **Unconstrained** → single constraint with only the `owner_id` filter.
+    /// - **Deny-all** → stays deny-all.
+    /// - **No existing owner filter** → `owner_id` is injected.
+    /// - **Existing owner filter containing `owner_id`** → narrowed to `Eq`.
+    /// - **Existing owner filter NOT containing `owner_id`** → constraint dropped
+    ///   (constraints use OR semantics, so dropping one narrows access; dropping
+    ///   all yields deny-all).
+    ///
+    /// Use this as a defence-in-depth measure for user-owned resources when
+    /// the PDP may not always return `owner_id` constraints or may return a
+    /// broader set than the current subject.
+    #[must_use]
+    pub fn ensure_owner(&self, owner_id: Uuid) -> Self {
+        if self.is_deny_all() {
+            return Self::deny_all();
+        }
+
+        let owner_filter = ScopeFilter::eq(pep_properties::OWNER_ID, owner_id);
+
+        if self.unconstrained {
+            return Self::single(ScopeConstraint::new(vec![owner_filter]));
+        }
+
+        let constraints = self
+            .constraints
+            .iter()
+            .filter_map(|c| {
+                let owner_filters: Vec<&ScopeFilter> = c
+                    .filters()
+                    .iter()
+                    .filter(|f| f.property() == pep_properties::OWNER_ID)
+                    .collect();
+
+                if owner_filters.is_empty() {
+                    let mut filters = c.filters().to_vec();
+                    filters.push(owner_filter.clone());
+                    return Some(ScopeConstraint::new(filters));
+                }
+
+                // Intersection semantics: ALL owner_id predicates must contain
+                // the supplied owner_id, otherwise the constraint is dropped.
+                let all_match = owner_filters
+                    .iter()
+                    .all(|f| f.values().iter().any(|v| v.as_uuid() == Some(owner_id)));
+                if !all_match {
+                    return None;
+                }
+
+                // Fast path: single Eq already matches → constraint unchanged.
+                if owner_filters.len() == 1 && matches!(owner_filters[0], ScopeFilter::Eq(_)) {
+                    return Some(c.clone());
+                }
+
+                // Replace all owner_id filters with a single Eq.
+                let mut filters: Vec<ScopeFilter> = c
+                    .filters()
+                    .iter()
+                    .filter(|f| f.property() != pep_properties::OWNER_ID)
+                    .cloned()
+                    .collect();
+                filters.push(owner_filter.clone());
+                Some(ScopeConstraint::new(filters))
+            })
+            .collect();
+
+        Self::from_constraints(constraints)
+    }
+
     /// Internal helper: build a new scope keeping only filters whose property
     /// is in the given whitelist.
     fn retain_properties(&self, properties: &[&str]) -> Self {
         if self.unconstrained {
-            return self.clone();
+            return Self::deny_all();
         }
 
         let constraints = self
@@ -672,10 +748,10 @@ mod tests {
     }
 
     #[test]
-    fn tenant_only_preserves_unconstrained() {
+    fn tenant_only_unconstrained_becomes_deny_all() {
         let scope = AccessScope::allow_all();
         let tenant_scope = scope.tenant_only();
-        assert!(tenant_scope.is_unconstrained());
+        assert!(tenant_scope.is_deny_all());
     }
 
     #[test]
@@ -713,9 +789,9 @@ mod tests {
     }
 
     #[test]
-    fn tenant_and_owner_preserves_unconstrained() {
+    fn tenant_and_owner_unconstrained_becomes_deny_all() {
         let scope = AccessScope::allow_all();
-        assert!(scope.tenant_and_owner().is_unconstrained());
+        assert!(scope.tenant_and_owner().is_deny_all());
     }
 
     #[test]
@@ -725,5 +801,110 @@ mod tests {
             uid(T1),
         )]));
         assert!(scope.tenant_and_owner().is_deny_all());
+    }
+
+    // --- ensure_owner ---
+
+    #[test]
+    fn ensure_owner_adds_owner_when_missing() {
+        let scope = AccessScope::for_tenant(uid(T1));
+        let owner_id = uid(T2);
+
+        let scoped = scope.ensure_owner(owner_id);
+        assert!(scoped.contains_uuid(pep_properties::OWNER_TENANT_ID, uid(T1)));
+        assert!(scoped.contains_uuid(pep_properties::OWNER_ID, owner_id));
+    }
+
+    #[test]
+    fn ensure_owner_keeps_existing_owner() {
+        let existing_owner = uid(T2);
+        let scope = AccessScope::single(ScopeConstraint::new(vec![
+            ScopeFilter::eq(pep_properties::OWNER_TENANT_ID, uid(T1)),
+            ScopeFilter::eq(pep_properties::OWNER_ID, existing_owner),
+        ]));
+
+        let scoped = scope.ensure_owner(existing_owner);
+        assert_eq!(
+            scoped.all_uuid_values_for(pep_properties::OWNER_ID),
+            &[existing_owner]
+        );
+    }
+
+    #[test]
+    fn ensure_owner_on_unconstrained_creates_owner_scope() {
+        let scope = AccessScope::allow_all();
+        let owner_id = uid(T1);
+
+        let scoped = scope.ensure_owner(owner_id);
+        assert!(!scoped.is_unconstrained());
+        assert!(scoped.contains_uuid(pep_properties::OWNER_ID, owner_id));
+    }
+
+    #[test]
+    fn ensure_owner_on_deny_all_stays_deny_all() {
+        let scope = AccessScope::deny_all();
+        let scoped = scope.ensure_owner(uid(T1));
+        assert!(scoped.is_deny_all());
+    }
+
+    #[test]
+    fn ensure_owner_narrows_existing_owner_to_subject() {
+        let user_a = uid(T1);
+        let user_b = uid(T2);
+        let scope = AccessScope::single(ScopeConstraint::new(vec![
+            ScopeFilter::eq(pep_properties::OWNER_TENANT_ID, uid(T1)),
+            ScopeFilter::in_uuids(pep_properties::OWNER_ID, vec![user_a, user_b]),
+        ]));
+
+        let scoped = scope.ensure_owner(user_a);
+        assert_eq!(
+            scoped.all_uuid_values_for(pep_properties::OWNER_ID),
+            &[user_a],
+            "Must narrow to exactly the subject's owner_id"
+        );
+        assert!(scoped.contains_uuid(pep_properties::OWNER_TENANT_ID, uid(T1)));
+    }
+
+    #[test]
+    fn ensure_owner_drops_constraint_when_subject_not_in_pdp() {
+        let user_x = uid(T1);
+        let user_y = uid(T2);
+        let scope = AccessScope::single(ScopeConstraint::new(vec![
+            ScopeFilter::eq(pep_properties::OWNER_TENANT_ID, uid(T1)),
+            ScopeFilter::eq(pep_properties::OWNER_ID, user_x),
+        ]));
+
+        let scoped = scope.ensure_owner(user_y);
+        assert!(
+            scoped.is_deny_all(),
+            "Must be deny-all when subject not in PDP's owner set"
+        );
+    }
+
+    #[test]
+    fn ensure_owner_checks_all_owner_filters_in_constraint() {
+        let alice = uid(T1);
+        let bob = uid(T2);
+        // Contrived: two owner_id filters in one constraint.
+        // alice is in the first but not the second → must be dropped.
+        let scope = AccessScope::single(ScopeConstraint::new(vec![
+            ScopeFilter::in_uuids(pep_properties::OWNER_ID, vec![alice, bob]),
+            ScopeFilter::in_uuids(pep_properties::OWNER_ID, vec![bob]),
+        ]));
+
+        let scoped = scope.ensure_owner(alice);
+        assert!(
+            scoped.is_deny_all(),
+            "Must deny when subject is missing from any owner_id filter"
+        );
+
+        // bob is in both → should pass and narrow to Eq.
+        let scoped = scope.ensure_owner(bob);
+        assert!(!scoped.is_deny_all());
+        assert_eq!(
+            scoped.all_uuid_values_for(pep_properties::OWNER_ID),
+            &[bob],
+            "Must narrow to single Eq for the matching owner"
+        );
     }
 }

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
@@ -102,6 +102,9 @@ pub(crate) async fn stream_message(
     let (tx, rx) = mpsc::channel::<StreamEvent>(capacity);
     let cancel = CancellationToken::new();
 
+    // Capture tenant_id before `ctx` is moved into `run_stream`.
+    let tenant_id = ctx.subject_tenant_id();
+
     info!(model = %resolved.model_id, provider_id = %resolved.provider_id, "starting SSE stream");
 
     // Pre-stream checks + spawn the provider task
@@ -122,7 +125,7 @@ pub(crate) async fn stream_message(
     {
         Ok(handle) => handle,
         Err(StreamError::Replay { turn }) => {
-            return replay_response(&svc, &selected_model, &turn, ping_secs).await;
+            return replay_response(&svc, tenant_id, &selected_model, &turn, ping_secs).await;
         }
         Err(e) => return stream_error_response(&e),
     };
@@ -232,11 +235,12 @@ fn stream_error_response(err: &StreamError) -> Response {
 /// the same `SseRelay` infrastructure as normal streaming.
 async fn replay_response(
     svc: &AppServices,
+    tenant_id: uuid::Uuid,
     selected_model: &str,
     turn: &TurnModel,
     ping_secs: u64,
 ) -> Response {
-    let scope = modkit_security::AccessScope::allow_all().tenant_only();
+    let scope = modkit_security::AccessScope::for_tenant(tenant_id);
 
     let events = match replay::replay_turn(
         &svc.db,

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
@@ -177,9 +177,19 @@ impl<
             .await?;
 
         let conn = self.db.conn().map_err(DomainError::from)?;
+
+        // Verify user owns the chat (ensure_owner for defence-in-depth).
+        let chat_scope = scope.ensure_owner(ctx.subject_id());
+        self.chat_repo
+            .get(&conn, &chat_scope, chat_id)
+            .await?
+            .ok_or_else(|| DomainError::not_found("Chat", chat_id))?;
+
+        // Attachment entity is no_owner — use tenant-only scope.
+        let att_scope = scope.tenant_only();
         let row = self
             .attachment_repo
-            .get(&conn, &scope, attachment_id)
+            .get(&conn, &att_scope, attachment_id)
             .await?
             .ok_or_else(|| DomainError::not_found("Attachment", attachment_id))?;
 
@@ -218,10 +228,18 @@ impl<
 
         let conn = self.db.conn().map_err(DomainError::from)?;
 
-        // Load row (including soft-deleted)
+        // Verify user owns the chat (ensure_owner for defence-in-depth).
+        let chat_scope = scope.ensure_owner(ctx.subject_id());
+        self.chat_repo
+            .get(&conn, &chat_scope, chat_id)
+            .await?
+            .ok_or_else(|| DomainError::not_found("Chat", chat_id))?;
+
+        // Load row (including soft-deleted); attachment is no_owner → tenant scope.
+        let att_scope = scope.tenant_only();
         let row = self
             .attachment_repo
-            .get(&conn, &scope, attachment_id)
+            .get(&conn, &att_scope, attachment_id)
             .await?
             .ok_or_else(|| DomainError::not_found("Attachment", attachment_id))?;
 
@@ -517,9 +535,10 @@ impl<
             .await?;
 
         let conn = self.db.conn().map_err(DomainError::from)?;
+        let chat_scope = scope.ensure_owner(ctx.subject_id());
         let chat = self
             .chat_repo
-            .get(&conn, &scope, chat_id)
+            .get(&conn, &chat_scope, chat_id)
             .await?
             .ok_or_else(|| DomainError::not_found("Chat", chat_id))?;
         let resolved = self
@@ -533,6 +552,7 @@ impl<
         let attachment_repo = Arc::clone(&self.attachment_repo);
         let chat_repo = Arc::clone(&self.chat_repo);
         let rag_config = self.rag_config.clone();
+        let chat_scope_tx = chat_scope.clone();
         let scope_tx = scope.clone();
         let kind_str = validated.kind.to_string();
         let insert_params = InsertAttachmentParams {
@@ -553,7 +573,7 @@ impl<
                 Box::pin(async move {
                     // Lock chat row to serialize concurrent uploads
                     let _chat = chat_repo
-                        .get_for_update(tx, &scope_tx, chat_id)
+                        .get_for_update(tx, &chat_scope_tx, chat_id)
                         .await
                         .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?
                         .ok_or_else(|| {

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service_test.rs
@@ -724,10 +724,10 @@ async fn test_delete_attachment_idempotent_already_deleted() {
     assert!(result.is_ok(), "idempotent delete should succeed");
 }
 
-// ── P5-F3: Delete by wrong user returns forbidden ──
+// ── P5-F3: Delete by wrong user masked as not-found ──
 
 #[tokio::test]
-async fn test_delete_attachment_wrong_user_forbidden() {
+async fn test_delete_attachment_wrong_user_not_found() {
     let db = inmem_db().await;
     let tenant_id = Uuid::new_v4();
     let chat_id = Uuid::new_v4();
@@ -744,7 +744,8 @@ async fn test_delete_attachment_wrong_user_forbidden() {
     let att_id =
         crate::domain::service::test_helpers::insert_test_attachment(&db_prov, params).await;
 
-    // Different user tries to delete
+    // Different user tries to delete — chat ownership check rejects first
+    // (more secure: user doesn't even learn the chat exists).
     let ctx =
         crate::domain::service::test_helpers::test_security_ctx_with_id(tenant_id, other_user_id);
     let oagw = MockOagwGateway::with_responses(vec![]);
@@ -752,13 +753,88 @@ async fn test_delete_attachment_wrong_user_forbidden() {
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
     let result = svc.delete_attachment(&ctx, chat_id, att_id).await;
-    assert!(result.is_err());
     assert!(
         matches!(
             result.unwrap_err(),
-            crate::domain::error::DomainError::Forbidden
+            crate::domain::error::DomainError::NotFound { .. }
         ),
-        "expected Forbidden"
+        "cross-owner delete must be masked as NotFound"
+    );
+}
+
+// ── Cross-owner isolation (tenant-only authz, ensure_owner defence-in-depth) ──
+
+#[tokio::test]
+async fn test_get_attachment_cross_owner_not_found() {
+    let db = inmem_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let other_user_id = Uuid::new_v4();
+    let db_prov = mock_db_provider(db.clone());
+    insert_chat_for_user(&db_prov, tenant_id, chat_id, owner_id).await;
+
+    let mut params =
+        crate::domain::service::test_helpers::InsertTestAttachmentParams::ready_document(
+            tenant_id, chat_id,
+        );
+    params.uploaded_by_user_id = owner_id;
+    let att_id =
+        crate::domain::service::test_helpers::insert_test_attachment(&db_prov, params).await;
+
+    // Different user (same tenant) tries to read the attachment
+    let ctx =
+        crate::domain::service::test_helpers::test_security_ctx_with_id(tenant_id, other_user_id);
+    let oagw = MockOagwGateway::with_responses(vec![]);
+    let outbox = Arc::new(NoopOutboxEnqueuer);
+    let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
+
+    let result = svc.get_attachment(&ctx, chat_id, att_id).await;
+    assert!(
+        matches!(
+            result.unwrap_err(),
+            crate::domain::error::DomainError::NotFound { .. }
+        ),
+        "cross-owner get_attachment must be masked as NotFound"
+    );
+}
+
+#[tokio::test]
+async fn test_upload_attachment_cross_owner_not_found() {
+    let db = inmem_db().await;
+    let tenant_id = Uuid::new_v4();
+    let chat_id = Uuid::new_v4();
+    let owner_id = Uuid::new_v4();
+    let other_user_id = Uuid::new_v4();
+    let db_prov = mock_db_provider(db.clone());
+    insert_chat_for_user(&db_prov, tenant_id, chat_id, owner_id).await;
+
+    // Different user (same tenant) tries to upload to owner's chat
+    let ctx =
+        crate::domain::service::test_helpers::test_security_ctx_with_id(tenant_id, other_user_id);
+    let oagw = MockOagwGateway::with_responses(vec![]);
+    let outbox = Arc::new(NoopOutboxEnqueuer);
+    let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
+
+    let result = svc
+        .upload_file(
+            &ctx,
+            chat_id,
+            "test.pdf".to_owned(),
+            "application/pdf",
+            Bytes::from_static(b"dummy content"),
+        )
+        .await;
+    assert!(
+        matches!(
+            result.unwrap_err(),
+            crate::domain::error::DomainError::NotFound { .. }
+        ),
+        "cross-owner upload must be masked as NotFound"
+    );
+    assert!(
+        oagw.captured_requests.lock().unwrap().is_empty(),
+        "cross-owner upload must fail before any provider call"
     );
 }
 

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service.rs
@@ -115,18 +115,19 @@ impl<CR: ChatRepository + 'static, TSR: ThreadSummaryRepository + 'static> ChatS
 
         let conn = self.db.conn().map_err(DomainError::from)?;
 
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(ctx, &resources::CHAT, actions::READ, Some(id))
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
         let chat = self
             .chat_repo
-            .get(&conn, &scope, id)
+            .get(&conn, &chat_scope, id)
             .await?
             .ok_or_else(|| DomainError::chat_not_found(id))?;
 
-        let msg_scope = scope.tenant_only();
+        let msg_scope = chat_scope.tenant_only();
         let message_count = self.chat_repo.count_messages(&conn, &msg_scope, id).await?;
 
         tracing::debug!("Successfully retrieved chat");
@@ -144,15 +145,16 @@ impl<CR: ChatRepository + 'static, TSR: ThreadSummaryRepository + 'static> ChatS
 
         let conn = self.db.conn().map_err(DomainError::from)?;
 
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(ctx, &resources::CHAT, actions::LIST, None)
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
-        let page = self.chat_repo.list_page(&conn, &scope, query).await?;
+        let page = self.chat_repo.list_page(&conn, &chat_scope, query).await?;
 
         // Batch count: single GROUP BY query for all chat IDs.
-        let msg_scope = scope.tenant_only();
+        let msg_scope = chat_scope.tenant_only();
         let chat_ids: Vec<Uuid> = page.items.iter().map(|c| c.id).collect();
         let counts = if chat_ids.is_empty() {
             std::collections::HashMap::new()
@@ -193,16 +195,17 @@ impl<CR: ChatRepository + 'static, TSR: ThreadSummaryRepository + 'static> ChatS
             validate_title(Some(title.as_str()))?;
         }
 
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(ctx, &resources::CHAT, actions::UPDATE, Some(id))
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
         let chat_repo = Arc::clone(&self.chat_repo);
         let (updated, message_count) = self
             .db
             .transaction(|tx| {
-                let scope = scope.clone();
+                let scope = chat_scope.clone();
                 Box::pin(async move {
                     let map = |e: DomainError| modkit_db::DbError::Other(anyhow::Error::new(e));
 
@@ -248,12 +251,13 @@ impl<CR: ChatRepository + 'static, TSR: ThreadSummaryRepository + 'static> ChatS
 
         let conn = self.db.conn().map_err(DomainError::from)?;
 
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(ctx, &resources::CHAT, actions::DELETE, Some(id))
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
-        let deleted = self.chat_repo.soft_delete(&conn, &scope, id).await?;
+        let deleted = self.chat_repo.soft_delete(&conn, &chat_scope, id).await?;
         if !deleted {
             return Err(DomainError::chat_not_found(id));
         }

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
@@ -16,24 +16,9 @@ use crate::domain::service::test_helpers::{
 
 // ── Test Helpers ──
 
-fn build_service(db: modkit_db::Db) -> ChatService<OrmChatRepository, MockThreadSummaryRepo> {
-    let db = mock_db_provider(db);
-    let chat_repo = Arc::new(OrmChatRepository::new(modkit_db::odata::LimitCfg {
-        default: 20,
-        max: 100,
-    }));
-
-    ChatService::new(
-        db,
-        chat_repo,
-        mock_thread_summary_repo(),
-        mock_enforcer(),
-        mock_model_resolver(),
-    )
-}
-
-fn build_service_tenant_only_authz(
+fn build_service_with_enforcer(
     db: modkit_db::Db,
+    enforcer: authz_resolver_sdk::PolicyEnforcer,
 ) -> ChatService<OrmChatRepository, MockThreadSummaryRepo> {
     let db = mock_db_provider(db);
     let chat_repo = Arc::new(OrmChatRepository::new(modkit_db::odata::LimitCfg {
@@ -45,9 +30,19 @@ fn build_service_tenant_only_authz(
         db,
         chat_repo,
         mock_thread_summary_repo(),
-        mock_tenant_only_enforcer(),
+        enforcer,
         mock_model_resolver(),
     )
+}
+
+fn build_service(db: modkit_db::Db) -> ChatService<OrmChatRepository, MockThreadSummaryRepo> {
+    build_service_with_enforcer(db, mock_enforcer())
+}
+
+fn build_service_tenant_only_authz(
+    db: modkit_db::Db,
+) -> ChatService<OrmChatRepository, MockThreadSummaryRepo> {
+    build_service_with_enforcer(db, mock_tenant_only_enforcer())
 }
 
 // ── Tests ──
@@ -967,5 +962,48 @@ async fn delete_chat_tenant_only_authz_cross_owner_not_found() {
     assert!(
         matches!(result.unwrap_err(), DomainError::ChatNotFound { .. }),
         "Expected ChatNotFound for cross-owner delete with tenant-only authz"
+    );
+}
+
+#[tokio::test]
+async fn update_chat_tenant_only_authz_cross_owner_not_found() {
+    let db = inmem_db().await;
+    let svc = build_service_tenant_only_authz(db);
+
+    let tenant_id = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    let ctx_a = test_security_ctx_with_id(tenant_id, user_a);
+    let ctx_b = test_security_ctx_with_id(tenant_id, user_b);
+
+    let created = svc
+        .create_chat(
+            &ctx_a,
+            NewChat {
+                model: Some("gpt-5.2".to_owned()),
+                title: Some("User A chat".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create failed");
+
+    // User B (same tenant) tries to update User A's chat — must fail
+    let result = svc
+        .update_chat(
+            &ctx_b,
+            created.id,
+            ChatPatch {
+                title: Some(Some("Hijacked".to_owned())),
+            },
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "Cross-owner update must fail with tenant-only authz"
+    );
+    assert!(
+        matches!(result.unwrap_err(), DomainError::ChatNotFound { .. }),
+        "Expected ChatNotFound for cross-owner update with tenant-only authz"
     );
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
@@ -10,7 +10,8 @@ use crate::infra::db::repo::chat_repo::ChatRepository as OrmChatRepository;
 use super::ChatService;
 use crate::domain::service::test_helpers::{
     MockThreadSummaryRepo, inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver,
-    mock_thread_summary_repo, test_security_ctx, test_security_ctx_with_id,
+    mock_tenant_only_enforcer, mock_thread_summary_repo, test_security_ctx,
+    test_security_ctx_with_id,
 };
 
 // ── Test Helpers ──
@@ -27,6 +28,24 @@ fn build_service(db: modkit_db::Db) -> ChatService<OrmChatRepository, MockThread
         chat_repo,
         mock_thread_summary_repo(),
         mock_enforcer(),
+        mock_model_resolver(),
+    )
+}
+
+fn build_service_tenant_only_authz(
+    db: modkit_db::Db,
+) -> ChatService<OrmChatRepository, MockThreadSummaryRepo> {
+    let db = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(modkit_db::odata::LimitCfg {
+        default: 20,
+        max: 100,
+    }));
+
+    ChatService::new(
+        db,
+        chat_repo,
+        mock_thread_summary_repo(),
+        mock_tenant_only_enforcer(),
         mock_model_resolver(),
     )
 }
@@ -834,5 +853,119 @@ async fn list_chats_pagination_backward_cursor() {
     assert_eq!(
         back_ids, page1_ids,
         "Backward navigation must return to page 1 items"
+    );
+}
+
+// ── Tenant-only AuthZ: user isolation via ensure_owner ──
+
+#[tokio::test]
+async fn list_chats_tenant_only_authz_cross_owner_returns_empty() {
+    let db = inmem_db().await;
+    let svc = build_service_tenant_only_authz(db);
+
+    let tenant_id = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    let ctx_a = test_security_ctx_with_id(tenant_id, user_a);
+    let ctx_b = test_security_ctx_with_id(tenant_id, user_b);
+
+    // User A creates a chat (AuthZ returns only tenant constraint, no owner_id)
+    svc.create_chat(
+        &ctx_a,
+        NewChat {
+            model: Some("gpt-5.2".to_owned()),
+            title: Some("User A chat".to_owned()),
+            is_temporary: false,
+        },
+    )
+    .await
+    .expect("create failed");
+
+    // User B (same tenant) lists — must still see nothing thanks to ensure_owner
+    let page = svc
+        .list_chats(&ctx_b, &ODataQuery::default())
+        .await
+        .expect("list failed");
+    assert_eq!(
+        page.items.len(),
+        0,
+        "User B must not see User A chats even when AuthZ returns tenant-only constraints"
+    );
+
+    // User A sees their own chat
+    let page = svc
+        .list_chats(&ctx_a, &ODataQuery::default())
+        .await
+        .expect("list failed");
+    assert_eq!(page.items.len(), 1, "User A must see their own chat");
+}
+
+#[tokio::test]
+async fn get_chat_tenant_only_authz_cross_owner_not_found() {
+    let db = inmem_db().await;
+    let svc = build_service_tenant_only_authz(db);
+
+    let tenant_id = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    let ctx_a = test_security_ctx_with_id(tenant_id, user_a);
+    let ctx_b = test_security_ctx_with_id(tenant_id, user_b);
+
+    let created = svc
+        .create_chat(
+            &ctx_a,
+            NewChat {
+                model: Some("gpt-5.2".to_owned()),
+                title: Some("User A chat".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create failed");
+
+    // User B (same tenant) tries to get User A's chat — must fail
+    let result = svc.get_chat(&ctx_b, created.id).await;
+    assert!(
+        result.is_err(),
+        "Cross-owner get must fail with tenant-only authz"
+    );
+    assert!(
+        matches!(result.unwrap_err(), DomainError::ChatNotFound { .. }),
+        "Expected ChatNotFound for cross-owner access with tenant-only authz"
+    );
+}
+
+#[tokio::test]
+async fn delete_chat_tenant_only_authz_cross_owner_not_found() {
+    let db = inmem_db().await;
+    let svc = build_service_tenant_only_authz(db);
+
+    let tenant_id = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    let ctx_a = test_security_ctx_with_id(tenant_id, user_a);
+    let ctx_b = test_security_ctx_with_id(tenant_id, user_b);
+
+    let created = svc
+        .create_chat(
+            &ctx_a,
+            NewChat {
+                model: Some("gpt-5.2".to_owned()),
+                title: Some("User A chat".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create failed");
+
+    // User B (same tenant) tries to delete — must fail
+    let result = svc.delete_chat(&ctx_b, created.id).await;
+    assert!(
+        result.is_err(),
+        "Cross-owner delete must fail with tenant-only authz"
+    );
+    assert!(
+        matches!(result.unwrap_err(), DomainError::ChatNotFound { .. }),
+        "Expected ChatNotFound for cross-owner delete with tenant-only authz"
     );
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/message_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/message_service.rs
@@ -53,18 +53,19 @@ impl<MR: MessageRepository, CR: ChatRepository, RR: ReactionRepository> MessageS
 
         let conn = self.db.conn().map_err(DomainError::from)?;
 
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(ctx, &resources::CHAT, actions::LIST_MESSAGES, Some(chat_id))
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
         // Verify chat exists (scoped)
         self.chat_repo
-            .get(&conn, &scope, chat_id)
+            .get(&conn, &chat_scope, chat_id)
             .await?
             .ok_or_else(|| DomainError::chat_not_found(chat_id))?;
 
-        let msg_scope = scope.tenant_only();
+        let msg_scope = chat_scope.tenant_only();
         let page = self
             .message_repo
             .list_by_chat(&conn, &msg_scope, chat_id, query)
@@ -78,7 +79,7 @@ impl<MR: MessageRepository, CR: ChatRepository, RR: ReactionRepository> MessageS
             .await?;
 
         // Batch-fetch the current user's reactions for all returned messages.
-        let reaction_scope = scope.tenant_and_owner();
+        let reaction_scope = chat_scope.tenant_and_owner();
         let mut reaction_map = self
             .reaction_repo
             .batch_by_user(&conn, &reaction_scope, &msg_ids, ctx.subject_id())

--- a/modules/mini-chat/mini-chat/src/domain/service/message_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/message_service_test.rs
@@ -16,7 +16,8 @@ use crate::domain::repos::{
 };
 use crate::domain::service::test_helpers::{
     MockThreadSummaryRepo, inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver,
-    mock_thread_summary_repo, test_security_ctx, test_security_ctx_with_id,
+    mock_tenant_only_enforcer, mock_thread_summary_repo, test_security_ctx,
+    test_security_ctx_with_id,
 };
 use crate::infra::db::entity::attachment::{
     ActiveModel as AttAm, AttachmentKind, AttachmentStatus, Entity as AttEntity,
@@ -63,6 +64,34 @@ fn build_message_service(
         chat_repo,
         reaction_repo,
         mock_enforcer(),
+    )
+}
+
+fn build_message_service_tenant_only_authz(
+    db_provider: Arc<crate::domain::service::DbProvider>,
+    chat_repo: Arc<OrmChatRepository>,
+) -> MessageService<OrmMessageRepository, OrmChatRepository, OrmReactionRepository> {
+    let message_repo = Arc::new(OrmMessageRepository::new(limit_cfg()));
+    let reaction_repo = Arc::new(OrmReactionRepository);
+    MessageService::new(
+        db_provider,
+        message_repo,
+        chat_repo,
+        reaction_repo,
+        mock_tenant_only_enforcer(),
+    )
+}
+
+fn build_chat_service_tenant_only_authz(
+    db_provider: Arc<crate::domain::service::DbProvider>,
+    chat_repo: Arc<OrmChatRepository>,
+) -> ChatService<OrmChatRepository, MockThreadSummaryRepo> {
+    ChatService::new(
+        db_provider,
+        chat_repo,
+        mock_thread_summary_repo(),
+        mock_tenant_only_enforcer(),
+        mock_model_resolver(),
     )
 }
 
@@ -973,5 +1002,51 @@ async fn list_messages_returns_my_reaction() {
         asst_msg.my_reaction,
         Some(ReactionKind::Like),
         "assistant message should have Like reaction"
+    );
+}
+
+// ── Tenant-only AuthZ: user isolation via ensure_owner ──
+
+#[tokio::test]
+async fn list_messages_tenant_only_authz_cross_owner_not_found() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let tenant_id = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    let ctx_a = test_security_ctx_with_id(tenant_id, user_a);
+    let ctx_b = test_security_ctx_with_id(tenant_id, user_b);
+
+    // User A creates a chat via a tenant-only authz chat service
+    let chat_svc =
+        build_chat_service_tenant_only_authz(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let chat = chat_svc
+        .create_chat(
+            &ctx_a,
+            NewChat {
+                model: None,
+                title: Some("User A chat".to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create_chat failed");
+
+    // User B (same tenant) tries to list messages in User A's chat
+    let msg_svc =
+        build_message_service_tenant_only_authz(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let result = msg_svc
+        .list_messages(&ctx_b, chat.id, &ODataQuery::default())
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Cross-owner list_messages must fail with tenant-only authz"
+    );
+    assert!(
+        matches!(result.unwrap_err(), DomainError::ChatNotFound { .. }),
+        "Expected ChatNotFound for cross-owner access with tenant-only authz"
     );
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/reaction_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/reaction_service.rs
@@ -61,19 +61,20 @@ impl<RR: ReactionRepository, MR: MessageRepository, CR: ChatRepository>
 
         let conn = self.db.conn().map_err(DomainError::from)?;
 
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(ctx, &resources::CHAT, actions::SET_REACTION, Some(chat_id))
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
         // Verify chat exists (scoped)
         self.chat_repo
-            .get(&conn, &scope, chat_id)
+            .get(&conn, &chat_scope, chat_id)
             .await?
             .ok_or_else(|| DomainError::chat_not_found(chat_id))?;
 
-        let msg_scope = scope.tenant_only();
-        let reaction_scope = scope.tenant_and_owner();
+        let msg_scope = chat_scope.tenant_only();
+        let reaction_scope = chat_scope.tenant_and_owner();
 
         // Verify message exists in this chat and is an assistant message
         let message = self
@@ -123,7 +124,7 @@ impl<RR: ReactionRepository, MR: MessageRepository, CR: ChatRepository>
 
         let conn = self.db.conn().map_err(DomainError::from)?;
 
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(
                 ctx,
@@ -131,18 +132,19 @@ impl<RR: ReactionRepository, MR: MessageRepository, CR: ChatRepository>
                 actions::DELETE_REACTION,
                 Some(chat_id),
             )
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
         // Verify chat exists (scoped)
         self.chat_repo
-            .get(&conn, &scope, chat_id)
+            .get(&conn, &chat_scope, chat_id)
             .await?
             .ok_or_else(|| DomainError::chat_not_found(chat_id))?;
 
         // Messages use `no_owner` — strip owner_id constraints to avoid
         // deny-all when the PDP returns owner-scoped predicates.
-        let msg_scope = scope.tenant_only();
-        let reaction_scope = scope.tenant_and_owner();
+        let msg_scope = chat_scope.tenant_only();
+        let reaction_scope = chat_scope.tenant_and_owner();
 
         // Verify message exists in this chat
         self.message_repo

--- a/modules/mini-chat/mini-chat/src/domain/service/reaction_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/reaction_service_test.rs
@@ -11,7 +11,8 @@ use crate::domain::repos::{
 };
 use crate::domain::service::test_helpers::{
     MockThreadSummaryRepo, inmem_db, mock_db_provider, mock_enforcer, mock_model_resolver,
-    mock_thread_summary_repo, test_security_ctx,
+    mock_tenant_only_enforcer, mock_thread_summary_repo, test_security_ctx,
+    test_security_ctx_with_id,
 };
 use crate::infra::db::repo::chat_repo::ChatRepository as OrmChatRepository;
 use crate::infra::db::repo::message_repo::MessageRepository as OrmMessageRepository;
@@ -54,6 +55,21 @@ fn build_reaction_service(
         message_repo,
         chat_repo,
         mock_enforcer(),
+    )
+}
+
+fn build_reaction_service_tenant_only_authz(
+    db_provider: Arc<crate::domain::service::DbProvider>,
+    chat_repo: Arc<OrmChatRepository>,
+) -> ReactionService<OrmReactionRepository, OrmMessageRepository, OrmChatRepository> {
+    let reaction_repo = Arc::new(OrmReactionRepository);
+    let message_repo = Arc::new(OrmMessageRepository::new(limit_cfg()));
+    ReactionService::new(
+        db_provider,
+        reaction_repo,
+        message_repo,
+        chat_repo,
+        mock_tenant_only_enforcer(),
     )
 }
 
@@ -362,5 +378,40 @@ async fn set_reaction_cross_tenant_rejected() {
     assert!(
         matches!(result.unwrap_err(), DomainError::ChatNotFound { .. }),
         "Expected ChatNotFound for cross-tenant access"
+    );
+}
+
+// ── Tenant-only AuthZ: user isolation via ensure_owner ──
+
+#[tokio::test]
+async fn set_reaction_tenant_only_authz_cross_owner_not_found() {
+    let db = inmem_db().await;
+    let db_provider = mock_db_provider(db);
+    let chat_repo = Arc::new(OrmChatRepository::new(limit_cfg()));
+
+    let tenant_id = Uuid::new_v4();
+    let user_a = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+    let ctx_a = test_security_ctx_with_id(tenant_id, user_a);
+    let ctx_b = test_security_ctx_with_id(tenant_id, user_b);
+
+    // User A creates a chat with messages (using permissive enforcer for setup)
+    let (chat_id, _user_msg_id, assistant_msg_id) =
+        setup_chat_with_messages(&db_provider, &chat_repo, &ctx_a, tenant_id).await;
+
+    // User B (same tenant) tries to react via tenant-only enforcer
+    let reaction_svc =
+        build_reaction_service_tenant_only_authz(Arc::clone(&db_provider), Arc::clone(&chat_repo));
+    let result = reaction_svc
+        .set_reaction(&ctx_b, chat_id, assistant_msg_id, "like")
+        .await;
+
+    assert!(
+        result.is_err(),
+        "Cross-owner reaction must fail with tenant-only authz"
+    );
+    assert!(
+        matches!(result.unwrap_err(), DomainError::ChatNotFound { .. }),
+        "Expected ChatNotFound for cross-owner access with tenant-only authz"
     );
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/replay.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/replay.rs
@@ -300,7 +300,7 @@ mod tests {
     async fn replay_turn_happy_path() {
         let db_raw = inmem_db().await;
         let db = mock_db_provider(db_raw);
-        let scope = AccessScope::allow_all().tenant_only();
+        let scope = AccessScope::allow_all();
 
         let msg_id = Uuid::new_v4();
         let turn = make_completed_turn(Some(msg_id), Some("gpt-5.2".to_owned()));
@@ -342,7 +342,7 @@ mod tests {
     async fn replay_turn_no_downgrade() {
         let db_raw = inmem_db().await;
         let db = mock_db_provider(db_raw);
-        let scope = AccessScope::allow_all().tenant_only();
+        let scope = AccessScope::allow_all();
 
         let msg_id = Uuid::new_v4();
         let turn = make_completed_turn(Some(msg_id), Some("gpt-5.2".to_owned()));
@@ -370,7 +370,7 @@ mod tests {
     async fn replay_turn_downgrade_detected() {
         let db_raw = inmem_db().await;
         let db = mock_db_provider(db_raw);
-        let scope = AccessScope::allow_all().tenant_only();
+        let scope = AccessScope::allow_all();
 
         let msg_id = Uuid::new_v4();
         // effective_model differs from selected_model → downgrade
@@ -400,7 +400,7 @@ mod tests {
     async fn replay_turn_missing_assistant_message_id() {
         let db_raw = inmem_db().await;
         let db = mock_db_provider(db_raw);
-        let scope = AccessScope::allow_all().tenant_only();
+        let scope = AccessScope::allow_all();
 
         let turn = make_completed_turn(None, Some("gpt-5.2".to_owned()));
         let repo = MockMessageRepo::new();
@@ -419,7 +419,7 @@ mod tests {
     async fn replay_turn_message_not_found() {
         let db_raw = inmem_db().await;
         let db = mock_db_provider(db_raw);
-        let scope = AccessScope::allow_all().tenant_only();
+        let scope = AccessScope::allow_all();
 
         let msg_id = Uuid::new_v4();
         let turn = make_completed_turn(Some(msg_id), Some("gpt-5.2".to_owned()));

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -524,10 +524,11 @@ impl<
         let user_id = ctx.subject_id();
 
         // ── Authorization ──
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(&ctx, &resources::CHAT, actions::SEND_MESSAGE, Some(chat_id))
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
         // Non-transactional connection for pre-stream checks (D6)
         let conn = self
@@ -539,12 +540,12 @@ impl<
 
         // ── Verify chat exists (scoped) ──
         self.chat_repo
-            .get(&conn, &scope, chat_id)
+            .get(&conn, &chat_scope, chat_id)
             .await
             .map_err(|e| StreamError::TurnCreationFailed { source: e })?
             .ok_or(StreamError::ChatNotFound { chat_id })?;
 
-        let scope = scope.tenant_only();
+        let scope = chat_scope.tenant_only();
 
         // ── Idempotency check (DESIGN §3.7 Check Priority Order) ──
         if let Some(existing_turn) = self
@@ -3772,7 +3773,7 @@ mod tests {
         assert!(done.downgrade_from.is_none());
 
         // Verify turn was created with real quota fields (not placeholder 1_000_000)
-        let scope = AccessScope::allow_all().tenant_only();
+        let scope = AccessScope::allow_all();
         let conn = db.conn().unwrap();
         let turn_repo = TurnRepo;
         let turn = turn_repo

--- a/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
@@ -159,10 +159,11 @@ impl<
         chat_id: Uuid,
         request_id: Uuid,
     ) -> Result<TurnModel, MutationError> {
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(ctx, &resources::CHAT, actions::READ_TURN, Some(chat_id))
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
         let conn = self.db.conn().map_err(|e| MutationError::Internal {
             message: e.to_string(),
@@ -170,14 +171,14 @@ impl<
 
         // Verify chat exists (scoped by authz)
         self.chat_repo
-            .get(&conn, &scope, chat_id)
+            .get(&conn, &chat_scope, chat_id)
             .await
             .map_err(|e| MutationError::Internal {
                 message: e.to_string(),
             })?
             .ok_or(MutationError::ChatNotFound { chat_id })?;
 
-        let scope = scope.tenant_only();
+        let scope = chat_scope.tenant_only();
 
         self.turn_repo
             .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
@@ -201,16 +202,17 @@ impl<
     ) -> Result<(), MutationError> {
         info!(%chat_id, %request_id, "turn delete");
 
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(ctx, &resources::CHAT, actions::DELETE_TURN, Some(chat_id))
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
         let start = std::time::Instant::now();
 
         let turn_repo = Arc::clone(&self.turn_repo);
         let chat_repo = Arc::clone(&self.chat_repo);
-        let scope_tx = scope.clone();
+        let scope_tx = chat_scope.clone();
         let ctx_clone = ctx.clone();
 
         let result = self
@@ -257,14 +259,15 @@ impl<
     ) -> Result<MutationResult, MutationError> {
         info!(%chat_id, %request_id, "turn retry");
 
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(ctx, &resources::CHAT, actions::RETRY_TURN, Some(chat_id))
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
         let start = std::time::Instant::now();
         let result = self
-            .mutate_for_stream(ctx, scope, chat_id, request_id, None)
+            .mutate_for_stream(ctx, chat_scope, chat_id, request_id, None)
             .await;
 
         let ms = start.elapsed().as_secs_f64() * 1000.0;
@@ -285,14 +288,15 @@ impl<
     ) -> Result<MutationResult, MutationError> {
         info!(%chat_id, %request_id, "turn edit");
 
-        let scope = self
+        let chat_scope = self
             .enforcer
             .access_scope(ctx, &resources::CHAT, actions::EDIT_TURN, Some(chat_id))
-            .await?;
+            .await?
+            .ensure_owner(ctx.subject_id());
 
         let start = std::time::Instant::now();
         let result = self
-            .mutate_for_stream(ctx, scope, chat_id, request_id, Some(new_content))
+            .mutate_for_stream(ctx, chat_scope, chat_id, request_id, Some(new_content))
             .await;
 
         let ms = start.elapsed().as_secs_f64() * 1000.0;

--- a/modules/mini-chat/mini-chat/src/domain/service/turn_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/turn_service_test.rs
@@ -627,3 +627,98 @@ async fn delete_success_emits_metrics() {
         "should record turn_mutation_latency_ms histogram"
     );
 }
+
+// ── Tenant-only AuthZ: user isolation via ensure_owner ──
+
+/// Build a `TurnService` with tenant-only enforcer for cross-owner tests.
+/// Creates a chat owned by `chat_owner_id` and returns the service, `tenant_id`, and `chat_id`.
+async fn setup_tenant_only_authz(
+    chat_owner_id: Uuid,
+) -> (
+    TurnService<
+        repo::turn_repo::TurnRepository,
+        repo::message_repo::MessageRepository,
+        repo::chat_repo::ChatRepository,
+        repo::message_attachment_repo::MessageAttachmentRepository,
+    >,
+    Uuid, // tenant_id
+    Uuid, // chat_id
+) {
+    let db = inmem_db().await;
+    let db = mock_db_provider(db);
+    let tenant_id = Uuid::new_v4();
+
+    let chat_repo = Arc::new(repo::chat_repo::ChatRepository::new(
+        modkit_db::odata::LimitCfg {
+            default: 20,
+            max: 100,
+        },
+    ));
+    let turn_repo = Arc::new(repo::turn_repo::TurnRepository);
+    let message_repo = Arc::new(repo::message_repo::MessageRepository::new(
+        modkit_db::odata::LimitCfg {
+            default: 20,
+            max: 100,
+        },
+    ));
+
+    let chat_id = Uuid::now_v7();
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = db.conn().unwrap();
+    chat_repo
+        .create(
+            &conn,
+            &scope,
+            crate::domain::models::Chat {
+                id: chat_id,
+                tenant_id,
+                user_id: chat_owner_id,
+                model: "gpt-5.2".to_owned(),
+                title: Some("Test chat".to_owned()),
+                is_temporary: false,
+                created_at: time::OffsetDateTime::now_utc(),
+                updated_at: time::OffsetDateTime::now_utc(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let svc = TurnService::new(
+        Arc::clone(&db),
+        turn_repo,
+        message_repo,
+        chat_repo,
+        Arc::new(crate::infra::db::repo::message_attachment_repo::MessageAttachmentRepository),
+        mock_tenant_only_enforcer(),
+        Arc::new(crate::domain::ports::metrics::NoopMetrics),
+    );
+
+    (svc, tenant_id, chat_id)
+}
+
+#[tokio::test]
+async fn get_turn_tenant_only_authz_cross_owner_not_found() {
+    let user_a = Uuid::new_v4();
+    let user_b = Uuid::new_v4();
+
+    let (svc, tenant_id, chat_id) = setup_tenant_only_authz(user_a).await;
+
+    // Create a turn owned by user_a
+    let request_id = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        user_a,
+    )
+    .await;
+
+    // User B (same tenant) tries to read the turn — must fail
+    let ctx_b = test_security_ctx_with_id(tenant_id, user_b);
+    let err = svc.get(&ctx_b, chat_id, request_id).await.unwrap_err();
+    assert!(
+        matches!(err, MutationError::ChatNotFound { .. }),
+        "Cross-owner get must fail with ChatNotFound, got: {err:?}"
+    );
+}


### PR DESCRIPTION
- Add `AccessScope::ensure_owner()` to intersect PDP scope with the current subject's owner_id, preventing cross-user access when the PDP returns only tenant-level constraints.
- Apply ensure_owner to all mini-chat service entry points: chat, message, attachment, reaction, stream, and turn services.
- Attachment service now verifies chat ownership before accessing no_owner attachment entities.
- Add tests covering cross-owner isolation under tenant-only AuthZ.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enforced owner checks earlier across chats, attachments, messages, reactions, turns, and streams; authorization now scopes to the chat/tenant before lookups.
  * Replay handling now explicitly uses tenant context during streaming.

* **Bug Fixes**
  * Unconstrained scopes now fail-closed (deny-all) to tighten access; cross-owner access is masked as NotFound.

* **Tests**
  * Added extensive tests for owner enforcement, tenant-only behaviors, and cross-owner isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->