### PR TITLE
fix(ci): exclude helm templates from gts validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ gts-docs:
 		--exclude "target/*" \
 		--exclude "docs/api/*" \
 		--exclude "modules/chat-engine/*" \
+		--exclude "**/helm/*/templates/*" \
 		docs modules libs examples
 
 ## Validate GTS docs with vendor check (ensures all IDs use vendor "x")


### PR DESCRIPTION
- Update Make command `gts-docs` to exclude helm templates since the templates are not valid yaml and gts validator considers non-parseable files as failures. This fix should correct any currently failing gts validator workflows. [Failing workflow reference](https://github.com/cyberfabric/cyberfabric-core/actions/runs/23546733211/job/68549054117)

Screenshot of successful run: 

<img width="1306" height="298" alt="image" src="https://github.com/user-attachments/assets/7c08b1e2-04ac-473f-a5c6-2492161936a3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build validation configuration to exclude certain template files from processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->