### PR TITLE
feat(oagw): validate content-type header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,6 +1783,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "inventory",
+ "mime",
  "pingora-core",
  "pingora-http",
  "pingora-load-balancing",

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -49,6 +49,7 @@ credstore-sdk = { workspace = true }
 dashmap = { workspace = true }
 psl = { workspace = true }
 thiserror = { workspace = true }
+mime = { workspace = true }
 # DP deps
 form_urlencoded = "1"
 pingora-memory-cache = "0.8"

--- a/modules/system/oagw/oagw/src/infra/proxy/headers.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/headers.rs
@@ -150,6 +150,20 @@ pub fn apply_header_rules(headers: &mut HeaderMap, rules: &RequestHeaderRules) {
     }
 }
 
+/// Returns `true` if the Content-Type header (when present) is a valid MIME type.
+/// Returns `false` if the value is not valid UTF-8 or cannot be parsed as a MIME type.
+/// Returns `true` if the header is absent (nothing to validate).
+pub fn is_valid_content_type(headers: &HeaderMap) -> bool {
+    match headers.get(http::header::CONTENT_TYPE) {
+        None => true,
+        Some(ct) => ct
+            .to_str()
+            .ok()
+            .and_then(|v| v.parse::<mime::Mime>().ok())
+            .is_some(),
+    }
+}
+
 /// Set the Host header to match the upstream endpoint.
 pub fn set_host_header(headers: &mut HeaderMap, host: &str, port: u16) {
     let host_value = if port == 443 || port == 80 {
@@ -556,5 +570,32 @@ mod tests {
         assert!(headers.get("x-oagw-debug").is_none());
         assert!(headers.get("x-oagw-trace-id").is_none());
         assert_eq!(headers.get("x-custom").unwrap(), "keep");
+    }
+
+    #[test]
+    fn valid_content_type_accepted() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+        assert!(is_valid_content_type(&headers));
+    }
+
+    #[test]
+    fn valid_content_type_with_charset_accepted() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "text/html; charset=utf-8".parse().unwrap());
+        assert!(is_valid_content_type(&headers));
+    }
+
+    #[test]
+    fn missing_content_type_accepted() {
+        let headers = HeaderMap::new();
+        assert!(is_valid_content_type(&headers));
+    }
+
+    #[test]
+    fn invalid_content_type_rejected() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "not a valid mime type!!!".parse().unwrap());
+        assert!(!is_valid_content_type(&headers));
     }
 }

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -321,6 +321,14 @@ impl DataPlaneService for DataPlaneServiceImpl {
             });
         }
 
+        // Validate Content-Type format if present.
+        if !headers::is_valid_content_type(&req_headers) {
+            return Err(DomainError::Validation {
+                detail: "Content-Type header is not a recognized MIME type".into(),
+                instance: instance_uri,
+            });
+        }
+
         // Conditional body conversion — keep streams for streaming request bodies.
         let max_body = self.max_body_size;
         let (body_bytes, body_stream): (Bytes, Option<BodyStream>) = match body {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Implemented stricter Content-Type header validation in the API gateway to reject requests with invalid or unrecognized MIME types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->