### PR TITLE
new: switch user-info endpoints to canonical errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8670,10 +8670,9 @@ dependencies = [
  "cf-api-gateway",
  "cf-authz-resolver-sdk",
  "cf-modkit",
+ "cf-modkit-canonical-errors",
  "cf-modkit-db",
  "cf-modkit-db-macros",
- "cf-modkit-errors",
- "cf-modkit-errors-macro",
  "cf-modkit-http",
  "cf-modkit-macros",
  "cf-modkit-odata",
@@ -8721,6 +8720,28 @@ dependencies = [
  "time",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "users-info-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cf-api-gateway",
+ "cf-authn-resolver",
+ "cf-authz-resolver",
+ "cf-grpc-hub",
+ "cf-modkit",
+ "cf-single-tenant-tr-plugin",
+ "cf-static-authn-plugin",
+ "cf-static-authz-plugin",
+ "cf-tenant-resolver",
+ "cf-types-registry",
+ "clap",
+ "tokio",
+ "tracing",
+ "types",
+ "users-info",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "modules/system/module-orchestrator",
     "examples/modkit/users-info/users-info-sdk",
     "examples/modkit/users-info/users-info",
+    "examples/modkit/users-info/users-info-server",
     "examples/oop-modules/calculator-gateway/calculator-gateway-sdk",
     "examples/oop-modules/calculator-gateway/calculator-gateway",
     "examples/oop-modules/calculator/calculator-sdk",

--- a/apps/hyperspot-server/src/main.rs
+++ b/apps/hyperspot-server/src/main.rs
@@ -44,7 +44,7 @@ struct Cli {
     #[arg(long)]
     dump_modules_config_json: bool,
 
-    /// Log verbosity level (-v info, -vv debug, -vvv trace)
+    /// Log verbosity level (-v debug, -vv trace)
     #[arg(short, long, action = clap::ArgAction::Count)]
     verbose: u8,
 

--- a/examples/modkit/users-info/users-info-server/Cargo.toml
+++ b/examples/modkit/users-info/users-info-server/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "users-info-server"
+version = "0.1.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Standalone server binary for the users-info example module"
+
+[lints]
+workspace = true
+
+[dependencies]
+# ModKit bootstrap (host mode)
+modkit = { workspace = true, features = ["bootstrap"] }
+
+# System modules (minimum set for users-info)
+api_gateway = { package = "cf-api-gateway", path = "../../../../modules/system/api-gateway" }
+grpc_hub = { package = "cf-grpc-hub", path = "../../../../modules/system/grpc-hub" }
+types_registry = { package = "cf-types-registry", path = "../../../../modules/system/types-registry/types-registry" }
+types = { path = "../../../../modules/system/types" }
+authn-resolver = { package = "cf-authn-resolver", path = "../../../../modules/system/authn-resolver/authn-resolver" }
+authz-resolver = { package = "cf-authz-resolver", path = "../../../../modules/system/authz-resolver/authz-resolver" }
+tenant-resolver = { package = "cf-tenant-resolver", path = "../../../../modules/system/tenant-resolver/tenant-resolver" }
+
+# Static plugins for standalone operation
+static-authn-plugin = { package = "cf-static-authn-plugin", path = "../../../../modules/system/authn-resolver/plugins/static-authn-plugin" }
+static-authz-plugin = { package = "cf-static-authz-plugin", path = "../../../../modules/system/authz-resolver/plugins/static-authz-plugin" }
+single-tenant-tr-plugin = { package = "cf-single-tenant-tr-plugin", path = "../../../../modules/system/tenant-resolver/plugins/single-tenant-tr-plugin" }
+
+# Target module
+users-info = { path = "../users-info", default-features = true }
+
+# Runtime dependencies
+anyhow = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+clap = { workspace = true }

--- a/examples/modkit/users-info/users-info-server/src/main.rs
+++ b/examples/modkit/users-info/users-info-server/src/main.rs
@@ -1,0 +1,39 @@
+mod registered_modules;
+
+use anyhow::Result;
+use clap::Parser;
+use modkit::bootstrap::{AppConfig, run_server};
+use std::path::PathBuf;
+
+/// Standalone server for the users-info example module
+#[derive(Parser)]
+#[command(name = "users-info-server")]
+#[command(about = "Standalone server for users-info example module")]
+struct Cli {
+    /// Path to configuration file
+    #[arg(short, long)]
+    config: Option<PathBuf>,
+
+    /// Log verbosity level (-v debug, -vv trace)
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
+
+    /// Print effective configuration and exit
+    #[arg(long)]
+    print_config: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    let mut config = AppConfig::load_or_default(cli.config.as_ref())?;
+    config.apply_cli_overrides(cli.verbose);
+
+    if cli.print_config {
+        tracing::info!("Effective configuration:\n{}", config.to_yaml()?);
+        return Ok(());
+    }
+
+    run_server(config).await
+}

--- a/examples/modkit/users-info/users-info-server/src/registered_modules.rs
+++ b/examples/modkit/users-info/users-info-server/src/registered_modules.rs
@@ -1,0 +1,20 @@
+#![allow(unused_imports)]
+
+// Ensure modules are linked and discoverable via inventory
+
+// System modules
+use api_gateway as _;
+use authn_resolver as _;
+use authz_resolver as _;
+use grpc_hub as _;
+use tenant_resolver as _;
+use types as _;
+use types_registry as _;
+
+// Static plugins for standalone operation
+use single_tenant_tr_plugin as _;
+use static_authn_plugin as _;
+use static_authz_plugin as _;
+
+// Target module
+use users_info as _;

--- a/examples/modkit/users-info/users-info/Cargo.toml
+++ b/examples/modkit/users-info/users-info/Cargo.toml
@@ -62,8 +62,7 @@ modkit-http = { workspace = true }
 modkit-db = { workspace = true, features = ["sqlite", "pg"] }
 modkit-db-macros = { workspace = true }
 modkit-security = { workspace = true }
-modkit-errors = { workspace = true }
-modkit-errors-macro = { workspace = true }
+modkit-canonical-errors = { workspace = true }
 modkit-odata = { workspace = true, features = ["with-utoipa"] }
 modkit-sdk = { workspace = true }
 modkit-macros = { workspace = true }

--- a/examples/modkit/users-info/users-info/src/api/rest/error.rs
+++ b/examples/modkit/users-info/users-info/src/api/rest/error.rs
@@ -1,75 +1,189 @@
-use modkit::api::problem::Problem;
+use modkit::api::problem::{Problem, ValidationViolation};
+use modkit_canonical_errors::{CanonicalError, FieldViolation, InvalidArgument};
 
 use crate::domain::error::DomainError;
-use crate::errors::ErrorCode;
 
-/// Map domain error to RFC9457 Problem using the catalog
-pub fn domain_error_to_problem(e: &DomainError, instance: &str) -> Problem {
-    // Extract trace ID from current tracing span if available
-    let trace_id = tracing::Span::current()
-        .id()
-        .map(|id| id.into_u64().to_string());
+// Resource-scoped canonical error types for each entity in this module.
+#[modkit_canonical_errors::resource_error("gts.hx.example1.users.user.v1~")]
+struct UserResourceError;
 
-    match &e {
-        DomainError::UserNotFound { id } => ErrorCode::example1_user_not_found_v1().with_context(
-            format!("User with id {id} was not found"),
-            instance,
-            trace_id,
-        ),
-        DomainError::NotFound { entity_type, id } => ErrorCode::example1_user_not_found_v1()
-            .with_context(
-                format!("{entity_type} with id {id} was not found"),
-                instance,
-                trace_id,
-            ),
-        DomainError::EmailAlreadyExists { email } => ErrorCode::example1_user_invalid_email_v1()
-            .with_context(
-                format!("Email '{email}' is already in use"),
-                instance,
-                trace_id,
-            ),
-        DomainError::InvalidEmail { email } => ErrorCode::example1_user_invalid_email_v1()
-            .with_context(format!("Email '{email}' is invalid"), instance, trace_id),
-        DomainError::EmptyDisplayName => ErrorCode::example1_user_validation_v1().with_context(
-            "Display name cannot be empty",
-            instance,
-            trace_id,
-        ),
-        DomainError::DisplayNameTooLong { .. } | DomainError::Validation { .. } => {
-            ErrorCode::example1_user_validation_v1().with_context(
-                format!("{e}"),
-                instance,
-                trace_id,
-            )
+#[modkit_canonical_errors::resource_error("gts.hx.example1.users.city.v1~")]
+struct CityResourceError;
+
+#[modkit_canonical_errors::resource_error("gts.hx.example1.users.address.v1~")]
+struct AddressResourceError;
+
+/// Convert a [`DomainError`] into a [`CanonicalError`].
+fn domain_error_to_canonical(e: &DomainError) -> CanonicalError {
+    match e {
+        DomainError::UserNotFound { id } => {
+            UserResourceError::not_found(format!("User with id {id} was not found",))
+                .with_resource(id.to_string())
+                .create()
         }
+
+        DomainError::NotFound { entity_type, id } => {
+            let detail = format!("{entity_type} with id {id} was not found");
+            match entity_type.as_str() {
+                "City" => CityResourceError::not_found(detail)
+                    .with_resource(id.to_string())
+                    .create(),
+                "Address" => AddressResourceError::not_found(detail)
+                    .with_resource(id.to_string())
+                    .create(),
+                _ => UserResourceError::not_found(detail)
+                    .with_resource(id.to_string())
+                    .create(),
+            }
+        }
+
+        DomainError::EmailAlreadyExists { email } => {
+            UserResourceError::already_exists(format!("Email '{email}' is already in use"))
+                .with_resource(email.clone())
+                .create()
+        }
+
+        DomainError::InvalidEmail { email } => UserResourceError::invalid_argument()
+            .with_field_violation(
+                "email",
+                format!("Email '{email}' is invalid"),
+                "INVALID_FORMAT",
+            )
+            .create(),
+
+        DomainError::EmptyDisplayName => UserResourceError::invalid_argument()
+            .with_field_violation("display_name", "Display name cannot be empty", "REQUIRED")
+            .create(),
+
+        DomainError::DisplayNameTooLong { len, max } => UserResourceError::invalid_argument()
+            .with_field_violation(
+                "display_name",
+                format!("Display name too long: {len} characters (max: {max})"),
+                "MAX_LENGTH",
+            )
+            .create(),
+
+        DomainError::Validation { field, message } => UserResourceError::invalid_argument()
+            .with_field_violation(field, message, "VALIDATION")
+            .create(),
+
         DomainError::Database { .. } => {
-            // Log the internal error details but don't expose them to the client
             tracing::error!(error = ?e, "Database error occurred");
-            ErrorCode::example1_user_internal_database_v1().with_context(
-                "An internal database error occurred",
-                instance,
-                trace_id,
-            )
+            CanonicalError::internal("An internal database error occurred").create()
         }
-        DomainError::Forbidden => Problem::new(
-            http::StatusCode::FORBIDDEN,
-            "Access denied",
-            "You do not have permission to perform this action",
-        ),
+
+        DomainError::Forbidden => UserResourceError::permission_denied()
+            .with_reason("ACCESS_DENIED")
+            .create(),
+
         DomainError::InternalError => {
             tracing::error!(error = ?e, "Internal error occurred");
-            ErrorCode::example1_user_internal_database_v1().with_context(
-                "An internal error occurred",
-                instance,
-                trace_id,
-            )
+            CanonicalError::internal("An internal error occurred").create()
         }
     }
 }
 
-/// Implement Into<Problem> for `DomainError` so `?` works in handlers
+/// Convert a [`CanonicalError`] into the axum-compatible [`Problem`].
+fn canonical_to_problem(ce: &CanonicalError) -> Problem {
+    let status = http::StatusCode::from_u16(ce.status_code())
+        .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR);
+
+    let mut problem =
+        Problem::new(status, ce.title(), ce.detail()).with_type(format!("gts://{}", ce.gts_type()));
+
+    if let Some(diag) = ce.diagnostic() {
+        tracing::debug!(diagnostic = %diag, "Canonical error diagnostic");
+    }
+
+    // Build context from canonical error metadata
+    let mut ctx = serde_json::Map::new();
+    if let Some(rt) = ce.resource_type() {
+        ctx.insert(
+            "resource_type".to_owned(),
+            serde_json::Value::String(rt.to_owned()),
+        );
+    }
+    if let Some(rn) = ce.resource_name() {
+        ctx.insert(
+            "resource_name".to_owned(),
+            serde_json::Value::String(rn.to_owned()),
+        );
+    }
+    if !ctx.is_empty() {
+        problem = problem.with_context(serde_json::Value::Object(ctx));
+    }
+
+    // Extract structured violations from applicable error categories
+    let errors = extract_violations(ce);
+    if !errors.is_empty() {
+        problem = problem.with_errors(errors);
+    }
+
+    // Enrich trace_id from current span
+    if let Some(span_id) = tracing::Span::current().id() {
+        problem = problem.with_trace_id(span_id.into_u64().to_string());
+    }
+
+    problem
+}
+
+/// Implement `Into<Problem>` for `DomainError` so `?` works in handlers
 impl From<DomainError> for Problem {
     fn from(e: DomainError) -> Self {
-        domain_error_to_problem(&e, "/")
+        let ce = domain_error_to_canonical(&e);
+        canonical_to_problem(&ce)
+    }
+}
+
+/// Map a [`FieldViolation`] to a [`ValidationViolation`].
+fn field_violation_to_validation(fv: &FieldViolation) -> ValidationViolation {
+    ValidationViolation {
+        field: fv.field.clone(),
+        message: fv.description.clone(),
+        code: Some(fv.reason.clone()),
+    }
+}
+
+/// Extract structured violations from a [`CanonicalError`] into a flat
+/// [`ValidationViolation`] list.  Covers every category that carries
+/// violation arrays: `InvalidArgument`, `OutOfRange`, `FailedPrecondition`,
+/// and `ResourceExhausted`.
+fn extract_violations(ce: &CanonicalError) -> Vec<ValidationViolation> {
+    match ce {
+        CanonicalError::InvalidArgument {
+            ctx: InvalidArgument::FieldViolations { field_violations },
+            ..
+        } => field_violations
+            .iter()
+            .map(field_violation_to_validation)
+            .collect(),
+
+        CanonicalError::OutOfRange { ctx, .. } => ctx
+            .field_violations
+            .iter()
+            .map(field_violation_to_validation)
+            .collect(),
+
+        CanonicalError::FailedPrecondition { ctx, .. } => ctx
+            .violations
+            .iter()
+            .map(|pv| ValidationViolation {
+                field: pv.subject.clone(),
+                message: pv.description.clone(),
+                code: Some(pv.type_.clone()),
+            })
+            .collect(),
+
+        CanonicalError::ResourceExhausted { ctx, .. } => ctx
+            .violations
+            .iter()
+            .map(|qv| ValidationViolation {
+                field: qv.subject.clone(),
+                message: qv.description.clone(),
+                code: None,
+            })
+            .collect(),
+
+        _ => Vec::new(),
     }
 }

--- a/examples/modkit/users-info/users-info/src/domain/service/users.rs
+++ b/examples/modkit/users-info/users-info/src/domain/service/users.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use modkit_macros::domain_model;
+use tokio::sync::Semaphore;
 use tracing::instrument;
 
 use crate::domain::error::DomainError;
@@ -73,18 +75,30 @@ impl<R: UsersRepository + 'static, CR: CitiesRepository, AR: AddressesRepository
     }
 }
 
-async fn audit_get_user_access_best_effort<
-    R: UsersRepository,
-    CR: CitiesRepository,
-    AR: AddressesRepository,
->(
-    svc: &UsersService<R, CR, AR>,
-    id: Uuid,
-) {
-    let audit_result = svc.audit.get_user_access(id).await;
-    if let Err(e) = audit_result {
-        tracing::debug!("Audit service call failed (continuing): {}", e);
-    }
+/// Cap concurrent best-effort audit tasks to avoid unbounded spawns.
+static AUDIT_SEMAPHORE: Semaphore = Semaphore::const_new(10);
+
+/// Timeout for a single best-effort audit call.
+const AUDIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn audit_get_user_access_best_effort(audit: &Arc<dyn AuditPort>, id: Uuid) {
+    let Ok(permit) = AUDIT_SEMAPHORE.try_acquire() else {
+        tracing::debug!("Audit semaphore full, skipping best-effort audit for user {id}");
+        return;
+    };
+    let audit = Arc::clone(audit);
+    tokio::spawn(async move {
+        let _permit = permit;
+        match tokio::time::timeout(AUDIT_TIMEOUT, audit.get_user_access(id)).await {
+            Ok(Err(e)) => {
+                tracing::debug!("Audit service call failed (continuing): {}", e);
+            }
+            Err(_) => {
+                tracing::debug!("Audit call timed out for user {id}, dropping");
+            }
+            Ok(Ok(())) => {}
+        }
+    });
 }
 
 // Business logic methods
@@ -97,7 +111,7 @@ impl<R: UsersRepository + 'static, CR: CitiesRepository, AR: AddressesRepository
 
         let conn = self.db.conn().map_err(DomainError::from)?;
 
-        audit_get_user_access_best_effort(self, id).await;
+        audit_get_user_access_best_effort(&self.audit, id);
 
         // Prefetch: load user to extract owner_tenant_id for PDP.
         // PDP returns a narrow `eq` constraint instead of expanding the subtree.

--- a/examples/modkit/users-info/users-info/src/lib.rs
+++ b/examples/modkit/users-info/users-info/src/lib.rs
@@ -74,10 +74,6 @@ pub use users_info_sdk::{
     UpdateCityRequest, UpdateUserRequest, User, UserPatch, UsersInfoClientV1, UsersInfoError,
 };
 
-// === ERROR CATALOG ===
-// Generated error catalog from gts/errors.json
-pub mod errors;
-
 // === MODULE DEFINITION ===
 // ModKit needs access to the module struct for instantiation
 pub mod module;

--- a/examples/oop-modules/calculator/calculator/src/main.rs
+++ b/examples/oop-modules/calculator/calculator/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
         #[arg(short, long)]
         config: Option<std::path::PathBuf>,
 
-        /// Log verbosity level (-v info, -vv debug, -vvv trace)
+        /// Log verbosity level (-v debug, -vv trace)
         #[arg(short, long, action = clap::ArgAction::Count)]
         verbose: u8,
     }

--- a/libs/modkit-errors/Cargo.toml
+++ b/libs/modkit-errors/Cargo.toml
@@ -24,10 +24,8 @@ axum = ["dep:axum", "dep:tracing"]
 
 [dependencies]
 serde = { workspace = true }
+serde_json = { workspace = true }
 utoipa = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 http = { workspace = true }
-
-[dev-dependencies]
-serde_json = "1"

--- a/libs/modkit-errors/src/problem.rs
+++ b/libs/modkit-errors/src/problem.rs
@@ -2,6 +2,7 @@
 
 use http::StatusCode;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
 
 #[cfg(feature = "utoipa")]
 use utoipa::ToSchema;
@@ -56,13 +57,20 @@ pub struct Problem {
     /// A human-readable explanation specific to this occurrence of the problem.
     pub detail: String,
     /// A URI reference that identifies the specific occurrence of the problem.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub instance: String,
     /// Optional machine-readable error code defined by the application.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub code: String,
     /// Optional trace id useful for tracing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trace_id: Option<String>,
     /// Optional validation errors for 4xx problems.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub errors: Option<Vec<ValidationViolation>>,
+    /// Optional structured context (e.g. `resource_type`, `resource_name`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<Value>,
 }
 
 /// Individual validation violation for a specific field or property.
@@ -113,6 +121,7 @@ impl Problem {
             code: String::new(),
             trace_id: None,
             errors: None,
+            context: None,
         }
     }
 
@@ -138,6 +147,11 @@ impl Problem {
 
     pub fn with_errors(mut self, errors: Vec<ValidationViolation>) -> Self {
         self.errors = Some(errors);
+        self
+    }
+
+    pub fn with_context(mut self, context: Value) -> Self {
+        self.context = Some(context);
         self
     }
 }
@@ -210,7 +224,7 @@ mod tests {
 
     #[test]
     fn problem_deserializes_status_from_u16() {
-        let json = r#"{"type":"about:blank","title":"Not Found","status":404,"detail":"Resource not found","instance":"","code":"","trace_id":null,"errors":null}"#;
+        let json = r#"{"type":"about:blank","title":"Not Found","status":404,"detail":"Resource not found"}"#;
         let p: Problem = serde_json::from_str(json).unwrap();
         assert_eq!(p.status, StatusCode::NOT_FOUND);
     }

--- a/libs/modkit/src/bootstrap/oop.rs
+++ b/libs/modkit/src/bootstrap/oop.rs
@@ -78,7 +78,7 @@ pub struct OopRunOptions {
     /// Path to configuration file
     pub config_path: Option<PathBuf>,
 
-    /// Log verbosity level (0=default, 1=info, 2=debug, 3=trace)
+    /// Log verbosity level (0=default, 1=debug, 2=trace)
     pub verbose: u8,
 
     /// Print effective configuration and exit

--- a/modules/system/oagw/oagw/src/api/rest/error.rs
+++ b/modules/system/oagw/oagw/src/api/rest/error.rs
@@ -413,7 +413,6 @@ mod tests {
             assert!(parsed.get("status").is_some());
             assert!(parsed.get("title").is_some());
             assert!(parsed.get("detail").is_some());
-            assert!(parsed.get("instance").is_some());
         }
     }
 

--- a/testing/e2e/modules/mini_chat/test_chat_crud.py
+++ b/testing/e2e/modules/mini_chat/test_chat_crud.py
@@ -35,7 +35,8 @@ class TestCreateChat:
     def test_create_chat_invalid_model(self, server):
         resp = httpx.post(f"{API_PREFIX}/chats", json={"model": "nonexistent-model"})
         assert resp.status_code in (400, 404)
-        assert "code" in resp.json()
+        body = resp.json()
+        assert "type" in body and "status" in body and "detail" in body
 
 
 @pytest.mark.multi_provider
@@ -56,7 +57,8 @@ class TestGetChat:
         fake_id = str(uuid.uuid4())
         resp = httpx.get(f"{API_PREFIX}/chats/{fake_id}")
         assert resp.status_code == 404
-        assert "code" in resp.json()
+        body = resp.json()
+        assert "type" in body and "status" in body and "detail" in body
 
 
 @pytest.mark.multi_provider
@@ -142,4 +144,5 @@ class TestDeleteChat:
         fake_id = str(uuid.uuid4())
         resp = httpx.delete(f"{API_PREFIX}/chats/{fake_id}")
         assert resp.status_code == 404
-        assert "code" in resp.json()
+        body = resp.json()
+        assert "type" in body and "status" in body and "detail" in body

--- a/testing/e2e/modules/mini_chat/test_idempotency.py
+++ b/testing/e2e/modules/mini_chat/test_idempotency.py
@@ -106,7 +106,7 @@ class TestIdempotency:
         t.join(timeout=60)
 
         assert second_resp.status_code == 409
-        assert second_resp.json().get("code") == "request_id_conflict"
+        assert second_resp.json().get("title") == "request_id_conflict"
 
     @pytest.mark.xfail(reason="BUG: 409 missing error_code request_id_conflict")
     def test_failed_turn_same_request_id_409(self, request, chat, mock_provider):
@@ -142,7 +142,7 @@ class TestIdempotency:
             timeout=30,
         )
         assert second_resp.status_code == 409
-        assert second_resp.json().get("code") == "request_id_conflict"
+        assert second_resp.json().get("title") == "request_id_conflict"
 
     @pytest.mark.xfail(reason="BUG: 409 missing error_code request_id_conflict")
     def test_cancelled_turn_same_request_id_409(self, chat, mock_provider):
@@ -183,7 +183,7 @@ class TestIdempotency:
             timeout=30,
         )
         assert second_resp.status_code == 409
-        assert second_resp.json().get("code") == "request_id_conflict"
+        assert second_resp.json().get("title") == "request_id_conflict"
 
     def test_replay_priority_over_parallel_check(self, chat, mock_provider):
         """Replay of a completed turn returns 200 even while another turn is running."""

--- a/testing/e2e/modules/mini_chat/test_parallel_turn.py
+++ b/testing/e2e/modules/mini_chat/test_parallel_turn.py
@@ -63,7 +63,7 @@ class TestParallelTurn:
         assert first_result[0].status_code == 200
 
         assert second_resp.status_code == 409
-        assert second_resp.json().get("code") == "generation_in_progress"
+        assert second_resp.json().get("title") == "generation_in_progress"
 
     @pytest.mark.multi_provider
     def test_new_stream_succeeds_after_terminal(self, chat, mock_provider):

--- a/testing/e2e/modules/mini_chat/test_streaming.py
+++ b/testing/e2e/modules/mini_chat/test_streaming.py
@@ -249,7 +249,7 @@ class TestStreamPreflightErrors:
         )
         assert resp.status_code == 404
         body = resp.json()
