### PR TITLE
feat(oagw): apply response header rules, validate header values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,6 +1783,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "inventory",
+ "mime",
  "pingora-core",
  "pingora-http",
  "pingora-load-balancing",

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -49,6 +49,7 @@ credstore-sdk = { workspace = true }
 dashmap = { workspace = true }
 psl = { workspace = true }
 thiserror = { workspace = true }
+mime = { workspace = true }
 # DP deps
 form_urlencoded = "1"
 pingora-memory-cache = "0.8"

--- a/modules/system/oagw/oagw/src/infra/proxy/headers.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/headers.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::domain::model::{PassthroughMode, RequestHeaderRules};
+use crate::domain::model::{PassthroughMode, RequestHeaderRules, ResponseHeaderRules};
 use http::{HeaderMap, HeaderName, HeaderValue};
 use oagw_sdk::api::ErrorSource;
 
@@ -122,16 +122,45 @@ pub fn sanitize_response_headers(headers: &mut HeaderMap) {
     strip_internal_headers(headers);
 }
 
-/// Apply set/add/remove header rules from upstream config.
-pub fn apply_header_rules(headers: &mut HeaderMap, rules: &RequestHeaderRules) {
+trait HeaderRules {
+    fn remove(&self) -> &[String];
+    fn set(&self) -> &HashMap<String, String>;
+    fn add(&self) -> &HashMap<String, String>;
+}
+
+impl HeaderRules for RequestHeaderRules {
+    fn remove(&self) -> &[String] {
+        &self.remove
+    }
+    fn set(&self) -> &HashMap<String, String> {
+        &self.set
+    }
+    fn add(&self) -> &HashMap<String, String> {
+        &self.add
+    }
+}
+
+impl HeaderRules for ResponseHeaderRules {
+    fn remove(&self) -> &[String] {
+        &self.remove
+    }
+    fn set(&self) -> &HashMap<String, String> {
+        &self.set
+    }
+    fn add(&self) -> &HashMap<String, String> {
+        &self.add
+    }
+}
+
+fn apply_rules(headers: &mut HeaderMap, rules: &impl HeaderRules) {
     // Remove first.
-    for name in &rules.remove {
+    for name in rules.remove() {
         if let Ok(n) = HeaderName::from_bytes(name.to_lowercase().as_bytes()) {
             headers.remove(n);
         }
     }
     // Set (overwrite).
-    for (name, value) in &rules.set {
+    for (name, value) in rules.set() {
         if let (Ok(n), Ok(v)) = (
             HeaderName::from_bytes(name.to_lowercase().as_bytes()),
             HeaderValue::from_str(value),
@@ -140,7 +169,7 @@ pub fn apply_header_rules(headers: &mut HeaderMap, rules: &RequestHeaderRules) {
         }
     }
     // Add (append).
-    for (name, value) in &rules.add {
+    for (name, value) in rules.add() {
         if let (Ok(n), Ok(v)) = (
             HeaderName::from_bytes(name.to_lowercase().as_bytes()),
             HeaderValue::from_str(value),
@@ -148,6 +177,16 @@ pub fn apply_header_rules(headers: &mut HeaderMap, rules: &RequestHeaderRules) {
             headers.append(n, v);
         }
     }
+}
+
+/// Apply set/add/remove header rules from upstream config to outbound request headers.
+pub fn apply_request_header_rules(headers: &mut HeaderMap, rules: &RequestHeaderRules) {
+    apply_rules(headers, rules);
+}
+
+/// Apply set/add/remove header rules to upstream response headers.
+pub fn apply_response_header_rules(headers: &mut HeaderMap, rules: &ResponseHeaderRules) {
+    apply_rules(headers, rules);
 }
 
 /// Set the Host header to match the upstream endpoint.
@@ -398,7 +437,7 @@ mod tests {
             passthrough_allowlist: vec![],
         };
 
-        apply_header_rules(&mut headers, &rules);
+        apply_request_header_rules(&mut headers, &rules);
         assert_eq!(headers.get("x-api-version").unwrap(), "v2");
     }
 
@@ -419,7 +458,7 @@ mod tests {
             passthrough_allowlist: vec![],
         };
 
-        apply_header_rules(&mut headers, &rules);
+        apply_request_header_rules(&mut headers, &rules);
         let values: Vec<&str> = headers
             .get_all("x-tag")
             .iter()
@@ -443,7 +482,7 @@ mod tests {
             passthrough_allowlist: vec![],
         };
 
-        apply_header_rules(&mut headers, &rules);
+        apply_request_header_rules(&mut headers, &rules);
         assert!(headers.get("x-remove-me").is_none());
         assert_eq!(headers.get("x-keep-me").unwrap(), "stay");
     }
@@ -556,5 +595,37 @@ mod tests {
         assert!(headers.get("x-oagw-debug").is_none());
         assert!(headers.get("x-oagw-trace-id").is_none());
         assert_eq!(headers.get("x-custom").unwrap(), "keep");
+    }
+
+    #[test]
+    fn response_header_rules_set_add_remove() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-remove-me", "gone".parse().unwrap());
+        headers.insert("x-overwrite", "old".parse().unwrap());
+        headers.insert("content-type", "application/json".parse().unwrap());
+
+        let rules = ResponseHeaderRules {
+            set: [("x-overwrite".into(), "new".into())].into_iter().collect(),
+            add: [("x-extra".into(), "added".into())].into_iter().collect(),
+            remove: vec!["x-remove-me".into()],
+        };
+
+        apply_response_header_rules(&mut headers, &rules);
+
+        assert!(headers.get("x-remove-me").is_none());
+        assert_eq!(headers.get("x-overwrite").unwrap(), "new");
+        assert_eq!(headers.get("x-extra").unwrap(), "added");
+        assert_eq!(headers.get("content-type").unwrap(), "application/json");
+    }
+
+    #[test]
+    fn response_header_rules_empty_is_noop() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-keep", "value".parse().unwrap());
+
+        let rules = ResponseHeaderRules::default();
+        apply_response_header_rules(&mut headers, &rules);
+
+        assert_eq!(headers.get("x-keep").unwrap(), "value");
     }
 }

--- a/modules/system/oagw/oagw/src/infra/proxy/headers.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/headers.rs
@@ -190,17 +190,37 @@ pub fn apply_response_header_rules(headers: &mut HeaderMap, rules: &ResponseHead
 }
 
 /// Returns `true` if the Content-Type header (when present) is a valid MIME type.
-/// Returns `false` if the value is not valid UTF-8 or cannot be parsed as a MIME type.
-/// Returns `true` if the header is absent (nothing to validate).
+/// Returns `false` if duplicates exist, the value is not valid UTF-8, or it
+/// cannot be parsed as a MIME type. Returns `true` if the header is absent.
 pub fn is_valid_content_type(headers: &HeaderMap) -> bool {
-    match headers.get(http::header::CONTENT_TYPE) {
-        None => true,
-        Some(ct) => ct
-            .to_str()
-            .ok()
-            .and_then(|v| v.parse::<mime::Mime>().ok())
-            .is_some(),
+    let mut iter = headers.get_all(http::header::CONTENT_TYPE).iter();
+    let Some(ct) = iter.next() else {
+        return true;
+    };
+    // Reject duplicate Content-Type headers.
+    if iter.next().is_some() {
+        return false;
     }
+    ct.to_str()
+        .ok()
+        .and_then(|v| v.parse::<mime::Mime>().ok())
+        .is_some()
+}
+
+/// Returns `true` if the Transfer-Encoding header is absent or exactly `chunked`.
+/// Returns `false` for duplicates or any encoding other than `chunked`.
+pub fn is_valid_transfer_encoding(headers: &HeaderMap) -> bool {
+    let mut iter = headers.get_all(http::header::TRANSFER_ENCODING).iter();
+    let Some(val) = iter.next() else {
+        return true;
+    };
+    // Reject duplicate Transfer-Encoding headers (HTTP smuggling vector).
+    if iter.next().is_some() {
+        return false;
+    }
+    val.to_str()
+        .ok()
+        .is_some_and(|v| v.trim().eq_ignore_ascii_case("chunked"))
 }
 
 /// Set the Host header to match the upstream endpoint.
@@ -668,5 +688,55 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "not a valid mime type!!!".parse().unwrap());
         assert!(!is_valid_content_type(&headers));
+    }
+
+    #[test]
+    fn transfer_encoding_absent_is_valid() {
+        let headers = HeaderMap::new();
+        assert!(is_valid_transfer_encoding(&headers));
+    }
+
+    #[test]
+    fn transfer_encoding_chunked_is_valid() {
+        let mut headers = HeaderMap::new();
+        headers.insert("transfer-encoding", "chunked".parse().unwrap());
+        assert!(is_valid_transfer_encoding(&headers));
+    }
+
+    #[test]
+    fn transfer_encoding_chunked_case_insensitive() {
+        let mut headers = HeaderMap::new();
+        headers.insert("transfer-encoding", "Chunked".parse().unwrap());
+        assert!(is_valid_transfer_encoding(&headers));
+    }
+
+    #[test]
+    fn transfer_encoding_gzip_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert("transfer-encoding", "gzip".parse().unwrap());
+        assert!(!is_valid_transfer_encoding(&headers));
+    }
+
+    #[test]
+    fn transfer_encoding_mixed_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert("transfer-encoding", "gzip, chunked".parse().unwrap());
+        assert!(!is_valid_transfer_encoding(&headers));
+    }
+
+    #[test]
+    fn duplicate_content_type_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.append("content-type", "application/json".parse().unwrap());
+        headers.append("content-type", "text/html".parse().unwrap());
+        assert!(!is_valid_content_type(&headers));
+    }
+
+    #[test]
+    fn duplicate_transfer_encoding_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.append("transfer-encoding", "chunked".parse().unwrap());
+        headers.append("transfer-encoding", "chunked".parse().unwrap());
+        assert!(!is_valid_transfer_encoding(&headers));
     }
 }

