### PR TITLE
feat(mini-chat): image inlining in Responses API

### DIFF
--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/messages.rs
@@ -205,6 +205,36 @@ fn stream_error_response(err: &StreamError) -> Response {
             )
             .into_response()
         }
+        StreamError::ImagesDisabled => {
+            info!(
+                reason = "kill_switch",
+                "images disabled via kill switch, request rejected"
+            );
+            Problem::new(
+                StatusCode::BAD_REQUEST,
+                "images_disabled",
+                "Image inputs are currently disabled",
+            )
+            .into_response()
+        }
+        StreamError::TooManyImages { count, max } => {
+            info!(count, max, "too many image attachments in request");
+            Problem::new(
+                StatusCode::BAD_REQUEST,
+                "too_many_images",
+                format!("Request includes {count} images, maximum is {max}"),
+            )
+            .into_response()
+        }
+        StreamError::UnsupportedMedia => {
+            info!("model does not support image input, request rejected");
+            Problem::new(
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "unsupported_media",
+                "The selected model does not support image input",
+            )
+            .into_response()
+        }
         StreamError::InvalidAttachment { code, message } => {
             info!(code = %code, message = %message, "invalid attachment in request");
             Problem::new(StatusCode::BAD_REQUEST, code, message).into_response()

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -709,6 +709,14 @@ pub struct RagConfig {
     /// Accept `text/csv` uploads remapped to `text/plain` for `file_search`.
     #[serde(default = "default_true")]
     pub allow_csv_upload: bool,
+
+    /// Maximum number of image attachments per message (DESIGN.md B.8).
+    #[serde(default = "default_max_images_per_message")]
+    pub max_images_per_message: u32,
+}
+
+fn default_max_images_per_message() -> u32 {
+    4
 }
 
 impl Default for RagConfig {
@@ -719,6 +727,7 @@ impl Default for RagConfig {
             uploaded_file_max_size_kb: default_uploaded_file_max_size_kb(),
             uploaded_image_max_size_kb: default_uploaded_image_max_size_kb(),
             allow_csv_upload: true,
+            max_images_per_message: default_max_images_per_message(),
         }
     }
 }
@@ -736,6 +745,9 @@ impl RagConfig {
         }
         if self.uploaded_image_max_size_kb == 0 {
             return Err("rag uploaded_image_max_size_kb must be > 0".into());
+        }
+        if self.max_images_per_message == 0 {
+            return Err("rag max_images_per_message must be > 0".into());
         }
         Ok(())
     }

--- a/modules/mini-chat/mini-chat/src/domain/ports/metrics.rs
+++ b/modules/mini-chat/mini-chat/src/domain/ports/metrics.rs
@@ -140,6 +140,9 @@ pub trait MiniChatMetricsPort: Send + Sync {
     /// `{prefix}_attachments_pending` — gauge increment/decrement
     fn increment_attachments_pending(&self);
     fn decrement_attachments_pending(&self);
+
+    /// `{prefix}_image_inputs_per_turn` — histogram
+    fn record_image_inputs_per_turn(&self, count: u32);
 }
 
 /// No-op implementation for use in tests or when metrics are disabled.
@@ -176,4 +179,5 @@ impl MiniChatMetricsPort for NoopMetrics {
     fn record_attachment_upload_bytes(&self, _: &str, _: f64) {}
     fn increment_attachments_pending(&self) {}
     fn decrement_attachments_pending(&self) {}
+    fn record_image_inputs_per_turn(&self, _: u32) {}
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/context_assembly.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/context_assembly.rs
@@ -6,7 +6,9 @@
 use modkit_macros::domain_model;
 
 use crate::config::EstimationBudgets;
-use crate::domain::llm::{ContextMessage, FileSearchFilter, LlmMessage, LlmTool, Role};
+use crate::domain::llm::{
+    ContentPart, ContextMessage, FileSearchFilter, LlmMessage, LlmTool, Role,
+};
 
 /// Token budget parameters for context truncation.
 ///
@@ -63,6 +65,8 @@ pub struct ContextInput<'a> {
     pub code_interpreter_file_ids: Vec<String>,
     /// Token budget for context truncation. `None` = no truncation.
     pub token_budget: Option<TokenBudget>,
+    /// Provider file IDs for image attachments on the current user message.
+    pub image_file_ids: &'a [String],
 }
 
 /// Output of context assembly — ready to feed into `LlmRequestBuilder`.
