### PR TITLE
feat(mini-chat): streaming file upload with incremental size enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,6 +1259,7 @@ dependencies = [
  "heck 0.5.0",
  "http",
  "inventory",
+ "multer",
  "opentelemetry",
  "opentelemetry_sdk",
  "pin-project-lite",

--- a/modules/mini-chat/docs/DESIGN.md
+++ b/modules/mini-chat/docs/DESIGN.md
@@ -1099,7 +1099,7 @@ For streaming endpoints, failures before any streaming begins MUST be returned a
 | `quota_exceeded` | 429 | Quota exhaustion. Always accompanied by a `quota_scope` field: `"tokens"` (token rate limits across all tiers exhausted, emergency flags, or all models disabled), `"uploads"` (daily upload quota exceeded for the attachment endpoint), `"web_search"` (per-user daily web search call quota exhausted), or `"image_inputs"` (per-turn or per-day image input limit exceeded). |
 | `web_search_disabled` | 400 | Request includes `web_search.enabled=true` but the global `disable_web_search` kill switch is active |
 | `rate_limited` | 429 | Provider upstream throttling (provider 429 after OAGW retry exhaustion) |
-| `file_too_large` | 413 | Uploaded file exceeds size limit |
+| `file_too_large` | 413 | Uploaded file exceeds the effective per-file size limit (`min(ConfigMap, CCM per-model)`). Enforced mid-stream during multipart ingestion — the handler aborts after the byte counter crosses the limit without buffering the full body. |
 | `unsupported_file_type` | 415 | File type not supported for upload |
 | `too_many_images` | 400 | Request includes more than the configured maximum images for a single turn |
 | `image_bytes_exceeded` | 413 | Request includes images whose total configured per-turn byte limit is exceeded |
@@ -1382,10 +1382,15 @@ sequenceDiagram
     participant OG as outbound_gateway
     participant OAI as OpenAI / Azure OpenAI
 
-    UI->>AG: POST /v1/chats/{id}/attachments (multipart)
-    AG->>CS: UploadAttachment(chat_id, file, security_ctx)
-    CS->>DB: Insert attachment metadata (status: pending, attachment_kind derived from MIME)
-    CS->>OG: POST /outbound/llm/files (upload)
+    UI->>AG: POST /v1/chats/{id}/attachments (multipart, streaming)
+    AG->>CS: UploadAttachment(chat_id, multipart_stream, security_ctx)
+
+    Note over CS: Handler: resolve MIME from field headers (before body read)
+    Note over CS: Handler: authz + model resolve → UploadLimits (min(ConfigMap, CCM per-model))
+    Note over CS: Handler: stream chunks with byte counter; abort 413 if limit exceeded
+
+    CS->>DB: Insert attachment metadata (status: pending, size_bytes=hint, attachment_kind from MIME)
+    CS->>OG: POST /outbound/llm/files (streaming multipart via OAGW SDK)
     OG->>OAI: Files API upload
     OAI-->>OG: provider_file_id
     OG-->>CS: provider_file_id
@@ -6687,7 +6692,14 @@ Estimation budgets are embedded **per-model** in the policy snapshot catalog. Ea
 | `thumbnail_max_pixels` | `integer` | `100000000` | **ConfigMap** |
 | `thumbnail_max_decode_bytes` | `integer` | `33554432` | **ConfigMap** |
 
-Note: per-model `max_file_size_mb` is available from **CCM API**: `GET /policies/{v}` → `snapshot.model_catalog[].general_config.max_file_size_mb`.
+**Two-layer per-file size limit resolution**: The effective per-file upload limit is `min(ConfigMap, CCM per-model)`:
+
+- **ConfigMap** (kind-specific): `uploaded_file_max_size_kb` for documents, `uploaded_image_max_size_kb` for images. Deployment-wide operational ceiling.
+- **CCM** (kind-agnostic): `max_file_size_mb` from `snapshot.model_catalog[].general_config.max_file_size_mb`. Per-model provider constraint, runtime-updatable via policy snapshot. Applies to both documents and images.
+
+The handler resolves the effective limit before streaming body bytes. If the CCM snapshot is unavailable, the system falls back to ConfigMap-only limits (safe — ConfigMap is always ≥ CCM).
+
+**Streaming upload**: The upload endpoint uses streaming multipart ingestion (`field.chunk()` loop) with incremental byte counting. Oversize files are rejected mid-stream with HTTP 413 (`file_too_large`) without buffering the full body. An Axum `DefaultBodyLimit` layer (25 MiB + 64 KiB overhead) acts as a coarse outer guard on the upload route, overriding the API gateway's default 16 MiB limit.
 
 ## B.9 Background workers
 

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -47,6 +47,7 @@ pin-project-lite = { workspace = true }
 futures = { workspace = true }
 bytes = { workspace = true }
 regex = { workspace = true }
+multer = "3.1"
 
 # Encoding
 base64 = { workspace = true }

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
@@ -1,70 +1,227 @@
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use axum::Extension;
-use axum::extract::{Multipart, Path};
+use axum::extract::Path;
+use bytes::Bytes;
+use futures::stream::Stream;
 use modkit::api::prelude::*;
 use modkit_security::SecurityContext;
 
 use crate::api::rest::dto::AttachmentDetailDto;
+use crate::domain::mime_validation::{
+    infer_mime_from_extension, normalize_mime, remap_csv_to_plain, validate_mime,
+};
 use crate::module::AppServices;
+
+// ── multer::Field → FileStream adapter ──────────────────────────────────
+
+/// Wraps `multer::Field<'static>` as a [`FileStream`] with a kind-specific
+/// size limit enforced during streaming.
+///
+/// `multer::Constraints` provides a coarse outer guard (max of file/image
+/// limits). This wrapper enforces the fine-grained per-kind limit after
+/// MIME validation determines whether the upload is a document or image.
+/// Fused: stops after error or completion.
+struct FieldStream {
+    field: multer::Field<'static>,
+    max_bytes: u64,
+    total_bytes: u64,
+    done: bool,
+}
+
+impl FieldStream {
+    fn new(field: multer::Field<'static>, max_bytes: u64) -> Self {
+        Self {
+            field,
+            max_bytes,
+            total_bytes: 0,
+            done: false,
+        }
+    }
+}
+
+impl Stream for FieldStream {
+    type Item = Result<Bytes, Box<dyn std::error::Error + Send + Sync>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if this.done {
+            return Poll::Ready(None);
+        }
+        match Pin::new(&mut this.field).poll_next(cx) {
+            Poll::Ready(Some(Ok(chunk))) => {
+                this.total_bytes += chunk.len() as u64;
+                if this.total_bytes > this.max_bytes {
+                    this.done = true;
+                    tracing::info!(
+                        total_bytes = this.total_bytes,
+                        max_bytes = this.max_bytes,
+                        "streaming upload: size limit exceeded"
+                    );
+                    Poll::Ready(Some(Err(Box::new(multer::Error::FieldSizeExceeded {
+                        limit: this.max_bytes,
+                        field_name: Some("file".to_owned()),
+                    }))))
+                } else {
+                    Poll::Ready(Some(Ok(chunk)))
+                }
+            }
+            Poll::Ready(Some(Err(e))) => {
+                this.done = true;
+                Poll::Ready(Some(Err(Box::new(e))))
+            }
+            Poll::Ready(None) => {
+                this.done = true;
+                tracing::debug!(
+                    total_bytes = this.total_bytes,
+                    "streaming upload: stream complete"
+                );
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+// ── Handlers ────────────────────────────────────────────────────────────
 
 /// POST /mini-chat/v1/chats/{id}/attachments
 ///
-/// Multipart upload: field name `"file"` with the file content.
-/// Content-Type of the file is validated against the MIME allowlist.
-#[tracing::instrument(skip(svc, ctx, multipart), fields(chat_id = %chat_id))]
+/// Streaming multipart upload with zero-copy size enforcement.
+/// Uses `multer` directly (not Axum's `Multipart` extractor) so the field
+/// is `'static` and can be wrapped as a `FileStream` without buffering.
+/// `multer::Constraints` enforces the per-field size limit at the parser
+/// level — oversize fields produce `multer::Error::FieldSizeExceeded`.
+#[tracing::instrument(skip(svc, ctx, headers, body), fields(chat_id = %chat_id))]
 pub(crate) async fn upload_attachment(
     Extension(ctx): Extension<SecurityContext>,
     Extension(svc): Extension<Arc<AppServices>>,
     Path(chat_id): Path<uuid::Uuid>,
-    mut multipart: Multipart,
+    headers: http::HeaderMap,
+    body: axum::body::Body,
 ) -> ApiResult<impl IntoResponse> {
-    // Extract file from multipart (field name: "file")
-    let mut filename: Option<String> = None;
-    let mut content_type: Option<String> = None;
-    let mut file_bytes: Option<bytes::Bytes> = None;
+    // 1. Resolve upload context (authz + model + limits) before reading body.
+    let upload_ctx = svc.attachments.get_upload_context(&ctx, chat_id).await?;
 
-    while let Some(field) = multipart.next_field().await.map_err(|e| {
+    // 2. Parse multipart boundary from Content-Type header.
+    let content_type = headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let boundary = multer::parse_boundary(content_type).map_err(|_| {
         Problem::new(
             http::StatusCode::BAD_REQUEST,
-            "Multipart Error",
-            format!("Failed to read multipart field: {e}"),
+            "Missing Boundary",
+            "Content-Type must be multipart/form-data with a boundary",
         )
-    })? {
-        let field_name = field.name().unwrap_or("").to_owned();
-        if field_name == "file" {
-            filename = field.file_name().map(ToString::to_string);
-            content_type = field.content_type().map(ToString::to_string);
-            file_bytes = Some(field.bytes().await.map_err(|e| {
-                Problem::new(
+    })?;
+
+    // 3. Create multer::Multipart with per-field size constraint.
+    //    We don't know the attachment kind yet (need to read headers first),
+    //    so we use the larger of the two limits. The actual kind-specific
+    //    limit is enforced after MIME validation if needed.
+    let coarse_limit = upload_ctx
+        .limits
+        .max_file_bytes
+        .max(upload_ctx.limits.max_image_bytes);
+    let constraints = multer::Constraints::new().size_limit(
+        multer::SizeLimit::new()
+            .whole_stream(coarse_limit + 64 * 1024) // file + multipart overhead
+            .for_field("file", coarse_limit),
+    );
+    let mut multipart =
+        multer::Multipart::with_constraints(body.into_data_stream(), boundary, constraints);
+
+    // 4. Find the "file" field.
+    let field = loop {
+        match multipart.next_field().await.map_err(|e| {
+            Problem::new(
+                http::StatusCode::BAD_REQUEST,
+                "Multipart Error",
+                format!("Failed to read multipart field: {e}"),
+            )
+        })? {
+            Some(f) if f.name() == Some("file") => break f,
+            Some(_) => {}
+            None => {
+                return Err(Problem::new(
                     http::StatusCode::BAD_REQUEST,
-                    "Multipart Error",
-                    format!("Failed to read file data: {e}"),
-                )
-            })?);
-            break;
+                    "Missing File",
+                    "No file field found in multipart request",
+                ));
+            }
         }
-    }
+    };
 
-    let filename = filename.unwrap_or_else(|| "upload".to_owned());
-    let content_type = content_type.ok_or_else(|| {
-        Problem::new(
-            http::StatusCode::BAD_REQUEST,
-            "Missing File",
-            "No file field found in multipart request",
-        )
-    })?;
-    let file_bytes = file_bytes.ok_or_else(|| {
-        Problem::new(
-            http::StatusCode::BAD_REQUEST,
-            "Missing File",
-            "No file data found in multipart request",
-        )
-    })?;
+    // 5. Extract headers (available before body bytes).
+    let filename = field
+        .file_name()
+        .map_or_else(|| "upload".to_owned(), ToString::to_string);
+    // Truncate to 255 chars (DB column is VARCHAR(255)).
+    let filename = if filename.len() > 255 {
+        filename[..255].to_owned()
+    } else {
+        filename
+    };
+    let raw_ct = field
+        .content_type()
+        .map(ToString::to_string)
+        .ok_or_else(|| {
+            Problem::new(
+                http::StatusCode::BAD_REQUEST,
+                "Missing Content-Type",
+                "File field has no content type",
+            )
+        })?;
 
+    // 6. MIME validation (from field headers, before reading body bytes).
+    let effective_ct = if normalize_mime(&raw_ct) == "application/octet-stream" {
+        infer_mime_from_extension(&filename).unwrap_or(&raw_ct)
+    } else {
+        &raw_ct
+    };
+    let effective_ct = if upload_ctx.allow_csv_upload {
+        remap_csv_to_plain(effective_ct).unwrap_or(effective_ct)
+    } else {
+        effective_ct
+    };
+    let validated = validate_mime(effective_ct)?;
+    let is_document = validated.kind == crate::domain::mime_validation::AttachmentKind::Document;
+
+    // 7. Kind-specific size limit (multer's coarse constraint uses the max).
+    let max_bytes = if is_document {
+        upload_ctx.limits.max_file_bytes
+    } else {
+        upload_ctx.limits.max_image_bytes
+    };
+
+    // 8. Wrap field as FileStream with kind-specific size enforcement.
+    //    Zero buffering in handler — multer provides the coarse guard,
+    //    FieldStream enforces the fine-grained per-kind limit.
+    let file_stream: crate::domain::ports::FileStream =
+        Box::pin(FieldStream::new(field, max_bytes));
+
+    // 8. Best-effort size_hint from Content-Length (enables aggregate check).
+    let size_hint = headers
+        .get(http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok());
+
+    // 9. Call domain service with pre-resolved context.
     let row = svc
         .attachments
-        .upload_file(&ctx, chat_id, filename, &content_type, file_bytes)
+        .upload_file(
+            &ctx,
+            chat_id,
+            upload_ctx,
+            filename,
+            validated.mime,
+            validated.kind,
+            file_stream,
+            size_hint,
+        )
         .await?;
 
     Ok((

--- a/modules/mini-chat/mini-chat/src/api/rest/routes/attachments.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/routes/attachments.rs
@@ -1,4 +1,5 @@
 use axum::Router;
+use axum::extract::DefaultBodyLimit;
 use modkit::api::OpenApiRegistry;
 use modkit::api::operation_builder::OperationBuilder;
 
@@ -7,12 +8,23 @@ use crate::api::rest::handlers;
 
 const API_TAG: &str = "Mini Chat Attachments";
 
+/// Coarse outer body-size guard for the upload route.
+///
+/// Set to the largest allowed upload (25 MiB for files) plus 64 KiB for
+/// multipart overhead. The fine-grained per-kind limit is enforced by the
+/// handler's streaming byte counter.
+///
+/// This overrides the API gateway's global `DefaultBodyLimit` (16 MiB)
+/// so that file uploads up to 25 MiB are not rejected by the framework.
+const UPLOAD_BODY_LIMIT: usize = 25 * 1024 * 1024 + 65536;
+
 pub(super) fn register_attachment_routes(
     mut router: Router,
     openapi: &dyn OpenApiRegistry,
     prefix: &str,
 ) -> Router {
     // POST {prefix}/v1/chats/{id}/attachments (multipart/form-data)
+    // DefaultBodyLimit overrides the gateway's global 16 MiB limit for this route.
     router = OperationBuilder::post(format!("{prefix}/v1/chats/{{id}}/attachments"))
         .operation_id("mini_chat.upload_attachment")
         .summary("Upload an attachment to a chat")
@@ -24,7 +36,8 @@ pub(super) fn register_attachment_routes(
         .json_response(http::StatusCode::CREATED, "Attachment uploaded")
         .error_415(openapi)
         .standard_errors(openapi)
-        .register(router, openapi);
+        .register(router, openapi)
+        .layer(DefaultBodyLimit::max(UPLOAD_BODY_LIMIT));
 
     // GET {prefix}/v1/chats/{id}/attachments/{attachment_id}
     router = OperationBuilder::get(format!(

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -670,12 +670,12 @@ fn default_max_total_upload_mb_per_chat() -> u32 {
     100
 }
 
-fn default_max_document_size_kb() -> u32 {
+fn default_uploaded_file_max_size_kb() -> u32 {
     // 25 MB in KB
     25 * 1024
 }
 
-fn default_max_image_size_kb() -> u32 {
+fn default_uploaded_image_max_size_kb() -> u32 {
     // 5 MB in KB
     5 * 1024
 }
@@ -692,13 +692,13 @@ pub struct RagConfig {
     #[serde(default = "default_max_total_upload_mb_per_chat")]
     pub max_total_upload_mb_per_chat: u32,
 
-    /// Maximum single document file size in KB.
-    #[serde(default = "default_max_document_size_kb")]
-    pub max_document_size_kb: u32,
+    /// Maximum single uploaded file (document) size in KB.
+    #[serde(default = "default_uploaded_file_max_size_kb")]
+    pub uploaded_file_max_size_kb: u32,
 
-    /// Maximum single image file size in KB.
-    #[serde(default = "default_max_image_size_kb")]
-    pub max_image_size_kb: u32,
+    /// Maximum single uploaded image size in KB.
+    #[serde(default = "default_uploaded_image_max_size_kb")]
+    pub uploaded_image_max_size_kb: u32,
 
     /// Accept `text/csv` uploads remapped to `text/plain` for `file_search`.
     #[serde(default = "default_true")]
@@ -710,8 +710,8 @@ impl Default for RagConfig {
         Self {
             max_documents_per_chat: default_max_documents_per_chat(),
             max_total_upload_mb_per_chat: default_max_total_upload_mb_per_chat(),
-            max_document_size_kb: default_max_document_size_kb(),
-            max_image_size_kb: default_max_image_size_kb(),
+            uploaded_file_max_size_kb: default_uploaded_file_max_size_kb(),
+            uploaded_image_max_size_kb: default_uploaded_image_max_size_kb(),
             allow_csv_upload: true,
         }
     }
@@ -725,11 +725,11 @@ impl RagConfig {
         if self.max_total_upload_mb_per_chat == 0 {
             return Err("rag max_total_upload_mb_per_chat must be > 0".into());
         }
-        if self.max_document_size_kb == 0 {
-            return Err("rag max_document_size_kb must be > 0".into());
+        if self.uploaded_file_max_size_kb == 0 {
+            return Err("rag uploaded_file_max_size_kb must be > 0".into());
         }
-        if self.max_image_size_kb == 0 {
-            return Err("rag max_image_size_kb must be > 0".into());
+        if self.uploaded_image_max_size_kb == 0 {
+            return Err("rag uploaded_image_max_size_kb must be > 0".into());
         }
         Ok(())
     }

--- a/modules/mini-chat/mini-chat/src/domain/models.rs
+++ b/modules/mini-chat/mini-chat/src/domain/models.rs
@@ -162,6 +162,10 @@ pub struct ResolvedModel {
     pub description: Option<String>,
     pub multimodal_capabilities: Vec<String>,
     pub context_window: u32,
+    /// Per-model upload file size limit in MB, from CCM policy snapshot.
+    /// Used as the provider-side ceiling in two-layer limit resolution
+    /// (`min(ConfigMap, CCM)`).
+    pub max_file_size_mb: u32,
     /// System prompt sent as `instructions` in every LLM request for this model.
     /// Sourced from `ModelCatalogEntry.system_prompt` (per-model, per-policy-version).
     pub system_prompt: String,
@@ -186,6 +190,7 @@ impl From<&mini_chat_sdk::ModelCatalogEntry> for ResolvedModel {
             },
             multimodal_capabilities: e.multimodal_capabilities.clone(),
             context_window: e.context_window,
+            max_file_size_mb: e.general_config.max_file_size_mb,
             system_prompt: e.system_prompt.clone(),
         }
     }

--- a/modules/mini-chat/mini-chat/src/domain/ports/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/ports/mod.rs
@@ -7,13 +7,23 @@
 //! live in `infra::llm::providers` and `infra::metrics`.
 
 use std::collections::HashMap;
+use std::pin::Pin;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::stream::Stream;
 use modkit_macros::domain_model;
 use modkit_security::SecurityContext;
 
 use super::error::DomainError;
+
+/// Async byte stream used for streaming file uploads through the domain layer.
+///
+/// Identical shape to `oagw_sdk::BodyStream` — conversion at the infra
+/// boundary is zero-cost. Defined here to keep the domain layer free of
+/// HTTP / infra SDK dependencies (enforced by dylint).
+pub type FileStream =
+    Pin<Box<dyn Stream<Item = Result<Bytes, Box<dyn std::error::Error + Send + Sync>>> + Send>>;
 
 pub(crate) mod metric_labels;
 pub(crate) mod metrics;
@@ -69,11 +79,14 @@ impl From<FileStorageError> for DomainError {
 // ── Param structs ───────────────────────────────────────────────────────
 
 /// Parameters for uploading a file to a provider.
+///
+/// `file_stream` is an async byte stream — the provider implementation
+/// forwards chunks to OAGW without buffering the entire file.
 #[domain_model]
 pub struct UploadFileParams {
     pub filename: String,
     pub content_type: String,
-    pub file_bytes: Bytes,
+    pub file_stream: FileStream,
     pub purpose: String,
 }
 
@@ -90,13 +103,13 @@ pub struct AddFileToVectorStoreParams {
 /// Port for file upload/delete operations against a storage provider.
 #[async_trait]
 pub trait FileStorageProvider: Send + Sync {
-    /// Upload a file and return the provider-assigned file ID.
+    /// Upload a file and return `(provider_file_id, bytes_uploaded)`.
     async fn upload_file(
         &self,
         ctx: SecurityContext,
         provider_id: &str,
         params: UploadFileParams,
-    ) -> Result<String, FileStorageError>;
+    ) -> Result<(String, u64), FileStorageError>;
 
     /// Delete a file from the provider. Best-effort — errors are logged, not fatal.
     async fn delete_file(

--- a/modules/mini-chat/mini-chat/src/domain/repos/attachment_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/attachment_repo.rs
@@ -25,10 +25,14 @@ pub struct InsertAttachmentParams {
 }
 
 /// Parameters for CAS transition `pending → uploaded`.
+///
+/// `size_bytes` is the exact byte count observed during streaming upload,
+/// set here because the size is unknown at INSERT time (streaming).
 #[domain_model]
 pub struct SetUploadedParams {
     pub id: Uuid,
     pub provider_file_id: String,
+    pub size_bytes: i64,
 }
 
 /// Parameters for CAS transition `uploaded → ready`.

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use authz_resolver_sdk::PolicyEnforcer;
-use bytes::Bytes;
 use modkit_macros::domain_model;
 use modkit_security::{AccessScope, SecurityContext};
 use uuid::Uuid;
@@ -57,6 +56,28 @@ impl Drop for PendingGuard {
             self.metrics.decrement_attachments_pending();
         }
     }
+}
+
+// ── Upload limits ────────────────────────────────────────────────────────
+
+/// Effective per-file size limits resolved from config + CCM per-model.
+#[domain_model]
+#[derive(Debug, Clone, Copy)]
+pub struct UploadLimits {
+    pub max_file_bytes: u64,
+    pub max_image_bytes: u64,
+}
+
+/// Pre-resolved context returned by `get_upload_context` so that
+/// `upload_file` can skip the duplicate authz + model resolution.
+#[domain_model]
+pub struct UploadContext {
+    pub scope: AccessScope,
+    pub provider_id: String,
+    pub storage_backend: String,
+    pub limits: UploadLimits,
+    /// Whether `text/csv` uploads should be remapped to `text/plain`.
+    pub allow_csv_upload: bool,
 }
 
 // ── Error helpers for transaction boundary crossing ─────────────────────
@@ -155,6 +176,85 @@ impl<
             rag_config,
             metrics,
         }
+    }
+
+    /// Resolve the effective upload size limits for a chat.
+    ///
+    /// Performs authz + chat ownership + model resolution, then computes
+    /// `min(ConfigMap, CCM per-model)` for each kind. Returns an
+    /// `UploadContext` that `upload_file` can reuse (no double-authz).
+    ///
+    /// Falls back to ConfigMap-only limits if model resolution fails
+    /// (e.g., CCM snapshot unavailable).
+    pub(crate) async fn get_upload_context(
+        &self,
+        ctx: &SecurityContext,
+        chat_id: Uuid,
+    ) -> Result<UploadContext, DomainError> {
+        let scope = self
+            .enforcer
+            .access_scope(
+                ctx,
+                &super::resources::CHAT,
+                super::actions::UPLOAD_ATTACHMENT,
+                Some(chat_id),
+            )
+            .await?;
+
+        let conn = self.db.conn().map_err(DomainError::from)?;
+        let chat_scope = scope.ensure_owner(ctx.subject_id());
+        let chat = self
+            .chat_repo
+            .get(&conn, &chat_scope, chat_id)
+            .await?
+            .ok_or_else(|| DomainError::not_found("Chat", chat_id))?;
+
+        // ConfigMap ceiling (always available).
+        let config_file_bytes = u64::from(self.rag_config.uploaded_file_max_size_kb) * 1024;
+        let config_image_bytes = u64::from(self.rag_config.uploaded_image_max_size_kb) * 1024;
+
+        // CCM per-model limit (best-effort — fall back to ConfigMap on failure).
+        let (provider_id, storage_backend, ccm_bytes) = match self
+            .model_resolver
+            .resolve_model(ctx.subject_id(), Some(chat.model))
+            .await
+        {
+            Ok(resolved) => {
+                let backend = self
+                    .provider_resolver
+                    .resolve_storage_backend(&resolved.provider_id);
+                let ccm = u64::from(resolved.max_file_size_mb) * 1_048_576;
+                (resolved.provider_id, backend, Some(ccm))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    chat_id = %chat_id,
+                    error = %e,
+                    "model resolution failed for upload limits; using ConfigMap only"
+                );
+                // Fall back: use first configured provider as best guess.
+                // upload_file will re-attempt model resolution anyway.
+                let fallback_provider = "openai".to_owned();
+                let backend = self
+                    .provider_resolver
+                    .resolve_storage_backend(&fallback_provider);
+                (fallback_provider, backend, None)
+            }
+        };
+
+        let limits = UploadLimits {
+            max_file_bytes: ccm_bytes.map_or(config_file_bytes, |ccm| config_file_bytes.min(ccm)),
+            max_image_bytes: ccm_bytes
+                .map_or(config_image_bytes, |ccm| config_image_bytes.min(ccm)),
+        };
+
+        Ok(UploadContext {
+            scope,
+            provider_id,
+            storage_backend,
+            limits,
+            allow_csv_upload: self.rag_config.allow_csv_upload,
+        })
     }
 
     /// Get attachment metadata by ID.
@@ -523,11 +623,16 @@ impl<
 
     /// Upload a file attachment to a chat.
     ///
-    /// Flow: resolve provider from chat model -> validate MIME ->
+    /// Flow: use pre-resolved `UploadContext` (from `get_upload_context`) ->
     ///   TX(lock chat, check limits, insert pending) -> COMMIT ->
-    ///   upload to provider via OAGW -> CAS `set_uploaded` -> branch on kind:
+    ///   upload stream to provider via OAGW -> CAS `set_uploaded` (with exact size) ->
+    ///   branch on kind:
     ///   - Document: vector store get-or-create + add file with attributes + CAS `set_ready`
     ///   - Image: CAS `set_ready` directly
+    ///
+    /// MIME validation and per-file size enforcement are handled by the
+    /// handler before calling this method. The handler passes the
+    /// pre-validated MIME, attachment kind, and a size-limited `FileStream`.
     ///
     /// Returns the created attachment row.
     #[allow(
@@ -540,94 +645,45 @@ impl<
         &self,
         ctx: &SecurityContext,
         chat_id: Uuid,
+        upload_ctx: UploadContext,
         filename: String,
-        content_type: &str,
-        file_bytes: Bytes,
+        validated_mime: &str,
+        attachment_kind: AttachmentKind,
+        file_stream: crate::domain::ports::FileStream,
+        size_hint: Option<u64>,
     ) -> Result<AttachmentModel, DomainError> {
-        use crate::domain::mime_validation::{
-            infer_mime_from_extension, normalize_mime, remap_csv_to_plain, structured_filename,
-            validate_mime,
-        };
+        use crate::domain::mime_validation::structured_filename;
         use crate::domain::repos::InsertAttachmentParams;
 
         let tenant_id = ctx.subject_tenant_id();
         let user_id = ctx.subject_id();
+        let is_document = attachment_kind == AttachmentKind::Document;
 
-        // 1. MIME validate
-        // Step A: infer from extension when client sends octet-stream
-        let effective_ct = if normalize_mime(content_type) == "application/octet-stream"
-            && let Some(inferred) = infer_mime_from_extension(&filename)
-        {
-            tracing::debug!(
-                original = %content_type,
-                inferred,
-                filename = %filename,
-                "MIME inferred from file extension (client sent octet-stream)"
-            );
-            inferred
-        } else {
-            content_type
-        };
-        // Step B: remap CSV → text/plain when allowed
-        let effective_ct = if self.rag_config.allow_csv_upload
-            && let Some(remapped) = remap_csv_to_plain(effective_ct)
-        {
-            tracing::debug!(original = %effective_ct, remapped, "CSV content-type remapped to text/plain");
-            remapped
-        } else {
-            effective_ct
-        };
-        let validated = validate_mime(effective_ct)?;
-        let is_document = validated.kind == AttachmentKind::Document;
+        let scope = upload_ctx.scope;
+        let provider_id = upload_ctx.provider_id;
+        let storage_backend = upload_ctx.storage_backend;
 
         #[allow(clippy::cast_possible_wrap)]
-        let size_bytes = file_bytes.len() as i64;
-
-        // Per-file size check
-        Self::check_file_size(size_bytes, is_document, &self.rag_config)?;
+        let hint_bytes = size_hint.map_or(0i64, |h| h as i64);
 
         let attachment_id = Uuid::now_v7();
 
-        // 2. Authz scope + resolve provider from chat model
-        let scope = self
-            .enforcer
-            .access_scope(
-                ctx,
-                &super::resources::CHAT,
-                super::actions::UPLOAD_ATTACHMENT,
-                Some(chat_id),
-            )
-            .await?;
-
-        let conn = self.db.conn().map_err(DomainError::from)?;
         let chat_scope = scope.ensure_owner(ctx.subject_id());
-        let chat = self
-            .chat_repo
-            .get(&conn, &chat_scope, chat_id)
-            .await?
-            .ok_or_else(|| DomainError::not_found("Chat", chat_id))?;
-        let resolved = self
-            .model_resolver
-            .resolve_model(user_id, Some(chat.model))
-            .await?;
-        let provider_id = resolved.provider_id;
-
-        let storage_backend = self.provider_resolver.resolve_storage_backend(&provider_id);
 
         let attachment_repo = Arc::clone(&self.attachment_repo);
         let chat_repo = Arc::clone(&self.chat_repo);
         let rag_config = self.rag_config.clone();
         let chat_scope_tx = chat_scope.clone();
         let scope_tx = scope.clone();
-        let kind_str = validated.kind.to_string();
+        let kind_str = attachment_kind.to_string();
         let insert_params = InsertAttachmentParams {
             id: attachment_id,
             tenant_id,
             chat_id,
             uploaded_by_user_id: user_id,
             filename: filename.clone(),
-            content_type: validated.mime.to_owned(),
-            size_bytes,
+            content_type: validated_mime.to_owned(),
+            size_bytes: hint_bytes,
             storage_backend: storage_backend.clone(),
             attachment_kind: kind_str,
         };
@@ -663,20 +719,24 @@ impl<
                         }
                     }
 
-                    let current_bytes = attachment_repo
-                        .sum_size_bytes(tx, &scope_tx, chat_id)
-                        .await
-                        .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
-                    let max_bytes = i64::from(rag_config.max_total_upload_mb_per_chat) * 1_048_576;
-                    if current_bytes + size_bytes > max_bytes {
-                        return Err(mutation_to_db_err(
-                            AttachmentMutationError::StorageLimitExceeded {
-                                message: format!("Upload would exceed {max_bytes} byte limit"),
-                            },
-                        ));
+                    // Aggregate size check (best-effort with size_hint).
+                    if hint_bytes > 0 {
+                        let current_bytes = attachment_repo
+                            .sum_size_bytes(tx, &scope_tx, chat_id)
+                            .await
+                            .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
+                        let max_bytes =
+                            i64::from(rag_config.max_total_upload_mb_per_chat) * 1_048_576;
+                        if current_bytes + hint_bytes > max_bytes {
+                            return Err(mutation_to_db_err(
+                                AttachmentMutationError::StorageLimitExceeded {
+                                    message: format!("Upload would exceed {max_bytes} byte limit"),
+                                },
+                            ));
+                        }
                     }
 
-                    // Insert pending row
+                    // Insert pending row (size_bytes = hint or 0; exact set in set_uploaded)
                     let row = attachment_repo
                         .insert(tx, &scope_tx, insert_params)
                         .await
@@ -697,25 +757,40 @@ impl<
         };
         let pending_guard = PendingGuard::new(&self.metrics);
 
-        // 3. Upload to provider (outside TX — avoids holding pool)
-        let structured_name = structured_filename(chat_id, attachment_id, validated.mime);
+        // 3. Upload stream to provider (outside TX — avoids holding pool)
+        let structured_name = structured_filename(chat_id, attachment_id, validated_mime);
 
-        let provider_file_id = match self
+        let (provider_file_id, bytes_uploaded) = match self
             .file_storage
             .upload_file(
                 ctx.clone(),
                 &provider_id,
                 UploadFileParams {
                     filename: structured_name,
-                    content_type: validated.mime.to_owned(),
-                    file_bytes,
+                    content_type: validated_mime.to_owned(),
+                    file_stream,
                     purpose: "assistants".to_owned(),
                 },
             )
             .await
         {
-            Ok(id) => id,
+            Ok(result) => result,
             Err(e) => {
+                // Size-limit error from the streaming adapter → FileTooLarge (413).
+                if let crate::domain::ports::FileStorageError::Rejected {
+                    ref code,
+                    ref message,
+                } = e
+                    && code == "file_too_large"
+                {
+                    self.try_set_failed(&scope, attachment_id, "pending", "file_too_large")
+                        .await;
+                    self.metrics
+                        .record_attachment_upload(kind_metric, upload_result::FILE_TOO_LARGE);
+                    return Err(DomainError::FileTooLarge {
+                        message: message.clone(),
+                    });
+                }
                 // P1-13: upload failure → CAS set_failed from pending
                 self.try_set_failed(&scope, attachment_id, "pending", "upload_failed")
                     .await;
@@ -725,9 +800,11 @@ impl<
             }
         };
 
-        // 4. CAS: pending → uploaded
+        // 4. CAS: pending → uploaded (with exact size from provider)
         {
             use crate::domain::repos::SetUploadedParams;
+            #[allow(clippy::cast_possible_wrap)]
+            let exact_i64 = bytes_uploaded as i64;
             let conn = self.db.conn().map_err(DomainError::from)?;
             let affected = self
                 .attachment_repo
@@ -737,6 +814,7 @@ impl<
                     SetUploadedParams {
                         id: attachment_id,
                         provider_file_id: provider_file_id.clone(),
+                        size_bytes: exact_i64,
                     },
                 )
                 .await?;
@@ -816,7 +894,7 @@ impl<
             .record_attachment_upload(kind_metric, upload_result::OK);
         #[allow(clippy::cast_precision_loss)]
         self.metrics
-            .record_attachment_upload_bytes(kind_metric, size_bytes as f64);
+            .record_attachment_upload_bytes(kind_metric, bytes_uploaded as f64);
         pending_guard.defuse();
 
         // Reload final state
@@ -825,28 +903,6 @@ impl<
             .get(&conn, &scope, attachment_id)
             .await?
             .ok_or_else(|| DomainError::not_found("Attachment", attachment_id))
-    }
-
-    fn check_file_size(
-        size_bytes: i64,
-        is_document: bool,
-        rag_config: &RagConfig,
-    ) -> Result<(), DomainError> {
-        let max_kb = if is_document {
-            rag_config.max_document_size_kb
-        } else {
-            rag_config.max_image_size_kb
-        };
-        let max_bytes_per_file = i64::from(max_kb) * 1024;
-        if size_bytes > max_bytes_per_file {
-            let kind_label = if is_document { "Document" } else { "Image" };
-            return Err(DomainError::FileTooLarge {
-                message: format!(
-                    "{kind_label} size {size_bytes} bytes exceeds limit of {max_kb} KB"
-                ),
-            });
-        }
-        Ok(())
     }
 
     /// Best-effort CAS `set_failed` — log on failure, never propagate.

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service_test.rs
@@ -8,9 +8,9 @@ use crate::config::{ProviderEntry, RagConfig, StorageKind};
 use crate::domain::repos::VectorStoreRepository as VectorStoreRepoTrait;
 use crate::domain::service::test_helpers::{
     MockModelResolver, MockOagwGateway, NoopOutboxEnqueuer, RecordingOutboxEnqueuer,
-    TestCatalogEntryParams, inmem_db, insert_chat_for_user, insert_chat_with_model,
-    insert_test_message, mock_db_provider, mock_model_resolver, mock_tenant_only_enforcer,
-    test_catalog_entry,
+    TestCatalogEntryParams, bytes_to_stream, inmem_db, insert_chat_for_user,
+    insert_chat_with_model, insert_test_message, mock_db_provider, mock_model_resolver,
+    mock_tenant_only_enforcer, test_catalog_entry,
 };
 use crate::infra::db::repo::{
     chat_repo::ChatRepository as OrmChatRepository,
@@ -163,6 +163,53 @@ fn vector_store_add_file_response() -> serde_json::Value {
     serde_json::json!({ "id": "vsf-abc123", "status": "in_progress" })
 }
 
+/// Test helper: wraps the new streaming `upload_file` with the old simple interface.
+///
+/// Calls `get_upload_context`, validates MIME, converts bytes to stream, and
+/// calls `upload_file` with the full parameter set.
+async fn test_upload_file(
+    svc: &TestAttachmentService,
+    ctx: &modkit_security::SecurityContext,
+    chat_id: Uuid,
+    filename: &str,
+    content_type: &str,
+    data: Bytes,
+) -> Result<crate::infra::db::entity::attachment::Model, crate::domain::error::DomainError> {
+    use crate::domain::mime_validation::{
+        infer_mime_from_extension, normalize_mime, remap_csv_to_plain, validate_mime,
+    };
+    // Resolve upload context (authz + limits)
+    let upload_ctx = svc.get_upload_context(ctx, chat_id).await?;
+
+    // MIME validation (mirrors what the handler does)
+    let effective_ct = if normalize_mime(content_type) == "application/octet-stream" {
+        infer_mime_from_extension(filename).unwrap_or(content_type)
+    } else {
+        content_type
+    };
+    let effective_ct = if upload_ctx.allow_csv_upload {
+        remap_csv_to_plain(effective_ct).unwrap_or(effective_ct)
+    } else {
+        effective_ct
+    };
+    let validated = validate_mime(effective_ct)?;
+
+    let size = data.len() as u64;
+    let stream = bytes_to_stream(data);
+
+    svc.upload_file(
+        ctx,
+        chat_id,
+        upload_ctx,
+        filename.to_owned(),
+        validated.mime,
+        validated.kind,
+        stream,
+        Some(size),
+    )
+    .await
+}
+
 // ── P5-B1: Upload document full lifecycle ──
 
 #[tokio::test]
@@ -186,15 +233,15 @@ async fn test_upload_document_full_lifecycle() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "report.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 1024]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "report.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 1024]),
+    )
+    .await;
 
     assert!(result.is_ok(), "upload_file failed: {result:?}");
     let attachment = result.unwrap();
@@ -277,15 +324,15 @@ async fn test_upload_image_skips_vector_store() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "photo.png".to_owned(),
-            "image/png",
-            Bytes::from(vec![0u8; 2048]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "photo.png",
+        "image/png",
+        Bytes::from(vec![0u8; 2048]),
+    )
+    .await;
 
     assert!(result.is_ok(), "upload image failed: {result:?}");
     let attachment = result.unwrap();
@@ -336,27 +383,27 @@ async fn test_second_upload_reuses_vector_store() {
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
     // First upload
-    let r1 = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "a.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let r1 = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "a.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
     assert!(r1.is_ok(), "1st upload failed: {r1:?}");
 
     // Second upload — should reuse existing vector store
-    let r2 = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "b.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let r2 = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "b.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
     assert!(r2.is_ok(), "2nd upload failed: {r2:?}");
 
     let requests = oagw.captured_requests.lock().unwrap();
@@ -394,15 +441,15 @@ async fn test_upload_unsupported_mime_rejected() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "video.mp4".to_owned(),
-            "video/mp4",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "video.mp4",
+        "video/mp4",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
 
     assert!(result.is_err());
     let requests = oagw.captured_requests.lock().unwrap();
@@ -424,15 +471,15 @@ async fn test_upload_chat_not_found() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            nonexistent_chat,
-            "doc.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        nonexistent_chat,
+        "doc.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
 
     assert!(result.is_err(), "upload to nonexistent chat should fail");
 }
@@ -470,15 +517,15 @@ async fn test_upload_document_limit_exceeded() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, config);
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "third.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "third.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -523,15 +570,15 @@ async fn test_upload_storage_limit_exceeded() {
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, config);
 
     // Try to upload another 200KB — would exceed 1 MB
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "big.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 200_000]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "big.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 200_000]),
+    )
+    .await;
 
     assert!(result.is_err());
     let err = result.unwrap_err();
@@ -567,15 +614,15 @@ async fn test_upload_provider_failure_sets_failed() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "fail.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "fail.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
 
     assert!(result.is_err(), "upload should fail when provider errors");
     assert!(
@@ -818,15 +865,15 @@ async fn test_upload_attachment_cross_owner_not_found() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "test.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from_static(b"dummy content"),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "test.pdf",
+        "application/pdf",
+        Bytes::from_static(b"dummy content"),
+    )
+    .await;
     assert!(
         matches!(
             result.unwrap_err(),
@@ -863,15 +910,15 @@ async fn test_upload_mime_charset_stripped() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "notes.txt".to_owned(),
-            "text/plain; charset=utf-8", // charset should be stripped
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "notes.txt",
+        "text/plain; charset=utf-8", // charset should be stripped
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
 
     assert!(
         result.is_ok(),
@@ -913,15 +960,15 @@ async fn test_upload_vector_store_indexing_fails() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "big_doc.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "big_doc.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
 
     assert!(result.is_err(), "indexing failure should propagate");
     assert!(
@@ -971,15 +1018,15 @@ async fn test_create_vector_store_failure_cleans_up_placeholder_row() {
         RagConfig::default(),
     );
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "test.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "test.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
 
     assert!(result.is_err(), "VS create failure should propagate");
 
@@ -1031,15 +1078,15 @@ async fn test_vector_store_failure_sets_attachment_failed() {
         RagConfig::default(),
     );
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "report.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "report.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
 
     assert!(result.is_err(), "VS create failure should propagate");
 
@@ -1317,15 +1364,15 @@ async fn test_vector_store_created_on_first_document_upload() {
         RagConfig::default(),
     );
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "doc.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "doc.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
     assert!(result.is_ok(), "upload failed: {result:?}");
 
     // Verify vector store row was created with the OAGW-returned ID
@@ -1372,15 +1419,15 @@ async fn test_vector_store_preexisting_row_reused() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "doc.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "doc.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
     assert!(
         result.is_ok(),
         "upload with preexisting VS failed: {result:?}"
@@ -1443,15 +1490,15 @@ async fn test_storage_within_limit_after_deletions() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, config);
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "new.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 500_000]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "new.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 500_000]),
+    )
+    .await;
 
     assert!(
         result.is_ok(),
@@ -1482,16 +1529,16 @@ async fn test_cas_transition_chain_full_lifecycle() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let att = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "chain.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await
-        .expect("upload should succeed");
+    let att = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "chain.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await
+    .expect("upload should succeed");
 
     // Final state is Ready with provider_file_id set (proves pending→uploaded→ready)
     assert_eq!(
@@ -2050,15 +2097,15 @@ async fn test_upload_document_azure_provider_all_calls_same_alias() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service_azure(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "report.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 1024]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "report.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 1024]),
+    )
+    .await;
 
     assert!(result.is_ok(), "azure upload_file failed: {result:?}");
 
@@ -2118,16 +2165,16 @@ async fn test_upload_document_azure_storage_backend_and_vs_provider_persisted() 
         RagConfig::default(),
     );
 
-    let attachment = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "doc.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 512]),
-        )
-        .await
-        .expect("azure upload should succeed");
+    let attachment = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "doc.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 512]),
+    )
+    .await
+    .expect("azure upload should succeed");
 
     // Verify attachment storage_backend = "azure" (from config field, not "azure_openai")
     assert_eq!(
@@ -2184,15 +2231,15 @@ async fn test_second_upload_provider_mismatch_rejected() {
     let outbox = Arc::new(NoopOutboxEnqueuer);
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, RagConfig::default());
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "b.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 100]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "b.pdf",
+        "application/pdf",
+        Bytes::from(vec![0u8; 100]),
+    )
+    .await;
 
     assert!(result.is_err(), "provider mismatch should be rejected");
     let err = result.unwrap_err();
@@ -2228,15 +2275,15 @@ async fn test_rag_http_client_multipart_uses_params_purpose() {
     let params = crate::domain::ports::UploadFileParams {
         filename: "test.txt".to_owned(),
         content_type: "text/plain".to_owned(),
-        file_bytes: Bytes::from("hello"),
+        file_stream: bytes_to_stream(Bytes::from("hello")),
         purpose: "user_data".to_owned(),
     };
 
     let result = client
-        .multipart_upload(ctx, "/test-host/v1/files", &params)
+        .multipart_upload(ctx, "/test-host/v1/files", params)
         .await;
     assert!(result.is_ok(), "upload failed: {result:?}");
-    assert_eq!(result.unwrap(), "file-001");
+    assert_eq!(result.unwrap().0, "file-001");
 
     // Verify the multipart body contains the custom purpose, not hardcoded "assistants"
     let requests = oagw.captured_requests.lock().unwrap();
@@ -2292,7 +2339,7 @@ async fn test_openai_file_storage_uri_pattern() {
     let params = crate::domain::ports::UploadFileParams {
         filename: "test.txt".to_owned(),
         content_type: "text/plain".to_owned(),
-        file_bytes: Bytes::from("hello"),
+        file_stream: bytes_to_stream(Bytes::from("hello")),
         purpose: "assistants".to_owned(),
     };
 
@@ -2333,7 +2380,7 @@ async fn test_azure_file_storage_uri_pattern() {
     let params = crate::domain::ports::UploadFileParams {
         filename: "test.txt".to_owned(),
         content_type: "text/plain".to_owned(),
-        file_bytes: Bytes::from("hello"),
+        file_stream: bytes_to_stream(Bytes::from("hello")),
         purpose: "assistants".to_owned(),
     };
 
@@ -2395,24 +2442,38 @@ async fn test_dispatching_file_storage_routes_correctly() {
 
     let tenant_id = Uuid::new_v4();
     let ctx = crate::domain::service::test_helpers::test_security_ctx(tenant_id);
-    let params = || crate::domain::ports::UploadFileParams {
-        filename: "test.txt".to_owned(),
-        content_type: "text/plain".to_owned(),
-        file_bytes: Bytes::from("hello"),
-        purpose: "assistants".to_owned(),
-    };
 
     // Upload via OpenAI
-    let r1: Result<String, _> = dispatch.upload_file(ctx.clone(), "openai", params()).await;
+    let r1: Result<(String, u64), _> = dispatch
+        .upload_file(
+            ctx.clone(),
+            "openai",
+            crate::domain::ports::UploadFileParams {
+                filename: "test.txt".to_owned(),
+                content_type: "text/plain".to_owned(),
+                file_stream: bytes_to_stream(Bytes::from("hello")),
+                purpose: "assistants".to_owned(),
+            },
+        )
+        .await;
     assert!(r1.is_ok());
-    assert_eq!(r1.unwrap(), "file-oai-001");
+    assert_eq!(r1.unwrap().0, "file-oai-001");
 
     // Upload via Azure
-    let r2: Result<String, _> = dispatch
-        .upload_file(ctx.clone(), "azure_openai", params())
+    let r2: Result<(String, u64), _> = dispatch
+        .upload_file(
+            ctx.clone(),
+            "azure_openai",
+            crate::domain::ports::UploadFileParams {
+                filename: "test.txt".to_owned(),
+                content_type: "text/plain".to_owned(),
+                file_stream: bytes_to_stream(Bytes::from("hello")),
+                purpose: "assistants".to_owned(),
+            },
+        )
         .await;
     assert!(r2.is_ok());
-    assert_eq!(r2.unwrap(), "file-az-001");
+    assert_eq!(r2.unwrap().0, "file-az-001");
 
     // Verify routing: first request → /v1/, second → /openai/
     let requests = oagw.captured_requests.lock().unwrap();
@@ -2439,11 +2500,11 @@ async fn test_dispatching_file_storage_unknown_provider_returns_error() {
     let params = crate::domain::ports::UploadFileParams {
         filename: "test.txt".to_owned(),
         content_type: "text/plain".to_owned(),
-        file_bytes: Bytes::from("hello"),
+        file_stream: bytes_to_stream(Bytes::from("hello")),
         purpose: "assistants".to_owned(),
     };
 
-    let result: Result<String, _> = dispatch.upload_file(ctx, "nonexistent", params).await;
+    let result: Result<(String, u64), _> = dispatch.upload_file(ctx, "nonexistent", params).await;
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(
@@ -2510,7 +2571,7 @@ async fn test_openai_file_storage_uses_tenant_specific_alias() {
     let params = crate::domain::ports::UploadFileParams {
         filename: "test.txt".to_owned(),
         content_type: "text/plain".to_owned(),
-        file_bytes: Bytes::from("hello"),
+        file_stream: bytes_to_stream(Bytes::from("hello")),
         purpose: "assistants".to_owned(),
     };
 
@@ -2527,11 +2588,14 @@ async fn test_openai_file_storage_uses_tenant_specific_alias() {
     );
 }
 
-// ── Per-file size validation ──
+// ════════════════════════════════════════════════════════════════════════════
+// Upload limits resolution (get_upload_context)
+// ════════════════════════════════════════════════════════════════════════════
 
+/// CCM per-model limit is tighter than `ConfigMap` → effective = CCM.
 #[tokio::test]
-async fn test_document_exceeding_max_size_returns_file_too_large() {
-    use crate::domain::error::DomainError;
+async fn test_upload_limits_ccm_tighter_than_configmap() {
+    use mini_chat_sdk::ModelTier;
 
     let db = inmem_db().await;
     let tenant_id = Uuid::new_v4();
@@ -2542,37 +2606,83 @@ async fn test_document_exceeding_max_size_returns_file_too_large() {
 
     let ctx = crate::domain::service::test_helpers::test_security_ctx_with_id(tenant_id, user_id);
 
+    // Model with max_file_size_mb = 10 (tighter than ConfigMap's 25 MB default)
+    let mut entry = test_catalog_entry(TestCatalogEntryParams {
+        model_id: "gpt-5.2".to_owned(),
+        provider_model_id: "gpt-5.2-2025-03-26".to_owned(),
+        display_name: "GPT 5.2".to_owned(),
+        tier: ModelTier::Standard,
+        enabled: true,
+        is_default: true,
+        input_tokens_credit_multiplier_micro: 1_000_000,
+        output_tokens_credit_multiplier_micro: 3_000_000,
+        multimodal_capabilities: vec![],
+        context_window: 128_000,
+        max_output_tokens: 16_384,
+        description: String::new(),
+        provider_display_name: "OpenAI".to_owned(),
+        multiplier_display: "1x".to_owned(),
+        provider_id: "openai".to_owned(),
+    });
+    entry.general_config.max_file_size_mb = 10; // 10 MB — tighter than 25 MB default
+
+    let model_resolver: Arc<dyn crate::domain::repos::ModelResolver> =
+        Arc::new(MockModelResolver::new(vec![entry]));
+
     let oagw = MockOagwGateway::with_responses(vec![]);
-    let outbox = Arc::new(NoopOutboxEnqueuer);
+    let db_prov_arc = mock_db_provider(db.clone());
+    let provider_resolver = test_provider_resolver(&(Arc::clone(&oagw) as _));
+    let rag_config = RagConfig::default();
 
-    // Set max_document_size_kb to 1 KB so a 2 KB file exceeds it
-    let rag_config = RagConfig {
-        max_document_size_kb: 1,
-        ..RagConfig::default()
-    };
-    let svc = build_service(db, Arc::clone(&oagw) as _, outbox, rag_config);
+    let svc =
+        AttachmentService::new(
+            db_prov_arc,
+            Arc::new(OrmAttachmentRepository),
+            Arc::new(OrmChatRepository::new(modkit_db::odata::LimitCfg {
+                default: 20,
+                max: 100,
+            })),
+            Arc::new(OrmVectorStoreRepository),
+            Arc::new(NoopOutboxEnqueuer),
+            mock_tenant_only_enforcer(),
+            Arc::new(
+                crate::infra::llm::providers::openai_file_storage::OpenAiFileStorage::new(
+                    Arc::new(
+                        crate::infra::llm::providers::rag_http_client::RagHttpClient::new(
+                            Arc::clone(&oagw) as _,
+                        ),
+                    ),
+                    Arc::clone(&provider_resolver),
+                ),
+            ),
+            Arc::new(
+                crate::infra::llm::providers::openai_vector_store::OpenAiVectorStore::new(
+                    Arc::new(
+                        crate::infra::llm::providers::rag_http_client::RagHttpClient::new(
+                            Arc::clone(&oagw) as _,
+                        ),
+                    ),
+                    Arc::clone(&provider_resolver),
+                ),
+            ),
+            provider_resolver,
+            model_resolver,
+            rag_config,
+            Arc::new(crate::domain::ports::metrics::NoopMetrics),
+        );
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "big.pdf".to_owned(),
-            "application/pdf",
-            Bytes::from(vec![0u8; 2048]),
-        )
-        .await;
+    let upload_ctx = svc.get_upload_context(&ctx, chat_id).await.unwrap();
 
-    assert!(result.is_err(), "should reject oversized document");
-    assert!(
-        matches!(result.unwrap_err(), DomainError::FileTooLarge { .. }),
-        "should be FileTooLarge"
-    );
+    // CCM = 10 MB = 10_485_760 bytes; ConfigMap = 25 MB = 25_600 KB * 1024 = 26_214_400
+    // Effective = min(26_214_400, 10_485_760) = 10_485_760
+    assert_eq!(upload_ctx.limits.max_file_bytes, 10_485_760);
+    // Image: ConfigMap = 5 MB = 5_242_880; CCM = 10_485_760; effective = 5_242_880
+    assert_eq!(upload_ctx.limits.max_image_bytes, 5_242_880);
 }
 
+/// `ConfigMap` limit is tighter than CCM → effective = `ConfigMap`.
 #[tokio::test]
-async fn test_image_exceeding_max_size_returns_file_too_large() {
-    use crate::domain::error::DomainError;
-
+async fn test_upload_limits_configmap_tighter_than_ccm() {
     let db = inmem_db().await;
     let tenant_id = Uuid::new_v4();
     let chat_id = Uuid::new_v4();
@@ -2585,28 +2695,17 @@ async fn test_image_exceeding_max_size_returns_file_too_large() {
     let oagw = MockOagwGateway::with_responses(vec![]);
     let outbox = Arc::new(NoopOutboxEnqueuer);
 
-    // Set max_image_size_kb to 1 KB so a 2 KB image exceeds it
+    // ConfigMap with very small file limit (1 KB)
     let rag_config = RagConfig {
-        max_image_size_kb: 1,
+        uploaded_file_max_size_kb: 1,
         ..RagConfig::default()
     };
     let svc = build_service(db, Arc::clone(&oagw) as _, outbox, rag_config);
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "big.png".to_owned(),
-            "image/png",
-            Bytes::from(vec![0u8; 2048]),
-        )
-        .await;
+    let upload_ctx = svc.get_upload_context(&ctx, chat_id).await.unwrap();
 
-    assert!(result.is_err(), "should reject oversized image");
-    assert!(
-        matches!(result.unwrap_err(), DomainError::FileTooLarge { .. }),
-        "should be FileTooLarge"
-    );
+    // ConfigMap = 1 KB = 1024 bytes; CCM default = 25 MB; effective = 1024
+    assert_eq!(upload_ctx.limits.max_file_bytes, 1024);
 }
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -2640,15 +2739,15 @@ async fn upload_image_emits_metrics_and_gauge_balanced() {
         Arc::clone(&metrics) as _,
     );
 
-    let result = svc
-        .upload_file(
-            &ctx,
-            chat_id,
-            "photo.png".to_owned(),
-            "image/png",
-            Bytes::from(vec![0u8; 2048]),
-        )
-        .await;
+    let result = test_upload_file(
+        &svc,
+        &ctx,
+        chat_id,
+        "photo.png",
+        "image/png",
+        Bytes::from(vec![0u8; 2048]),
+    )
+    .await;
     assert!(result.is_ok(), "upload should succeed: {result:?}");
 
     assert_eq!(

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -2898,6 +2898,7 @@ mod tests {
             description: None,
             multimodal_capabilities: vec![],
             context_window: 128_000,
+            max_file_size_mb: 25,
             system_prompt: String::new(),
         }
     }
@@ -4044,6 +4045,7 @@ mod tests {
                     description: None,
                     multimodal_capabilities: vec![],
                     context_window: 128_000,
+                    max_file_size_mb: 25,
                     system_prompt: String::new(),
                 },
                 false,

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -379,6 +379,13 @@ pub fn mock_db_provider(db: Db) -> Arc<DBProvider<modkit_db::DbError>> {
     Arc::new(DBProvider::new(db))
 }
 
+// ── Stream helpers ──
+
+/// Convert `Bytes` into a `FileStream` for test use.
+pub fn bytes_to_stream(data: bytes::Bytes) -> crate::domain::ports::FileStream {
+    Box::pin(futures::stream::once(async { Ok(data) }))
+}
+
 // ── Mock Policy Snapshot Provider ──
 
 use mini_chat_sdk::{PolicySnapshot, UserLimits};

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/attachment_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/attachment_repo.rs
@@ -87,6 +87,7 @@ impl crate::domain::repos::AttachmentRepository for AttachmentRepository {
                 Column::ProviderFileId,
                 Expr::value(Some(params.provider_file_id)),
             )
+            .col_expr(Column::SizeBytes, Expr::value(params.size_bytes))
             .col_expr(Column::UpdatedAt, Expr::value(now))
             .filter(
                 Condition::all()

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/azure_file_storage.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/azure_file_storage.rs
@@ -59,9 +59,9 @@ impl FileStorageProvider for AzureFileStorage {
         ctx: SecurityContext,
         provider_id: &str,
         params: UploadFileParams,
-    ) -> Result<String, FileStorageError> {
+    ) -> Result<(String, u64), FileStorageError> {
         let uri = self.resolve_uri(&ctx, provider_id, "files")?;
-        self.client.multipart_upload(ctx, &uri, &params).await
+        self.client.multipart_upload(ctx, &uri, params).await
     }
 
     async fn delete_file(

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/dispatching_storage.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/dispatching_storage.rs
@@ -44,7 +44,7 @@ impl FileStorageProvider for DispatchingFileStorage {
         ctx: SecurityContext,
         provider_id: &str,
         params: UploadFileParams,
-    ) -> Result<String, FileStorageError> {
+    ) -> Result<(String, u64), FileStorageError> {
         self.get(provider_id)?
             .upload_file(ctx, provider_id, params)
             .await

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_file_storage.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_file_storage.rs
@@ -47,9 +47,9 @@ impl FileStorageProvider for OpenAiFileStorage {
         ctx: SecurityContext,
         provider_id: &str,
         params: UploadFileParams,
-    ) -> Result<String, FileStorageError> {
+    ) -> Result<(String, u64), FileStorageError> {
         let uri = self.resolve_uri(&ctx, provider_id, "files")?;
-        self.client.multipart_upload(ctx, &uri, &params).await
+        self.client.multipart_upload(ctx, &uri, params).await
     }
 
     async fn delete_file(

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/rag_http_client.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/rag_http_client.rs
@@ -8,9 +8,9 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use modkit_security::SecurityContext;
+use oagw_sdk::multipart::{MultipartBody, Part};
 use oagw_sdk::{Body, ServiceGatewayClientV1};
 use serde::de::DeserializeOwned;
-use uuid::Uuid;
 
 use crate::domain::ports::{FileStorageError, UploadFileParams};
 
@@ -30,58 +30,75 @@ impl RagHttpClient {
 
     /// Upload a file via multipart/form-data POST.
     ///
-    /// Builds the multipart body with `params.purpose` and file content,
-    /// sends to `uri`, and parses the JSON response to extract `id`.
+    /// Collects the `FileStream` into bytes, then uses `Part::bytes` to build
+    /// a buffered multipart body with `Content-Length`. The handler already
+    /// collected chunks for size enforcement, so this is a move (not a copy)
+    /// from the handler's `Vec<Bytes>` into the multipart body.
+    ///
+    /// True streaming via `Part::stream` is blocked by OAGW chunked encoding
+    /// issues (premature connection close before termination chunk). Once OAGW
+    /// stabilizes chunked request body support, this can switch to `Part::stream`.
+    ///
+    /// Returns `(provider_file_id, bytes_uploaded)`.
     pub async fn multipart_upload(
         &self,
         ctx: SecurityContext,
         uri: &str,
-        params: &UploadFileParams,
-    ) -> Result<String, FileStorageError> {
+        params: UploadFileParams,
+    ) -> Result<(String, u64), FileStorageError> {
+        use futures::StreamExt;
+
         #[derive(serde::Deserialize)]
         struct FileObject {
             id: String,
         }
-        let boundary = format!("----boundary{}", Uuid::now_v7().as_simple());
-        let mut body_buf = Vec::new();
 
-        // purpose field
-        body_buf.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
-        body_buf.extend_from_slice(
-            format!(
-                "Content-Disposition: form-data; name=\"purpose\"\r\n\r\n{}\r\n",
-                params.purpose
-            )
-            .as_bytes(),
+        // Collect stream into bytes.
+        // The stream may yield `multer::Error::FieldSizeExceeded` from the
+        // handler's size constraints — propagate as Rejected so the domain
+        // layer maps it to FileTooLarge (413), not ProviderError (502).
+        let mut file_buf = Vec::new();
+        let mut stream = params.file_stream;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| {
+                if e.downcast_ref::<multer::Error>().is_some_and(|me| {
+                    matches!(
+                        me,
+                        multer::Error::FieldSizeExceeded { .. }
+                            | multer::Error::StreamSizeExceeded { .. }
+                    )
+                }) {
+                    FileStorageError::Rejected {
+                        code: "file_too_large".to_owned(),
+                        message: e.to_string(),
+                    }
+                } else {
+                    FileStorageError::Unavailable {
+                        message: format!("file stream error: {e}"),
+                    }
+                }
+            })?;
+            file_buf.extend_from_slice(&chunk);
+        }
+        let bytes_uploaded = file_buf.len() as u64;
+
+        tracing::debug!(bytes_uploaded, uri, "multipart upload: building request");
+
+        let multipart = MultipartBody::new().text("purpose", params.purpose).part(
+            Part::bytes("file", file_buf)
+                .filename(params.filename)
+                .content_type(params.content_type),
         );
 
-        // file field
-        // SAFETY: filename is produced by structured_filename() — UUID hex + static ext,
-        // no user input. No header injection risk (no quotes, CR, LF possible).
-        body_buf.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
-        body_buf.extend_from_slice(
-            format!(
-                "Content-Disposition: form-data; name=\"file\"; filename=\"{}\"\r\nContent-Type: {}\r\n\r\n",
-                params.filename, params.content_type
-            )
-            .as_bytes(),
-        );
-        body_buf.extend_from_slice(&params.file_bytes);
-        body_buf.extend_from_slice(b"\r\n");
-        body_buf.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
-
-        let req = http::Request::builder()
-            .method(http::Method::POST)
-            .uri(uri)
-            .header(
-                http::header::CONTENT_TYPE,
-                format!("multipart/form-data; boundary={boundary}"),
-            )
-            .header(http::header::ACCEPT, "application/json")
-            .body(Body::Bytes(Bytes::from(body_buf)))
+        let mut req = multipart
+            .into_request(http::Method::POST, uri)
             .map_err(|e| FileStorageError::Configuration {
                 message: format!("failed to build file upload request: {e}"),
             })?;
+        req.headers_mut().insert(
+            http::header::ACCEPT,
+            http::HeaderValue::from_static("application/json"),
+        );
 
         let bytes = self.send(ctx, req, "file upload").await?;
 
@@ -90,7 +107,7 @@ impl RagHttpClient {
                 message: format!("failed to parse upload response: {e}"),
             })?;
 
-        Ok(file_obj.id)
+        Ok((file_obj.id, bytes_uploaded))
     }
 
     /// Send a JSON POST and parse the typed response.

--- a/testing/e2e/modules/mini_chat/test_attachments.py
+++ b/testing/e2e/modules/mini_chat/test_attachments.py
@@ -538,3 +538,144 @@ class TestImageRecognition:
         azure_chat = chat_with_model(AZURE_MODEL)
         cat_bytes = self._load_cat_image()
         self._upload_image_and_ask(azure_chat["id"], cat_bytes, "cat-az.jpg", "image/jpeg", "Azure")
+
+
+# ---------------------------------------------------------------------------
+# Streaming upload: size enforcement and size_bytes accuracy
+# ---------------------------------------------------------------------------
+
+@pytest.mark.openai
+class TestUploadSizeEnforcement:
+    """Upload size limit enforcement — files exceeding the configured limit
+    are rejected with HTTP 413 and error code ``file_too_large``.
+
+    NOTE: these tests rely on the server's default config limits:
+    - ``uploaded_file_max_size_kb``: 25600 (25 MB)
+    - ``uploaded_image_max_size_kb``: 5120 (5 MB)
+
+    Generating a 26 MB payload in-memory is acceptable for e2e.
+    """
+
+    def test_oversize_image_rejected_413(self, chat):
+        """Upload an image exceeding uploaded_image_max_size_kb (5 MB) → 413.
+
+        Uses ~6 MB which is over the image limit but under the API gateway's
+        global 16 MiB body limit, so our handler's streaming size check runs.
+        """
+        chat_id = chat["id"]
+        # 6 MB > 5 MB default image limit, but < 16 MiB gateway limit
+        oversize_payload = b"\x89PNG" + b"\x00" * (6 * 1024 * 1024)
+        resp = upload_file(
+            chat_id,
+            content=oversize_payload,
+            filename="huge.png",
+            content_type="image/png",
+        )
+        assert resp.status_code == 413, (
+            f"Expected 413 for oversize image, got {resp.status_code}: {resp.text}"
+        )
+        body = resp.json()
+        assert body.get("code") == "file_too_large" or "file_too_large" in resp.text, (
+            f"Expected file_too_large error code, got: {body}"
+        )
+
+    def test_oversize_document_rejected_by_gateway(self, chat):
+        """Upload a document exceeding the API gateway body limit (16 MiB) → 400.
+
+        Documents can be up to 25 MB, but the gateway's global
+        RequestBodyLimitLayer (16 MiB) rejects before our handler runs.
+        This verifies the gateway guard works as a coarse outer limit.
+        """
+        chat_id = chat["id"]
+        # 17 MB > 16 MiB gateway limit
+        oversize_payload = b"\x00" * (17 * 1024 * 1024)
+        resp = upload_file(
+            chat_id,
+            content=oversize_payload,
+            filename="huge.pdf",
+            content_type="application/pdf",
+        )
+        # Rejected by one of: OAGW body limit (502), gateway RequestBodyLimitLayer (400), or handler (413)
+        assert resp.status_code in (400, 413, 502), (
+            f"Expected 400/413/502 for oversize doc, got {resp.status_code}: {resp.text}"
+        )
+
+    def test_document_within_limit_succeeds(self, chat):
+        """Upload a document just under the limit → succeeds."""
+        chat_id = chat["id"]
+        # 1 MB — well under 25 MB
+        payload = b"x" * (1 * 1024 * 1024)
+        resp = upload_file(
+            chat_id,
+            content=payload,
+            filename="medium.txt",
+            content_type="text/plain",
+        )
+        assert resp.status_code == 201, (
+            f"Expected 201 for within-limit doc, got {resp.status_code}: {resp.text}"
+        )
+        att_id = resp.json()["id"]
+        detail = poll_until_ready(chat_id, att_id)
+        assert detail["status"] == "ready"
+
+
+@pytest.mark.openai
+class TestUploadSizeBytesAccuracy:
+    """Verify that size_bytes in the attachment metadata matches the actual
+    uploaded file size."""
+
+    def test_size_bytes_matches_actual(self, chat):
+        """Upload a file of known size, verify size_bytes in GET response."""
+        chat_id = chat["id"]
+        # Use a specific, non-round size to catch off-by-one issues
+        payload = b"A" * 123_456
+        resp = upload_file(
+            chat_id,
+            content=payload,
+            filename="sized.txt",
+            content_type="text/plain",
+        )
+        assert resp.status_code == 201
+        att_id = resp.json()["id"]
+        detail = poll_until_ready(chat_id, att_id)
+        assert detail["status"] == "ready"
+        assert detail["size_bytes"] == 123_456, (
+            f"Expected size_bytes=123456, got {detail['size_bytes']}"
+        )
+
+
+@pytest.mark.openai
+class TestUploadStreamingPipeline:
+    """End-to-end test with a medium-sized file (~500 KB) through the full
+    streaming upload pipeline: upload → ready → send message → SSE done."""
+
+    @pytest.mark.online_only
+    def test_medium_file_upload_and_stream(self, chat):
+        chat_id = chat["id"]
+        # 500 KB document
+        payload = b"The quick brown fox. " * 25_000  # ~500 KB
+        resp = upload_file(
+            chat_id,
+            content=payload,
+            filename="medium_doc.txt",
+            content_type="text/plain",
+        )
+        assert resp.status_code == 201
+        att_id = resp.json()["id"]
+        detail = poll_until_ready(chat_id, att_id)
+        assert detail["status"] == "ready", f"Expected ready, got: {detail}"
+
+        # Send a message referencing the attachment
+        status, events, raw = stream_message(
+            chat_id,
+            content="Summarize the attached document briefly.",
+            attachment_ids=[att_id],
+        )
+        assert status == 200, f"Stream failed: {status} {raw}"
+
+        started = expect_stream_started(events)
+        assert started is not None, "Expected stream_started event"
+
+        done = expect_done(events)
+        assert done is not None, "Expected done event"
+        assert done.data.get("usage", {}).get("input_tokens", 0) > 0


### PR DESCRIPTION
feat(mini-chat): streaming file upload with incremental size enforcement.

Stream multipart uploads chunk-by-chunk instead of buffering the full body. Enforce per-file size limits mid-stream (413 early abort). 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming multipart uploads with larger route body limit (~25 MiB), MIME detection before body read, and optional CSV remapping.
  * Upload limits resolved via two-layer policy (system config + per-model cap) with config-only fallback.

* **Bug Fixes**
  * Oversize uploads now abort mid-stream and return HTTP 413; recorded stored size is later reconciled with actual uploaded bytes.

* **Tests**
  * Added end-to-end tests for size enforcement, byte-accuracy, and streaming upload flow.

* **Documentation**
  * Clarified streaming upload contract, error behavior, and limit computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->