### PR TITLE
bugfix(oafw)- fix DNS resolution failure which caused panic

### DIFF
--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
@@ -203,11 +203,32 @@ pub(crate) async fn upload_attachment(
     let file_stream: crate::domain::ports::FileStream =
         Box::pin(FieldStream::new(field, max_bytes));
 
-    // 8. Best-effort size_hint from Content-Length (enables aggregate check).
+    // 8b. Best-effort size_hint from Content-Length (enables aggregate check).
     let size_hint = headers
         .get(http::header::CONTENT_LENGTH)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.parse::<u64>().ok());
+
+    // 8c. Pre-flight: reject obvious oversize uploads from Content-Length.
+    //     Content-Length includes multipart framing, so subtract the same
+    //     overhead budget used by the multer constraints (step 3).
+    //     FieldStream remains the authoritative check for borderline cases,
+    //     but this avoids a DB round-trip for clearly oversize uploads.
+    const MULTIPART_OVERHEAD: u64 = 64 * 1024;
+    if let Some(cl) = size_hint {
+        let estimated_file_bytes = cl.saturating_sub(MULTIPART_OVERHEAD);
+        if estimated_file_bytes > max_bytes {
+            let kind = if is_document { "document" } else { "image" };
+            return Err(Problem::new(
+                http::StatusCode::PAYLOAD_TOO_LARGE,
+                "file_too_large",
+                format!(
+                    "Uploaded {kind} (~{estimated_file_bytes} bytes) exceeds the {kind} size limit of {max_bytes} bytes"
+                ),
+            )
+            .with_code("file_too_large".to_owned()));
+        }
+    }
 
     // 9. Call domain service with pre-resolved context.
     let row = svc

--- a/modules/system/oagw/oagw/src/domain/services/mod.rs
+++ b/modules/system/oagw/oagw/src/domain/services/mod.rs
@@ -5,15 +5,28 @@ pub(crate) use client::ServiceGatewayClientV1Facade;
 pub(crate) use management::ControlPlaneServiceImpl;
 
 use async_trait::async_trait;
+use modkit_macros::domain_model;
 use modkit_security::SecurityContext;
 use oagw_sdk::Body;
 use uuid::Uuid;
+
+use std::net::SocketAddr;
 
 use crate::domain::error::DomainError;
 use crate::domain::model::{
     CreateRouteRequest, CreateUpstreamRequest, Endpoint, ListQuery, Route, UpdateRouteRequest,
     UpdateUpstreamRequest, Upstream,
 };
+
+/// Result of endpoint selection: the domain endpoint plus an optional
+/// pre-resolved socket address from the load balancer's DNS cache.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub(crate) struct SelectedEndpoint {
+    pub endpoint: Endpoint,
+    /// When set, `upstream_peer` can skip DNS and connect directly.
+    pub resolved_addr: Option<SocketAddr>,
+}
 
 /// Internal Control Plane service trait — configuration management and resolution.
 #[async_trait]