@@ -103,6 +107,26 @@ impl std::fmt::Display for ContextAssemblyError {
 }
 
 impl std::error::Error for ContextAssemblyError {}
+
+/// Build the current user message with optional image content parts.
+fn build_user_message(text: &str, image_file_ids: &[String]) -> LlmMessage {
+    if image_file_ids.is_empty() {
+        LlmMessage::user(text)
+    } else {
+        let mut content = vec![ContentPart::Text {
+            text: text.to_owned(),
+        }];
+        for file_id in image_file_ids {
+            content.push(ContentPart::Image {
+                file_id: file_id.clone(),
+            });
+        }
+        LlmMessage {
+            role: Role::User,
+            content,
+        }
+    }
+}
 
 /// Compute the available input token budget after deducting output reservation
 /// and tool surcharges.
@@ -205,8 +229,10 @@ pub fn assemble_context(
 
         // P2: Current user message (mandatory)
         let user_tokens = estimate_item_tokens(input.user_message.len() as u64, budgets);
+        let image_tokens = (input.image_file_ids.len() as u64)
+            .saturating_mul(u64::from(budgets.image_token_budget));
 
-        let mandatory = sys_tokens + user_tokens;
+        let mandatory = sys_tokens + user_tokens + image_tokens;
         if mandatory > available {
             return Err(ContextAssemblyError::BudgetExceeded {
                 required_tokens: mandatory,
@@ -260,7 +286,7 @@ pub fn assemble_context(
             }
         }
 
-        messages.push(LlmMessage::user(input.user_message));
+        messages.push(build_user_message(input.user_message, input.image_file_ids));
 
         Ok(AssembledContext {
             system_instructions,
@@ -283,7 +309,7 @@ pub fn assemble_context(
             }
         }
 
-        messages.push(LlmMessage::user(input.user_message));
+        messages.push(build_user_message(input.user_message, input.image_file_ids));
 
         Ok(AssembledContext {
             system_instructions,
@@ -350,6 +376,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         assert!(result.system_instructions.is_none());
@@ -375,6 +402,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         let instructions = result.system_instructions.unwrap();
@@ -400,6 +428,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         let instructions = result.system_instructions.unwrap();
@@ -425,6 +454,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         let instructions = result.system_instructions.unwrap();
@@ -452,6 +482,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         // First message should be the thread summary
@@ -490,6 +521,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         assert_eq!(result.messages.len(), 3); // 2 recent + current
@@ -518,6 +550,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         // system message skipped: 2 recent (user+assistant) + 1 current = 3
@@ -543,6 +576,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         let last = result.messages.last().unwrap();
@@ -575,6 +609,7 @@ mod tests {
             file_search_max_num_results: 7,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         assert_eq!(result.tools.len(), 2);
@@ -608,6 +643,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         assert!(result.tools.is_empty());
@@ -628,6 +664,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         assert_eq!(result.tools.len(), 1);
@@ -743,6 +780,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: Some(test_budget(context_window, 4096)),
+            image_file_ids: &[],
         })
         .unwrap();
 
@@ -782,6 +820,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: Some(test_budget(context_window, 4096)),
+            image_file_ids: &[],
         })
         .unwrap();
 
@@ -831,6 +870,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: Some(test_budget(context_window, 4096)),
+            image_file_ids: &[],
         })
         .unwrap();
 
@@ -857,6 +897,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: Some(test_budget(5000, 4096)),
+            image_file_ids: &[],
         });
 
         assert!(matches!(
@@ -888,6 +929,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
 
@@ -927,6 +969,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec!["file-abc123".to_owned()],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         assert_eq!(result.tools.len(), 1);
@@ -954,6 +997,7 @@ mod tests {
             file_search_max_num_results: 5,
             code_interpreter_file_ids: vec![],
             token_budget: None,
+            image_file_ids: &[],
         })
         .unwrap();
         assert!(result.tools.is_empty());
@@ -973,5 +1017,153 @@ mod tests {
         // available = 128_000 - 4096 - 1000 (code_interpreter) - 100 (overhead)
         let available = compute_available_budget(&budget).unwrap();
         assert_eq!(available, 128_000 - 4096 - 1000 - 100);
+    }
+
+    // ── Image inlining tests ──
+
+    #[test]
+    fn single_image_produces_image_content_part() {
+        let images = vec!["file-abc".to_owned()];
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "Describe this",
+            web_search_enabled: false,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+            file_search_filters: None,
+            web_search_context_size: crate::domain::llm::WebSearchContextSize::Low,
+            file_search_max_num_results: 5,
+            code_interpreter_file_ids: vec![],
+            token_budget: None,
+            image_file_ids: &images,
+        })
+        .unwrap();
+        assert_eq!(result.messages.len(), 1);
+        let msg = &result.messages[0];
+        assert_eq!(msg.content.len(), 2);
+        assert!(matches!(&msg.content[0], ContentPart::Text { text } if text == "Describe this"));
+        assert!(matches!(&msg.content[1], ContentPart::Image { file_id } if file_id == "file-abc"));
+    }
+
+    #[test]
+    fn multiple_images_produce_multiple_content_parts() {
+        let images = vec!["file-1".to_owned(), "file-2".to_owned()];
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "Compare these",
+            web_search_enabled: false,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+            file_search_filters: None,
+            web_search_context_size: crate::domain::llm::WebSearchContextSize::Low,
+            file_search_max_num_results: 5,
+            code_interpreter_file_ids: vec![],
+            token_budget: None,
+            image_file_ids: &images,
+        })
+        .unwrap();
+        let msg = &result.messages[0];
+        assert_eq!(msg.content.len(), 3);
+        assert!(matches!(&msg.content[1], ContentPart::Image { file_id } if file_id == "file-1"));
+        assert!(matches!(&msg.content[2], ContentPart::Image { file_id } if file_id == "file-2"));
+    }
+
+    #[test]
+    fn no_images_produces_text_only() {
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "hello",
+            web_search_enabled: false,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+            file_search_filters: None,
+            web_search_context_size: crate::domain::llm::WebSearchContextSize::Low,
+            file_search_max_num_results: 5,
+            code_interpreter_file_ids: vec![],
+            token_budget: None,
+            image_file_ids: &[],
+        })
+        .unwrap();
+        let msg = &result.messages[0];
+        assert_eq!(msg.content.len(), 1);
+        assert!(matches!(&msg.content[0], ContentPart::Text { .. }));
+    }
+
+    #[test]
+    fn image_tokens_included_in_budget_mandatory() {
+        let images = vec!["file-1".to_owned(), "file-2".to_owned()];
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "hi",
+            web_search_enabled: false,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+            file_search_filters: None,
+            web_search_context_size: crate::domain::llm::WebSearchContextSize::Low,
+            file_search_max_num_results: 5,
+            code_interpreter_file_ids: vec![],
+            token_budget: Some(test_budget(10_000, 4096)),
+            image_file_ids: &images,
+        });
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn image_tokens_cause_budget_exceeded() {
+        let images = vec!["file-1".to_owned(), "file-2".to_owned()];
+        let result = assemble_context(&ContextInput {
+            system_prompt: "",
+            web_search_guard: "",
+            file_search_guard: "",
+            thread_summary: None,
+            recent_messages: &[],
+            user_message: "hi",
+            web_search_enabled: false,
+            file_search_enabled: false,
+            vector_store_ids: &[],
+            file_search_filters: None,
+            web_search_context_size: crate::domain::llm::WebSearchContextSize::Low,
+            file_search_max_num_results: 5,
+            code_interpreter_file_ids: vec![],
+            token_budget: Some(test_budget(5100, 4096)),
+            image_file_ids: &images,
+        });
+        assert!(matches!(
+            result,
+            Err(ContextAssemblyError::BudgetExceeded { .. })
+        ));
+    }
+
+    #[test]
+    fn build_user_message_helper_text_only() {
+        let msg = super::build_user_message("hello", &[]);
+        assert_eq!(msg.content.len(), 1);
+        assert!(matches!(&msg.content[0], ContentPart::Text { text } if text == "hello"));
+    }
+
+    #[test]
+    fn build_user_message_helper_with_images() {
+        let ids = vec!["f1".to_owned(), "f2".to_owned()];
+        let msg = super::build_user_message("look", &ids);
+        assert_eq!(msg.content.len(), 3);
+        assert!(matches!(&msg.content[0], ContentPart::Text { text } if text == "look"));
+        assert!(matches!(&msg.content[1], ContentPart::Image { file_id } if file_id == "f1"));
+        assert!(matches!(&msg.content[2], ContentPart::Image { file_id } if file_id == "f2"));
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -263,6 +263,7 @@ impl<
                 Arc::clone(&repos.vector_store),
                 Arc::clone(&repos.message_attachment),
                 context_config,
+                rag_config.clone(),
                 Arc::clone(&metrics),
             ),
             turns,

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service.rs
@@ -154,6 +154,12 @@ pub enum StreamError {
     },
     /// Web search is disabled via kill switch but was requested.
     WebSearchDisabled,