--- a/modules/system/oagw/oagw/src/infra/proxy/headers.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/headers.rs
@@ -189,6 +189,20 @@ pub fn apply_response_header_rules(headers: &mut HeaderMap, rules: &ResponseHead
     apply_rules(headers, rules);
 }
 
+/// Returns `true` if the Content-Type header (when present) is a valid MIME type.
+/// Returns `false` if the value is not valid UTF-8 or cannot be parsed as a MIME type.
+/// Returns `true` if the header is absent (nothing to validate).
+pub fn is_valid_content_type(headers: &HeaderMap) -> bool {
+    match headers.get(http::header::CONTENT_TYPE) {
+        None => true,
+        Some(ct) => ct
+            .to_str()
+            .ok()
+            .and_then(|v| v.parse::<mime::Mime>().ok())
+            .is_some(),
+    }
+}
+
 /// Set the Host header to match the upstream endpoint.
 pub fn set_host_header(headers: &mut HeaderMap, host: &str, port: u16) {
     let host_value = if port == 443 || port == 80 {
@@ -627,5 +641,32 @@ mod tests {
         apply_response_header_rules(&mut headers, &rules);
 
         assert_eq!(headers.get("x-keep").unwrap(), "value");
+    }
+
+    #[test]
+    fn valid_content_type_accepted() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+        assert!(is_valid_content_type(&headers));
+    }
+
+    #[test]
+    fn valid_content_type_with_charset_accepted() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "text/html; charset=utf-8".parse().unwrap());
+        assert!(is_valid_content_type(&headers));
+    }
+
+    #[test]
+    fn missing_content_type_accepted() {
+        let headers = HeaderMap::new();
+        assert!(is_valid_content_type(&headers));
+    }
+
+    #[test]
+    fn invalid_content_type_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "not a valid mime type!!!".parse().unwrap());
+        assert!(!is_valid_content_type(&headers));
     }
 }

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -336,6 +336,14 @@ impl DataPlaneService for DataPlaneServiceImpl {
             });
         }
 