@@ -105,7 +118,7 @@ pub(crate) trait DataPlaneService: Send + Sync {
 pub(crate) trait EndpointSelector: Send + Sync {
     /// Select the next healthy endpoint for the given upstream.
     /// Returns `None` if all backends are unhealthy or the endpoint list is empty.
-    async fn select(&self, upstream_id: Uuid, endpoints: &[Endpoint]) -> Option<Endpoint>;
+    async fn select(&self, upstream_id: Uuid, endpoints: &[Endpoint]) -> Option<SelectedEndpoint>;
 
     /// Invalidate cached state for the given upstream (called on CRUD).
     fn invalidate(&self, upstream_id: Uuid);

--- a/modules/system/oagw/oagw/src/infra/proxy/headers.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/headers.rs
@@ -348,6 +348,39 @@ mod tests {
         assert_eq!(headers.get("x-custom").unwrap(), "keep");
     }
 
+    /// Client-supplied internal headers (including x-oagw-internal-resolved-addr)
+    /// must be stripped before service.rs injects its own values.
+    /// This prevents a malicious client from influencing upstream routing.
+    #[test]
+    fn strip_removes_spoofed_internal_context_headers() {
+        let mut headers = HeaderMap::new();
+        // Simulate a malicious client injecting all internal context headers.
+        headers.insert("x-oagw-internal-endpoint-host", "evil.com".parse().unwrap());
+        headers.insert("x-oagw-internal-endpoint-port", "9999".parse().unwrap());
+        headers.insert("x-oagw-internal-endpoint-scheme", "http".parse().unwrap());
+        headers.insert(
+            "x-oagw-internal-resolved-addr",
+            "1.2.3.4:443".parse().unwrap(),
+        );
+        headers.insert("x-oagw-internal-instance-uri", "/pwned".parse().unwrap());
+        headers.insert(
+            "x-oagw-internal-upstream-id",
+            "00000000-0000-0000-0000-000000000000".parse().unwrap(),
+        );
+        // Legitimate header that should survive.
+        headers.insert("authorization", "Bearer token".parse().unwrap());
+
+        strip_internal_headers(&mut headers);
+
+        assert!(headers.get("x-oagw-internal-endpoint-host").is_none());
+        assert!(headers.get("x-oagw-internal-endpoint-port").is_none());
+        assert!(headers.get("x-oagw-internal-endpoint-scheme").is_none());
+        assert!(headers.get("x-oagw-internal-resolved-addr").is_none());
+        assert!(headers.get("x-oagw-internal-instance-uri").is_none());
+        assert!(headers.get("x-oagw-internal-upstream-id").is_none());
+        assert_eq!(headers.get("authorization").unwrap(), "Bearer token");
+    }
+
     #[test]
     fn set_overwrites_existing() {
         let mut headers = HeaderMap::new();

--- a/modules/system/oagw/oagw/src/infra/proxy/pingora_proxy.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/pingora_proxy.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 
 use crate::domain::error::DomainError;
 use crate::domain::model::{Endpoint, Scheme};
-use crate::domain::services::EndpointSelector;
+use crate::domain::services::{EndpointSelector, SelectedEndpoint};
 use modkit::api::Problem;
 
 // ---------------------------------------------------------------------------
@@ -34,6 +34,7 @@ pub(crate) const H_ENDPOINT_HOST: &str = "x-oagw-internal-endpoint-host";
 pub(crate) const H_ENDPOINT_PORT: &str = "x-oagw-internal-endpoint-port";
 pub(crate) const H_ENDPOINT_SCHEME: &str = "x-oagw-internal-endpoint-scheme";
 pub(crate) const H_INSTANCE_URI: &str = "x-oagw-internal-instance-uri";
+pub(crate) const H_RESOLVED_ADDR: &str = "x-oagw-internal-resolved-addr";
 
 /// Hop-by-hop headers that must not be forwarded in responses (mirrors headers.rs).
 const HOP_BY_HOP: &[&str] = &[
@@ -245,13 +246,18 @@ impl PingoraEndpointSelector {
 
 #[async_trait]
 impl EndpointSelector for PingoraEndpointSelector {
-    async fn select(&self, upstream_id: Uuid, endpoints: &[Endpoint]) -> Option<Endpoint> {
+    async fn select(&self, upstream_id: Uuid, endpoints: &[Endpoint]) -> Option<SelectedEndpoint> {
         // Fast path: LB already cached.
         if let Some(entry) = self.cache.get(&upstream_id) {
             let backend = entry.lb.select(b"", 256)?;
+            let resolved_addr = backend.addr.as_inet();
             let addr_key = backend.addr.to_string();
             let map = entry.addr_map.load();
-            return map.get(&addr_key).cloned();
+            let endpoint = map.get(&addr_key)?.clone();
+            return Some(SelectedEndpoint {
+                endpoint,
+                resolved_addr: resolved_addr.copied(),
+            });
         }
 
         // Slow path: build a new LB entry then atomically insert-if-absent.
@@ -260,9 +266,14 @@ impl EndpointSelector for PingoraEndpointSelector {
         let entry = self.build_entry(endpoints).await?;
         let entry_ref = self.cache.entry(upstream_id).or_insert(entry);
         let backend = entry_ref.lb.select(b"", 256)?;
+        let resolved_addr = backend.addr.as_inet();
         let addr_key = backend.addr.to_string();
         let map = entry_ref.addr_map.load();
-        map.get(&addr_key).cloned()
+        let endpoint = map.get(&addr_key)?.clone();
+        Some(SelectedEndpoint {
+            endpoint,
+            resolved_addr: resolved_addr.copied(),
+        })
     }
 
     fn invalidate(&self, upstream_id: Uuid) {
@@ -279,6 +290,47 @@ impl EndpointSelector for PingoraEndpointSelector {
 pub struct ProxyCtx {
     endpoint: Endpoint,
     instance_uri: String,
+    /// Upstream that owns this endpoint (for diagnostic logs).
+    upstream_id: Option<Uuid>,
+    /// Pre-resolved socket address from the load balancer's DNS cache.
+    /// When set, `upstream_peer` skips DNS and connects directly.
+    resolved_addr: Option<std::net::SocketAddr>,
+}
+
+impl ProxyCtx {
+    /// Populate context fields from internal headers.
+    ///
+    /// Extracted from `request_filter` so the parsing logic is unit-testable
+    /// without constructing a full Pingora `Session`.
+    fn populate_from_headers(&mut self, headers: &http::HeaderMap) {
+        if let Some(v) = headers.get(H_ENDPOINT_HOST).and_then(|v| v.to_str().ok()) {
+            self.endpoint.host = v.to_string();
+        }
+        if let Some(v) = headers.get(H_ENDPOINT_PORT).and_then(|v| v.to_str().ok())
+            && let Ok(port) = v.parse()
+        {
+            self.endpoint.port = port;
+        }
+        if let Some(v) = headers.get(H_ENDPOINT_SCHEME).and_then(|v| v.to_str().ok()) {
+            self.endpoint.scheme = match v {
+                "http" => Scheme::Http,
+                "https" => Scheme::Https,
+                "wss" => Scheme::Wss,
+                "wt" => Scheme::Wt,
+                "grpc" => Scheme::Grpc,
+                _ => Scheme::Https,
+            };
+        }
+        if let Some(v) = headers.get(H_INSTANCE_URI).and_then(|v| v.to_str().ok()) {
+            self.instance_uri = v.to_string();
+        }
+        if let Some(v) = headers.get(H_UPSTREAM_ID).and_then(|v| v.to_str().ok()) {
+            self.upstream_id = v.parse().ok();
+        }
+        if let Some(v) = headers.get(H_RESOLVED_ADDR).and_then(|v| v.to_str().ok()) {
+            self.resolved_addr = v.parse().ok();
+        }
+    }
 }
 
 impl Default for ProxyCtx {
@@ -290,6 +342,8 @@ impl Default for ProxyCtx {
                 port: 443,
             },
             instance_uri: String::new(),
+            upstream_id: None,
+            resolved_addr: None,
         }
     }
 }
@@ -312,44 +366,7 @@ impl ProxyHttp for PingoraProxy {
         session: &mut Session,
         ctx: &mut Self::CTX,
     ) -> pingora_core::Result<bool> {
-        // Read context from internal headers.
-        let req = session.req_header();
-        if let Some(v) = req
-            .headers
-            .get(H_ENDPOINT_HOST)
-            .and_then(|v| v.to_str().ok())
-        {
-            ctx.endpoint.host = v.to_string();
-        }
-        if let Some(v) = req
-            .headers
-            .get(H_ENDPOINT_PORT)
-            .and_then(|v| v.to_str().ok())
-            && let Ok(port) = v.parse()
-        {
-            ctx.endpoint.port = port;
-        }
-        if let Some(v) = req
-            .headers
-            .get(H_ENDPOINT_SCHEME)
-            .and_then(|v| v.to_str().ok())
-        {
-            ctx.endpoint.scheme = match v {
-                "http" => Scheme::Http,
-                "https" => Scheme::Https,
-                "wss" => Scheme::Wss,
-                "wt" => Scheme::Wt,
-                "grpc" => Scheme::Grpc,
-                _ => Scheme::Https,
-            };
-        }
-        if let Some(v) = req
-            .headers
-            .get(H_INSTANCE_URI)
-            .and_then(|v| v.to_str().ok())
-        {
-            ctx.instance_uri = v.to_string();
-        }
+        ctx.populate_from_headers(&session.req_header().headers);
 
         // Strip all internal headers before forwarding.
         let to_remove: Vec<http::HeaderName> = session
@@ -368,6 +385,11 @@ impl ProxyHttp for PingoraProxy {
     }
 
     /// Build `HttpPeer` from the resolved endpoint. (D3, D4, D7)
+    ///
+    /// Uses the pre-resolved `SocketAddr` from the load balancer's DNS cache
+    /// when available, falling back to an explicit `lookup_host` otherwise.
+    /// Both paths pass a `SocketAddr` to `HttpPeer::new`, avoiding the
+    /// `unwrap()` panic on DNS failure in pingora-core 0.8.0. (See bug: https://github.com/cloudflare/pingora/issues/570)
     async fn upstream_peer(
         &self,
         _session: &mut Session,
@@ -376,7 +398,33 @@ impl ProxyHttp for PingoraProxy {
         let ep = &ctx.endpoint;
         let tls = matches!(ep.scheme, Scheme::Https | Scheme::Wss | Scheme::Wt);
 
-        let mut peer = HttpPeer::new(format!("{}:{}", ep.host, ep.port), tls, ep.host.clone());
+        let addr = match ctx.resolved_addr {
+            Some(a) => a,
+            None => {
+                // Fallback: resolve DNS explicitly (single-endpoint bypass, target-host header).
+                tokio::net::lookup_host((ep.host.as_str(), ep.port))
+                    .await
+                    .map_err(|e| {
+                        warn!(upstream_id = ?ctx.upstream_id, host = %ep.host, port = ep.port, error = %e, "DNS resolution failed");
+                        pingora_core::Error::because(
+                            pingora_core::ErrorType::ConnectError,
+                            "DNS resolution failed",
+                            e,
+                        )
+                    })?
+                    .next()
+                    .ok_or_else(|| {
+                        warn!(upstream_id = ?ctx.upstream_id, host = %ep.host, port = ep.port, "DNS returned no addresses");
+                        pingora_core::Error::explain(
+                            pingora_core::ErrorType::ConnectError,
+                            format!("DNS returned no addresses for {}:{}", ep.host, ep.port),
+                        )
+                    })?
+            }
+        };
+
+        // Pass SocketAddr directly — no DNS inside HttpPeer::new.
+        let mut peer = HttpPeer::new(addr, tls, ep.host.clone());
 
         peer.options.connection_timeout = Some(self.connect_timeout);
         peer.options.read_timeout = Some(self.read_timeout);
@@ -639,7 +687,7 @@ mod tests {
         let mut port_b = 0u32;
         for _ in 0..4 {
             let selected = selector.select(id, &endpoints).await.unwrap();
-            match selected.port {
+            match selected.endpoint.port {
                 10001 => port_a += 1,
                 10002 => port_b += 1,
                 other => panic!("unexpected port: {other}"),
@@ -656,13 +704,13 @@ mod tests {
 
         let v1 = vec![ep("127.0.0.1", 20001, Scheme::Https)];
         let selected = selector.select(id, &v1).await.unwrap();
-        assert_eq!(selected.port, 20001);
+        assert_eq!(selected.endpoint.port, 20001);
 
         selector.invalidate(id);
 
         let v2 = vec![ep("127.0.0.1", 20002, Scheme::Https)];
         let selected = selector.select(id, &v2).await.unwrap();
-        assert_eq!(selected.port, 20002);
+        assert_eq!(selected.endpoint.port, 20002);
     }
 
     #[tokio::test]
@@ -672,9 +720,9 @@ mod tests {
         let endpoints = vec![ep("127.0.0.1", 30001, Scheme::Http)];
 
         let selected = selector.select(id, &endpoints).await.unwrap();
-        assert_eq!(selected.host, "127.0.0.1");
-        assert_eq!(selected.port, 30001);
-        assert_eq!(selected.scheme, Scheme::Http);
+        assert_eq!(selected.endpoint.host, "127.0.0.1");
+        assert_eq!(selected.endpoint.port, 30001);
+        assert_eq!(selected.endpoint.scheme, Scheme::Http);
     }
 
     /// Endpoints in an upstream share scheme/port (by design).
@@ -694,9 +742,16 @@ mod tests {
         let mut found_2 = false;
         for _ in 0..20 {
             let selected = selector.select(id, &endpoints).await.unwrap();
-            assert_eq!(selected.scheme, Scheme::Https, "scheme must be preserved");
-            assert_eq!(selected.host, "127.0.0.1", "host must be preserved");
-            match selected.port {
+            assert_eq!(
+                selected.endpoint.scheme,
+                Scheme::Https,
+                "scheme must be preserved"
+            );
+            assert_eq!(
+                selected.endpoint.host, "127.0.0.1",
+                "host must be preserved"
+            );
+            match selected.endpoint.port {
                 40001 => found_1 = true,
                 40002 => found_2 = true,
                 other => panic!("unexpected port: {other}"),
@@ -726,9 +781,9 @@ mod tests {
         );
         let selected = selected.unwrap();
         // The returned endpoint must match the original — host stays "localhost".
-        assert_eq!(selected.host, "localhost");
-        assert_eq!(selected.port, 50001);
-        assert_eq!(selected.scheme, Scheme::Https);
+        assert_eq!(selected.endpoint.host, "localhost");
+        assert_eq!(selected.endpoint.port, 50001);
+        assert_eq!(selected.endpoint.scheme, Scheme::Https);
     }
 
     // -- DnsDiscovery unit tests --
@@ -888,7 +943,7 @@ mod tests {
         // Initial endpoints.
         let v1 = vec![ep("127.0.0.1", 60001, Scheme::Https)];
         let selected = selector.select(id, &v1).await.unwrap();
-        assert_eq!(selected.port, 60001);
+        assert_eq!(selected.endpoint.port, 60001);
 
         // Access the addr_map to verify it's populated.
         let entry = selector.cache.get(&id).unwrap();
@@ -901,7 +956,7 @@ mod tests {
 
         let v2 = vec![ep("127.0.0.1", 60002, Scheme::Https)];
         let selected = selector.select(id, &v2).await.unwrap();
-        assert_eq!(selected.port, 60002);
+        assert_eq!(selected.endpoint.port, 60002);
 
         // New addr_map should only contain the new endpoint.
         let entry = selector.cache.get(&id).unwrap();
@@ -925,9 +980,12 @@ mod tests {
     //   alpn = if tls && !Wss { H2H1 } else { H1 }
 
     /// Build an HttpPeer using the same logic as `upstream_peer`.
+    /// Uses a dummy IP (production resolves via `lookup_host`); the `host`
+    /// string is passed as the SNI, matching `upstream_peer` behaviour.
     fn build_peer(scheme: Scheme, host: &str, port: u16) -> HttpPeer {
         let tls = matches!(scheme, Scheme::Https | Scheme::Wss | Scheme::Wt);
-        let mut peer = HttpPeer::new(format!("{host}:{port}"), tls, host.to_string());
+        let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+        let mut peer = HttpPeer::new(addr, tls, host.to_string());
         peer.options.alpn = if tls && !matches!(scheme, Scheme::Wss) {
             pingora_core::protocols::tls::ALPN::H2H1
         } else {
@@ -986,5 +1044,68 @@ mod tests {
         // Verify timeouts are stored correctly on the proxy.
         assert_eq!(proxy.connect_timeout, Duration::from_secs(7));
         assert_eq!(proxy.read_timeout, Duration::from_secs(15));
+    }
+
+    #[test]
+    fn populate_from_headers_parses_resolved_addr() {
+        let mut ctx = ProxyCtx::default();
+        let mut headers = http::HeaderMap::new();
+        let upstream_id = Uuid::new_v4();
+        headers.insert(H_ENDPOINT_HOST, "api.example.com".parse().unwrap());
+        headers.insert(H_ENDPOINT_PORT, "8443".parse().unwrap());
+        headers.insert(H_ENDPOINT_SCHEME, "https".parse().unwrap());
+        headers.insert(H_INSTANCE_URI, "/test/instance".parse().unwrap());
+        headers.insert(H_UPSTREAM_ID, upstream_id.to_string().parse().unwrap());
+        headers.insert(H_RESOLVED_ADDR, "93.184.216.34:8443".parse().unwrap());
+
+        ctx.populate_from_headers(&headers);
+
+        assert_eq!(ctx.endpoint.host, "api.example.com");
+        assert_eq!(ctx.endpoint.port, 8443);
+        assert_eq!(ctx.endpoint.scheme, Scheme::Https);
+        assert_eq!(ctx.instance_uri, "/test/instance");
+        assert_eq!(ctx.upstream_id, Some(upstream_id));
+        let expected: std::net::SocketAddr = "93.184.216.34:8443".parse().unwrap();
+        assert_eq!(ctx.resolved_addr, Some(expected));
+    }
+
+    #[test]
+    fn populate_from_headers_missing_resolved_addr_leaves_none() {
+        let mut ctx = ProxyCtx::default();
+        let mut headers = http::HeaderMap::new();
+        headers.insert(H_ENDPOINT_HOST, "api.example.com".parse().unwrap());
+        headers.insert(H_ENDPOINT_PORT, "443".parse().unwrap());
+        // No H_RESOLVED_ADDR header.
+
+        ctx.populate_from_headers(&headers);
+
+        assert_eq!(ctx.endpoint.host, "api.example.com");
+        assert!(ctx.resolved_addr.is_none());
+    }
+
+    #[test]
+    fn populate_from_headers_invalid_resolved_addr_leaves_none() {
+        let mut ctx = ProxyCtx::default();
+        let mut headers = http::HeaderMap::new();
+        headers.insert(H_RESOLVED_ADDR, "not-an-addr".parse().unwrap());
+
+        ctx.populate_from_headers(&headers);
+
+        assert!(ctx.resolved_addr.is_none());
+    }
+
+    #[tokio::test]
+    async fn select_populates_resolved_addr() {
+        let selector = PingoraEndpointSelector::new();
+        let id = Uuid::new_v4();
+        // IP-based endpoint — resolved_addr should be populated.
+        let endpoints = vec![ep("127.0.0.1", 30001, Scheme::Http)];
+
+        let selected = selector.select(id, &endpoints).await.unwrap();
+        assert!(
+            selected.resolved_addr.is_some(),
+            "resolved_addr should be populated for IP endpoint"
+        );
+        assert_eq!(selected.resolved_addr.unwrap().port(), 30001);
     }
 }

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -17,20 +17,22 @@ use tokio::sync::watch;
 
 use crate::config::TokenCacheConfig;
 use crate::domain::error::DomainError;
-use crate::domain::model::{Endpoint, PassthroughMode, PathSuffixMode, Scheme, Upstream};
+use crate::domain::model::{PassthroughMode, PathSuffixMode, Scheme, Upstream};
 use crate::domain::plugin::{
     AuthContext, GuardContext, GuardDecision, TransformErrorContext, TransformRequestContext,
     TransformResponseContext,
 };
 use crate::domain::rate_limit::RateLimiter;
-use crate::domain::services::{ControlPlaneService, DataPlaneService, EndpointSelector};
+use crate::domain::services::{
+    ControlPlaneService, DataPlaneService, EndpointSelector, SelectedEndpoint,
+};
 use crate::infra::plugin::{AuthPluginRegistry, GuardPluginRegistry, TransformPluginRegistry};
 use crate::infra::proxy::{actions, resources};
 
 use super::headers;
 use super::pingora_proxy::{
-    H_ENDPOINT_HOST, H_ENDPOINT_PORT, H_ENDPOINT_SCHEME, H_INSTANCE_URI, H_UPSTREAM_ID,
-    PingoraProxy,
+    H_ENDPOINT_HOST, H_ENDPOINT_PORT, H_ENDPOINT_SCHEME, H_INSTANCE_URI, H_RESOLVED_ADDR,
+    H_UPSTREAM_ID, PingoraProxy,
 };
 use super::{request_builder, session_bridge};
 
@@ -157,7 +159,7 @@ impl DataPlaneServiceImpl {
         upstream: &Upstream,
         req_headers: &http::HeaderMap,
         instance_uri: &str,
-    ) -> Result<Endpoint, DomainError> {
+    ) -> Result<SelectedEndpoint, DomainError> {
         let endpoints = &upstream.server.endpoints;
 
         if endpoints.is_empty() {
@@ -184,8 +186,8 @@ impl DataPlaneServiceImpl {
                 });
             }
 
-            // Find matching endpoint by host.
-            return endpoints
+            // Find matching endpoint by host (no LB — no resolved addr).
+            let endpoint = endpoints
                 .iter()
                 .find(|ep| ep.host.eq_ignore_ascii_case(target_host))
                 .cloned()
@@ -204,13 +206,23 @@ impl DataPlaneServiceImpl {
                         ),
                         instance: instance_uri.to_string(),
                     }
-                });
+                })?;
+            return Ok(SelectedEndpoint {
+                endpoint,
+                resolved_addr: None,
+            });
         }
 
         // Tier 2: Automatic selection.
         if endpoints.len() == 1 {
-            // Single-endpoint: use directly, no LB overhead.
-            return Ok(endpoints[0].clone());
+            // Single-endpoint: bypass LB. `resolved_addr` is None, so
+            // `upstream_peer` will fall back to DNS on the request path.
+            // Acceptable trade-off: single-endpoint upstreams don't benefit
+            // from health-checked LB selection anyway.
+            return Ok(SelectedEndpoint {
+                endpoint: endpoints[0].clone(),
+                resolved_addr: None,
+            });
         }
 
         // Multi-endpoint: round-robin via BackendSelector.
@@ -522,9 +534,10 @@ impl DataPlaneService for DataPlaneServiceImpl {
         }
 
         // 5a. Endpoint selection (D1 — two-tier).
-        let endpoint = self
+        let selected = self
             .select_endpoint(&upstream, &req_headers, &instance_uri)
             .await?;
+        let endpoint = &selected.endpoint;
 
         // 5b. Enforce HTTPS-only constraint (cpt-cf-oagw-constraint-https-only).
         if !self.allow_http_upstream && matches!(endpoint.scheme, Scheme::Http) {
@@ -556,7 +569,7 @@ impl DataPlaneService for DataPlaneServiceImpl {
             .map_or("/", |h| h.path.as_str());
         let remaining_suffix = path_suffix.strip_prefix(route_path).unwrap_or("");
         let url = request_builder::build_upstream_url(
-            &endpoint,
+            endpoint,
             route_path,
             remaining_suffix,
             &query_params,
@@ -582,6 +595,11 @@ impl DataPlaneService for DataPlaneServiceImpl {
         outbound_headers.insert(H_ENDPOINT_SCHEME, HeaderValue::from_static(scheme_str));
         if let Ok(v) = HeaderValue::from_str(&instance_uri) {
             outbound_headers.insert(H_INSTANCE_URI, v);
+        }
+        if let Some(addr) = selected.resolved_addr
+            && let Ok(v) = HeaderValue::from_str(&addr.to_string())
+        {
+            outbound_headers.insert(H_RESOLVED_ADDR, v);
         }
 
         let pipeline = ResponsePipelineCtx {
@@ -1161,9 +1179,16 @@ mod tests {
 
     #[async_trait]
     impl EndpointSelector for MockSelector {
-        async fn select(&self, _upstream_id: Uuid, endpoints: &[Endpoint]) -> Option<Endpoint> {
+        async fn select(
+            &self,
+            _upstream_id: Uuid,
+            endpoints: &[Endpoint],
+        ) -> Option<SelectedEndpoint> {
             let idx = self.call_count.fetch_add(1, Ordering::Relaxed) % endpoints.len();
-            Some(endpoints[idx].clone())
+            Some(SelectedEndpoint {
+                endpoint: endpoints[idx].clone(),
+                resolved_addr: None,
+            })
         }
 
         fn invalidate(&self, _upstream_id: Uuid) {}
@@ -1366,7 +1391,7 @@ mod tests {
         // after select_endpoint returns. Verify the endpoint is returned here (enforcement
         // is at a higher level).
         assert!(err.is_ok(), "select_endpoint should return the endpoint");
-        assert_eq!(err.unwrap().scheme, Scheme::Http);
+        assert_eq!(err.unwrap().endpoint.scheme, Scheme::Http);
     }
 
     // positive-2.2 (custom-header-routing): X-OAGW-Target-Host matches an endpoint.
@@ -1383,7 +1408,7 @@ mod tests {
             .select_endpoint(&upstream, &headers, "/test")
             .await
             .unwrap();
-        assert_eq!(result.host, "a.com");
+        assert_eq!(result.endpoint.host, "a.com");
         assert_eq!(selector.calls(), 0, "BackendSelector should not be called");
     }
 
@@ -1470,8 +1495,8 @@ mod tests {
             "BackendSelector should be called for multi-endpoint"
         );
         // MockSelector returns endpoints in order: [0], [1], [0], ...
-        assert_eq!(ep1.host, "a.com");
-        assert_eq!(ep2.host, "b.com");
+        assert_eq!(ep1.endpoint.host, "a.com");
+        assert_eq!(ep2.endpoint.host, "b.com");
     }
 
     // positive-1.1 (custom-header-routing): Single-endpoint bypass (no header, no BackendSelector call).
@@ -1486,7 +1511,7 @@ mod tests {
             .select_endpoint(&upstream, &headers, "/test")
             .await
             .unwrap();
-        assert_eq!(result.host, "only.com");
+        assert_eq!(result.endpoint.host, "only.com");
         assert_eq!(
             selector.calls(),
             0,
@@ -1507,7 +1532,7 @@ mod tests {
             .select_endpoint(&upstream, &headers, "/test")
             .await
             .unwrap();
-        assert_eq!(result.host, "a.com");
+        assert_eq!(result.endpoint.host, "a.com");
 
         // Invalid header not matching → UnknownTargetHost.
         let mut headers = HeaderMap::new();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upstream routing prefers already-resolved addresses when present and improves DNS-fallback error handling and logging to reduce connection failures.
* **New Features**
  * Proxy carries an internal resolved address for routing, conditionally includes it upstream, and strips client-supplied internal context headers to prevent spoofing.
  * Attachment uploads now pre-check Content-Length and reject obviously oversized files early with a clear error.
* **Tests**
  * Added unit tests for header stripping and endpoint selection/resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->