### PR TITLE
fix(oagw): close Pingora read pipe on streaming body limit breach

### DIFF
--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -779,6 +779,9 @@ impl DataPlaneService for DataPlaneServiceImpl {
                     }
                 }
                 if exceeded {
+                    // Shutdown sends EOF to Pingora's read side before we
+                    // signal the limit breach (drop alone won't close the pipe).
+                    let _ = client_write.shutdown().await;
                     let _ = limit_tx.send(total_bytes);
                 } else {
                     // Chunked terminator: signals end-of-body to Pingora.
@@ -797,11 +800,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
 
             // 9. Parse response from the read half, but short-circuit to 413
             //    if the body-forwarding task signals a limit breach.
-            //
-            // TODO(hardening): a fast upstream can respond before the body-forwarder
-            // detects the limit breach, causing the client to see 200 instead of 413.
-            // Fix: wrap the write half in a LimitedAsyncWrite that returns io::Error
-            // at the byte limit, so Pingora aborts the exchange before responding.
             let resp_future =
                 tokio::time::timeout(timeout, session_bridge::parse_response_stream(client_read));
             tokio::select! {

--- a/modules/system/oagw/oagw/tests/proxy_integration.rs
+++ b/modules/system/oagw/oagw/tests/proxy_integration.rs
@@ -1609,11 +1609,8 @@ async fn proxy_unreachable_backend_returns_rfc9457_problem_body() {
 // negative-8.1 (body-validation): Streaming body exceeding max_body_size returns 413 PayloadTooLarge.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn proxy_streaming_body_exceeding_limit_returns_413() {
-    // Gate the upstream response so it cannot reply before the body-forwarding
-    // task detects the limit breach — eliminates the race between the upstream
-    // response and the PayloadTooLarge signal.
     let mut guard = MockGuard::new();
-    let _gate = guard.mock_gated(
+    guard.mock(
         "POST",
         "/v1/upload",
         MockResponse {


### PR DESCRIPTION
Fixes: https://github.com/cyberfabric/cyberfabric-core/issues/881

Await shutdown() on the DuplexStream write half so Pingora's read side sees EOF before the biased select! observes the 413 limit signal, preventing a race where a fast upstream could return 200 instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling of streaming uploads that exceed size limits: the server now ensures EOF is delivered to the forwarded connection before returning a 413 Payload Too Large, preventing races and ensuring consistent error responses.

* **Tests**
  * Updated integration test behavior to reflect the new timing/handshake for oversized streaming uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->