### PR TITLE
feat(mini-chat): add quota status endpoint and quota warnings in SSE done event

### DIFF
--- a/modules/mini-chat/docs/DESIGN.md
+++ b/modules/mini-chat/docs/DESIGN.md
@@ -390,9 +390,19 @@ All period boundaries use UTC. Per-tenant timezone configuration (`quota_timezon
 
 **Quota period boundary invariant (normative)**: All settlement operations (reserve release and commit) MUST target the same `(period_type, period_start)` bucket rows as the original reserve. The `period_start` values are computed at preflight time and MUST NOT be recomputed at settlement time using the current clock. Implementations MUST persist the preflight `period_start` values alongside the reserve (e.g., in the `chat_turns` row or in context passed to the settlement path) and use those persisted values for all subsequent settlement operations. This ensures that in-flight reserves straddling period boundaries (e.g., a turn started at 23:59:59 UTC and completed at 00:00:01 UTC) are settled against the correct day-1 bucket rows rather than incorrectly targeting day-2 — which would cause `reserved_credits_micro` in day-1 to remain permanently inflated while day-2 is double-reserved.
 
-#### Quota Warning Thresholds (P2+)
+#### Quota Warning Thresholds (P1)
 
-Quota warning thresholds (`warning_threshold_pct`, `quota_warnings` array in the SSE `done` event) are deferred to P2+. P1 does not emit quota warning notifications in the SSE stream.
+The SSE `done` event carries a `quota_warnings` array with per-tier, per-period remaining percentage, warning flag, and exhausted flag. A REST endpoint `GET /v1/quota/status` provides the same data plus credit breakdowns and next-reset timestamps for at-rest queries.
+
+**Configuration:** `warning_threshold_pct` (integer, default 80, range 1-99). Warning fires when `remaining_percentage <= (100 - warning_threshold_pct)`. Exhausted fires when `remaining_percentage == 0`.
+
+#### Quota Status Endpoint (P1)
+
+`GET /v1/quota/status` returns per-tier, per-period quota breakdown for the authenticated user. No query parameters — returns all tiers and periods.
+
+Response includes: `tier` (premium/total), `period` (daily/monthly), `limit_credits_micro`, `used_credits_micro` (spent + reserved, conservative), `remaining_credits_micro`, `remaining_percentage` (0-100), `next_reset` (RFC 3339 — midnight UTC tomorrow for daily, midnight UTC 1st of next month for monthly), `warning` (boolean), `exhausted` (boolean), and `warning_threshold_pct` (config value).
+
+Authorization: authenticated + licensed. Scoped to tenant + user. Billing outcomes and settlement details are NOT exposed — only remaining quota data.
 
 Background tasks (thread summary update, document summary generation) MUST run with `requester_type=system` and MUST NOT be charged to an arbitrary end user. Usage for these tasks is charged to a tenant operational bucket (implementation-defined) and still emitted to `audit_service`.
 
@@ -968,7 +978,7 @@ Finalizes the stream. Provides usage and model selection metadata.
 | `quota_decision` | `"allow"` \| `"downgrade"` (required) | Always present. `"allow"` when the turn used the selected model without override; `"downgrade"` when a quota-driven downgrade occurred. |
 | `downgrade_from` | string (optional) | Always equals `selected_model` when present — the model from which the quota-driven downgrade occurred. Present only when `quota_decision="downgrade"`. |
 | `downgrade_reason` | string (optional) | Why downgrade occurred. Present only when `quota_decision="downgrade"`. Values: `"premium_quota_exhausted"` (user's premium quota exhausted — quota-driven downgrade); `"force_standard_tier"` (operator kill switch: premium tier forcibly disabled for this tenant via `force_standard_tier=true`); `"disable_premium_tier"` (operator kill switch: premium tier globally disabled via `disable_premium_tier=true`); `"model_disabled"` (operator kill switch: the selected model's `global_enabled=false`). |
-| `quota_warnings` | array of objects (optional) | Deferred to P2+. Not emitted in P1. |
+| `quota_warnings` | array of objects (optional) | Per-tier quota status. Each entry: `{ tier, period, remaining_percentage, warning, exhausted }`. Present on CAS-winning completed/incomplete turns. Absent on error, cancelled, replay, and CAS-loser paths. |
 
 ##### `event: error`
 
@@ -6630,6 +6640,7 @@ Estimation budgets are embedded **per-model** in the policy snapshot catalog. Ea
 | Parameter | Type | Default | Valid range | Source |
 |-----------|------|---------|-------------|--------|
 | `quota.overshoot_tolerance_factor` | `float` | `1.10` | `1.00..=1.50` | **ConfigMap** |
+| `quota.warning_threshold_pct` | `integer` | `80` | `1..=99` | **ConfigMap** |
 
 ### B.5.4 Quota downgrade negative threshold
 

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/mod.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/mod.rs
@@ -2,5 +2,6 @@ pub mod attachments;
 pub mod chats;
 pub mod messages;
 pub mod models;
+pub mod quota;
 pub mod reactions;
 pub mod turns;

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/quota.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/quota.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use axum::Extension;
+use modkit::api::prelude::*;
+use modkit_security::SecurityContext;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::domain::model::quota::{PeriodResult, QuotaStatusResult, TierResult};
+use crate::domain::service::{actions, resources};
+use crate::domain::stream_events::{QuotaPeriod, QuotaTier};
+use crate::module::AppServices;
+
+// ════════════════════════════════════════════════════════════════════════════
+// Response DTOs
+// ════════════════════════════════════════════════════════════════════════════
+
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct QuotaStatusResponse {
+    pub tiers: Vec<QuotaTierStatus>,
+    pub warning_threshold_pct: u8,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct QuotaTierStatus {
+    pub tier: QuotaTier,
+    pub periods: Vec<QuotaPeriodStatus>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct QuotaPeriodStatus {
+    pub period: QuotaPeriod,
+    pub limit_credits_micro: i64,
+    pub used_credits_micro: i64,
+    pub remaining_credits_micro: i64,
+    pub remaining_percentage: u8,
+    #[serde(with = "time::serde::rfc3339")]
+    pub next_reset: time::OffsetDateTime,
+    pub warning: bool,
+    pub exhausted: bool,
+}
+
+impl modkit::api::api_dto::ResponseApiDto for QuotaStatusResponse {}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Domain → DTO mapping
+// ════════════════════════════════════════════════════════════════════════════
+
+impl From<QuotaStatusResult> for QuotaStatusResponse {
+    fn from(r: QuotaStatusResult) -> Self {
+        Self {
+            tiers: r.tiers.into_iter().map(QuotaTierStatus::from).collect(),
+            warning_threshold_pct: r.warning_threshold_pct,
+        }
+    }
+}
+
+impl From<TierResult> for QuotaTierStatus {
+    fn from(t: TierResult) -> Self {
+        Self {
+            tier: t.tier,
+            periods: t.periods.into_iter().map(QuotaPeriodStatus::from).collect(),
+        }
+    }
+}
+
+impl From<PeriodResult> for QuotaPeriodStatus {
+    fn from(p: PeriodResult) -> Self {
+        Self {
+            period: p.period,
+            limit_credits_micro: p.limit_credits_micro,
+            used_credits_micro: p.used_credits_micro,
+            remaining_credits_micro: p.remaining_credits_micro,
+            remaining_percentage: p.remaining_percentage,
+            next_reset: p.next_reset,
+            warning: p.warning,
+            exhausted: p.exhausted,
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Handler
+// ════════════════════════════════════════════════════════════════════════════
+
+/// GET /mini-chat/v1/quota/status
+#[tracing::instrument(skip(svc, ctx))]
+pub(crate) async fn get_quota_status(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<AppServices>>,
+) -> ApiResult<JsonBody<QuotaStatusResponse>> {
+    // Permission check — quota data is user-specific via tenant_id + user_id,
+    // not ORM scope. ensure_owner intersects with subject_id for defence-in-depth.
+    let scope = svc
+        .enforcer
+        .access_scope(&ctx, &resources::USER_QUOTA, actions::READ, None)
+        .await
+        .map_err(crate::domain::error::DomainError::from)?
+        .ensure_owner(ctx.subject_id());
+
+    let tenant_id = ctx.subject_tenant_id();
+    let user_id = ctx.subject_id();
+
+    let status = svc
+        .quota
+        .get_quota_status(&scope, tenant_id, user_id)
+        .await?;
+    Ok(Json(QuotaStatusResponse::from(status)))
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/mod.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/mod.rs
@@ -2,6 +2,7 @@ mod attachments;
 mod chats;
 mod messages;
 mod models;
+mod quota;
 mod reactions;
 mod turns;
 
@@ -43,6 +44,7 @@ pub(crate) fn register_routes(
     let router = turns::register_turn_routes(router, openapi, prefix);
     let router = models::register_model_routes(router, openapi, prefix);
     let router = reactions::register_reaction_routes(router, openapi, prefix);
+    let router = quota::register_quota_routes(router, openapi, prefix);
 
     router.layer(axum::Extension(services))
 }

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/quota.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/quota.rs
@@ -1,0 +1,31 @@
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::api::operation_builder::OperationBuilder;
+
+use super::AiChatLicense;
+use crate::api::rest::handlers;
+use crate::api::rest::handlers::quota::QuotaStatusResponse;
+
+pub(super) fn register_quota_routes(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    prefix: &str,
+) -> Router {
+    // GET {prefix}/v1/quota/status
+    router = OperationBuilder::get(format!("{prefix}/v1/quota/status"))
+        .operation_id("mini_chat.get_quota_status")
+        .summary("Get quota status for the authenticated user")
+        .tag("quota")
+        .authenticated()
+        .require_license_features([&AiChatLicense])
+        .handler(handlers::quota::get_quota_status)
+        .json_response_with_schema::<QuotaStatusResponse>(
+            openapi,
+            http::StatusCode::OK,
+            "Quota status with remaining percentages and warning flags",
+        )
+        .standard_errors(openapi)
+        .register(router, openapi);
+
+    router
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/sse.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/sse.rs
@@ -239,6 +239,7 @@ mod tests {
             quota_decision: "allow".into(),
             downgrade_from: None,
             downgrade_reason: None,
+            quota_warnings: None,
         };
         let json = serde_json::to_string(&data).unwrap();
         assert!(json.contains("\"effective_model\":\"gpt-4o\""));
@@ -259,6 +260,7 @@ mod tests {
             quota_decision: "downgrade".into(),
             downgrade_from: Some("gpt-4o".into()),
             downgrade_reason: Some("premium_quota_exhausted".into()),
+            quota_warnings: None,
         };
         let json = serde_json::to_string(&data).unwrap();
         assert!(json.contains("\"downgrade_reason\":\"premium_quota_exhausted\""));
@@ -276,10 +278,57 @@ mod tests {
                 quota_decision: "allow".into(),
                 downgrade_from: None,
                 downgrade_reason: None,
+                quota_warnings: None,
             }))
             .into_sse_event()
             .is_ok()
         );
+    }
+
+    #[test]
+    fn done_serializes_with_quota_warnings() {
+        use crate::domain::stream_events::QuotaWarning;
+        let data = DoneData {
+            message_id: Some("msg-456".into()),
+            usage: Some(Usage {
+                input_tokens: 50,
+                output_tokens: 20,
+            }),
+            effective_model: "gpt-5.2".into(),
+            selected_model: "gpt-5.2".into(),
+            quota_decision: "allow".into(),
+            downgrade_from: None,
+            downgrade_reason: None,
+            quota_warnings: Some(vec![QuotaWarning {
+                tier: crate::domain::stream_events::QuotaTier::Premium,
+                period: crate::domain::stream_events::QuotaPeriod::Daily,
+                remaining_percentage: 20,
+                warning: true,
+                exhausted: false,
+            }]),
+        };
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(json.contains("\"quota_warnings\""));
+        assert!(json.contains("\"remaining_percentage\":20"));
+        assert!(json.contains("\"warning\":true"));
+        assert!(json.contains("\"exhausted\":false"));
+        assert!(json.contains("\"tier\":\"premium\""));
+    }
+
+    #[test]
+    fn done_omits_quota_warnings_when_none() {
+        let data = DoneData {
+            message_id: None,
+            usage: None,
+            effective_model: "gpt-4o".into(),
+            selected_model: "gpt-4o".into(),
+            quota_decision: "allow".into(),
+            downgrade_from: None,
+            downgrade_reason: None,
+            quota_warnings: None,
+        };
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(!json.contains("quota_warnings"));
     }
 
     #[test]

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -466,6 +466,9 @@ fn default_web_search_max_calls() -> u32 {
 fn default_web_search_daily_quota() -> u32 {
     75
 }
+fn default_warning_threshold_pct() -> u8 {
+    80
+}
 
 /// Quota enforcement configuration.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -477,6 +480,8 @@ pub struct QuotaConfig {
     pub web_search_max_calls_per_message: u32,
     #[serde(default = "default_web_search_daily_quota")]
     pub web_search_daily_quota: u32,
+    #[serde(default = "default_warning_threshold_pct")]
+    pub warning_threshold_pct: u8,
 }
 
 impl Default for QuotaConfig {
@@ -485,6 +490,7 @@ impl Default for QuotaConfig {
             overshoot_tolerance_factor: default_overshoot_tolerance(),
             web_search_max_calls_per_message: default_web_search_max_calls(),
             web_search_daily_quota: default_web_search_daily_quota(),
+            warning_threshold_pct: default_warning_threshold_pct(),
         }
     }
 }
@@ -502,6 +508,12 @@ impl QuotaConfig {
         }
         if self.web_search_daily_quota == 0 {
             return Err("web_search_daily_quota must be > 0".to_owned());
+        }
+        if self.warning_threshold_pct == 0 || self.warning_threshold_pct >= 100 {
+            return Err(format!(
+                "warning_threshold_pct must be 1-99, got {}",
+                self.warning_threshold_pct
+            ));
         }
         Ok(())
     }

--- a/modules/mini-chat/mini-chat/src/domain/model/quota.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/quota.rs
@@ -133,3 +133,37 @@ pub enum SettlementPath {
     /// Pre-provider failure — reserve fully released.
     Released,
 }
+
+// ════════════════════════════════════════════════════════════════════════════
+// Quota status types — returned by QuotaService for REST endpoint
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Full quota status for a user, returned by `QuotaService::get_quota_status()`.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct QuotaStatusResult {
+    pub tiers: Vec<TierResult>,
+    pub warning_threshold_pct: u8,
+}
+
+/// Per-tier quota breakdown.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct TierResult {
+    pub tier: crate::domain::stream_events::QuotaTier,
+    pub periods: Vec<PeriodResult>,
+}
+
+/// Per-period quota details within a tier.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct PeriodResult {
+    pub period: crate::domain::stream_events::QuotaPeriod,
+    pub limit_credits_micro: i64,
+    pub used_credits_micro: i64,
+    pub remaining_credits_micro: i64,
+    pub remaining_percentage: u8,
+    pub next_reset: time::OffsetDateTime,
+    pub warning: bool,
+    pub exhausted: bool,
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -68,6 +68,11 @@ pub(crate) mod resources {
         name: "gts.cf.core.ai_chat.model.v1~cf.core.mini_chat.model.v1",
         supported_properties: &[pep_properties::OWNER_TENANT_ID],
     };
+
+    pub const USER_QUOTA: ResourceType = ResourceType {
+        name: "gts.cf.core.ai_chat.user_quota.v1~cf.core.mini_chat.user_quota.v1",
+        supported_properties: &[pep_properties::OWNER_TENANT_ID, pep_properties::OWNER_ID],
+    };
 }
 
 #[allow(dead_code)]

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
@@ -19,6 +19,7 @@ use modkit_db::secure::DBRunner;
 use modkit_macros::domain_model;
 use modkit_security::AccessScope;
 use time::OffsetDateTime;
+use uuid::Uuid;
 
 use crate::config::{EstimationBudgets, QuotaConfig};
 use crate::domain::error::DomainError;
@@ -66,6 +67,149 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
     pub(crate) fn web_search_max_calls_per_message(&self) -> u32 {
         self.quota_config.web_search_max_calls_per_message
     }
+
+    /// Compute per-tier, per-period quota warnings for the SSE `done` event.
+    /// Delegates to `get_quota_status` and flattens the result.
+    pub(crate) async fn compute_quota_warnings(
+        &self,
+        scope: &AccessScope,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Vec<crate::domain::stream_events::QuotaWarning>, DomainError> {
+        use crate::domain::stream_events::QuotaWarning;
+
+        let status = self.get_quota_status(scope, tenant_id, user_id).await?;
+        Ok(status
+            .tiers
+            .into_iter()
+            .flat_map(|t| {
+                let tier = t.tier;
+                t.periods.into_iter().map(move |p| QuotaWarning {
+                    tier,
+                    period: p.period,
+                    remaining_percentage: p.remaining_percentage,
+                    warning: p.warning,
+                    exhausted: p.exhausted,
+                })
+            })
+            .collect())
+    }
+
+    /// Full quota status for the REST endpoint.
+    pub(crate) async fn get_quota_status(
+        &self,
+        scope: &AccessScope,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<crate::domain::model::quota::QuotaStatusResult, DomainError> {
+        use crate::domain::model::quota::{PeriodResult, QuotaStatusResult, TierResult};
+        use crate::domain::stream_events::{QuotaPeriod, QuotaTier};
+
+        let conn = self.db.conn()?;
+
+        let version = self.policy_provider.get_current_version(user_id).await?;
+        let limits = self.limits_provider.get_limits(user_id, version).await?;
+
+        let today = time::OffsetDateTime::now_utc().date();
+        let month_start = today
+            .replace_day(1)
+            .map_err(|e| DomainError::internal(e.to_string()))?;
+
+        let rows = self
+            .repo
+            .find_bucket_rows(&conn, scope, tenant_id, user_id)
+            .await?;
+
+        let threshold = self.quota_config.warning_threshold_pct;
+        let mut tiers = Vec::new();
+
+        for (bucket, tier_enum, tier_limits) in [
+            ("tier:premium", QuotaTier::Premium, &limits.premium),
+            ("total", QuotaTier::Total, &limits.standard),
+        ] {
+            let mut periods = Vec::new();
+            for (period_type, period_start, limit, period_enum, next_reset) in [
+                (
+                    PeriodType::Daily,
+                    today,
+                    tier_limits.limit_daily_credits_micro,
+                    QuotaPeriod::Daily,
+                    next_daily_reset(today),
+                ),
+                (
+                    PeriodType::Monthly,
+                    month_start,
+                    tier_limits.limit_monthly_credits_micro,
+                    QuotaPeriod::Monthly,
+                    next_monthly_reset(today)?,
+                ),
+            ] {
+                if limit <= 0 {
+                    continue;
+                }
+
+                let used = rows
+                    .iter()
+                    .find(|r| {
+                        r.bucket == bucket
+                            && r.period_type == period_type
+                            && r.period_start == period_start
+                    })
+                    .map_or(0, |r| r.spent_credits_micro + r.reserved_credits_micro);
+
+                let remaining = (limit - used).max(0);
+                let remaining_pct = remaining_percentage(remaining, limit);
+
+                periods.push(PeriodResult {
+                    period: period_enum,
+                    limit_credits_micro: limit,
+                    used_credits_micro: used,
+                    remaining_credits_micro: remaining,
+                    remaining_percentage: remaining_pct,
+                    next_reset,
+                    warning: remaining_pct <= (100 - threshold),
+                    exhausted: remaining_pct == 0,
+                });
+            }
+            tiers.push(TierResult {
+                tier: tier_enum,
+                periods,
+            });
+        }
+
+        Ok(QuotaStatusResult {
+            tiers,
+            warning_threshold_pct: threshold,
+        })
+    }
+}
+
+/// Integer percentage of `remaining` relative to `limit` (0..=100).
+///
+/// Precondition: `limit > 0` and `remaining ∈ [0, limit]`.
+#[allow(clippy::integer_division)] // intentional: integer percentage
+fn remaining_percentage(remaining: i64, limit: i64) -> u8 {
+    debug_assert!(limit > 0, "limit must be positive");
+    debug_assert!(remaining >= 0 && remaining <= limit);
+    // u128 avoids overflow for large credit values.
+    u8::try_from(remaining as u128 * 100 / limit as u128).unwrap_or(100)
+}
+
+fn next_daily_reset(today: time::Date) -> time::OffsetDateTime {
+    let tomorrow = today + time::Duration::days(1);
+    tomorrow.midnight().assume_utc()
+}
+
+fn next_monthly_reset(today: time::Date) -> Result<time::OffsetDateTime, DomainError> {
+    let next_month = if today.month() == time::Month::December {
+        time::Date::from_calendar_date(today.year() + 1, time::Month::January, 1)
+    } else {
+        time::Date::from_calendar_date(today.year(), today.month().next(), 1)
+    };
+    Ok(next_month
+        .map_err(|e| DomainError::internal(e.to_string()))?
+        .midnight()
+        .assume_utc())
 }
 
 // ── Cascade types ──

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_settler.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_settler.rs
@@ -1,11 +1,13 @@
 use async_trait::async_trait;
 use modkit_db::secure::DbTx;
 use modkit_security::AccessScope;
+use uuid::Uuid;
 
 use crate::domain::error::DomainError;
 use crate::domain::model::quota::{SettlementInput, SettlementOutcome};
 use crate::domain::repos::QuotaUsageRepository;
 use crate::domain::service::QuotaService;
+use crate::domain::stream_events::QuotaWarning;
 
 /// Type-erased settlement interface for `FinalizationService`.
 ///
@@ -38,5 +40,31 @@ impl<QR: QuotaUsageRepository + 'static> QuotaSettler for QuotaService<QR> {
     ) -> Result<SettlementOutcome, DomainError> {
         // DbTx implements DBRunner, so we can pass it to the generic settle().
         self.settle(tx, scope, input).await
+    }
+}
+
+/// Type-erased quota warnings interface for `spawn_provider_task`.
+///
+/// Erases the `QuotaService<QR>` generic so that `FinalizationCtx` can hold
+/// a reference without propagating repository type parameters.
+#[async_trait]
+pub trait QuotaWarningsProvider: Send + Sync {
+    async fn get_quota_warnings(
+        &self,
+        scope: &AccessScope,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Vec<QuotaWarning>, DomainError>;
+}
+
+#[async_trait]
+impl<QR: QuotaUsageRepository + 'static> QuotaWarningsProvider for QuotaService<QR> {
+    async fn get_quota_warnings(
+        &self,
+        scope: &AccessScope,
+        tenant_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<Vec<QuotaWarning>, DomainError> {
+        self.compute_quota_warnings(scope, tenant_id, user_id).await
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/replay.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/replay.rs
@@ -69,6 +69,7 @@ pub async fn replay_turn<MR: MessageRepository>(
         quota_decision: reconstruct_quota_decision(turn, selected_model),
         downgrade_from: reconstruct_downgrade_from(turn, selected_model),
         downgrade_reason: None,
+        quota_warnings: None,
     }));
 
     Ok(ReplayEvents { delta, done })

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -196,6 +196,8 @@ struct FinalizationCtx<TR: TurnRepository + 'static, MR: MessageRepository + 'st
     provider_id: String,
     /// Metrics port for recording stream metrics in the spawned task.
     metrics: Arc<dyn MiniChatMetricsPort>,
+    /// Quota warnings provider for computing `quota_warnings` in the `done` event.
+    quota_warnings_provider: Arc<dyn crate::domain::service::quota_settler::QuotaWarningsProvider>,
 }
 
 impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> FinalizationCtx<TR, MR> {
@@ -729,6 +731,8 @@ impl<
             period_starts,
             provider_id: provider_id.clone(),
             metrics: Arc::clone(&self.metrics),
+            quota_warnings_provider: Arc::clone(&self.quota)
+                as Arc<dyn crate::domain::service::quota_settler::QuotaWarningsProvider>,
         };
 
         // ── Context assembly ──
@@ -1309,6 +1313,8 @@ impl<
             period_starts,
             provider_id: provider_id.clone(),
             metrics: Arc::clone(&self.metrics),
+            quota_warnings_provider: Arc::clone(&self.quota)
+                as Arc<dyn crate::domain::service::quota_settler::QuotaWarningsProvider>,
         };
 
         // ── Context assembly ──
@@ -1840,6 +1846,18 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                     ))
                                     .await;
                             }
+                            // Compute quota warnings post-commit (advisory, best-effort)
+                            let quota_warnings = match fctx
+                                .quota_warnings_provider
+                                .get_quota_warnings(&fctx.scope, fctx.tenant_id, fctx.user_id)
+                                .await
+                            {
+                                Ok(w) => Some(w),
+                                Err(e) => {
+                                    warn!(error = %e, "failed to compute quota_warnings");
+                                    None
+                                }
+                            };
                             let _ = tx
                                 .send(StreamEvent::Done(Box::new(DoneData {
                                     message_id: msg_id_str.clone(),
@@ -1849,6 +1867,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                     quota_decision: fctx.quota_decision.clone(),
                                     downgrade_from: fctx.downgrade_from.clone(),
                                     downgrade_reason: fctx.downgrade_reason.clone(),
+                                    quota_warnings,
                                 })))
                                 .await;
                         }
@@ -1865,6 +1884,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                     quota_decision: "allow".into(),
                                     downgrade_from: None,
                                     downgrade_reason: None,
+                                    quota_warnings: None,
                                 })))
                                 .await;
                         }
@@ -1891,6 +1911,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                             quota_decision: "allow".into(),
                             downgrade_from: None,
                             downgrade_reason: None,
+                            quota_warnings: None,
                         })))
                         .await;
                 }
@@ -1936,6 +1957,17 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                     );
                     match fctx.finalization_svc.finalize_turn_cas(input).await {
                         Ok(outcome) if outcome.won_cas => {
+                            let quota_warnings = match fctx
+                                .quota_warnings_provider
+                                .get_quota_warnings(&fctx.scope, fctx.tenant_id, fctx.user_id)
+                                .await
+                            {
+                                Ok(w) => Some(w),
+                                Err(e) => {
+                                    warn!(error = %e, "failed to compute quota_warnings");
+                                    None
+                                }
+                            };
                             let _ = tx
                                 .send(StreamEvent::Done(Box::new(DoneData {
                                     message_id: msg_id_str.clone(),
@@ -1945,6 +1977,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                     quota_decision: fctx.quota_decision.clone(),
                                     downgrade_from: fctx.downgrade_from.clone(),
                                     downgrade_reason: fctx.downgrade_reason.clone(),
+                                    quota_warnings,
                                 })))
                                 .await;
                         }
@@ -1960,6 +1993,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                                     quota_decision: "allow".into(),
                                     downgrade_from: None,
                                     downgrade_reason: None,
+                                    quota_warnings: None,
                                 })))
                                 .await;
                         }
@@ -1974,6 +2008,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                             quota_decision: "allow".into(),
                             downgrade_from: None,
                             downgrade_reason: None,
+                            quota_warnings: None,
                         })))
                         .await;
                 }
@@ -2088,6 +2123,23 @@ mod tests {
     use oagw_sdk::error::StreamingError;
 
     // ── Noop OutboxEnqueuer ──
+
+    #[allow(de0309_must_have_domain_model)]
+    struct NoopQuotaWarningsProvider;
+    #[async_trait::async_trait]
+    impl crate::domain::service::quota_settler::QuotaWarningsProvider for NoopQuotaWarningsProvider {
+        async fn get_quota_warnings(
+            &self,
+            _scope: &modkit_security::AccessScope,
+            _tenant_id: Uuid,
+            _user_id: Uuid,
+        ) -> Result<
+            Vec<crate::domain::stream_events::QuotaWarning>,
+            crate::domain::error::DomainError,
+        > {
+            Ok(Vec::new())
+        }
+    }
 
     #[allow(de0309_must_have_domain_model)]
     struct NoopOutboxEnqueuer;
@@ -3542,6 +3594,7 @@ mod tests {
             period_starts: Vec::new(),
             provider_id: "openai".to_owned(),
             metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
+            quota_warnings_provider: Arc::new(NoopQuotaWarningsProvider),
         };
 
         let provider: Arc<dyn LlmProvider> = Arc::new(MockProvider::completed(&["Hello"]));

--- a/modules/mini-chat/mini-chat/src/domain/stream_events.rs
+++ b/modules/mini-chat/mini-chat/src/domain/stream_events.rs
@@ -5,7 +5,7 @@
 //! `api::rest::sse`.
 
 use modkit_macros::domain_model;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use uuid::Uuid;
@@ -69,6 +69,8 @@ pub struct DoneData {
     pub downgrade_from: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub downgrade_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quota_warnings: Option<Vec<QuotaWarning>>,
 }
 
 /// Stream error (terminal).
@@ -84,6 +86,35 @@ pub struct ErrorData {
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct TurnStartedData {
     pub request_id: Uuid,
+}
+
+/// Quota tier classification.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QuotaTier {
+    Premium,
+    Total,
+}
+
+/// Quota period classification.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QuotaPeriod {
+    Daily,
+    Monthly,
+}
+
+/// Per-tier, per-period quota warning entry in the SSE `done` event.
+#[domain_model]
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct QuotaWarning {
+    pub tier: QuotaTier,
+    pub period: QuotaPeriod,
+    pub remaining_percentage: u8,
+    pub warning: bool,
+    pub exhausted: bool,
 }
 
 // ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
feat(mini-chat): add quota status endpoint and quota warnings in SSE done event

Promote quota_warnings from P2+ to P1. Add GET /v1/quota/status endpoint for at-rest quota queries. Implement warning_threshold_pct configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New quota status API (GET /mini-chat/v1/quota/status) returning per-tier, per-period breakdowns (remaining %, warning, exhausted) and next reset.
  * Final event stream and Done responses now include per-tier/per-period quota warnings for real-time client visibility.
  * Configurable quota warning threshold (default 80%) to control when warnings are emitted.

* **Documentation**
  * Updated design docs to reflect P1-facing quota reporting, SSE exposure, and threshold configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->