+    /// Images are disabled via kill switch but image attachments were included.
+    ImagesDisabled,
+    /// Too many image attachments in one message (`max_images_per_message` exceeded).
+    TooManyImages { count: u32, max: u32 },
+    /// Model does not support image input (missing `VISION_INPUT` capability).
+    UnsupportedMedia,
     /// One or more attachment IDs are invalid (not found, wrong status, wrong chat, etc.).
     InvalidAttachment { code: String, message: String },
     /// Context budget exceeded — mandatory items don't fit in the token budget.
@@ -458,6 +464,7 @@ pub struct StreamService<
     vector_store_repo: Arc<VSR>,
     message_attachment_repo: Arc<MAR>,
     context_config: ContextConfig,
+    rag_config: crate::config::RagConfig,
     metrics: Arc<dyn MiniChatMetricsPort>,
 }
 
@@ -490,6 +497,7 @@ impl<
         vector_store_repo: Arc<VSR>,
         message_attachment_repo: Arc<MAR>,
         context_config: ContextConfig,
+        rag_config: crate::config::RagConfig,
         metrics: Arc<dyn MiniChatMetricsPort>,
     ) -> Self {
         Self {
@@ -507,6 +515,7 @@ impl<
             vector_store_repo,
             message_attachment_repo,
             context_config,
+            rag_config,
             metrics,
         }
     }
