### PR TITLE
fix(minichat): Add thumbnail generation in attachment API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1312,7 @@ dependencies = [
  "futures",
  "heck 0.5.0",
  "http",
+ "image 0.25.10",
  "inventory",
  "k8s-openapi",
  "kube",
@@ -2763,7 +2770,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2907,7 +2914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3331,6 +3338,16 @@ name = "gif"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
 dependencies = [
  "color_quant",
  "weezl",
@@ -4003,12 +4020,40 @@ dependencies = [
  "byteorder",
  "color_quant",
  "exr",
- "gif",
+ "gif 0.13.3",
  "jpeg-decoder",
  "num-traits",
- "png",
+ "png 0.17.16",
  "qoi",
  "tiff",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif 0.14.1",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -4094,7 +4139,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4621,6 +4666,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4780,7 +4835,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5764,6 +5819,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "pom"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5824,7 +5892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f7bef20173da9d560ffb6b67cba2d2b834375d0d262e5aeb86f44e069ae446"
 dependencies = [
  "base64 0.22.1",
- "image",
+ "image 0.24.9",
  "rayon",
  "roxmltree",
  "thiserror 2.0.18",
@@ -5956,7 +6024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6033,6 +6101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6055,6 +6129,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -6514,7 +6594,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7698,7 +7778,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8942,7 +9022,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9687,10 +9767,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
 name = "zune-inflate"
 version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -452,6 +452,9 @@ nvml-wrapper = "0.11"
 # Public Suffix List
 psl = "2"
 
+# Image processing (thumbnail generation)
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
+
 # Text processing
 base64 = "0.22"
 postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -56,6 +56,9 @@ multer = "3.1"
 # Encoding
 base64 = { workspace = true }
 
+# Image processing (thumbnail generation)
+image = { workspace = true }
+
 # Serde and JSON
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -49,6 +49,9 @@ pub struct MiniChatConfig {
     /// Cleanup background worker for soft-deleted chat resources.
     #[serde(default)]
     pub cleanup_worker: CleanupWorkerConfig,
+    /// Image thumbnail generation settings.
+    #[serde(default)]
+    pub thumbnail: ThumbnailConfig,
 }
 
 /// Which file/vector-store implementation to use for RAG operations.
@@ -400,6 +403,7 @@ impl Default for MiniChatConfig {
             orphan_watchdog: OrphanWatchdogConfig::default(),
             thread_summary_worker: ThreadSummaryWorkerConfig::default(),
             cleanup_worker: CleanupWorkerConfig::default(),
+            thumbnail: ThumbnailConfig::default(),
         }
     }
 }
@@ -797,6 +801,78 @@ impl RagConfig {
     }
 }
 
+// ── Thumbnail config ────────────────────────────────────────────────────
+
+fn default_thumbnail_width() -> u32 {
+    128
+}
+fn default_thumbnail_height() -> u32 {
+    128
+}
+fn default_thumbnail_max_bytes() -> usize {
+    131_072 // 128 KiB
+}
+fn default_thumbnail_max_pixels() -> u64 {
+    100_000_000
+}
+fn default_thumbnail_max_decode_bytes() -> usize {
+    33_554_432 // 32 MiB
+}
+
+/// Configuration for server-generated image thumbnails (DESIGN.md §B.6).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ThumbnailConfig {
+    /// Target thumbnail width in pixels.
+    #[serde(default = "default_thumbnail_width")]
+    pub width: u32,
+    /// Target thumbnail height in pixels.
+    #[serde(default = "default_thumbnail_height")]
+    pub height: u32,
+    /// Maximum decoded thumbnail size in bytes (128 KiB).
+    #[serde(default = "default_thumbnail_max_bytes")]
+    pub max_bytes: usize,
+    /// Maximum source image pixel count before skipping thumbnail generation.
+    #[serde(default = "default_thumbnail_max_pixels")]
+    pub max_pixels: u64,
+    /// Maximum bytes the image decoder may allocate before aborting.
+    #[serde(default = "default_thumbnail_max_decode_bytes")]
+    pub max_decode_bytes: usize,
+}
+
+impl Default for ThumbnailConfig {
+    fn default() -> Self {
+        Self {
+            width: default_thumbnail_width(),
+            height: default_thumbnail_height(),
+            max_bytes: default_thumbnail_max_bytes(),
+            max_pixels: default_thumbnail_max_pixels(),
+            max_decode_bytes: default_thumbnail_max_decode_bytes(),
+        }
+    }
+}
+
+impl ThumbnailConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.width == 0 {
+            return Err("thumbnail width must be > 0".into());
+        }
+        if self.height == 0 {
+            return Err("thumbnail height must be > 0".into());
+        }
+        if self.max_bytes == 0 {
+            return Err("thumbnail max_bytes must be > 0".into());
+        }
+        if self.max_pixels == 0 {
+            return Err("thumbnail max_pixels must be > 0".into());
+        }
+        if self.max_decode_bytes == 0 {
+            return Err("thumbnail max_decode_bytes must be > 0".into());
+        }
+        Ok(())
+    }
+}
+
 fn default_url_prefix() -> String {
     DEFAULT_URL_PREFIX.to_owned()
 }
