### PR TITLE
fix(minichat): Fix 500 on second attachment upload

### DIFF
--- a/modules/mini-chat/mini-chat/src/infra/db/repo/attachment_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/attachment_repo.rs
@@ -301,7 +301,12 @@ impl crate::domain::repos::AttachmentRepository for AttachmentRepository {
             .scope_with(scope)
             .project_all(runner, |q| {
                 q.select_only()
-                    .column_as(Column::SizeBytes.sum(), "total")
+                    .column_as(
+                        Column::SizeBytes
+                            .sum()
+                            .cast_as(sea_orm::sea_query::Alias::new("bigint")),
+                        "total",
+                    )
                     .into_model::<SumRow>()
             })
             .await


### PR DESCRIPTION
In PostgreSQL, SUM(bigint) returns NUMERIC, not INT8. The sum_size_bytes query decoded the result into Option<i64> (mapped as INT8), which worked on the first upload — because an empty table returns NULL and sqlx skips type checking for NULL — but failed on the second upload when a real non-NULL NUMERIC value was returned.

Fixed by casting: SUM(size_bytes)::bigint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment storage size calculations by enhancing database data type handling, ensuring accurate file size reporting and better support for larger attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->