### PR TITLE
feat(mini-chat): update model policy plugin models

### DIFF
--- a/modules/mini-chat/mini-chat-sdk/src/models.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/models.rs
@@ -83,7 +83,7 @@ pub struct ModelCatalogEntry {
     /// Full general config captured at snapshot time.
     pub general_config: ModelGeneralConfig,
     /// Tenant preference settings captured at snapshot time.
-    pub preference: ModelPreference,
+    pub preference: Option<ModelPreference>,
     /// System prompt sent as `instructions` in every LLM request for this model.
     /// Empty string = no system instructions.
     #[serde(default)]
@@ -213,8 +213,10 @@ pub struct ModelGeneralConfig {
     /// CTI type identifier of the config.
     #[serde(rename = "type")]
     pub config_type: String,
-    /// Model tier CTI identifier.
-    pub tier: String,
+    /// Credential UUID used for this model.
+    pub model_credential_id: Uuid,
+    /// Tenant ID of the credential used for this model.
+    pub credential_tenant_id: Uuid,
     #[serde(with = "time::serde::rfc3339")]
     pub available_from: OffsetDateTime,
     pub max_file_size_mb: u32,
@@ -364,10 +366,10 @@ mod tests {
             estimation_budgets: EstimationBudgets::default(),
             max_retrieved_chunks_per_turn: 5,
             general_config: sample_general_config(),
-            preference: ModelPreference {
+            preference: Some(ModelPreference {
                 is_default: false,
                 sort_order: 0,
-            },
+            }),
             system_prompt: String::new(),
             thread_summary_prompt: String::new(),
         }
@@ -376,7 +378,8 @@ mod tests {
     fn sample_general_config() -> ModelGeneralConfig {
         ModelGeneralConfig {
             config_type: "model.general.v1".to_owned(),
-            tier: "premium".to_owned(),
+            model_credential_id: Uuid::nil(),
+            credential_tenant_id: Uuid::nil(),
             available_from: OffsetDateTime::UNIX_EPOCH,
             max_file_size_mb: 25,
             api_params: ModelApiParams {
@@ -457,7 +460,10 @@ mod tests {
         let deserialized: ModelGeneralConfig = serde_json::from_value(json).unwrap();
 
         assert_eq!(deserialized.config_type, original.config_type);
-        assert_eq!(deserialized.tier, original.tier);
+        assert_eq!(
+            deserialized.credential_tenant_id,
+            original.credential_tenant_id
+        );
     }
 
     // ── ModelCatalogEntry: optional fields default when absent ──
@@ -477,12 +483,14 @@ mod tests {
         obj.remove("estimation_budgets");
         obj.remove("system_prompt");
         obj.remove("thread_summary_prompt");
+        obj.remove("preference");
 
         let entry: ModelCatalogEntry = serde_json::from_value(json).unwrap();
         assert!(entry.description.is_empty());
         assert!(entry.version.is_empty());
         assert!(entry.icon.is_empty());
         assert!(!entry.enabled);
+        assert!(entry.preference.is_none());
         assert!(entry.multimodal_capabilities.is_empty());
         assert!(entry.multiplier_display.is_empty());
         assert_eq!(

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
@@ -320,7 +320,7 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
                     catalog
                         .iter()
                         .filter(|m| tier_matches(m))
-                        .find(|m| m.preference.is_default)
+                        .find(|m| m.preference.as_ref().is_some_and(|p| p.is_default))
                 })
                 .or_else(|| catalog.iter().find(|m| tier_matches(m)));
 

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -186,7 +186,7 @@ impl ModelResolver for MockModelResolver {
             None => {
                 let default = catalog
                     .iter()
-                    .find(|m| m.preference.is_default && m.enabled)
+                    .find(|m| m.preference.as_ref().is_some_and(|p| p.is_default) && m.enabled)
                     .or_else(|| catalog.iter().find(|m| m.enabled));
                 match default {
                     Some(e) => Ok(ResolvedModel::from(e)),
@@ -403,10 +403,6 @@ pub fn test_catalog_entry(params: TestCatalogEntryParams) -> ModelCatalogEntry {
     use mini_chat_sdk::models::*;
     use time::OffsetDateTime;
 
-    let tier_str = match params.tier {
-        mini_chat_sdk::ModelTier::Premium => "premium",
-        mini_chat_sdk::ModelTier::Standard => "standard",
-    };
     let input_mult = params.input_tokens_credit_multiplier_micro as f64 / 1_000_000.0;
     let output_mult = params.output_tokens_credit_multiplier_micro as f64 / 1_000_000.0;
     let has_vision = params
@@ -436,7 +432,8 @@ pub fn test_catalog_entry(params: TestCatalogEntryParams) -> ModelCatalogEntry {
         max_retrieved_chunks_per_turn: 5,
         general_config: ModelGeneralConfig {
             config_type: String::new(),
-            tier: tier_str.to_owned(),
+            model_credential_id: Uuid::nil(),
+            credential_tenant_id: Uuid::nil(),
             available_from: OffsetDateTime::UNIX_EPOCH,
             max_file_size_mb: 25,
             api_params: ModelApiParams {
@@ -495,10 +492,10 @@ pub fn test_catalog_entry(params: TestCatalogEntryParams) -> ModelCatalogEntry {
                 speed_tokens_per_second: 100,
             },
         },
-        preference: ModelPreference {
+        preference: Some(ModelPreference {
             is_default: params.is_default,
             sort_order: 0,
-        },
+        }),
         system_prompt: String::new(),
         thread_summary_prompt: String::new(),
     }

--- a/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
@@ -103,7 +103,7 @@ impl ModelResolver for ModelPolicyGateway {
                 let default = snapshot
                     .model_catalog
                     .iter()
-                    .find(|m| m.preference.is_default && m.enabled)
+                    .find(|m| m.preference.as_ref().is_some_and(|p| p.is_default) && m.enabled)
                     .or_else(|| snapshot.model_catalog.iter().find(|m| m.enabled));
 
                 match default {

--- a/modules/mini-chat/plugins/static-model-policy-plugin/src/domain/client.rs
+++ b/modules/mini-chat/plugins/static-model-policy-plugin/src/domain/client.rs
@@ -97,10 +97,6 @@ mod tests {
     use time::OffsetDateTime;
 
     fn make_entry(model_id: &str, tier: ModelTier) -> ModelCatalogEntry {
-        let tier_str = match tier {
-            ModelTier::Standard => "standard",
-            ModelTier::Premium => "premium",
-        };
         ModelCatalogEntry {
             model_id: model_id.to_owned(),
             provider_model_id: format!("{model_id}-v1"),
@@ -123,7 +119,8 @@ mod tests {
             max_retrieved_chunks_per_turn: 5,
             general_config: ModelGeneralConfig {
                 config_type: String::new(),
-                tier: tier_str.to_owned(),
+                model_credential_id: Uuid::nil(),
+                credential_tenant_id: Uuid::nil(),
                 available_from: OffsetDateTime::UNIX_EPOCH,
                 max_file_size_mb: 25,
                 api_params: ModelApiParams {
@@ -182,10 +179,10 @@ mod tests {
                     speed_tokens_per_second: 100,
                 },
             },
-            preference: ModelPreference {
+            preference: Some(ModelPreference {
                 is_default: false,
                 sort_order: 0,
-            },
+            }),
             system_prompt: String::new(),
             thread_summary_prompt: String::new(),
         }


### PR DESCRIPTION
Replace `tier` field with `model_credential_id` and `credential_tenant_id` in ModelGeneralConfig, and make `preference` optional in ModelCatalogEntry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved model selection logic to better handle cases where model preferences may not be defined.
  * Enhanced model configuration structure with credential management fields for improved credential wiring and authorization handling.
  * Updated internal credential handling to support more flexible model credential assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->