### PR TITLE
feat(oagw): add guard + transform plugin in proxy lifecycle

### DIFF
--- a/modules/system/oagw/oagw-sdk/src/error.rs
+++ b/modules/system/oagw/oagw-sdk/src/error.rs
@@ -50,6 +50,15 @@ pub enum ServiceGatewayError {
     #[error("{detail}")]
     RequestTimeout { detail: String, instance: String },
 
+    /// A guard plugin rejected the request.
+    #[error("guard rejected: {detail}")]
+    GuardRejected {
+        status: u16,
+        error_code: String,
+        detail: String,
+        instance: String,
+    },
+
     /// The caller is authenticated but not authorized to perform the requested action.
     #[error("access forbidden: {detail}")]
     Forbidden { detail: String },

--- a/modules/system/oagw/oagw-sdk/src/lib.rs
+++ b/modules/system/oagw/oagw-sdk/src/lib.rs
@@ -11,9 +11,9 @@ pub mod models;
 pub use models::{
     AuthConfig, BurstConfig, CreateRouteRequest, CreateRouteRequestBuilder, CreateUpstreamRequest,
     CreateUpstreamRequestBuilder, Endpoint, GrpcMatch, HeadersConfig, HttpMatch, HttpMethod,
-    ListQuery, MatchRules, PassthroughMode, PathSuffixMode, PluginsConfig, RateLimitAlgorithm,
-    RateLimitConfig, RateLimitScope, RateLimitStrategy, RequestHeaderRules, ResponseHeaderRules,
-    Route, Scheme, Server, SharingMode, SustainedRate, UpdateRouteRequest,
+    ListQuery, MatchRules, PassthroughMode, PathSuffixMode, PluginBinding, PluginsConfig,
+    RateLimitAlgorithm, RateLimitConfig, RateLimitScope, RateLimitStrategy, RequestHeaderRules,
+    ResponseHeaderRules, Route, Scheme, Server, SharingMode, SustainedRate, UpdateRouteRequest,
     UpdateRouteRequestBuilder, UpdateUpstreamRequest, UpdateUpstreamRequestBuilder, Upstream,
     Window,
 };

--- a/modules/system/oagw/oagw-sdk/src/models.rs
+++ b/modules/system/oagw/oagw-sdk/src/models.rs
@@ -190,15 +190,22 @@ pub enum RateLimitStrategy {
 }
 
 // ---------------------------------------------------------------------------
-// PluginsConfig
+// PluginBinding / PluginsConfig
 // ---------------------------------------------------------------------------
+
+/// A single plugin binding: reference + optional per-plugin config.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PluginBinding {
+    pub plugin_ref: String,
+    pub config: HashMap<String, String>,
+}
 
 /// Plugin chain configuration.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct PluginsConfig {
     pub sharing: SharingMode,
-    /// Plugin references: GTS identifiers (builtin) or UUIDs (custom).
-    pub items: Vec<String>,
+    /// Plugin bindings: GTS identifiers (builtin) or UUIDs (custom) with optional config.
+    pub items: Vec<PluginBinding>,
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/system/oagw/oagw/src/api/rest/dto.rs
+++ b/modules/system/oagw/oagw/src/api/rest/dto.rs
@@ -191,15 +191,22 @@ pub enum RateLimitStrategy {
 }
 
 // ---------------------------------------------------------------------------
-// PluginsConfig
+// PluginBinding / PluginsConfig
 // ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct PluginBinding {
+    pub plugin_ref: String,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub config: HashMap<String, String>,
+}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, utoipa::ToSchema)]
 pub struct PluginsConfig {
     #[serde(default)]
     pub sharing: SharingMode,
     #[serde(default)]
-    pub items: Vec<String>,
+    pub items: Vec<PluginBinding>,
 }
 
 // ---------------------------------------------------------------------------
@@ -541,11 +548,20 @@ impl From<RateLimitConfig> for domain::RateLimitConfig {
     }
 }
 
+impl From<PluginBinding> for domain::PluginBinding {
+    fn from(v: PluginBinding) -> Self {
+        Self {
+            plugin_ref: v.plugin_ref,
+            config: v.config,
+        }
+    }
+}
+
 impl From<PluginsConfig> for domain::PluginsConfig {
     fn from(v: PluginsConfig) -> Self {
         Self {
             sharing: v.sharing.into(),
-            items: v.items,
+            items: v.items.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -768,11 +784,20 @@ impl From<domain::RateLimitConfig> for RateLimitConfig {
     }
 }
 
+impl From<domain::PluginBinding> for PluginBinding {
+    fn from(v: domain::PluginBinding) -> Self {
+        Self {
+            plugin_ref: v.plugin_ref,
+            config: v.config,
+        }
+    }
+}
+
 impl From<domain::PluginsConfig> for PluginsConfig {
     fn from(v: domain::PluginsConfig) -> Self {
         Self {
             sharing: v.sharing.into(),
-            items: v.items,
+            items: v.items.into_iter().map(Into::into).collect(),
         }
     }
 }

--- a/modules/system/oagw/oagw/src/api/rest/error.rs
+++ b/modules/system/oagw/oagw/src/api/rest/error.rs
@@ -31,6 +31,7 @@ pub(crate) const ERR_UPSTREAM_DISABLED: &str =
 pub(crate) const ERR_CONNECTION_TIMEOUT: &str =
     "gts.x.core.errors.err.v1~x.oagw.timeout.connection.v1";
 pub(crate) const ERR_REQUEST_TIMEOUT: &str = "gts.x.core.errors.err.v1~x.oagw.timeout.request.v1";
+pub(crate) const ERR_GUARD_REJECTED: &str = "gts.x.core.errors.err.v1~x.oagw.guard.rejected.v1";
 pub(crate) const ERR_FORBIDDEN: &str = "gts.x.core.errors.err.v1~x.oagw.authz.forbidden.v1";
 
 // ---------------------------------------------------------------------------
@@ -56,6 +57,7 @@ fn gts_type(err: &DomainError) -> &str {
         DomainError::UpstreamDisabled { .. } => ERR_UPSTREAM_DISABLED,
         DomainError::ConnectionTimeout { .. } => ERR_CONNECTION_TIMEOUT,
         DomainError::RequestTimeout { .. } => ERR_REQUEST_TIMEOUT,
+        DomainError::GuardRejected { .. } => ERR_GUARD_REJECTED,
         DomainError::Forbidden { .. } => ERR_FORBIDDEN,
     }
 }
@@ -81,6 +83,10 @@ fn http_status_code(err: &DomainError) -> StatusCode {
         DomainError::ConnectionTimeout { .. } | DomainError::RequestTimeout { .. } => {
             StatusCode::GATEWAY_TIMEOUT
         }
+        DomainError::GuardRejected { status, .. } => StatusCode::from_u16(*status)
+            .ok()
+            .filter(|code| code.is_client_error() || code.is_server_error())
+            .unwrap_or(StatusCode::BAD_REQUEST),
         DomainError::Forbidden { .. } => StatusCode::FORBIDDEN,
     }
 }
@@ -102,6 +108,7 @@ fn error_title(err: &DomainError) -> &str {
         DomainError::UpstreamDisabled { .. } => "Upstream Disabled",
         DomainError::ConnectionTimeout { .. } => "Connection Timeout",
         DomainError::RequestTimeout { .. } => "Request Timeout",
+        DomainError::GuardRejected { .. } => "Guard Rejected",
         DomainError::Forbidden { .. } => "Forbidden",
     }
 }
