### PR TITLE
feat(mini-chat): soft-delete messages when turn is deleted, retried, or edited

### DIFF
--- a/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
@@ -143,6 +143,19 @@ pub trait MessageRepository: Send + Sync {
         boundary: Option<SnapshotBoundary>,
     ) -> Result<Vec<MessageModel>, DomainError>;
 
+    /// Soft-delete all messages belonging to a turn identified by `(chat_id, request_id)`.
+    ///
+    /// Sets `deleted_at = now()` on every message where `chat_id` and `request_id` match
+    /// and `deleted_at IS NULL`. Used during retry, edit, and delete mutations to ensure
+    /// old messages disappear from active conversation history.
+    async fn soft_delete_by_request_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<u64, DomainError>;
+
     /// Fetch recent messages after a thread summary boundary for context assembly.
     ///
     /// Same as [`recent_for_context`] but only returns messages with

--- a/modules/mini-chat/mini-chat/src/domain/service/replay.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/replay.rs
@@ -206,6 +206,16 @@ mod tests {
             unimplemented!()
         }
 
+        async fn soft_delete_by_request_id<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+            _: Uuid,
+        ) -> Result<u64, DomainError> {
+            unimplemented!()
+        }
+
         async fn snapshot_boundary<C: DBRunner>(
             &self,
             _: &C,

--- a/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/turn_service.rs
@@ -211,6 +211,7 @@ impl<
         let start = std::time::Instant::now();
 
         let turn_repo = Arc::clone(&self.turn_repo);
+        let message_repo = Arc::clone(&self.message_repo);
         let chat_repo = Arc::clone(&self.chat_repo);
         let scope_tx = chat_scope.clone();
         let ctx_clone = ctx.clone();
@@ -233,6 +234,10 @@ impl<
 
                     turn_repo
                         .soft_delete(tx, &scope, target.id, None)
+                        .await
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
+                    message_repo
+                        .soft_delete_by_request_id(tx, &scope, chat_id, request_id)
                         .await
                         .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
 
@@ -355,9 +360,13 @@ impl<
 
                     let user_content = override_content.unwrap_or(original_msg.content);
 
-                    // Soft-delete old turn with replacement link
+                    // Soft-delete old turn and its messages
                     turn_repo
                         .soft_delete(tx, &scope, target.id, Some(new_request_id))
+                        .await
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
+                    message_repo
+                        .soft_delete_by_request_id(tx, &scope, chat_id, request_id)
                         .await
                         .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
 

--- a/modules/mini-chat/mini-chat/src/domain/service/turn_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/turn_service_test.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use modkit_security::AccessScope;
 use uuid::Uuid;
 
-use crate::domain::repos::{ChatRepository, TurnRepository};
+use crate::domain::repos::{ChatRepository, MessageRepository, TurnRepository};
 use crate::domain::service::TurnService;
 use crate::domain::service::test_helpers::TestMetrics;
 use crate::domain::service::test_helpers::*;
@@ -453,6 +453,53 @@ async fn delete_already_deleted_turn_returns_not_latest() {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
+// 7.1b: delete soft-deletes messages alongside turn
+// ════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn delete_soft_deletes_messages_alongside_turn() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    let request_id = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        ctx.subject_id(),
+    )
+    .await;
+
+    // Before delete: messages are visible
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = svc.db.conn().unwrap();
+    let msgs_before = svc
+        .message_repo
+        .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        msgs_before.len(),
+        2,
+        "user + assistant messages should exist"
+    );
+
+    svc.delete(&ctx, chat_id, request_id).await.unwrap();
+
+    // After delete: messages are hidden (find_by_chat_and_request_id filters deleted_at IS NULL)
+    let msgs_after = svc
+        .message_repo
+        .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+        .await
+        .unwrap();
+    assert!(
+        msgs_after.is_empty(),
+        "messages should be soft-deleted after turn delete, got {} messages",
+        msgs_after.len()
+    );
+}
+
+// ════════════════════════════════════════════════════════════════════════════
 // 7.2: TurnService::retry
 // ════════════════════════════════════════════════════════════════════════════
 
@@ -496,6 +543,50 @@ async fn retry_success_returns_new_request_id_and_content() {
     assert_eq!(new_turn.state, TurnState::Running);
 }
 
