### PR TITLE
fix: fix test_reject_duplicate_keys_in_module_file test on windows

### DIFF
--- a/libs/modkit/src/bootstrap/config/mod.rs
+++ b/libs/modkit/src/bootstrap/config/mod.rs
@@ -17,6 +17,11 @@ use crate::ConfigProvider;
 use crate::telemetry::OpenTelemetryConfig;
 use url::Url;
 
+/// Normalize a path to use forward slashes (for cross-platform YAML/DSN compatibility).
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
 /// Error type for vendor configuration access.
 #[derive(thiserror::Error, Debug)]
 pub enum VendorConfigError {
@@ -563,7 +568,7 @@ fn resolve_sqlite_dsn(
                 module_dir.join(file_path)
             };
 
-            let normalized_path = resolved_path.to_string_lossy().replace('\\', "/");
+            let normalized_path = normalize_path(&resolved_path);
             // For Windows absolute paths (C:/...), use sqlite:path format
             // For Unix absolute paths (/...), use sqlite://path format
             if normalized_path.len() > 1 && normalized_path.chars().nth(1) == Some(':') {
@@ -590,7 +595,7 @@ fn resolve_sqlite_dsn(
             })?;
         }
         let db_path = module_dir.join(format!("{module_name}.sqlite"));
-        let normalized_path = db_path.to_string_lossy().replace('\\', "/");
+        let normalized_path = normalize_path(&db_path);
         // For Windows absolute paths (C:/...), use sqlite:path format
         // For Unix absolute paths (/...), use sqlite://path format
         if normalized_path.len() > 1 && normalized_path.chars().nth(1) == Some(':') {
@@ -691,7 +696,7 @@ fn build_sqlite_dsn_with_dbname_override(
         })?;
     }
     let db_path = module_dir.join(dbname);
-    let normalized_path = db_path.to_string_lossy().replace('\\', "/");
+    let normalized_path = normalize_path(&db_path);
 
     // Build the new DSN with correct format for the platform
     let dsn_base = if normalized_path.len() > 1 && normalized_path.chars().nth(1) == Some(':') {
@@ -745,7 +750,7 @@ fn build_sqlite_dsn(
         } else {
             home_dir.join(path)
         };
-        let normalized_path = absolute_path.to_string_lossy().replace('\\', "/");
+        let normalized_path = normalize_path(&absolute_path);
         // For Windows absolute paths (C:/...), use sqlite:path format
         // For Unix absolute paths (/...), use sqlite://path format
         if normalized_path.len() > 1 && normalized_path.chars().nth(1) == Some(':') {
@@ -768,7 +773,7 @@ fn build_sqlite_dsn(
             })?;
         }
         let db_path = module_dir.join(file);
-        let normalized_path = db_path.to_string_lossy().replace('\\', "/");
+        let normalized_path = normalize_path(&db_path);
         // For Windows absolute paths (C:/...), use sqlite:path format
         // For Unix absolute paths (/...), use sqlite://path format
         if normalized_path.len() > 1 && normalized_path.chars().nth(1) == Some(':') {
@@ -790,7 +795,7 @@ fn build_sqlite_dsn(
         })?;
     }
     let db_path = module_dir.join(format!("{module_name}.sqlite"));
-    let normalized_path = db_path.to_string_lossy().replace('\\', "/");
+    let normalized_path = normalize_path(&db_path);
     // For Windows absolute paths (C:/...), use sqlite:path format
     // For Unix absolute paths (/...), use sqlite://path format
     if normalized_path.len() > 1 && normalized_path.chars().nth(1) == Some(':') {
@@ -1491,7 +1496,7 @@ setting2: 42
         .unwrap();
 
         // Convert Windows paths to forward slashes for YAML compatibility
-        let modules_dir_str = modules_dir.to_string_lossy().replace('\\', "/");
+        let modules_dir_str = normalize_path(&modules_dir);
         let yaml = format!(
             r#"
 server:
@@ -3081,7 +3086,7 @@ server:
   home_dir: "~/.test_dup_modfile"
 modules_dir: "{}"
 "#,
-            modules_dir.display()
+            normalize_path(&modules_dir)
         );
         let cfg_path = tmp.path().join("cfg.yaml");
         fs::write(&cfg_path, cfg_yaml).unwrap();


### PR DESCRIPTION
error 
```
---- bootstrap::config::tests::test_reject_duplicate_keys_in_module_file stdout ----

thread 'bootstrap::config::tests::test_reject_duplicate_keys_in_module_file' (18704) panicked at libs\modkit\src\bootstrap\config\mod.rs:3095:9:
error should mention duplicates: Failed to extract config from figment

Caused by:
    error: line 4 column 14: while parsing a quoted scalar, found unknown escape character at line 4, column 14
     --> <input>:4:14
      |
    2 | server:
    3 |   home_dir: "~/.test_dup_modfile"
    4 | modules_dir: "C:\Temp\.tmpJQPJd8\modules.d"
      |              ^ while parsing a quoted scalar, found unknown escape character at line 4, column 14 in C:\Temp\.tmpJQPJd8\cfg.yaml YAML file
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent normalization of file paths so database connection strings and YAML configs use forward slashes across platforms.
  * Resolved Windows-specific path handling issues that previously caused incorrect DSN or module config parsing, improving cross-platform reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->