@@ -119,7 +126,8 @@ fn error_instance(err: &DomainError) -> &str {
         | DomainError::DownstreamError { instance, .. }
         | DomainError::ProtocolError { instance, .. }
         | DomainError::ConnectionTimeout { instance, .. }
-        | DomainError::RequestTimeout { instance, .. } => instance,
+        | DomainError::RequestTimeout { instance, .. }
+        | DomainError::GuardRejected { instance, .. } => instance,
         DomainError::NotFound { .. }
         | DomainError::Conflict { .. }
         | DomainError::UpstreamDisabled { .. }
@@ -303,6 +311,12 @@ mod tests {
             DomainError::Internal {
                 message: "test".into(),
             },
+            DomainError::GuardRejected {
+                status: 400,
+                error_code: "MISSING_HEADER".into(),
+                detail: "test".into(),
+                instance: "/test".into(),
+            },
             DomainError::Forbidden {
                 detail: "test".into(),
             },
@@ -337,6 +351,66 @@ mod tests {
         };
         let p = domain_error_to_problem(err, "/fallback");
         assert_eq!(p.instance, "/oagw/v1/upstreams");
+    }
+
+    #[test]
+    fn guard_rejected_4xx_passes_through() {
+        let err = DomainError::GuardRejected {
+            status: 403,
+            error_code: "FORBIDDEN".into(),
+            detail: "test".into(),
+            instance: "/test".into(),
+        };
+        let p: Problem = err.into();
+        assert_eq!(p.status, StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn guard_rejected_5xx_passes_through() {
+        let err = DomainError::GuardRejected {
+            status: 503,
+            error_code: "UNAVAILABLE".into(),
+            detail: "test".into(),
+            instance: "/test".into(),
+        };
+        let p: Problem = err.into();
+        assert_eq!(p.status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn guard_rejected_2xx_falls_back_to_400() {
+        let err = DomainError::GuardRejected {
+            status: 200,
+            error_code: "OK".into(),
+            detail: "test".into(),
+            instance: "/test".into(),
+        };
+        let p: Problem = err.into();
+        assert_eq!(p.status, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn guard_rejected_3xx_falls_back_to_400() {
+        let err = DomainError::GuardRejected {
+            status: 301,
+            error_code: "REDIRECT".into(),
+            detail: "test".into(),
+            instance: "/test".into(),
+        };
+        let p: Problem = err.into();
+        assert_eq!(p.status, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn guard_rejected_invalid_status_falls_back_to_400() {
+        let err = DomainError::GuardRejected {
+            status: 999,
+            error_code: "INVALID".into(),
+            detail: "test".into(),
+            instance: "/test".into(),
+        };
+        let p: Problem = err.into();
+        assert_eq!(p.status, StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/modules/system/oagw/oagw/src/domain/error.rs
+++ b/modules/system/oagw/oagw/src/domain/error.rs
@@ -59,6 +59,15 @@ pub enum DomainError {
     #[error("{detail}")]
     RequestTimeout { detail: String, instance: String },
 
+    /// A guard plugin rejected the request with a specific status and error code.
+    #[error("guard rejected: {detail}")]
+    GuardRejected {
+        status: u16,
+        error_code: String,
+        detail: String,
+        instance: String,
+    },
+
     /// The request was denied by the authorization policy.
     #[error("access forbidden: {detail}")]
     Forbidden { detail: String },

--- a/modules/system/oagw/oagw/src/domain/gts_helpers.rs
+++ b/modules/system/oagw/oagw/src/domain/gts_helpers.rs
@@ -32,6 +32,8 @@ pub const OAUTH2_CLIENT_CRED_BASIC_AUTH_PLUGIN_ID: &str =
 // -- Builtin guard plugin instances --
 pub const TIMEOUT_GUARD_PLUGIN_ID: &str = "gts.x.core.oagw.guard_plugin.v1~x.core.oagw.timeout.v1";
 pub const CORS_GUARD_PLUGIN_ID: &str = "gts.x.core.oagw.guard_plugin.v1~x.core.oagw.cors.v1";
+pub const REQUIRED_HEADERS_GUARD_PLUGIN_ID: &str =
+    "gts.x.core.oagw.guard_plugin.v1~x.core.oagw.required_headers.v1";
 
 // -- Builtin transform plugin instances --
 pub const LOGGING_TRANSFORM_PLUGIN_ID: &str =

--- a/modules/system/oagw/oagw/src/domain/model.rs
+++ b/modules/system/oagw/oagw/src/domain/model.rs
@@ -198,14 +198,21 @@ pub enum RateLimitStrategy {
 }
 
 // ---------------------------------------------------------------------------
-// PluginsConfig
+// PluginBinding / PluginsConfig
 // ---------------------------------------------------------------------------
+
+#[domain_model]
+#[derive(Debug, Clone, PartialEq)]
+pub struct PluginBinding {
+    pub plugin_ref: String,
+    pub config: HashMap<String, String>,
+}
 
 #[domain_model]
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct PluginsConfig {
     pub sharing: SharingMode,
-    pub items: Vec<String>,
+    pub items: Vec<PluginBinding>,
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/system/oagw/oagw/src/domain/plugin/mod.rs
+++ b/modules/system/oagw/oagw/src/domain/plugin/mod.rs
@@ -50,3 +50,150 @@ pub trait AuthPlugin: Send + Sync {
     /// Apply authentication to the outbound request context.
     async fn authenticate(&self, ctx: &mut AuthContext) -> Result<(), PluginError>;
 }
+
+// ---------------------------------------------------------------------------
+// Guard plugin
+// ---------------------------------------------------------------------------
+
+/// Outcome of a guard plugin's request evaluation.
+#[domain_model]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuardDecision {
+    /// Allow the request to proceed to the next pipeline stage.
+    Allow,
+    /// Reject the request with a specific HTTP status and error code.
+    Reject {
+        /// HTTP status code for the rejection response (e.g. 400, 403, 429).
+        status: u16,
+        /// Machine-readable error code for programmatic consumer handling.
+        error_code: String,
+        /// Human-readable explanation of the rejection.
+        detail: String,
+    },
+}
+
+/// Context passed to a guard plugin for validation.
+///
+/// Used for both request and response phases. Guard context is immutable —
+/// guards validate but do not mutate. Mutation is the responsibility of
+/// transform plugins.
+///
+/// During the request phase, `status` is `None` and `headers` contains the
+/// inbound request headers. During the response phase, `status` is
+/// `Some(http_status)` and `headers` contains the upstream response headers.
+#[domain_model]
+#[allow(dead_code)] // Part of guard plugin API; fields read by plugin implementations.
+pub struct GuardContext {
+    /// HTTP method of the request.
+    pub method: String,
+    /// Path of the request (after alias resolution).
+    pub path: String,
+    /// HTTP status code from the upstream response. `None` during request phase.
+    pub status: Option<u16>,
+    /// Request headers (request phase) or response headers (response phase).
+    pub headers: Vec<(String, String)>,
+    /// Plugin-specific configuration key/value pairs
+    /// (from the plugin binding on the upstream or route).
+    pub config: HashMap<String, String>,
+    /// Security context of the calling subject.
+    pub security_context: SecurityContext,
+}
+
+/// Trait for guard plugins that validate requests and responses.
+///
+/// Implementations inspect [`GuardContext`] and return a [`GuardDecision`].
+/// [`PluginError`] is reserved for plugin infrastructure failures (invalid
+/// config, internal errors). Policy decisions use [`GuardDecision::Reject`].
+///
+/// Both methods default to [`GuardDecision::Allow`], so implementations only
+/// need to override the phases they care about.
+#[async_trait]
+pub trait GuardPlugin: Send + Sync {
+    /// Evaluate the inbound request before forwarding to upstream.
+    async fn guard_request(&self, _ctx: &GuardContext) -> Result<GuardDecision, PluginError> {
+        Ok(GuardDecision::Allow)
+    }
+
+    /// Evaluate the upstream response before returning to the client.
+    async fn guard_response(&self, _ctx: &GuardContext) -> Result<GuardDecision, PluginError> {
+        Ok(GuardDecision::Allow)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transform plugin
+// ---------------------------------------------------------------------------
+
+/// Mutable request context passed to a transform plugin during the `on_request` phase.
+#[domain_model]
+#[allow(dead_code)] // Part of transform plugin API; fields read by custom plugin implementations.
+pub struct TransformRequestContext {
+    /// HTTP method of the request.
+    pub method: String,
+    /// Path of the request (after alias resolution). Mutable — plugins can rewrite paths.
+    pub path: String,
+    /// Query parameters. Mutable — plugins can add/remove/modify query params.
+    pub query: Vec<(String, String)>,
+    /// Request headers. Mutable — plugins can set/add/remove headers.
+    pub headers: Vec<(String, String)>,
+    /// Plugin-specific configuration key/value pairs
+    /// (from the plugin binding on the upstream or route).
+    pub config: HashMap<String, String>,
+    /// Security context of the calling subject.
+    pub security_context: SecurityContext,
+}
+
+/// Mutable response context passed to a transform plugin during the `on_response` phase.
+#[domain_model]
+#[allow(dead_code)] // Part of transform plugin API; fields read by custom plugin implementations.
+pub struct TransformResponseContext {
+    /// HTTP status code from the upstream response.
+    pub status: u16,
+    /// Response headers. Mutable — plugins can set/add/remove headers.
+    pub headers: Vec<(String, String)>,
+    /// Plugin-specific configuration key/value pairs.
+    pub config: HashMap<String, String>,
+    /// Security context of the calling subject.
+    pub security_context: SecurityContext,
+}
+
+/// Mutable error context passed to a transform plugin during the `on_error` phase.
+#[domain_model]
+#[allow(dead_code)] // Part of transform plugin API; fields read by custom plugin implementations.
+pub struct TransformErrorContext {
+    /// The error that occurred during the upstream call.
+    pub error_type: String,
+    /// HTTP status code that will be returned to the client.
+    pub status: u16,
+    /// Human-readable error detail. Mutable — plugins can enrich error messages.
+    pub detail: String,
+    /// Plugin-specific configuration key/value pairs.
+    pub config: HashMap<String, String>,
+    /// Security context of the calling subject.
+    pub security_context: SecurityContext,
+}
+
+/// Trait for transform plugins that mutate request/response/error data.
+///
+/// Implementations modify context in-place. [`PluginError`] is reserved for
+/// plugin infrastructure failures (invalid config, internal errors).
+///
+/// All methods default to no-op, so implementations only need to override the
+/// phases they participate in.
+#[async_trait]
+pub trait TransformPlugin: Send + Sync {
+    /// Mutate the outbound request before forwarding to upstream.
+    async fn on_request(&self, _ctx: &mut TransformRequestContext) -> Result<(), PluginError> {
+        Ok(())
+    }
+
+    /// Mutate the upstream response before returning to the client.
+    async fn on_response(&self, _ctx: &mut TransformResponseContext) -> Result<(), PluginError> {
+        Ok(())
+    }
+
+    /// Mutate the error response before returning to the client.
+    async fn on_error(&self, _ctx: &mut TransformErrorContext) -> Result<(), PluginError> {
+        Ok(())
+    }
+}

--- a/modules/system/oagw/oagw/src/domain/services/client.rs
+++ b/modules/system/oagw/oagw/src/domain/services/client.rs
@@ -248,6 +248,17 @@ fn domain_err_to_sdk(err: DomainError) -> ServiceGatewayError {
         DomainError::RequestTimeout { detail, instance } => {
             ServiceGatewayError::RequestTimeout { detail, instance }
         }
+        DomainError::GuardRejected {
+            status,
+            error_code,
+            detail,
+            instance,
+        } => ServiceGatewayError::GuardRejected {
+            status,
+            error_code,
+            detail,
+            instance,
+        },
         DomainError::Forbidden { detail } => ServiceGatewayError::Forbidden { detail },
     }
 }
@@ -427,10 +438,17 @@ fn rate_limit_config_to_domain(v: oagw_sdk::RateLimitConfig) -> model::RateLimit
     }
 }
 
+fn plugin_binding_to_domain(v: oagw_sdk::PluginBinding) -> model::PluginBinding {
+    model::PluginBinding {
+        plugin_ref: v.plugin_ref,
+        config: v.config,
+    }
+}
+
 fn plugins_config_to_domain(v: oagw_sdk::PluginsConfig) -> model::PluginsConfig {
     model::PluginsConfig {
         sharing: sharing_mode_to_domain(v.sharing),
-        items: v.items,
+        items: v.items.into_iter().map(plugin_binding_to_domain).collect(),
     }
 }
 
@@ -536,7 +554,14 @@ fn upstream_to_sdk(u: model::Upstream) -> oagw_sdk::Upstream {
         }),
         plugins: u.plugins.map(|p| oagw_sdk::PluginsConfig {
             sharing: sharing_mode_to_sdk(p.sharing),
-            items: p.items,
+            items: p
+                .items
+                .into_iter()
+                .map(|b| oagw_sdk::PluginBinding {
+                    plugin_ref: b.plugin_ref,
+                    config: b.config,
+                })
+                .collect(),
         }),
         rate_limit: u.rate_limit.map(rate_limit_config_to_sdk),
         tags: u.tags,
@@ -575,7 +600,14 @@ fn route_to_sdk(r: model::Route) -> oagw_sdk::Route {
         },
         plugins: r.plugins.map(|p| oagw_sdk::PluginsConfig {
             sharing: sharing_mode_to_sdk(p.sharing),
-            items: p.items,
+            items: p
+                .items
+                .into_iter()
+                .map(|b| oagw_sdk::PluginBinding {
+                    plugin_ref: b.plugin_ref,
+                    config: b.config,
+                })
+                .collect(),
         }),
         rate_limit: r.rate_limit.map(rate_limit_config_to_sdk),
         tags: r.tags,

--- a/modules/system/oagw/oagw/src/domain/services/management.rs
+++ b/modules/system/oagw/oagw/src/domain/services/management.rs
@@ -1226,7 +1226,7 @@ pub(crate) fn compute_effective_config(
                         .map(|p| p.items.clone())
                         .unwrap_or_default();
                     for item in &route_plugins.items {
-                        if !merged_items.contains(item) {
+                        if !merged_items.iter().any(|m| m == item) {
                             merged_items.push(item.clone());
                         }
                     }
@@ -1379,7 +1379,7 @@ fn merge_plugins(effective: &mut Upstream, layer: &Upstream) {
                     .map(|p| p.items.clone())
                     .unwrap_or_default();
                 for item in &descendant_plugins.items {
-                    if !merged.contains(item) {
+                    if !merged.iter().any(|m| m == item) {
                         merged.push(item.clone());
                     }
                 }
@@ -1399,7 +1399,7 @@ fn merge_plugins(effective: &mut Upstream, layer: &Upstream) {
                     .map(|p| p.items.clone())
                     .unwrap_or_default();
                 for item in &descendant_plugins.items {
-                    if !merged.contains(item) {
+                    if !merged.iter().any(|m| m == item) {
                         merged.push(item.clone());
                     }
                 }
@@ -2350,9 +2350,11 @@ mod tests {
 
     // -- Effective config merge tests --
 
+    use std::collections::HashMap;
+
     use crate::domain::model::{
-        AuthConfig, PluginsConfig, RateLimitAlgorithm, RateLimitConfig, RateLimitScope,
-        RateLimitStrategy, SharingMode, SustainedRate, Window,
+        AuthConfig, PluginBinding, PluginsConfig, RateLimitAlgorithm, RateLimitConfig,
+        RateLimitScope, RateLimitStrategy, SharingMode, SustainedRate, Window,
     };
 
     fn make_upstream(
@@ -2497,11 +2499,29 @@ mod tests {
 
         let root_plugins = PluginsConfig {
             sharing: SharingMode::Inherit,
-            items: vec!["plugin-a".into(), "plugin-b".into()],
+            items: vec![
+                PluginBinding {
+                    plugin_ref: "plugin-a".into(),
+                    config: HashMap::new(),
+                },
+                PluginBinding {
+                    plugin_ref: "plugin-b".into(),
+                    config: HashMap::new(),
+                },
+            ],
         };
         let child_plugins = PluginsConfig {
             sharing: SharingMode::Inherit,
-            items: vec!["plugin-b".into(), "plugin-c".into()],
+            items: vec![
+                PluginBinding {
+                    plugin_ref: "plugin-b".into(),
+                    config: HashMap::new(),
+                },
+                PluginBinding {
+                    plugin_ref: "plugin-c".into(),
+                    config: HashMap::new(),
+                },
+            ],
         };
 
         let root = make_upstream(root_id, "openai", None, None, Some(root_plugins), vec![]);
@@ -2510,7 +2530,13 @@ mod tests {
         let effective = compute_effective_config(&[root, child], None).unwrap();
         let items = effective.plugins.unwrap().items;
         // ancestor + descendant (dedup): [a, b, c]
-        assert_eq!(items, vec!["plugin-a", "plugin-b", "plugin-c"]);
+        assert_eq!(
+            items
+                .iter()
+                .map(|b| b.plugin_ref.as_str())
+                .collect::<Vec<_>>(),
+            vec!["plugin-a", "plugin-b", "plugin-c"]
+        );
     }
 
     #[test]
@@ -2520,11 +2546,17 @@ mod tests {
 
         let root_plugins = PluginsConfig {
             sharing: SharingMode::Enforce,
-            items: vec!["required-plugin".into()],
+            items: vec![PluginBinding {
+                plugin_ref: "required-plugin".into(),
+                config: HashMap::new(),
+            }],
         };
         let child_plugins = PluginsConfig {
             sharing: SharingMode::Enforce,
-            items: vec!["extra-plugin".into()],
+            items: vec![PluginBinding {
+                plugin_ref: "extra-plugin".into(),
+                config: HashMap::new(),
+            }],
         };
 
         let root = make_upstream(root_id, "openai", None, None, Some(root_plugins), vec![]);
@@ -2533,8 +2565,8 @@ mod tests {
         let effective = compute_effective_config(&[root, child], None).unwrap();
         let items = effective.plugins.unwrap().items;
         // Enforced plugins remain: required-plugin + extra-plugin.
-        assert!(items.contains(&"required-plugin".to_string()));
-        assert!(items.contains(&"extra-plugin".to_string()));
+        assert!(items.iter().any(|b| b.plugin_ref == "required-plugin"));
+        assert!(items.iter().any(|b| b.plugin_ref == "extra-plugin"));
     }
 
     #[test]
@@ -2609,7 +2641,10 @@ mod tests {
             Some(make_rate_limit(SharingMode::Enforce, 1000, Window::Minute)),
             Some(PluginsConfig {
                 sharing: SharingMode::Enforce,
-                items: vec!["audit-log".into()],
+                items: vec![PluginBinding {
+                    plugin_ref: "audit-log".into(),
+                    config: HashMap::new(),
+                }],
             }),
             vec!["env:prod".into()],
         );
@@ -2624,7 +2659,10 @@ mod tests {
             Some(make_rate_limit(SharingMode::Inherit, 500, Window::Minute)),
             Some(PluginsConfig {
                 sharing: SharingMode::Inherit,
-                items: vec!["rate-guard".into()],
+                items: vec![PluginBinding {
+                    plugin_ref: "rate-guard".into(),
+                    config: HashMap::new(),
+                }],
             }),
             vec!["team:partner".into()],
         );
@@ -2635,7 +2673,10 @@ mod tests {
             Some(make_rate_limit(SharingMode::Inherit, 200, Window::Minute)),
             Some(PluginsConfig {
                 sharing: SharingMode::Inherit,
-                items: vec!["transform-x".into()],
+                items: vec![PluginBinding {
+                    plugin_ref: "transform-x".into(),
+                    config: HashMap::new(),
+                }],
             }),
             vec!["region:us".into()],
         );
@@ -2651,9 +2692,9 @@ mod tests {
 
         // Plugins: enforced audit-log + rate-guard + transform-x.
         let items = effective.plugins.unwrap().items;
-        assert!(items.contains(&"audit-log".to_string()));
-        assert!(items.contains(&"rate-guard".to_string()));
-        assert!(items.contains(&"transform-x".to_string()));
+        assert!(items.iter().any(|b| b.plugin_ref == "audit-log"));
+        assert!(items.iter().any(|b| b.plugin_ref == "rate-guard"));
+        assert!(items.iter().any(|b| b.plugin_ref == "transform-x"));
 
         // Tags: union of all three.
         assert!(effective.tags.contains(&"env:prod".to_string()));
@@ -3213,7 +3254,10 @@ mod tests {
         let t = Uuid::new_v4();
         let upstream_plugins = PluginsConfig {
             sharing: SharingMode::Inherit,
-            items: vec!["upstream-plugin".into()],
+            items: vec![PluginBinding {
+                plugin_ref: "upstream-plugin".into(),
+                config: HashMap::new(),
+            }],
         };
         let u = make_upstream(t, "openai", None, None, Some(upstream_plugins), vec![]);
 
@@ -3227,7 +3271,10 @@ mod tests {
             },
             plugins: Some(PluginsConfig {
                 sharing: SharingMode::Private,
-                items: vec!["route-plugin".into()],
+                items: vec![PluginBinding {
+                    plugin_ref: "route-plugin".into(),
+                    config: HashMap::new(),
+                }],
             }),
             rate_limit: None,
             tags: vec![],
@@ -3238,7 +3285,13 @@ mod tests {
         let effective = compute_effective_config(&[u], Some(&route)).unwrap();
         let items = effective.plugins.unwrap().items;
         // Route plugins with Private sharing are skipped — only upstream plugins remain.
-        assert_eq!(items, vec!["upstream-plugin".to_string()]);
+        assert_eq!(
+            items
+                .iter()
+                .map(|b| b.plugin_ref.as_str())
+                .collect::<Vec<_>>(),
+            vec!["upstream-plugin"]
+        );
     }
 
     #[test]
@@ -3318,11 +3371,17 @@ mod tests {
 
         let root_plugins = PluginsConfig {
             sharing: SharingMode::Enforce,
-            items: vec!["audit-log".into()],
+            items: vec![PluginBinding {
+                plugin_ref: "audit-log".into(),
+                config: HashMap::new(),
+            }],
         };
         let child_plugins = PluginsConfig {
             sharing: SharingMode::Private,
-            items: vec!["my-plugin".into()],
+            items: vec![PluginBinding {
+                plugin_ref: "my-plugin".into(),
+                config: HashMap::new(),
+            }],
         };
 
         let root = make_upstream(root_id, "openai", None, None, Some(root_plugins), vec![]);
@@ -3331,8 +3390,8 @@ mod tests {
         let effective = compute_effective_config(&[root, child], None).unwrap();
         let items = effective.plugins.unwrap().items;
         // Enforced "audit-log" must survive even though descendant set Private.
-        assert!(items.contains(&"audit-log".to_string()));
-        assert!(items.contains(&"my-plugin".to_string()));
+        assert!(items.iter().any(|b| b.plugin_ref == "audit-log"));
+        assert!(items.iter().any(|b| b.plugin_ref == "my-plugin"));
     }
 
     // -- Alias enforcement tests --

--- a/modules/system/oagw/oagw/src/domain/type_catalog.rs
+++ b/modules/system/oagw/oagw/src/domain/type_catalog.rs
@@ -1,6 +1,6 @@
 //! Centralized catalog of all OAGW GTS entities for Types Registry registration.
 //!
-//! Returns all 20 entities (7 schemas + 13 instances) in a single batch,
+//! Returns all 21 entities (7 schemas + 14 instances) in a single batch,
 //! ready for `TypesRegistryClient::register()`.
 
 use serde_json::{Value, json};
@@ -55,9 +55,13 @@ pub fn oagw_gts_entities() -> Vec<Value> {
             OAUTH2_CLIENT_CRED_BASIC_AUTH_PLUGIN_ID,
             "OAuth2 client credentials (Basic)",
         ),
-        // -- Guard plugin instances (2) --
+        // -- Guard plugin instances (3) --
         instance_entity(TIMEOUT_GUARD_PLUGIN_ID, "Request timeout"),
         instance_entity(CORS_GUARD_PLUGIN_ID, "CORS handling"),
+        instance_entity(
+            REQUIRED_HEADERS_GUARD_PLUGIN_ID,
+            "Required headers enforcement",
+        ),
         // -- Transform plugin instances (3) --
         instance_entity(LOGGING_TRANSFORM_PLUGIN_ID, "Request/response logging"),
         instance_entity(METRICS_TRANSFORM_PLUGIN_ID, "Prometheus metrics"),
@@ -75,12 +79,12 @@ mod tests {
     }
 
     #[test]
-    fn catalog_returns_exactly_20_entities() {
+    fn catalog_returns_exactly_21_entities() {
         let entities = oagw_gts_entities();
         assert_eq!(
             entities.len(),
-            20,
-            "expected 20 entities (7 schemas + 13 instances)"
+            21,
+            "expected 21 entities (7 schemas + 14 instances)"
         );
     }
 
@@ -124,7 +128,7 @@ mod tests {
             .collect();
 
         assert_eq!(schemas.len(), 7, "expected 7 schemas");
-        assert_eq!(instances.len(), 13, "expected 13 instances");
+        assert_eq!(instances.len(), 14, "expected 14 instances");
     }
 
     #[test]

--- a/modules/system/oagw/oagw/src/infra/plugin/mod.rs
+++ b/modules/system/oagw/oagw/src/infra/plugin/mod.rs
@@ -2,5 +2,9 @@ pub(crate) mod apikey_auth;
 pub(crate) mod noop_auth;
 pub(crate) mod oauth2_client_cred_auth;
 pub(crate) mod registry;
+pub(crate) mod request_id_transform;
+pub(crate) mod required_headers_guard;
 
 pub(crate) use registry::AuthPluginRegistry;
+pub(crate) use registry::GuardPluginRegistry;
+pub(crate) use registry::TransformPluginRegistry;

--- a/modules/system/oagw/oagw/src/infra/plugin/registry.rs
+++ b/modules/system/oagw/oagw/src/infra/plugin/registry.rs
@@ -4,15 +4,18 @@ use std::sync::Arc;
 use modkit_auth::oauth2::types::ClientAuthMethod;
 
 use crate::config::TokenCacheConfig;
-use crate::domain::plugin::{AuthPlugin, PluginError};
+use crate::domain::plugin::{AuthPlugin, GuardPlugin, PluginError, TransformPlugin};
 use credstore_sdk::CredStoreClientV1;
 
 use super::apikey_auth::ApiKeyAuthPlugin;
 use super::noop_auth::NoopAuthPlugin;
 use super::oauth2_client_cred_auth::OAuth2ClientCredAuthPlugin;
+use super::request_id_transform::RequestIdTransformPlugin;
+use super::required_headers_guard::RequiredHeadersGuardPlugin;
 use crate::domain::gts_helpers::{
-    APIKEY_AUTH_PLUGIN_ID, NOOP_AUTH_PLUGIN_ID, OAUTH2_CLIENT_CRED_AUTH_PLUGIN_ID,
-    OAUTH2_CLIENT_CRED_BASIC_AUTH_PLUGIN_ID,
+    APIKEY_AUTH_PLUGIN_ID, GUARD_PLUGIN_SCHEMA, NOOP_AUTH_PLUGIN_ID,
+    OAUTH2_CLIENT_CRED_AUTH_PLUGIN_ID, OAUTH2_CLIENT_CRED_BASIC_AUTH_PLUGIN_ID,
+    REQUEST_ID_TRANSFORM_PLUGIN_ID, REQUIRED_HEADERS_GUARD_PLUGIN_ID, TRANSFORM_PLUGIN_SCHEMA,
 };
 
 /// Registry that resolves auth plugin GTS identifiers to plugin implementations.
@@ -75,6 +78,84 @@ impl AuthPluginRegistry {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Guard plugin registry
+// ---------------------------------------------------------------------------
+
+/// Registry that resolves guard plugin GTS identifiers to plugin implementations.
+pub struct GuardPluginRegistry {
+    plugins: HashMap<String, Arc<dyn GuardPlugin>>,
+}
+
+impl GuardPluginRegistry {
+    /// Create a registry with the built-in guard plugins.
+    #[must_use]
+    pub fn with_builtins() -> Self {
+        let mut plugins: HashMap<String, Arc<dyn GuardPlugin>> = HashMap::new();
+        plugins.insert(
+            REQUIRED_HEADERS_GUARD_PLUGIN_ID.to_string(),
+            Arc::new(RequiredHeadersGuardPlugin),
+        );
+        Self { plugins }
+    }
+
+    /// Resolve a guard plugin by its GTS identifier.
+    ///
+    /// # Errors
+    /// Returns `PluginError::Internal` if the plugin is not registered.
+    pub fn resolve(&self, plugin_id: &str) -> Result<Arc<dyn GuardPlugin>, PluginError> {
+        self.plugins
+            .get(plugin_id)
+            .cloned()
+            .ok_or_else(|| PluginError::Internal(format!("unknown guard plugin: {plugin_id}")))
+    }
+
+    /// Check if a GTS identifier belongs to the guard plugin schema.
+    #[must_use]
+    pub fn is_guard_plugin(gts_id: &str) -> bool {
+        gts_id.starts_with(GUARD_PLUGIN_SCHEMA)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transform plugin registry
+// ---------------------------------------------------------------------------
+
+/// Registry that resolves transform plugin GTS identifiers to plugin implementations.
+pub struct TransformPluginRegistry {
+    plugins: HashMap<String, Arc<dyn TransformPlugin>>,
+}
+
+impl TransformPluginRegistry {
+    /// Create a registry with the built-in transform plugins.
+    #[must_use]
+    pub fn with_builtins() -> Self {
+        let mut plugins: HashMap<String, Arc<dyn TransformPlugin>> = HashMap::new();
+        plugins.insert(
+            REQUEST_ID_TRANSFORM_PLUGIN_ID.to_string(),
+            Arc::new(RequestIdTransformPlugin),
+        );
+        Self { plugins }
+    }
+
+    /// Resolve a transform plugin by its GTS identifier.
+    ///
+    /// # Errors
+    /// Returns `PluginError::Internal` if the plugin is not registered.
+    pub fn resolve(&self, plugin_id: &str) -> Result<Arc<dyn TransformPlugin>, PluginError> {
+        self.plugins
+            .get(plugin_id)
+            .cloned()
+            .ok_or_else(|| PluginError::Internal(format!("unknown transform plugin: {plugin_id}")))
+    }
+
+    /// Check if a GTS identifier belongs to the transform plugin schema.
+    #[must_use]
+    pub fn is_transform_plugin(gts_id: &str) -> bool {
+        gts_id.starts_with(TRANSFORM_PLUGIN_SCHEMA)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -124,5 +205,49 @@ mod tests {
         let registry = make_registry();
         let err = registry.resolve("gts.x.core.oagw.auth_plugin.v1~x.core.oagw.unknown.v1");
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn resolves_required_headers_guard_plugin() {
+        let registry = GuardPluginRegistry::with_builtins();
+        assert!(registry.resolve(REQUIRED_HEADERS_GUARD_PLUGIN_ID).is_ok());
+    }
+
+    #[test]
+    fn unknown_guard_plugin_returns_error() {
+        let registry = GuardPluginRegistry::with_builtins();
+        let err = registry.resolve("gts.x.core.oagw.guard_plugin.v1~x.core.oagw.unknown.v1");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn is_guard_plugin_matches_guard_schema() {
+        assert!(GuardPluginRegistry::is_guard_plugin(
+            REQUIRED_HEADERS_GUARD_PLUGIN_ID
+        ));
+        assert!(!GuardPluginRegistry::is_guard_plugin(APIKEY_AUTH_PLUGIN_ID));
+    }
+
+    #[test]
+    fn resolves_request_id_transform_plugin() {
+        let registry = TransformPluginRegistry::with_builtins();
+        assert!(registry.resolve(REQUEST_ID_TRANSFORM_PLUGIN_ID).is_ok());
+    }
+
+    #[test]
+    fn unknown_transform_plugin_returns_error() {
+        let registry = TransformPluginRegistry::with_builtins();
+        let err = registry.resolve("gts.x.core.oagw.transform_plugin.v1~x.core.oagw.unknown.v1");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn is_transform_plugin_matches_transform_schema() {
+        assert!(TransformPluginRegistry::is_transform_plugin(
+            REQUEST_ID_TRANSFORM_PLUGIN_ID
+        ));
+        assert!(!TransformPluginRegistry::is_transform_plugin(
+            APIKEY_AUTH_PLUGIN_ID
+        ));
     }
 }

--- a/modules/system/oagw/oagw/src/infra/plugin/request_id_transform.rs
+++ b/modules/system/oagw/oagw/src/infra/plugin/request_id_transform.rs
@@ -1,0 +1,121 @@
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::domain::plugin::{PluginError, TransformPlugin, TransformRequestContext};
+
+const REQUEST_ID_HEADER: &str = "x-request-id";
+
+/// Built-in transform plugin that injects or propagates `X-Request-ID` headers.
+///
+/// - **on_request**: If the inbound request contains an `X-Request-ID` header,
+///   propagate it unchanged. Otherwise, generate a new UUID v4 and inject it.
+/// - **on_response / on_error**: Default no-op. Cross-phase state sharing
+///   (propagating request ID to response) is a future enhancement.
+pub struct RequestIdTransformPlugin;
+
+#[async_trait]
+impl TransformPlugin for RequestIdTransformPlugin {
+    async fn on_request(&self, ctx: &mut TransformRequestContext) -> Result<(), PluginError> {
+        let has_request_id = ctx
+            .headers
+            .iter()
+            .any(|(k, _)| k.eq_ignore_ascii_case(REQUEST_ID_HEADER));
+        if !has_request_id {
+            ctx.headers
+                .push((REQUEST_ID_HEADER.to_string(), Uuid::new_v4().to_string()));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use modkit_security::SecurityContext;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::domain::plugin::{TransformPlugin, TransformResponseContext};
+
+    fn test_security_context() -> SecurityContext {
+        SecurityContext::builder()
+            .subject_tenant_id(Uuid::new_v4())
+            .subject_id(Uuid::new_v4())
+            .build()
+            .expect("test security context")
+    }
+
+    fn make_request_ctx(headers: Vec<(String, String)>) -> TransformRequestContext {
+        TransformRequestContext {
+            method: "POST".to_string(),
+            path: "/v1/test".to_string(),
+            query: Vec::new(),
+            headers,
+            config: HashMap::new(),
+            security_context: test_security_context(),
+        }
+    }
+
+    #[tokio::test]
+    async fn injects_request_id_when_missing() {
+        let plugin = RequestIdTransformPlugin;
+        let mut ctx = make_request_ctx(Vec::new());
+        plugin.on_request(&mut ctx).await.unwrap();
+
+        let id = ctx
+            .headers
+            .iter()
+            .find(|(k, _)| k == "x-request-id")
+            .map(|(_, v)| v.as_str())
+            .expect("should inject header");
+        // Verify it is a valid UUID.
+        Uuid::parse_str(id).expect("should be valid UUID");
+    }
+
+    #[tokio::test]
+    async fn preserves_existing_request_id() {
+        let plugin = RequestIdTransformPlugin;
+        let headers = vec![("x-request-id".into(), "custom-id-123".into())];
+        let mut ctx = make_request_ctx(headers);
+        plugin.on_request(&mut ctx).await.unwrap();
+
+        let val = ctx
+            .headers
+            .iter()
+            .find(|(k, _)| k == "x-request-id")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(val, Some("custom-id-123"));
+    }
+
+    #[tokio::test]
+    async fn preserves_existing_request_id_mixed_case() {
+        let plugin = RequestIdTransformPlugin;
+        let headers = vec![("X-Request-ID".into(), "mixed-case-id".into())];
+        let mut ctx = make_request_ctx(headers);
+        plugin.on_request(&mut ctx).await.unwrap();
+
+        // Should NOT inject a duplicate — the mixed-case key should be detected.
+        assert_eq!(ctx.headers.len(), 1, "should not inject duplicate header");
+        let val = ctx
+            .headers
+            .iter()
+            .find(|(k, _)| k == "X-Request-ID")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(val, Some("mixed-case-id"));
+    }
+
+    #[tokio::test]
+    async fn on_response_default_is_noop() {
+        let plugin = RequestIdTransformPlugin;
+        let mut ctx = TransformResponseContext {
+            status: 200,
+            headers: vec![("content-type".into(), "application/json".into())],
+            config: HashMap::new(),
+            security_context: test_security_context(),
+        };
+        let original_headers = ctx.headers.clone();
+        plugin.on_response(&mut ctx).await.unwrap();
+        assert_eq!(ctx.headers, original_headers);
+    }
+}

--- a/modules/system/oagw/oagw/src/infra/plugin/required_headers_guard.rs
+++ b/modules/system/oagw/oagw/src/infra/plugin/required_headers_guard.rs
@@ -1,0 +1,251 @@
+use async_trait::async_trait;
+
+use crate::domain::plugin::{GuardContext, GuardDecision, GuardPlugin, PluginError};
+
+/// Guard plugin that enforces required headers on requests and responses.
+///
+/// - **Request phase**: Rejects requests missing any configured required headers
+///   (e.g. enforce `X-Correlation-ID`, `Accept`, or API version headers).
+/// - **Response phase**: Rejects upstream responses missing required headers
+///   (e.g. block responses lacking `Content-Type` — defense against compromised upstreams).
+pub struct RequiredHeadersGuardPlugin;
+
+/// Parse a comma-separated list of header names, trimming whitespace and lowercasing.
+/// Empty/blank entries are skipped.
+fn parse_header_list(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Check if all required headers are present (case-insensitive) in the given header map.
+/// Returns the first missing header name, or `None` if all are present.
+fn find_missing_header(required: &[String], headers: &[(String, String)]) -> Option<String> {
+    for name in required {
+        let found = headers.iter().any(|(k, _)| k.eq_ignore_ascii_case(name));
+        if !found {
+            return Some(name.clone());
+        }
+    }
+    None
+}
+
+#[async_trait]
+impl GuardPlugin for RequiredHeadersGuardPlugin {
+    async fn guard_request(&self, ctx: &GuardContext) -> Result<GuardDecision, PluginError> {
+        let required = match ctx.config.get("required_request_headers") {
+            Some(v) if !v.trim().is_empty() => parse_header_list(v),
+            _ => return Ok(GuardDecision::Allow),
+        };
+
+        if let Some(missing) = find_missing_header(&required, &ctx.headers) {
+            return Ok(GuardDecision::Reject {
+                status: 400,
+                error_code: "REQUIRED_HEADER_MISSING".into(),
+                detail: format!("Missing required header: {missing}"),
+            });
+        }
+
+        Ok(GuardDecision::Allow)
+    }
+
+    async fn guard_response(&self, ctx: &GuardContext) -> Result<GuardDecision, PluginError> {
+        let required = match ctx.config.get("required_response_headers") {
+            Some(v) if !v.trim().is_empty() => parse_header_list(v),
+            _ => return Ok(GuardDecision::Allow),
+        };
+
+        if let Some(missing) = find_missing_header(&required, &ctx.headers) {
+            return Ok(GuardDecision::Reject {
+                status: 502,
+                error_code: "REQUIRED_HEADER_MISSING".into(),
+                detail: format!("Upstream response missing required header: {missing}"),
+            });
+        }
+
+        Ok(GuardDecision::Allow)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use modkit_security::SecurityContext;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::domain::plugin::GuardPlugin;
+
+    fn test_security_context() -> SecurityContext {
+        SecurityContext::builder()
+            .subject_tenant_id(Uuid::new_v4())
+            .subject_id(Uuid::new_v4())
+            .build()
+            .expect("test security context")
+    }
+
+    fn make_request_ctx(
+        config: HashMap<String, String>,
+        headers: Vec<(String, String)>,
+    ) -> GuardContext {
+        GuardContext {
+            method: "POST".to_string(),
+            path: "/v1/test".to_string(),
+            status: None,
+            headers,
+            config,
+            security_context: test_security_context(),
+        }
+    }
+
+    fn make_response_ctx(
+        config: HashMap<String, String>,
+        headers: Vec<(String, String)>,
+    ) -> GuardContext {
+        GuardContext {
+            method: "POST".to_string(),
+            path: "/v1/test".to_string(),
+            status: Some(200),
+            headers,
+            config,
+            security_context: test_security_context(),
+        }
+    }
+
+    // -- Unconfigured --
+
+    #[tokio::test]
+    async fn allows_when_not_configured() {
+        let plugin = RequiredHeadersGuardPlugin;
+        let ctx = make_request_ctx(HashMap::new(), vec![]);
+        let decision = plugin.guard_request(&ctx).await.unwrap();
+        assert_eq!(decision, GuardDecision::Allow);
+    }
+
+    // -- Request phase --
+
+    #[tokio::test]
+    async fn allows_request_with_required_headers() {
+        let plugin = RequiredHeadersGuardPlugin;
+        let config = HashMap::from([(
+            "required_request_headers".into(),
+            "x-correlation-id, accept".into(),
+        )]);
+        let headers = vec![
+            ("x-correlation-id".into(), "abc-123".into()),
+            ("accept".into(), "application/json".into()),
+        ];
+        let ctx = make_request_ctx(config, headers);
+        let decision = plugin.guard_request(&ctx).await.unwrap();
+        assert_eq!(decision, GuardDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn rejects_request_missing_header() {
+        let plugin = RequiredHeadersGuardPlugin;
+        let config =
+            HashMap::from([("required_request_headers".into(), "x-correlation-id".into())]);
+        let ctx = make_request_ctx(config, vec![]);
+        let decision = plugin.guard_request(&ctx).await.unwrap();
+        assert!(matches!(
+            decision,
+            GuardDecision::Reject { status: 400, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn request_check_is_case_insensitive() {
+        let plugin = RequiredHeadersGuardPlugin;
+        let config =
+            HashMap::from([("required_request_headers".into(), "x-correlation-id".into())]);
+        // Key uses different casing than the config.
+        let headers = vec![("X-Correlation-ID".into(), "abc-123".into())];
+        let ctx = make_request_ctx(config, headers);
+        let decision = plugin.guard_request(&ctx).await.unwrap();
+        assert_eq!(decision, GuardDecision::Allow);
+    }
+
+    // -- Response phase --
+
+    #[tokio::test]
+    async fn allows_response_with_required_headers() {
+        let plugin = RequiredHeadersGuardPlugin;
+        let config = HashMap::from([("required_response_headers".into(), "content-type".into())]);
+        let headers = vec![("content-type".into(), "application/json".into())];
+        let ctx = make_response_ctx(config, headers);
+        let decision = plugin.guard_response(&ctx).await.unwrap();
+        assert_eq!(decision, GuardDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn rejects_response_missing_header() {
+        let plugin = RequiredHeadersGuardPlugin;
+        let config = HashMap::from([("required_response_headers".into(), "content-type".into())]);
+        let ctx = make_response_ctx(config, vec![]);
+        let decision = plugin.guard_response(&ctx).await.unwrap();
+        assert!(matches!(
+            decision,
+            GuardDecision::Reject { status: 502, .. }
+        ));
+    }
+
+    // -- Multiple headers --
+
+    #[tokio::test]
+    async fn multiple_required_headers_first_missing_reported() {
+        let plugin = RequiredHeadersGuardPlugin;
+        let config = HashMap::from([(
+            "required_request_headers".into(),
+            "x-correlation-id, x-api-version".into(),
+        )]);
+        let ctx = make_request_ctx(config, vec![]);
+        let decision = plugin.guard_request(&ctx).await.unwrap();
+        match decision {
+            GuardDecision::Reject { detail, .. } => {
+                assert!(
+                    detail.contains("x-correlation-id"),
+                    "should report first missing header, got: {detail}"
+                );
+            }
+            _ => panic!("expected Reject"),
+        }
+    }
+
+    // -- Phase isolation --
+
+    #[tokio::test]
+    async fn skips_request_check_in_response_phase() {
+        let plugin = RequiredHeadersGuardPlugin;
+        // Only required_request_headers configured — response phase should allow.
+        let config =
+            HashMap::from([("required_request_headers".into(), "x-correlation-id".into())]);
+        let ctx = make_response_ctx(config, vec![]);
+        let decision = plugin.guard_response(&ctx).await.unwrap();
+        assert_eq!(decision, GuardDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn skips_response_check_in_request_phase() {
+        let plugin = RequiredHeadersGuardPlugin;
+        // Only required_response_headers configured — request phase should allow.
+        let config = HashMap::from([("required_response_headers".into(), "content-type".into())]);
+        let ctx = make_request_ctx(config, vec![]);
+        let decision = plugin.guard_request(&ctx).await.unwrap();
+        assert_eq!(decision, GuardDecision::Allow);
+    }
+
+    // -- Edge cases --
+
+    #[tokio::test]
+    async fn blank_header_names_are_ignored() {
+        let plugin = RequiredHeadersGuardPlugin;
+        let config = HashMap::from([("required_request_headers".into(), ", , ,".into())]);
+        let ctx = make_request_ctx(config, vec![]);
+        // All entries are blank after trim — effectively unconfigured.
+        let decision = plugin.guard_request(&ctx).await.unwrap();
+        assert_eq!(decision, GuardDecision::Allow);
+    }
+}

--- a/modules/system/oagw/oagw/src/infra/proxy/headers.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/headers.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::domain::model::{PassthroughMode, RequestHeaderRules};
 use http::{HeaderMap, HeaderName, HeaderValue};
 use oagw_sdk::api::ErrorSource;
@@ -160,10 +162,88 @@ pub fn set_host_header(headers: &mut HeaderMap, host: &str, port: u16) {
     }
 }
 
+/// Convert an HTTP `HeaderMap` to a `HashMap<String, String>` for plugin contexts.
+///
+/// Non-UTF-8 header values are silently dropped (they cannot be represented as
+/// `String` and are rare in practice).
+pub fn header_map_to_hash_map(headers: &HeaderMap) -> HashMap<String, String> {
+    headers
+        .iter()
+        .filter_map(|(k, v)| {
+            v.to_str()
+                .ok()
+                .map(|s| (k.as_str().to_string(), s.to_string()))
+        })
+        .collect()
+}
+
+/// Convert an HTTP `HeaderMap` to a `Vec<(String, String)>` preserving multi-valued headers.
+///
+/// Non-UTF-8 header values are silently dropped (they cannot be represented as
+/// `String` and are rare in practice).
+pub fn header_map_to_vec(headers: &HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .filter_map(|(k, v)| {
+            v.to_str()
+                .ok()
+                .map(|s| (k.as_str().to_string(), s.to_string()))
+        })
+        .collect()
+}
+
+/// Convert a `Vec<(String, String)>` back to an HTTP `HeaderMap`, preserving multi-values.
+///
+/// Entries with invalid header names or values are logged at `debug` level and
+/// dropped — this can happen when a plugin injects malformed headers.
+pub fn vec_to_header_map(headers: &[(String, String)]) -> HeaderMap {
+    let mut out = HeaderMap::new();
+    for (k, v) in headers {
+        match (
+            HeaderName::from_bytes(k.as_bytes()),
+            HeaderValue::from_str(v),
+        ) {
+            (Ok(name), Ok(val)) => {
+                out.append(name, val);
+            }
+            _ => {
+                tracing::debug!(
+                    header_name = %k,
+                    "plugin-mutated header dropped: invalid name or value"
+                );
+            }
+        }
+    }
+    out
+}
+
+/// Convert a `HashMap<String, String>` back to an HTTP `HeaderMap`.
+///
+/// Entries with invalid header names or values are logged at `debug` level and
+/// dropped — this can happen when a plugin injects malformed headers.
+pub fn hash_map_to_header_map(headers: &HashMap<String, String>) -> HeaderMap {
+    let mut out = HeaderMap::new();
+    for (k, v) in headers {
+        match (
+            HeaderName::from_bytes(k.as_bytes()),
+            HeaderValue::from_str(v),
+        ) {
+            (Ok(name), Ok(val)) => {
+                out.insert(name, val);
+            }
+            _ => {
+                tracing::debug!(
+                    header_name = %k,
+                    "plugin-mutated header dropped: invalid name or value"
+                );
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
 
     #[test]

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -8,7 +7,7 @@ use authz_resolver_sdk::pep::AccessRequest;
 use bytes::Bytes;
 use credstore_sdk::CredStoreClientV1;
 use futures_util::StreamExt;
-use http::{HeaderMap, HeaderName, HeaderValue};
+use http::{HeaderMap, HeaderValue};
 use modkit_security::SecurityContext;
 use oagw_sdk::body::{Body, BodyStream};
 use pingora_core::apps::HttpServerApp;
@@ -19,10 +18,13 @@ use tokio::sync::watch;
 use crate::config::TokenCacheConfig;
 use crate::domain::error::DomainError;
 use crate::domain::model::{Endpoint, PassthroughMode, PathSuffixMode, Scheme, Upstream};
-use crate::domain::plugin::AuthContext;
+use crate::domain::plugin::{
+    AuthContext, GuardContext, GuardDecision, TransformErrorContext, TransformRequestContext,
+    TransformResponseContext,
+};
 use crate::domain::rate_limit::RateLimiter;
 use crate::domain::services::{ControlPlaneService, DataPlaneService, EndpointSelector};
-use crate::infra::plugin::AuthPluginRegistry;
+use crate::infra::plugin::{AuthPluginRegistry, GuardPluginRegistry, TransformPluginRegistry};
 use crate::infra::proxy::{actions, resources};
 
 use super::headers;
@@ -45,6 +47,8 @@ pub struct DataPlaneServiceImpl {
     _shutdown_tx: watch::Sender<bool>,
     shutdown_rx: watch::Receiver<bool>,
     auth_registry: AuthPluginRegistry,
+    guard_registry: GuardPluginRegistry,
+    transform_registry: TransformPluginRegistry,
     rate_limiter: RateLimiter,
     request_timeout: Duration,
     /// Enforces authorization policy before proxying each request.
@@ -67,6 +71,8 @@ impl DataPlaneServiceImpl {
     ) -> Self {
         let auth_registry =
             AuthPluginRegistry::with_builtins(credstore, token_http_config, token_cache_config);
+        let guard_registry = GuardPluginRegistry::with_builtins();
+        let transform_registry = TransformPluginRegistry::with_builtins();
         let rate_limiter = RateLimiter::new();
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
@@ -77,6 +83,8 @@ impl DataPlaneServiceImpl {
             _shutdown_tx: shutdown_tx,
             shutdown_rx,
             auth_registry,
+            guard_registry,
+            transform_registry,
             rate_limiter,
             request_timeout: REQUEST_TIMEOUT,
             policy_enforcer,
@@ -104,6 +112,41 @@ impl DataPlaneServiceImpl {
     pub fn with_allow_http_upstream(mut self, allow: bool) -> Self {
         self.allow_http_upstream = allow;
         self
+    }
+
+    /// Execute the post-response plugin pipeline (guard + transform) and build
+    /// the final proxy response.
+    async fn finalize_response(
+        &self,
+        pipeline: &ResponsePipelineCtx<'_>,
+        status: http::StatusCode,
+        resp_headers: HeaderMap,
+        resp_body_stream: BodyStream,
+        instance_uri: String,
+    ) -> Result<http::Response<Body>, DomainError> {
+        execute_guard_responses(
+            &self.guard_registry,
+            &pipeline.guard_bindings,
+            status,
+            &resp_headers,
+            pipeline.method,
+            pipeline.path_suffix,
+            &instance_uri,
+            pipeline.ctx,
+        )
+        .await?;
+
+        let mut resp_headers = resp_headers;
+        execute_transform_responses(
+            &self.transform_registry,
+            &pipeline.transform_bindings,
+            status,
+            &mut resp_headers,
+            pipeline.ctx,
+        )
+        .await;
+
+        build_proxy_response(status, resp_headers, resp_body_stream, instance_uri)
     }
 
     /// Two-tier endpoint selection (D1):
@@ -216,7 +259,7 @@ impl DataPlaneService for DataPlaneServiceImpl {
         };
 
         // Parse query parameters with proper URL decoding.
-        let query_params: Vec<(String, String)> = req
+        let mut query_params: Vec<(String, String)> = req
             .uri()
             .query()
             .map(|q| {
@@ -323,22 +366,15 @@ impl DataPlaneService for DataPlaneServiceImpl {
 
         // 4. Execute auth plugin.
         if let Some(ref auth) = upstream.auth {
+            tracing::debug!(plugin = %auth.plugin_type, "executing auth plugin");
             let plugin = self.auth_registry.resolve(&auth.plugin_type).map_err(|e| {
                 DomainError::AuthenticationFailed {
                     detail: e.to_string(),
                     instance: instance_uri.clone(),
                 }
             })?;
-            let auth_headers: HashMap<String, String> = outbound_headers
-                .iter()
-                .filter_map(|(k, v)| {
-                    v.to_str()
-                        .ok()
-                        .map(|s| (k.as_str().to_string(), s.to_string()))
-                })
-                .collect();
             let mut auth_ctx = AuthContext {
-                headers: auth_headers,
+                headers: headers::header_map_to_hash_map(&outbound_headers),
                 config: auth.config.clone().unwrap_or_default(),
                 security_context: ctx.clone(),
             };
@@ -367,22 +403,122 @@ impl DataPlaneService for DataPlaneServiceImpl {
                         }
                     }
                 })?;
-            outbound_headers = HeaderMap::new();
-            for (k, v) in &auth_ctx.headers {
-                if let (Ok(name), Ok(val)) = (
-                    HeaderName::from_bytes(k.as_bytes()),
-                    HeaderValue::from_str(v),
-                ) {
-                    outbound_headers.insert(name, val);
+            outbound_headers = headers::hash_map_to_header_map(&auth_ctx.headers);
+            tracing::debug!(plugin = %auth.plugin_type, "auth plugin succeeded");
+        }
+
+        // 4b. Execute guard plugins (upstream then route).
+        //
+        // Guards are blocking gates: a rejection short-circuits the pipeline
+        // immediately. This is intentional — guards enforce hard policies
+        // (allowlists, rate limits, schema validation). Compare with transforms
+        // (step 5-transform) which use log-and-continue semantics.
+        let guard_bindings =
+            collect_plugin_bindings(&upstream, GuardPluginRegistry::is_guard_plugin);
+
+        let guard_headers = headers::header_map_to_vec(&outbound_headers);
+        for binding in &guard_bindings {
+            let guard = self
+                .guard_registry
+                .resolve(&binding.plugin_ref)
+                .map_err(|e| DomainError::Internal {
+                    message: format!(
+                        "guard plugin '{}' resolution failed: {e}",
+                        binding.plugin_ref
+                    ),
+                })?;
+
+            let guard_ctx = GuardContext {
+                method: method.to_string(),
+                path: path_suffix.clone(),
+                status: None,
+                headers: guard_headers.clone(),
+                config: binding.config.clone(),
+                security_context: ctx.clone(),
+            };
+
+            match guard.guard_request(&guard_ctx).await {
+                Ok(GuardDecision::Allow) => {}
+                Ok(GuardDecision::Reject {
+                    status,
+                    error_code,
+                    detail,
+                }) => {
+                    return Err(DomainError::GuardRejected {
+                        status,
+                        error_code,
+                        detail,
+                        instance: instance_uri,
+                    });
+                }
+                Err(e) => {
+                    return Err(DomainError::Internal {
+                        message: format!("guard plugin error: {e}"),
+                    });
                 }
             }
         }
+
+        // 4c. Collect transform plugin bindings (upstream then route).
+        let transform_bindings =
+            collect_plugin_bindings(&upstream, TransformPluginRegistry::is_transform_plugin);
 
         // 5. Apply header rules + set Host.
         if let Some(ref hc) = upstream.headers
             && let Some(ref rules) = hc.request
         {
             headers::apply_header_rules(&mut outbound_headers, rules);
+        }
+
+        // 5-transform. Execute transform plugins (on_request phase).
+        //
+        // Placed after header rules so transforms have the final word on
+        // outbound headers. Errors are logged and skipped — transforms use
+        // log-and-continue semantics so a single misbehaving transform cannot
+        // block the pipeline. Compare with guards (step 4b) which fail-hard.
+        if !transform_bindings.is_empty() {
+            let mut transform_headers = headers::header_map_to_vec(&outbound_headers);
+            let mut transform_query: Vec<(String, String)> = query_params.clone();
+
+            for binding in &transform_bindings {
+                let mut transform_ctx = TransformRequestContext {
+                    method: method.to_string(),
+                    path: path_suffix.clone(),
+                    query: transform_query.clone(),
+                    headers: transform_headers.clone(),
+                    config: binding.config.clone(),
+                    security_context: ctx.clone(),
+                };
+                match self.transform_registry.resolve(&binding.plugin_ref) {
+                    Ok(transform) => match transform.on_request(&mut transform_ctx).await {
+                        Ok(()) => {
+                            transform_headers = transform_ctx.headers;
+                            transform_query = transform_ctx.query;
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                plugin = %binding.plugin_ref,
+                                error = %e,
+                                "transform on_request failed, continuing"
+                            );
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            plugin = %binding.plugin_ref,
+                            error = %e,
+                            "transform plugin resolution failed, continuing"
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            // Write mutated headers back to outbound_headers.
+            outbound_headers = headers::vec_to_header_map(&transform_headers);
+
+            // Write mutated query params back.
+            query_params = transform_query;
         }
 
         // 5a. Endpoint selection (D1 — two-tier).
@@ -448,6 +584,14 @@ impl DataPlaneService for DataPlaneServiceImpl {
             outbound_headers.insert(H_INSTANCE_URI, v);
         }
 
+        let pipeline = ResponsePipelineCtx {
+            guard_bindings,
+            transform_bindings,
+            method: method.as_str(),
+            path_suffix: &path_suffix,
+            ctx: &ctx,
+        };
+
         // 8. Bridge request into Pingora via in-memory DuplexStream.
         let (client_io, server_io) = tokio::io::duplex(65_536);
 
@@ -465,7 +609,10 @@ impl DataPlaneService for DataPlaneServiceImpl {
         // Write the request and read the response from the client side.
         let timeout = self.request_timeout;
 
-        if let Some(mut body_stream) = body_stream {
+        let upstream_result: Result<http::Response<Body>, DomainError> = if let Some(
+            mut body_stream,
+        ) = body_stream
+        {
             // Streaming path: write headers, then forward body chunks concurrently.
             let (client_read, mut client_write) = tokio::io::split(client_io);
 
@@ -527,12 +674,12 @@ impl DataPlaneService for DataPlaneServiceImpl {
             tokio::select! {
                 biased;
                 Ok(total) = limit_rx => {
-                    return Err(DomainError::PayloadTooLarge {
+                    Err(DomainError::PayloadTooLarge {
                         detail: format!(
                             "streaming request body of {total} bytes exceeds maximum of {max_body} bytes"
                         ),
                         instance: body_instance_uri,
-                    });
+                    })
                 }
                 result = resp_future => {
                     let (status, resp_headers, resp_body_stream) = result
@@ -544,7 +691,14 @@ impl DataPlaneService for DataPlaneServiceImpl {
                             detail: format!("proxy bridge error: {e}"),
                             instance: instance_uri.clone(),
                         })?;
-                    Ok(build_proxy_response(status, resp_headers, resp_body_stream, instance_uri)?)
+                    self.finalize_response(
+                        &pipeline,
+                        status,
+                        resp_headers,
+                        resp_body_stream,
+                        instance_uri,
+                    )
+                    .await
                 }
             }
         } else {
@@ -580,17 +734,271 @@ impl DataPlaneService for DataPlaneServiceImpl {
                         instance: instance_uri.clone(),
                     })?;
 
-            Ok(build_proxy_response(
+            self.finalize_response(
+                &pipeline,
                 status,
                 resp_headers,
                 resp_body_stream,
                 instance_uri,
-            )?)
+            )
+            .await
+        };
+
+        // 9d. Execute transform error plugins on upstream failures.
+        match upstream_result {
+            Ok(resp) => Ok(resp),
+            Err(err) => {
+                execute_transform_errors(
+                    &self.transform_registry,
+                    &pipeline.transform_bindings,
+                    &err,
+                    pipeline.ctx,
+                )
+                .await;
+                Err(err)
+            }
         }
     }
 
     fn remove_rate_limit_key(&self, key: &str) {
         self.rate_limiter.remove_key(key);
+    }
+}
+
+/// Collect plugin bindings from the effective upstream, filtered by a type predicate.
+///
+/// The upstream already contains merged route plugins (via `compute_effective_config`),
+/// so only the upstream's plugin list is consulted.
+fn collect_plugin_bindings(
+    upstream: &Upstream,
+    predicate: fn(&str) -> bool,
+) -> Vec<&crate::domain::model::PluginBinding> {
+    upstream
+        .plugins
+        .as_ref()
+        .into_iter()
+        .flat_map(|pc| &pc.items)
+        .filter(|b| predicate(&b.plugin_ref))
+        .collect()
+}
+
+/// Execute `guard_response` for all guard bindings, returning the first rejection.
+///
+/// Guards use fail-hard semantics: the first rejection or error terminates the
+/// pipeline. This is intentional — response guards enforce hard policies such as
+/// blocking unexpected content types from compromised upstreams.
+#[allow(clippy::too_many_arguments)]
+async fn execute_guard_responses(
+    guard_registry: &GuardPluginRegistry,
+    guard_bindings: &[&crate::domain::model::PluginBinding],
+    resp_status: http::StatusCode,
+    resp_headers: &HeaderMap,
+    method: &str,
+    path: &str,
+    instance_uri: &str,
+    security_context: &SecurityContext,
+) -> Result<(), DomainError> {
+    let resp_header_map = headers::header_map_to_vec(resp_headers);
+
+    for binding in guard_bindings {
+        let guard =
+            guard_registry
+                .resolve(&binding.plugin_ref)
+                .map_err(|e| DomainError::Internal {
+                    message: format!(
+                        "guard plugin '{}' resolution failed: {e}",
+                        binding.plugin_ref
+                    ),
+                })?;
+
+        let guard_ctx = GuardContext {
+            method: method.to_string(),
+            path: path.to_string(),
+            status: Some(resp_status.as_u16()),
+            headers: resp_header_map.clone(),
+            config: binding.config.clone(),
+            security_context: security_context.clone(),
+        };
+
+        match guard.guard_response(&guard_ctx).await {
+            Ok(GuardDecision::Allow) => {}
+            Ok(GuardDecision::Reject {
+                status,
+                error_code,
+                detail,
+            }) => {
+                return Err(DomainError::GuardRejected {
+                    status,
+                    error_code,
+                    detail,
+                    instance: instance_uri.to_string(),
+                });
+            }
+            Err(e) => {
+                return Err(DomainError::Internal {
+                    message: format!("guard plugin error: {e}"),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Execute `on_response` for all transform bindings, logging errors without aborting.
+///
+/// Unlike guard execution, transform errors are logged and skipped — a single
+/// misbehaving transform must not block the response pipeline.
+async fn execute_transform_responses(
+    transform_registry: &TransformPluginRegistry,
+    transform_bindings: &[&crate::domain::model::PluginBinding],
+    resp_status: http::StatusCode,
+    resp_headers: &mut HeaderMap,
+    security_context: &SecurityContext,
+) {
+    if transform_bindings.is_empty() {
+        return;
+    }
+
+    let mut header_map = headers::header_map_to_vec(resp_headers);
+
+    for binding in transform_bindings {
+        let mut transform_ctx = TransformResponseContext {
+            status: resp_status.as_u16(),
+            headers: header_map.clone(),
+            config: binding.config.clone(),
+            security_context: security_context.clone(),
+        };
+
+        match transform_registry.resolve(&binding.plugin_ref) {
+            Ok(transform) => match transform.on_response(&mut transform_ctx).await {
+                Ok(()) => {
+                    header_map = transform_ctx.headers;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        plugin = %binding.plugin_ref,
+                        error = %e,
+                        "transform on_response failed, continuing"
+                    );
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    plugin = %binding.plugin_ref,
+                    error = %e,
+                    "transform plugin resolution failed, continuing"
+                );
+                continue;
+            }
+        }
+    }
+
+    // Write mutated headers back.
+    *resp_headers = headers::vec_to_header_map(&header_map);
+}
+
+/// Per-request plugin pipeline state shared across the streaming and buffered
+/// response paths.
+struct ResponsePipelineCtx<'a> {
+    guard_bindings: Vec<&'a crate::domain::model::PluginBinding>,
+    transform_bindings: Vec<&'a crate::domain::model::PluginBinding>,
+    method: &'a str,
+    path_suffix: &'a str,
+    ctx: &'a SecurityContext,
+}
+
+/// Execute `on_error` for all transform bindings, logging errors without aborting.
+///
+/// Called when the upstream exchange fails (timeout, downstream error, guard
+/// rejection, etc.). Transforms can enrich error details or inject diagnostic
+/// headers. The original `DomainError` is not modified — transforms operate on
+/// a snapshot via `TransformErrorContext`.
+async fn execute_transform_errors(
+    transform_registry: &TransformPluginRegistry,
+    transform_bindings: &[&crate::domain::model::PluginBinding],
+    err: &DomainError,
+    security_context: &SecurityContext,
+) {
+    if transform_bindings.is_empty() {
+        return;
+    }
+
+    let status = domain_error_status(err);
+    let error_type = domain_error_type_name(err);
+
+    for binding in transform_bindings {
+        let mut transform_ctx = TransformErrorContext {
+            error_type: error_type.to_string(),
+            status,
+            detail: err.to_string(),
+            config: binding.config.clone(),
+            security_context: security_context.clone(),
+        };
+
+        match transform_registry.resolve(&binding.plugin_ref) {
+            Ok(transform) => {
+                if let Err(e) = transform.on_error(&mut transform_ctx).await {
+                    tracing::warn!(
+                        plugin = %binding.plugin_ref,
+                        error = %e,
+                        "transform on_error failed, continuing"
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    plugin = %binding.plugin_ref,
+                    error = %e,
+                    "transform plugin resolution failed, continuing"
+                );
+                continue;
+            }
+        }
+    }
+}
+
+/// Map a `DomainError` to its HTTP status code (proxy-layer only).
+fn domain_error_status(err: &DomainError) -> u16 {
+    match err {
+        DomainError::Validation { .. }
+        | DomainError::MissingTargetHost { .. }
+        | DomainError::InvalidTargetHost { .. }
+        | DomainError::UnknownTargetHost { .. } => 400,
+        DomainError::AuthenticationFailed { .. } => 401,
+        DomainError::Forbidden { .. } => 403,
+        DomainError::NotFound { .. } => 404,
+        DomainError::Conflict { .. } => 409,
+        DomainError::PayloadTooLarge { .. } => 413,
+        DomainError::RateLimitExceeded { .. } => 429,
+        DomainError::SecretNotFound { .. } | DomainError::Internal { .. } => 500,
+        DomainError::DownstreamError { .. } | DomainError::ProtocolError { .. } => 502,
+        DomainError::UpstreamDisabled { .. } => 503,
+        DomainError::ConnectionTimeout { .. } | DomainError::RequestTimeout { .. } => 504,
+        DomainError::GuardRejected { status, .. } => *status,
+    }
+}
+
+/// Short discriminant name for a `DomainError` variant.
+fn domain_error_type_name(err: &DomainError) -> &'static str {
+    match err {
+        DomainError::Validation { .. } => "ValidationError",
+        DomainError::Conflict { .. } => "Conflict",
+        DomainError::MissingTargetHost { .. } => "MissingTargetHost",
+        DomainError::InvalidTargetHost { .. } => "InvalidTargetHost",
+        DomainError::UnknownTargetHost { .. } => "UnknownTargetHost",
+        DomainError::AuthenticationFailed { .. } => "AuthenticationFailed",
+        DomainError::NotFound { .. } => "NotFound",
+        DomainError::PayloadTooLarge { .. } => "PayloadTooLarge",
+        DomainError::RateLimitExceeded { .. } => "RateLimitExceeded",
+        DomainError::SecretNotFound { .. } => "SecretNotFound",
+        DomainError::DownstreamError { .. } => "DownstreamError",
+        DomainError::ProtocolError { .. } => "ProtocolError",
+        DomainError::UpstreamDisabled { .. } => "UpstreamDisabled",
+        DomainError::ConnectionTimeout { .. } => "ConnectionTimeout",
+        DomainError::RequestTimeout { .. } => "RequestTimeout",
+        DomainError::Internal { .. } => "Internal",
+        DomainError::GuardRejected { .. } => "GuardRejected",
+        DomainError::Forbidden { .. } => "Forbidden",
     }
 }
 

--- a/modules/system/oagw/oagw/src/infra/type_provisioning.rs
+++ b/modules/system/oagw/oagw/src/infra/type_provisioning.rs
@@ -123,12 +123,19 @@ struct HeadersConfig {
     response: Option<ResponseHeaderRules>,
 }
 
+#[derive(Deserialize)]
+struct PluginBinding {
+    plugin_ref: String,
+    #[serde(default)]
+    config: HashMap<String, String>,
+}
+
 #[derive(Deserialize, Default)]
 struct PluginsConfig {
     #[serde(default)]
     sharing: SharingMode,
     #[serde(default)]
-    items: Vec<String>,
+    items: Vec<PluginBinding>,
 }
 
 #[derive(Deserialize, Default)]
@@ -449,11 +456,20 @@ impl From<RateLimitConfig> for domain::RateLimitConfig {
     }
 }
 
+impl From<PluginBinding> for domain::PluginBinding {
+    fn from(v: PluginBinding) -> Self {
+        Self {
+            plugin_ref: v.plugin_ref,
+            config: v.config,
+        }
+    }
+}
+
 impl From<PluginsConfig> for domain::PluginsConfig {
     fn from(v: PluginsConfig) -> Self {
         Self {
             sharing: v.sharing.into(),
-            items: v.items,
+            items: v.items.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -916,7 +932,7 @@ mod tests {
             },
             "plugins": {
                 "sharing": "inherit",
-                "items": ["plugin-a"]
+                "items": [{"plugin_ref": "plugin-a"}]
             },
             "rate_limit": {
                 "sustained": {"rate": 100, "window": "minute"},
@@ -951,7 +967,8 @@ mod tests {
 
         let plugins = req.plugins.as_ref().unwrap();
         assert_eq!(plugins.sharing, domain::SharingMode::Inherit);
-        assert_eq!(plugins.items, vec!["plugin-a"]);
+        assert_eq!(plugins.items.len(), 1);
+        assert_eq!(plugins.items[0].plugin_ref, "plugin-a");
 
         let rl = req.rate_limit.as_ref().unwrap();
         assert_eq!(rl.sustained.rate, 100);

--- a/modules/system/oagw/oagw/tests/proxy_integration.rs
+++ b/modules/system/oagw/oagw/tests/proxy_integration.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use http::{Method, StatusCode};
 use oagw::test_support::{
     APIKEY_AUTH_PLUGIN_ID, AppHarness, MockBody, MockGuard, MockResponse, MockUpstream,
@@ -6,9 +8,10 @@ use oagw::test_support::{
 use oagw_sdk::Body;
 use oagw_sdk::api::ErrorSource;
 use oagw_sdk::{
-    BurstConfig, CreateRouteRequest, CreateUpstreamRequest, Endpoint, HttpMatch, HttpMethod,
-    MatchRules, PathSuffixMode, RateLimitAlgorithm, RateLimitConfig, RateLimitScope,
-    RateLimitStrategy, Scheme, Server, SharingMode, SustainedRate, Window,
+    BurstConfig, CreateRouteRequest, CreateUpstreamRequest, Endpoint, HeadersConfig, HttpMatch,
+    HttpMethod, MatchRules, PassthroughMode, PathSuffixMode, PluginBinding, PluginsConfig,
+    RateLimitAlgorithm, RateLimitConfig, RateLimitScope, RateLimitStrategy, RequestHeaderRules,
+    Scheme, Server, SharingMode, SustainedRate, Window,
 };
 use serde_json::json;
 
@@ -1913,4 +1916,557 @@ async fn proxy_oauth2_missing_credentials_returns_error() {
 
     // Should fail with a secret-not-found error.
     assert!(response.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Guard plugin integration tests
+// ---------------------------------------------------------------------------
+
+const REQUIRED_HEADERS_GUARD_PLUGIN_ID: &str =
+    "gts.x.core.oagw.guard_plugin.v1~x.core.oagw.required_headers.v1";
+
+/// Verify that the RequiredHeadersGuardPlugin allows requests that include
+/// all required headers.
+#[tokio::test]
+async fn proxy_guard_allows_when_required_header_present() {
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "POST",
+        "/guard-hdr-ok",
+        MockResponse {
+            status: 200,
+            headers: vec![("content-type".into(), "application/json".into())],
+            body: MockBody::Json(json!({"ok": true})),
+        },
+    );
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("guard-hdr-ok")
+            .headers(HeadersConfig {
+                request: Some(RequestHeaderRules {
+                    passthrough: PassthroughMode::All,
+                    ..Default::default()
+                }),
+                response: None,
+            })
+            .plugins(PluginsConfig {
+                sharing: SharingMode::Private,
+                items: vec![PluginBinding {
+                    plugin_ref: REQUIRED_HEADERS_GUARD_PLUGIN_ID.to_string(),
+                    config: [("required_request_headers".into(), "x-correlation-id".into())].into(),
+                }],
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Post],
+                        path: guard.path("/guard-hdr-ok"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Disabled,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    let req = http::Request::builder()
+        .method(Method::POST)
+        .uri(format!("/guard-hdr-ok{}", guard.path("/guard-hdr-ok")))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header("x-correlation-id", "test-123")
+        .body(Body::from(r#"{"test": true}"#))
+        .unwrap();
+
+    let response = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// Verify that the RequiredHeadersGuardPlugin rejects requests missing a
+/// required header, returning a 400 GuardRejected error.
+#[tokio::test]
+async fn proxy_guard_rejects_missing_required_header() {
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "POST",
+        "/guard-hdr-miss",
+        MockResponse {
+            status: 200,
+            headers: vec![("content-type".into(), "application/json".into())],
+            body: MockBody::Json(json!({"ok": true})),
+        },
+    );
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("guard-hdr-miss")
+            .plugins(PluginsConfig {
+                sharing: SharingMode::Private,
+                items: vec![PluginBinding {
+                    plugin_ref: REQUIRED_HEADERS_GUARD_PLUGIN_ID.to_string(),
+                    config: [("required_request_headers".into(), "x-correlation-id".into())].into(),
+                }],
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Post],
+                        path: guard.path("/guard-hdr-miss"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Disabled,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Send request WITHOUT the required x-correlation-id header.
+    let req = http::Request::builder()
+        .method(Method::POST)
+        .uri(format!("/guard-hdr-miss{}", guard.path("/guard-hdr-miss")))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"test": true}"#))
+        .unwrap();
+
+    let err = h
+        .facade()
+        .proxy_request(ctx.clone(), req)
+        .await
+        .expect_err("guard should reject missing required header");
+
+    match err {
+        oagw_sdk::error::ServiceGatewayError::GuardRejected {
+            status, error_code, ..
+        } => {
+            assert_eq!(status, 400);
+            assert_eq!(error_code, "REQUIRED_HEADER_MISSING");
+        }
+        other => panic!("expected GuardRejected, got: {other:?}"),
+    }
+
+    // Verify the request never reached the upstream.
+    let recorded = guard.recorded_requests().await;
+    assert!(
+        recorded.is_empty(),
+        "rejected request should not reach upstream"
+    );
+}
+
+/// Verify that an unconfigured RequiredHeadersGuardPlugin allows all requests.
+#[tokio::test]
+async fn proxy_guard_allows_unconfigured() {
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "POST",
+        "/guard-hdr-noconf",
+        MockResponse {
+            status: 200,
+            headers: vec![("content-type".into(), "application/json".into())],
+            body: MockBody::Json(json!({"ok": true})),
+        },
+    );
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("guard-hdr-noconf")
+            .plugins(PluginsConfig {
+                sharing: SharingMode::Private,
+                items: vec![PluginBinding {
+                    plugin_ref: REQUIRED_HEADERS_GUARD_PLUGIN_ID.to_string(),
+                    config: HashMap::new(),
+                }],
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Post],
+                        path: guard.path("/guard-hdr-noconf"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Disabled,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    let req = http::Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/guard-hdr-noconf{}",
+            guard.path("/guard-hdr-noconf")
+        ))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"test": true}"#))
+        .unwrap();
+
+    let response = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// ---------------------------------------------------------------------------
+// Transform plugin integration tests
+// ---------------------------------------------------------------------------
+
+const REQUEST_ID_TRANSFORM_PLUGIN_ID: &str =
+    "gts.x.core.oagw.transform_plugin.v1~x.core.oagw.request_id.v1";
+
+/// Verify that the RequestIdTransformPlugin injects an X-Request-ID header when
+/// the inbound request does not include one.
+#[tokio::test]
+async fn proxy_transform_injects_request_id() {
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "POST",
+        "/transform-test",
+        MockResponse {
+            status: 200,
+            headers: vec![("content-type".into(), "application/json".into())],
+            body: MockBody::Json(json!({"ok": true})),
+        },
+    );
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("transform-inject")
+            .plugins(PluginsConfig {
+                sharing: SharingMode::Private,
+                items: vec![PluginBinding {
+                    plugin_ref: REQUEST_ID_TRANSFORM_PLUGIN_ID.to_string(),
+                    config: Default::default(),
+                }],
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Post],
+                        path: guard.path("/transform-test"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Disabled,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Send request WITHOUT X-Request-ID.
+    let req = http::Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/transform-inject{}",
+            guard.path("/transform-test")
+        ))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"test": true}"#))
+        .unwrap();
+
+    let response = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // The mock upstream should have received the request WITH an X-Request-ID.
+    let recorded = guard.recorded_requests().await;
+    assert_eq!(recorded.len(), 1);
+    let has_request_id = recorded[0]
+        .headers
+        .iter()
+        .any(|(k, _)| k.eq_ignore_ascii_case("x-request-id"));
+    assert!(
+        has_request_id,
+        "upstream should have received x-request-id header injected by transform plugin"
+    );
+}
+
+/// Verify that the RequestIdTransformPlugin preserves an existing X-Request-ID
+/// from the inbound request (does not overwrite it).
+#[tokio::test]
+async fn proxy_transform_preserves_request_id() {
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "POST",
+        "/transform-preserve",
+        MockResponse {
+            status: 200,
+            headers: vec![("content-type".into(), "application/json".into())],
+            body: MockBody::Json(json!({"ok": true})),
+        },
+    );
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("transform-preserve")
+            .headers(HeadersConfig {
+                request: Some(RequestHeaderRules {
+                    passthrough: PassthroughMode::All,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+            .plugins(PluginsConfig {
+                sharing: SharingMode::Private,
+                items: vec![PluginBinding {
+                    plugin_ref: REQUEST_ID_TRANSFORM_PLUGIN_ID.to_string(),
+                    config: Default::default(),
+                }],
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Post],
+                        path: guard.path("/transform-preserve"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Disabled,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Send request WITH an existing X-Request-ID.
+    let req = http::Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/transform-preserve{}",
+            guard.path("/transform-preserve")
+        ))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header("x-request-id", "custom-trace-id-999")
+        .body(Body::from(r#"{"test": true}"#))
+        .unwrap();
+
+    let response = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // The mock upstream should have received the ORIGINAL X-Request-ID.
+    let recorded = guard.recorded_requests().await;
+    assert_eq!(recorded.len(), 1);
+    let request_id = recorded[0]
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("x-request-id"))
+        .map(|(_, v)| v.as_str());
+    assert_eq!(
+        request_id,
+        Some("custom-trace-id-999"),
+        "upstream should have received the original x-request-id, not a generated one"
+    );
+}
+
+/// Verify that a failing transform plugin (unknown GTS ID) does not block the
+/// proxy pipeline — the request still succeeds (log-and-continue).
+#[tokio::test]
+async fn proxy_transform_error_continues_pipeline() {
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "POST",
+        "/transform-error",
+        MockResponse {
+            status: 200,
+            headers: vec![("content-type".into(), "application/json".into())],
+            body: MockBody::Json(json!({"ok": true})),
+        },
+    );
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    // Bind a non-existent transform plugin — resolution will fail.
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("transform-error")
+            .plugins(PluginsConfig {
+                sharing: SharingMode::Private,
+                items: vec![PluginBinding {
+                    plugin_ref: "gts.x.core.oagw.transform_plugin.v1~x.core.oagw.nonexistent.v1"
+                        .to_string(),
+                    config: Default::default(),
+                }],
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Post],
+                        path: guard.path("/transform-error"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Disabled,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Request should succeed despite the broken transform plugin.
+    let req = http::Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/transform-error{}",
+            guard.path("/transform-error")
+        ))
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(r#"{"test": true}"#))
+        .unwrap();
+
+    let response = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "pipeline should continue despite transform resolution failure"
+    );
 }

--- a/testing/e2e/modules/oagw/helpers.py
+++ b/testing/e2e/modules/oagw/helpers.py
@@ -30,9 +30,10 @@ BEARER_AUTH_PLUGIN_ID = "gts.x.core.oagw.auth_plugin.v1~x.core.oagw.bearer.v1"
 OAUTH2_CLIENT_CRED_AUTH_PLUGIN_ID = "gts.x.core.oagw.auth_plugin.v1~x.core.oagw.oauth2_client_cred.v1"
 OAUTH2_CLIENT_CRED_BASIC_AUTH_PLUGIN_ID = "gts.x.core.oagw.auth_plugin.v1~x.core.oagw.oauth2_client_cred_basic.v1"
 
-# Guard plugin instances (2)
+# Guard plugin instances (3)
 TIMEOUT_GUARD_PLUGIN_ID = "gts.x.core.oagw.guard_plugin.v1~x.core.oagw.timeout.v1"
 CORS_GUARD_PLUGIN_ID = "gts.x.core.oagw.guard_plugin.v1~x.core.oagw.cors.v1"
+REQUIRED_HEADERS_GUARD_PLUGIN_ID = "gts.x.core.oagw.guard_plugin.v1~x.core.oagw.required_headers.v1"
 
 # Transform plugin instances (3)
 LOGGING_TRANSFORM_PLUGIN_ID = "gts.x.core.oagw.transform_plugin.v1~x.core.oagw.logging.v1"
@@ -51,7 +52,7 @@ OAGW_INSTANCES = [
     NOOP_AUTH_PLUGIN_ID, APIKEY_AUTH_PLUGIN_ID, BASIC_AUTH_PLUGIN_ID,
     BEARER_AUTH_PLUGIN_ID, OAUTH2_CLIENT_CRED_AUTH_PLUGIN_ID,
     OAUTH2_CLIENT_CRED_BASIC_AUTH_PLUGIN_ID,
-    TIMEOUT_GUARD_PLUGIN_ID, CORS_GUARD_PLUGIN_ID,
+    TIMEOUT_GUARD_PLUGIN_ID, CORS_GUARD_PLUGIN_ID, REQUIRED_HEADERS_GUARD_PLUGIN_ID,
     LOGGING_TRANSFORM_PLUGIN_ID, METRICS_TRANSFORM_PLUGIN_ID,
     REQUEST_ID_TRANSFORM_PLUGIN_ID,
 ]
@@ -128,9 +129,14 @@ async def create_upstream(
     headers: dict,
     mock_url: str,
     alias: Optional[str] = None,
+    upstream_headers: Optional[dict] = None,
     **kwargs,
 ) -> dict:
     """Create an upstream via the Management API and return the response JSON.
+
+    ``upstream_headers`` maps to the upstream resource ``headers`` field
+    (e.g., ``{"request": {"passthrough": "all"}}``).  It is accepted as a
+    separate parameter to avoid colliding with the HTTP ``headers`` argument.
 
     ``kwargs`` are merged into the request body (e.g., ``enabled=False``,
     ``auth={...}``, ``rate_limit={...}``).
@@ -152,6 +158,8 @@ async def create_upstream(
     }
     if alias is not None:
         body["alias"] = alias
+    if upstream_headers is not None:
+        body["headers"] = upstream_headers
 
     body.update(kwargs)
 

--- a/testing/e2e/modules/oagw/test_guard_plugins.py
+++ b/testing/e2e/modules/oagw/test_guard_plugins.py
@@ -1,0 +1,185 @@
+"""E2E tests for OAGW guard plugins (required headers guard)."""
+import httpx
+import pytest
+
+from .helpers import (
+    REQUIRED_HEADERS_GUARD_PLUGIN_ID,
+    create_route,
+    create_upstream,
+    delete_upstream,
+    unique_alias,
+)
+
+
+def _required_headers_plugins(request_headers=None, response_headers=None):
+    """Build a plugins payload with the RequiredHeadersGuardPlugin bound."""
+    config = {}
+    if request_headers:
+        config["required_request_headers"] = ",".join(request_headers)
+    if response_headers:
+        config["required_response_headers"] = ",".join(response_headers)
+    return {
+        "sharing": "private",
+        "items": [
+            {
+                "plugin_ref": REQUIRED_HEADERS_GUARD_PLUGIN_ID,
+                "config": config,
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test A: required header present → allowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_required_headers_allows_when_present(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Request with required header present passes the guard."""
+    _ = mock_upstream
+    alias = unique_alias("guard-hdr-ok")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            plugins=_required_headers_plugins(request_headers=["x-correlation-id"]),
+            upstream_headers={"request": {"passthrough": "all"}},
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid, ["POST"], "/echo",
+        )
+
+        resp = await client.post(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/echo",
+            headers={
+                **oagw_headers,
+                "content-type": "application/json",
+                "x-correlation-id": "test-123",
+            },
+            json={"guard": "headers-test"},
+        )
+        assert resp.status_code == 200, (
+            f"Expected 200, got {resp.status_code}: {resp.text[:500]}"
+        )
+        body = resp.json()
+        assert "headers" in body, "Expected echoed headers from /echo"
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+# ---------------------------------------------------------------------------
+# Test B: required header missing → rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_required_headers_rejects_when_missing(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Request without required header is rejected (400)."""
+    _ = mock_upstream
+    alias = unique_alias("guard-hdr-miss")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            plugins=_required_headers_plugins(request_headers=["x-correlation-id"]),
+            upstream_headers={"request": {"passthrough": "all"}},
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid, ["POST"], "/echo",
+        )
+
+        # Send WITHOUT x-correlation-id.
+        resp = await client.post(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/echo",
+            headers={**oagw_headers, "content-type": "application/json"},
+            json={"guard": "headers-missing"},
+        )
+        assert resp.status_code == 400, (
+            f"Expected 400, got {resp.status_code}: {resp.text[:500]}"
+        )
+        assert resp.headers.get("x-oagw-error-source") == "gateway"
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+# ---------------------------------------------------------------------------
+# Test C: unconfigured guard allows all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_required_headers_allows_unconfigured(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Guard with empty config (no required headers) allows all requests."""
+    _ = mock_upstream
+    alias = unique_alias("guard-hdr-open")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            plugins=_required_headers_plugins(),
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid, ["POST"], "/echo",
+        )
+
+        resp = await client.post(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/echo",
+            headers={**oagw_headers, "content-type": "application/json"},
+            json={"guard": "unconfigured"},
+        )
+        assert resp.status_code == 200, (
+            f"Expected 200 (unconfigured = fail-open), got {resp.status_code}: {resp.text[:500]}"
+        )
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+# ---------------------------------------------------------------------------
+# Test D: case-insensitive header matching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_required_headers_case_insensitive(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Required header check is case-insensitive."""
+    _ = mock_upstream
+    alias = unique_alias("guard-hdr-case")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            plugins=_required_headers_plugins(request_headers=["X-Correlation-ID"]),
+            upstream_headers={"request": {"passthrough": "all"}},
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid, ["POST"], "/echo",
+        )
+
+        # Send with lowercase header name (HTTP normalizes to lowercase).
+        resp = await client.post(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/echo",
+            headers={
+                **oagw_headers,
+                "content-type": "application/json",
+                "x-correlation-id": "case-test",
+            },
+            json={"guard": "case-insensitive"},
+        )
+        assert resp.status_code == 200, (
+            f"Expected 200 (case-insensitive match), got {resp.status_code}: {resp.text[:500]}"
+        )
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)

--- a/testing/e2e/modules/oagw/test_oagw_types_registered.py
+++ b/testing/e2e/modules/oagw/test_oagw_types_registered.py
@@ -25,7 +25,7 @@ async def test_all_oagw_schemas_registered(oagw_base_url, oagw_headers):
 
 @pytest.mark.asyncio
 async def test_all_oagw_instances_registered(oagw_base_url, oagw_headers):
-    """After platform startup, all 13 builtin instances should be present in types-registry."""
+    """After platform startup, all 14 builtin instances should be present in types-registry."""
     async with httpx.AsyncClient(timeout=10.0) as client:
         entities = await list_oagw_types(client, oagw_base_url, oagw_headers)
         registered_ids = {e["gts_id"] for e in entities}
@@ -38,14 +38,14 @@ async def test_all_oagw_instances_registered(oagw_base_url, oagw_headers):
 
 @pytest.mark.asyncio
 async def test_oagw_entity_count(oagw_base_url, oagw_headers):
-    """Types-registry should contain at least 20 OAGW entities (7 schemas + 13 instances)."""
+    """Types-registry should contain at least 21 OAGW entities (7 schemas + 14 instances)."""
     async with httpx.AsyncClient(timeout=10.0) as client:
         entities = await list_oagw_types(client, oagw_base_url, oagw_headers)
         registered_ids = {e["gts_id"] for e in entities}
 
         oagw_ids = registered_ids & set(ALL_OAGW_GTS_IDS)
-        assert len(oagw_ids) == 20, (
-            f"Expected 20 OAGW entities, found {len(oagw_ids)}. "
+        assert len(oagw_ids) == 21, (
+            f"Expected 21 OAGW entities, found {len(oagw_ids)}. "
             f"Missing: {set(ALL_OAGW_GTS_IDS) - registered_ids}"
         )
 

--- a/testing/e2e/modules/oagw/test_transform_plugins.py
+++ b/testing/e2e/modules/oagw/test_transform_plugins.py
@@ -1,0 +1,162 @@
+"""E2E tests for OAGW transform plugins (request-id transform)."""
+import re
+
+import httpx
+import pytest
+
+from .helpers import (
+    REQUEST_ID_TRANSFORM_PLUGIN_ID,
+    create_route,
+    create_upstream,
+    delete_upstream,
+    unique_alias,
+)
+
+UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def _request_id_plugins() -> dict:
+    """Build a plugins payload with the RequestIdTransformPlugin bound."""
+    return {
+        "sharing": "private",
+        "items": [
+            {
+                "plugin_ref": REQUEST_ID_TRANSFORM_PLUGIN_ID,
+                "config": {},
+            },
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test E: transform injects x-request-id when absent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_id_transform_injects_header(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """RequestIdTransformPlugin injects a UUID x-request-id when none is present."""
+    _ = mock_upstream
+    alias = unique_alias("xform-rid-inj")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            plugins=_request_id_plugins(),
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid, ["POST"], "/echo",
+        )
+
+        resp = await client.post(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/echo",
+            headers={**oagw_headers, "content-type": "application/json"},
+            json={"transform": "test"},
+        )
+        assert resp.status_code == 200, (
+            f"Expected 200, got {resp.status_code}: {resp.text[:500]}"
+        )
+
+        echoed = resp.json().get("headers", {})
+        request_id = echoed.get("x-request-id", "")
+        assert request_id, "Expected x-request-id header to be injected"
+        assert UUID_RE.match(request_id), (
+            f"Expected x-request-id to be a UUID, got: {request_id!r}"
+        )
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+# ---------------------------------------------------------------------------
+# Test F: transform preserves existing x-request-id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_id_transform_preserves_existing(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """RequestIdTransformPlugin preserves an existing x-request-id from the client."""
+    _ = mock_upstream
+    alias = unique_alias("xform-rid-keep")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            plugins=_request_id_plugins(),
+            upstream_headers={"request": {"passthrough": "all"}},
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid, ["POST"], "/echo",
+        )
+
+        custom_id = "e2e-trace-abc123"
+        resp = await client.post(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/echo",
+            headers={
+                **oagw_headers,
+                "content-type": "application/json",
+                "x-request-id": custom_id,
+            },
+            json={"transform": "preserve"},
+        )
+        assert resp.status_code == 200, (
+            f"Expected 200, got {resp.status_code}: {resp.text[:500]}"
+        )
+
+        echoed = resp.json().get("headers", {})
+        request_id = echoed.get("x-request-id", "")
+        assert request_id == custom_id, (
+            f"Expected x-request-id to be preserved as {custom_id!r}, got: {request_id!r}"
+        )
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+# ---------------------------------------------------------------------------
+# Test G: unknown transform plugin does not block the pipeline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_transform_does_not_block_pipeline(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """An unresolvable transform plugin is logged and skipped — the request succeeds."""
+    _ = mock_upstream
+    alias = unique_alias("xform-unknown")
+    fake_plugin = "gts.x.core.oagw.transform_plugin.v1~x.core.oagw.nonexistent.v1"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            plugins={
+                "sharing": "private",
+                "items": [
+                    {"plugin_ref": fake_plugin, "config": {}},
+                ],
+            },
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid, ["POST"], "/echo",
+        )
+
+        resp = await client.post(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/echo",
+            headers={**oagw_headers, "content-type": "application/json"},
+            json={"transform": "unknown-plugin"},
+        )
+        assert resp.status_code == 200, (
+            f"Expected 200 (unknown transform should be skipped), "
+            f"got {resp.status_code}: {resp.text[:500]}"
+        )
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guard and Transform plugin frameworks (including a Required Headers guard and Request-ID transform)
  * Per-plugin configuration via plugin binding objects and runtime plugin registries
  * Plugin execution wired into the data plane (request/response/error phases)
  * Header conversion utilities for proxy header handling
  * New GuardRejected error path surfaced for guard rejections

* **Tests**
  * Expanded unit, integration, and end-to-end tests for plugins, types, and catalog counts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->