@@ -571,6 +580,10 @@ impl<
         cancel: CancellationToken,
         tx: mpsc::Sender<StreamEvent>,
     ) -> Result<tokio::task::JoinHandle<StreamOutcome>, StreamError> {
+        let has_vision_input = resolved_model
+            .multimodal_capabilities
+            .iter()
+            .any(|c| c == "VISION_INPUT");
         let ResolvedModel {
             model_id: model,
             provider_id,
@@ -658,6 +671,39 @@ impl<
             .await
             .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
 
+        // ── Pre-fetch image attachment count for guards + token estimation ──
+        // Validates chat_id to prevent cross-chat attachment references.
+        let image_file_ids: Vec<String> = if attachment_ids.is_empty() {
+            Vec::new()
+        } else {
+            let rows = self
+                .attachment_repo
+                .get_batch(&conn, &scope, &attachment_ids)
+                .await
+                .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
+            rows.iter()
+                .filter(|r| {
+                    r.chat_id == chat_id
+                        && r.attachment_kind
+                            == crate::infra::db::entity::attachment::AttachmentKind::Image
+                        && r.status == crate::infra::db::entity::attachment::AttachmentStatus::Ready
+                })
+                .filter_map(|r| r.provider_file_id.clone())
+                .collect()
+        };
+        let num_images = u32::try_from(image_file_ids.len()).unwrap_or(u32::MAX);
+
+        // ── Image count guard (before preflight, before TX) ──
+        if num_images > 0 {
+            let max = self.rag_config.max_images_per_message;
+            if num_images > max {
+                return Err(StreamError::TooManyImages {
+                    count: num_images,
+                    max,
+                });
+            }
+        }
+
         // ── Preflight quota evaluate (external I/O, no DB writes) ──
         let selected_model = model.clone();
         let computed = self
@@ -667,7 +713,7 @@ impl<
                 user_id,
                 selected_model: selected_model.clone(),
                 utf8_bytes: content.len() as u64,
-                num_images: 0,
+                num_images,
                 tools_enabled: pre_ready_doc_count > 0,
                 web_search_enabled,
                 code_interpreter_enabled: !pre_ci_file_ids.is_empty(),
@@ -683,6 +729,22 @@ impl<
         self.record_preflight_metrics(&computed, &selected_model);
 
         let pf = flatten_preflight(computed.decision.clone())?;
+
+        // ── Post-preflight image guards (kill switches + vision capability) ──
+        if num_images > 0 {
+            if computed.kill_switches.disable_images {
+                return Err(StreamError::ImagesDisabled);
+            }
+            // DESIGN.md line 181: check VISION_INPUT on the effective_model.
+            // DESIGN.md line 3206: P1 catalog invariant — ALL enabled models
+            // MUST include VISION_INPUT (enforced at startup). Under a valid
+            // P1 config, quota downgrade cannot demote to a non-vision model,
+            // so checking the selected_model is sufficient. This guard is
+            // defensive for future non-vision models or catalog misconfiguration.
+            if !has_vision_input {
+                return Err(StreamError::UnsupportedMedia);
+            }
+        }
 
         // Metrics: estimated tokens (only on allow/downgrade)
         #[allow(clippy::cast_precision_loss)]
@@ -833,9 +895,14 @@ impl<
                 pf.max_retrieved_chunks_per_turn,
                 ci_file_ids,
                 token_budget,
+                &image_file_ids,
             )
             .await?;
 
+        // Record image metrics
+        if num_images > 0 {
+            self.metrics.record_image_inputs_per_turn(num_images);
+        }
         let tenant_id_str = tenant_id.to_string();
         let resolved_provider = self
             .provider_resolver
@@ -1105,6 +1172,7 @@ impl<
         file_search_max_num_results: u32,
         code_interpreter_file_ids: Vec<String>,
         token_budget: Option<super::context_assembly::TokenBudget>,
+        image_file_ids: &[String],
     ) -> Result<super::context_assembly::AssembledContext, StreamError> {
         let conn = self
             .db
@@ -1182,6 +1250,7 @@ impl<
             file_search_max_num_results,
             code_interpreter_file_ids,
             token_budget,
+            image_file_ids,
         })
         .map_err(|e| StreamError::ContextBudgetExceeded {
             required_tokens: match &e {
@@ -1439,6 +1508,7 @@ impl<
                 pf.max_retrieved_chunks_per_turn,
                 ci_file_ids,
                 token_budget,
+                &[], // retry/edit: no new image attachments
             )
             .await?;
 
@@ -2942,6 +3012,7 @@ mod tests {
             Arc::new(crate::infra::db::repo::vector_store_repo::VectorStoreRepository),
             Arc::new(crate::infra::db::repo::message_attachment_repo::MessageAttachmentRepository),
             crate::config::ContextConfig::default(),
+            crate::config::RagConfig::default(),
             metrics,
         )
     }
@@ -3925,6 +3996,7 @@ mod tests {
             Arc::new(crate::infra::db::repo::vector_store_repo::VectorStoreRepository),
             Arc::new(crate::infra::db::repo::message_attachment_repo::MessageAttachmentRepository),
             crate::config::ContextConfig::default(),
+            crate::config::RagConfig::default(),
             Arc::new(crate::domain::ports::metrics::NoopMetrics),
         )
     }
