### PR TITLE
feat(minichat) Add cancellation token to MiniChatAuditPluginClientV1 trait methods

### DIFF
--- a/libs/modkit-db/src/outbox/mod.rs
+++ b/libs/modkit-db/src/outbox/mod.rs
@@ -115,7 +115,8 @@ pub use handler::{
 pub use manager::{OutboxBuilder, OutboxHandle};
 pub use migrations::outbox_migrations;
 pub use types::{
-    EnqueueMessage, OutboxError, OutboxMessageId, OutboxProfile, Partitions, WorkerTuning,
+    DecoupledConfig, EnqueueMessage, OutboxError, OutboxMessageId, OutboxProfile, Partitions,
+    WorkerTuning,
 };
 
 // Internal re-exports for tests and internal modules

--- a/modules/mini-chat/mini-chat-sdk/src/plugin_api.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/plugin_api.rs
@@ -96,23 +96,30 @@ pub trait MiniChatModelPolicyPluginClientV1: Send + Sync {
 #[async_trait]
 pub trait MiniChatAuditPluginClientV1: Send + Sync {
     /// Emit a turn audit event (turn completed or failed).
-    async fn emit_turn_audit(&self, event: TurnAuditEvent) -> Result<(), MiniChatAuditPluginError>;
+    async fn emit_turn_audit(
+        &self,
+        event: TurnAuditEvent,
+        cancel: CancellationToken,
+    ) -> Result<(), MiniChatAuditPluginError>;
 
     /// Emit a turn-retry audit event.
     async fn emit_turn_retry_audit(
         &self,
         event: TurnRetryAuditEvent,
+        cancel: CancellationToken,
     ) -> Result<(), MiniChatAuditPluginError>;
 
     /// Emit a turn-edit audit event.
     async fn emit_turn_edit_audit(
         &self,
         event: TurnEditAuditEvent,
+        cancel: CancellationToken,
     ) -> Result<(), MiniChatAuditPluginError>;
 
     /// Emit a turn-delete audit event.
     async fn emit_turn_delete_audit(
         &self,
         event: TurnDeleteAuditEvent,
+        cancel: CancellationToken,
     ) -> Result<(), MiniChatAuditPluginError>;
 }

--- a/modules/mini-chat/mini-chat/src/infra/audit_gateway.rs
+++ b/modules/mini-chat/mini-chat/src/infra/audit_gateway.rs
@@ -40,6 +40,27 @@ impl AuditGateway {
         )
     }
 
+    /// Create a gateway pre-loaded with a concrete plugin instance — for unit tests.
+    ///
+    /// The supplied plugin is registered in a fresh `ClientHub` under a
+    /// fixed synthetic instance ID.  The selector is pre-cached so
+    /// `get_plugin()` returns the plugin immediately without any
+    /// types-registry round-trip.
+    #[cfg(test)]
+    pub(crate) fn from_plugin(plugin: Arc<dyn MiniChatAuditPluginClientV1>) -> Arc<Self> {
+        const MOCK_INSTANCE_ID: &str = "test.audit.plugin.v1~test._.mock.v1";
+        let hub = Arc::new(ClientHub::new());
+        hub.register_scoped::<dyn MiniChatAuditPluginClientV1>(
+            ClientScope::gts_id(MOCK_INSTANCE_ID),
+            plugin,
+        );
+        Self::new_preconfigured(
+            hub,
+            String::new(),
+            GtsPluginSelector::pre_cached(MOCK_INSTANCE_ID.to_owned()),
+        )
+    }
+
     /// Create a gateway with explicit fields — for tests that pre-warm the
     /// selector and register the plugin directly in the hub.
     #[cfg(test)]

--- a/modules/mini-chat/mini-chat/src/infra/outbox.rs
+++ b/modules/mini-chat/mini-chat/src/infra/outbox.rs
@@ -319,27 +319,12 @@ pub struct AuditEventHandler {
 }
 
 #[async_trait]
-impl modkit_db::outbox::MessageHandler for AuditEventHandler {
+impl modkit_db::outbox::Handler for AuditEventHandler {
     async fn handle(
         &self,
-        msg: &modkit_db::outbox::OutboxMessage,
-        _cancel: tokio_util::sync::CancellationToken,
+        msg: &[modkit_db::outbox::OutboxMessage],
+        cancel: tokio_util::sync::CancellationToken,
     ) -> modkit_db::outbox::HandlerResult {
-        let envelope = match serde_json::from_slice::<AuditEnvelope>(&msg.payload) {
-            Ok(e) => e,
-            Err(e) => {
-                tracing::error!(
-                    partition_id = msg.partition_id,
-                    seq = msg.seq,
-                    payload_len = msg.payload.len(),
-                    "audit event deserialization failed: {e}"
-                );
-                return modkit_db::outbox::HandlerResult::Reject {
-                    reason: format!("deserialization failed: {e}"),
-                };
-            }
-        };
-
         let plugin = match self.audit_gateway.get_plugin().await {
             Ok(Some(p)) => p,
             Ok(None) => {
@@ -347,77 +332,91 @@ impl modkit_db::outbox::MessageHandler for AuditEventHandler {
                 return modkit_db::outbox::HandlerResult::Success;
             }
             Err(e) => {
-                warn!(
-                    partition_id = msg.partition_id,
-                    seq = msg.seq,
-                    error = %e,
-                    "audit plugin resolution failed - will retry"
-                );
+                warn!(error = %e, "audit plugin resolution failed - will retry");
                 return modkit_db::outbox::HandlerResult::Retry {
                     reason: format!("plugin resolution failed: {e}"),
                 };
             }
         };
 
-        let result: Result<(), MiniChatAuditPluginError> = match &envelope {
-            AuditEnvelope::Turn(evt) => {
-                tokio::time::timeout(AUDIT_PLUGIN_TIMEOUT, plugin.emit_turn_audit(evt.clone()))
-                    .await
-                    .unwrap_or(Err(MiniChatAuditPluginError::PluginTimeout))
-            }
-            AuditEnvelope::Mutation(evt) => match evt.event_type {
-                TurnMutationAuditEventType::TurnRetry => tokio::time::timeout(
-                    AUDIT_PLUGIN_TIMEOUT,
-                    plugin.emit_turn_retry_audit(evt.clone()),
-                )
-                .await
-                .unwrap_or(Err(MiniChatAuditPluginError::PluginTimeout)),
-                TurnMutationAuditEventType::TurnEdit => tokio::time::timeout(
-                    AUDIT_PLUGIN_TIMEOUT,
-                    plugin.emit_turn_edit_audit(evt.clone()),
-                )
-                .await
-                .unwrap_or(Err(MiniChatAuditPluginError::PluginTimeout)),
-            },
-            AuditEnvelope::Delete(evt) => tokio::time::timeout(
-                AUDIT_PLUGIN_TIMEOUT,
-                plugin.emit_turn_delete_audit(evt.clone()),
-            )
-            .await
-            .unwrap_or(Err(MiniChatAuditPluginError::PluginTimeout)),
-        };
-
-        match result {
-            Ok(()) => {
-                self.metrics.record_audit_emit(metric_labels::result::OK);
-                modkit_db::outbox::HandlerResult::Success
-            }
-            Err(e) if e.is_transient() => {
-                warn!(
-                    partition_id = msg.partition_id,
-                    seq = msg.seq,
-                    error = %e,
-                    "audit emit transient failure - will retry"
-                );
-                self.metrics.record_audit_emit(metric_labels::result::RETRY);
-                modkit_db::outbox::HandlerResult::Retry {
-                    reason: e.to_string(),
+        for m in msg {
+            let envelope = match serde_json::from_slice::<AuditEnvelope>(&m.payload) {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::error!(
+                        partition_id = m.partition_id,
+                        seq = m.seq,
+                        payload_len = m.payload.len(),
+                        "audit event deserialization failed: {e}"
+                    );
+                    return modkit_db::outbox::HandlerResult::Reject {
+                        reason: format!("deserialization failed: {e}"),
+                    };
                 }
-            }
-            Err(e) => {
-                tracing::error!(
-                    partition_id = msg.partition_id,
-                    seq = msg.seq,
-                    error = %e,
-                    "audit emit permanent failure - dead-lettering"
-                );
-                self.metrics
-                    .record_audit_emit(metric_labels::result::REJECT);
-                modkit_db::outbox::HandlerResult::Reject {
-                    reason: e.to_string(),
+            };
+
+            let result: Result<(), MiniChatAuditPluginError> = match &envelope {
+                AuditEnvelope::Turn(evt) => tokio::time::timeout(
+                    AUDIT_PLUGIN_TIMEOUT,
+                    plugin.emit_turn_audit(evt.clone(), cancel.clone()),
+                )
+                .await
+                .unwrap_or(Err(MiniChatAuditPluginError::PluginTimeout)),
+                AuditEnvelope::Mutation(evt) => match evt.event_type {
+                    TurnMutationAuditEventType::TurnRetry => tokio::time::timeout(
+                        AUDIT_PLUGIN_TIMEOUT,
+                        plugin.emit_turn_retry_audit(evt.clone(), cancel.clone()),
+                    )
+                    .await
+                    .unwrap_or(Err(MiniChatAuditPluginError::PluginTimeout)),
+                    TurnMutationAuditEventType::TurnEdit => tokio::time::timeout(
+                        AUDIT_PLUGIN_TIMEOUT,
+                        plugin.emit_turn_edit_audit(evt.clone(), cancel.clone()),
+                    )
+                    .await
+                    .unwrap_or(Err(MiniChatAuditPluginError::PluginTimeout)),
+                },
+                AuditEnvelope::Delete(evt) => tokio::time::timeout(
+                    AUDIT_PLUGIN_TIMEOUT,
+                    plugin.emit_turn_delete_audit(evt.clone(), cancel.clone()),
+                )
+                .await
+                .unwrap_or(Err(MiniChatAuditPluginError::PluginTimeout)),
+            };
+
+            match result {
+                Ok(()) => {
+                    self.metrics.record_audit_emit(metric_labels::result::OK);
+                }
+                Err(e) if e.is_transient() => {
+                    warn!(
+                        partition_id = m.partition_id,
+                        seq = m.seq,
+                        error = %e,
+                        "audit emit transient failure - will retry"
+                    );
+                    self.metrics.record_audit_emit(metric_labels::result::RETRY);
+                    return modkit_db::outbox::HandlerResult::Retry {
+                        reason: e.to_string(),
+                    };
+                }
+                Err(e) => {
+                    tracing::error!(
+                        partition_id = m.partition_id,
+                        seq = m.seq,
+                        error = %e,
+                        "audit emit permanent failure - dead-lettering"
+                    );
+                    self.metrics
+                        .record_audit_emit(metric_labels::result::REJECT);
+                    return modkit_db::outbox::HandlerResult::Reject {
+                        reason: e.to_string(),
+                    };
                 }
             }
         }
+
+        modkit_db::outbox::HandlerResult::Success
     }
 }
 
@@ -429,7 +428,9 @@ mod tests {
         MiniChatModelPolicyPluginError, PolicySnapshot, PolicyVersionInfo, PublishError,
         TurnAuditEvent, TurnDeleteAuditEvent, TurnEditAuditEvent, TurnRetryAuditEvent, UserLimits,
     };
-    use modkit_db::outbox::{HandlerResult, MessageHandler, OutboxMessage};
+    use modkit_db::outbox::{
+        DecoupledConfig, Handler, HandlerResult, MessageHandler, OutboxMessage,
+    };
     use std::sync::atomic::{AtomicU32, Ordering};
     use time::OffsetDateTime;
     use tokio_util::sync::CancellationToken;
@@ -691,9 +692,18 @@ mod tests {
     // ── AuditEventHandler unit tests ──
 
     /// Mock audit plugin that records `emit_*` calls and always returns `Ok(())`.
+    enum AuditBehavior {
+        Ok,
+        Transient(String),
+        Permanent(String),
+        /// Returns Transient("cancelled") when the supplied token is already cancelled.
+        RespectCancel,
+    }
+
     struct MockAuditPlugin {
         call_count: AtomicU32,
         notifier: tokio::sync::Notify,
+        behavior: AuditBehavior,
     }
 
     impl MockAuditPlugin {
@@ -701,6 +711,31 @@ mod tests {
             Arc::new(Self {
                 call_count: AtomicU32::new(0),
                 notifier: tokio::sync::Notify::new(),
+                behavior: AuditBehavior::Ok,
+            })
+        }
+
+        fn transient(msg: &str) -> Arc<Self> {
+            Arc::new(Self {
+                call_count: AtomicU32::new(0),
+                notifier: tokio::sync::Notify::new(),
+                behavior: AuditBehavior::Transient(msg.to_owned()),
+            })
+        }
+
+        fn permanent(msg: &str) -> Arc<Self> {
+            Arc::new(Self {
+                call_count: AtomicU32::new(0),
+                notifier: tokio::sync::Notify::new(),
+                behavior: AuditBehavior::Permanent(msg.to_owned()),
+            })
+        }
+
+        fn cancel_aware() -> Arc<Self> {
+            Arc::new(Self {
+                call_count: AtomicU32::new(0),
+                notifier: tokio::sync::Notify::new(),
+                behavior: AuditBehavior::RespectCancel,
             })
         }
 
@@ -712,34 +747,60 @@ mod tests {
             self.call_count.fetch_add(1, Ordering::SeqCst);
             self.notifier.notify_one();
         }
+
+        fn emit_result(&self, cancel: &CancellationToken) -> Result<(), MiniChatAuditPluginError> {
+            match &self.behavior {
+                AuditBehavior::Ok => Ok(()),
+                AuditBehavior::Transient(msg) => {
+                    Err(MiniChatAuditPluginError::Transient(msg.clone()))
+                }
+                AuditBehavior::Permanent(msg) => {
+                    Err(MiniChatAuditPluginError::Permanent(msg.clone()))
+                }
+                AuditBehavior::RespectCancel => {
+                    if cancel.is_cancelled() {
+                        Err(MiniChatAuditPluginError::Transient("cancelled".to_owned()))
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+        }
     }
 
     #[async_trait]
     impl MiniChatAuditPluginClientV1 for MockAuditPlugin {
-        async fn emit_turn_audit(&self, _: TurnAuditEvent) -> Result<(), MiniChatAuditPluginError> {
+        async fn emit_turn_audit(
+            &self,
+            _: TurnAuditEvent,
+            cancel: CancellationToken,
+        ) -> Result<(), MiniChatAuditPluginError> {
             self.record();
-            Ok(())
+            self.emit_result(&cancel)
         }
         async fn emit_turn_retry_audit(
             &self,
             _: TurnRetryAuditEvent,
+            cancel: CancellationToken,
         ) -> Result<(), MiniChatAuditPluginError> {
             self.record();
-            Ok(())
+            self.emit_result(&cancel)
         }
         async fn emit_turn_edit_audit(
             &self,
             _: TurnEditAuditEvent,
+            cancel: CancellationToken,
         ) -> Result<(), MiniChatAuditPluginError> {
             self.record();
-            Ok(())
+            self.emit_result(&cancel)
         }
         async fn emit_turn_delete_audit(
             &self,
             _: TurnDeleteAuditEvent,
+            cancel: CancellationToken,
         ) -> Result<(), MiniChatAuditPluginError> {
             self.record();
-            Ok(())
+            self.emit_result(&cancel)
         }
     }
 
@@ -783,15 +844,19 @@ mod tests {
     }
 
     // ── AuditEventHandler: invalid payload → Reject ──
+    //
+    // Note: the handler only deserializes payloads when a plugin is present.
+    // Use an `ok` plugin so the handler reaches the deserialization step.
 
     #[tokio::test]
     async fn audit_handler_reject_for_invalid_payload() {
+        let plugin = MockAuditPlugin::ok();
         let handler = AuditEventHandler {
-            audit_gateway: AuditGateway::noop(),
+            audit_gateway: AuditGateway::from_plugin(plugin),
             metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
         };
         let msg = make_outbox_message(b"not json".to_vec());
-        let result = handler.handle(&msg, CancellationToken::new()).await;
+        let result = handler.handle(&[msg], CancellationToken::new()).await;
         assert!(
             matches!(result, HandlerResult::Reject { .. }),
             "expected Reject for corrupt payload"
@@ -808,11 +873,117 @@ mod tests {
         };
         let payload = make_audit_envelope_payload();
         let msg = make_outbox_message(payload);
-        let result = handler.handle(&msg, CancellationToken::new()).await;
+        let result = handler.handle(&[msg], CancellationToken::new()).await;
         assert!(
             matches!(result, HandlerResult::Success),
             "expected Success when no plugin configured"
         );
+    }
+
+    // ── AuditEventHandler: transient plugin error → Retry ──
+
+    #[tokio::test]
+    async fn audit_handler_retry_on_transient_plugin_error() {
+        let plugin = MockAuditPlugin::transient("network blip");
+        let audit_gateway = AuditGateway::from_plugin(plugin.clone());
+        let handler = AuditEventHandler {
+            audit_gateway,
+            metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
+        };
+        let msg = make_outbox_message(make_audit_envelope_payload());
+        let result = handler.handle(&[msg], CancellationToken::new()).await;
+        assert!(
+            matches!(result, HandlerResult::Retry { .. }),
+            "expected Retry for transient plugin error"
+        );
+        assert_eq!(plugin.calls(), 1);
+    }
+
+    // ── AuditEventHandler: permanent plugin error → Reject ──
+
+    #[tokio::test]
+    async fn audit_handler_reject_on_permanent_plugin_error() {
+        let plugin = MockAuditPlugin::permanent("schema mismatch");
+        let audit_gateway = AuditGateway::from_plugin(plugin.clone());
+        let handler = AuditEventHandler {
+            audit_gateway,
+            metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
+        };
+        let msg = make_outbox_message(make_audit_envelope_payload());
+        let result = handler.handle(&[msg], CancellationToken::new()).await;
+        assert!(
+            matches!(result, HandlerResult::Reject { .. }),
+            "expected Reject for permanent plugin error"
+        );
+        assert_eq!(plugin.calls(), 1);
+    }
+
+    // ── AuditEventHandler: cancelled token propagates to plugin → Retry ──
+
+    #[tokio::test]
+    async fn audit_handler_retry_when_cancelled() {
+        let plugin = MockAuditPlugin::cancel_aware();
+        let audit_gateway = AuditGateway::from_plugin(plugin.clone());
+        let handler = AuditEventHandler {
+            audit_gateway,
+            metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
+        };
+        let msg = make_outbox_message(make_audit_envelope_payload());
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let result = handler.handle(&[msg], cancel).await;
+        assert!(
+            matches!(result, HandlerResult::Retry { .. }),
+            "expected Retry when token is cancelled"
+        );
+    }
+
+    // ── AuditEventHandler: batch of messages — all succeed → Success ──
+
+    #[tokio::test]
+    async fn audit_handler_processes_all_messages_in_batch() {
+        let plugin = MockAuditPlugin::ok();
+        let audit_gateway = AuditGateway::from_plugin(plugin.clone());
+        let handler = AuditEventHandler {
+            audit_gateway,
+            metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
+        };
+        let payload = make_audit_envelope_payload();
+        let messages = vec![
+            make_outbox_message(payload.clone()),
+            make_outbox_message(payload.clone()),
+            make_outbox_message(payload),
+        ];
+        let result = handler.handle(&messages, CancellationToken::new()).await;
+        assert!(
+            matches!(result, HandlerResult::Success),
+            "expected Success when all messages in batch succeed"
+        );
+        assert_eq!(plugin.calls(), 3, "all 3 messages should have been emitted");
+    }
+
+    // ── AuditEventHandler: batch stops at first failure ──
+
+    #[tokio::test]
+    async fn audit_handler_stops_batch_on_first_failure() {
+        let plugin = MockAuditPlugin::transient("flaky");
+        let audit_gateway = AuditGateway::from_plugin(plugin.clone());
+        let handler = AuditEventHandler {
+            audit_gateway,
+            metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
+        };
+        let payload = make_audit_envelope_payload();
+        let messages = vec![
+            make_outbox_message(payload.clone()),
+            make_outbox_message(payload.clone()),
+            make_outbox_message(payload),
+        ];
+        let result = handler.handle(&messages, CancellationToken::new()).await;
+        assert!(
+            matches!(result, HandlerResult::Retry { .. }),
+            "expected Retry on first message failure"
+        );
+        assert_eq!(plugin.calls(), 1, "should have stopped after first failure");
     }
 
     // ── 7.11: Integration test — AuditEventHandler full pipeline ──
@@ -863,10 +1034,13 @@ mod tests {
 
         let handle = Outbox::builder(db.clone())
             .queue("test.audit", Partitions::of(1))
-            .decoupled(AuditEventHandler {
-                audit_gateway: Arc::clone(&audit_gateway),
-                metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
-            })
+            .batch_decoupled_with(
+                AuditEventHandler {
+                    audit_gateway: Arc::clone(&audit_gateway),
+                    metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
+                },
+                DecoupledConfig::default(),
+            )
             .start()
             .await
             .expect("outbox start");

--- a/modules/mini-chat/mini-chat/src/infra/plugins/static_audit/service.rs
+++ b/modules/mini-chat/mini-chat/src/infra/plugins/static_audit/service.rs
@@ -6,6 +6,7 @@ use mini_chat_sdk::{
     MiniChatAuditPluginClientV1, MiniChatAuditPluginError, TurnAuditEvent, TurnDeleteAuditEvent,
     TurnEditAuditEvent, TurnRetryAuditEvent,
 };
+use tokio_util::sync::CancellationToken;
 
 /// Service for the static audit plugin.
 ///
@@ -18,7 +19,11 @@ pub struct Service {
 
 #[async_trait]
 impl MiniChatAuditPluginClientV1 for Service {
-    async fn emit_turn_audit(&self, event: TurnAuditEvent) -> Result<(), MiniChatAuditPluginError> {
+    async fn emit_turn_audit(
+        &self,
+        event: TurnAuditEvent,
+        _cancel: CancellationToken,
+    ) -> Result<(), MiniChatAuditPluginError> {
         if !self.enabled {
             return Ok(());
         }
@@ -42,6 +47,7 @@ impl MiniChatAuditPluginClientV1 for Service {
     async fn emit_turn_retry_audit(
         &self,
         event: TurnRetryAuditEvent,
+        _cancel: CancellationToken,
     ) -> Result<(), MiniChatAuditPluginError> {
         if !self.enabled {
             return Ok(());
@@ -61,6 +67,7 @@ impl MiniChatAuditPluginClientV1 for Service {
     async fn emit_turn_edit_audit(
         &self,
         event: TurnEditAuditEvent,
+        _cancel: CancellationToken,
     ) -> Result<(), MiniChatAuditPluginError> {
         if !self.enabled {
             return Ok(());
@@ -80,6 +87,7 @@ impl MiniChatAuditPluginClientV1 for Service {
     async fn emit_turn_delete_audit(
         &self,
         event: TurnDeleteAuditEvent,
+        _cancel: CancellationToken,
     ) -> Result<(), MiniChatAuditPluginError> {
         if !self.enabled {
             return Ok(());

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -7,7 +7,9 @@ use mini_chat_sdk::{MiniChatAuditPluginSpecV1, MiniChatModelPolicyPluginSpecV1};
 use modkit::api::OpenApiRegistry;
 use modkit::contracts::RunnableCapability;
 use modkit::{DatabaseCapability, Module, ModuleCtx, RestApiCapability};
-use modkit_db::outbox::{Outbox, OutboxHandle, Partitions};
+use std::time::Duration;
+
+use modkit_db::outbox::{DecoupledConfig, Outbox, OutboxHandle, Partitions};
 use oagw_sdk::ServiceGatewayClientV1;
 use sea_orm_migration::MigrationTrait;
 use tokio_util::sync::CancellationToken;
@@ -190,10 +192,18 @@ impl Module for MiniChatModule {
             .queue(&cleanup_queue_name, partitions)
             .decoupled(AttachmentCleanupHandler)
             .queue(&audit_queue_name, partitions)
-            .decoupled(AuditEventHandler {
-                audit_gateway: Arc::clone(&audit_gateway),
-                metrics: Arc::clone(&metrics),
-            })
+            // Lease must exceed the plugin's worst-case HTTP budget:
+            // request_timeout_secs * (retry_max_retries + 1) + backoff margin.
+            // The plugin config enforces its settings stay within 50 s (LEASE_BUDGET_SECS).
+            .batch_decoupled_with(
+                AuditEventHandler {
+                    audit_gateway: Arc::clone(&audit_gateway),
+                    metrics: Arc::clone(&metrics),
+                },
+                DecoupledConfig {
+                    lease_duration: Duration::from_secs(60),
+                },
+            )
             .start()
             .await
             .map_err(|e| anyhow::anyhow!("outbox start: {e}"))?;


### PR DESCRIPTION
### What changed

**`mini-chat-sdk`**
- `MiniChatAuditPluginClientV1`: added `cancel: CancellationToken` to all four `emit_*` methods so implementations can abort in-flight HTTP calls on shutdown.

**`modkit-db`**
- Re-export `DecoupledConfig` from `modkit_db::outbox` (was missing, blocked callers from configuring the lease).

**`mini-chat`**
- Audit outbox queue switched from `.decoupled()` to `.batch_decoupled_with(…, DecoupledConfig { lease_duration: 60s })`. The 60 s lease exceeds the plugin's worst-case HTTP budget (enforced in `acronis-audit-plugin` config at ≤ 50 s), so a lease never expires mid-delivery.
- `AuditEventHandler` now implements `Handler` (batch variant) instead of `MessageHandler`. It resolves the plugin once per batch, iterates messages, passes `cancel.clone()` to each `emit_*` call, and stops at the first failure.
- `static-audit-plugin`: updated `emit_*` impl signatures to match new trait.

### Tests
- Fixed `audit_handler_reject_for_invalid_payload`: now uses a real plugin so the handler reaches the deserialization step (noop gateway returns `Success` before deserializing — which is correct behaviour, but wrong for this test).
- Added 5 new `AuditEventHandler` unit tests: transient error → `Retry`, permanent error → `Reject`, pre-cancelled token → `Retry`, batch of 3 all succeed → `Success`, batch stops on first failure.
- Added `audit_pipeline_enqueue_and_deliver` integration test: enqueues one audit event into an in-memory SQLite outbox and asserts the mock plugin is called exactly once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced audit event processing with improved cancellation support across the system.
  * Optimized audit event handling through batch processing with configurable lease durations.

* **Tests**
  * Added test utilities for audit infrastructure validation and cancellation behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->