### PR TITLE
fix(modkit): pass fresh deadline token to stop() for graceful shutdown

### DIFF
--- a/libs/modkit/src/bootstrap/oop.rs
+++ b/libs/modkit/src/bootstrap/oop.rs
@@ -594,6 +594,7 @@ pub async fn run_oop_with_options(opts: OopRunOptions) -> Result<()> {
         )],
         instance_id,
         oop: None, // OoP modules don't spawn other OoP modules
+        shutdown_deadline: None,
     };
 
     let result = run(run_options).await;

--- a/libs/modkit/src/bootstrap/run.rs
+++ b/libs/modkit/src/bootstrap/run.rs
@@ -82,6 +82,7 @@ pub async fn run_server(config: AppConfig) -> Result<()> {
         clients: vec![],
         instance_id,
         oop: oop_options,
+        shutdown_deadline: None,
     };
 
     let result = run(run_options).await;

--- a/libs/modkit/src/contracts.rs
+++ b/libs/modkit/src/contracts.rs
@@ -92,10 +92,62 @@ pub trait ApiGatewayCapability: Send + Sync + 'static {
     fn as_registry(&self) -> &dyn OpenApiRegistry;
 }
 
+/// Capability for modules that have a long-running background task.
+///
+/// # Shutdown Contract
+///
+/// The `stop` method receives a **deadline token** that implements two-phase shutdown:
+///
+/// 1. **Graceful stop request**: When `stop(deadline_token)` is called, the `deadline_token`
+///    is *not* cancelled. This is the signal to begin graceful shutdown.
+///
+/// 2. **Hard-stop deadline**: After the runtime's `shutdown_deadline` expires (default 30s),
+///    the `deadline_token` is cancelled. This signals that graceful shutdown time is over
+///    and the module should abort immediately.
+///
+/// ## Recommended Implementation Pattern
+///
+/// ```ignore
+/// async fn stop(&self, deadline_token: CancellationToken) -> anyhow::Result<()> {
+///     // 1. Request cooperative shutdown of child tasks
+///     self.request_graceful_shutdown();
+///
+///     // 2. Wait for graceful completion OR hard-stop deadline
+///     tokio::select! {
+///         _ = self.wait_for_graceful_completion() => {
+///             // Graceful shutdown succeeded
+///         }
+///         _ = deadline_token.cancelled() => {
+///             // Deadline reached, force abort
+///             self.force_abort();
+///         }
+///     }
+///     Ok(())
+/// }
+/// ```
+///
+/// ## Important Notes
+///
+/// - The `deadline_token` passed to `stop()` is a **fresh token**, not the root cancellation
+///   token that triggered the shutdown. This allows modules to implement real graceful shutdown.
+/// - Modules should NOT assume the token is already cancelled when `stop()` is called.
+/// - The `WithLifecycle` wrapper handles this contract automatically via its `stop_timeout`.
 #[async_trait]
 pub trait RunnableCapability: Send + Sync {
+    /// Start the module's background task.
+    ///
+    /// The `cancel` token is a child of the runtime's root cancellation token.
+    /// When cancelled, the module should stop its background work.
     async fn start(&self, cancel: CancellationToken) -> anyhow::Result<()>;
-    async fn stop(&self, cancel: CancellationToken) -> anyhow::Result<()>;
+
+    /// Stop the module's background task.
+    ///
+    /// The `deadline_token` implements two-phase shutdown:
+    /// - Initially not cancelled: begin graceful shutdown
+    /// - When cancelled: graceful period expired, abort immediately
+    ///
+    /// See trait-level documentation for the full shutdown contract.
+    async fn stop(&self, deadline_token: CancellationToken) -> anyhow::Result<()>;
 }
 
 /// Represents a gRPC service registration callback used by the gRPC hub.

--- a/libs/modkit/src/lib.rs
+++ b/libs/modkit/src/lib.rs
@@ -155,8 +155,8 @@ pub use backends::{
 pub use lifecycle::{Lifecycle, Runnable, Status, StopReason, WithLifecycle};
 pub use plugins::GtsPluginSelector;
 pub use runtime::{
-    DbOptions, Endpoint, ModuleInstance, ModuleManager, OopModuleSpawnConfig, OopSpawnOptions,
-    RunOptions, ShutdownOptions, run,
+    DEFAULT_SHUTDOWN_DEADLINE, DbOptions, Endpoint, ModuleInstance, ModuleManager,
+    OopModuleSpawnConfig, OopSpawnOptions, RunOptions, ShutdownOptions, run,
 };
 
 #[cfg(feature = "bootstrap")]

--- a/libs/modkit/src/lifecycle.rs
+++ b/libs/modkit/src/lifecycle.rs
@@ -533,6 +533,21 @@ impl<T: Runnable> WithLifecycle<T> {
         }
     }
 
+    /// Set a custom stop timeout for graceful lifecycle shutdown.
+    ///
+    /// This is how long `Lifecycle::stop()` will wait for the task to finish
+    /// before aborting it.
+    ///
+    /// # Relationship with `HostRuntime::shutdown_deadline`
+    ///
+    /// When running under `HostRuntime`, this `stop_timeout` races against the
+    /// runtime's `shutdown_deadline` (both default to 30s). To ensure deterministic behavior:
+    ///
+    /// - `stop_timeout` should be **less than** `shutdown_deadline`
+    /// - This allows the lifecycle's internal timeout to trigger first for graceful cleanup
+    /// - The runtime's `deadline_token` then acts as a hard backstop
+    ///
+    /// Example: `stop_timeout = 25s`, `shutdown_deadline = 30s`
     pub fn with_stop_timeout(mut self, d: Duration) -> Self {
         self.stop_timeout = d;
         self

--- a/libs/modkit/src/lifecycle.rs
+++ b/libs/modkit/src/lifecycle.rs
@@ -606,14 +606,25 @@ impl<T: Runnable> crate::contracts::RunnableCapability for WithLifecycle<T> {
         }
     }
 