@@ -5353,6 +5425,7 @@ mod tests {
             Arc::new(crate::infra::db::repo::vector_store_repo::VectorStoreRepository),
             Arc::new(crate::infra::db::repo::message_attachment_repo::MessageAttachmentRepository),
             crate::config::ContextConfig::default(),
+            crate::config::RagConfig::default(),
             Arc::new(crate::domain::ports::metrics::NoopMetrics),
         )
     }
@@ -5660,6 +5733,7 @@ mod tests {
         fn record_attachment_upload_bytes(&self, _: &str, _: f64) {}
         fn increment_attachments_pending(&self) {}
         fn decrement_attachments_pending(&self) {}
+        fn record_image_inputs_per_turn(&self, _: u32) {}
     }
 
     // ── Metric emission tests ────────────────────────────────────────────

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -1164,6 +1164,7 @@ impl crate::domain::ports::MiniChatMetricsPort for TestMetrics {
     fn decrement_attachments_pending(&self) {
         self.attachments_pending.fetch_add(-1, Ordering::Relaxed);
     }
+    fn record_image_inputs_per_turn(&self, _count: u32) {}
 }
 
 // ── Mock User Limits Provider ──

--- a/modules/mini-chat/mini-chat/src/infra/metrics.rs
+++ b/modules/mini-chat/mini-chat/src/infra/metrics.rs
@@ -791,6 +791,10 @@ impl MiniChatMetricsPort for MiniChatMetricsMeter {
     fn decrement_attachments_pending(&self) {
         self.attachments_pending.add(-1, &[]);
     }
+
+    fn record_image_inputs_per_turn(&self, count: u32) {
+        self.image_inputs_per_turn.record(f64::from(count), &[]);
+    }
 }
 
 #[cfg(test)]