-        assert "code" in body
+        assert "type" in body and "status" in body and "detail" in body
 
     def test_empty_content_rejected(self, provider_chat):
         resp = httpx.post(
@@ -260,7 +260,7 @@ class TestStreamPreflightErrors:
         )
         assert resp.status_code == 400
         body = resp.json()
-        assert "code" in body, f"Error response must have 'code' field: {body}"
+        assert "type" in body and "status" in body and "detail" in body, f"Error response must be RFC 7807 format: {body}"
 
     def test_missing_content_rejected(self, provider_chat):
         resp = httpx.post(
@@ -272,7 +272,7 @@ class TestStreamPreflightErrors:
         assert resp.status_code in (400, 422)
         if resp.headers.get("content-type", "").startswith("application/json"):
             body = resp.json()
-            assert "code" in body
+            assert "type" in body and "status" in body and "detail" in body
 
     def test_invalid_attachment_id_rejected(self, provider_chat):
         """04-04: Invalid attachment ID format should be rejected."""

--- a/testing/e2e/modules/mini_chat/test_turn_mutations.py
+++ b/testing/e2e/modules/mini_chat/test_turn_mutations.py
@@ -123,7 +123,7 @@ class TestTurnRetry:
             timeout=10,
         )
         assert retry_resp.status_code == 400
-        assert retry_resp.json().get("code") == "invalid_turn_state"
+        assert retry_resp.json().get("title") == "invalid_turn_state"
 
         t.join(timeout=60)
 
@@ -245,7 +245,7 @@ class TestTurnDelete:
             timeout=10,
         )
         assert del_resp.status_code == 400
-        assert del_resp.json().get("code") == "invalid_turn_state"
+        assert del_resp.json().get("title") == "invalid_turn_state"
 
         t.join(timeout=60)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standalone example server for the users‑info module.
  * Error responses can include an optional structured "context" payload.

* **Improvements**
  * Audit/background checks now run asynchronously with a global concurrency cap and timeouts.
  * Unified error mapping with consistent HTTP status/type, standardized reason codes, richer diagnostics, flattened validation details, and trace enrichment.

* **Breaking Changes**
  * Crate no longer re-exports the errors module.

* **Tests**
  * End-to-end tests updated to validate RFC 7807-style error fields (type/status/title/detail).

* **Chores**
  * Workspace member and dependency manifest updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->