-    #[tracing::instrument(skip(self, external_cancel), level = "debug")]
-    async fn stop(&self, external_cancel: CancellationToken) -> TaskResult<()> {
+    /// Stop the lifecycle-managed task.
+    ///
+    /// Implements the two-phase shutdown contract:
+    /// 1. Attempts graceful stop using `self.stop_timeout` (default 30s)
+    /// 2. If `deadline_token` is cancelled before graceful stop completes,
+    ///    immediately aborts with zero timeout
+    ///
+    /// The `deadline_token` is a fresh token from the runtime (not already cancelled),
+    /// allowing real graceful shutdown to occur.
+    #[tracing::instrument(skip(self, deadline_token), level = "debug")]
+    async fn stop(&self, deadline_token: CancellationToken) -> TaskResult<()> {
         tokio::select! {
             res = self.lc.stop(self.stop_timeout) => {
                 _ = res.map_err(anyhow::Error::from)?;
                 Ok(())
             }
-            () = external_cancel.cancelled() => {
+            () = deadline_token.cancelled() => {
+                // Hard-stop deadline reached, abort immediately
+                tracing::debug!("Hard-stop deadline reached, aborting lifecycle");
                 _ = self.lc.stop(Duration::from_millis(0)).await?;
                 Ok(())
             }

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -131,6 +131,17 @@ impl HostRuntime {
     ///
     /// This is the maximum time the runtime will wait for modules to stop gracefully
     /// before sending the hard-stop signal (cancelling the deadline token).
+    ///
+    /// # Relationship with `WithLifecycle::stop_timeout`
+    ///
+    /// When using `WithLifecycle`, its `stop_timeout` (default 30s) races against this
+    /// `shutdown_deadline` (also default 30s). To ensure deterministic behavior:
+    ///
+    /// - `WithLifecycle::stop_timeout` should be **less than** `shutdown_deadline`
+    /// - This allows the lifecycle's internal timeout to trigger first for graceful cleanup
+    /// - The runtime's `deadline_token` then acts as a hard backstop
+    ///
+    /// Example: `stop_timeout = 25s`, `shutdown_deadline = 30s`
     #[must_use]
     pub fn with_shutdown_deadline(mut self, deadline: std::time::Duration) -> Self {
         self.shutdown_deadline = deadline;
@@ -578,14 +589,17 @@ impl HostRuntime {
     ///
     /// # Two-Phase Shutdown Contract
     ///
-    /// This phase implements a proper two-phase shutdown:
+    /// This phase implements a proper two-phase shutdown for **each module**:
     ///
     /// 1. **Graceful stop request**: Each module's `stop(deadline_token)` is called with a
     ///    *fresh* cancellation token (not the already-cancelled root token). Modules should
     ///    interpret this as "please stop gracefully".
     ///
-    /// 2. **Hard-stop deadline**: After `shutdown_deadline` expires, the `deadline_token` is
-    ///    cancelled. Modules should interpret this as "abort immediately".
+    /// 2. **Hard-stop deadline**: After `shutdown_deadline` expires **for that module**,
+    ///    its `deadline_token` is cancelled. Modules should interpret this as "abort immediately".
+    ///
+    /// Each module gets its own independent deadline — if module A takes 25s to stop,
+    /// module B still gets the full `shutdown_deadline` for its graceful shutdown.
     ///
     /// This allows modules to implement real graceful shutdown:
     /// - Request cooperative shutdown of child tasks
@@ -598,32 +612,34 @@ impl HostRuntime {
     async fn run_stop_phase(&self) -> Result<(), RegistryError> {
         tracing::info!("Phase: stop");
 
-        // Create a fresh deadline token for the stop phase.
-        // This token is NOT already cancelled (unlike self.cancel which triggered the stop phase).
-        // Modules can use this to implement two-phase shutdown:
-        // - Start graceful shutdown immediately
-        // - Switch to hard-abort when deadline_token is cancelled
-        let deadline_token = CancellationToken::new();
         let deadline = self.shutdown_deadline;
 
-        // Spawn a task to cancel the deadline token after the shutdown deadline
-        let deadline_token_for_timeout = deadline_token.clone();
-        let deadline_task = tokio::spawn(async move {
-            tokio::time::sleep(deadline).await;
-            tracing::warn!(
-                deadline_secs = deadline.as_secs(),
-                "Shutdown deadline reached, sending hard-stop signal"
-            );
-            deadline_token_for_timeout.cancel();
-        });
-
-        // Stop all modules in reverse order with the fresh deadline token
+        // Stop all modules in reverse order, each with its own independent deadline
         for e in self.registry.modules().iter().rev() {
-            Self::stop_one_module(e, deadline_token.clone()).await;
-        }
+            // Create a fresh deadline token for THIS module
+            // Each module gets the full shutdown_deadline independently
+            let deadline_token = CancellationToken::new();
+            let deadline_token_for_timeout = deadline_token.clone();
 
-        // Cancel the deadline task if all modules stopped before the deadline
-        deadline_task.abort();
+            // Spawn a task to cancel this module's deadline token after shutdown_deadline
+            let module_name = e.name;
+            let deadline_task = tokio::spawn(async move {
+                tokio::time::sleep(deadline).await;
+                tracing::warn!(
+                    module = module_name,
+                    deadline_secs = deadline.as_secs(),
+                    "Module shutdown deadline reached, sending hard-stop signal"
+                );
+                deadline_token_for_timeout.cancel();
+            });
+
+            // Stop this module with its own deadline token
+            Self::stop_one_module(e, deadline_token).await;
+
+            // Cancel the deadline task and await it to ensure full cleanup
+            deadline_task.abort();
+            drop(deadline_task.await);
+        }
 
         Ok(())
     }
@@ -1136,6 +1152,7 @@ mod tests {
         use std::sync::atomic::AtomicBool;
 
         struct TokenCheckModule {
+            stop_was_called: Arc<AtomicBool>,
             token_was_cancelled_on_entry: Arc<AtomicBool>,
         }
 
@@ -1152,6 +1169,8 @@ mod tests {
                 Ok(())
             }
             async fn stop(&self, deadline_token: CancellationToken) -> anyhow::Result<()> {
+                // Record that stop() was called
+                self.stop_was_called.store(true, Ordering::SeqCst);
                 // Record whether the token was already cancelled when stop() was called
                 self.token_was_cancelled_on_entry
                     .store(deadline_token.is_cancelled(), Ordering::SeqCst);
@@ -1159,8 +1178,10 @@ mod tests {
             }
         }
 
+        let stop_was_called = Arc::new(AtomicBool::new(false));
         let token_was_cancelled = Arc::new(AtomicBool::new(true)); // Default to true to detect if not set
         let module = Arc::new(TokenCheckModule {
+            stop_was_called: stop_was_called.clone(),
             token_was_cancelled_on_entry: token_was_cancelled.clone(),
         });
 
@@ -1185,6 +1206,12 @@ mod tests {
 
         // Run stop phase - the deadline token should NOT be cancelled
         runtime.run_stop_phase().await.unwrap();
+
+        // First, verify stop() was actually called (guards against silent registration failures)
+        assert!(
+            stop_was_called.load(Ordering::SeqCst),
+            "stop() was never called - module may not have been registered correctly"
+        );
 
         // The token should NOT have been cancelled when stop() was called
         // This is the key fix: modules get a fresh token, not the already-cancelled root token

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -58,6 +58,9 @@ pub const MODKIT_DIRECTORY_ENDPOINT_ENV: &str = "MODKIT_DIRECTORY_ENDPOINT";
 /// Environment variable name for passing rendered module config to `OoP` modules.
 pub const MODKIT_MODULE_CONFIG_ENV: &str = "MODKIT_MODULE_CONFIG";
 
+/// Default shutdown deadline for graceful module stop (30 seconds).
+pub const DEFAULT_SHUTDOWN_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// `HostRuntime` owns the lifecycle orchestration for `ModKit`.
 ///
 /// It encapsulates all runtime state and drives modules through the full lifecycle (see module docs).
@@ -74,6 +77,8 @@ pub struct HostRuntime {
     db_options: DbOptions,
     /// `OoP` module spawn configuration and backend
     oop_options: Option<OopSpawnOptions>,
+    /// Maximum time allowed for graceful shutdown before hard-stop signal is sent.
+    shutdown_deadline: std::time::Duration,
 }
 
 impl HostRuntime {
@@ -118,7 +123,18 @@ impl HostRuntime {
             cancel,
             db_options,
             oop_options,
+            shutdown_deadline: DEFAULT_SHUTDOWN_DEADLINE,
         }
+    }
+
+    /// Set a custom shutdown deadline for graceful module stop.
+    ///
+    /// This is the maximum time the runtime will wait for modules to stop gracefully
+    /// before sending the hard-stop signal (cancelling the deadline token).
+    #[must_use]
+    pub fn with_shutdown_deadline(mut self, deadline: std::time::Duration) -> Self {
+        self.shutdown_deadline = deadline;
+        self
     }
 
     /// `PRE_INIT` phase: wire runtime internals into system modules.
@@ -560,15 +576,54 @@ impl HostRuntime {
 
     /// STOP phase: stop all stateful modules in reverse order.
     ///
+    /// # Two-Phase Shutdown Contract
+    ///
+    /// This phase implements a proper two-phase shutdown:
+    ///
+    /// 1. **Graceful stop request**: Each module's `stop(deadline_token)` is called with a
+    ///    *fresh* cancellation token (not the already-cancelled root token). Modules should
+    ///    interpret this as "please stop gracefully".
+    ///
+    /// 2. **Hard-stop deadline**: After `shutdown_deadline` expires, the `deadline_token` is
+    ///    cancelled. Modules should interpret this as "abort immediately".
+    ///
+    /// This allows modules to implement real graceful shutdown:
+    /// - Request cooperative shutdown of child tasks
+    /// - Wait for them to finish gracefully
+    /// - If `deadline_token` fires, switch to hard-abort mode
+    ///
     /// Errors are logged but do not fail the shutdown process.
     /// Note: `OoP` modules are stopped automatically by the backend when the
     /// cancellation token is triggered.
     async fn run_stop_phase(&self) -> Result<(), RegistryError> {
         tracing::info!("Phase: stop");
 
+        // Create a fresh deadline token for the stop phase.
+        // This token is NOT already cancelled (unlike self.cancel which triggered the stop phase).
+        // Modules can use this to implement two-phase shutdown:
+        // - Start graceful shutdown immediately
+        // - Switch to hard-abort when deadline_token is cancelled
+        let deadline_token = CancellationToken::new();
+        let deadline = self.shutdown_deadline;
+
+        // Spawn a task to cancel the deadline token after the shutdown deadline
+        let deadline_token_for_timeout = deadline_token.clone();
+        let deadline_task = tokio::spawn(async move {
+            tokio::time::sleep(deadline).await;
+            tracing::warn!(
+                deadline_secs = deadline.as_secs(),
+                "Shutdown deadline reached, sending hard-stop signal"
+            );
+            deadline_token_for_timeout.cancel();
+        });
+
+        // Stop all modules in reverse order with the fresh deadline token
         for e in self.registry.modules().iter().rev() {
-            Self::stop_one_module(e, self.cancel.clone()).await;
+            Self::stop_one_module(e, deadline_token.clone()).await;
         }
+
+        // Cancel the deadline task if all modules stopped before the deadline
+        deadline_task.abort();
 
         Ok(())
     }
@@ -1073,6 +1128,225 @@ mod tests {
                 "init:user_c",
                 "post_init:sys_a",
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stop_phase_provides_fresh_deadline_token() {
+        use std::sync::atomic::AtomicBool;
+
+        struct TokenCheckModule {
+            token_was_cancelled_on_entry: Arc<AtomicBool>,
+        }
+
+        #[async_trait::async_trait]
+        impl Module for TokenCheckModule {
+            async fn init(&self, _ctx: &ModuleCtx) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl RunnableCapability for TokenCheckModule {
+            async fn start(&self, _cancel: CancellationToken) -> anyhow::Result<()> {
+                Ok(())
+            }
+            async fn stop(&self, deadline_token: CancellationToken) -> anyhow::Result<()> {
+                // Record whether the token was already cancelled when stop() was called
+                self.token_was_cancelled_on_entry
+                    .store(deadline_token.is_cancelled(), Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let token_was_cancelled = Arc::new(AtomicBool::new(true)); // Default to true to detect if not set
+        let module = Arc::new(TokenCheckModule {
+            token_was_cancelled_on_entry: token_was_cancelled.clone(),
+        });
+
+        let mut builder = RegistryBuilder::default();
+        builder.register_core_with_meta("test", &[], module.clone() as Arc<dyn Module>);
+        builder.register_stateful_with_meta("test", module.clone() as Arc<dyn RunnableCapability>);
+
+        let registry = builder.build_topo_sorted().unwrap();
+        let client_hub = Arc::new(ClientHub::new());
+        let cancel = CancellationToken::new();
+        let config_provider: Arc<dyn ConfigProvider> = Arc::new(EmptyConfigProvider);
+
+        let runtime = HostRuntime::new(
+            registry,
+            config_provider,
+            DbOptions::None,
+            client_hub,
+            cancel.clone(),
+            Uuid::new_v4(),
+            None,
+        );
+
+        // Run stop phase - the deadline token should NOT be cancelled
+        runtime.run_stop_phase().await.unwrap();
+
+        // The token should NOT have been cancelled when stop() was called
+        // This is the key fix: modules get a fresh token, not the already-cancelled root token
+        assert!(
+            !token_was_cancelled.load(Ordering::SeqCst),
+            "deadline_token should NOT be cancelled when stop() is called - this enables graceful shutdown"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stop_phase_graceful_shutdown_completes_before_deadline() {
+        use std::sync::atomic::AtomicBool;
+        use std::time::Duration;
+
+        struct GracefulModule {
+            graceful_completed: Arc<AtomicBool>,
+            deadline_fired: Arc<AtomicBool>,
+        }
+
+        #[async_trait::async_trait]
+        impl Module for GracefulModule {
+            async fn init(&self, _ctx: &ModuleCtx) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl RunnableCapability for GracefulModule {
+            async fn start(&self, _cancel: CancellationToken) -> anyhow::Result<()> {
+                Ok(())
+            }
+            async fn stop(&self, deadline_token: CancellationToken) -> anyhow::Result<()> {
+                // Simulate graceful shutdown that completes quickly (10ms)
+                tokio::select! {
+                    () = tokio::time::sleep(Duration::from_millis(10)) => {
+                        self.graceful_completed.store(true, Ordering::SeqCst);
+                    }
+                    () = deadline_token.cancelled() => {
+                        self.deadline_fired.store(true, Ordering::SeqCst);
+                    }
+                }
+                Ok(())
+            }
+        }
+
+        let graceful_completed = Arc::new(AtomicBool::new(false));
+        let deadline_fired = Arc::new(AtomicBool::new(false));
+        let module = Arc::new(GracefulModule {
+            graceful_completed: graceful_completed.clone(),
+            deadline_fired: deadline_fired.clone(),
+        });
+
+        let mut builder = RegistryBuilder::default();
+        builder.register_core_with_meta("test", &[], module.clone() as Arc<dyn Module>);
+        builder.register_stateful_with_meta("test", module.clone() as Arc<dyn RunnableCapability>);
+
+        let registry = builder.build_topo_sorted().unwrap();
+        let client_hub = Arc::new(ClientHub::new());
+        let cancel = CancellationToken::new();
+        let config_provider: Arc<dyn ConfigProvider> = Arc::new(EmptyConfigProvider);
+
+        // Use a long deadline (5s) - module should complete gracefully before this
+        let runtime = HostRuntime::new(
+            registry,
+            config_provider,
+            DbOptions::None,
+            client_hub,
+            cancel.clone(),
+            Uuid::new_v4(),
+            None,
+        )
+        .with_shutdown_deadline(Duration::from_secs(5));
+
+        runtime.run_stop_phase().await.unwrap();
+
+        // Graceful shutdown should have completed
+        assert!(
+            graceful_completed.load(Ordering::SeqCst),
+            "graceful shutdown should complete"
+        );
+        // Deadline should NOT have fired (module finished before deadline)
+        assert!(
+            !deadline_fired.load(Ordering::SeqCst),
+            "deadline should not fire when graceful shutdown completes quickly"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stop_phase_deadline_fires_for_slow_module() {
+        use std::sync::atomic::AtomicBool;
+        use std::time::Duration;
+
+        struct SlowModule {
+            graceful_completed: Arc<AtomicBool>,
+            deadline_fired: Arc<AtomicBool>,
+        }
+
+        #[async_trait::async_trait]
+        impl Module for SlowModule {
+            async fn init(&self, _ctx: &ModuleCtx) -> anyhow::Result<()> {
+                Ok(())
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl RunnableCapability for SlowModule {
+            async fn start(&self, _cancel: CancellationToken) -> anyhow::Result<()> {
+                Ok(())
+            }
+            async fn stop(&self, deadline_token: CancellationToken) -> anyhow::Result<()> {
+                // Simulate slow graceful shutdown (would take 10s, but deadline is 100ms)
+                tokio::select! {
+                    () = tokio::time::sleep(Duration::from_secs(10)) => {
+                        self.graceful_completed.store(true, Ordering::SeqCst);
+                    }
+                    () = deadline_token.cancelled() => {
+                        self.deadline_fired.store(true, Ordering::SeqCst);
+                    }
+                }
+                Ok(())
+            }
+        }
+
+        let graceful_completed = Arc::new(AtomicBool::new(false));
+        let deadline_fired = Arc::new(AtomicBool::new(false));
+        let module = Arc::new(SlowModule {
+            graceful_completed: graceful_completed.clone(),
+            deadline_fired: deadline_fired.clone(),
+        });
+
+        let mut builder = RegistryBuilder::default();
+        builder.register_core_with_meta("test", &[], module.clone() as Arc<dyn Module>);
+        builder.register_stateful_with_meta("test", module.clone() as Arc<dyn RunnableCapability>);
+
+        let registry = builder.build_topo_sorted().unwrap();
+        let client_hub = Arc::new(ClientHub::new());
+        let cancel = CancellationToken::new();
+        let config_provider: Arc<dyn ConfigProvider> = Arc::new(EmptyConfigProvider);
+
+        // Use a short deadline (100ms) - module should be interrupted by deadline
+        let runtime = HostRuntime::new(
+            registry,
+            config_provider,
+            DbOptions::None,
+            client_hub,
+            cancel.clone(),
+            Uuid::new_v4(),
+            None,
+        )
+        .with_shutdown_deadline(Duration::from_millis(100));
+
+        runtime.run_stop_phase().await.unwrap();
+
+        // Graceful shutdown should NOT have completed (deadline fired first)
+        assert!(
+            !graceful_completed.load(Ordering::SeqCst),
+            "graceful shutdown should not complete when deadline fires first"
+        );
+        // Deadline should have fired
+        assert!(
+            deadline_fired.load(Ordering::SeqCst),
+            "deadline should fire for slow modules"
         );
     }
 }

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -58,8 +58,12 @@ pub const MODKIT_DIRECTORY_ENDPOINT_ENV: &str = "MODKIT_DIRECTORY_ENDPOINT";
 /// Environment variable name for passing rendered module config to `OoP` modules.
 pub const MODKIT_MODULE_CONFIG_ENV: &str = "MODKIT_MODULE_CONFIG";
 
-/// Default shutdown deadline for graceful module stop (30 seconds).
-pub const DEFAULT_SHUTDOWN_DEADLINE: std::time::Duration = std::time::Duration::from_secs(30);
+/// Default shutdown deadline for graceful module stop (35 seconds).
+///
+/// This is intentionally 5 seconds longer than `WithLifecycle::stop_timeout` (30s default)
+/// to ensure deterministic behavior: the lifecycle's internal timeout fires first,
+/// and the runtime deadline acts as a hard backstop.
+pub const DEFAULT_SHUTDOWN_DEADLINE: std::time::Duration = std::time::Duration::from_secs(35);
 
 /// `HostRuntime` owns the lifecycle orchestration for `ModKit`.
 ///
@@ -129,7 +133,7 @@ impl HostRuntime {
 
     /// Set a custom shutdown deadline for graceful module stop.
     ///
-    /// This is the maximum time the runtime will wait for modules to stop gracefully
+    /// This is the maximum time the runtime will wait for each module to stop gracefully
     /// before sending the hard-stop signal (cancelling the deadline token).
     ///
     /// # Relationship with `WithLifecycle::stop_timeout`
@@ -617,27 +621,31 @@ impl HostRuntime {
         // Stop all modules in reverse order, each with its own independent deadline
         for e in self.registry.modules().iter().rev() {
             let module_name = e.name;
+
+            // Create a fresh deadline token for THIS module
+            // Each module gets the full shutdown_deadline independently
             let deadline_token = CancellationToken::new();
+            let deadline_token_for_timeout = deadline_token.clone();
 
-            tokio::select! {
-                () = tokio::time::sleep(deadline) => {
-                    tracing::warn!(
-                        module = module_name,
-                        deadline_secs = deadline.as_secs(),
-                        "Module shutdown deadline reached, sending hard-stop signal"
-                    );
+            // Spawn a task to cancel this module's deadline token after shutdown_deadline
+            let deadline_task = tokio::spawn(async move {
+                tokio::time::sleep(deadline).await;
+                tracing::warn!(
+                    module = module_name,
+                    deadline_secs = deadline.as_secs(),
+                    "Module shutdown deadline reached, sending hard-stop signal"
+                );
+                deadline_token_for_timeout.cancel();
+            });
 
-                    // Hard-stop signal for this module
-                    deadline_token.cancel();
+            // Stop this module with its own deadline token
+            // The module can observe the token transition from uncancelled→cancelled
+            Self::stop_one_module(e, deadline_token).await;
 
-                    // Optional: wait for stop_one_module to observe cancellation and finish.
-                    Self::stop_one_module(e, deadline_token).await;
-                }
-
-                () = Self::stop_one_module(e, deadline_token.clone()) => {
-                    // Module stopped before deadline
-                }
-            }
+            // Cancel the deadline task and await it to ensure full cleanup
+            deadline_task.abort();
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = deadline_task.await;
         }
 
         Ok(())
@@ -1225,8 +1233,8 @@ mod tests {
         use std::time::Duration;
 
         struct GracefulModule {
-            graceful_completed: Arc<AtomicBool>,
-            deadline_fired: Arc<AtomicBool>,
+            graceful_completed: AtomicBool,
+            deadline_fired: AtomicBool,
         }
 
         #[async_trait::async_trait]
@@ -1255,11 +1263,9 @@ mod tests {
             }
         }
 
-        let graceful_completed = Arc::new(AtomicBool::new(false));
-        let deadline_fired = Arc::new(AtomicBool::new(false));
         let module = Arc::new(GracefulModule {
-            graceful_completed: graceful_completed.clone(),
-            deadline_fired: deadline_fired.clone(),
+            graceful_completed: AtomicBool::new(false),
+            deadline_fired: AtomicBool::new(false),
         });
 
         let mut builder = RegistryBuilder::default();
@@ -1287,12 +1293,12 @@ mod tests {
 
         // Graceful shutdown should have completed
         assert!(
-            graceful_completed.load(Ordering::SeqCst),
+            module.graceful_completed.load(Ordering::SeqCst),
             "graceful shutdown should complete"
         );
         // Deadline should NOT have fired (module finished before deadline)
         assert!(
-            !deadline_fired.load(Ordering::SeqCst),
+            !module.deadline_fired.load(Ordering::SeqCst),
             "deadline should not fire when graceful shutdown completes quickly"
         );
     }
@@ -1303,8 +1309,8 @@ mod tests {
         use std::time::Duration;
 
         struct SlowModule {
-            graceful_completed: Arc<AtomicBool>,
-            deadline_fired: Arc<AtomicBool>,
+            graceful_completed: AtomicBool,
+            deadline_fired: AtomicBool,
         }
 
         #[async_trait::async_trait]
@@ -1333,11 +1339,9 @@ mod tests {
             }
         }
 
-        let graceful_completed = Arc::new(AtomicBool::new(false));
-        let deadline_fired = Arc::new(AtomicBool::new(false));
         let module = Arc::new(SlowModule {
-            graceful_completed: graceful_completed.clone(),
-            deadline_fired: deadline_fired.clone(),
+            graceful_completed: AtomicBool::new(false),
+            deadline_fired: AtomicBool::new(false),
         });
 
         let mut builder = RegistryBuilder::default();
@@ -1365,12 +1369,12 @@ mod tests {
 
         // Graceful shutdown should NOT have completed (deadline fired first)
         assert!(
-            !graceful_completed.load(Ordering::SeqCst),
+            !module.graceful_completed.load(Ordering::SeqCst),
             "graceful shutdown should not complete when deadline fires first"
         );
         // Deadline should have fired
         assert!(
-            deadline_fired.load(Ordering::SeqCst),
+            module.deadline_fired.load(Ordering::SeqCst),
             "deadline should fire for slow modules"
         );
     }

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -616,29 +616,28 @@ impl HostRuntime {
 
         // Stop all modules in reverse order, each with its own independent deadline
         for e in self.registry.modules().iter().rev() {
-            // Create a fresh deadline token for THIS module
-            // Each module gets the full shutdown_deadline independently
-            let deadline_token = CancellationToken::new();
-            let deadline_token_for_timeout = deadline_token.clone();
-
-            // Spawn a task to cancel this module's deadline token after shutdown_deadline
             let module_name = e.name;
-            let deadline_task = tokio::spawn(async move {
-                tokio::time::sleep(deadline).await;
-                tracing::warn!(
-                    module = module_name,
-                    deadline_secs = deadline.as_secs(),
-                    "Module shutdown deadline reached, sending hard-stop signal"
-                );
-                deadline_token_for_timeout.cancel();
-            });
+            let deadline_token = CancellationToken::new();
 
-            // Stop this module with its own deadline token
-            Self::stop_one_module(e, deadline_token).await;
+            tokio::select! {
+                () = tokio::time::sleep(deadline) => {
+                    tracing::warn!(
+                        module = module_name,
+                        deadline_secs = deadline.as_secs(),
+                        "Module shutdown deadline reached, sending hard-stop signal"
+                    );
 
-            // Cancel the deadline task and await it to ensure full cleanup
-            deadline_task.abort();
-            drop(deadline_task.await);
+                    // Hard-stop signal for this module
+                    deadline_token.cancel();
+
+                    // Optional: wait for stop_one_module to observe cancellation and finish.
+                    Self::stop_one_module(e, deadline_token).await;
+                }
+
+                () = Self::stop_one_module(e, deadline_token.clone()) => {
+                    // Module stopped before deadline
+                }
+            }
         }
 
         Ok(())
@@ -1152,8 +1151,8 @@ mod tests {
         use std::sync::atomic::AtomicBool;
 
         struct TokenCheckModule {
-            stop_was_called: Arc<AtomicBool>,
-            token_was_cancelled_on_entry: Arc<AtomicBool>,
+            stop_was_called: AtomicBool,
+            token_was_cancelled_on_entry: AtomicBool,
         }
 
         #[async_trait::async_trait]
@@ -1178,11 +1177,10 @@ mod tests {
             }
         }
 
-        let stop_was_called = Arc::new(AtomicBool::new(false));
-        let token_was_cancelled = Arc::new(AtomicBool::new(true)); // Default to true to detect if not set
         let module = Arc::new(TokenCheckModule {
-            stop_was_called: stop_was_called.clone(),
-            token_was_cancelled_on_entry: token_was_cancelled.clone(),
+            stop_was_called: AtomicBool::new(false),
+            // Default to true to detect if stop() was never called
+            token_was_cancelled_on_entry: AtomicBool::new(true),
         });
 
         let mut builder = RegistryBuilder::default();
@@ -1209,14 +1207,14 @@ mod tests {
 
         // First, verify stop() was actually called (guards against silent registration failures)
         assert!(
-            stop_was_called.load(Ordering::SeqCst),
+            module.stop_was_called.load(Ordering::SeqCst),
             "stop() was never called - module may not have been registered correctly"
         );
 
         // The token should NOT have been cancelled when stop() was called
         // This is the key fix: modules get a fresh token, not the already-cancelled root token
         assert!(
-            !token_was_cancelled.load(Ordering::SeqCst),
+            !module.token_was_cancelled_on_entry.load(Ordering::SeqCst),
             "deadline_token should NOT be cancelled when stop() is called - this enables graceful shutdown"
         );
     }

--- a/libs/modkit/src/runtime/mod.rs
+++ b/libs/modkit/src/runtime/mod.rs
@@ -12,7 +12,8 @@ mod tests;
 
 pub use grpc_installers::{GrpcInstallerData, GrpcInstallerStore, ModuleInstallers};
 pub use host_runtime::{
-    DbOptions, HostRuntime, MODKIT_DIRECTORY_ENDPOINT_ENV, MODKIT_MODULE_CONFIG_ENV,
+    DEFAULT_SHUTDOWN_DEADLINE, DbOptions, HostRuntime, MODKIT_DIRECTORY_ENDPOINT_ENV,
+    MODKIT_MODULE_CONFIG_ENV,
 };
 pub use module_manager::{Endpoint, InstanceState, ModuleInstance, ModuleManager};
 pub use runner::{

--- a/libs/modkit/src/runtime/runner.rs
+++ b/libs/modkit/src/runtime/runner.rs
@@ -119,6 +119,13 @@ pub struct RunOptions {
     /// These modules are spawned after the start phase, once `grpc-hub` is running
     /// and the real directory endpoint is known.
     pub oop: Option<OopSpawnOptions>,
+    /// Maximum time allowed for each module's graceful shutdown before hard-stop.
+    ///
+    /// If `None`, uses `DEFAULT_SHUTDOWN_DEADLINE` (30 seconds).
+    ///
+    /// See `HostRuntime::with_shutdown_deadline` for details on the relationship
+    /// with `WithLifecycle::stop_timeout`.
+    pub shutdown_deadline: Option<std::time::Duration>,
 }
 
 /// Full cycle is orchestrated by `HostRuntime` (see `runtime/host_runtime.rs` docs).
@@ -181,7 +188,7 @@ pub async fn run(opts: RunOptions) -> anyhow::Result<()> {
     }
 
     // 5. Instantiate HostRuntime
-    let host = HostRuntime::new(
+    let mut host = HostRuntime::new(
         registry,
         opts.modules_cfg.clone(),
         opts.db,
@@ -190,6 +197,11 @@ pub async fn run(opts: RunOptions) -> anyhow::Result<()> {
         opts.instance_id,
         opts.oop,
     );
+
+    // 5b. Apply custom shutdown deadline if provided
+    if let Some(deadline) = opts.shutdown_deadline {
+        host = host.with_shutdown_deadline(deadline);
+    }
 
     // 6. Run full lifecycle
     host.run_module_phases().await

--- a/libs/modkit/tests/db_phase_tests.rs
+++ b/libs/modkit/tests/db_phase_tests.rs
@@ -93,6 +93,7 @@ async fn test_db_phase_with_manager_succeeds() {
         clients: Vec::new(),
         instance_id: Uuid::new_v4(),
         oop: None,
+        shutdown_deadline: None,
     };
 
     let result = timeout(Duration::from_millis(500), run(opts)).await;
@@ -123,6 +124,7 @@ async fn test_db_phase_without_config_skips_migration() {
         clients: Vec::new(),
         instance_id: Uuid::new_v4(),
         oop: None,
+        shutdown_deadline: None,
     };
 
     let result = timeout(Duration::from_millis(500), run(opts)).await;
@@ -153,6 +155,7 @@ async fn test_db_phase_with_none_option() {
         clients: Vec::new(),
         instance_id: Uuid::new_v4(),
         oop: None,
+        shutdown_deadline: None,
     };
 
     let result = timeout(Duration::from_millis(500), run(opts)).await;
@@ -205,6 +208,7 @@ async fn test_db_phase_error_propagation() {
         clients: Vec::new(),
         instance_id: Uuid::new_v4(),
         oop: None,
+        shutdown_deadline: None,
     };
 
     // Run should either succeed (if no modules try to use bad config)
@@ -231,6 +235,7 @@ async fn test_db_phase_completes_before_init() {
         clients: Vec::new(),
         instance_id: Uuid::new_v4(),
         oop: None,
+        shutdown_deadline: None,
     };
 
     let start = std::time::Instant::now();

--- a/libs/modkit/tests/runner_tests.rs
+++ b/libs/modkit/tests/runner_tests.rs
@@ -371,6 +371,7 @@ async fn test_db_options_none() {
         shutdown: ShutdownOptions::Token(cancel),
         clients: vec![],
         oop: None,
+        shutdown_deadline: None,
     };
 
     // This test requires registry discovery to work, which won't work in isolation
@@ -407,6 +408,7 @@ async fn test_db_options_manager() {
         shutdown: ShutdownOptions::Token(cancel),
         clients: vec![],
         oop: None,
+        shutdown_deadline: None,
     };
 
     let result = timeout(Duration::from_millis(1000), run(opts)).await;
@@ -427,6 +429,7 @@ async fn test_shutdown_options_token() {
         shutdown: ShutdownOptions::Token(cancel.clone()),
         clients: vec![],
         oop: None,
+        shutdown_deadline: None,
     };
 
     // Start the runner in a background task
@@ -458,6 +461,7 @@ async fn test_shutdown_options_future() {
         })),
         clients: vec![],
         oop: None,
+        shutdown_deadline: None,
     };
 
     // Start the runner in a background task
@@ -496,6 +500,7 @@ async fn test_runner_with_config_provider() {
         shutdown: ShutdownOptions::Token(cancel),
         clients: vec![],
         oop: None,
+        shutdown_deadline: None,
     };
 
     let result = timeout(Duration::from_millis(100), run(opts)).await;
@@ -517,6 +522,7 @@ async fn test_complete_lifecycle_success() {
         shutdown: ShutdownOptions::Token(cancel),
         clients: vec![],
         oop: None,
+        shutdown_deadline: None,
     };
 
     let result = run(opts).await;
@@ -534,6 +540,7 @@ fn test_run_options_construction() {
         shutdown: ShutdownOptions::Token(cancel),
         clients: vec![],
         oop: None,
+        shutdown_deadline: None,
     };
 
     // Test that we can construct RunOptions with all variants
@@ -559,6 +566,7 @@ async fn test_cancellation_during_startup() {
         shutdown: ShutdownOptions::Token(cancel.clone()),
         clients: vec![],
         oop: None,
+        shutdown_deadline: None,
     };
 
     // Start the runner in a background task
@@ -595,6 +603,7 @@ async fn test_multiple_config_provider_scenarios() {
         shutdown: ShutdownOptions::Token(cancel.clone()),
         clients: vec![],
         oop: None,
+        shutdown_deadline: None,
     };
 
     let result = run(opts).await;
@@ -630,6 +639,7 @@ async fn test_multiple_config_provider_scenarios() {
         shutdown: ShutdownOptions::Token(cancel2),
         clients: vec![],
         oop: None,
+        shutdown_deadline: None,
     };
 
     let result2 = run(opts2).await;
@@ -648,6 +658,7 @@ async fn test_runner_timeout_scenarios() {
         shutdown: ShutdownOptions::Token(cancel.clone()),
         clients: vec![],
         oop: None,
+        shutdown_deadline: None,
     };
 
     let runner_handle = tokio::spawn(run(opts));


### PR DESCRIPTION
Problem
The runtime was passing the already-cancelled root cancellation token to RunnableCapability::stop(), making it impossible for modules to implement real two-phase shutdown.

When a module's stop(cancel) was called, the cancel token was already cancelled because:

Runtime waits for self.cancel.cancelled().await to trigger shutdown
Then calls stop(self.cancel.clone()) — but the token is already cancelled
This forced modules into immediate abort behavior, with no graceful shutdown window.

Solution
Implement Option B from the issue: call stop() with a fresh deadline token that is only cancelled after the graceful shutdown window expires.

Create a new deadline_token in run_stop_phase() (not already cancelled)
Spawn a task to cancel it after shutdown_deadline (default 30s)
Modules can now implement proper two-phase shutdown:
Start graceful shutdown immediately
Switch to hard-abort when deadline_token fires
Changes
host_runtime.rs: Rewrote run_stop_phase() with fresh deadline token, added shutdown_deadline field and with_shutdown_deadline() builder
contracts.rs: Added comprehensive docs for RunnableCapability explaining the shutdown contract
lifecycle.rs: Updated WithLifecycle::stop() docs for clarity
mod.rs / lib.rs: Exported DEFAULT_SHUTDOWN_DEADLINE
Testing
Added 3 regression tests:

test_stop_phase_provides_fresh_deadline_token — verifies token is NOT cancelled on entry
test_stop_phase_graceful_shutdown_completes_before_deadline — verifies graceful path works
test_stop_phase_deadline_fires_for_slow_module — verifies hard-stop deadline fires
All 213 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-phase shutdown with a default 30s hard-stop deadline.
  * Runtime-level and per-run configuration to customize the shutdown deadline; new builder option to set per-component stop timeout.

* **Behavior Changes**
  * Module stop now uses a deadline-oriented stop signal: graceful attempt first, then immediate abort when the deadline elapses.

* **Tests**
  * Added tests for graceful stop, deadline expiry, and two-phase shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->