+        // Validate Transfer-Encoding — only chunked is supported.
+        if !headers::is_valid_transfer_encoding(&req_headers) {
+            return Err(DomainError::Validation {
+                detail: "unsupported Transfer-Encoding; only chunked is accepted".into(),
+                instance: instance_uri,
+            });
+        }
+
         // Conditional body conversion — keep streams for streaming request bodies.
         let max_body = self.max_body_size;
         let (body_bytes, body_stream): (Bytes, Option<BodyStream>) = match body {

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -17,7 +17,9 @@ use tokio::sync::watch;
 
 use crate::config::TokenCacheConfig;
 use crate::domain::error::DomainError;
-use crate::domain::model::{PassthroughMode, PathSuffixMode, Scheme, Upstream};
+use crate::domain::model::{
+    PassthroughMode, PathSuffixMode, ResponseHeaderRules, Scheme, Upstream,
+};
 use crate::domain::plugin::{
     AuthContext, GuardContext, GuardDecision, TransformErrorContext, TransformRequestContext,
     TransformResponseContext,
@@ -165,6 +167,11 @@ impl DataPlaneServiceImpl {
                     }
                 }
             }
+        }
+
+        // Apply response header rules (set/add/remove) from upstream config.
+        if let Some(rules) = pipeline.response_header_rules {
+            headers::apply_response_header_rules(&mut resp_headers, rules);
         }
 
         build_proxy_response(status, resp_headers, resp_body_stream, instance_uri)
