### PR TITLE
feat(modkit): add FIPS-140-3 support via aws-lc-fips-sys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
       - name: Validate module naming conventions
         run: python3 scripts/validate_module_names.py
 
+      - name: Install Go (required for aws-lc-fips-sys FIPS build)
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: 'stable'
+          cache: false
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,11 +467,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.13.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bce4948d2520386c6d92a6ea2d472300257702242e5a1d01d6add52bd2e7c1"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "regex",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
+ "aws-lc-fips-sys",
  "aws-lc-sys",
  "untrusted 0.7.1",
  "zeroize",
@@ -602,6 +617,26 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1027,6 +1062,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cf-api-gateway"
 version = "0.1.21"
 dependencies = [
@@ -1337,6 +1381,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
+ "rustls",
  "schemars 1.2.1",
  "sea-orm-migration",
  "serde",
@@ -2127,6 +2172,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -3776,6 +3832,7 @@ dependencies = [
  "cf-grpc-hub",
  "cf-mini-chat",
  "cf-modkit",
+ "cf-modkit-http",
  "cf-module-orchestrator",
  "cf-nodes-registry",
  "cf-oagw",

--- a/Makefile
+++ b/Makefile
@@ -482,6 +482,10 @@ example:
 	cargo run --bin hyperspot-server $(E2E_ARGS) -- --config config/quickstart.yaml run
 
 # mini-chat targets are for running the mini-chat module locally and in Kubernetes, with options for building Docker images and deploying with Helm.
+## Run server with fips module
+fips:
+	cargo run --bin hyperspot-server --features fips,static-authn,static-authz,single-tenant,static-credstore,otel -- --config config/quickstart.yaml run
+
 ## Run server with mini-chat module
 mini-chat:
 	cargo run --bin hyperspot-server --features mini-chat,static-authn,static-authz,single-tenant,static-credstore,otel -- --config config/mini-chat.yaml run

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -11,6 +11,8 @@ workspace = true
 
 [features]
 default = []
+# FIPS-140-3: use the AWS-LC FIPS-validated crypto module for all cryptographic operations
+fips = ["modkit/fips", "modkit-http/fips", "api_egress/fips"]
 users-info-example = ["dep:users-info"]
 oop-example = ["dep:calculator-gateway", "dep:calculator"]
 single-tenant = ["dep:single-tenant-tr-plugin"]
@@ -26,6 +28,7 @@ otel = ["modkit/otel"]
 mimalloc = { version = "0.1" }
 # Local crates
 modkit = { workspace = true, features = ["bootstrap"] }
+modkit-http = { workspace = true }
 
 # System modules
 api_gateway = { package = "cf-api-gateway", path = "../../modules/system/api-gateway" }

--- a/apps/hyperspot-server/src/main.rs
+++ b/apps/hyperspot-server/src/main.rs
@@ -65,6 +65,11 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install FIPS crypto provider before anything else.
+    // Must run before any TLS config, HTTP client, DB connection, or JWT operation.
+    #[cfg(feature = "fips")]
+    modkit::bootstrap::init_fips_crypto_provider();
+
     let cli = Cli::parse();
 
     // Layered config:

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -204,7 +204,17 @@ The project uses `aws-lc-rs` (via `rustls`) as its primary TLS cryptographic bac
 | JWT validation | `jsonwebtoken`, `aliri` | `sha2`, `hmac`, `ring` |
 | Database TLS | `sqlx` (`tls-rustls-aws-lc-rs`) | `aws-lc-rs` |
 
-**FIPS-140-3 status:** the current build **does not** enable FIPS mode. `aws-lc-rs` supports a `fips` feature flag that switches to the FIPS-validated AWS-LC module (`aws-lc-fips-sys`), providing a viable path to FIPS-140-3 compliance. Enabling it requires replacing `ring`-dependent libraries and building with CMake + Go toolchains. See [Opportunities for Improvement](#13-opportunities-for-improvement) for the roadmap.
+**FIPS-140-3 support:** the application can be built with FIPS-140-3 approved cryptography by enabling the `fips` feature flag:
+
+```sh
+cargo build -p hyperspot-server --features fips
+```
+
+This switches the underlying cryptographic module from `aws-lc-sys` to `aws-lc-fips-sys` — the FIPS-validated AWS-LC module (NIST Certificate #4816). At startup, the FIPS crypto provider is installed as the process-wide default before any TLS, database, JWT, or other cryptographic operations occur. Runtime assertions verify that TLS configurations are operating in FIPS mode; the application fails fast if FIPS mode is expected but not active.
+
+**Build requirements for FIPS:** CMake, Go, C compiler, C++ compiler. These are needed to build the AWS-LC FIPS module with its required integrity checks.
+
+**Important:** enabling the `fips` feature does not automatically make the entire application FIPS-140-3 compliant. Full compliance also depends on the deployment environment, operating system, and adherence to the AWS-LC security policy constraints. The `ring` crate remains in the dependency graph via `pingora-rustls` (certificate hashing only, not TLS crypto) and `aliri` (token lifecycle); these do not participate in TLS cryptographic operations.
 
 ## 8. Continuous Fuzzing
 
@@ -290,7 +300,7 @@ This ensures every new service or module repository starts with the same defense
 
 The following areas have been identified for future hardening:
 
-1. **FIPS-140-3 compliance** — enable the `aws-lc-rs` `fips` feature to switch TLS to the FIPS-validated AWS-LC module; replace `ring`-dependent libraries (`aliri`, `rustls-webpki`) with FIPS-capable alternatives; route JWT and hashing operations through `aws-lc-fips-sys`
+1. **FIPS-140-3 compliance (remaining work)** — the `fips` feature flag is implemented and enables FIPS-validated TLS via `aws-lc-fips-sys`. Remaining items: replace `ring`-dependent libraries (`aliri` for token lifecycle, `pingora-rustls` for certificate hashing) to fully eliminate `ring` from the dependency graph; route JWT and hashing operations through `aws-lc-fips-sys`
 2. **Security guidelines in spec templates** — add explicit security checklist sections to PRD and DESIGN templates (threat modeling, data classification, authentication requirements per feature)
 3. **Security-focused dylint lints** — extend the `DE07xx` series with additional rules, such as:
    - Detecting hardcoded secrets or API keys

--- a/libs/modkit-http/Cargo.toml
+++ b/libs/modkit-http/Cargo.toml
@@ -19,6 +19,8 @@ workspace = true
 
 [features]
 default = []
+# FIPS-140-3: compile rustls and its TLS stack with FIPS-approved cipher suites only
+fips = ["rustls/fips", "hyper-rustls/fips"]
 # OpenTelemetry integration for distributed tracing
 otel = ["dep:opentelemetry", "dep:tracing-opentelemetry"]
 

--- a/libs/modkit-http/src/tls.rs
+++ b/libs/modkit-http/src/tls.rs
@@ -63,7 +63,16 @@ pub fn native_root_certs() -> &'static [CertificateDer<'static>] {
 pub fn get_crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
     rustls::crypto::CryptoProvider::get_default()
         .cloned()
-        .unwrap_or_else(|| Arc::new(rustls::crypto::aws_lc_rs::default_provider()))
+        .unwrap_or_else(|| {
+            #[cfg(feature = "fips")]
+            {
+                Arc::new(rustls::crypto::default_fips_provider())
+            }
+            #[cfg(not(feature = "fips"))]
+            {
+                Arc::new(rustls::crypto::aws_lc_rs::default_provider())
+            }
+        })
 }
 
 /// Build a rustls `ClientConfig` using the cached native root certificates.
@@ -110,6 +119,13 @@ pub fn native_roots_client_config() -> Result<rustls::ClientConfig, String> {
         .map_err(|e| format!("failed to set TLS protocol versions: {e}"))?
         .with_root_certificates(root_store)
         .with_no_client_auth();
+
+    #[cfg(feature = "fips")]
+    assert!(
+        config.fips(),
+        "TLS ClientConfig is NOT in FIPS mode - this indicates the FIPS crypto provider \
+         was not installed before TLS configuration was created"
+    );
 
     Ok(config)
 }

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -21,6 +21,8 @@ workspace = true
 # Enable the runner and the runtime integration by default.
 default = ["otel", "db"]
 coverage_nightly = []
+# FIPS-140-3: install the AWS-LC FIPS-validated crypto provider at bootstrap
+fips = ["dep:rustls", "rustls/fips"]
 
 # Database integration (modkit-db, migrations, DbManager/DbHandle in contexts/runtime)
 db = ["dep:modkit-db", "dep:sea-orm-migration"]
@@ -72,6 +74,7 @@ chrono = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 dsn = { workspace = true, optional = true }
 modkit-utils = { workspace = true }
+rustls = { workspace = true, optional = true }
 
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/libs/modkit/src/bootstrap/crypto.rs
+++ b/libs/modkit/src/bootstrap/crypto.rs
@@ -1,0 +1,23 @@
+/// Install the FIPS-validated AWS-LC crypto provider as the process-wide default.
+///
+/// This **must** be called before any TLS configuration, HTTP client, database
+/// connection, or JWT operation is created. It sets the global [`rustls::crypto::CryptoProvider`]
+/// that all downstream consumers (rustls, sqlx, jsonwebtoken, pingora, etc.) will use.
+///
+/// Outputs to stderr (always visible, even before tracing is initialized) and
+/// to `tracing::info!` (visible in structured logs if a subscriber is active).
+///
+/// # Process exit
+///
+/// Exits with code 1 if another crypto provider has already been installed.
+pub fn init_fips_crypto_provider() {
+    if let Err(_existing) = rustls::crypto::default_fips_provider().install_default() {
+        eprintln!(
+            "[FIPS] FATAL: failed to install FIPS crypto provider - another provider is already installed"
+        );
+        std::process::exit(1);
+    }
+
+    eprintln!("[FIPS] FIPS-140-3 crypto provider installed (AWS-LC FIPS module)");
+    tracing::info!("FIPS-140-3 crypto provider installed (AWS-LC FIPS module)");
+}

--- a/libs/modkit/src/bootstrap/mod.rs
+++ b/libs/modkit/src/bootstrap/mod.rs
@@ -15,6 +15,8 @@
 //! Backend types for spawning `OoP` modules have been moved to `modkit::backends`.
 
 pub mod config;
+#[cfg(feature = "fips")]
+mod crypto;
 pub mod host;
 
 pub mod oop;
@@ -32,3 +34,6 @@ pub use oop::{OopRunOptions, run_oop_with_options};
 
 mod run;
 pub use run::{run_migrate, run_server};
+
+#[cfg(feature = "fips")]
+pub use crypto::init_fips_crypto_provider;

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -16,6 +16,8 @@ name = "oagw"
 path = "src/lib.rs"
 
 [features]
+# FIPS-140-3: compile TLS deps with FIPS-approved cipher suites only
+fips = ["modkit-http/fips"]
 test-utils = ["axum/ws", "dep:async-stream", "dep:futures", "dep:tower", "dep:rustls", "tokio/net", "tokio/sync", "tokio/rt"]
 
 [dependencies]


### PR DESCRIPTION
- Add opt-in `fips` Cargo feature that switches the crypto backend from `aws-lc-sys` to
  `aws-lc-fips-sys` (NIST Certificate #4816)
- Install the FIPS crypto provider as the process-wide default before any TLS, DB, or JWT operations
- Fail fast at startup if the FIPS provider cannot be installed
- Assert `config.fips() == true` on every TLS `ClientConfig` built under the `fips` feature
- Update `docs/security/SECURITY.md` with FIPS build instructions, requirements, and compliance
  caveats

Resolves #905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in FIPS mode with a convenience build/run target and startup behavior that installs a process-wide FIPS crypto provider when enabled.

* **Documentation**
  * Expanded security docs with FIPS build/run instructions, required native toolchain notes, runtime checks that enforce FIPS-mode crypto, and guidance on remaining work.

* **Chores**
  * CI updated to install the Go toolchain to support FIPS-related native builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->