### PR TITLE
feat(mini-chat): rename turn_started to stream_started, add is_new_turn, emit on replay

### DIFF
--- a/modules/mini-chat/docs/DESIGN.md
+++ b/modules/mini-chat/docs/DESIGN.md
@@ -795,7 +795,7 @@ If any of the above validations fail, the request MUST be rejected with an appro
 | State | Server behavior |
 |-------|----------------|
 | Active generation exists for key | Return `409 Conflict` (JSON error response; no SSE stream is opened). (P2+: attach to existing stream.) |
-| Completed generation exists for key | Return a fast replay SSE stream without triggering a new provider request: one `delta` event containing the full persisted assistant text, then `citations` if available, then `done`. |
+| Completed generation exists for key | Return a fast replay SSE stream without triggering a new provider request: `stream_started` (with `is_new_turn: false`), one `delta` event containing the full persisted assistant text, then `citations` if available, then `done`. |
 | No record for key | Start a new generation normally (subject to the Parallel Turn Policy below). |
 
 If `request_id` is omitted in the request body, the server MUST generate a UUID v4 and assign it as the turn's `request_id`. The generated key participates in normal idempotency semantics: if the client persists the server-assigned value (e.g. from the SSE `done` event or Turn Status response), it can resubmit it for replay or recovery. In the public DTO, `request_id` is always present and non-null on every Message. Within a normal turn, the user message and assistant response always share the same `request_id` (turn correlation key). System/background messages (e.g. `doc_summary`, `thread_summary`) carry an independently server-generated UUID v4 and do not correspond to `chat_turns` rows.
@@ -878,15 +878,19 @@ UI guidance: if the SSE stream disconnects before a terminal event, the UI SHOUL
 
 #### SSE Event Definitions
 
-Seven event types. The stream always begins with `turn_started` (carrying the server-generated `request_id`) and ends with exactly one terminal event: `done` or `error`. Image-bearing turns use the same event types; no new SSE events are required for image support. The `citations` event MAY include items from both `file_search` (`source="file"`) and `web_search` (`source="web"`). Image inputs do not produce citations by themselves.
+Seven event types. The stream always begins with `stream_started` (carrying the resolved `request_id`, pre-generated `message_id`, and `is_new_turn` flag) and ends with exactly one terminal event: `done` or `error`. Image-bearing turns use the same event types; no new SSE events are required for image support. The `citations` event MAY include items from both `file_search` (`source="file"`) and `web_search` (`source="web"`). Image inputs do not produce citations by themselves.
 
-##### `event: turn_started`
+##### `event: stream_started`
 
-Emitted once at stream start, before any content events. Carries the server-generated `request_id` for this turn. Present on `POST /messages:stream`, `POST /turns/{id}/retry`, and `PATCH /turns/{id}`.
+Emitted once at stream start, before any content events. Present on all SSE streams: new generations (`POST /messages:stream`, `POST /turns/{id}/retry`, `PATCH /turns/{id}`) and idempotent replays.
+
+Carries the resolved `request_id` (client-provided when supplied, otherwise server-generated) and the assistant `message_id`. For new generations, `message_id` is a **pre-allocated UUID** — the assistant `messages` row does not yet exist in the database at this point; it will be persisted during finalization (see Content durability invariant, §5.8). For replays, `message_id` is the persisted assistant message ID. The `is_new_turn` flag distinguishes the two cases.
+
+This allows clients to reference the assistant message before the stream completes (e.g., for optimistic rendering, scroll-to-message, or cancellation) in all scenarios, including recovery after network interruption.
 
 ```
-event: turn_started
-data: {"request_id": "550e8400-e29b-41d4-a716-446655440000"}
+event: stream_started
+data: {"request_id": "550e8400-e29b-41d4-a716-446655440000", "message_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890", "is_new_turn": true}
 ```
 
 ##### `event: delta`
@@ -953,7 +957,6 @@ Finalizes the stream. Provides usage and model selection metadata.
 
 ```json
 {
-  "message_id": "uuid",
   "usage": {
     "input_tokens": 500,
     "output_tokens": 120,
@@ -969,7 +972,6 @@ Finalizes the stream. Provides usage and model selection metadata.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `message_id` | UUID | Persisted assistant message ID. |
 | `usage.input_tokens` | number | Actual input tokens consumed. |
 | `usage.output_tokens` | number | Actual output tokens consumed. |
 | `usage.model` | string | Effective model used for generation (same value as top-level `effective_model`; kept for backward compatibility). |
@@ -1027,7 +1029,7 @@ A well-formed stream follows this ordering:
 **P1 normative ordering**:
 
 ```text
