### PR TITLE
fix(oagw): chunked transfer encoding for streaming request bodies

### DIFF
--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -625,16 +625,19 @@ impl DataPlaneService for DataPlaneServiceImpl {
                 }
             })?;
 
-            // Spawn task to forward body stream chunks, then shutdown.
+            // Spawn task to forward body stream chunks with chunked encoding.
             // Enforce max_body_size on the streaming path: signal 413 if exceeded.
+            // Signal abort on stream/write errors so the main select! can fail
+            // fast instead of waiting for the full request timeout.
             let (limit_tx, limit_rx) = tokio::sync::oneshot::channel::<usize>();
+            let (abort_tx, abort_rx) = tokio::sync::oneshot::channel::<String>();
             let body_instance_uri = instance_uri.clone();
             tokio::spawn(async move {
                 let mut total_bytes: usize = 0;
                 let mut exceeded = false;
                 while let Some(chunk) = body_stream.next().await {
                     match chunk {
-                        Ok(bytes) => {
+                        Ok(bytes) if !bytes.is_empty() => {
                             total_bytes = total_bytes.saturating_add(bytes.len());
                             if total_bytes > max_body {
                                 tracing::warn!(
@@ -645,21 +648,47 @@ impl DataPlaneService for DataPlaneServiceImpl {
                                 exceeded = true;
                                 break;
                             }
+                            // Chunked transfer encoding: {size_hex}\r\n{data}\r\n
+                            let chunk_header = format!("{:x}\r\n", bytes.len());
+                            if let Err(e) = client_write.write_all(chunk_header.as_bytes()).await {
+                                tracing::debug!(error = %e, "body stream write error");
+                                let _ = abort_tx.send(format!("body stream write error: {e}"));
+                                return;
+                            }
                             if let Err(e) = client_write.write_all(&bytes).await {
                                 tracing::debug!(error = %e, "body stream write error");
-                                break;
+                                let _ = abort_tx.send(format!("body stream write error: {e}"));
+                                return;
+                            }
+                            if let Err(e) = client_write.write_all(b"\r\n").await {
+                                tracing::debug!(error = %e, "body stream write error");
+                                let _ = abort_tx.send(format!("body stream write error: {e}"));
+                                return;
                             }
                         }
+                        Ok(_) => {} // skip empty chunks
                         Err(e) => {
                             tracing::debug!(error = %e, "body stream chunk error");
-                            break;
+                            let _ = abort_tx.send(format!("body stream read error: {e}"));
+                            return;
                         }
                     }
                 }
                 if exceeded {
                     let _ = limit_tx.send(total_bytes);
+                } else {
+                    // Chunked terminator: signals end-of-body to Pingora.
+                    // Only written after a clean end-of-stream — not after
+                    // write failures or stream errors, where the body is
+                    // incomplete and signalling clean EOF would be wrong.
+                    let _ = client_write.write_all(b"0\r\n\r\n").await;
+                    // Do NOT call shutdown() here — Pingora still needs the
+                    // duplex open to send the response. The chunked terminator
+                    // is sufficient to signal end-of-body. Calling shutdown()
+                    // on the write half of a DuplexStream closes it for the
+                    // peer's read, which can cause Pingora to see EOF before
+                    // it finishes proxying (especially with fast streams).
                 }
-                let _ = client_write.shutdown().await;
             });
 
             // 9. Parse response from the read half, but short-circuit to 413
@@ -678,6 +707,12 @@ impl DataPlaneService for DataPlaneServiceImpl {
                         detail: format!(
                             "streaming request body of {total} bytes exceeds maximum of {max_body} bytes"
                         ),
+                        instance: body_instance_uri,
+                    })
+                }
+                Ok(reason) = abort_rx => {
+                    Err(DomainError::DownstreamError {
+                        detail: format!("streaming request body failed mid-stream: {reason}"),
                         instance: body_instance_uri,
                     })
                 }

--- a/modules/system/oagw/oagw/src/infra/proxy/session_bridge.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/session_bridge.rs
@@ -40,14 +40,16 @@ fn url_path_and_query(url: &str) -> &str {
 ///
 /// - **`body = Some(bytes)`** (buffered path) — emits `Content-Length` and
 ///   appends the body after the blank line.
-/// - **`body = None`** (streaming path) — omits `Content-Length`; the caller
-///   writes body chunks afterward and signals the boundary by shutting down
-///   the write half (EOF), which is valid HTTP/1.1 framing for single-shot
-///   requests.
+/// - **`body = None`** (streaming path) — emits `Transfer-Encoding: chunked`;
+///   the caller writes each body piece in chunked encoding format and
+///   terminates with the final chunk `0\r\n\r\n`. The write half of the
+///   duplex must **not** be shut down — Pingora still needs the connection
+///   open to relay the upstream response.
 ///
 /// In both cases the function emits `Connection: close` (single-shot bridge,
-/// no keep-alive). Any inbound `Content-Length` or `Connection` values
-/// carried in `headers` are dropped to prevent duplicate framing headers.
+/// no keep-alive). Any inbound `Content-Length`, `Connection`, or
+/// `Transfer-Encoding` values carried in `headers` are stripped to prevent
+/// duplicate framing headers.
 pub(crate) fn serialize_request_wire(
     method: &Method,
     url: &str,
@@ -71,7 +73,10 @@ pub(crate) fn serialize_request_wire(
     let _ = write!(buf, "{} {} HTTP/1.1\r\n", method, pq);
     for (name, value) in headers {
         // Skip framing headers — authoritative values are appended below.
-        if name == http::header::CONTENT_LENGTH || name == http::header::CONNECTION {
+        if name == http::header::CONTENT_LENGTH
+            || name == http::header::CONNECTION
+            || name == http::header::TRANSFER_ENCODING
+        {
             continue;
         }
         buf.extend_from_slice(name.as_str().as_bytes());
@@ -80,9 +85,11 @@ pub(crate) fn serialize_request_wire(
         buf.extend_from_slice(b"\r\n");
     }
     // Include Content-Length only for the buffered path so Pingora knows
-    // the body boundary. The streaming path relies on EOF instead.
+    // the body boundary. The streaming path uses chunked transfer encoding.
     if let Some(b) = body {
         let _ = write!(buf, "Content-Length: {}\r\n", b.len());
+    } else {
+        buf.extend_from_slice(b"Transfer-Encoding: chunked\r\n");
     }
     // Single-shot bridge — no keep-alive on the in-memory session.
     buf.extend_from_slice(b"Connection: close\r\n");
@@ -540,28 +547,55 @@ mod tests {
         assert!(text.contains("Connection: close\r\n"));
     }
 
+    #[test]
+    fn serialize_request_buffered_strips_transfer_encoding() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::TRANSFER_ENCODING,
+            HeaderValue::from_static("chunked"),
+        );
+        let body = Bytes::from_static(b"payload");
+        let wire = serialize_request_wire(
+            &Method::POST,
+            "https://example.com/api",
+            &headers,
+            Some(&body),
+        );
+        let text = String::from_utf8_lossy(&wire);
+        assert!(
+            !text.contains("Transfer-Encoding"),
+            "buffered path must not emit Transfer-Encoding"
+        );
+        assert!(text.contains("Content-Length: 7\r\n"));
+    }
+
     // -- serialize_request_wire tests (streaming: body = None) --
 
     #[test]
-    fn streaming_no_content_length() {
+    fn streaming_emits_chunked_te() {
         let mut headers = HeaderMap::new();
         headers.insert("upgrade", HeaderValue::from_static("websocket"));
         let wire = serialize_request_wire(&Method::GET, "wss://example.com/ws", &headers, None);
         let text = String::from_utf8_lossy(&wire);
         assert!(!text.contains("Content-Length"));
+        assert!(text.contains("Transfer-Encoding: chunked\r\n"));
         assert!(text.contains("upgrade: websocket\r\n"));
         assert!(text.contains("Connection: close\r\n"));
         assert!(wire.ends_with(b"\r\n\r\n"));
     }
 
     #[test]
-    fn streaming_no_duplicate_connection_or_content_length() {
+    fn streaming_no_duplicate_framing_headers() {
         let mut headers = HeaderMap::new();
         headers.insert(
             http::header::CONNECTION,
             HeaderValue::from_static("keep-alive"),
         );
         headers.insert(http::header::CONTENT_LENGTH, HeaderValue::from_static("42"));
+        headers.insert(
+            http::header::TRANSFER_ENCODING,
+            HeaderValue::from_static("gzip"),
+        );
         let wire = serialize_request_wire(&Method::POST, "https://example.com/api", &headers, None);
         let text = String::from_utf8_lossy(&wire);
         assert_eq!(
@@ -574,6 +608,12 @@ mod tests {
             !text.contains("Content-Length"),
             "streaming path must not emit Content-Length"
         );
+        assert_eq!(
+            text.matches("Transfer-Encoding:").count(),
+            1,
+            "duplicate Transfer-Encoding"
+        );
+        assert!(text.contains("Transfer-Encoding: chunked\r\n"));
     }
 
     #[test]

--- a/modules/system/oagw/oagw/tests/proxy_integration.rs
+++ b/modules/system/oagw/oagw/tests/proxy_integration.rs
@@ -1697,6 +1697,365 @@ async fn proxy_streaming_body_exceeding_limit_returns_413() {
     }
 }
 
+// Body::Stream POST must reach the upstream intact via chunked transfer
+// encoding on the internal Pingora bridge.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn proxy_streaming_body_post_arrives_intact() {
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "POST",
+        "/v1/upload",
+        MockResponse {
+            status: 200,
+            headers: vec![],
+            body: MockBody::Json(serde_json::json!({"received": true})),
+        },
+    );
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("stream-body-test")
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Post],
+                        path: guard.path("/v1/upload"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Disabled,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Build a multi-chunk streaming body (simulates multipart/streaming upload).
+    let chunk_a = bytes::Bytes::from_static(b"hello ");
+    let chunk_b = bytes::Bytes::from_static(b"streamed ");
+    let chunk_c = bytes::Bytes::from_static(b"world");
+    let chunks: Vec<Result<bytes::Bytes, oagw_sdk::body::BoxError>> =
+        vec![Ok(chunk_a), Ok(chunk_b), Ok(chunk_c)];
+    let stream: oagw_sdk::body::BodyStream = Box::pin(futures_util::stream::iter(chunks));
+    let body = Body::Stream(stream);
+
+    let req = http::Request::builder()
+        .method(Method::POST)
+        .uri(format!("/stream-body-test{}/v1/upload", guard.prefix()))
+        .header(http::header::CONTENT_TYPE, "application/octet-stream")
+        .body(body)
+        .unwrap();
+
+    let resp = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "streaming POST should succeed"
+    );
+
+    // Verify the upstream mock received the complete, reassembled body.
+    let recorded = guard.recorded_requests().await;
+    assert_eq!(recorded.len(), 1, "expected exactly one recorded request");
+    assert_eq!(
+        recorded[0].body, b"hello streamed world",
+        "upstream must receive the full concatenated streaming body"
+    );
+}
+
+// Empty chunks in a Body::Stream must be silently skipped — writing a
+// zero-length chunk would emit the chunked terminator (0\r\n\r\n) and
+// prematurely end the body.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn proxy_streaming_body_with_empty_chunks_succeeds() {
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "POST",
+        "/v1/upload-empty",
+        MockResponse {
+            status: 200,
+            headers: vec![],
+            body: MockBody::Json(serde_json::json!({"received": true})),
+        },
+    );
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("stream-empty-chunks")
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Post],
+                        path: guard.path("/v1/upload-empty"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Disabled,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Interleave real chunks with empty ones.
+    let chunks: Vec<Result<bytes::Bytes, oagw_sdk::body::BoxError>> = vec![
+        Ok(bytes::Bytes::new()), // empty — must be skipped
+        Ok(bytes::Bytes::from_static(b"AB")),
+        Ok(bytes::Bytes::new()), // empty — must be skipped
+        Ok(bytes::Bytes::new()), // empty — must be skipped
+        Ok(bytes::Bytes::from_static(b"CD")),
+        Ok(bytes::Bytes::new()), // trailing empty
+    ];
+    let stream: oagw_sdk::body::BodyStream = Box::pin(futures_util::stream::iter(chunks));
+    let body = Body::Stream(stream);
+
+    let req = http::Request::builder()
+        .method(Method::POST)
+        .uri(format!(
+            "/stream-empty-chunks{}/v1/upload-empty",
+            guard.prefix()
+        ))
+        .header(http::header::CONTENT_TYPE, "application/octet-stream")
+        .body(body)
+        .unwrap();
+
+    let resp = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "streaming POST with empty chunks should succeed"
+    );
+
+    let recorded = guard.recorded_requests().await;
+    assert_eq!(recorded.len(), 1, "expected exactly one recorded request");
+    assert_eq!(
+        recorded[0].body, b"ABCD",
+        "upstream must receive only the non-empty chunks, concatenated"
+    );
+}
+
+// Single-chunk streaming body (boundary condition).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn proxy_streaming_body_single_chunk() {
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "POST",
+        "/v1/upload",
+        MockResponse {
+            status: 200,
+            headers: vec![],
+            body: MockBody::Json(serde_json::json!({"received": true})),
+        },
+    );
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("stream-single-chunk")
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Post],
+                        path: guard.path("/v1/upload"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Disabled,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    let chunks: Vec<Result<bytes::Bytes, oagw_sdk::body::BoxError>> =
+        vec![Ok(bytes::Bytes::from_static(b"single-payload"))];
+    let stream: oagw_sdk::body::BodyStream = Box::pin(futures_util::stream::iter(chunks));
+    let body = Body::Stream(stream);
+
+    let req = http::Request::builder()
+        .method(Method::POST)
+        .uri(format!("/stream-single-chunk{}/v1/upload", guard.prefix()))
+        .header(http::header::CONTENT_TYPE, "application/octet-stream")
+        .body(body)
+        .unwrap();
+
+    let resp = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "single-chunk streaming POST should succeed"
+    );
+
+    let recorded = guard.recorded_requests().await;
+    assert_eq!(recorded.len(), 1, "expected exactly one recorded request");
+    assert_eq!(
+        recorded[0].body, b"single-payload",
+        "upstream must receive the single chunk intact"
+    );
+}
+
+// A stream error mid-body sends the cause on the abort channel so the chunked
+// terminator is NOT written.  The main select! receives the reason immediately,
+// returning a DownstreamError without waiting for the request timeout.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn proxy_streaming_body_error_mid_stream_does_not_send_terminator() {
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "POST",
+        "/v1/upload-err",
+        MockResponse {
+            status: 200,
+            headers: vec![],
+            body: MockBody::Json(serde_json::json!({"received": true})),
+        },
+    );
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("stream-err-test")
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Post],
+                        path: guard.path("/v1/upload-err"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Disabled,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // First chunk succeeds, second chunk is an error — triggers the abort channel.
+    let chunks: Vec<Result<bytes::Bytes, oagw_sdk::body::BoxError>> = vec![
+        Ok(bytes::Bytes::from_static(b"partial")),
+        Err(Box::new(std::io::Error::other("simulated stream failure"))),
+    ];
+    let stream: oagw_sdk::body::BodyStream = Box::pin(futures_util::stream::iter(chunks));
+    let body = Body::Stream(stream);
+
+    let req = http::Request::builder()
+        .method(Method::POST)
+        .uri(format!("/stream-err-test{}/v1/upload-err", guard.prefix()))
+        .header(http::header::CONTENT_TYPE, "application/octet-stream")
+        .body(body)
+        .unwrap();
+
+    match h.facade().proxy_request(ctx.clone(), req).await {
+        Err(err) => assert!(
+            matches!(
+                err,
+                oagw_sdk::error::ServiceGatewayError::DownstreamError { .. }
+            ),
+            "expected DownstreamError, got: {err:?}"
+        ),
+        Ok(resp) => panic!(
+            "expected DownstreamError, got response with status {}",
+            resp.status()
+        ),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // OAuth2 Client Credentials integration tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Streaming Body::Stream requests through the Pingora proxy bridge
were using close-delimited framing, which required shutdown() on
the DuplexStream write half to signal body end. This caused race
conditions where Pingora saw EOF before finishing the proxy cycle.
 
- Emit Transfer-Encoding: chunked header for streaming bodies in
  serialize_request_wire; strip inbound TE to prevent duplicates
- Chunk-encode each body piece (size\r\n data\r\n) and write
  chunked terminator (0\r\n\r\n) when the stream ends cleanly
- Skip empty chunks to avoid premature terminator emission
- Remove shutdown() on write half — chunked terminator is
  sufficient; shutdown closes the peer's read side and races
  with Pingora's upstream connection lifecycle
- Track aborted flag on stream/write errors; only write the
  chunked terminator after clean end-of-stream
- Add abort_tx/abort_rx oneshot so stream errors signal the main
  select! immediately instead of waiting for request timeout
 
Adds 4 e2e tests (multi-chunk, single-chunk, empty-chunk,
error-mid-stream) and 1 unit test (buffered path strips TE).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming requests now use proper chunked-transfer framing: empty chunks skipped, total body size enforced, mid-stream errors abort forwarding and surface as downstream errors, and a chunked terminator marks completion while preserving the connection. Buffered requests keep Content-Length and framing headers are stripped to avoid duplicates.

* **Tests**
  * Added integration tests covering multi-chunk streaming, empty/single-chunk cases, mid-stream errors, size limits, and framing-header duplication.

* **Documentation**
  * Clarified streaming vs buffered framing semantics and header handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->