### PR TITLE
fix(modkit-db, mini-chat): handle unique-constraint violations for vector stores

### DIFF
--- a/dylint_lints/Cargo.lock
+++ b/dylint_lints/Cargo.lock
@@ -645,9 +645,10 @@ dependencies = [
  "cf-modkit-errors",
  "cf-modkit-errors-macro",
  "chrono",
+ "chrono-tz",
  "hex",
  "http",
- "odata-params",
+ "peg",
  "serde",
  "serde_json",
  "sha2",
@@ -722,10 +723,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2648,20 +2647,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "odata-params"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32ae3978a6fc4114aec5b7907038efa81452336845a98a1e2ec957c8f32ade6"
-dependencies = [
- "bigdecimal",
- "chrono",
- "chrono-tz",
- "peg",
- "thiserror 1.0.69",
- "uuid",
 ]
 
 [[package]]

--- a/libs/modkit-db/src/secure/error.rs
+++ b/libs/modkit-db/src/secure/error.rs
@@ -19,3 +19,44 @@ pub enum ScopeError {
     #[error("access denied: {0}")]
     Denied(&'static str),
 }
+
+impl ScopeError {
+    /// Returns `true` if this error wraps a unique-constraint violation.
+    #[must_use]
+    pub fn is_unique_violation(&self) -> bool {
+        match self {
+            Self::Db(db_err) => is_unique_violation(db_err),
+            _ => false,
+        }
+    }
+}
+
+/// Check whether a `sea_orm::DbErr` represents a unique-constraint violation.
+///
+/// First tries `SeaORM`'s built-in `sql_err()` detection (SQLSTATE-based).
+/// Falls back to string matching on the error message for cases where
+/// `sql_err()` fails to classify the error (e.g. certain connection proxies
+/// or driver wrappers that strip the SQLSTATE code).
+///
+/// Recognized patterns across backends:
+/// - **Postgres** SQLSTATE `23505` — "`unique_violation`" / "duplicate key"
+/// - **`SQLite`** extended code `2067` — "UNIQUE constraint failed"
+/// - **`MySQL`** error `1062` — "Duplicate entry"
+#[must_use]
+pub fn is_unique_violation(err: &sea_orm::DbErr) -> bool {
+    // Fast path: SeaORM parsed the SQLSTATE / vendor code correctly.
+    if matches!(
+        err.sql_err(),
+        Some(sea_orm::SqlErr::UniqueConstraintViolation(_))
+    ) {
+        return true;
+    }
+
+    // Fallback: string-based detection for wrapped / proxied errors.
+    let msg = err.to_string().to_lowercase();
+    msg.contains("unique constraint")
+        || msg.contains("duplicate key")
+        || msg.contains("unique_violation")
+        || msg.contains("duplicate entry")
+        || msg.contains("unique constraint failed")
+}

--- a/libs/modkit-db/src/secure/mod.rs
+++ b/libs/modkit-db/src/secure/mod.rs
@@ -122,7 +122,7 @@ mod tx_error;
 
 // Core types
 pub use entity_traits::ScopableEntity;
-pub use error::ScopeError;
+pub use error::{ScopeError, is_unique_violation};
 
 // Security types from modkit-security
 pub use modkit_security::{

--- a/modules/mini-chat/mini-chat/src/domain/error.rs
+++ b/modules/mini-chat/mini-chat/src/domain/error.rs
@@ -204,5 +204,14 @@ fn map_db_err(db_err: &sea_orm::DbErr) -> DomainError {
             message: msg,
         };
     }
+    // Fallback: SeaORM's sql_err() may fail to classify the violation when
+    // the error is wrapped by a connection proxy or driver layer. Use the
+    // robust string-based detector from modkit-db.
+    if modkit_db::secure::is_unique_violation(db_err) {
+        return DomainError::Conflict {
+            code: "unique_violation".into(),
+            message: db_err.to_string(),
+        };
+    }
     DomainError::database(db_err.to_string())
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
@@ -432,7 +432,46 @@ impl<
                 // Loser path: another upload already inserted the row.
                 self.poll_vector_store(scope, chat_id).await
             }
-            Err(e) => Err(e),
+            Err(e) => {
+                self.handle_vector_store_insert_race(&conn, scope, chat_id, e)
+                    .await
+            }
+        }
+    }
+
+    /// Defensive fallback for vector-store insert failures that may be
+    /// unrecognised unique-constraint violations (race with a concurrent upload).
+    /// If a row now exists, treat as a loser path; otherwise propagate the error.
+    async fn handle_vector_store_insert_race(
+        &self,
+        conn: &modkit_db::DbConn<'_>,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        original_err: DomainError,
+    ) -> Result<String, DomainError> {
+        match self
+            .vector_store_repo
+            .find_by_chat(conn, scope, chat_id)
+            .await
+        {
+            Ok(Some(row)) if row.vector_store_id.is_some() => {
+                tracing::warn!(
+                    chat_id = %chat_id,
+                    error = %original_err,
+                    "vector store insert failed but row exists (concurrent insert); using existing"
+                );
+                #[allow(clippy::unwrap_used)]
+                Ok(row.vector_store_id.unwrap())
+            }
+            Ok(Some(_)) => {
+                tracing::warn!(
+                    chat_id = %chat_id,
+                    error = %original_err,
+                    "vector store insert failed but placeholder exists (concurrent insert); polling"
+                );
+                self.poll_vector_store(scope, chat_id).await
+            }
+            _ => Err(original_err),
         }
     }
 


### PR DESCRIPTION
- Add `is_unique_violation()` to modkit-db
- Use it in mini-chat's `map_db_err` so the vector-store race on duplicate file uploads returns 409 Conflict instead of 500 Internal Error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better detection of database unique-constraint violations across Postgres, SQLite, and MySQL, producing clearer "conflict" responses when duplicates are detected.
  * More resilient handling of concurrent vector-store creation: insert races are detected and resolved via fallback checks, polling, and warnings to recover existing assignments and avoid spurious failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->