-turn_started  ping*  (delta | tool)*  citations?  (done | error)
+stream_started  ping*  (delta | tool)*  citations?  (done | error)
 ```
 
 - Zero or more `ping` events may appear at any point before terminal.
@@ -2643,7 +2645,7 @@ A turn is a user-message + assistant-response pair identified by `request_id` in
 3. Retry, edit, and delete are allowed only if the target turn is in a terminal state (`completed`, `failed`, or `cancelled`). If the turn is `running`, reject with `400 Bad Request` — the client must wait for completion or cancel by disconnecting the SSE stream (see `cpt-cf-mini-chat-seq-cancellation`).
 4. Retry and edit soft-delete the previous turn (set `deleted_at`) and set `replaced_by_request_id` on the old turn pointing to the new turn's `request_id`. Delete sets `deleted_at` only (no replacement turn). Mutation eligibility considers only non-deleted turns, so delete cannot target an already replaced (soft-deleted) turn.
 5. Soft-deleted turns (`deleted_at IS NOT NULL`) are excluded from active conversation history and context assembly but retained in storage for audit traceability.
-6. **New request_id invariant (normative)**: Both retry and edit create a new turn with a **new `request_id`** generated by the **server** (`Uuid::new_v4()`). The client does not provide the new `request_id` — the retry endpoint has no request body, and the edit endpoint body contains only `content`. The server-generated `request_id` is returned to the client via the SSE `event: turn_started` event (same contract as `sendMessage`). The old turn's `replaced_by_request_id` is set to the new `request_id` for audit traceability. The old `request_id` is no longer valid for idempotent replay — the soft-deleted turn is excluded from the replay path (replay requires `deleted_at IS NULL`). Audit events include both `original_request_id` and `new_request_id` (see audit event payloads for `turn_retry` and `turn_edit`).
+6. **New request_id invariant (normative)**: Both retry and edit create a new turn with a **new `request_id`** generated by the **server** (`Uuid::new_v4()`). The client does not provide the new `request_id` — the retry endpoint has no request body, and the edit endpoint body contains only `content`. The server-generated `request_id` is returned to the client via the SSE `event: stream_started` event (same contract as `sendMessage`). The old turn's `replaced_by_request_id` is set to the new `request_id` for audit traceability. The old `request_id` is no longer valid for idempotent replay — the soft-deleted turn is excluded from the replay path (replay requires `deleted_at IS NULL`). Audit events include both `original_request_id` and `new_request_id` (see audit event payloads for `turn_retry` and `turn_edit`).
 7. **Atomicity invariant (normative)**: The "latest turn" identity check (rule 1), the terminal state check (rule 3), the soft-delete of the old turn, and the INSERT of the new `running` turn MUST all execute within a single DB transaction using `SELECT FOR UPDATE` or equivalent serializable isolation. Without this, two concurrent retry/edit requests for the same turn can both pass the validation checks simultaneously, both soft-delete the old turn (the second soft-delete is a no-op since `deleted_at` is already set), and both attempt to INSERT a new running turn — which violates the `UNIQUE(chat_id) WHERE state = 'running' AND deleted_at IS NULL` index. If the new running turn INSERT fails due to this unique constraint (concurrent race condition), the mutation MUST return `409 Conflict` with `code = "generation_in_progress"` (not HTTP 500).
 
 #### Turn Mutation API Contracts

--- a/modules/mini-chat/docs/openapi.json
+++ b/modules/mini-chat/docs/openapi.json
@@ -268,7 +268,7 @@
         "operationId": "sendMessage",
         "tags": ["messages"],
         "summary": "Send message and receive streamed AI response",
-        "description": "Sends a user message and opens an SSE stream for the assistant response. If `request_id` matches an active generation, returns 409 Conflict (JSON, no SSE). If `request_id` matches a completed generation, replays the response as SSE (side-effect-free: no new quota reserve, no billing events).\n\nThe optional `web_search` parameter enables web search for this turn (disabled by default, backward compatible).\n\n**Attachment fields**: `attachment_ids` identifies attachments explicitly attached to this message (persisted into `message_attachments`, returned in message `attachments[]`; images included in multimodal input for the current turn). In P1, retrieval always covers all documents in the chat vector store — `attachment_ids` does not scope or filter retrieval. `file_search` is only included when the chat has at least one ready document attachment.\n\n**SSE event ordering**: `turn_started ping* (delta | tool)* citations? (done | error)`. `delta` and `tool` may interleave; at most one `citations` event, emitted after all `delta` events and before the terminal event.\n\nExactly one terminal event (`done` or `error`) ends the stream.\n\n**SSE event types and payloads**:\n- `event: turn_started` — first event, carries `request_id`. Payload: `SseTurnStartedEvent`.\n- `event: ping` — keepalive, payload: `{}`. Clients MUST ignore.\n- `event: delta` — incremental text. Payload: `SseDeltaEvent`.\n- `event: tool` — tool activity (file_search, web_search at P1). Payload: `SseToolEvent`.\n- `event: citations` — source references (file and web). Payload: `SseCitationsEvent`.\n- `event: done` — terminal success with usage and quota_decision. Emitted for both full completions and truncated-but-successful completions (provider `response.incomplete`). Payload: `SseDoneEvent`.\n- `event: error` — terminal failure. Payload: `SseErrorEvent`.\n\nSee component schemas for payload definitions.\n\n**Pre-stream errors**: If validation, authorization, or quota preflight fails before streaming, a JSON error response with the appropriate HTTP status is returned and no SSE stream is opened.\n\n**Cancellation**: If the client disconnects mid-stream, the server cancels the in-flight provider request and applies a bounded best-effort debit for quota. No SSE error event is emitted (the stream is already broken). The Turn Status API is authoritative for final state after disconnect.",
+        "description": "Sends a user message and opens an SSE stream for the assistant response. If `request_id` matches an active generation, returns 409 Conflict (JSON, no SSE). If `request_id` matches a completed generation, replays the response as SSE (side-effect-free: no new quota reserve, no billing events).\n\nThe optional `web_search` parameter enables web search for this turn (disabled by default, backward compatible).\n\n**Attachment fields**: `attachment_ids` identifies attachments explicitly attached to this message (persisted into `message_attachments`, returned in message `attachments[]`; images included in multimodal input for the current turn). In P1, retrieval always covers all documents in the chat vector store — `attachment_ids` does not scope or filter retrieval. `file_search` is only included when the chat has at least one ready document attachment.\n\n**SSE event ordering**: `stream_started ping* (delta | tool)* citations? (done | error)`. `delta` and `tool` may interleave; at most one `citations` event, emitted after all `delta` events and before the terminal event.\n\nExactly one terminal event (`done` or `error`) ends the stream.\n\n**SSE event types and payloads**:\n- `event: stream_started` — first event, carries `request_id`, assistant `message_id`, and `is_new_turn` flag. Payload: `SseStreamStartedEvent`.\n- `event: ping` — keepalive, payload: `{}`. Clients MUST ignore.\n- `event: delta` — incremental text. Payload: `SseDeltaEvent`.\n- `event: tool` — tool activity (file_search, web_search at P1). Payload: `SseToolEvent`.\n- `event: citations` — source references (file and web). Payload: `SseCitationsEvent`.\n- `event: done` — terminal success with usage and quota_decision. Emitted for both full completions and truncated-but-successful completions (provider `response.incomplete`). Payload: `SseDoneEvent`.\n- `event: error` — terminal failure. Payload: `SseErrorEvent`.\n\nSee component schemas for payload definitions.\n\n**Pre-stream errors**: If validation, authorization, or quota preflight fails before streaming, a JSON error response with the appropriate HTTP status is returned and no SSE stream is opened.\n\n**Cancellation**: If the client disconnects mid-stream, the server cancels the in-flight provider request and applies a bounded best-effort debit for quota. No SSE error event is emitted (the stream is already broken). The Turn Status API is authoritative for final state after disconnect.",
         "requestBody": {
           "required": true,
           "content": {
@@ -305,9 +305,9 @@
             "content": {
               "text/event-stream": {
                 "schema": {
-                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `turn_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
+                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `stream_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
                   "oneOf": [
-                    { "$ref": "#/components/schemas/SseTurnStartedEvent" },
+                    { "$ref": "#/components/schemas/SseStreamStartedEvent" },
                     { "$ref": "#/components/schemas/SseDeltaEvent" },
                     { "$ref": "#/components/schemas/SseToolEvent" },
                     { "$ref": "#/components/schemas/SseCitationsEvent" },
@@ -794,9 +794,9 @@
             "content": {
               "text/event-stream": {
                 "schema": {
-                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `turn_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
+                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `stream_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
                   "oneOf": [
-                    { "$ref": "#/components/schemas/SseTurnStartedEvent" },
+                    { "$ref": "#/components/schemas/SseStreamStartedEvent" },
                     { "$ref": "#/components/schemas/SseDeltaEvent" },
                     { "$ref": "#/components/schemas/SseToolEvent" },
                     { "$ref": "#/components/schemas/SseCitationsEvent" },
@@ -956,9 +956,9 @@
             "content": {
               "text/event-stream": {
                 "schema": {
-                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `turn_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
+                  "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `stream_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
                   "oneOf": [
-                    { "$ref": "#/components/schemas/SseTurnStartedEvent" },
+                    { "$ref": "#/components/schemas/SseStreamStartedEvent" },
                     { "$ref": "#/components/schemas/SseDeltaEvent" },
                     { "$ref": "#/components/schemas/SseToolEvent" },
                     { "$ref": "#/components/schemas/SseCitationsEvent" },
@@ -1750,15 +1750,24 @@
           }
         }
       },
-      "SseTurnStartedEvent": {
+      "SseStreamStartedEvent": {
         "type": "object",
-        "required": ["request_id"],
-        "description": "SSE `event: turn_started` payload. First event in the stream, emitted exactly once. Carries the server-assigned request_id for correlation.",
+        "required": ["request_id", "message_id", "is_new_turn"],
+        "description": "SSE `event: stream_started` payload. First event in every SSE stream (both new generations and replays). Carries the server-assigned request_id, assistant message_id, and is_new_turn flag.",
         "properties": {
           "request_id": {
             "type": "string",
             "format": "uuid",
             "description": "Server-assigned request ID for this turn."
+          },
+          "message_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Assistant message ID. Pre-allocated for new generations; persisted ID for replays. Allows clients to reference the assistant message before the stream completes."
+          },
+          "is_new_turn": {
+            "type": "boolean",
+            "description": "true for a live generation (new turn); false when the stream replays an already-completed turn (idempotent replay)."
           }
         }
       },