--- a/testing/e2e/modules/mini_chat/config/base.yaml
+++ b/testing/e2e/modules/mini_chat/config/base.yaml
@@ -242,7 +242,7 @@ modules:
           system_prompt: "You are a helpful assistant. IMPORTANT RULE: When the user says exactly 'PING', you MUST respond with exactly 'PONG' and nothing else."
           input_tokens_credit_multiplier_micro: 1000000
           output_tokens_credit_multiplier_micro: 3000000
-          multimodal_capabilities: []
+          multimodal_capabilities: ["VISION_INPUT"]
           context_window: 128000
           max_output_tokens: 4096
           max_input_tokens: 120000
@@ -287,7 +287,7 @@ modules:
               chat_prefix_completion: false
             input_type:
               text: true
-              image: false
+              image: true
               audio: false
               video: false
             tool_support:
@@ -328,7 +328,7 @@ modules:
           system_prompt: "You are a helpful assistant. IMPORTANT RULE: When the user says exactly 'PING', you MUST respond with exactly 'PONG' and nothing else."
           input_tokens_credit_multiplier_micro: 500000
           output_tokens_credit_multiplier_micro: 1500000
-          multimodal_capabilities: []
+          multimodal_capabilities: ["VISION_INPUT"]
           context_window: 64000
           max_output_tokens: 4096
           max_input_tokens: 56000
@@ -373,7 +373,7 @@ modules:
               chat_prefix_completion: false
             input_type:
               text: true
-              image: false
+              image: true
               audio: false
               video: false
             tool_support:
@@ -414,7 +414,7 @@ modules:
           system_prompt: "You are a helpful assistant. IMPORTANT RULE: When the user says exactly 'PING', you MUST respond with exactly 'PONG' and nothing else."
           input_tokens_credit_multiplier_micro: 1000000
           output_tokens_credit_multiplier_micro: 3000000
-          multimodal_capabilities: []
+          multimodal_capabilities: ["VISION_INPUT"]
           context_window: 128000
           max_output_tokens: 4096
           max_input_tokens: 120000
@@ -459,7 +459,7 @@ modules:
               chat_prefix_completion: false
             input_type:
               text: true
-              image: false
+              image: true
               audio: false
               video: false
             tool_support:

--- a/testing/e2e/modules/mini_chat/test_attachments.py
+++ b/testing/e2e/modules/mini_chat/test_attachments.py
@@ -510,7 +510,7 @@ class TestImageRecognition:
         # Ask the LLM to identify the animal
         status, events, raw = stream_message(
             chat_id,
-            "What animal is in the attached image? Answer in one word.",
+            "Describe exactly what you see in the attached image. If you cannot see any image, respond with exactly 'NO_IMAGE_VISIBLE'.",
             attachment_ids=[att_id],
         )
         assert status == 200, f"[{provider_label}] Stream failed: {status} {raw[:500]}"
@@ -524,11 +524,19 @@ class TestImageRecognition:
 
         assert len(delta_text) > 0, f"[{provider_label}] Expected non-empty response"
 
-        # Soft check — will pass once image inlining is wired
+        # The LLM must see the image — if it responds with NO_IMAGE_VISIBLE
+        # or doesn't mention a cat, image inlining is broken.
         response_lower = delta_text.lower()
+        assert "no_image_visible" not in response_lower, (
+            f"[{provider_label}] LLM cannot see the image — file_id not included "
+            f"as multimodal input in the Responses API request (image inlining gap). "
+            f"Response: {delta_text!r}"
+        )
         recognized = any(w in response_lower for w in ("cat", "kitten", "feline"))
-        print(f"\n[{provider_label} image recognition]: {delta_text!r}"
-              f" → {'recognized cat' if recognized else 'no cat (image inlining not yet wired)'}")
+        assert recognized, (
+            f"[{provider_label}] LLM responded but did not recognize the cat. "
+            f"Response: {delta_text!r}"
+        )
 
     def test_image_recognition_cat_openai(self, chat):
         cat_bytes = self._load_cat_image()