@@ -817,6 +893,7 @@ mod tests {
         OutboxConfig::default().validate().unwrap();
         ContextConfig::default().validate().unwrap();
         RagConfig::default().validate().unwrap();
+        ThumbnailConfig::default().validate().unwrap();
     }
 
     #[test]

--- a/modules/mini-chat/mini-chat/src/domain/repos/attachment_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/attachment_repo.rs
@@ -41,6 +41,11 @@ pub struct SetUploadedParams {
 #[domain_model]
 pub struct SetReadyParams {
     pub id: Uuid,
+    /// Server-generated thumbnail bytes (WebP). `None` for documents or
+    /// when thumbnail generation failed/was skipped.
+    pub img_thumbnail: Option<Vec<u8>>,
+    pub img_thumbnail_width: Option<i32>,
+    pub img_thumbnail_height: Option<i32>,
 }
 
 /// Parameters for CAS transition `pending|uploaded → failed`.

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
@@ -6,7 +6,7 @@ use modkit_macros::domain_model;
 use modkit_security::{AccessScope, SecurityContext};
 use uuid::Uuid;
 
-use crate::config::RagConfig;
+use crate::config::{RagConfig, ThumbnailConfig};
 use crate::domain::error::DomainError;
 use crate::domain::mime_validation::{AttachmentKind, AttachmentPurpose};
 use crate::domain::ports::MiniChatMetricsPort;
@@ -154,6 +154,7 @@ pub struct AttachmentService<
     provider_resolver: Arc<ProviderResolver>,
     model_resolver: Arc<dyn ModelResolver>,
     rag_config: RagConfig,
+    thumbnail_config: ThumbnailConfig,
     metrics: Arc<dyn MiniChatMetricsPort>,
 }
 
@@ -176,6 +177,7 @@ impl<
         provider_resolver: Arc<ProviderResolver>,
         model_resolver: Arc<dyn ModelResolver>,
         rag_config: RagConfig,
+        thumbnail_config: ThumbnailConfig,
         metrics: Arc<dyn MiniChatMetricsPort>,
     ) -> Self {
         Self {
@@ -190,6 +192,7 @@ impl<
             provider_resolver,
             model_resolver,
             rag_config,
+            thumbnail_config,
             metrics,
         }
     }
@@ -857,8 +860,43 @@ impl<
         };
         let pending_guard = PendingGuard::new(&self.metrics);
 
-        // 3. Upload stream to provider (outside TX — avoids holding pool)
+        // 3. Upload stream to provider (outside TX — avoids holding pool).
+        //    For images, buffer the raw bytes while streaming so we can
+        //    generate a thumbnail after the upload completes.
         let structured_name = structured_filename(chat_id, attachment_id, validated_mime);
+
+        // Arc<Mutex> is required because the stream closure must be Send + 'static;
+        // in practice the stream is consumed sequentially so contention never occurs.
+        let image_buffer: std::sync::Arc<std::sync::Mutex<Option<Vec<u8>>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(if is_document {
+                None
+            } else {
+                Some(Vec::new())
+            }));
+
+        let upload_stream: crate::domain::ports::FileStream = if is_document {
+            file_stream
+        } else {
+            let buf = std::sync::Arc::clone(&image_buffer);
+            let max_buf = self.thumbnail_config.max_decode_bytes;
+            Box::pin(futures::stream::StreamExt::map(file_stream, move |chunk| {
+                if let Ok(ref bytes) = chunk {
+                    let mut guard = buf
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    if let Some(ref mut v) = *guard {
+                        // Stop buffering if we exceed decode limit — thumbnail
+                        // generation will be skipped, but upload continues.
+                        if v.len() + bytes.len() <= max_buf {
+                            v.extend_from_slice(bytes);
+                        } else {
+                            *guard = None;
+                        }
+                    }
+                }
+                chunk
+            }))
+        };
 
         let (provider_file_id, bytes_uploaded) = match self
             .file_storage