@@ -1872,16 +1881,13 @@
       },
       "SseDoneEvent": {
         "type": "object",
-        "required": ["message_id", "usage", "effective_model", "selected_model", "quota_decision"],
-        "description": "SSE `event: done` payload. Terminal event finalizing the stream with usage and model selection metadata. Used for both full completions and truncated-but-successful completions (provider `response.incomplete`).",
+        "required": ["usage", "effective_model", "selected_model", "quota_decision"],
+        "description": "SSE `event: done` payload. Terminal event finalizing the stream with usage and model selection metadata. Used for both full completions and truncated-but-successful completions (provider `response.incomplete`). The assistant message_id is provided in the preceding `stream_started` event.",
         "properties": {
-          "message_id": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Persisted assistant message ID."
-          },
           "usage": {
-            "$ref": "#/components/schemas/SseUsage"
+            "nullable": true,
+            "description": "Token usage for this turn. Null when usage is unavailable (e.g. provider error before any tokens were consumed).",
+            "allOf": [{ "$ref": "#/components/schemas/SseUsage" }]
           },
           "effective_model": {
             "type": "string",

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
@@ -265,6 +265,7 @@ async fn replay_response(
 
     let (tx, rx) = mpsc::channel::<StreamEvent>(4);
     tokio::spawn(async move {
+        drop(tx.send(events.stream_started).await);
         drop(tx.send(events.delta).await);
         drop(tx.send(events.done).await);
     });
@@ -405,7 +406,7 @@ impl Stream for SseRelay {
             Poll::Pending => {
                 // No event ready — check if ping timer fired
                 if this.ping_timer.poll_tick(cx).is_ready() {
-                    // Only emit pings in Idle or Pinging phase
+                    // Only emit pings in Started or Pinging phase
                     let kind = StreamEventKind::Ping;
                     match this.phase.try_advance(kind) {
                         Ok(new_phase) => {

--- a/modules/mini-chat/mini-chat/src/api/rest/sse.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/sse.rs
@@ -3,7 +3,7 @@
 //! - `into_sse_event()`: converts domain `StreamEvent` to Axum SSE `Event`
 //! - `From<ClientSseEvent>`: translates provider events to domain events
 //! - `StreamPhase`: state machine enforcing the ordering grammar
-//!   `turn_started ping* (delta | tool)* citations? (done | error)`
+//!   `stream_started ping* (delta | tool)* citations? (done | error)`
 
 use axum::response::sse::Event;
 
@@ -21,7 +21,7 @@ impl StreamEvent {
     /// and `data:` JSON payload.
     pub fn into_sse_event(self) -> Result<Event, axum::Error> {
         match self {
-            StreamEvent::TurnStarted(d) => Event::default().event("turn_started").json_data(&d),
+            StreamEvent::StreamStarted(d) => Event::default().event("stream_started").json_data(&d),
             StreamEvent::Ping => Ok(Event::default().event("ping").data("{}")),
             StreamEvent::Delta(d) => Event::default().event("delta").json_data(&d),
             StreamEvent::Tool(t) => Event::default().event("tool").json_data(&t),
@@ -65,7 +65,7 @@ impl From<ClientSseEvent> for StreamEvent {
 impl std::fmt::Display for StreamEventKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::TurnStarted => f.write_str("TurnStarted"),
+            Self::StreamStarted => f.write_str("StreamStarted"),
             Self::Ping => f.write_str("Ping"),
             Self::Delta => f.write_str("Delta"),
             Self::Tool => f.write_str("Tool"),
@@ -80,16 +80,16 @@ impl std::fmt::Display for StreamEventKind {
 // ════════════════════════════════════════════════════════════════════════════
 
 /// Enforces the SSE ordering grammar:
-/// `turn_started ping* (delta | tool)* citations? (done | error)`.
+/// `stream_started ping* (delta | tool)* citations? (done | error)`.
 ///
 /// Delta and tool events may interleave freely within the `Streaming` phase.
 /// Only forward transitions are allowed. Out-of-order events produce an
 /// [`OrderingViolation`] error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamPhase {
-    /// Before any events. Accepts `turn_started`, ping, delta, tool, citations, terminal.
+    /// Before any events. Accepts only `stream_started` (or terminal for immediate errors).
     Idle,
-    /// After `turn_started`. Same transitions as `Idle` except `turn_started` (exactly-once).
+    /// After `stream_started`. Same transitions as `Idle` except `stream_started` (exactly-once).
     Started,
     /// After one or more pings. Accepts ping, delta, tool, citations, terminal.
     Pinging,
@@ -144,39 +144,34 @@ impl StreamPhase {
     /// event would break the grammar.
     pub fn try_advance(self, kind: StreamEventKind) -> Result<StreamPhase, OrderingViolation> {
         match (self, kind) {
-            // Terminal phase rejects everything
-            (StreamPhase::Terminal, _) => Err(OrderingViolation {
-                phase: self,
-                event: kind,
-            }),
-
-            // Terminal events are always accepted from non-terminal phases
-            (_, StreamEventKind::Terminal) => Ok(StreamPhase::Terminal),
-
-            // TurnStarted: only from Idle (exactly-once)
-            (StreamPhase::Idle, StreamEventKind::TurnStarted) => Ok(StreamPhase::Started),
-
-            // Ping: from Idle, Started, or Pinging
-            (
-                StreamPhase::Idle | StreamPhase::Started | StreamPhase::Pinging,
-                StreamEventKind::Ping,
-            ) => Ok(StreamPhase::Pinging),
-
-            // Delta or Tool: from Idle, Started, Pinging, or Streaming
+            // Terminal events are accepted from any phase after stream_started
+            // (plus Idle for immediate pre-stream errors)
             (
                 StreamPhase::Idle
                 | StreamPhase::Started
                 | StreamPhase::Pinging
-                | StreamPhase::Streaming,
+                | StreamPhase::Streaming
+                | StreamPhase::Citations,
+                StreamEventKind::Terminal,
+            ) => Ok(StreamPhase::Terminal),
+
+            // StreamStarted: only from Idle (exactly-once)
+            (StreamPhase::Idle, StreamEventKind::StreamStarted) => Ok(StreamPhase::Started),
+
+            // Ping: from Started or Pinging
+            (StreamPhase::Started | StreamPhase::Pinging, StreamEventKind::Ping) => {
+                Ok(StreamPhase::Pinging)
+            }
+
+            // Delta or Tool: from Started, Pinging, or Streaming
+            (
+                StreamPhase::Started | StreamPhase::Pinging | StreamPhase::Streaming,
                 StreamEventKind::Delta | StreamEventKind::Tool,
             ) => Ok(StreamPhase::Streaming),
 
-            // Citations: from Idle, Started, Pinging, or Streaming (at most once)
+            // Citations: from Started, Pinging, or Streaming (at most once)
             (
-                StreamPhase::Idle
-                | StreamPhase::Started
-                | StreamPhase::Pinging
-                | StreamPhase::Streaming,
+                StreamPhase::Started | StreamPhase::Pinging | StreamPhase::Streaming,
                 StreamEventKind::Citations,
             ) => Ok(StreamPhase::Citations),
 
@@ -232,7 +227,6 @@ mod tests {
     #[test]
     fn done_serializes_without_optional_fields() {
         let data = DoneData {
-            message_id: None,
             usage: None,
             effective_model: "gpt-4o".into(),
             selected_model: "gpt-4o".into(),
@@ -250,7 +244,6 @@ mod tests {
     #[test]
     fn done_serializes_with_downgrade() {
         let data = DoneData {
-            message_id: Some("msg-123".into()),
             usage: Some(Usage {
                 input_tokens: 100,
                 output_tokens: 50,
@@ -271,7 +264,6 @@ mod tests {
     fn done_converts_to_sse_event() {
         assert!(
             StreamEvent::Done(Box::new(DoneData {
-                message_id: None,
                 usage: None,
                 effective_model: "gpt-4o".into(),
                 selected_model: "gpt-4o".into(),
@@ -289,7 +281,6 @@ mod tests {
     fn done_serializes_with_quota_warnings() {
         use crate::domain::stream_events::QuotaWarning;
         let data = DoneData {
-            message_id: Some("msg-456".into()),
             usage: Some(Usage {
                 input_tokens: 50,
                 output_tokens: 20,
@@ -318,7 +309,6 @@ mod tests {
     #[test]
     fn done_omits_quota_warnings_when_none() {
         let data = DoneData {
-            message_id: None,
             usage: None,
             effective_model: "gpt-4o".into(),
             selected_model: "gpt-4o".into(),
@@ -357,31 +347,31 @@ mod tests {
     // ── StreamPhase tests ──
 
     #[test]
-    fn phase_idle_accepts_all_kinds() {
-        assert_eq!(
+    fn phase_idle_rejects_non_start_events() {
+        assert!(
             StreamPhase::Idle
                 .try_advance(StreamEventKind::Ping)
-                .unwrap(),
-            StreamPhase::Pinging
+                .is_err()
         );
-        assert_eq!(
+        assert!(
             StreamPhase::Idle
                 .try_advance(StreamEventKind::Delta)
-                .unwrap(),
-            StreamPhase::Streaming
+                .is_err()
         );
-        assert_eq!(
+        assert!(
             StreamPhase::Idle
                 .try_advance(StreamEventKind::Tool)
-                .unwrap(),
-            StreamPhase::Streaming
+                .is_err()
         );
-        assert_eq!(
+        assert!(
             StreamPhase::Idle
                 .try_advance(StreamEventKind::Citations)
-                .unwrap(),
-            StreamPhase::Citations
+                .is_err()
         );
+    }
+
+    #[test]
+    fn phase_idle_accepts_terminal() {
         assert_eq!(
             StreamPhase::Idle
                 .try_advance(StreamEventKind::Terminal)
@@ -450,6 +440,8 @@ mod tests {
     #[test]
     fn normal_stream_sequence() {
         let mut phase = StreamPhase::Idle;
+        phase = phase.try_advance(StreamEventKind::StreamStarted).unwrap();
+        assert_eq!(phase, StreamPhase::Started);
         phase = phase.try_advance(StreamEventKind::Ping).unwrap();
         assert_eq!(phase, StreamPhase::Pinging);
         phase = phase.try_advance(StreamEventKind::Delta).unwrap();
@@ -463,6 +455,7 @@ mod tests {
     #[test]
     fn tool_stream_sequence() {
         let mut phase = StreamPhase::Idle;
+        phase = phase.try_advance(StreamEventKind::StreamStarted).unwrap();
         phase = phase.try_advance(StreamEventKind::Delta).unwrap();
         phase = phase.try_advance(StreamEventKind::Tool).unwrap();
         assert_eq!(phase, StreamPhase::Streaming);
@@ -479,6 +472,7 @@ mod tests {
     #[test]
     fn interleaved_delta_tool_delta() {
         let mut phase = StreamPhase::Idle;
+        phase = phase.try_advance(StreamEventKind::StreamStarted).unwrap();
         phase = phase.try_advance(StreamEventKind::Delta).unwrap();
         assert_eq!(phase, StreamPhase::Streaming);
         phase = phase.try_advance(StreamEventKind::Tool).unwrap();
@@ -496,6 +490,7 @@ mod tests {
     #[test]
     fn tool_then_delta_accepted() {
         let mut phase = StreamPhase::Idle;
+        phase = phase.try_advance(StreamEventKind::StreamStarted).unwrap();
         phase = phase.try_advance(StreamEventKind::Tool).unwrap();
         assert_eq!(phase, StreamPhase::Streaming);
         phase = phase.try_advance(StreamEventKind::Delta).unwrap();
@@ -505,6 +500,7 @@ mod tests {
     #[test]
     fn ping_rejected_after_first_delta() {
         let mut phase = StreamPhase::Idle;
+        phase = phase.try_advance(StreamEventKind::StreamStarted).unwrap();
         phase = phase.try_advance(StreamEventKind::Delta).unwrap();
         assert!(phase.try_advance(StreamEventKind::Ping).is_err());
     }
@@ -512,17 +508,18 @@ mod tests {
     #[test]
     fn ping_rejected_after_first_tool() {
         let mut phase = StreamPhase::Idle;
+        phase = phase.try_advance(StreamEventKind::StreamStarted).unwrap();
         phase = phase.try_advance(StreamEventKind::Tool).unwrap();
         assert!(phase.try_advance(StreamEventKind::Ping).is_err());
     }
 
-    // ── TurnStarted / Started phase tests ──
+    // ── StreamStarted / Started phase tests ──
 
     #[test]
-    fn phase_idle_accepts_turn_started() {
+    fn phase_idle_accepts_stream_started() {
         assert_eq!(
             StreamPhase::Idle
-                .try_advance(StreamEventKind::TurnStarted)
+                .try_advance(StreamEventKind::StreamStarted)
                 .unwrap(),
             StreamPhase::Started
         );
@@ -563,18 +560,18 @@ mod tests {
     }
 
     #[test]
-    fn phase_started_rejects_turn_started() {
+    fn phase_started_rejects_stream_started() {
         assert!(
             StreamPhase::Started
-                .try_advance(StreamEventKind::TurnStarted)
+                .try_advance(StreamEventKind::StreamStarted)
                 .is_err()
         );
     }
 
     #[test]
-    fn turn_started_then_ping_then_deltas_then_done() {
+    fn stream_started_then_ping_then_deltas_then_done() {
         let mut phase = StreamPhase::Idle;
-        phase = phase.try_advance(StreamEventKind::TurnStarted).unwrap();
+        phase = phase.try_advance(StreamEventKind::StreamStarted).unwrap();
         assert_eq!(phase, StreamPhase::Started);
         phase = phase.try_advance(StreamEventKind::Ping).unwrap();
         assert_eq!(phase, StreamPhase::Pinging);
@@ -587,9 +584,9 @@ mod tests {
     }
 
     #[test]
-    fn turn_started_then_tool_delta_citations_done() {
+    fn stream_started_then_tool_delta_citations_done() {
         let mut phase = StreamPhase::Idle;
-        phase = phase.try_advance(StreamEventKind::TurnStarted).unwrap();
+        phase = phase.try_advance(StreamEventKind::StreamStarted).unwrap();
         assert_eq!(phase, StreamPhase::Started);
         phase = phase.try_advance(StreamEventKind::Tool).unwrap();
         assert_eq!(phase, StreamPhase::Streaming);
@@ -602,21 +599,33 @@ mod tests {
     }
 
     #[test]
-    fn idle_still_accepts_delta_directly_backwards_compat() {
-        let mut phase = StreamPhase::Idle;
-        phase = phase.try_advance(StreamEventKind::Delta).unwrap();
-        assert_eq!(phase, StreamPhase::Streaming);
-        phase = phase.try_advance(StreamEventKind::Terminal).unwrap();
-        assert_eq!(phase, StreamPhase::Terminal);
+    fn stream_started_converts_to_sse_event() {
+        use crate::domain::stream_events::StreamStartedData;
+        let rid = uuid::Uuid::new_v4();
+        let mid = uuid::Uuid::new_v4();
+        let data = StreamStartedData {
+            request_id: rid,
+            message_id: mid,
+            is_new_turn: true,
+        };
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(json.contains(&format!("\"request_id\":\"{rid}\"")));
+        assert!(json.contains(&format!("\"message_id\":\"{mid}\"")));
+        assert!(json.contains("\"is_new_turn\":true"));
+
+        let event = StreamEvent::StreamStarted(data);
+        assert!(event.into_sse_event().is_ok());
     }
 
     #[test]
-    fn turn_started_converts_to_sse_event() {
-        use crate::domain::stream_events::TurnStartedData;
-        let event = StreamEvent::TurnStarted(TurnStartedData {
+    fn stream_started_replay_serializes_correctly() {
+        use crate::domain::stream_events::StreamStartedData;
+        let data = StreamStartedData {
             request_id: uuid::Uuid::new_v4(),
-        });
-        let sse = event.into_sse_event();
-        assert!(sse.is_ok());
+            message_id: uuid::Uuid::new_v4(),
+            is_new_turn: false,
+        };
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(json.contains("\"is_new_turn\":false"));
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/replay.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/replay.rs
@@ -7,16 +7,17 @@
 use crate::domain::error::DomainError;
 use crate::domain::llm::Usage;
 use crate::domain::repos::MessageRepository;
-use crate::domain::stream_events::{DeltaData, DoneData, StreamEvent};
+use crate::domain::stream_events::{DeltaData, DoneData, StreamEvent, StreamStartedData};
 use crate::infra::db::entity::chat_turn::Model as TurnModel;
 use modkit_security::AccessScope;
 
 use super::DbProvider;
 
-/// Pair of SSE events produced by replay.
+/// Triple of SSE events produced by replay.
 #[derive(Debug)]
 #[allow(de0309_must_have_domain_model)]
 pub struct ReplayEvents {
+    pub stream_started: StreamEvent,
     pub delta: StreamEvent,
     pub done: StreamEvent,
 }
@@ -53,13 +54,18 @@ pub async fn replay_turn<MR: MessageRepository>(
             ))
         })?;
 
+    let stream_started = StreamEvent::StreamStarted(StreamStartedData {
+        request_id: turn.request_id,
+        message_id: assistant_msg_id,
+        is_new_turn: false,
+    });
+
     let delta = StreamEvent::Delta(DeltaData {
         r#type: "text",
         content: message.content,
     });
 
     let done = StreamEvent::Done(Box::new(DoneData {
-        message_id: Some(assistant_msg_id.to_string()),
         usage: Some(Usage {
             input_tokens: message.input_tokens,
             output_tokens: message.output_tokens,
@@ -72,7 +78,11 @@ pub async fn replay_turn<MR: MessageRepository>(
         quota_warnings: None,
     }));
 
-    Ok(ReplayEvents { delta, done })
+    Ok(ReplayEvents {
+        stream_started,
+        delta,
+        done,
+    })
 }
 
 fn reconstruct_quota_decision(turn: &TurnModel, selected_model: &str) -> String {
@@ -324,6 +334,16 @@ mod tests {
             .await
             .expect("replay should succeed");
 
+        // Verify stream_started
+        match &result.stream_started {
+            StreamEvent::StreamStarted(d) => {
+                assert_eq!(d.request_id, turn.request_id);
+                assert_eq!(d.message_id, msg_id);
+                assert!(!d.is_new_turn);
+            }
+            other => panic!("expected StreamStarted, got {other:?}"),
+        }
+
         // Verify delta
         match &result.delta {
             StreamEvent::Delta(d) => {
@@ -336,7 +356,6 @@ mod tests {
         // Verify done
         match &result.done {
             StreamEvent::Done(d) => {
-                assert_eq!(d.message_id, Some(msg_id.to_string()));
                 assert_eq!(d.effective_model, "gpt-5.2");
                 assert_eq!(d.selected_model, "gpt-5.2");
                 let usage = d.usage.as_ref().expect("usage should be present");

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -20,7 +20,7 @@ use crate::domain::repos::{
     MessageAttachmentRepository, MessageRepository, QuotaUsageRepository, SnapshotBoundary,
     ThreadSummaryRepository, TurnRepository, VectorStoreRepository,
 };
-use crate::domain::stream_events::{DoneData, ErrorData, StreamEvent, TurnStartedData};
+use crate::domain::stream_events::{DoneData, ErrorData, StreamEvent, StreamStartedData};
 use crate::infra::db::entity::chat_turn::{Model as TurnModel, TurnState};
 use crate::infra::llm::{
     ClientSseEvent, LlmMessage, LlmProvider, LlmProviderError, LlmRequestBuilder, LlmTool,
@@ -175,7 +175,7 @@ struct FinalizationCtx<TR: TurnRepository + 'static, MR: MessageRepository + 'st
     chat_id: Uuid,
     request_id: Uuid,
     user_id: Uuid,
-    /// Pre-generated assistant message ID, also sent in `DoneData`.
+    /// Pre-generated assistant message ID, sent in `StreamStartedData` (`stream_started` event).
     message_id: Uuid,
     // ── Quota/preflight fields (from PreflightDecision) ──
     effective_model: String,
@@ -706,7 +706,7 @@ impl<
             }
         }
 
-        // Pre-generate assistant message ID (sent in DoneData and used in CAS)
+        // Pre-generate assistant message ID (sent in StreamStartedData and used in CAS)
         let message_id = Uuid::new_v4();
 
         let finalization_ctx = FinalizationCtx {
@@ -772,14 +772,7 @@ impl<
             .replace("{model}", &provider_model_id);
         let proxy_path = format!("{}{api_path}", resolved_provider.upstream_alias);
 
-        // Emit turn_started before handing tx to the provider task (D3).
-        if tx
-            .send(StreamEvent::TurnStarted(TurnStartedData { request_id }))
-            .await
-            .is_err()
-        {
-            warn!(%request_id, "turn_started send failed (client disconnected before first event)");
-        }
+        emit_stream_started(&tx, request_id, message_id).await;
 
         Ok(spawn_provider_task(
             resolved_provider.adapter,
@@ -1352,14 +1345,7 @@ impl<
             .replace("{model}", &provider_model_id);
         let proxy_path = format!("{}{api_path}", resolved_provider.upstream_alias);
 
-        // Emit turn_started before handing tx to the provider task (D3).
-        if tx
-            .send(StreamEvent::TurnStarted(TurnStartedData { request_id }))
-            .await
-            .is_err()
-        {
-            warn!(%request_id, "turn_started send failed (client disconnected before first event)");
-        }
+        emit_stream_started(&tx, request_id, message_id).await;
 
         Ok(spawn_provider_task(
             resolved_provider.adapter,
@@ -1384,6 +1370,21 @@ impl<
 /// a [`StreamOutcome`]. After the stream ends, atomically finalizes the turn
 /// via `FinalizationService::finalize_turn_cas()` if a context is provided.
 ///
+/// Emit `stream_started` before handing `tx` to the provider task (D3).
+async fn emit_stream_started(tx: &mpsc::Sender<StreamEvent>, request_id: Uuid, message_id: Uuid) {
+    if tx
+        .send(StreamEvent::StreamStarted(StreamStartedData {
+            request_id,
+            message_id,
+            is_new_turn: true,
+        }))
+        .await
+        .is_err()
+    {
+        warn!(%request_id, "stream_started send failed (client disconnected before first event)");
+    }
+}
+
 /// All five terminal paths (provider done, incomplete, provider error,
 /// client disconnect, pre-stream error) route through `finalize_turn_cas()`.
 /// SSE terminal events (Done/Error) are emitted only after the CAS winner
@@ -1426,7 +1427,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
     tokio::spawn(async move {
         let stream_start = std::time::Instant::now();
         let mut first_token_time: Option<std::time::Duration> = None;
-        let msg_id_str = fin_ctx.as_ref().map(|p| p.message_id.to_string());
 
         // ── Metrics: stream started + active gauge ──
         // ActiveStreamGuard ensures decrement on every exit path (Drop-based).
@@ -1860,7 +1860,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                             };
                             let _ = tx
                                 .send(StreamEvent::Done(Box::new(DoneData {
-                                    message_id: msg_id_str.clone(),
                                     usage: Some(usage),
                                     effective_model: fctx.effective_model.clone(),
                                     selected_model: fctx.selected_model.clone(),
@@ -1877,7 +1876,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                             // Emit Done anyway so client isn't left hanging
                             let _ = tx
                                 .send(StreamEvent::Done(Box::new(DoneData {
-                                    message_id: msg_id_str.clone(),
                                     usage: Some(usage),
                                     effective_model: fctx.effective_model.clone(),
                                     selected_model: fctx.selected_model.clone(),
@@ -1904,7 +1902,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                     }
                     let _ = tx
                         .send(StreamEvent::Done(Box::new(DoneData {
-                            message_id: msg_id_str.clone(),
                             usage: Some(usage),
                             effective_model: model.clone(),
                             selected_model: model.clone(),
@@ -1970,7 +1967,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                             };
                             let _ = tx
                                 .send(StreamEvent::Done(Box::new(DoneData {
-                                    message_id: msg_id_str.clone(),
                                     usage: Some(usage),
                                     effective_model: fctx.effective_model.clone(),
                                     selected_model: fctx.selected_model.clone(),
@@ -1986,7 +1982,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                             warn!(error = %fe, "finalization failed on incomplete stream");
                             let _ = tx
                                 .send(StreamEvent::Done(Box::new(DoneData {
-                                    message_id: msg_id_str.clone(),
                                     usage: Some(usage),
                                     effective_model: fctx.effective_model.clone(),
                                     selected_model: fctx.selected_model.clone(),
@@ -2001,7 +1996,6 @@ fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'st
                 } else {
                     let _ = tx
                         .send(StreamEvent::Done(Box::new(DoneData {
-                            message_id: msg_id_str.clone(),
                             usage: Some(usage),
                             effective_model: model.clone(),
                             selected_model: model.clone(),
@@ -3410,9 +3404,9 @@ mod tests {
             .await
             .expect("should start stream");
 
-        // Read the turn_started event, then the first delta
-        let started = rx.recv().await.expect("should get turn_started");
-        assert!(matches!(started, StreamEvent::TurnStarted(_)));
+        // Read the stream_started event, then the first delta
+        let started = rx.recv().await.expect("should get stream_started");
+        assert!(matches!(started, StreamEvent::StreamStarted(_)));
         let first = rx.recv().await.expect("should get delta");
         assert!(matches!(first, StreamEvent::Delta(_)));
 
@@ -5460,9 +5454,9 @@ mod tests {
             .await
             .expect("should succeed");
 
-        // Wait for turn_started and first delta to arrive, then cancel
-        let started = rx.recv().await.expect("should get turn_started");
-        assert!(matches!(started, StreamEvent::TurnStarted(_)));
+        // Wait for stream_started and first delta to arrive, then cancel
+        let started = rx.recv().await.expect("should get stream_started");
+        assert!(matches!(started, StreamEvent::StreamStarted(_)));
         let ev = rx.recv().await.expect("should receive delta");
         assert!(
             matches!(ev, StreamEvent::Delta(_)),

--- a/modules/mini-chat/mini-chat/src/domain/stream_events.rs
+++ b/modules/mini-chat/mini-chat/src/domain/stream_events.rs
@@ -19,11 +19,11 @@ use crate::domain::llm::{Citation, ToolPhase, Usage};
 /// Stream event envelope for the `messages:stream` pipeline.
 ///
 /// Each variant maps to a distinct SSE `event:` name and `data:` JSON payload.
-/// Ordering grammar: `turn_started ping* (delta | tool)* citations? (done | error)`.
+/// Ordering grammar: `stream_started ping* (delta | tool)* citations? (done | error)`.
 #[domain_model]
 #[derive(Debug, Clone, ToSchema)]
 pub enum StreamEvent {
-    TurnStarted(TurnStartedData),
+    StreamStarted(StreamStartedData),
     Ping,
     Delta(DeltaData),
     Tool(ToolData),
@@ -60,7 +60,6 @@ pub struct CitationsData {
 #[domain_model]
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct DoneData {
-    pub message_id: Option<String>,
     pub usage: Option<Usage>,
     pub effective_model: String,
     pub selected_model: String,
@@ -81,11 +80,20 @@ pub struct ErrorData {
     pub message: String,
 }
 
-/// Initial lifecycle event carrying the server-generated request ID.
+/// Stream header event carrying the stream request ID and server-generated
+/// assistant message ID.
+///
+/// Emitted as the first event in every SSE stream (both new generations and
+/// replays). `is_new_turn` distinguishes replayed completed turns from live
+/// generations.
 #[domain_model]
 #[derive(Debug, Clone, Serialize, ToSchema)]
-pub struct TurnStartedData {
+pub struct StreamStartedData {
     pub request_id: Uuid,
+    pub message_id: Uuid,
+    /// `true` for a live generation (new turn); `false` when the stream
+    /// replays an already-completed turn (idempotent replay).
+    pub is_new_turn: bool,
 }
 
 /// Quota tier classification.
@@ -125,7 +133,7 @@ pub struct QuotaWarning {
 #[domain_model]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StreamEventKind {
-    TurnStarted,
+    StreamStarted,
     Ping,
     Delta,
     Tool,
@@ -139,7 +147,7 @@ impl StreamEvent {
     #[must_use]
     pub fn event_kind(&self) -> StreamEventKind {
         match self {
-            StreamEvent::TurnStarted(_) => StreamEventKind::TurnStarted,
+            StreamEvent::StreamStarted(_) => StreamEventKind::StreamStarted,
             StreamEvent::Ping => StreamEventKind::Ping,
             StreamEvent::Delta(_) => StreamEventKind::Delta,
             StreamEvent::Tool(_) => StreamEventKind::Tool,

--- a/testing/e2e/modules/mini_chat/conftest.py
+++ b/testing/e2e/modules/mini_chat/conftest.py
@@ -78,6 +78,15 @@ def parse_sse(text: str) -> list[SSEEvent]:
     return events
 
 
+def expect_stream_started(events: list[SSEEvent]) -> SSEEvent:
+    """Find the 'stream_started' event or fail with diagnostics."""
+    for e in events:
+        if e.event == "stream_started":
+            return e
+    event_types = [e.event for e in events]
+    raise AssertionError(f"No 'stream_started' event. Events received: {event_types}")
+
+
 def expect_done(events: list[SSEEvent]) -> SSEEvent:
     """Find the 'done' event or fail with diagnostics."""
     for e in events:

--- a/testing/e2e/modules/mini_chat/test_attachments.py
+++ b/testing/e2e/modules/mini_chat/test_attachments.py
@@ -12,7 +12,7 @@ import zlib
 import pytest
 import httpx
 
-from .conftest import API_PREFIX, AZURE_MODEL, SSEEvent, expect_done, stream_message
+from .conftest import API_PREFIX, AZURE_MODEL, SSEEvent, expect_done, expect_stream_started, stream_message
 
 FIXTURES_DIR = pathlib.Path(__file__).parent / "fixtures"
 
@@ -207,8 +207,9 @@ class TestSendMessageWithAttachments:
             attachment_ids=att_ids,
         )
         assert status == 200, f"Stream failed: {status} {raw[:500]}"
-        done = expect_done(events)
-        assert done.data.get("message_id")
+        expect_done(events)
+        ss = expect_stream_started(events)
+        assert ss.data.get("message_id")
 
 
 # ---------------------------------------------------------------------------
@@ -315,8 +316,9 @@ class TestAzureSendMessageWithAttachment:
             attachment_ids=[att_id],
         )
         assert status == 200, f"Stream failed: {status} {raw[:500]}"
-        done = expect_done(events)
-        assert done.data.get("message_id")
+        expect_done(events)
+        ss = expect_stream_started(events)
+        assert ss.data.get("message_id")
 
 
 @pytest.mark.openai
@@ -351,8 +353,9 @@ def upload_and_stream(chat_id: str, filename: str, content: bytes, question: str
     att_id = upload_and_verify(chat_id, filename, content)
     status, events, raw = stream_message(chat_id, question, attachment_ids=[att_id])
     assert status == 200, f"Stream failed: {status} {raw[:500]}"
+    ss = expect_stream_started(events)
+    assert ss.data.get("message_id")
     done = expect_done(events)
-    assert done.data.get("message_id")
     usage = done.data.get("usage", {})
     assert usage.get("input_tokens", 0) > 0, "Expected non-zero input_tokens"
     assert usage.get("output_tokens", 0) > 0, "Expected non-zero output_tokens"
@@ -457,8 +460,9 @@ class TestImageUploadAndSend:
             attachment_ids=[att_id],
         )
         assert status == 200, f"Stream failed: {status} {raw[:500]}"
-        done = expect_done(events)
-        assert done.data.get("message_id"), "Expected message_id in done event"
+        expect_done(events)
+        ss = expect_stream_started(events)
+        assert ss.data.get("message_id"), "Expected message_id in stream_started event"
 
         # Collect delta text to see what the LLM said
         delta_text = ""

--- a/testing/e2e/modules/mini_chat/test_full_scenario.py
+++ b/testing/e2e/modules/mini_chat/test_full_scenario.py
@@ -13,7 +13,7 @@ import uuid
 import pytest
 import httpx
 
-from .conftest import API_PREFIX, DB_PATH, DEFAULT_MODEL, STANDARD_MODEL, expect_done, stream_message
+from .conftest import API_PREFIX, DB_PATH, DEFAULT_MODEL, STANDARD_MODEL, expect_done, expect_stream_started, stream_message
 
 pytestmark = pytest.mark.openai
 
@@ -62,10 +62,13 @@ class TestFullConversationScenario:
         s1, ev1, _ = stream_message(chat_id, "What is 2+2? Reply with just the number.", request_id=rid1)
         assert s1 == 200
 
+        ss1 = expect_stream_started(ev1)
+        msg_id1 = ss1.data["message_id"]
+        assert ss1.data["is_new_turn"] is True
+
         done1 = expect_done(ev1)
         assert done1.data["quota_decision"] == "allow"
         assert done1.data["effective_model"] == DEFAULT_MODEL
-        msg_id1 = done1.data["message_id"]
         usage1 = done1.data["usage"]
         assert usage1["input_tokens"] > 0
         assert usage1["output_tokens"] > 0
@@ -79,8 +82,11 @@ class TestFullConversationScenario:
         s2, ev2, _ = stream_message(chat_id, "Now multiply that result by 10.", request_id=rid2)
         assert s2 == 200
 
+        ss2 = expect_stream_started(ev2)
+        msg_id2 = ss2.data["message_id"]
+        assert ss2.data["is_new_turn"] is True
+
         done2 = expect_done(ev2)
-        msg_id2 = done2.data["message_id"]
         usage2 = done2.data["usage"]
 
         # Input tokens should be higher (conversation context grows)
@@ -97,8 +103,10 @@ class TestFullConversationScenario:
         s3, ev3, _ = stream_message(chat_id, "What was my first question?", request_id=rid3)
         assert s3 == 200
 
-        done3 = expect_done(ev3)
-        msg_id3 = done3.data["message_id"]
+        ss3 = expect_stream_started(ev3)
+        msg_id3 = ss3.data["message_id"]
+        assert ss3.data["is_new_turn"] is True
+        expect_done(ev3)
 
         # ── 5. Verify message history via API ────────────────────────────
         resp = httpx.get(f"{API_PREFIX}/chats/{chat_id}/messages")
@@ -180,9 +188,10 @@ class TestFullConversationScenario:
             chat_id, "What is 2+2? Reply with just the number.", request_id=rid1,
         )
         assert s_replay == 200
-        # Replay should return done event with same message_id
-        done_replay = expect_done(ev_replay)
-        assert done_replay.data["message_id"] == msg_id1
+        # Replay should return stream_started with same message_id and is_new_turn=false
+        ss_replay = expect_stream_started(ev_replay)
+        assert ss_replay.data["message_id"] == msg_id1
+        assert ss_replay.data["is_new_turn"] is False
 
         # ── 12. Delete chat ──────────────────────────────────────────────
         resp = httpx.delete(f"{API_PREFIX}/chats/{chat_id}")

--- a/testing/e2e/modules/mini_chat/test_stream_started.py
+++ b/testing/e2e/modules/mini_chat/test_stream_started.py
@@ -1,9 +1,11 @@
-"""Tests for the turn_started SSE lifecycle event and cancelled message persistence.
+"""Tests for the stream_started SSE lifecycle event and cancelled message persistence.
 
 Covers:
-- turn_started as first SSE event on initial send, retry, and edit
-- turn_started.request_id matches Turn Status API
-- Full event grammar ordering with turn_started
+- stream_started as first SSE event on initial send, retry, and edit
+- stream_started.request_id / message_id / is_new_turn fields
+- stream_started.request_id matches Turn Status API
+- Full event grammar ordering with stream_started
+- stream_started emitted on replay with is_new_turn=false
 - Cancelled stream persists partial assistant message
 - Cancelled message appears in GET /messages
 - Retry of cancelled turn replaces partial message
@@ -15,22 +17,13 @@ import uuid
 import pytest
 import httpx
 
-from .conftest import API_PREFIX, expect_done, parse_sse, stream_message
+from .conftest import API_PREFIX, expect_done, expect_stream_started, parse_sse, stream_message
 
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def expect_turn_started(events):
-    """Find the 'turn_started' event or fail."""
-    for e in events:
-        if e.event == "turn_started":
-            return e
-    event_types = [e.event for e in events]
-    raise AssertionError(f"No 'turn_started' event. Events: {event_types}")
-
 
 def stream_message_raw_partial(chat_id: str, content: str, read_bytes: int = 512):
     """Start a streaming request, read a small chunk, then close the connection.
@@ -79,38 +72,51 @@ def poll_turn_status(chat_id: str, request_id: str, target_state: str,
 
 
 # ---------------------------------------------------------------------------
-# Tests: turn_started event on initial send
+# Tests: stream_started event on initial send
 # ---------------------------------------------------------------------------
 
-class TestTurnStartedOnSend:
-    """turn_started is the first SSE event on POST /messages:stream."""
+class TestStreamStartedOnSend:
+    """stream_started is the first SSE event on POST /messages:stream."""
 
-    def test_turn_started_is_first_event(self, provider_chat):
+    def test_stream_started_is_first_event(self, provider_chat):
         _, events, _ = stream_message(provider_chat["id"], "Say OK.")
         assert len(events) >= 2, f"Expected >=2 events, got {len(events)}"
-        assert events[0].event == "turn_started", (
-            f"First event should be turn_started, got {events[0].event}"
+        assert events[0].event == "stream_started", (
+            f"First event should be stream_started, got {events[0].event}"
         )
 
-    def test_turn_started_has_request_id(self, provider_chat):
+    def test_stream_started_has_request_id(self, provider_chat):
         _, events, _ = stream_message(provider_chat["id"], "Say OK.")
-        ts = expect_turn_started(events)
-        rid = ts.data.get("request_id")
-        assert rid is not None, "turn_started should have request_id"
+        ss = expect_stream_started(events)
+        rid = ss.data.get("request_id")
+        assert rid is not None, "stream_started should have request_id"
         uuid.UUID(rid)  # validates it's a UUID
 
-    def test_turn_started_request_id_matches_client_id(self, provider_chat):
-        """When client provides request_id, turn_started echoes it back."""
+    def test_stream_started_has_message_id(self, provider_chat):
+        _, events, _ = stream_message(provider_chat["id"], "Say OK.")
+        ss = expect_stream_started(events)
+        mid = ss.data.get("message_id")
+        assert mid is not None, "stream_started should have message_id"
+        uuid.UUID(mid)  # validates it's a UUID
+
+    def test_stream_started_is_new_turn_true_on_send(self, provider_chat):
+        """Live generation should have is_new_turn=true."""
+        _, events, _ = stream_message(provider_chat["id"], "Say OK.")
+        ss = expect_stream_started(events)
+        assert ss.data.get("is_new_turn") is True
+
+    def test_stream_started_request_id_matches_client_id(self, provider_chat):
+        """When client provides request_id, stream_started echoes it back."""
         request_id = str(uuid.uuid4())
         _, events, _ = stream_message(provider_chat["id"], "Say OK.", request_id=request_id)
-        ts = expect_turn_started(events)
-        assert ts.data["request_id"] == request_id
+        ss = expect_stream_started(events)
+        assert ss.data["request_id"] == request_id
 
-    def test_turn_started_request_id_matches_turn_status(self, provider_chat):
-        """request_id from turn_started matches GET /turns/{request_id}."""
+    def test_stream_started_request_id_matches_turn_status(self, provider_chat):
+        """request_id from stream_started matches GET /turns/{request_id}."""
         _, events, _ = stream_message(provider_chat["id"], "Say OK.")
-        ts = expect_turn_started(events)
-        rid = ts.data["request_id"]
+        ss = expect_stream_started(events)
+        rid = ss.data["request_id"]
 
         resp = httpx.get(f"{API_PREFIX}/chats/{provider_chat['id']}/turns/{rid}")
         assert resp.status_code == 200
@@ -123,27 +129,27 @@ class TestTurnStartedOnSend:
 # Tests: event ordering grammar
 # ---------------------------------------------------------------------------
 
-class TestTurnStartedOrdering:
-    """Grammar: turn_started ping* (delta | tool)* citations? (done | error)."""
+class TestStreamStartedOrdering:
+    """Grammar: stream_started ping* (delta | tool)* citations? (done | error)."""
 
-    def test_turn_started_before_deltas_before_done(self, provider_chat):
+    def test_stream_started_before_deltas_before_done(self, provider_chat):
         _, events, _ = stream_message(provider_chat["id"], "Say hello briefly.")
         types = [e.event for e in events]
 
-        # turn_started must be first
-        assert types[0] == "turn_started"
+        # stream_started must be first
+        assert types[0] == "stream_started"
 
         # done must be last
         assert types[-1] == "done"
 
-        # No turn_started after the first one
-        assert types.count("turn_started") == 1
+        # No stream_started after the first one
+        assert types.count("stream_started") == 1
 
-        # Deltas between turn_started and done
+        # Deltas between stream_started and done
         deltas = [e for e in events if e.event == "delta"]
         assert len(deltas) > 0
 
-    def test_pings_only_between_turn_started_and_first_content(self, provider_chat):
+    def test_pings_only_between_stream_started_and_first_content(self, provider_chat):
         """Pings should only appear before the first delta/tool."""
         _, events, _ = stream_message(provider_chat["id"], "Say hi.")
         first_content_idx = None
@@ -157,13 +163,13 @@ class TestTurnStartedOrdering:
 
 
 # ---------------------------------------------------------------------------
-# Tests: turn_started on retry and edit
+# Tests: stream_started on retry and edit
 # ---------------------------------------------------------------------------
 
-class TestTurnStartedOnMutation:
-    """turn_started carries a NEW request_id on retry and edit."""
+class TestStreamStartedOnMutation:
+    """stream_started carries a NEW request_id on retry and edit."""
 
-    def test_retry_emits_turn_started_with_new_request_id(self, provider_chat):
+    def test_retry_emits_stream_started_with_new_request_id(self, provider_chat):
         chat_id = provider_chat["id"]
 
         # Complete a turn
@@ -184,15 +190,15 @@ class TestTurnStartedOnMutation:
         assert resp.status_code == 200, f"Retry failed: {resp.status_code} {resp.text}"
         retry_events = parse_sse(resp.text)
 
-        ts = expect_turn_started(retry_events)
-        new_rid = ts.data["request_id"]
+        ss = expect_stream_started(retry_events)
+        new_rid = ss.data["request_id"]
         assert new_rid != orig_rid, "Retry should generate a new request_id"
         uuid.UUID(new_rid)
 
         # Verify done event present
         expect_done(retry_events)
 
-    def test_edit_emits_turn_started_with_new_request_id(self, provider_chat):
+    def test_edit_emits_stream_started_with_new_request_id(self, provider_chat):
         chat_id = provider_chat["id"]
 
         # Complete a turn
@@ -214,12 +220,39 @@ class TestTurnStartedOnMutation:
         assert resp.status_code == 200, f"Edit failed: {resp.status_code} {resp.text}"
         edit_events = parse_sse(resp.text)
 
-        ts = expect_turn_started(edit_events)
-        new_rid = ts.data["request_id"]
+        ss = expect_stream_started(edit_events)
+        new_rid = ss.data["request_id"]
         assert new_rid != orig_rid, "Edit should generate a new request_id"
         uuid.UUID(new_rid)
 
         expect_done(edit_events)
+
+
+# ---------------------------------------------------------------------------
+# Tests: stream_started on replay (idempotent)
+# ---------------------------------------------------------------------------
+
+class TestStreamStartedOnReplay:
+    """Replay of a completed turn emits stream_started with is_new_turn=false."""
+
+    def test_replay_emits_stream_started_with_is_new_turn_false(self, provider_chat):
+        chat_id = provider_chat["id"]
+
+        # Complete a turn
+        rid = str(uuid.uuid4())
+        status, events, _ = stream_message(chat_id, "Say OK.", request_id=rid)
+        assert status == 200
+        ss_orig = expect_stream_started(events)
+        orig_msg_id = ss_orig.data["message_id"]
+
+        # Replay same request_id
+        status2, events2, _ = stream_message(chat_id, "Say OK.", request_id=rid)
+        assert status2 == 200
+
+        ss_replay = expect_stream_started(events2)
+        assert ss_replay.data["is_new_turn"] is False
+        assert ss_replay.data["message_id"] == orig_msg_id
+        assert ss_replay.data["request_id"] == rid
 
 
 # ---------------------------------------------------------------------------
@@ -234,7 +267,7 @@ class TestCancelledMessagePersistence:
         chat_id = provider_chat["id"]
 
         # Use a long prompt to trigger slow-response scenario in mock.
-        # read_bytes=256 reads just turn_started + first deltas, then disconnects.
+        # read_bytes=256 reads just stream_started + first deltas, then disconnects.
         request_id, _ = stream_message_raw_partial(
             chat_id,
             "Write a detailed 500-word essay about the history of computing.",
@@ -301,21 +334,21 @@ class TestCancelledMessagePersistence:
         assert resp.status_code == 200, f"Retry failed: {resp.status_code} {resp.text}"
         retry_events = parse_sse(resp.text)
 
-        # Retry should emit turn_started with a new request_id
-        ts = expect_turn_started(retry_events)
-        new_rid = ts.data["request_id"]
+        # Retry should emit stream_started with a new request_id and message_id
+        ss = expect_stream_started(retry_events)
+        new_rid = ss.data["request_id"]
+        new_msg_id = ss.data["message_id"]
         assert new_rid != request_id, "Retry should use a new request_id"
-
-        # Retry should complete with a done event
-        retry_done = expect_done(retry_events)
-        new_msg_id = retry_done.data.get("message_id")
-        assert new_msg_id is not None, "Retry done should have message_id"
+        assert new_msg_id is not None, "stream_started should have message_id"
 
         # The new message should be different from the partial one
         if partial_msg_id is not None:
             assert new_msg_id != partial_msg_id, (
                 "Retry should produce a new message, not reuse the partial"
             )
+
+        # Retry should complete with a done event
+        expect_done(retry_events)
 
         # Verify the new turn is in 'done' state
         new_turn = poll_turn_status(chat_id, new_rid, "done")

--- a/testing/e2e/modules/mini_chat/test_streaming.py
+++ b/testing/e2e/modules/mini_chat/test_streaming.py
@@ -9,7 +9,7 @@ import uuid
 import pytest
 import httpx
 
-from .conftest import API_PREFIX, DEFAULT_MODEL, STANDARD_MODEL, expect_done, parse_sse, stream_message
+from .conftest import API_PREFIX, DEFAULT_MODEL, STANDARD_MODEL, expect_done, expect_stream_started, parse_sse, stream_message
 
 
 
@@ -67,12 +67,18 @@ class TestStreamDoneEvent:
         assert usage["input_tokens"] > 0
         assert usage["output_tokens"] > 0
 
-    def test_done_has_message_id(self, provider_chat):
+    def test_done_does_not_have_message_id(self, provider_chat):
+        """message_id moved to stream_started; done should not carry it."""
         _, events, _ = stream_message(provider_chat["id"], "Say OK.")
         done = expect_done(events)
-        msg_id = done.data.get("message_id")
+        assert "message_id" not in done.data
+
+    def test_stream_started_has_message_id(self, provider_chat):
+        """message_id is now in stream_started."""
+        _, events, _ = stream_message(provider_chat["id"], "Say OK.")
+        ss = expect_stream_started(events)
+        msg_id = ss.data.get("message_id")
         assert msg_id is not None
-        # Should be a valid UUID
         uuid.UUID(msg_id)
 
     def test_done_effective_model_matches_chat(self, provider_chat):


### PR DESCRIPTION
Clients can now reference the in-progress assistant message before the stream completes (e.g., optimistic rendering, scroll-to-message, cancellation). The pre-generated message_id is emitted in turn_started instead of done, and removed from DoneData.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Initial SSE event renamed to "stream_started" and now includes request_id, a pre-generated message_id, and is_new_turn (true/false).
  * Delta and final "done" events no longer include per-turn message_id; assistant_message_id is provided in stream_started.
  * Replay behavior revised: replay emits stream_started with is_new_turn=false and preserves message_id.

* **Documentation**
  * Streaming contract and OpenAPI docs updated to reflect stream_started naming, payloads, and ordering.

* **Tests**
  * E2E tests and helpers updated to expect and validate message_id/is_new_turn on stream_started and remove message_id assertions from done.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->