@@ -538,6 +546,99 @@ class TestImageRecognition:
         azure_chat = chat_with_model(AZURE_MODEL)
         cat_bytes = self._load_cat_image()
         self._upload_image_and_ask(azure_chat["id"], cat_bytes, "cat-az.jpg", "image/jpeg", "Azure")
+
+
+# ---------------------------------------------------------------------------
+# Mixed document + image: both mechanisms must work simultaneously
+# ---------------------------------------------------------------------------
+
+@pytest.mark.openai
+@pytest.mark.online_only
+class TestDocumentAndImageTogether:
+    """Upload a document AND an image, send a message referencing both.
+
+    The LLM must use file_search to read the document AND see the image
+    via multimodal input. The question is designed so the correct answer
+    requires information from BOTH sources.
+    """
+
+    def test_document_and_image_combined(self, chat):
+        chat_id = chat["id"]
+
+        # 1. Upload a document with a secret code word
+        doc_content = (
+            "CONFIDENTIAL REPORT\n"
+            "The secret code word for this project is: FLAMINGO.\n"
+            "Do not share this code word with anyone.\n"
+        )
+        doc_resp = upload_file(
+            chat_id,
+            content=doc_content.encode(),
+            filename="secret-report.txt",
+            content_type="text/plain",
+        )
+        assert doc_resp.status_code == 201
+        doc_id = doc_resp.json()["id"]
+        doc_detail = poll_until_ready(chat_id, doc_id)
+        assert doc_detail["status"] == "ready"
+        assert doc_detail["kind"] == "document"
+
+        # 2. Upload the cat image
+        cat_bytes = (pathlib.Path(__file__).parent / "fixtures" / "cat.jpg").read_bytes()
+        img_resp = upload_file(
+            chat_id,
+            content=cat_bytes,
+            filename="animal.jpg",
+            content_type="image/jpeg",
+        )
+        assert img_resp.status_code == 201
+        img_id = img_resp.json()["id"]
+        img_detail = poll_until_ready(chat_id, img_id)
+        assert img_detail["status"] == "ready"
+        assert img_detail["kind"] == "image"
+
+        # 3. Ask a question that requires BOTH sources
+        #    - The document contains the code word "FLAMINGO"
+        #    - The image contains a cat
+        #    The LLM must mention both to prove it accessed both.
+        status, events, raw = stream_message(
+            chat_id,
+            content=(
+                "I attached a document and an image. "
+                "Tell me: 1) What is the secret code word from the document? "
+                "2) What animal is in the image? "
+                "Answer both questions."
+            ),
+            attachment_ids=[doc_id, img_id],
+        )
+        assert status == 200, f"Stream failed: {status} {raw[:500]}"
+        done = expect_done(events)
+
+        # Collect response text
+        delta_text = ""
+        for ev in events:
+            if ev.event == "delta" and isinstance(ev.data, dict):
+                delta_text += ev.data.get("content", "")
+
+        assert len(delta_text) > 0, "Expected non-empty response"
+        response_lower = delta_text.lower()
+
+        # Must recognize the cat from the image (multimodal input) — hard assert
+        has_cat = any(w in response_lower for w in ("cat", "kitten", "feline"))
+        assert has_cat, (
+            f"LLM did not recognize the cat from the image. "
+            f"Image inlining (input_image) may not be working. Response: {delta_text!r}"
+        )
+
+        # Should mention the code word from the document (file_search)
+        # Soft check: file_search depends on vector store indexing timing
+        has_code_word = "flamingo" in response_lower
+        if not has_code_word:
+            print(
+                f"\n[WARN] LLM saw the cat but did not find 'FLAMINGO' from the document. "
+                f"file_search may not have retrieved the document (indexing timing). "
+                f"Response: {delta_text!r}"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
feat(mini-chat): image inlining in Responses API

Closes #1257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image attachment support with configurable max images per message (default: 4).
  * Detects vision-capable models, includes images in token budgeting, enforces image limits, and returns clear errors for disabled images, too many images, or unsupported media.
  * Records image-inputs-per-turn metric for telemetry.

* **Tests**
  * Strengthened image-recognition assertions.
  * Added end-to-end test for combined document+image messaging.

* **Chores**
  * Updated test model configs to declare vision capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->