@@ -868,7 +906,7 @@ impl<
                 UploadFileParams {
                     filename: structured_name,
                     content_type: validated_mime.to_owned(),
-                    file_stream,
+                    file_stream: upload_stream,
                     purpose: "assistants".to_owned(),
                 },
             )
@@ -929,7 +967,7 @@ impl<
         // 5. Execute purpose-specific paths (each fires independently).
         // - FileSearch + document → vector store indexing
         // - CodeInterpreter → (no extra step during upload; file is used at stream time)
-        // - Images → (no extra step; sent inline)
+        // - Images → generate thumbnail (best-effort, sync)
         // When an attachment has multiple purposes, all matching paths execute.
         if is_document && purposes.contains(&AttachmentPurpose::FileSearch) {
             // Get or create vector store
@@ -977,13 +1015,59 @@ impl<
             }
         }
 
-        // 6. CAS: uploaded → ready
+        // 5b. Image thumbnail generation (best-effort, offloaded to blocking thread).
+        // Thumbnail failure never blocks the upload — the attachment transitions
+        // to `ready` with `img_thumbnail = null`.
+        let thumbnail = if is_document {
+            None
+        } else {
+            let raw_bytes = image_buffer
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .take();
+            match raw_bytes {
+                Some(raw) => {
+                    let cfg = self.thumbnail_config.clone();
+                    match tokio::task::spawn_blocking(move || {
+                        super::thumbnail::generate(&cfg, &raw)
+                    })
+                    .await
+                    {
+                        Ok(thumb) => thumb,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "thumbnail spawn_blocking failed");
+                            None
+                        }
+                    }
+                }
+                None => None,
+            }
+        };
+
+        // 6. CAS: uploaded → ready (with thumbnail if available)
         {
             use crate::domain::repos::SetReadyParams;
+            let (thumb_bytes, thumb_w, thumb_h) = match thumbnail {
+                Some(t) => (
+                    Some(t.bytes),
+                    i32::try_from(t.width).ok(),
+                    i32::try_from(t.height).ok(),
+                ),
+                None => (None, None, None),
+            };
             let conn = self.db.conn().map_err(DomainError::from)?;
             let affected = self
                 .attachment_repo
-                .cas_set_ready(&conn, &scope, SetReadyParams { id: attachment_id })
+                .cas_set_ready(
+                    &conn,
+                    &scope,
+                    SetReadyParams {
+                        id: attachment_id,
+                        img_thumbnail: thumb_bytes,
+                        img_thumbnail_width: thumb_w,
+                        img_thumbnail_height: thumb_h,
+                    },
+                )
                 .await?;
             if affected == 0 {
                 // P1-14: Concurrent soft-delete — best-effort cleanup

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service_test.rs
@@ -97,6 +97,7 @@ fn build_service(
         provider_resolver,
         mock_model_resolver(),
         rag_config,
+        crate::config::ThumbnailConfig::default(),
         Arc::new(crate::domain::ports::metrics::NoopMetrics),
     )
 }
@@ -144,6 +145,7 @@ fn build_service_with_metrics(
         provider_resolver,
         mock_model_resolver(),
         rag_config,
+        crate::config::ThumbnailConfig::default(),
         metrics,
     )
 }
@@ -2070,6 +2072,7 @@ fn build_service_azure(
         provider_resolver,
         azure_model_resolver(),
         rag_config,
+        crate::config::ThumbnailConfig::default(),
         Arc::new(crate::domain::ports::metrics::NoopMetrics),
     )
 }
@@ -2668,6 +2671,7 @@ async fn test_upload_limits_ccm_tighter_than_configmap() {
             provider_resolver,
             model_resolver,
             rag_config,
+            crate::config::ThumbnailConfig::default(),
             Arc::new(crate::domain::ports::metrics::NoopMetrics),
         );
 

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -8,7 +8,9 @@ use authz_resolver_sdk::{AuthZResolverClient, PolicyEnforcer};
 use modkit_db::DBProvider;
 use modkit_macros::domain_model;
 