@@ -563,7 +570,7 @@ impl DataPlaneService for DataPlaneServiceImpl {
         if let Some(ref hc) = upstream.headers
             && let Some(ref rules) = hc.request
         {
-            headers::apply_header_rules(&mut outbound_headers, rules);
+            headers::apply_request_header_rules(&mut outbound_headers, rules);
         }
 
         // 5-transform. Execute transform plugins (on_request phase).
@@ -686,6 +693,11 @@ impl DataPlaneService for DataPlaneServiceImpl {
             outbound_headers.insert(H_RESOLVED_ADDR, v);
         }
 
+        let response_header_rules = upstream
+            .headers
+            .as_ref()
+            .and_then(|hc| hc.response.as_ref());
+
         let pipeline = ResponsePipelineCtx {
             guard_bindings,
             transform_bindings,
@@ -694,6 +706,7 @@ impl DataPlaneService for DataPlaneServiceImpl {
             ctx: &ctx,
             cors_config: effective_cors.as_ref(),
             origin: request_origin,
+            response_header_rules,
         };
 
         // 8. Bridge request into Pingora via in-memory DuplexStream.
@@ -1046,6 +1059,7 @@ struct ResponsePipelineCtx<'a> {
     ctx: &'a SecurityContext,
     cors_config: Option<&'a crate::domain::model::CorsConfig>,
     origin: Option<String>,
+    response_header_rules: Option<&'a ResponseHeaderRules>,
 }
 
 /// Execute `on_error` for all transform bindings, logging errors without aborting.

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -328,6 +328,14 @@ impl DataPlaneService for DataPlaneServiceImpl {
             });
         }
 
+        // Validate Content-Type format if present.
+        if !headers::is_valid_content_type(&req_headers) {
+            return Err(DomainError::Validation {
+                detail: "Content-Type header is not a recognized MIME type".into(),
+                instance: instance_uri,
+            });
+        }
+
         // Conditional body conversion — keep streams for streaming request bodies.
         let max_body = self.max_body_size;
         let (body_bytes, body_stream): (Bytes, Option<BodyStream>) = match body {

--- a/modules/system/oagw/oagw/tests/proxy_integration.rs
+++ b/modules/system/oagw/oagw/tests/proxy_integration.rs
@@ -11,7 +11,8 @@ use oagw_sdk::{
     BurstConfig, CorsConfig, CorsHttpMethod, CreateRouteRequest, CreateUpstreamRequest, Endpoint,
     HeadersConfig, HttpMatch, HttpMethod, MatchRules, PassthroughMode, PathSuffixMode,
     PluginBinding, PluginsConfig, RateLimitAlgorithm, RateLimitConfig, RateLimitScope,
-    RateLimitStrategy, RequestHeaderRules, Scheme, Server, SharingMode, SustainedRate, Window,
+    RateLimitStrategy, RequestHeaderRules, ResponseHeaderRules, Scheme, Server, SharingMode,
+    SustainedRate, Window,
 };
 use serde_json::json;
 
@@ -3503,5 +3504,88 @@ async fn cors_multiple_specific_origins() {
             .get("access-control-allow-origin")
             .is_none(),
         "non-matching origin should not get CORS headers"
+    );
+}
+
+// Response header rules: set/add/remove operations applied to upstream response.
+#[tokio::test]
+async fn proxy_response_header_rules_applied() {
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("resp-rules-test")
+            .headers(HeadersConfig {
+                request: None,
+                response: Some(ResponseHeaderRules {
+                    set: [("x-custom-safe".into(), "overwritten".into())]
+                        .into_iter()
+                        .collect(),
+                    add: [("x-injected".into(), "added-value".into())]
+                        .into_iter()
+                        .collect(),
+                    remove: vec!["x-remove-target".into()],
+                }),
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get],
+                        path: "/response-headers".into(),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Append,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/resp-rules-test/response-headers")
+        .body(Body::Empty)
+        .unwrap();
+    let response = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let headers = response.headers();
+
+    // "set" overwrites existing header from upstream mock.
+    assert_eq!(
+        headers.get("x-custom-safe").unwrap(),
+        "overwritten",
+        "response set rule should overwrite upstream header"
+    );
+
+    // "add" injects a new header.
+    assert_eq!(
+        headers.get("x-injected").unwrap(),
+        "added-value",
+        "response add rule should inject header"
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support declarative response header manipulation (set, add, remove) for proxied responses
  * Request validation now enforces Content-Type and Transfer-Encoding rules

* **Tests**
  * Integration tests verifying response header manipulation
  * Integration tests covering Content-Type and Transfer-Encoding validation scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->