### PR TITLE
feat(mini-chat) - allow CSV and octet-stream uploads via MIME inference, dd file names into the citation titles

### DIFF
--- a/modules/mini-chat/docs/DESIGN.md
+++ b/modules/mini-chat/docs/DESIGN.md
@@ -926,7 +926,7 @@ data: {"items": [{"source": "file", "title": "Q3 Report.pdf", "attachment_id": "
 | Field | Type | Description |
 |-------|------|-------------|
 | `items[].source` | `"file"` \| `"web"` | Citation source type. |
-| `items[].title` | string | Document or page title. |
+| `items[].title` | string | Citation title. For file citations (`source="file"`), contains the original uploaded filename (e.g. `"Q3_Report.pdf"`). For web citations (`source="web"`), contains the page title. |
 | `items[].url` | string (optional) | URL for web sources. |
 | `items[].attachment_id` | UUID (optional) | Internal attachment identifier for file sources. This is the only file identifier exposed to clients. |
 | `items[].span` | object (optional) | Reserved for mapping citations to the final assistant text. If provided: `{ "start": number, "end": number }` character offsets into the full assistant output. |
@@ -2992,21 +2992,21 @@ Retrieved file search excerpts are integrated into the prompt as follows:
 5. Retrieved chunks are subject to the token budget truncation rules in Context Plan Assembly: thread summary and system prompt always have higher priority; retrieval excerpts are truncated first when the budget is exceeded.
 6. Maximum retrieved chunks per turn and maximum retrieved tokens per turn are configurable (see RAG defaults below).
 
-#### Citation File ID Resolution
+#### Citation File ID and Title Resolution
 
-File citations returned by the provider include a provider-specific file identifier (`provider_file_id`) in the annotation payload. Before constructing the client-visible citation object, the backend MUST resolve this provider identifier to the internal `attachment_id` used by the Mini Chat system.
+File citations returned by the provider include a provider-specific file identifier (`provider_file_id`) in the annotation payload. Before constructing the client-visible citation object, the backend MUST resolve this provider identifier to the internal `attachment_id` and populate the `title` field with the original uploaded `filename` from the `attachments` table.
 
 Resolution is performed by a lookup in the `attachments` table:
 
 ```
-(chat_id, provider_file_id) → attachment_id
+(chat_id, provider_file_id) → (attachment_id, filename)
 ```
 
-The lookup MUST be restricted to the current `chat_id` to preserve tenant and chat isolation. Raw `provider_file_id` values MUST NOT be exposed in API responses. The citation payload returned to the client MUST contain the internal `attachment_id` only.
+The lookup MUST be restricted to the current `chat_id` to preserve tenant and chat isolation. Raw `provider_file_id` values MUST NOT be exposed in API responses. The citation payload returned to the client MUST contain the internal `attachment_id` and the human-readable `filename` as the citation `title`.
 
 **Citation resolution rules**:
 
-1. If a matching attachment row is found and the attachment is not soft-deleted (`deleted_at IS NULL`), the citation MUST include the corresponding `attachment_id`.
+1. If a matching attachment row is found and the attachment is not soft-deleted (`deleted_at IS NULL`), the citation MUST include the corresponding `attachment_id` and set `title` to the attachment's `filename`.
 2. If no matching attachment is found (e.g., provider returns an unknown file ID), the citation MUST be omitted from the `citations` event. The backend MUST NOT expose the raw `provider_file_id` to the client.
 3. If the attachment exists but is soft-deleted (`deleted_at IS NOT NULL`), the citation MUST be omitted. The raw provider identifier MUST NOT be returned.
 4. The `attachments` table MUST maintain an index on `(chat_id, provider_file_id)` to ensure deterministic and efficient lookup.

--- a/modules/mini-chat/docs/openapi.json
+++ b/modules/mini-chat/docs/openapi.json
@@ -261,7 +261,7 @@
         "operationId": "sendMessage",
         "tags": ["messages"],
         "summary": "Send message and receive streamed AI response",
-        "description": "Sends a user message and opens an SSE stream for the assistant response. If `request_id` matches an active generation, returns 409 Conflict (JSON, no SSE). If `request_id` matches a completed generation, replays the response as SSE (side-effect-free: no new quota reserve, no billing events).\n\nThe optional `web_search` parameter enables web search for this turn (disabled by default, backward compatible).\n\n**Attachment fields**: `attachment_ids` identifies attachments explicitly attached to this message (persisted into `message_attachments`, returned in message `attachments[]`; images included in multimodal input for the current turn). In P1, retrieval always covers all documents in the chat vector store — `attachment_ids` does not scope or filter retrieval. `file_search` is only included when the chat has at least one ready document attachment.\n\n**SSE event ordering (P1)**: `ping* (delta | tool)* citations? (done | error)`. `delta` and `tool` may interleave; at most one `citations` event, emitted after all `delta` events and before the terminal event.\n\nExactly one terminal event (`done` or `error`) ends the stream.\n\n**SSE event types and payloads**:\n- `event: ping` — keepalive, payload: `{}`. Clients MUST ignore.\n- `event: delta` — incremental text. Payload: `SseDeltaEvent`.\n- `event: tool` — tool activity (file_search, web_search at P1). Payload: `SseToolEvent`.\n- `event: citations` — source references (file and web). Payload: `SseCitationsEvent`.\n- `event: done` — terminal success with usage and quota_decision. Emitted for both full completions and truncated-but-successful completions (provider `response.incomplete`). Payload: `SseDoneEvent`.\n- `event: error` — terminal failure. Payload: `SseErrorEvent`.\n\nSee component schemas for payload definitions.\n\n**Pre-stream errors**: If validation, authorization, or quota preflight fails before streaming, a JSON error response with the appropriate HTTP status is returned and no SSE stream is opened.\n\n**Cancellation**: If the client disconnects mid-stream, the server cancels the in-flight provider request and applies a bounded best-effort debit for quota. No SSE error event is emitted (the stream is already broken). The Turn Status API is authoritative for final state after disconnect.",
+        "description": "Sends a user message and opens an SSE stream for the assistant response. If `request_id` matches an active generation, returns 409 Conflict (JSON, no SSE). If `request_id` matches a completed generation, replays the response as SSE (side-effect-free: no new quota reserve, no billing events).\n\nThe optional `web_search` parameter enables web search for this turn (disabled by default, backward compatible).\n\n**Attachment fields**: `attachment_ids` identifies attachments explicitly attached to this message (persisted into `message_attachments`, returned in message `attachments[]`; images included in multimodal input for the current turn). In P1, retrieval always covers all documents in the chat vector store — `attachment_ids` does not scope or filter retrieval. `file_search` is only included when the chat has at least one ready document attachment.\n\n**SSE event ordering**: `turn_started ping* (delta | tool)* citations? (done | error)`. `delta` and `tool` may interleave; at most one `citations` event, emitted after all `delta` events and before the terminal event.\n\nExactly one terminal event (`done` or `error`) ends the stream.\n\n**SSE event types and payloads**:\n- `event: turn_started` — first event, carries `request_id`. Payload: `SseTurnStartedEvent`.\n- `event: ping` — keepalive, payload: `{}`. Clients MUST ignore.\n- `event: delta` — incremental text. Payload: `SseDeltaEvent`.\n- `event: tool` — tool activity (file_search, web_search at P1). Payload: `SseToolEvent`.\n- `event: citations` — source references (file and web). Payload: `SseCitationsEvent`.\n- `event: done` — terminal success with usage and quota_decision. Emitted for both full completions and truncated-but-successful completions (provider `response.incomplete`). Payload: `SseDoneEvent`.\n- `event: error` — terminal failure. Payload: `SseErrorEvent`.\n\nSee component schemas for payload definitions.\n\n**Pre-stream errors**: If validation, authorization, or quota preflight fails before streaming, a JSON error response with the appropriate HTTP status is returned and no SSE stream is opened.\n\n**Cancellation**: If the client disconnects mid-stream, the server cancels the in-flight provider request and applies a bounded best-effort debit for quota. No SSE error event is emitted (the stream is already broken). The Turn Status API is authoritative for final state after disconnect.",
         "requestBody": {
           "required": true,
           "content": {
@@ -298,8 +298,9 @@
             "content": {
               "text/event-stream": {
                 "schema": {
-                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering (P1): `ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
+                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `turn_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
                   "oneOf": [
+                    { "$ref": "#/components/schemas/SseTurnStartedEvent" },
                     { "$ref": "#/components/schemas/SseDeltaEvent" },
                     { "$ref": "#/components/schemas/SseToolEvent" },
                     { "$ref": "#/components/schemas/SseCitationsEvent" },
@@ -419,7 +420,7 @@
         "operationId": "uploadAttachment",
         "tags": ["attachments"],
         "summary": "Upload a document or image to a chat",
-        "description": "Uploads a file as an attachment. MIME type determines `kind`: `image/png`, `image/jpeg`, `image/webp` produce `image` attachments; all other supported types produce `document` attachments. Documents are indexed in the chat's dedicated vector store and optionally summarized. Images are stored via the provider Files API but NOT indexed in vector stores. Returns immediately with `status: pending`; transitions to `ready` or `failed` asynchronously.",
+        "description": "Uploads a file as an attachment. MIME type determines `kind`: `image/png`, `image/jpeg`, `image/webp` produce `image` attachments; all other supported types produce `document` attachments. Documents are indexed in the chat's dedicated vector store and optionally summarized. Images are stored via the provider Files API but NOT indexed in vector stores. Returns immediately with `status: pending`; transitions to `ready` or `failed` asynchronously.\n\n**MIME inference**: When the browser sends `application/octet-stream` (common for `.md` and other text files), the server infers the actual MIME type from the file extension. Supported extensions include `.pdf`, `.md`, `.txt`, `.html`, `.docx`, `.pptx`, `.json`, `.csv`, and others.\n\n**CSV support**: `text/csv` files are accepted and internally remapped to `text/plain` for indexing compatibility. This behavior is controlled by server configuration (`allow_csv_upload`, default: true).",
         "requestBody": {
           "required": true,
           "content": {
@@ -789,8 +790,9 @@
             "content": {
               "text/event-stream": {
                 "schema": {
-                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering (P1): `ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
+                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `turn_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
                   "oneOf": [
+                    { "$ref": "#/components/schemas/SseTurnStartedEvent" },
                     { "$ref": "#/components/schemas/SseDeltaEvent" },
                     { "$ref": "#/components/schemas/SseToolEvent" },
                     { "$ref": "#/components/schemas/SseCitationsEvent" },
@@ -950,8 +952,9 @@
             "content": {
               "text/event-stream": {
                 "schema": {
-                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering (P1): `ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
+                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `turn_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
                   "oneOf": [
+                    { "$ref": "#/components/schemas/SseTurnStartedEvent" },
                     { "$ref": "#/components/schemas/SseDeltaEvent" },
                     { "$ref": "#/components/schemas/SseToolEvent" },
                     { "$ref": "#/components/schemas/SseCitationsEvent" },
@@ -1671,6 +1674,18 @@
           }
         }
       },
+      "SseTurnStartedEvent": {
+        "type": "object",
+        "required": ["request_id"],
+        "description": "SSE `event: turn_started` payload. First event in the stream, emitted exactly once. Carries the server-assigned request_id for correlation.",
+        "properties": {
+          "request_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Server-assigned request ID for this turn."
+          }
+        }
+      },
       "SseDeltaEvent": {
         "type": "object",
         "required": ["type", "content"],
@@ -1737,7 +1752,8 @@
             "description": "Citation source type. P1: \"file\" and \"web\" (when web search is enabled)."
           },
           "title": {
-            "type": "string"
+            "type": "string",
+            "description": "Citation title. For file citations (source=\"file\"), contains the original uploaded filename (e.g. \"Q3_Report.pdf\"). For web citations (source=\"web\"), contains the page title."
           },
           "url": {
             "type": "string",

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -658,6 +658,10 @@ pub struct RagConfig {
     /// Maximum single image file size in KB.
     #[serde(default = "default_max_image_size_kb")]
     pub max_image_size_kb: u32,
+
+    /// Accept `text/csv` uploads remapped to `text/plain` for `file_search`.
+    #[serde(default = "default_true")]
+    pub allow_csv_upload: bool,
 }
 
 impl Default for RagConfig {
@@ -667,6 +671,7 @@ impl Default for RagConfig {
             max_total_upload_mb_per_chat: default_max_total_upload_mb_per_chat(),
             max_document_size_kb: default_max_document_size_kb(),
             max_image_size_kb: default_max_image_size_kb(),
+            allow_csv_upload: true,
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/citation_mapping.rs
+++ b/modules/mini-chat/mini-chat/src/domain/citation_mapping.rs
@@ -5,19 +5,18 @@
 
 use std::collections::HashMap;
 
-use uuid::Uuid;
+use crate::domain::llm::{AttachmentRef, Citation, CitationSource};
 
-use crate::domain::llm::{Citation, CitationSource};
-
-/// Map provider `file_ids` in citations to internal attachment UUIDs.
+/// Map provider `file_ids` in citations to internal attachment UUIDs and filenames.
 ///
 /// - **Web citations**: pass through unchanged.
 /// - **File citations** with `attachment_id: None` (malformed): dropped with warning.
 /// - **File citations** with unknown `file_id` (not in map): dropped with warning.
-/// - **File citations** with known `file_id`: `attachment_id` replaced with UUID string.
+/// - **File citations** with known `file_id`: `attachment_id` replaced with UUID string,
+///   `title` replaced with the DB filename.
 pub fn map_citation_ids<S: ::std::hash::BuildHasher>(
     citations: Vec<Citation>,
-    provider_file_id_map: &HashMap<String, Uuid, S>,
+    provider_file_id_map: &HashMap<String, AttachmentRef, S>,
 ) -> Vec<Citation> {
     let total = citations.len();
     let mapped: Vec<Citation> = citations
@@ -26,11 +25,12 @@ pub fn map_citation_ids<S: ::std::hash::BuildHasher>(
             CitationSource::Web => Some(c),
             CitationSource::File => {
                 let file_id = if let Some(id) = &c.attachment_id { id.clone() } else {
-                    tracing::warn!("malformed file citation: attachment_id is None");
+                    tracing::warn!(title = %c.title, "malformed file citation: attachment_id is None");
                     return None;
                 };
-                if let Some(uuid) = provider_file_id_map.get(&file_id) {
-                    c.attachment_id = Some(uuid.to_string());
+                if let Some(att) = provider_file_id_map.get(&file_id) {
+                    c.attachment_id = Some(att.id.to_string());
+                    c.title.clone_from(&att.filename);
                     Some(c)
                 } else {
                     tracing::warn!(file_id = %file_id, "unmapped file_id in citation (soft-deleted or unknown)");
@@ -56,6 +56,7 @@ pub fn map_citation_ids<S: ::std::hash::BuildHasher>(
 mod tests {
     use super::*;
     use crate::domain::llm::TextSpan;
+    use uuid::Uuid;
 
     fn file_citation(file_id: Option<&str>) -> Citation {
         Citation {
@@ -84,15 +85,22 @@ mod tests {
     #[test]
     fn known_mapping() {
         let uuid = Uuid::nil();
-        let map = HashMap::from([("file-abc".into(), uuid)]);
+        let map = HashMap::from([(
+            "file-abc".into(),
+            AttachmentRef {
+                id: uuid,
+                filename: "report.pdf".into(),
+            },
+        )]);
         let result = map_citation_ids(vec![file_citation(Some("file-abc"))], &map);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].attachment_id.as_deref(), Some(&*uuid.to_string()));
+        assert_eq!(result[0].title, "report.pdf");
     }
 
     #[test]
     fn unknown_dropped() {
-        let map = HashMap::new();
+        let map: HashMap<String, AttachmentRef> = HashMap::new();
         let result = map_citation_ids(vec![file_citation(Some("file-unknown"))], &map);
         assert!(result.is_empty());
     }
@@ -100,7 +108,13 @@ mod tests {
     #[test]
     fn soft_deleted_dropped() {
         // If file was soft-deleted, it's not in the map
-        let map = HashMap::from([("file-abc".into(), Uuid::nil())]);
+        let map = HashMap::from([(
+            "file-abc".into(),
+            AttachmentRef {
+                id: Uuid::nil(),
+                filename: "test.pdf".into(),
+            },
+        )]);
         let result = map_citation_ids(vec![file_citation(Some("file-other"))], &map);
         assert!(result.is_empty());
     }
@@ -115,13 +129,20 @@ mod tests {
 
     #[test]
     fn empty_map() {
-        let result = map_citation_ids(vec![file_citation(Some("file-x"))], &HashMap::new());
+        let map: HashMap<String, AttachmentRef> = HashMap::new();
+        let result = map_citation_ids(vec![file_citation(Some("file-x"))], &map);
         assert!(result.is_empty());
     }
 
     #[test]
     fn malformed_none_file_id() {
-        let map = HashMap::from([("file-abc".into(), Uuid::nil())]);
+        let map = HashMap::from([(
+            "file-abc".into(),
+            AttachmentRef {
+                id: Uuid::nil(),
+                filename: "test.pdf".into(),
+            },
+        )]);
         let result = map_citation_ids(vec![file_citation(None)], &map);
         assert!(result.is_empty());
     }
@@ -129,7 +150,13 @@ mod tests {
     #[test]
     fn mixed_citations_partial_mapping() {
         let uuid = Uuid::nil();
-        let map = HashMap::from([("file-known".into(), uuid)]);
+        let map = HashMap::from([(
+            "file-known".into(),
+            AttachmentRef {
+                id: uuid,
+                filename: "known.pdf".into(),
+            },
+        )]);
         let citations = vec![
             file_citation(Some("file-known")),
             file_citation(Some("file-unknown")),
@@ -140,6 +167,7 @@ mod tests {
         assert_eq!(result.len(), 2); // known file + web
         assert!(matches!(result[0].source, CitationSource::File));
         assert_eq!(result[0].attachment_id.as_deref(), Some(&*uuid.to_string()));
+        assert_eq!(result[0].title, "known.pdf");
         assert!(matches!(result[1].source, CitationSource::Web));
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/llm.rs
+++ b/modules/mini-chat/mini-chat/src/domain/llm.rs
@@ -7,6 +7,7 @@
 use modkit_macros::domain_model;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 // ════════════════════════════════════════════════════════════════════════════
 // Message types
@@ -188,6 +189,13 @@ pub enum CitationSource {
 pub struct TextSpan {
     pub start: usize,
     pub end: usize,
+}
+
+/// Resolved attachment identity returned by [`build_provider_file_id_map`].
+#[derive(Debug, Clone)]
+pub struct AttachmentRef {
+    pub id: Uuid,
+    pub filename: String,
 }
 
 /// Lifecycle phase of a tool invocation within a stream.

--- a/modules/mini-chat/mini-chat/src/domain/llm.rs
+++ b/modules/mini-chat/mini-chat/src/domain/llm.rs
@@ -192,6 +192,7 @@ pub struct TextSpan {
 }
 
 /// Resolved attachment identity returned by [`build_provider_file_id_map`].
+#[domain_model]
 #[derive(Debug, Clone)]
 pub struct AttachmentRef {
     pub id: Uuid,

--- a/modules/mini-chat/mini-chat/src/domain/mime_validation.rs
+++ b/modules/mini-chat/mini-chat/src/domain/mime_validation.rs
@@ -28,6 +28,16 @@ pub struct ValidatedMime {
     pub kind: AttachmentKind,
 }
 
+/// Strip charset and other parameters: `text/plain; charset=utf-8` → `text/plain`.
+pub(crate) fn normalize_mime(content_type: &str) -> String {
+    content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim()
+        .to_ascii_lowercase()
+}
+
 /// MIME allowlist: 20 types (19 from spec + image/gif per spec:64).
 ///
 /// Strips charset parameters (e.g., `text/plain; charset=utf-8` → `text/plain`).
@@ -35,13 +45,7 @@ pub struct ValidatedMime {
 ///
 /// Returns the canonical MIME string and the attachment kind (Document or Image).
 pub fn validate_mime(content_type: &str) -> Result<ValidatedMime, DomainError> {
-    // Strip charset and other parameters: take only the media type before `;`
-    let mime = content_type
-        .split(';')
-        .next()
-        .unwrap_or(content_type)
-        .trim()
-        .to_ascii_lowercase();
+    let mime = normalize_mime(content_type);
 
     match mime.as_str() {
         // Document types (16)
@@ -131,6 +135,50 @@ pub fn validate_mime(content_type: &str) -> Result<ValidatedMime, DomainError> {
             kind: AttachmentKind::Image,
         }),
         _ => Err(DomainError::UnsupportedFileType { mime: mime.clone() }),
+    }
+}
+
+/// Infer MIME type from filename extension when the client sends an unhelpful
+/// Content-Type (e.g. `application/octet-stream`). Returns `None` if the
+/// extension is unknown — the caller should keep the original Content-Type.
+#[must_use]
+pub fn infer_mime_from_extension(filename: &str) -> Option<&'static str> {
+    let (_, ext_raw) = filename.rsplit_once('.')?;
+    let ext = ext_raw.to_ascii_lowercase();
+    match ext.as_str() {
+        "pdf" => Some("application/pdf"),
+        "txt" => Some("text/plain"),
+        "md" | "markdown" => Some("text/markdown"),
+        "html" | "htm" => Some("text/html"),
+        "json" => Some("application/json"),
+        "docx" => Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        "pptx" => Some("application/vnd.openxmlformats-officedocument.presentationml.presentation"),
+        "py" => Some("text/x-python"),
+        "java" => Some("text/x-java"),
+        "js" | "mjs" => Some("text/javascript"),
+        "ts" | "mts" => Some("text/typescript"),
+        "rs" => Some("text/x-rust"),
+        "go" => Some("text/x-go"),
+        "cs" => Some("text/x-csharp"),
+        "rb" => Some("text/x-ruby"),
+        "sql" => Some("text/x-sql"),
+        "csv" => Some("text/csv"),
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "webp" => Some("image/webp"),
+        "gif" => Some("image/gif"),
+        _ => None,
+    }
+}
+
+/// Remap `text/csv` to `text/plain` so it passes [`validate_mime`] and is indexed
+/// as plain text by the provider. Returns `None` for non-CSV content types.
+#[must_use]
+pub fn remap_csv_to_plain(content_type: &str) -> Option<&'static str> {
+    if normalize_mime(content_type) == "text/csv" {
+        Some("text/plain")
+    } else {
+        None
     }
 }
 
@@ -282,6 +330,7 @@ mod tests {
         assert!(validate_mime("video/mp4").is_err());
         assert!(validate_mime("audio/mpeg").is_err());
         assert!(validate_mime("application/zip").is_err());
+        // CSV is only accepted via remap_csv_to_plain; validate_mime alone rejects it.
         assert!(validate_mime("text/csv").is_err());
     }
 
@@ -307,6 +356,82 @@ mod tests {
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("pdf"))
         );
         assert!(name.contains('_'));
+    }
+
+    #[test]
+    fn infer_md_from_extension() {
+        assert_eq!(
+            infer_mime_from_extension("readme.md"),
+            Some("text/markdown")
+        );
+        assert_eq!(infer_mime_from_extension("NOTES.MD"), Some("text/markdown"));
+        assert_eq!(
+            infer_mime_from_extension("doc.markdown"),
+            Some("text/markdown")
+        );
+    }
+
+    #[test]
+    fn infer_csv_from_extension() {
+        assert_eq!(infer_mime_from_extension("data.csv"), Some("text/csv"));
+    }
+
+    #[test]
+    fn infer_common_extensions() {
+        assert_eq!(
+            infer_mime_from_extension("file.pdf"),
+            Some("application/pdf")
+        );
+        assert_eq!(infer_mime_from_extension("code.rs"), Some("text/x-rust"));
+        assert_eq!(infer_mime_from_extension("photo.jpg"), Some("image/jpeg"));
+        assert_eq!(infer_mime_from_extension("photo.jpeg"), Some("image/jpeg"));
+        assert_eq!(infer_mime_from_extension("app.ts"), Some("text/typescript"));
+        assert_eq!(
+            infer_mime_from_extension("app.mts"),
+            Some("text/typescript")
+        );
+    }
+
+    #[test]
+    fn infer_unknown_extension_returns_none() {
+        assert_eq!(infer_mime_from_extension("archive.zip"), None);
+        assert_eq!(infer_mime_from_extension("video.mp4"), None);
+        assert_eq!(infer_mime_from_extension("noext"), None);
+        // Dotless filename that coincides with a known extension must not match.
+        assert_eq!(infer_mime_from_extension("md"), None);
+        assert_eq!(infer_mime_from_extension("pdf"), None);
+    }
+
+    #[test]
+    fn infer_then_validate_md() {
+        let mime = infer_mime_from_extension("readme.md").unwrap();
+        let result = validate_mime(mime).unwrap();
+        assert_eq!(result.mime, "text/markdown");
+        assert!(matches!(result.kind, AttachmentKind::Document));
+    }
+
+    #[test]
+    fn csv_remapped_to_plain() {
+        assert_eq!(remap_csv_to_plain("text/csv"), Some("text/plain"));
+        assert_eq!(
+            remap_csv_to_plain("text/csv; charset=utf-8"),
+            Some("text/plain")
+        );
+        assert_eq!(remap_csv_to_plain("TEXT/CSV"), Some("text/plain"));
+    }
+
+    #[test]
+    fn remap_csv_ignores_non_csv() {
+        assert_eq!(remap_csv_to_plain("text/plain"), None);
+        assert_eq!(remap_csv_to_plain("application/pdf"), None);
+    }
+
+    #[test]
+    fn csv_after_remap_passes_validation() {
+        let remapped = remap_csv_to_plain("text/csv").unwrap();
+        let result = validate_mime(remapped).unwrap();
+        assert_eq!(result.mime, "text/plain");
+        assert!(matches!(result.kind, AttachmentKind::Document));
     }
 
     #[test]

--- a/modules/mini-chat/mini-chat/src/domain/repos/attachment_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/attachment_repo.rs
@@ -7,6 +7,7 @@ use modkit_security::AccessScope;
 use uuid::Uuid;
 
 use crate::domain::error::DomainError;
+use crate::domain::llm::AttachmentRef;
 use crate::infra::db::entity::attachment::Model as AttachmentModel;
 
 /// Parameters for inserting a new attachment row in `pending` status.
@@ -114,5 +115,5 @@ pub trait AttachmentRepository: Send + Sync {
         runner: &C,
         scope: &AccessScope,
         chat_id: Uuid,
-    ) -> Result<HashMap<String, Uuid>, DomainError>;
+    ) -> Result<HashMap<String, AttachmentRef>, DomainError>;
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
@@ -487,14 +487,40 @@ impl<
         content_type: &str,
         file_bytes: Bytes,
     ) -> Result<AttachmentModel, DomainError> {
-        use crate::domain::mime_validation::{structured_filename, validate_mime};
+        use crate::domain::mime_validation::{
+            infer_mime_from_extension, normalize_mime, remap_csv_to_plain, structured_filename,
+            validate_mime,
+        };
         use crate::domain::repos::InsertAttachmentParams;
 
         let tenant_id = ctx.subject_tenant_id();
         let user_id = ctx.subject_id();
 
         // 1. MIME validate
-        let validated = validate_mime(content_type)?;
+        // Step A: infer from extension when client sends octet-stream
+        let effective_ct = if normalize_mime(content_type) == "application/octet-stream"
+            && let Some(inferred) = infer_mime_from_extension(&filename)
+        {
+            tracing::debug!(
+                original = %content_type,
+                inferred,
+                filename = %filename,
+                "MIME inferred from file extension (client sent octet-stream)"
+            );
+            inferred
+        } else {
+            content_type
+        };
+        // Step B: remap CSV → text/plain when allowed
+        let effective_ct = if self.rag_config.allow_csv_upload
+            && let Some(remapped) = remap_csv_to_plain(effective_ct)
+        {
+            tracing::debug!(original = %effective_ct, remapped, "CSV content-type remapped to text/plain");
+            remapped
+        } else {
+            effective_ct
+        };
+        let validated = validate_mime(effective_ct)?;
         let is_document = validated.kind == AttachmentKind::Document;
 
         #[allow(clippy::cast_possible_wrap)]

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service_test.rs
@@ -1485,7 +1485,9 @@ async fn test_provider_file_id_map_excludes_non_ready() {
         .unwrap();
 
     assert_eq!(map.len(), 1, "only ready attachment should be in map");
-    assert_eq!(map.get("file-ready"), Some(&ready_id));
+    let att = map.get("file-ready").expect("file-ready should be in map");
+    assert_eq!(att.id, ready_id);
+    assert_eq!(att.filename, "test.pdf");
 }
 
 // ── P5-K8: build_provider_file_id_map excludes soft-deleted ──
@@ -1530,7 +1532,8 @@ async fn test_provider_file_id_map_excludes_deleted() {
         .unwrap();
 
     assert_eq!(map.len(), 1, "deleted attachment should not be in map");
-    assert_eq!(map.get("file-alive"), Some(&alive_id));
+    let att = map.get("file-alive").expect("file-alive should be in map");
+    assert_eq!(att.id, alive_id);
     assert!(!map.contains_key("file-deleted"));
 }
 

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -1402,7 +1402,7 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
     cancel: CancellationToken,
     tx: mpsc::Sender<StreamEvent>,
     fin_ctx: Option<FinalizationCtx<TR, MR>>,
-    provider_file_id_map: std::collections::HashMap<String, Uuid>,
+    provider_file_id_map: std::collections::HashMap<String, crate::domain::llm::AttachmentRef>,
 ) -> tokio::task::JoinHandle<StreamOutcome> {
     let span = if let Some(ref fctx) = fin_ctx {
         tracing::info_span!(

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/attachment_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/attachment_repo.rs
@@ -11,6 +11,7 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::domain::error::DomainError;
+use crate::domain::llm::AttachmentRef;
 use crate::domain::repos::{
     InsertAttachmentParams, SetFailedParams, SetReadyParams, SetUploadedParams,
 };
@@ -313,11 +314,12 @@ impl crate::domain::repos::AttachmentRepository for AttachmentRepository {
         runner: &C,
         scope: &AccessScope,
         chat_id: Uuid,
-    ) -> Result<HashMap<String, Uuid>, DomainError> {
+    ) -> Result<HashMap<String, AttachmentRef>, DomainError> {
         #[derive(Debug, FromQueryResult)]
         struct FileIdRow {
             id: Uuid,
             provider_file_id: String,
+            filename: String,
         }
 
         let rows: Vec<FileIdRow> = Entity::find()
@@ -334,13 +336,22 @@ impl crate::domain::repos::AttachmentRepository for AttachmentRepository {
                 q.select_only()
                     .column(Column::Id)
                     .column(Column::ProviderFileId)
+                    .column(Column::Filename)
                     .into_model::<FileIdRow>()
             })
             .await
             .map_err(db_err)?;
         Ok(rows
             .into_iter()
-            .map(|r| (r.provider_file_id, r.id))
+            .map(|r| {
+                (
+                    r.provider_file_id,
+                    AttachmentRef {
+                        id: r.id,
+                        filename: r.filename,
+                    },
+                )
+            })
             .collect())
     }
 }


### PR DESCRIPTION
- add file names into the citation titles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Citations for known attachments now surface resolved filenames in the client payload.
  * Streaming now emits an initial turn_started event carrying a request_id.
  * MIME inference from file extensions and optional CSV→text/plain remapping (enabled by config).

* **Bug Fixes**
  * Malformed file citations log clearer warnings including the citation title.
  * Unknown/unmapped file references are dropped and logged.

* **Documentation**
  * API and docs updated to reflect title semantics and the new turn_started SSE event.

* **Tests**
  * Expanded tests covering filename propagation, CSV remapping, and citation resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->