### PR TITLE
feat(mini-chat): add OData $filter with contains(title) for GET /v1/chats

### DIFF
--- a/modules/mini-chat/docs/openapi.json
+++ b/modules/mini-chat/docs/openapi.json
@@ -100,13 +100,16 @@
         "operationId": "listChats",
         "tags": ["chats"],
         "summary": "List chats for the current user",
-        "description": "Returns chats for the authenticated user ordered by most recent activity (`updated_at` DESC, `id` DESC tiebreaker). Supports cursor-based pagination via `limit` and `cursor` parameters.",
+        "description": "Returns chats for the authenticated user ordered by most recent activity (`updated_at` DESC, `id` DESC tiebreaker). Supports cursor-based pagination via `limit` and `cursor` parameters.\n\n**OData support**:\n- `$filter`: `title` — string functions `contains(title, '...')`, `startswith(title, '...')`, `endswith(title, '...')`; comparison operators `eq`, `ne`. Also supports `updated_at` (eq, ne, gt, ge, lt, le) and `id` (eq, ne).",
         "parameters": [
           {
             "$ref": "#/components/parameters/PaginationLimit"
           },
           {
             "$ref": "#/components/parameters/PaginationCursor"
+          },
+          {
+            "$ref": "#/components/parameters/ODataFilter"
           }
         ],
         "responses": {
@@ -522,16 +525,13 @@
         "operationId": "listMessages",
         "tags": ["messages"],
         "summary": "List messages with cursor pagination",
-        "description": "Returns paginated messages for a chat using cursor-based pagination with OData query support. Default ordering is `created_at asc` (chronological). Use `$orderby`, `$filter`, and `$select` for advanced queries.\n\n**OData support**:\n- `$orderby`: `created_at asc|desc`, `id asc|desc`\n- `$filter`: `created_at` (eq, ne, gt, ge, lt, le), `role` (eq, ne, in), `id` (eq, ne, in)\n- `$select`: any top-level field (including `attachments`)",
+        "description": "Returns paginated messages for a chat using cursor-based pagination with OData query support. Default ordering is `created_at asc` (chronological). Use `$orderby` and `$filter` for advanced queries.\n\n**OData support**:\n- `$orderby`: `created_at asc|desc`, `id asc|desc`\n- `$filter`: `created_at` (eq, ne, gt, ge, lt, le), `role` (eq, ne, in), `id` (eq, ne, in)",
         "parameters": [
           {
             "$ref": "#/components/parameters/PaginationLimit"
           },
           {
             "$ref": "#/components/parameters/PaginationCursor"
-          },
-          {
-            "$ref": "#/components/parameters/ODataSelect"
           },
           {
             "$ref": "#/components/parameters/ODataOrderBy"
@@ -1243,15 +1243,6 @@
         "in": "query",
         "required": false,
         "description": "Opaque cursor for fetching the next or previous page.",
-        "schema": {
-          "type": "string"
-        }
-      },
-      "ODataSelect": {
-        "name": "$select",
-        "in": "query",
-        "required": false,
-        "description": "OData v4 field projection. Comma-separated list of top-level fields. Case-insensitive.",
         "schema": {
           "type": "string"
         }

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/chats.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/chats.rs
@@ -1,9 +1,10 @@
 use axum::Router;
 use modkit::api::OpenApiRegistry;
-use modkit::api::operation_builder::OperationBuilder;
+use modkit::api::operation_builder::{OperationBuilder, OperationBuilderODataExt};
 
 use super::AiChatLicense;
 use crate::api::rest::{dto, handlers};
+use crate::infra::db::odata_mapper::ChatCursorField;
 
 pub(super) fn register_chat_routes(
     mut router: Router,
@@ -50,6 +51,7 @@ pub(super) fn register_chat_routes(
             http::StatusCode::OK,
             "Paginated list of chats",
         )
+        .with_odata_filter::<ChatCursorField>()
         .error_400(openapi)
         .error_401(openapi)
         .error_403(openapi)

--- a/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/chat_service_test.rs
@@ -1007,3 +1007,124 @@ async fn update_chat_tenant_only_authz_cross_owner_not_found() {
         "Expected ChatNotFound for cross-owner update with tenant-only authz"
     );
 }
+
+// ── Filter by title tests ──
+
+#[tokio::test]
+async fn list_chats_filter_contains_title() {
+    let db = inmem_db().await;
+    let svc = build_service(db);
+    let ctx = test_security_ctx(Uuid::new_v4());
+
+    for title in ["Q3 Financial Report", "Weekly Standup", "Report Draft"] {
+        svc.create_chat(
+            &ctx,
+            NewChat {
+                model: Some("gpt-5.2".to_owned()),
+                title: Some(title.to_owned()),
+                is_temporary: false,
+            },
+        )
+        .await
+        .expect("create failed");
+    }
+
+    // contains(title, 'Report') should match 2 chats
+    let filter = modkit_odata::ast::Expr::Function(
+        "contains".to_owned(),
+        vec![
+            modkit_odata::ast::Expr::Identifier("title".to_owned()),
+            modkit_odata::ast::Expr::Value(modkit_odata::ast::Value::String("Report".to_owned())),
+        ],
+    );
+    let query = ODataQuery::default().with_filter(filter);
+    let page = svc.list_chats(&ctx, &query).await.expect("list failed");
+
+    assert_eq!(page.items.len(), 2, "Expected 2 chats matching 'Report'");
+    assert!(
+        page.items
+            .iter()
+            .all(|c| c.title.as_deref().unwrap_or("").contains("Report")),
+        "All results must contain 'Report' in title"
+    );
+}
+
+#[tokio::test]
+async fn list_chats_filter_contains_title_no_match() {
+    let db = inmem_db().await;
+    let svc = build_service(db);
+    let ctx = test_security_ctx(Uuid::new_v4());
+
+    svc.create_chat(
+        &ctx,
+        NewChat {
+            model: Some("gpt-5.2".to_owned()),
+            title: Some("Weekly Standup".to_owned()),
+            is_temporary: false,
+        },
+    )
+    .await
+    .expect("create failed");
+
+    let filter = modkit_odata::ast::Expr::Function(
+        "contains".to_owned(),
+        vec![
+            modkit_odata::ast::Expr::Identifier("title".to_owned()),
+            modkit_odata::ast::Expr::Value(modkit_odata::ast::Value::String(
+                "xyz_nonexistent".to_owned(),
+            )),
+        ],
+    );
+    let query = ODataQuery::default().with_filter(filter);
+    let page = svc.list_chats(&ctx, &query).await.expect("list failed");
+
+    assert_eq!(page.items.len(), 0, "No chats should match");
+}
+
+#[tokio::test]
+async fn list_chats_filter_contains_title_excludes_null_titles() {
+    let db = inmem_db().await;
+    let svc = build_service(db);
+    let ctx = test_security_ctx(Uuid::new_v4());
+
+    // Chat with title
+    svc.create_chat(
+        &ctx,
+        NewChat {
+            model: Some("gpt-5.2".to_owned()),
+            title: Some("Q3 Report".to_owned()),
+            is_temporary: false,
+        },
+    )
+    .await
+    .expect("create failed");
+
+    // Chat without title (NULL)
+    svc.create_chat(
+        &ctx,
+        NewChat {
+            model: Some("gpt-5.2".to_owned()),
+            title: None,
+            is_temporary: false,
+        },
+    )
+    .await
+    .expect("create failed");
+
+    let filter = modkit_odata::ast::Expr::Function(
+        "contains".to_owned(),
+        vec![
+            modkit_odata::ast::Expr::Identifier("title".to_owned()),
+            modkit_odata::ast::Expr::Value(modkit_odata::ast::Value::String("Report".to_owned())),
+        ],
+    );
+    let query = ODataQuery::default().with_filter(filter);
+    let page = svc.list_chats(&ctx, &query).await.expect("list failed");
+
+    assert_eq!(page.items.len(), 1, "Only the titled chat should match");
+    assert_eq!(
+        page.items[0].title.as_deref(),
+        Some("Q3 Report"),
+        "Matched chat must be the one with title"
+    );
+}

--- a/modules/mini-chat/mini-chat/src/infra/db/odata_mapper.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/odata_mapper.rs
@@ -6,23 +6,25 @@ use crate::infra::db::entity::message::{
     Column as MsgColumn, Entity as MsgEntity, Model as MsgModel,
 };
 
-/// Cursor/sort field enum for chat pagination.
+/// Cursor/sort/filter field enum for chat pagination.
 ///
-/// P1 only supports cursor-based pagination with `updated_at DESC` + `id` tiebreaker.
-/// No user-facing $filter or $orderby is exposed.
+/// Pagination uses `updated_at DESC` + `id` tiebreaker.
+/// Filtering supports `contains(title, '...')` for chat title search.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ChatCursorField {
     UpdatedAt,
     Id,
+    Title,
 }
 
 impl FilterField for ChatCursorField {
-    const FIELDS: &'static [Self] = &[Self::UpdatedAt, Self::Id];
+    const FIELDS: &'static [Self] = &[Self::UpdatedAt, Self::Id, Self::Title];
 
     fn name(&self) -> &'static str {
         match self {
             Self::UpdatedAt => "updated_at",
             Self::Id => "id",
+            Self::Title => "title",
         }
     }
 
@@ -30,6 +32,7 @@ impl FilterField for ChatCursorField {
         match self {
             Self::UpdatedAt => FieldKind::DateTimeUtc,
             Self::Id => FieldKind::Uuid,
+            Self::Title => FieldKind::String,
         }
     }
 }
@@ -43,6 +46,7 @@ impl FieldToColumn<ChatCursorField> for ChatODataMapper {
         match field {
             ChatCursorField::UpdatedAt => Column::UpdatedAt,
             ChatCursorField::Id => Column::Id,
+            ChatCursorField::Title => Column::Title,
         }
     }
 }
@@ -56,6 +60,9 @@ impl ODataFieldMapping<ChatCursorField> for ChatODataMapper {
                 sea_orm::Value::TimeDateTimeWithTimeZone(Some(Box::new(model.updated_at)))
             }
             ChatCursorField::Id => sea_orm::Value::Uuid(Some(Box::new(model.id))),
+            ChatCursorField::Title => {
+                sea_orm::Value::String(model.title.as_ref().map(|s| Box::new(s.clone())))
+            }
         }
     }
 }


### PR DESCRIPTION
…hats

Enable title search on chat list endpoint via OData $filter expression. Supported operations: contains(), startswith(), endswith(), eq, ne for title field; comparison operators for updated_at and id.

Also removes undocumented $select from GET /v1/chats/{id}/messages (not implemented in backend).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat lists can be filtered and sorted by title using OData expressions, including substring matching for improved search.

* **Documentation**
  * API docs updated: chats endpoints now document OData $filter and $orderby support; mention of $select has been removed.

* **Tests**
  * Added tests covering title-based filtering, including contains(), no-match, and null-title exclusion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->