-use crate::config::{ContextConfig, EstimationBudgets, QuotaConfig, RagConfig, StreamingConfig};
+use crate::config::{
+    ContextConfig, EstimationBudgets, QuotaConfig, RagConfig, StreamingConfig, ThumbnailConfig,
+};
 use crate::domain::ports::MiniChatMetricsPort;
 use crate::domain::repos::{
     AttachmentRepository, ChatRepository, MessageAttachmentRepository, MessageRepository,
@@ -33,6 +35,7 @@ pub(crate) mod replay;
 mod stream_service;
 #[cfg(test)]
 pub(crate) mod test_helpers;
+pub(crate) mod thumbnail;
 pub(crate) mod token_estimator;
 mod turn_service;
 
@@ -198,6 +201,7 @@ impl<
         file_storage: Arc<dyn crate::domain::ports::FileStorageProvider>,
         vector_store_provider: Arc<dyn crate::domain::ports::VectorStoreProvider>,
         rag_config: RagConfig,
+        thumbnail_config: ThumbnailConfig,
         metrics: Arc<dyn MiniChatMetricsPort>,
     ) -> Self {
         let enforcer = PolicyEnforcer::new(authz);
@@ -286,6 +290,7 @@ impl<
                 Arc::clone(provider_resolver),
                 Arc::clone(model_resolver),
                 rag_config,
+                thumbnail_config,
                 Arc::clone(&metrics),
             ),
             models: ModelService::new(

--- a/modules/mini-chat/mini-chat/src/domain/service/thumbnail.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/thumbnail.rs
@@ -1,0 +1,232 @@
+use image::{ImageDecoder as _, ImageReader};
+use modkit_macros::domain_model;
+use std::io::Cursor;
+
+use crate::config::ThumbnailConfig;
+
+/// Generated thumbnail data ready to be persisted.
+#[domain_model]
+pub struct Thumbnail {
+    /// WebP-encoded thumbnail bytes.
+    pub bytes: Vec<u8>,
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
+}
+
+/// Best-effort thumbnail generation from raw image bytes.
+///
+/// Returns `None` (rather than an error) when:
+/// - the source image exceeds the configured pixel/decode-byte limits,
+/// - the image cannot be decoded (unsupported sub-format, corrupt data),
+/// - the produced WebP exceeds `max_bytes`.
+///
+/// This matches DESIGN.md: *"Thumbnail failure does not set `error_code`
+/// on the attachment; the attachment transitions to `ready` with
+/// `img_thumbnail = null`."*
+#[allow(clippy::cognitive_complexity)]
+pub fn generate(cfg: &ThumbnailConfig, raw: &[u8]) -> Option<Thumbnail> {
+    // Pre-screen: reject obviously oversized payloads before decoding.
+    if raw.len() > cfg.max_decode_bytes {
+        tracing::debug!(
+            raw_len = raw.len(),
+            max = cfg.max_decode_bytes,
+            "thumbnail skipped: source exceeds max_decode_bytes"
+        );
+        return None;
+    }
+
+    let reader = ImageReader::new(Cursor::new(raw))
+        .with_guessed_format()
+        .ok()?;
+
+    // Check pixel dimensions before full decode (cheap metadata read).
+    let (w, h) = match reader.into_dimensions() {
+        Ok(dims) => dims,
+        Err(e) => {
+            tracing::debug!(error = %e, "thumbnail skipped: cannot read dimensions");
+            return None;
+        }
+    };
+    if u64::from(w) * u64::from(h) > cfg.max_pixels {
+        tracing::debug!(
+            pixels = u64::from(w) * u64::from(h),
+            max = cfg.max_pixels,
+            "thumbnail skipped: source exceeds max_pixels"
+        );
+        return None;
+    }
+
+    // Deterministic pre-decode guard: reject images whose worst-case decoded
+    // size (RGBA = 4 bytes per pixel) would exceed the memory budget. This
+    // avoids relying solely on image::Limits::max_alloc inside the decoder.
+    let decoded_estimate = u64::from(w) * u64::from(h) * 4;
+    if decoded_estimate > cfg.max_decode_bytes as u64 {
+        tracing::debug!(
+            decoded_estimate,
+            max = cfg.max_decode_bytes,
+            "thumbnail skipped: estimated decoded size exceeds max_decode_bytes"
+        );
+        return None;
+    }
+
+    // Re-create reader and apply memory limit for the full decode.
+    let reader = ImageReader::new(Cursor::new(raw))
+        .with_guessed_format()
+        .ok()?;
+    let mut reader = reader;
+    let mut limits = image::Limits::default();
+    limits.max_alloc = Some(cfg.max_decode_bytes as u64);
+    reader.limits(limits);
+
+    let mut decoder = match reader.into_decoder() {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::debug!(error = %e, "thumbnail skipped: decoder creation failed");
+            return None;
+        }
+    };
+
+    // Read EXIF orientation before decoding pixels (best-effort; default to
+    // no-op orientation on unsupported formats).
+    let orientation = decoder
+        .orientation()
+        .unwrap_or(image::metadata::Orientation::NoTransforms);
+
+    let mut img: image::DynamicImage = match image::DynamicImage::from_decoder(decoder) {
+        Ok(img) => img,
+        Err(e) => {
+            tracing::debug!(error = %e, "thumbnail skipped: decode failed");
+            return None;
+        }
+    };
+
+    // Apply EXIF orientation so the thumbnail matches what the user sees.
+    img.apply_orientation(orientation);
+
+    // Resize to fit inside target dimensions, preserving aspect ratio.
+    let resized = img.thumbnail(cfg.width, cfg.height);
+
+    let tw = resized.width();
+    let th = resized.height();
+
+    // Encode as WebP.
+    let mut buf = Cursor::new(Vec::new());
+    if let Err(e) = resized.write_to(&mut buf, image::ImageFormat::WebP) {
+        tracing::debug!(error = %e, "thumbnail skipped: WebP encode failed");
+        return None;
+    }
+    let webp_bytes = buf.into_inner();
+
+    // Enforce size limit on the encoded output.
+    if webp_bytes.len() > cfg.max_bytes {
+        tracing::debug!(
+            encoded_len = webp_bytes.len(),
+            max = cfg.max_bytes,
+            "thumbnail skipped: encoded size exceeds max_bytes"
+        );
+        return None;
+    }
+
+    Some(Thumbnail {
+        bytes: webp_bytes,
+        width: tw,
+        height: th,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> ThumbnailConfig {
+        ThumbnailConfig::default()
+    }
+
+    #[test]
+    fn generates_thumbnail_from_valid_png() {
+        // Create a minimal 2x2 red PNG in memory.
+        let mut buf = Cursor::new(Vec::new());
+        let img = image::RgbImage::from_pixel(2, 2, image::Rgb([255, 0, 0]));
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut buf, image::ImageFormat::Png)
+            .unwrap();
+
+        let result = generate(&test_config(), buf.get_ref());
+        assert!(result.is_some());
+        let thumb = result.unwrap();
+        assert!(thumb.width <= 128);
+        assert!(thumb.height <= 128);
+        assert!(!thumb.bytes.is_empty());
+
+        // Verify output is valid WebP (RIFF....WEBP header).
+        assert!(thumb.bytes.len() >= 12, "WebP output too short");
+        assert_eq!(&thumb.bytes[0..4], b"RIFF", "missing RIFF header");
+        assert_eq!(&thumb.bytes[8..12], b"WEBP", "missing WEBP signature");
+    }
+
+    #[test]
+    fn returns_none_for_corrupt_data() {
+        let result = generate(&test_config(), b"not an image");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn returns_none_when_source_exceeds_decode_limit() {
+        let mut cfg = test_config();
+        cfg.max_decode_bytes = 10; // absurdly small
+        let mut buf = Cursor::new(Vec::new());
+        let img = image::RgbImage::from_pixel(2, 2, image::Rgb([0, 0, 0]));
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut buf, image::ImageFormat::Png)
+            .unwrap();
+
+        let result = generate(&cfg, buf.get_ref());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn respects_max_pixels_limit() {
+        let mut cfg = test_config();
+        cfg.max_pixels = 1; // only 1 pixel allowed
+        let mut buf = Cursor::new(Vec::new());
+        let img = image::RgbImage::from_pixel(2, 2, image::Rgb([0, 0, 0]));
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut buf, image::ImageFormat::Png)
+            .unwrap();
+
+        let result = generate(&cfg, buf.get_ref());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn returns_none_when_encoded_output_exceeds_max_bytes() {
+        let mut cfg = test_config();
+        cfg.max_bytes = 1; // impossibly small — any valid WebP will exceed this
+        let mut buf = Cursor::new(Vec::new());
+        let img = image::RgbImage::from_pixel(2, 2, image::Rgb([0, 0, 0]));
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut buf, image::ImageFormat::Png)
+            .unwrap();
+
+        let result = generate(&cfg, buf.get_ref());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn resizes_large_image() {
+        let mut buf = Cursor::new(Vec::new());
+        let img = image::RgbImage::from_pixel(1000, 500, image::Rgb([0, 128, 255]));
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut buf, image::ImageFormat::Png)
+            .unwrap();
+
+        let result = generate(&test_config(), buf.get_ref());
+        assert!(result.is_some());
+        let thumb = result.unwrap();
+        // 1000x500 → fit inside 128x128 → 128x64
+        assert_eq!(thumb.width, 128);
+        assert_eq!(thumb.height, 64);
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/attachment_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/attachment_repo.rs
@@ -112,15 +112,25 @@ impl crate::domain::repos::AttachmentRepository for AttachmentRepository {
         params: SetReadyParams,
     ) -> Result<u64, DomainError> {
         let now = OffsetDateTime::now_utc();
-        let result = Entity::update_many()
+        let mut query = Entity::update_many()
             .col_expr(Column::Status, Expr::value(AttachmentStatus::Ready))
             .col_expr(Column::UpdatedAt, Expr::value(now))
-            .filter(
-                Condition::all()
-                    .add(Column::Id.eq(params.id))
-                    .add(Column::Status.eq(AttachmentStatus::Uploaded))
-                    .add(Column::DeletedAt.is_null()),
+            .col_expr(Column::ImgThumbnail, Expr::value(params.img_thumbnail))
+            .col_expr(
+                Column::ImgThumbnailWidth,
+                Expr::value(params.img_thumbnail_width),
             )
+            .col_expr(
+                Column::ImgThumbnailHeight,
+                Expr::value(params.img_thumbnail_height),
+            );
+        query = query.filter(
+            Condition::all()
+                .add(Column::Id.eq(params.id))
+                .add(Column::Status.eq(AttachmentStatus::Uploaded))
+                .add(Column::DeletedAt.is_null()),
+        );
+        let result = query
             .secure()
             .scope_with(scope)
             .exec(runner)

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -132,6 +132,9 @@ impl Module for MiniChatModule {
         cfg.cleanup_worker
             .validate()
             .map_err(|e| anyhow::anyhow!("cleanup_worker config: {e}"))?;
+        cfg.thumbnail
+            .validate()
+            .map_err(|e| anyhow::anyhow!("thumbnail config: {e}"))?;
 
         let vendor = cfg.vendor.trim().to_owned();
         if vendor.is_empty() {
@@ -403,6 +406,7 @@ impl Module for MiniChatModule {
             file_storage,
             vector_store_prov,
             cfg.rag,
+            cfg.thumbnail,
             metrics,
         ));
 


### PR DESCRIPTION
## Summary
- Implement server-side image thumbnail generation during attachment upload
- When a user uploads an image, the upload stream is tee'd to buffer raw bytes while forwarding to the provider; after upload, a WebP thumbnail (fit inside 128x128, aspect-ratio preserved) is generated and stored in the `attachments` table
- Thumbnails are returned inline in the `listMessages` API response via the existing `img_thumbnail` DTO field, enabling the frontend to render image previews in chat bubbles
- Thumbnail generation is best-effort: failures (corrupt image, oversized source, encode error) result in `img_thumbnail = null` — the attachment still transitions to `ready`

## Changes
- **`image` crate** added to workspace and mini-chat dependencies (jpeg/png/gif/webp)
- **`ThumbnailConfig`** added to `MiniChatConfig` with 5 knobs from DESIGN.md (`width`, `height`, `max_bytes`, `max_pixels`, `max_decode_bytes`)
- **`thumbnail.rs`** — new module: decode → pre-screen pixels → resize → encode WebP → enforce size limit
- **`attachment_service.rs`** — wraps image upload stream to capture bytes; generates thumbnail after provider upload; passes result to `cas_set_ready`
- **`SetReadyParams` / `cas_set_ready`** — extended with `img_thumbnail`, `img_thumbnail_width`, `img_thumbnail_height` columns


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic server-side thumbnail generation for image attachments (WebP); supports JPEG, PNG, GIF, WebP.
  * Thumbnails included in attachment metadata when available; generation is asynchronous and best-effort.

* **Validation / Reliability**
  * Image processing enforces pixel, decode and byte limits to prevent resource exhaustion and falls back to “no thumbnail” on failures.

* **Configuration**
  * New thumbnail settings with sensible defaults and runtime validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->