### PR TITLE
Set individual version for each package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace.package]
-version = "0.6.1"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["Cyber Fabric"]

--- a/apps/gts-docs-validator/Cargo.toml
+++ b/apps/gts-docs-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gts-docs-validator"
-version.workspace = true
+version = "0.6.1"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperspot-server"
-version.workspace = true
+version = "0.6.1"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/dylint_lints/de05_client_layer/de0503_plugin_client_suffix/Cargo.toml
+++ b/dylint_lints/de05_client_layer/de0503_plugin_client_suffix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "de0503_plugin_client_suffix"
-version.workspace = true
+version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/dylint_lints/de05_client_layer/de0504_client_versioning/Cargo.toml
+++ b/dylint_lints/de05_client_layer/de0504_client_versioning/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "de0504_client_versioning"
-version.workspace = true
+version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/examples/modkit/users-info/users-info-sdk/Cargo.toml
+++ b/examples/modkit/users-info/users-info-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "users-info-sdk"
-version.workspace = true
+version = "0.6.1"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/examples/modkit/users-info/users-info/Cargo.toml
+++ b/examples/modkit/users-info/users-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "users-info"
-version.workspace = true
+version = "0.6.1"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/libs/modkit-auth/Cargo.toml
+++ b/libs/modkit-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-auth"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-canonical-errors/Cargo.toml
+++ b/libs/modkit-canonical-errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-canonical-errors"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-db-macros/Cargo.toml
+++ b/libs/modkit-db-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-db-macros"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-db/Cargo.toml
+++ b/libs/modkit-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-db"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-errors-macro/Cargo.toml
+++ b/libs/modkit-errors-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-errors-macro"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-errors/Cargo.toml
+++ b/libs/modkit-errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-errors"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-http/Cargo.toml
+++ b/libs/modkit-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-http"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-macros-tests/Cargo.toml
+++ b/libs/modkit-macros-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-macros-tests"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-macros/Cargo.toml
+++ b/libs/modkit-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-macros"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-node-info/Cargo.toml
+++ b/libs/modkit-node-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-node-info"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-odata-macros/Cargo.toml
+++ b/libs/modkit-odata-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-odata-macros"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-odata/Cargo.toml
+++ b/libs/modkit-odata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-odata"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-sdk/Cargo.toml
+++ b/libs/modkit-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-sdk"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-security/Cargo.toml
+++ b/libs/modkit-security/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-security"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-transport-grpc/Cargo.toml
+++ b/libs/modkit-transport-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-transport-grpc"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit-utils/Cargo.toml
+++ b/libs/modkit-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit-utils"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-modkit"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/mini-chat/plugins/static-model-policy-plugin/Cargo.toml
+++ b/modules/mini-chat/plugins/static-model-policy-plugin/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "cf-static-mini-chat-model-policy-plugin"
+version = "0.6.1"
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Static model-policy plugin for mini-chat with config-driven model catalog"
+
+[lib]
+name = "static_mini_chat_model_policy_plugin"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Plugin SDK
+mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.9.0", path = "../../mini-chat-sdk" }
+types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.5", path = "../../../system/types-registry/types-registry-sdk" }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-macros = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+tokio-util = { workspace = true }
+
+# Data structures
+uuid = { workspace = true }
+time = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# Required by modkit::module macro
+inventory = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/modules/system/types-sdk/Cargo.toml
+++ b/modules/system/types-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "types-sdk"
-version.workspace = true
+version = "0.6.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/modules/system/types/Cargo.toml
+++ b/modules/system/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "types"
-version.workspace = true
+version = "0.6.1"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,7 +1,7 @@
 [workspace]
 # Keep the defaults simple and explicit. We rely on Cargo manifests for:
 # - which crates are publishable (`publish = false` disables)
-# - per-crate versioning (explicit `version = ...` for modules/sdks, and `version.workspace = true` for ModKit libs)
+# - per-crate versioning (every crate has its own explicit `version = ...`)
 #
 # NOTE: release-plz may temporarily checkout commits while computing diffs.
 # Some repos can end up "dirty" due to generated/normalized files, so we allow it.


### PR DESCRIPTION
Set individual version for each package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workspace-level package version removed; crates now declare explicit versions.
  * Most crates pinned to 0.6.1; several lint/tooling crates set to 0.1.0.
  * Release configuration comment updated to reflect per-crate explicit versioning.
* **New Features**
  * Added a new static model policy plugin for the mini-chat module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->