+#[tokio::test]
+async fn retry_soft_deletes_old_messages_and_creates_new_user_message() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    let request_id = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        ctx.subject_id(),
+    )
+    .await;
+
+    let result = svc.retry(&ctx, chat_id, request_id).await.unwrap();
+
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = svc.db.conn().unwrap();
+
+    // Old messages should be soft-deleted
+    let old_msgs = svc
+        .message_repo
+        .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+        .await
+        .unwrap();
+    assert!(
+        old_msgs.is_empty(),
+        "old turn messages should be soft-deleted after retry"
+    );
+
+    // New user message should exist under the new request_id
+    let new_msgs = svc
+        .message_repo
+        .find_by_chat_and_request_id(&conn, &scope, chat_id, result.new_request_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        new_msgs.len(),
+        1,
+        "retry should create exactly one new user message"
+    );
+    assert_eq!(new_msgs[0].content, "Hello world");
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 // 7.3: TurnService::edit
 // ════════════════════════════════════════════════════════════════════════════
@@ -532,6 +623,53 @@ async fn edit_success_returns_updated_content() {
         .unwrap();
     assert!(old_turn.deleted_at.is_some());
     assert_eq!(old_turn.replaced_by_request_id, Some(result.new_request_id));
+}
+
+#[tokio::test]
+async fn edit_soft_deletes_old_messages_and_creates_new_user_message() {
+    let (svc, ctx, chat_id, tenant_id) = setup().await;
+
+    let request_id = create_completed_turn(
+        &svc.db,
+        &*svc.turn_repo,
+        &*svc.message_repo,
+        tenant_id,
+        chat_id,
+        ctx.subject_id(),
+    )
+    .await;
+
+    let result = svc
+        .edit(&ctx, chat_id, request_id, "Edited content".to_owned())
+        .await
+        .unwrap();
+
+    let scope = AccessScope::for_tenant(tenant_id);
+    let conn = svc.db.conn().unwrap();
+
+    // Old messages should be soft-deleted
+    let old_msgs = svc
+        .message_repo
+        .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+        .await
+        .unwrap();
+    assert!(
+        old_msgs.is_empty(),
+        "old turn messages should be soft-deleted after edit"
+    );
+
+    // New user message should exist with edited content
+    let new_msgs = svc
+        .message_repo
+        .find_by_chat_and_request_id(&conn, &scope, chat_id, result.new_request_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        new_msgs.len(),
+        1,
+        "edit should create exactly one new user message"
+    );
+    assert_eq!(new_msgs[0].content, "Edited content");
 }
 
 #[tokio::test]

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
@@ -4,9 +4,10 @@ use async_trait::async_trait;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use modkit_db::odata::{LimitCfg, paginate_odata};
-use modkit_db::secure::{DBRunner, SecureEntityExt, secure_insert};
+use modkit_db::secure::{DBRunner, SecureEntityExt, SecureUpdateExt, secure_insert};
 use modkit_odata::{ODataQuery, Page, SortDir};
 use modkit_security::AccessScope;
+use sea_orm::prelude::Expr;
 use sea_orm::{
     ColumnTrait, Condition, EntityTrait, FromQueryResult, JoinType, Order, QueryFilter, QueryOrder,
     QuerySelect, RelationTrait, Set,
@@ -273,6 +274,29 @@ impl crate::domain::repos::MessageRepository for MessageRepository {
         }
         Ok(map)
     }
+    async fn soft_delete_by_request_id<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        request_id: Uuid,
+    ) -> Result<u64, DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let result = MessageEntity::update_many()
+            .col_expr(Column::DeletedAt, Expr::value(Some(now)))
+            .filter(
+                Condition::all()
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::RequestId.eq(request_id))
+                    .add(Column::DeletedAt.is_null()),
+            )
+            .secure()
+            .scope_with(scope)
+            .exec(runner)
+            .await?;
+        Ok(result.rows_affected)
+    }
+
     async fn snapshot_boundary<C: DBRunner>(
         &self,
         runner: &C,


### PR DESCRIPTION
Turn mutations (delete, retry, edit) now cascade soft-deletion to associated messages via `soft_delete_by_request_id`. Previously only the turn row was marked deleted, leaving orphaned messages visible in conversation history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced message cleanup when users delete, retry, or edit conversation turns
  * Improved consistency in conversation history display after turn modifications

* **Tests**
  * Added comprehensive test coverage for message cleanup during turn operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->