### PR TITLE
feat(oagw): support websockets as part of proxy request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,7 @@ dependencies = [
  "hyper-util",
  "inventory",
  "mime",
+ "parking_lot",
  "pingora-core",
  "pingora-http",
  "pingora-load-balancing",

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -47,6 +47,7 @@ tenant-resolver-sdk = { workspace = true }
 credstore-sdk = { workspace = true }
 # CP deps
 dashmap = { workspace = true }
+parking_lot = { workspace = true }
 psl = { workspace = true }
 thiserror = { workspace = true }
 mime = { workspace = true }
@@ -55,6 +56,8 @@ form_urlencoded = "1"
 pingora-memory-cache = "0.8"
 futures-util = { workspace = true, features = ["sink"] }
 tokio = { workspace = true, features = ["time"] }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
 # Pingora proxy engine
 pingora-proxy = { version = "0.8", features = ["rustls"] }
 pingora-core = { version = "0.8", features = ["rustls"] }

--- a/modules/system/oagw/oagw/src/api/rest/handlers/proxy.rs
+++ b/modules/system/oagw/oagw/src/api/rest/handlers/proxy.rs
@@ -1,9 +1,15 @@
+use bytes::Bytes;
+
 use crate::domain::error::DomainError;
+use crate::infra::proxy::headers;
+use crate::infra::proxy::websocket::{WebSocketBridgeHandle, websocket_bridge};
 use axum::body::Body;
 use axum::extract::{Extension, Request};
 use axum::response::Response;
+use http::StatusCode;
 use modkit_security::SecurityContext;
 use oagw_sdk::api::ErrorSource;
+use tracing::Instrument;
 
 use crate::api::rest::error::error_response;
 use crate::module::AppState;
@@ -12,6 +18,10 @@ use crate::module::AppState;
 ///
 /// Parses the alias and path suffix from the URL, validates the request,
 /// builds an `http::Request<oagw_sdk::Body>`, and delegates to the Data Plane service.
+///
+/// For WebSocket upgrade requests (`Upgrade: websocket`), extracts the
+/// `hyper::upgrade::OnUpgrade` handle, skips body buffering, and spawns a
+/// bidirectional byte-forwarding task after receiving a 101 response.
 pub async fn proxy_handler(
     Extension(state): Extension<AppState>,
     Extension(ctx): Extension<SecurityContext>,
@@ -19,6 +29,36 @@ pub async fn proxy_handler(
 ) -> Result<Response, Response> {
     let max_body_size = state.config.max_body_size_bytes;
     let (mut parts, body) = req.into_parts();
+
+    // Detect WebSocket upgrade and extract the hyper upgrade handle.
+    // This must happen before body consumption — the OnUpgrade future is
+    // stored in extensions by hyper and is needed after returning the 101.
+    let is_upgrade = headers::is_websocket_upgrade(&parts.headers);
+
+    // RFC 6455 §4.1: WebSocket upgrade MUST be GET with no body.
+    if is_upgrade {
+        let path = parts.uri.path().to_string();
+        if parts.method != http::Method::GET {
+            return Err(error_response(DomainError::Validation {
+                detail: "WebSocket upgrade requires GET method".into(),
+                instance: path,
+            }));
+        }
+        if parts.headers.contains_key(http::header::CONTENT_LENGTH)
+            || parts.headers.contains_key(http::header::TRANSFER_ENCODING)
+        {
+            return Err(error_response(DomainError::Validation {
+                detail: "WebSocket upgrade request must not contain a body".into(),
+                instance: path,
+            }));
+        }
+    }
+
+    let on_upgrade = if is_upgrade {
+        parts.extensions.remove::<hyper::upgrade::OnUpgrade>()
+    } else {
+        None
+    };
 
     // Parse alias from the URI to validate it's present.
     let path = parts.uri.path();
@@ -39,8 +79,8 @@ pub async fn proxy_handler(
         }));
     }
 
-    // Validate Content-Length if present.
-    if let Some(cl) = parts.headers.get(http::header::CONTENT_LENGTH) {
+    // Validate Content-Length if present (skip for WebSocket — no body).
+    if !is_upgrade && let Some(cl) = parts.headers.get(http::header::CONTENT_LENGTH) {
         let cl_str = cl.to_str().map_err(|_| {
             error_response(DomainError::Validation {
                 detail: "invalid Content-Length header".into(),
@@ -64,14 +104,19 @@ pub async fn proxy_handler(
     }
 
     // Read body bytes (limited to max_body_size).
-    let body_bytes = axum::body::to_bytes(body, max_body_size)
-        .await
-        .map_err(|_| {
-            error_response(DomainError::PayloadTooLarge {
-                detail: format!("request body exceeds maximum of {max_body_size} bytes"),
-                instance: path.to_string(),
-            })
-        })?;
+    // WebSocket upgrade requests have no body — skip buffering.
+    let body_bytes = if is_upgrade {
+        Bytes::new()
+    } else {
+        axum::body::to_bytes(body, max_body_size)
+            .await
+            .map_err(|_| {
+                error_response(DomainError::PayloadTooLarge {
+                    detail: format!("request body exceeds maximum of {max_body_size} bytes"),
+                    instance: path.to_string(),
+                })
+            })?
+    };
 
     // Strip the proxy prefix from the URI so the DP receives /{alias}/{path}?query.
     let new_uri_str = if let Some(query) = parts.uri.query() {
@@ -98,7 +143,61 @@ pub async fn proxy_handler(
         .map_err(error_response)?;
 
     // Convert http::Response<oagw_sdk::Body> to axum Response.
-    let (resp_parts, sdk_body) = proxy_resp.into_parts();
+    let (mut resp_parts, sdk_body) = proxy_resp.into_parts();
+
+    // Handle WebSocket 101 Switching Protocols.
+    if resp_parts.status == StatusCode::SWITCHING_PROTOCOLS {
+        let bridge = resp_parts
+            .extensions
+            .remove::<WebSocketBridgeHandle>()
+            .and_then(|h| h.take())
+            .ok_or_else(|| {
+                error_response(DomainError::Internal {
+                    message: "101 Switching Protocols but WebSocket bridge handle is missing"
+                        .into(),
+                })
+            })?;
+        let on_upgrade = on_upgrade.ok_or_else(|| {
+            error_response(DomainError::ProtocolError {
+                detail: "WebSocket upgrade requested but connection does not support upgrades"
+                    .into(),
+                instance: String::new(),
+            })
+        })?;
+
+        // Build the 101 response to return to hyper (triggers the upgrade).
+        let mut builder = Response::builder().status(StatusCode::SWITCHING_PROTOCOLS);
+        for (name, value) in &resp_parts.headers {
+            builder = builder.header(name, value);
+        }
+        // Data now originates from upstream — consistent with the non-upgrade path.
+        builder = builder.header("x-oagw-error-source", ErrorSource::Upstream.as_str());
+        let response = builder.body(Body::empty()).map_err(|e| {
+            error_response(DomainError::Internal {
+                message: format!("failed to build WebSocket upgrade response: {e}"),
+            })
+        })?;
+
+        // Spawn the bidirectional bridge task. It awaits the upgrade
+        // (which completes after hyper sends the 101 to the client),
+        // then copies raw bytes between the client and the DuplexStream.
+        let span = tracing::Span::current();
+        tokio::spawn(
+            async move {
+                match on_upgrade.await {
+                    Ok(upgraded) => {
+                        websocket_bridge(upgraded, bridge).await;
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "WebSocket upgrade failed");
+                    }
+                }
+            }
+            .instrument(span),
+        );
+
+        return Ok(response);
+    }
 
     let error_source = resp_parts
         .extensions

--- a/modules/system/oagw/oagw/src/config.rs
+++ b/modules/system/oagw/oagw/src/config.rs
@@ -22,6 +22,21 @@ pub struct OagwConfig {
     /// Default: 10 000.
     #[serde(default = "default_token_cache_capacity")]
     pub token_cache_capacity: usize,
+    /// Idle timeout in seconds for WebSocket streaming connections.
+    /// A connection with no data in either direction for this duration
+    /// will be torn down. Must be > 0. Default: 300 (5 minutes).
+    #[serde(default = "default_websocket_idle_timeout_secs")]
+    pub websocket_idle_timeout_secs: u64,
+    /// Timeout in seconds for the WebSocket Close frame handshake.
+    /// After sending or forwarding a Close frame, the gateway waits this long
+    /// for the Close response before force-closing. Must be > 0. Default: 5.
+    #[serde(default = "default_websocket_close_timeout_secs")]
+    pub websocket_close_timeout_secs: u64,
+    /// Optional maximum WebSocket frame payload size in bytes.
+    /// Frames exceeding this limit trigger Close frame 1009 (Message Too Big).
+    /// Default: None (pass-through, no limit enforced).
+    #[serde(default)]
+    pub websocket_max_frame_size_bytes: Option<usize>,
 }
 
 impl Default for OagwConfig {
@@ -32,6 +47,9 @@ impl Default for OagwConfig {
             allow_http_upstream: false,
             token_cache_ttl_secs: default_token_cache_ttl_secs(),
             token_cache_capacity: default_token_cache_capacity(),
+            websocket_idle_timeout_secs: default_websocket_idle_timeout_secs(),
+            websocket_close_timeout_secs: default_websocket_close_timeout_secs(),
+            websocket_max_frame_size_bytes: None,
         }
     }
 }
@@ -52,18 +70,46 @@ fn default_token_cache_capacity() -> usize {
     10_000
 }
 
+fn default_websocket_idle_timeout_secs() -> u64 {
+    300 // 5 minutes
+}
+
+fn default_websocket_close_timeout_secs() -> u64 {
+    5
+}
+
+impl OagwConfig {
+    /// Validate configuration values. Returns an error for values that
+    /// would cause broken runtime behaviour.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.websocket_idle_timeout_secs == 0 {
+            return Err("websocket_idle_timeout_secs must be > 0".to_owned());
+        }
+        if self.websocket_close_timeout_secs == 0 {
+            return Err("websocket_close_timeout_secs must be > 0".to_owned());
+        }
+        Ok(())
+    }
+}
+
 /// Read-only runtime configuration exposed to handlers via `AppState`.
 ///
 /// Derived from [`OagwConfig`] at init time.
 #[derive(Debug, Clone)]
 pub struct RuntimeConfig {
     pub max_body_size_bytes: usize,
+    pub websocket_idle_timeout_secs: u64,
+    pub websocket_close_timeout_secs: u64,
+    pub websocket_max_frame_size_bytes: Option<usize>,
 }
 
 impl From<&OagwConfig> for RuntimeConfig {
     fn from(cfg: &OagwConfig) -> Self {
         Self {
             max_body_size_bytes: cfg.max_body_size_bytes,
+            websocket_idle_timeout_secs: cfg.websocket_idle_timeout_secs,
+            websocket_close_timeout_secs: cfg.websocket_close_timeout_secs,
+            websocket_max_frame_size_bytes: cfg.websocket_max_frame_size_bytes,
         }
     }
 }
@@ -101,6 +147,18 @@ impl fmt::Debug for OagwConfig {
             .field("allow_http_upstream", &self.allow_http_upstream)
             .field("token_cache_ttl_secs", &self.token_cache_ttl_secs)
             .field("token_cache_capacity", &self.token_cache_capacity)
+            .field(
+                "websocket_idle_timeout_secs",
+                &self.websocket_idle_timeout_secs,
+            )
+            .field(
+                "websocket_close_timeout_secs",
+                &self.websocket_close_timeout_secs,
+            )
+            .field(
+                "websocket_max_frame_size_bytes",
+                &self.websocket_max_frame_size_bytes,
+            )
             .finish()
     }
 }
@@ -127,5 +185,29 @@ mod tests {
     fn token_cache_capacity_defaults_to_10000() {
         let config = OagwConfig::default();
         assert_eq!(config.token_cache_capacity, 10_000);
+    }
+
+    #[test]
+    fn validate_rejects_zero_idle_timeout() {
+        let config = OagwConfig {
+            websocket_idle_timeout_secs: 0,
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_close_timeout() {
+        let config = OagwConfig {
+            websocket_close_timeout_secs: 0,
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_nonzero_timeouts() {
+        let config = OagwConfig::default();
+        assert!(config.validate().is_ok());
     }
 }

--- a/modules/system/oagw/oagw/src/domain/test_support.rs
+++ b/modules/system/oagw/oagw/src/domain/test_support.rs
@@ -432,6 +432,9 @@ pub struct TestDpBuilder {
     skip_upstream_tls_verify: bool,
     token_http_config: Option<modkit_http::HttpClientConfig>,
     token_cache_config: TokenCacheConfig,
+    websocket_idle_timeout: Option<Duration>,
+    websocket_close_timeout: Option<Duration>,
+    websocket_max_frame_size: Option<usize>,
 }
 
 impl TestDpBuilder {
@@ -445,6 +448,9 @@ impl TestDpBuilder {
             skip_upstream_tls_verify: false,
             token_http_config: None,
             token_cache_config: TokenCacheConfig::default(),
+            websocket_idle_timeout: None,
+            websocket_close_timeout: None,
+            websocket_max_frame_size: None,
         }
     }
 
@@ -499,6 +505,27 @@ impl TestDpBuilder {
         self
     }
 
+    /// Override the WebSocket idle timeout (useful for idle-timeout tests).
+    #[must_use]
+    pub fn with_websocket_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.websocket_idle_timeout = Some(timeout);
+        self
+    }
+
+    /// Override the WebSocket Close frame handshake timeout.
+    #[must_use]
+    pub fn with_websocket_close_timeout(mut self, timeout: Duration) -> Self {
+        self.websocket_close_timeout = Some(timeout);
+        self
+    }
+
+    /// Override the maximum WebSocket frame payload size.
+    #[must_use]
+    pub fn with_websocket_max_frame_size(mut self, size: Option<usize>) -> Self {
+        self.websocket_max_frame_size = size;
+        self
+    }
+
     /// Fetch `CredStoreClientV1` from the hub, create a DP service with
     /// the given CP, and return the trait object.
     pub(crate) fn build_and_register(
@@ -547,6 +574,15 @@ impl TestDpBuilder {
         if let Some(size) = self.max_body_size {
             svc = svc.with_max_body_size(size);
         }
+        if let Some(timeout) = self.websocket_idle_timeout {
+            svc = svc.with_websocket_idle_timeout(timeout);
+        }
+        if let Some(timeout) = self.websocket_close_timeout {
+            svc = svc.with_websocket_close_timeout(timeout);
+        }
+        if let Some(size) = self.websocket_max_frame_size {
+            svc = svc.with_websocket_max_frame_size(Some(size));
+        }
 
         Arc::new(svc)
     }
@@ -591,6 +627,9 @@ pub fn build_test_app_state(
             backend_selector,
             config: crate::config::RuntimeConfig {
                 max_body_size_bytes: 100 * 1024 * 1024, // 100 MB default for tests
+                websocket_idle_timeout_secs: 300,
+                websocket_close_timeout_secs: 5,
+                websocket_max_frame_size_bytes: None,
             },
         },
         facade,

--- a/modules/system/oagw/oagw/src/infra/proxy/headers.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/headers.rs
@@ -4,16 +4,7 @@ use crate::domain::model::{PassthroughMode, RequestHeaderRules, ResponseHeaderRu
 use http::{HeaderMap, HeaderName, HeaderValue};
 use oagw_sdk::api::ErrorSource;
 
-const HOP_BY_HOP_HEADERS: &[&str] = &[
-    "connection",
-    "keep-alive",
-    "proxy-authenticate",
-    "proxy-authorization",
-    "te",
-    "trailer",
-    "transfer-encoding",
-    "upgrade",
-];
+use super::HOP_BY_HOP_HEADERS;
 
 /// Sensitive headers that must never be forwarded to upstream services,
 /// even when `PassthroughMode::All` is used.
@@ -119,6 +110,65 @@ pub fn extract_error_source(headers: &HeaderMap) -> ErrorSource {
 /// Strips hop-by-hop headers and `x-oagw-*` internal headers.
 pub fn sanitize_response_headers(headers: &mut HeaderMap) {
     strip_hop_by_hop(headers);
+    strip_internal_headers(headers);
+}
+
+/// Returns `true` if the request headers indicate a WebSocket upgrade.
+///
+/// Per RFC 6455 §4.1, requires both `Upgrade: websocket` and
+/// `Connection: Upgrade` tokens (case-insensitive, handles multiple
+/// header instances via `get_all()` per RFC 7230).
+pub fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
+    let has_upgrade_websocket = headers
+        .get_all(http::header::UPGRADE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .any(|v| {
+            v.split(',')
+                .any(|t| t.trim().eq_ignore_ascii_case("websocket"))
+        });
+
+    let has_connection_upgrade = headers
+        .get_all(http::header::CONNECTION)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .any(|v| {
+            v.split(',')
+                .any(|t| t.trim().eq_ignore_ascii_case("upgrade"))
+        });
+
+    has_upgrade_websocket && has_connection_upgrade
+}
+
+/// Like [`strip_hop_by_hop`] but preserves `Upgrade` and `Connection` headers,
+/// which are required for WebSocket upgrade negotiation (RFC 6455 §4.1).
+pub fn strip_hop_by_hop_for_upgrade(headers: &mut HeaderMap) {
+    // Parse Connection-nominated headers but skip "upgrade" itself.
+    if let Some(conn_value) = headers.get("connection").and_then(|v| v.to_str().ok()) {
+        let named: Vec<String> = conn_value
+            .split(',')
+            .map(|token| token.trim().to_lowercase())
+            .filter(|token| !token.is_empty() && token != "upgrade")
+            .collect();
+        for name in &named {
+            if let Ok(header_name) = HeaderName::from_bytes(name.as_bytes()) {
+                headers.remove(header_name);
+            }
+        }
+    }
+
+    // Remove static hop-by-hop headers EXCEPT "connection" and "upgrade".
+    for name in HOP_BY_HOP_HEADERS {
+        if *name != "connection" && *name != "upgrade" {
+            headers.remove(*name);
+        }
+    }
+}
+
+/// Like [`sanitize_response_headers`] but preserves `Upgrade` and `Connection`
+/// headers needed for 101 Switching Protocols responses.
+pub fn sanitize_response_headers_for_upgrade(headers: &mut HeaderMap) {
+    strip_hop_by_hop_for_upgrade(headers);
     strip_internal_headers(headers);
 }
 
@@ -628,6 +678,125 @@ mod tests {
 
         assert!(headers.get("x-oagw-debug").is_none());
         assert!(headers.get("x-oagw-trace-id").is_none());
+        assert_eq!(headers.get("x-custom").unwrap(), "keep");
+    }
+
+    // -- is_websocket_upgrade tests --
+
+    #[test]
+    fn websocket_upgrade_detected() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "websocket".parse().unwrap());
+        headers.insert("connection", "Upgrade".parse().unwrap());
+        assert!(is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn websocket_upgrade_case_insensitive() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "WebSocket".parse().unwrap());
+        headers.insert("connection", "upgrade".parse().unwrap());
+        assert!(is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn websocket_upgrade_multi_value() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "h2c, websocket".parse().unwrap());
+        headers.insert("connection", "keep-alive, Upgrade".parse().unwrap());
+        assert!(is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn websocket_upgrade_absent() {
+        let headers = HeaderMap::new();
+        assert!(!is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn websocket_upgrade_non_websocket() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "h2c".parse().unwrap());
+        headers.insert("connection", "Upgrade".parse().unwrap());
+        assert!(!is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn websocket_upgrade_missing_connection() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "websocket".parse().unwrap());
+        assert!(!is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn websocket_upgrade_connection_without_upgrade_token() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "websocket".parse().unwrap());
+        headers.insert("connection", "keep-alive".parse().unwrap());
+        assert!(!is_websocket_upgrade(&headers));
+    }
+
+    #[test]
+    fn websocket_upgrade_multiple_header_instances() {
+        let mut headers = HeaderMap::new();
+        headers.append("upgrade", "h2c".parse().unwrap());
+        headers.append("upgrade", "websocket".parse().unwrap());
+        headers.append("connection", "keep-alive".parse().unwrap());
+        headers.append("connection", "Upgrade".parse().unwrap());
+        assert!(is_websocket_upgrade(&headers));
+    }
+
+    // -- strip_hop_by_hop_for_upgrade tests --
+
+    #[test]
+    fn upgrade_strip_preserves_upgrade_and_connection() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "websocket".parse().unwrap());
+        headers.insert("connection", "Upgrade".parse().unwrap());
+        headers.insert("transfer-encoding", "chunked".parse().unwrap());
+        headers.insert("keep-alive", "timeout=5".parse().unwrap());
+        headers.insert("x-custom", "keep".parse().unwrap());
+
+        strip_hop_by_hop_for_upgrade(&mut headers);
+
+        assert_eq!(headers.get("upgrade").unwrap(), "websocket");
+        assert_eq!(headers.get("connection").unwrap(), "Upgrade");
+        assert!(headers.get("transfer-encoding").is_none());
+        assert!(headers.get("keep-alive").is_none());
+        assert_eq!(headers.get("x-custom").unwrap(), "keep");
+    }
+
+    #[test]
+    fn upgrade_strip_removes_connection_nominated_except_upgrade() {
+        let mut headers = HeaderMap::new();
+        headers.insert("connection", "Upgrade, X-Custom-Hop".parse().unwrap());
+        headers.insert("upgrade", "websocket".parse().unwrap());
+        headers.insert("x-custom-hop", "secret".parse().unwrap());
+        headers.insert("x-safe", "keep".parse().unwrap());
+
+        strip_hop_by_hop_for_upgrade(&mut headers);
+
+        assert!(headers.get("x-custom-hop").is_none());
+        assert_eq!(headers.get("upgrade").unwrap(), "websocket");
+        assert!(headers.get("connection").is_some());
+        assert_eq!(headers.get("x-safe").unwrap(), "keep");
+    }
+
+    // -- sanitize_response_headers_for_upgrade tests --
+
+    #[test]
+    fn sanitize_upgrade_response_preserves_upgrade_strips_internal() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", "websocket".parse().unwrap());
+        headers.insert("connection", "Upgrade".parse().unwrap());
+        headers.insert("x-oagw-debug", "true".parse().unwrap());
+        headers.insert("x-custom", "keep".parse().unwrap());
+
+        sanitize_response_headers_for_upgrade(&mut headers);
+
+        assert_eq!(headers.get("upgrade").unwrap(), "websocket");
+        assert_eq!(headers.get("connection").unwrap(), "Upgrade");
+        assert!(headers.get("x-oagw-debug").is_none());
         assert_eq!(headers.get("x-custom").unwrap(), "keep");
     }
 

--- a/modules/system/oagw/oagw/src/infra/proxy/mod.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/mod.rs
@@ -1,10 +1,23 @@
 use authz_resolver_sdk::pep::ResourceType;
 
+/// Hop-by-hop headers that must not be forwarded by proxies (RFC 7230 §6.1).
+pub(crate) const HOP_BY_HOP_HEADERS: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+];
+
 pub(crate) mod headers;
 pub(crate) mod pingora_proxy;
 pub(crate) mod request_builder;
 pub(crate) mod service;
 pub(crate) mod session_bridge;
+pub(crate) mod websocket;
 
 pub(crate) use service::DataPlaneServiceImpl;
 

--- a/modules/system/oagw/oagw/src/infra/proxy/pingora_proxy.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/pingora_proxy.rs
@@ -36,17 +36,7 @@ pub(crate) const H_ENDPOINT_SCHEME: &str = "x-oagw-internal-endpoint-scheme";
 pub(crate) const H_INSTANCE_URI: &str = "x-oagw-internal-instance-uri";
 pub(crate) const H_RESOLVED_ADDR: &str = "x-oagw-internal-resolved-addr";
 
-/// Hop-by-hop headers that must not be forwarded in responses (mirrors headers.rs).
-const HOP_BY_HOP: &[&str] = &[
-    "connection",
-    "keep-alive",
-    "proxy-authenticate",
-    "proxy-authorization",
-    "te",
-    "trailer",
-    "transfer-encoding",
-    "upgrade",
-];
+use super::HOP_BY_HOP_HEADERS;
 
 // ---------------------------------------------------------------------------
 // PingoraProxy — ProxyHttp implementation (D3)
@@ -474,6 +464,13 @@ impl ProxyHttp for PingoraProxy {
             "upstream response received"
         );
 
+        // For 101 Switching Protocols, preserve Upgrade and Connection headers
+        // but strip Connection-nominated hop-by-hop headers and x-oagw-* internals.
+        if status == http::StatusCode::SWITCHING_PROTOCOLS {
+            super::headers::sanitize_response_headers_for_upgrade(&mut upstream_response.headers);
+            return Ok(());
+        }
+
         // Strip Connection-nominated headers.
         if let Some(conn_value) = upstream_response
             .headers
@@ -490,7 +487,7 @@ impl ProxyHttp for PingoraProxy {
         }
 
         // Strip static hop-by-hop headers.
-        for name in HOP_BY_HOP {
+        for name in HOP_BY_HOP_HEADERS {
             upstream_response.remove_header(*name);
         }
 

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -61,6 +61,12 @@ pub struct DataPlaneServiceImpl {
     allow_http_upstream: bool,
     /// Maximum request body size in bytes (applies to both buffered and streaming bodies).
     max_body_size: usize,
+    /// Idle timeout for WebSocket connections (no data in either direction).
+    websocket_idle_timeout: Duration,
+    /// Timeout for the WebSocket Close frame handshake.
+    websocket_close_timeout: Duration,
+    /// Optional max WebSocket frame payload size (Close 1009 on exceed).
+    websocket_max_frame_size: Option<usize>,
 }
 
 impl DataPlaneServiceImpl {
@@ -94,6 +100,9 @@ impl DataPlaneServiceImpl {
             policy_enforcer,
             allow_http_upstream: false,
             max_body_size: MAX_BODY_SIZE,
+            websocket_idle_timeout: Duration::from_secs(300),
+            websocket_close_timeout: Duration::from_secs(5),
+            websocket_max_frame_size: None,
         }
     }
 
@@ -115,6 +124,27 @@ impl DataPlaneServiceImpl {
     #[must_use]
     pub fn with_allow_http_upstream(mut self, allow: bool) -> Self {
         self.allow_http_upstream = allow;
+        self
+    }
+
+    /// Override the WebSocket idle timeout.
+    #[must_use]
+    pub fn with_websocket_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.websocket_idle_timeout = timeout;
+        self
+    }
+
+    /// Override the WebSocket Close frame handshake timeout.
+    #[must_use]
+    pub fn with_websocket_close_timeout(mut self, timeout: Duration) -> Self {
+        self.websocket_close_timeout = timeout;
+        self
+    }
+
+    /// Override the maximum WebSocket frame payload size.
+    #[must_use]
+    pub fn with_websocket_max_frame_size(mut self, size: Option<usize>) -> Self {
+        self.websocket_max_frame_size = size;
         self
     }
 
@@ -312,21 +342,7 @@ impl DataPlaneService for DataPlaneServiceImpl {
         let method = parts.method;
         let req_headers = parts.headers;
 
-        // Reject WebSocket upgrade requests — the current bridge is unidirectional
-        // and cannot support the bidirectional tunnel that WebSocket requires.
-        if req_headers
-            .get(http::header::UPGRADE)
-            .and_then(|v| v.to_str().ok())
-            .is_some_and(|v| {
-                v.split(',')
-                    .any(|t| t.trim().eq_ignore_ascii_case("websocket"))
-            })
-        {
-            return Err(DomainError::ProtocolError {
-                detail: "WebSocket upgrade is not supported by the proxy".into(),
-                instance: instance_uri,
-            });
-        }
+        let is_upgrade = headers::is_websocket_upgrade(&req_headers);
 
         // Validate Content-Type format if present.
         if !headers::is_valid_content_type(&req_headers) {
@@ -480,8 +496,32 @@ impl DataPlaneService for DataPlaneServiceImpl {
             .and_then(|h| h.request.as_ref())
             .map_or_else(Vec::new, |r| r.passthrough_allowlist.clone());
         let mut outbound_headers = headers::apply_passthrough(&req_headers, &mode, &allowlist);
-        headers::strip_hop_by_hop(&mut outbound_headers);
+        if is_upgrade {
+            headers::strip_hop_by_hop_for_upgrade(&mut outbound_headers);
+        } else {
+            headers::strip_hop_by_hop(&mut outbound_headers);
+        }
         headers::strip_internal_headers(&mut outbound_headers);
+
+        // For WebSocket, ensure Upgrade and Sec-WebSocket-* headers are forwarded
+        // even when passthrough mode is None/Allowlist.
+        if is_upgrade {
+            for name in &[
+                "upgrade",
+                "sec-websocket-key",
+                "sec-websocket-version",
+                "sec-websocket-protocol",
+                "sec-websocket-extensions",
+            ] {
+                if let Ok(n) = http::header::HeaderName::from_bytes(name.as_bytes())
+                    && !outbound_headers.contains_key(&n)
+                {
+                    for v in req_headers.get_all(&n) {
+                        outbound_headers.append(n.clone(), v.clone());
+                    }
+                }
+            }
+        }
 
         // 4. Execute auth plugin.
         if let Some(ref auth) = upstream.auth {
@@ -724,6 +764,101 @@ impl DataPlaneService for DataPlaneServiceImpl {
             origin: request_origin,
             response_header_rules,
         };
+
+        // 8. WebSocket upgrade path: bypass the normal request/response bridge
+        // and set up a bidirectional raw-byte tunnel through Pingora.
+        if is_upgrade {
+            let (mut client_io, server_io) = tokio::io::duplex(65_536);
+            let session =
+                pingora_core::protocols::http::ServerSession::new_http1(Box::new(server_io));
+            let proxy = self.proxy.clone();
+            let shutdown = self.shutdown_rx.clone();
+            tokio::spawn(async move {
+                proxy.process_new_http(session, &shutdown).await;
+            });
+
+            // Write the upgrade request (Connection: Upgrade, no body).
+            let wire =
+                session_bridge::serialize_upgrade_request_wire(&method, &url, &outbound_headers);
+            client_io
+                .write_all(&wire)
+                .await
+                .map_err(|e| DomainError::DownstreamError {
+                    detail: format!("failed to write upgrade request to proxy bridge: {e}"),
+                    instance: instance_uri.clone(),
+                })?;
+
+            // Parse only the response headers (IO stays intact for bidirectional copy).
+            let upgrade_timeout = self.request_timeout;
+            let (status, resp_headers, leftover) = tokio::time::timeout(
+                upgrade_timeout,
+                session_bridge::parse_upgrade_response(&mut client_io),
+            )
+            .await
+            .map_err(|_| DomainError::RequestTimeout {
+                detail: format!("WebSocket upgrade to {url} timed out after {upgrade_timeout:?}"),
+                instance: instance_uri.clone(),
+            })?
+            .map_err(|e| DomainError::DownstreamError {
+                detail: format!("proxy bridge error during WebSocket upgrade: {e}"),
+                instance: instance_uri.clone(),
+            })?;
+
+            if status != http::StatusCode::SWITCHING_PROTOCOLS {
+                // Upstream rejected the upgrade — pass through the upstream response.
+                let mut resp_headers = resp_headers;
+                resp_headers.insert("x-oagw-error-source", HeaderValue::from_static("upstream"));
+                let error_body_stream =
+                    session_bridge::response_body_stream(&resp_headers, leftover, client_io);
+                return self
+                    .finalize_response(
+                        &pipeline,
+                        status,
+                        resp_headers,
+                        error_body_stream,
+                        instance_uri,
+                    )
+                    .await;
+            }
+
+            // Execute response guards on the 101.
+            execute_guard_responses(
+                &self.guard_registry,
+                &pipeline.guard_bindings,
+                status,
+                &resp_headers,
+                pipeline.method,
+                pipeline.path_suffix,
+                &instance_uri,
+                pipeline.ctx,
+            )
+            .await?;
+
+            // Sanitize response headers, preserving Upgrade/Connection.
+            let mut resp_headers = resp_headers;
+            headers::sanitize_response_headers_for_upgrade(&mut resp_headers);
+
+            // Build the 101 response with the DuplexStream stashed in extensions.
+            let mut resp = http::Response::builder()
+                .status(http::StatusCode::SWITCHING_PROTOCOLS)
+                .body(Body::Empty)
+                .map_err(|e| DomainError::Internal {
+                    message: format!("failed to build WebSocket upgrade response: {e}"),
+                })?;
+            *resp.headers_mut() = resp_headers;
+            resp.extensions_mut()
+                .insert(super::websocket::WebSocketBridgeHandle::new(
+                    super::websocket::WebSocketBridgeIo {
+                        io: client_io,
+                        leftover,
+                        idle_timeout: self.websocket_idle_timeout,
+                        close_timeout: self.websocket_close_timeout,
+                        max_frame_size: self.websocket_max_frame_size,
+                        shutdown_rx: self.shutdown_rx.clone(),
+                    },
+                ));
+            return Ok(resp);
+        }
 
         // 8. Bridge request into Pingora via in-memory DuplexStream.
         let (client_io, server_io) = tokio::io::duplex(65_536);

--- a/modules/system/oagw/oagw/src/infra/proxy/session_bridge.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/session_bridge.rs
@@ -100,9 +100,104 @@ pub(crate) fn serialize_request_wire(
     buf
 }
 
+/// Serialize an HTTP/1.1 upgrade request (WebSocket handshake) to wire format.
+///
+/// Differs from [`serialize_request_wire`]:
+/// - Emits `Connection: Upgrade` (not `Connection: close`)
+/// - No `Content-Length` or `Transfer-Encoding` (upgrade requests have no body)
+/// - Preserves the `Upgrade` header from input
+pub(crate) fn serialize_upgrade_request_wire(
+    method: &Method,
+    url: &str,
+    headers: &HeaderMap,
+) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(512);
+    let pq_raw = url_path_and_query(url);
+    // Defense-in-depth: strip CR/LF to prevent header injection.
+    let pq_clean;
+    let pq = if pq_raw.contains('\r') || pq_raw.contains('\n') {
+        warn!("CRLF in request URI stripped (possible injection attempt)");
+        pq_clean = pq_raw.replace(['\r', '\n'], "");
+        pq_clean.as_str()
+    } else {
+        pq_raw
+    };
+    let _ = write!(buf, "{} {} HTTP/1.1\r\n", method, pq);
+    for (name, value) in headers {
+        // Skip framing headers — we emit our own Connection below.
+        if name == http::header::CONNECTION
+            || name == http::header::CONTENT_LENGTH
+            || name == http::header::TRANSFER_ENCODING
+        {
+            continue;
+        }
+        buf.extend_from_slice(name.as_str().as_bytes());
+        buf.extend_from_slice(b": ");
+        buf.extend_from_slice(value.as_bytes());
+        buf.extend_from_slice(b"\r\n");
+    }
+    buf.extend_from_slice(b"Connection: Upgrade\r\n");
+    buf.extend_from_slice(b"\r\n");
+    buf
+}
+
 // ---------------------------------------------------------------------------
 // Response parsing
 // ---------------------------------------------------------------------------
+
+/// Parse only the HTTP/1.1 response status line and headers from the IO,
+/// returning the parsed result and any leftover bytes read past the header
+/// boundary.
+///
+/// Unlike [`parse_response_stream`], this does **not** consume the IO into
+/// a body stream — the caller retains the IO for bidirectional WebSocket
+/// forwarding via `tokio::io::copy_bidirectional`.
+pub(crate) async fn parse_upgrade_response(
+    io: &mut (impl AsyncRead + Unpin + Send),
+) -> anyhow::Result<(StatusCode, HeaderMap, Bytes)> {
+    let mut buf = BytesMut::with_capacity(4096);
+    let (status, headers, body_offset) = loop {
+        let mut tmp = [0u8; 4096];
+        let n = io
+            .read(&mut tmp)
+            .await
+            .context("failed to read response from proxy")?;
+        if n == 0 {
+            anyhow::bail!("proxy closed connection before sending response headers");
+        }
+        buf.extend_from_slice(&tmp[..n]);
+        if buf.len() > MAX_HEADER_BYTES {
+            anyhow::bail!(
+                "response headers too large ({} bytes exceeds {} byte limit)",
+                buf.len(),
+                MAX_HEADER_BYTES
+            );
+        }
+
+        let mut parsed_headers = [httparse::EMPTY_HEADER; 128];
+        let mut resp = httparse::Response::new(&mut parsed_headers);
+        match resp.parse(&buf)? {
+            httparse::Status::Complete(offset) => {
+                let status = StatusCode::from_u16(resp.code.unwrap_or(502))?;
+                let mut headers = HeaderMap::new();
+                for h in resp.headers.iter() {
+                    if let (Ok(name), Ok(value)) = (
+                        HeaderName::from_bytes(h.name.as_bytes()),
+                        HeaderValue::from_bytes(h.value),
+                    ) {
+                        headers.append(name, value);
+                    }
+                }
+                break (status, headers, offset);
+            }
+            httparse::Status::Partial => continue,
+        }
+    };
+
+    let _ = buf.split_to(body_offset);
+    let remaining = buf.freeze();
+    Ok((status, headers, remaining))
+}
 
 /// Read an HTTP/1.1 response from the client side of a DuplexStream.
 ///
@@ -195,8 +290,30 @@ fn is_chunked_encoding(headers: &HeaderMap) -> bool {
 // Body stream builders
 // ---------------------------------------------------------------------------
 
+/// Select the appropriate body stream based on response headers.
+///
+/// - **Transfer-Encoding: chunked** → decoded chunks
+/// - **Content-Length** → exactly N bytes
+/// - **Otherwise** → read until EOF
+pub(crate) fn response_body_stream<R: AsyncRead + Unpin + Send + 'static>(
+    headers: &HeaderMap,
+    initial: Bytes,
+    io: R,
+) -> BodyStream {
+    if is_chunked_encoding(headers) {
+        chunked_body_stream(initial, io)
+    } else if let Some(len) = content_length_value(headers) {
+        content_length_body_stream(initial, io, len)
+    } else {
+        raw_body_stream(initial, io)
+    }
+}
+
 /// Read raw bytes until EOF (used for 101 Upgrade and connection-close).
-fn raw_body_stream<R: AsyncRead + Unpin + Send + 'static>(initial: Bytes, io: R) -> BodyStream {
+pub(crate) fn raw_body_stream<R: AsyncRead + Unpin + Send + 'static>(
+    initial: Bytes,
+    io: R,
+) -> BodyStream {
     struct State<R> {
         io: R,
         initial: Option<Bytes>,
@@ -787,5 +904,148 @@ mod tests {
         let chunks: Vec<Bytes> = body_stream.map(|r| r.unwrap()).collect().await;
         let all: Vec<u8> = chunks.iter().flat_map(|c| c.iter().copied()).collect();
         assert_eq!(all, body.as_slice());
+    }
+
+    // -- serialize_upgrade_request_wire tests --
+
+    #[test]
+    fn upgrade_wire_emits_connection_upgrade() {
+        let mut headers = HeaderMap::new();
+        headers.insert("host", HeaderValue::from_static("example.com"));
+        headers.insert("upgrade", HeaderValue::from_static("websocket"));
+        headers.insert(
+            "sec-websocket-key",
+            HeaderValue::from_static("dGhlIHNhbXBsZSBub25jZQ=="),
+        );
+        headers.insert("sec-websocket-version", HeaderValue::from_static("13"));
+
+        let wire = serialize_upgrade_request_wire(&Method::GET, "wss://example.com/ws", &headers);
+        let text = String::from_utf8_lossy(&wire);
+
+        assert!(text.starts_with("GET /ws HTTP/1.1\r\n"));
+        assert!(text.contains("upgrade: websocket\r\n"));
+        assert!(text.contains("Connection: Upgrade\r\n"));
+        assert!(text.contains("sec-websocket-key: dGhlIHNhbXBsZSBub25jZQ==\r\n"));
+        assert!(!text.contains("Content-Length"));
+        assert!(!text.contains("Transfer-Encoding"));
+        assert!(text.ends_with("\r\n\r\n"));
+    }
+
+    #[test]
+    fn upgrade_wire_strips_inbound_connection_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("upgrade", HeaderValue::from_static("websocket"));
+        headers.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("keep-alive"),
+        );
+
+        let wire = serialize_upgrade_request_wire(&Method::GET, "wss://example.com/ws", &headers);
+        let text = String::from_utf8_lossy(&wire);
+
+        assert_eq!(
+            text.matches("Connection:").count(),
+            1,
+            "duplicate Connection"
+        );
+        assert!(text.contains("Connection: Upgrade\r\n"));
+    }
+
+    #[test]
+    fn upgrade_wire_no_body() {
+        let wire =
+            serialize_upgrade_request_wire(&Method::GET, "wss://example.com/ws", &HeaderMap::new());
+        let text = String::from_utf8_lossy(&wire);
+        assert!(text.ends_with("\r\n\r\n"));
+        let parts: Vec<&str> = text.splitn(2, "\r\n\r\n").collect();
+        assert_eq!(parts.len(), 2);
+        assert!(parts[1].is_empty());
+    }
+
+    #[test]
+    fn upgrade_wire_crlf_injection_defense() {
+        let wire = serialize_upgrade_request_wire(
+            &Method::GET,
+            "wss://victim.com/path\r\nEvil: pwned\r\n",
+            &HeaderMap::new(),
+        );
+        let text = String::from_utf8_lossy(&wire);
+        assert!(
+            !text.contains("Evil: pwned\r\n"),
+            "CRLF injection produced a separate header"
+        );
+    }
+
+    // -- parse_upgrade_response tests --
+
+    #[tokio::test]
+    async fn parse_upgrade_101() {
+        let (mut writer, mut reader) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            writer
+                .write_all(
+                    b"HTTP/1.1 101 Switching Protocols\r\n\
+                      Upgrade: websocket\r\n\
+                      Connection: Upgrade\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            // Don't close — simulates a live WebSocket connection
+        });
+
+        let (status, headers, leftover) = parse_upgrade_response(&mut reader).await.unwrap();
+        assert_eq!(status, StatusCode::SWITCHING_PROTOCOLS);
+        assert_eq!(headers.get("upgrade").unwrap(), "websocket");
+        assert!(leftover.is_empty());
+        // reader is still usable (not consumed)
+        drop(reader);
+    }
+
+    #[tokio::test]
+    async fn parse_upgrade_101_with_leftover() {
+        let (mut writer, mut reader) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            // Headers + some WebSocket frame data in the same write
+            writer
+                .write_all(
+                    b"HTTP/1.1 101 Switching Protocols\r\n\
+                      Upgrade: websocket\r\n\
+                      Connection: Upgrade\r\n\r\n\
+                      ws-frame-data",
+                )
+                .await
+                .unwrap();
+        });
+
+        let (status, _headers, leftover) = parse_upgrade_response(&mut reader).await.unwrap();
+        assert_eq!(status, StatusCode::SWITCHING_PROTOCOLS);
+        assert_eq!(leftover.as_ref(), b"ws-frame-data");
+    }
+
+    #[tokio::test]
+    async fn parse_upgrade_non_101() {
+        let (mut writer, mut reader) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            writer
+                .write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
+                .await
+                .unwrap();
+            shut(&mut writer).await;
+        });
+
+        let (status, _headers, leftover) = parse_upgrade_response(&mut reader).await.unwrap();
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert!(leftover.is_empty());
+    }
+
+    #[tokio::test]
+    async fn parse_upgrade_eof_before_headers() {
+        let (mut writer, mut reader) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            shut(&mut writer).await;
+        });
+
+        let result = parse_upgrade_response(&mut reader).await;
+        assert!(result.is_err());
     }
 }

--- a/modules/system/oagw/oagw/src/infra/proxy/websocket.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/websocket.rs
@@ -1,0 +1,1557 @@
+use std::pin::Pin;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use bytes::{Buf, Bytes};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio::sync::watch;
+use tracing::{debug, warn};
+
+// ---------------------------------------------------------------------------
+// PrefixedReader — prepends buffered bytes before an inner AsyncRead
+// ---------------------------------------------------------------------------
+
+/// An `AsyncRead` wrapper that first yields bytes from a `Bytes` prefix,
+/// then delegates to the inner reader. Used to feed leftover bytes from
+/// HTTP header parsing back into the WebSocket frame relay loop.
+struct PrefixedReader<R> {
+    prefix: Bytes,
+    inner: R,
+}
+
+impl<R> PrefixedReader<R> {
+    fn new(prefix: Bytes, inner: R) -> Self {
+        Self { prefix, inner }
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for PrefixedReader<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        if !this.prefix.is_empty() {
+            let n = this.prefix.len().min(buf.remaining());
+            buf.put_slice(&this.prefix[..n]);
+            this.prefix.advance(n);
+            return Poll::Ready(Ok(()));
+        }
+        Pin::new(&mut this.inner).poll_read(cx, buf)
+    }
+}
+
+impl<R: Unpin> Unpin for PrefixedReader<R> {}
+
+// ---------------------------------------------------------------------------
+// RFC 6455 frame parser/writer
+// ---------------------------------------------------------------------------
+
+/// Absolute maximum frame payload size (64 MiB). Defense-in-depth cap
+/// applied before allocation, regardless of the configured `max_frame_size`.
+const HARD_MAX_FRAME_SIZE: usize = 64 * 1024 * 1024;
+
+/// WebSocket opcodes (RFC 6455 §5.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WsOpcode {
+    Continuation,
+    Text,
+    Binary,
+    Close,
+    Ping,
+    Pong,
+    Unknown(u8),
+}
+
+impl WsOpcode {
+    fn from_u8(v: u8) -> Self {
+        match v {
+            0x0 => Self::Continuation,
+            0x1 => Self::Text,
+            0x2 => Self::Binary,
+            0x8 => Self::Close,
+            0x9 => Self::Ping,
+            0xA => Self::Pong,
+            other => Self::Unknown(other),
+        }
+    }
+
+    fn as_u8(self) -> u8 {
+        match self {
+            Self::Continuation => 0x0,
+            Self::Text => 0x1,
+            Self::Binary => 0x2,
+            Self::Close => 0x8,
+            Self::Ping => 0x9,
+            Self::Pong => 0xA,
+            Self::Unknown(v) => v,
+        }
+    }
+}
+
+/// Read a single WebSocket frame from `reader`.
+///
+/// Returns `None` on clean EOF (zero-byte read on the first header byte).
+/// Returns `(fin, opcode, payload)` — the FIN bit is preserved for
+/// fragmented message forwarding (RFC 6455 §5.4).
+///
+/// `max_payload` caps the allocation size before reading. If the declared
+/// payload length exceeds `min(max_payload, HARD_MAX_FRAME_SIZE)`, an
+/// `InvalidData` error is returned without allocating. Unmasked payload is
+/// always returned regardless of wire masking.
+async fn read_frame(
+    reader: &mut (impl AsyncRead + Unpin),
+    max_payload: Option<usize>,
+) -> std::io::Result<Option<(bool, WsOpcode, Vec<u8>)>> {
+    // Read the 2-byte header.
+    let mut hdr = [0u8; 2];
+    match reader.read(&mut hdr[..1]).await? {
+        0 => return Ok(None), // clean EOF
+        1 => {}
+        _ => unreachable!(),
+    }
+    reader.read_exact(&mut hdr[1..2]).await?;
+
+    let fin = hdr[0] & 0x80 != 0;
+    let opcode = WsOpcode::from_u8(hdr[0] & 0x0F);
+    let masked = hdr[1] & 0x80 != 0;
+    let len_byte = (hdr[1] & 0x7F) as u64;
+
+    let payload_len: usize = if len_byte < 126 {
+        len_byte as usize
+    } else if len_byte == 126 {
+        let mut buf = [0u8; 2];
+        reader.read_exact(&mut buf).await?;
+        u16::from_be_bytes(buf) as usize
+    } else {
+        // len_byte == 127
+        let mut buf = [0u8; 8];
+        reader.read_exact(&mut buf).await?;
+        u64::from_be_bytes(buf) as usize
+    };
+
+    // Enforce size limit before allocation to prevent OOM.
+    let effective_max = max_payload
+        .map(|m| m.min(HARD_MAX_FRAME_SIZE))
+        .unwrap_or(HARD_MAX_FRAME_SIZE);
+    if payload_len > effective_max {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("frame payload {payload_len} bytes exceeds maximum {effective_max} bytes"),
+        ));
+    }
+
+    let mask_key = if masked {
+        let mut key = [0u8; 4];
+        reader.read_exact(&mut key).await?;
+        Some(key)
+    } else {
+        None
+    };
+
+    let mut payload = vec![0u8; payload_len];
+    if payload_len > 0 {
+        reader.read_exact(&mut payload).await?;
+    }
+
+    // Unmask if needed.
+    if let Some(key) = mask_key {
+        for (i, byte) in payload.iter_mut().enumerate() {
+            *byte ^= key[i % 4];
+        }
+    }
+
+    Ok(Some((fin, opcode, payload)))
+}
+
+/// Write a single WebSocket frame to `writer`.
+///
+/// The `fin` parameter controls the FIN bit — pass `true` for final/only
+/// frames, `false` for non-final fragments (RFC 6455 §5.4).
+/// If `masked` is true, applies a random 4-byte XOR mask (required for
+/// client-to-server direction per RFC 6455 §5.3).
+async fn write_frame(
+    writer: &mut (impl AsyncWrite + Unpin),
+    opcode: WsOpcode,
+    payload: &[u8],
+    masked: bool,
+    fin: bool,
+) -> std::io::Result<()> {
+    let len = payload.len();
+    // Pre-allocate: 2 header + 8 extended length + 4 mask + payload
+    let mut buf = Vec::with_capacity(14 + len);
+
+    let fin_bit = if fin { 0x80 } else { 0x00 };
+    buf.push(fin_bit | opcode.as_u8());
+
+    let mask_bit = if masked { 0x80 } else { 0x00 };
+    if len < 126 {
+        buf.push(mask_bit | len as u8);
+    } else if len < 65536 {
+        buf.push(mask_bit | 126);
+        buf.extend_from_slice(&(len as u16).to_be_bytes());
+    } else {
+        buf.push(mask_bit | 127);
+        buf.extend_from_slice(&(len as u64).to_be_bytes());
+    }
+
+    if masked {
+        let key: [u8; 4] = rand_mask_key();
+        buf.extend_from_slice(&key);
+        for (i, &byte) in payload.iter().enumerate() {
+            buf.push(byte ^ key[i % 4]);
+        }
+    } else {
+        buf.extend_from_slice(payload);
+    }
+
+    writer.write_all(&buf).await
+}
+
+/// Build a Close frame payload: 2-byte BE status code + UTF-8 reason.
+fn make_close_payload(code: u16, reason: &str) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(2 + reason.len());
+    payload.extend_from_slice(&code.to_be_bytes());
+    payload.extend_from_slice(reason.as_bytes());
+    payload
+}
+
+/// Extract status code and reason bytes from a Close frame payload.
+#[cfg(test)]
+fn parse_close_payload(payload: &[u8]) -> (u16, &[u8]) {
+    if payload.len() >= 2 {
+        let code = u16::from_be_bytes([payload[0], payload[1]]);
+        (code, &payload[2..])
+    } else {
+        (1005, b"") // No status code provided (RFC 6455 §7.1.5)
+    }
+}
+
+/// Generate a 4-byte mask key using OS-seeded randomness.
+///
+/// Uses `RandomState` (SipHash with OS-random seeds) per thread, hashing
+/// an atomic counter through it. Satisfies RFC 6455 §5.3 requirement that
+/// mask keys be chosen unpredictably.
+fn rand_mask_key() -> [u8; 4] {
+    use std::hash::{BuildHasher, Hasher};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    thread_local! {
+        static HASHER_STATE: std::collections::hash_map::RandomState =
+            std::collections::hash_map::RandomState::new();
+    }
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    HASHER_STATE.with(|state| {
+        let mut hasher = state.build_hasher();
+        hasher.write_u64(COUNTER.fetch_add(1, Ordering::Relaxed));
+        (hasher.finish() as u32).to_ne_bytes()
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Frame-aware relay
+// ---------------------------------------------------------------------------
+
+/// Outcome of the frame relay loop.
+#[derive(Debug)]
+pub(crate) enum RelayOutcome {
+    /// Both sides completed the Close handshake.
+    CleanClose,
+    /// No data in either direction within the idle timeout.
+    IdleTimeout,
+    /// Upstream connection dropped unexpectedly.
+    UpstreamDrop,
+    /// Caller disconnected unexpectedly.
+    CallerDrop,
+    /// A frame exceeded the configured max size.
+    FrameTooLarge,
+    /// Server is shutting down gracefully.
+    Shutdown,
+    /// IO or protocol error.
+    Error(std::io::Error),
+}
+
+/// Configuration for the frame relay loop.
+struct RelayConfig {
+    idle_timeout: Duration,
+    close_timeout: Duration,
+    max_frame_size: Option<usize>,
+    shutdown_rx: watch::Receiver<bool>,
+}
+
+/// Frame-aware WebSocket relay with idle timeout, close handshake,
+/// and optional max frame size enforcement.
+///
+/// Forwards frames bidirectionally between client and upstream, preserving
+/// FIN bits and continuation frames for fragmented messages (RFC 6455 §5.4).
+/// Client→upstream frames are re-masked; upstream→client frames are unmasked.
+async fn frame_relay(
+    client_read: &mut (impl AsyncRead + Unpin),
+    client_write: &mut (impl AsyncWrite + Unpin),
+    upstream_read: &mut (impl AsyncRead + Unpin),
+    upstream_write: &mut (impl AsyncWrite + Unpin),
+    cfg: RelayConfig,
+) -> RelayOutcome {
+    let RelayConfig {
+        idle_timeout,
+        close_timeout,
+        max_frame_size,
+        mut shutdown_rx,
+    } = cfg;
+    let deadline = tokio::time::sleep(idle_timeout);
+    tokio::pin!(deadline);
+
+    // Main relay loop (Open state).
+    loop {
+        tokio::select! {
+            result = read_frame(client_read, max_frame_size) => {
+                match result {
+                    Ok(Some((fin, opcode, payload))) => {
+                        deadline.as_mut().reset(tokio::time::Instant::now() + idle_timeout);
+                        match opcode {
+                            WsOpcode::Close => {
+                                // Forward close to upstream, then enter closing state.
+                                let _ = write_frame(upstream_write, WsOpcode::Close, &payload, true, true).await;
+                                return await_close_response(upstream_read, close_timeout).await;
+                            }
+                            WsOpcode::Text | WsOpcode::Binary | WsOpcode::Continuation => {
+                                if let Err(e) = write_frame(upstream_write, opcode, &payload, true, fin).await {
+                                    debug!(error = %e, "failed to forward frame to upstream");
+                                    return RelayOutcome::Error(e);
+                                }
+                            }
+                            WsOpcode::Ping | WsOpcode::Pong => {
+                                let _ = write_frame(upstream_write, opcode, &payload, true, true).await;
+                            }
+                            WsOpcode::Unknown(_) => {
+                                // Forward unknown opcodes transparently.
+                                let _ = write_frame(upstream_write, opcode, &payload, true, fin).await;
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        // Client EOF — send Close to upstream.
+                        let close = make_close_payload(1001, "Going Away");
+                        let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
+                        return RelayOutcome::CallerDrop;
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                        // Frame exceeded max size — send Close 1009 to both sides.
+                        let close = make_close_payload(1009, "Message Too Big");
+                        let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
+                        let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
+                        return RelayOutcome::FrameTooLarge;
+                    }
+                    Err(_) => {
+                        let close = make_close_payload(1001, "Going Away");
+                        let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
+                        return RelayOutcome::CallerDrop;
+                    }
+                }
+            }
+            result = read_frame(upstream_read, max_frame_size) => {
+                match result {
+                    Ok(Some((fin, opcode, payload))) => {
+                        deadline.as_mut().reset(tokio::time::Instant::now() + idle_timeout);
+                        match opcode {
+                            WsOpcode::Close => {
+                                // Forward close to client, then enter closing state.
+                                let _ = write_frame(client_write, WsOpcode::Close, &payload, false, true).await;
+                                return await_close_response(client_read, close_timeout).await;
+                            }
+                            WsOpcode::Text | WsOpcode::Binary | WsOpcode::Continuation => {
+                                if let Err(e) = write_frame(client_write, opcode, &payload, false, fin).await {
+                                    debug!(error = %e, "failed to forward frame to client");
+                                    return RelayOutcome::Error(e);
+                                }
+                            }
+                            WsOpcode::Ping | WsOpcode::Pong => {
+                                let _ = write_frame(client_write, opcode, &payload, false, true).await;
+                            }
+                            WsOpcode::Unknown(_) => {
+                                let _ = write_frame(client_write, opcode, &payload, false, fin).await;
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        // Upstream EOF — send Close 1001 to client.
+                        // RFC 6455 §7.4.1: status 1006 MUST NOT be sent on the wire;
+                        // use 1001 (Going Away) instead.
+                        let close = make_close_payload(1001, "Going Away");
+                        let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
+                        return RelayOutcome::UpstreamDrop;
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                        // Upstream frame exceeded max size — send Close 1009 to upstream
+                        // and close the client side.
+                        let close = make_close_payload(1009, "Message Too Big");
+                        let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
+                        let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
+                        return RelayOutcome::FrameTooLarge;
+                    }
+                    Err(_) => {
+                        let close = make_close_payload(1001, "Going Away");
+                        let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
+                        return RelayOutcome::UpstreamDrop;
+                    }
+                }
+            }
+            _ = &mut deadline => {
+                // Idle timeout — send Close 1001 to both sides.
+                let close = make_close_payload(1001, "Going Away");
+                let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
+                let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
+                return RelayOutcome::IdleTimeout;
+            }
+            result = shutdown_rx.changed() => {
+                // Graceful server shutdown — close both sides cleanly.
+                if result.is_ok() && *shutdown_rx.borrow() {
+                    let close = make_close_payload(1001, "Going Away");
+                    let _ = write_frame(client_write, WsOpcode::Close, &close, false, true).await;
+                    let _ = write_frame(upstream_write, WsOpcode::Close, &close, true, true).await;
+                    return RelayOutcome::Shutdown;
+                }
+            }
+        }
+    }
+}
+
+/// Wait for a Close frame response from `reader`, up to `timeout`.
+///
+/// Loops past non-Close frames (Ping, Pong, data) that the peer may send
+/// before responding with Close (permitted by RFC 6455 §5.5.1). Returns
+/// `CleanClose` regardless of whether the Close response arrives in time.
+async fn await_close_response(
+    reader: &mut (impl AsyncRead + Unpin),
+    timeout: Duration,
+) -> RelayOutcome {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            debug!("close handshake timed out");
+            break;
+        }
+        // Close frame payload is at most 125 bytes per RFC 6455 §5.5.
+        match tokio::time::timeout(remaining, read_frame(reader, Some(125))).await {
+            Ok(Ok(Some((_, WsOpcode::Close, _)))) => {
+                debug!("received Close response, completing handshake");
+                break;
+            }
+            Ok(Ok(Some(_))) => {
+                debug!("received non-Close frame during close handshake, skipping");
+                continue;
+            }
+            Ok(Ok(None)) => {
+                debug!("connection closed during close handshake");
+                break;
+            }
+            Ok(Err(e)) => {
+                debug!(error = %e, "error during close handshake");
+                break;
+            }
+            Err(_) => {
+                debug!("close handshake timed out");
+                break;
+            }
+        }
+    }
+    RelayOutcome::CleanClose
+}
+
+// ---------------------------------------------------------------------------
+// Bridge types and entry point
+// ---------------------------------------------------------------------------
+
+/// Carries the DuplexStream and leftover bytes from a successful 101 response
+/// through the response extensions, so the Axum handler can bridge the
+/// client's upgraded connection to the Pingora-managed upstream tunnel.
+pub(crate) struct WebSocketBridgeIo {
+    pub io: tokio::io::DuplexStream,
+    pub leftover: Bytes,
+    pub idle_timeout: Duration,
+    pub close_timeout: Duration,
+    pub max_frame_size: Option<usize>,
+    pub shutdown_rx: watch::Receiver<bool>,
+}
+
+/// Wrapper that satisfies `Clone + Send + Sync + 'static` required by
+/// `http::Extensions::insert`. The inner value is taken once by the handler.
+#[derive(Clone)]
+pub(crate) struct WebSocketBridgeHandle(pub Arc<Mutex<Option<WebSocketBridgeIo>>>);
+
+impl WebSocketBridgeHandle {
+    pub fn new(bridge: WebSocketBridgeIo) -> Self {
+        Self(Arc::new(Mutex::new(Some(bridge))))
+    }
+
+    /// Take the bridge IO out of the handle. Returns `None` if already taken.
+    pub fn take(&self) -> Option<WebSocketBridgeIo> {
+        self.0.lock().take()
+    }
+}
+
+/// Bridge a client's upgraded connection to the Pingora-managed upstream
+/// tunnel via frame-aware WebSocket relay.
+///
+/// Any leftover bytes read past the header boundary during 101 response
+/// parsing are prepended to the upstream read stream via [`PrefixedReader`],
+/// so they enter the frame relay loop and are parsed as WebSocket frames
+/// rather than being written raw to the client.
+pub(crate) async fn websocket_bridge(
+    upgraded: hyper::upgrade::Upgraded,
+    bridge: WebSocketBridgeIo,
+) {
+    use hyper_util::rt::TokioIo;
+    use tokio::io::split;
+
+    let WebSocketBridgeIo {
+        io,
+        leftover,
+        idle_timeout,
+        close_timeout,
+        max_frame_size,
+        shutdown_rx,
+    } = bridge;
+    let (upstream_read, mut upstream_write) = split(io);
+    // Prepend any leftover bytes from 101 header parsing to the upstream
+    // read stream so they are parsed as WebSocket frames by the relay.
+    let mut upstream_read = PrefixedReader::new(leftover, upstream_read);
+    // Wrap hyper's Upgraded in TokioIo so it implements tokio::io::AsyncRead/Write.
+    let tokio_upgraded = TokioIo::new(upgraded);
+    let (mut client_read, mut client_write) = split(tokio_upgraded);
+
+    match frame_relay(
+        &mut client_read,
+        &mut client_write,
+        &mut upstream_read,
+        &mut upstream_write,
+        RelayConfig {
+            idle_timeout,
+            close_timeout,
+            max_frame_size,
+            shutdown_rx,
+        },
+    )
+    .await
+    {
+        RelayOutcome::CleanClose => debug!("WebSocket closed normally"),
+        RelayOutcome::IdleTimeout => debug!("WebSocket idle timeout, closing"),
+        RelayOutcome::UpstreamDrop => warn!("upstream WebSocket connection dropped unexpectedly"),
+        RelayOutcome::CallerDrop => debug!("caller disconnected"),
+        RelayOutcome::FrameTooLarge => warn!("WebSocket frame exceeded max size"),
+        RelayOutcome::Shutdown => debug!("WebSocket closed due to server shutdown"),
+        RelayOutcome::Error(e) => debug!(error = %e, "WebSocket bridge error"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a no-op shutdown receiver for tests that don't exercise shutdown.
+    fn test_shutdown_rx() -> watch::Receiver<bool> {
+        let (_tx, rx) = watch::channel(false);
+        rx
+    }
+
+    // -- Frame parser/writer tests --
+
+    #[tokio::test]
+    async fn write_and_read_text_frame() {
+        let (mut writer_end, mut reader_end) = tokio::io::duplex(4096);
+        write_frame(&mut writer_end, WsOpcode::Text, b"hello", false, true)
+            .await
+            .unwrap();
+        drop(writer_end);
+
+        let (fin, op, payload) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
+        assert!(fin);
+        assert_eq!(op, WsOpcode::Text);
+        assert_eq!(payload, b"hello");
+    }
+
+    #[tokio::test]
+    async fn write_and_read_close_frame() {
+        let (mut writer_end, mut reader_end) = tokio::io::duplex(4096);
+        let payload = make_close_payload(1000, "Normal Closure");
+        write_frame(&mut writer_end, WsOpcode::Close, &payload, false, true)
+            .await
+            .unwrap();
+        drop(writer_end);
+
+        let (fin, op, data) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
+        assert!(fin);
+        assert_eq!(op, WsOpcode::Close);
+        let (code, reason) = parse_close_payload(&data);
+        assert_eq!(code, 1000);
+        assert_eq!(reason, b"Normal Closure");
+    }
+
+    #[tokio::test]
+    async fn read_masked_frame() {
+        let (mut writer_end, mut reader_end) = tokio::io::duplex(4096);
+        // Write a masked frame.
+        write_frame(
+            &mut writer_end,
+            WsOpcode::Binary,
+            b"masked data",
+            true,
+            true,
+        )
+        .await
+        .unwrap();
+        drop(writer_end);
+
+        // read_frame should unmask automatically.
+        let (fin, op, payload) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
+        assert!(fin);
+        assert_eq!(op, WsOpcode::Binary);
+        assert_eq!(payload, b"masked data");
+    }
+
+    #[tokio::test]
+    async fn extended_length_payloads() {
+        // 126-byte extended length (2-byte encoding).
+        let payload_126 = vec![0xAB; 200];
+        let (mut w, mut r) = tokio::io::duplex(4096);
+        write_frame(&mut w, WsOpcode::Binary, &payload_126, false, true)
+            .await
+            .unwrap();
+        drop(w);
+        let (_, _, data) = read_frame(&mut r, None).await.unwrap().unwrap();
+        assert_eq!(data.len(), 200);
+        assert_eq!(data, payload_126);
+
+        // 127-byte extended length (8-byte encoding) — use 70000 bytes.
+        let payload_127 = vec![0xCD; 70_000];
+        let (mut w, mut r) = tokio::io::duplex(256 * 1024);
+        write_frame(&mut w, WsOpcode::Binary, &payload_127, false, true)
+            .await
+            .unwrap();
+        drop(w);
+        let (_, _, data) = read_frame(&mut r, None).await.unwrap().unwrap();
+        assert_eq!(data.len(), 70_000);
+        assert_eq!(data, payload_127);
+    }
+
+    #[tokio::test]
+    async fn parse_close_payload_no_code() {
+        let (code, reason) = parse_close_payload(b"");
+        assert_eq!(code, 1005);
+        assert!(reason.is_empty());
+    }
+
+    #[tokio::test]
+    async fn eof_returns_none() {
+        let (writer_end, mut reader_end) = tokio::io::duplex(4096);
+        drop(writer_end);
+        let result = read_frame(&mut reader_end, None).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn read_frame_rejects_oversized_payload() {
+        let (mut writer_end, mut reader_end) = tokio::io::duplex(4096);
+        // Write a frame with 200-byte payload.
+        write_frame(&mut writer_end, WsOpcode::Text, &[0xAA; 200], false, true)
+            .await
+            .unwrap();
+        drop(writer_end);
+
+        // Reading with max_payload=50 should fail before allocation.
+        let err = read_frame(&mut reader_end, Some(50)).await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn fin_bit_preserved_for_fragments() {
+        let (mut writer_end, mut reader_end) = tokio::io::duplex(4096);
+
+        // Write a non-final text frame (FIN=0).
+        write_frame(&mut writer_end, WsOpcode::Text, b"part1", false, false)
+            .await
+            .unwrap();
+        // Write a continuation frame (FIN=0).
+        write_frame(
+            &mut writer_end,
+            WsOpcode::Continuation,
+            b"part2",
+            false,
+            false,
+        )
+        .await
+        .unwrap();
+        // Write a final continuation frame (FIN=1).
+        write_frame(
+            &mut writer_end,
+            WsOpcode::Continuation,
+            b"part3",
+            false,
+            true,
+        )
+        .await
+        .unwrap();
+        drop(writer_end);
+
+        let (fin, op, payload) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
+        assert!(!fin);
+        assert_eq!(op, WsOpcode::Text);
+        assert_eq!(payload, b"part1");
+
+        let (fin, op, payload) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
+        assert!(!fin);
+        assert_eq!(op, WsOpcode::Continuation);
+        assert_eq!(payload, b"part2");
+
+        let (fin, op, payload) = read_frame(&mut reader_end, None).await.unwrap().unwrap();
+        assert!(fin);
+        assert_eq!(op, WsOpcode::Continuation);
+        assert_eq!(payload, b"part3");
+    }
+
+    // -- Frame relay tests --
+
+    #[tokio::test]
+    async fn relay_close_propagation() {
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Client sends Close 1000.
+        let close = make_close_payload(1000, "Normal");
+        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
+            .await
+            .unwrap();
+
+        // Upstream should receive the forwarded Close.
+        let (fin, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert!(fin);
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1000);
+
+        // Upstream sends Close response.
+        let resp_close = make_close_payload(1000, "Normal");
+        write_frame(&mut upstream_a, WsOpcode::Close, &resp_close, false, true)
+            .await
+            .unwrap();
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::CleanClose));
+    }
+
+    #[tokio::test]
+    async fn relay_upstream_drop_sends_1001() {
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Drop upstream — triggers EOF.
+        drop(upstream_a);
+
+        // Client should receive Close 1001 (not 1006, which MUST NOT be sent
+        // on the wire per RFC 6455 §7.4.1).
+        let (fin, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
+        assert!(fin);
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1001);
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::UpstreamDrop));
+    }
+
+    #[tokio::test]
+    async fn relay_idle_timeout_sends_1001() {
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_millis(50),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::IdleTimeout));
+
+        // Both sides should have received Close 1001.
+        let (_, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1001);
+
+        let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1001);
+    }
+
+    #[tokio::test]
+    async fn relay_shutdown_sends_1001_to_both_sides() {
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx,
+                },
+            )
+            .await
+        });
+
+        // Signal shutdown.
+        shutdown_tx.send(true).unwrap();
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::Shutdown));
+
+        // Both sides should have received Close 1001 (Going Away).
+        let (_, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1001);
+
+        let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1001);
+    }
+
+    #[tokio::test]
+    async fn relay_max_frame_size_sends_1009() {
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: Some(10), // max 10 bytes
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Client sends a frame exceeding the limit.
+        write_frame(
+            &mut client_a,
+            WsOpcode::Text,
+            b"this is way too long",
+            true,
+            true,
+        )
+        .await
+        .unwrap();
+
+        // Client should receive Close 1009.
+        let (_, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1009);
+
+        // Upstream should also receive Close 1009.
+        let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1009);
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::FrameTooLarge));
+    }
+
+    #[tokio::test]
+    async fn relay_close_timeout_enforced() {
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (_upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_millis(50), // very short close timeout
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Client sends Close. The upstream side (_upstream_a) never responds.
+        let close = make_close_payload(1000, "bye");
+        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
+            .await
+            .unwrap();
+
+        // Should still complete with CleanClose after close timeout.
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::CleanClose));
+    }
+
+    // -- PrefixedReader tests --
+
+    #[tokio::test]
+    async fn prefixed_reader_yields_prefix_then_inner() {
+        let prefix = Bytes::from_static(b"prefix-");
+        let inner = &b"inner"[..];
+        let mut reader = PrefixedReader::new(prefix, inner);
+
+        let mut buf = vec![0u8; 32];
+        let n = reader.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"prefix-");
+
+        let n = reader.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"inner");
+    }
+
+    #[tokio::test]
+    async fn prefixed_reader_empty_prefix_reads_inner_directly() {
+        let prefix = Bytes::new();
+        let inner = &b"data"[..];
+        let mut reader = PrefixedReader::new(prefix, inner);
+
+        let mut buf = vec![0u8; 32];
+        let n = reader.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"data");
+    }
+
+    #[tokio::test]
+    async fn relay_leftover_bytes_forwarded_as_frames() {
+        // Simulate leftover bytes from 101 header parsing: a complete
+        // upstream WebSocket text frame sitting in the leftover buffer.
+        let mut leftover_buf = Vec::new();
+        // Build an unmasked text frame with payload "from-upstream".
+        let payload = b"from-upstream";
+        leftover_buf.push(0x81); // FIN + text opcode
+        leftover_buf.push(payload.len() as u8); // no mask, len < 126
+        leftover_buf.extend_from_slice(payload);
+        let leftover = Bytes::from(leftover_buf);
+
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (ur, mut uw) = tokio::io::split(upstream_b);
+        // Wrap upstream_read with leftover bytes, same as websocket_bridge does.
+        let mut ur = PrefixedReader::new(leftover, ur);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Client should receive the leftover frame parsed as a proper text frame.
+        let (fin, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
+        assert!(fin);
+        assert_eq!(op, WsOpcode::Text);
+        assert_eq!(data, b"from-upstream");
+
+        // Clean up: send Close from client to terminate the relay.
+        let close = make_close_payload(1000, "done");
+        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
+            .await
+            .unwrap();
+
+        // Upstream receives the forwarded Close.
+        let (_, op, _) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Close);
+
+        // Respond with Close to complete handshake.
+        let resp = make_close_payload(1000, "done");
+        write_frame(&mut upstream_a, WsOpcode::Close, &resp, false, true)
+            .await
+            .unwrap();
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::CleanClose));
+    }
+
+    // -- await_close_response loop tests --
+
+    #[tokio::test]
+    async fn await_close_response_skips_non_close_frames() {
+        let (mut writer, reader) = tokio::io::duplex(4096);
+        let (mut reader, _) = tokio::io::split(reader);
+
+        // Write a Pong frame, a Text frame, then a Close frame.
+        write_frame(&mut writer, WsOpcode::Pong, b"", false, true)
+            .await
+            .unwrap();
+        write_frame(&mut writer, WsOpcode::Text, b"queued", false, true)
+            .await
+            .unwrap();
+        let close = make_close_payload(1000, "bye");
+        write_frame(&mut writer, WsOpcode::Close, &close, false, true)
+            .await
+            .unwrap();
+
+        let outcome = await_close_response(&mut reader, Duration::from_secs(2)).await;
+        assert!(matches!(outcome, RelayOutcome::CleanClose));
+    }
+
+    #[tokio::test]
+    async fn await_close_response_timeout_with_only_data_frames() {
+        let (mut writer, reader) = tokio::io::duplex(4096);
+        let (mut reader, _) = tokio::io::split(reader);
+
+        // Write a few Pong frames but never a Close.
+        for _ in 0..3 {
+            write_frame(&mut writer, WsOpcode::Pong, b"", false, true)
+                .await
+                .unwrap();
+        }
+        // Keep writer alive so reads block (no EOF).
+        let _writer = writer;
+
+        let outcome = await_close_response(&mut reader, Duration::from_millis(50)).await;
+        assert!(matches!(outcome, RelayOutcome::CleanClose));
+    }
+
+    // -- Caller disconnect tests --
+
+    #[tokio::test]
+    async fn relay_caller_drop_sends_close_to_upstream() {
+        let (client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Drop client mid-session — triggers EOF on the client read side.
+        drop(client_a);
+
+        // Upstream should receive a Close 1001 (Going Away).
+        let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1001);
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::CallerDrop));
+    }
+
+    #[tokio::test]
+    async fn relay_caller_drop_during_upstream_activity() {
+        // Upstream is actively sending data when the caller disconnects.
+        let (client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Upstream sends a message first.
+        write_frame(&mut upstream_a, WsOpcode::Text, b"data", false, true)
+            .await
+            .unwrap();
+
+        // Small delay to let the relay forward it, then drop client.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        drop(client_a);
+
+        // Upstream should receive Close 1001.
+        // May need to read past the frame that was in flight.
+        loop {
+            match read_frame(&mut upstream_a, None).await {
+                Ok(Some((_, WsOpcode::Close, data))) => {
+                    let (code, _) = parse_close_payload(&data);
+                    assert_eq!(code, 1001);
+                    break;
+                }
+                Ok(Some(_)) => continue,    // skip in-flight frames
+                Ok(None) | Err(_) => break, // EOF is also acceptable
+            }
+        }
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(
+            outcome,
+            RelayOutcome::CallerDrop | RelayOutcome::Error(_)
+        ));
+    }
+
+    // -- Upstream Close during active client transmission --
+
+    #[tokio::test]
+    async fn relay_upstream_sends_close_while_client_is_sending() {
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Client sends a text frame.
+        write_frame(&mut client_a, WsOpcode::Text, b"hello", true, true)
+            .await
+            .unwrap();
+
+        // Upstream receives the frame...
+        let (_, op, _) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Text);
+
+        // ...then upstream initiates Close while client might still be sending.
+        let close = make_close_payload(1000, "Server done");
+        write_frame(&mut upstream_a, WsOpcode::Close, &close, false, true)
+            .await
+            .unwrap();
+
+        // Client should receive the Close frame forwarded by the relay.
+        let (_, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1000);
+
+        // Client sends Close response to complete the handshake.
+        let resp = make_close_payload(1000, "OK");
+        write_frame(&mut client_a, WsOpcode::Close, &resp, true, true)
+            .await
+            .unwrap();
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::CleanClose));
+    }
+
+    // -- Ping/Pong forwarding --
+
+    #[tokio::test]
+    async fn relay_ping_forwarded_to_upstream() {
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Client sends Ping.
+        write_frame(&mut client_a, WsOpcode::Ping, b"ping-data", true, true)
+            .await
+            .unwrap();
+
+        // Upstream should receive the Ping.
+        let (_, op, payload) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Ping);
+        assert_eq!(payload, b"ping-data");
+
+        // Upstream sends Pong back.
+        write_frame(&mut upstream_a, WsOpcode::Pong, b"pong-data", false, true)
+            .await
+            .unwrap();
+
+        // Client should receive the Pong.
+        let (_, op, payload) = read_frame(&mut client_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Pong);
+        assert_eq!(payload, b"pong-data");
+
+        // Verify Ping resets the idle timer by sending after a short pause.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        write_frame(&mut client_a, WsOpcode::Ping, b"", true, true)
+            .await
+            .unwrap();
+        let (_, op, _) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Ping);
+
+        // Clean up.
+        let close = make_close_payload(1000, "done");
+        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
+            .await
+            .unwrap();
+        let _ = read_frame(&mut upstream_a, None).await; // consume forwarded Close
+        write_frame(&mut upstream_a, WsOpcode::Close, &close, false, true)
+            .await
+            .unwrap();
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::CleanClose));
+    }
+
+    // -- Upstream oversized frame sends 1009 --
+
+    #[tokio::test]
+    async fn relay_upstream_oversized_frame_sends_1009() {
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: Some(10), // max 10 bytes
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Upstream sends an oversized frame.
+        write_frame(&mut upstream_a, WsOpcode::Text, &[0xBB; 50], false, true)
+            .await
+            .unwrap();
+
+        // Upstream should receive Close 1009.
+        let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1009);
+
+        // Client should also receive Close 1009.
+        let (_, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
+        assert_eq!(op, WsOpcode::Close);
+        let (code, _) = parse_close_payload(&data);
+        assert_eq!(code, 1009);
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::FrameTooLarge));
+    }
+
+    // -- Fragmented message relay --
+
+    #[tokio::test]
+    async fn relay_fragmented_message_preserved() {
+        // Verify that fragmented messages (FIN=0 + continuation frames)
+        // are forwarded through the relay with FIN bits intact.
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Client sends a fragmented text message: non-final + continuation + final.
+        write_frame(&mut client_a, WsOpcode::Text, b"frag1", true, false)
+            .await
+            .unwrap();
+        write_frame(&mut client_a, WsOpcode::Continuation, b"frag2", true, false)
+            .await
+            .unwrap();
+        write_frame(&mut client_a, WsOpcode::Continuation, b"frag3", true, true)
+            .await
+            .unwrap();
+
+        // Upstream should receive all three fragments with FIN bits preserved.
+        let (fin, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert!(!fin);
+        assert_eq!(op, WsOpcode::Text);
+        assert_eq!(data, b"frag1");
+
+        let (fin, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert!(!fin);
+        assert_eq!(op, WsOpcode::Continuation);
+        assert_eq!(data, b"frag2");
+
+        let (fin, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert!(fin);
+        assert_eq!(op, WsOpcode::Continuation);
+        assert_eq!(data, b"frag3");
+
+        // Clean up.
+        let close = make_close_payload(1000, "done");
+        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
+            .await
+            .unwrap();
+        let _ = read_frame(&mut upstream_a, None).await;
+        write_frame(&mut upstream_a, WsOpcode::Close, &close, false, true)
+            .await
+            .unwrap();
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::CleanClose));
+    }
+
+    // -- Binary frame opcode preservation --
+
+    #[tokio::test]
+    async fn relay_binary_opcode_preserved() {
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_secs(5),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Client sends a binary frame.
+        let binary_data = vec![0x00, 0xFF, 0x42, 0x13, 0x37];
+        write_frame(&mut client_a, WsOpcode::Binary, &binary_data, true, true)
+            .await
+            .unwrap();
+
+        // Upstream receives it as Binary (not Text).
+        let (fin, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+        assert!(fin);
+        assert_eq!(op, WsOpcode::Binary);
+        assert_eq!(data, binary_data);
+
+        // Upstream responds with Binary.
+        let response_data = vec![0xDE, 0xAD, 0xBE, 0xEF];
+        write_frame(
+            &mut upstream_a,
+            WsOpcode::Binary,
+            &response_data,
+            false,
+            true,
+        )
+        .await
+        .unwrap();
+
+        // Client receives it as Binary.
+        let (fin, op, data) = read_frame(&mut client_a, None).await.unwrap().unwrap();
+        assert!(fin);
+        assert_eq!(op, WsOpcode::Binary);
+        assert_eq!(data, response_data);
+
+        // Clean up.
+        let close = make_close_payload(1000, "done");
+        write_frame(&mut client_a, WsOpcode::Close, &close, true, true)
+            .await
+            .unwrap();
+        let _ = read_frame(&mut upstream_a, None).await;
+        write_frame(&mut upstream_a, WsOpcode::Close, &close, false, true)
+            .await
+            .unwrap();
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::CleanClose));
+    }
+
+    // -- Idle timer reset on activity --
+
+    #[tokio::test]
+    async fn relay_idle_timer_resets_on_data() {
+        // With a 100ms idle timeout, send a frame every 60ms to keep the
+        // connection alive — verify it survives past the original deadline.
+        let (mut client_a, client_b) = tokio::io::duplex(4096);
+        let (mut upstream_a, upstream_b) = tokio::io::duplex(4096);
+
+        let (mut cr, mut cw) = tokio::io::split(client_b);
+        let (mut ur, mut uw) = tokio::io::split(upstream_b);
+
+        let handle = tokio::spawn(async move {
+            frame_relay(
+                &mut cr,
+                &mut cw,
+                &mut ur,
+                &mut uw,
+                RelayConfig {
+                    idle_timeout: Duration::from_millis(100),
+                    close_timeout: Duration::from_secs(2),
+                    max_frame_size: None,
+                    shutdown_rx: test_shutdown_rx(),
+                },
+            )
+            .await
+        });
+
+        // Send 5 messages spaced 60ms apart. Total time ~300ms, well past
+        // the 100ms idle timeout — but each message resets the timer.
+        for i in 0..5 {
+            tokio::time::sleep(Duration::from_millis(60)).await;
+            let msg = format!("msg-{i}");
+            write_frame(&mut client_a, WsOpcode::Text, msg.as_bytes(), true, true)
+                .await
+                .unwrap();
+            let (_, op, data) = read_frame(&mut upstream_a, None).await.unwrap().unwrap();
+            assert_eq!(op, WsOpcode::Text);
+            assert_eq!(data, msg.as_bytes());
+        }
+
+        // Now stop sending and let the idle timeout fire.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, RelayOutcome::IdleTimeout));
+    }
+}

--- a/modules/system/oagw/oagw/src/module.rs
+++ b/modules/system/oagw/oagw/src/module.rs
@@ -60,6 +60,8 @@ impl Default for OutboundApiGatewayModule {
 impl Module for OutboundApiGatewayModule {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         let cfg: OagwConfig = ctx.config()?;
+        cfg.validate()
+            .map_err(|e| anyhow::anyhow!("invalid OAGW config: {e}"))?;
         info!("OAGW config: proxy_timeout_secs={}", cfg.proxy_timeout_secs);
 
         // -- Control Plane init --
@@ -120,7 +122,10 @@ impl Module for OutboundApiGatewayModule {
             )
             .with_request_timeout(Duration::from_secs(cfg.proxy_timeout_secs))
             .with_max_body_size(cfg.max_body_size_bytes)
-            .with_allow_http_upstream(cfg.allow_http_upstream),
+            .with_allow_http_upstream(cfg.allow_http_upstream)
+            .with_websocket_idle_timeout(Duration::from_secs(cfg.websocket_idle_timeout_secs))
+            .with_websocket_close_timeout(Duration::from_secs(cfg.websocket_close_timeout_secs))
+            .with_websocket_max_frame_size(cfg.websocket_max_frame_size_bytes),
         );
 
         // -- Facade (for external SDK consumers) --

--- a/modules/system/oagw/oagw/src/test_support/harness.rs
+++ b/modules/system/oagw/oagw/src/test_support/harness.rs
@@ -44,7 +44,7 @@ impl AppHarness {
         &self.ctx
     }
 
-    pub(crate) fn router(&self) -> &axum::Router {
+    pub fn router(&self) -> &axum::Router {
         &self.router
     }
 }
@@ -57,6 +57,9 @@ pub struct AppHarnessBuilder {
     authz_client: Option<Arc<dyn AuthZResolverClient>>,
     max_body_size: Option<usize>,
     skip_upstream_tls_verify: bool,
+    websocket_idle_timeout: Option<Duration>,
+    websocket_close_timeout: Option<Duration>,
+    websocket_max_frame_size: Option<usize>,
 }
 
 impl AppHarnessBuilder {
@@ -88,6 +91,24 @@ impl AppHarnessBuilder {
         self
     }
 
+    /// Override the WebSocket idle timeout (useful for idle-timeout tests).
+    pub fn with_websocket_idle_timeout(mut self, timeout: Duration) -> Self {
+        self.websocket_idle_timeout = Some(timeout);
+        self
+    }
+
+    /// Override the WebSocket Close frame handshake timeout.
+    pub fn with_websocket_close_timeout(mut self, timeout: Duration) -> Self {
+        self.websocket_close_timeout = Some(timeout);
+        self
+    }
+
+    /// Override the maximum WebSocket frame payload size.
+    pub fn with_websocket_max_frame_size(mut self, size: usize) -> Self {
+        self.websocket_max_frame_size = Some(size);
+        self
+    }
+
     pub async fn build(self) -> AppHarness {
         let hub = ClientHub::new();
 
@@ -107,6 +128,15 @@ impl AppHarnessBuilder {
             dp_builder = dp_builder.with_max_body_size(size);
         }
         dp_builder = dp_builder.with_skip_upstream_tls_verify(self.skip_upstream_tls_verify);
+        if let Some(timeout) = self.websocket_idle_timeout {
+            dp_builder = dp_builder.with_websocket_idle_timeout(timeout);
+        }
+        if let Some(timeout) = self.websocket_close_timeout {
+            dp_builder = dp_builder.with_websocket_close_timeout(timeout);
+        }
+        if let Some(size) = self.websocket_max_frame_size {
+            dp_builder = dp_builder.with_websocket_max_frame_size(Some(size));
+        }
         dp_builder =
             dp_builder.with_token_http_config(modkit_http::HttpClientConfig::for_testing());
 

--- a/modules/system/oagw/oagw/tests/proxy_integration.rs
+++ b/modules/system/oagw/oagw/tests/proxy_integration.rs
@@ -1435,9 +1435,9 @@ async fn proxy_with_mock_guard_custom_response() {
     assert!(recorded[0].uri.contains("/custom/endpoint"));
 }
 
-// P0 #3: WebSocket upgrade requests are rejected with ProtocolError.
-#[tokio::test]
-async fn proxy_websocket_upgrade_rejected() {
+// WebSocket upgrade request returns 101 Switching Protocols when upstream accepts.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn proxy_websocket_upgrade_returns_101() {
     let h = AppHarness::builder().build().await;
     let ctx = h.security_context().clone();
 
@@ -1455,7 +1455,7 @@ async fn proxy_websocket_upgrade_rejected() {
                 },
                 "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
             )
-            .alias("ws-reject-test")
+            .alias("ws-echo-test")
             .build(),
         )
         .await
@@ -1469,7 +1469,140 @@ async fn proxy_websocket_upgrade_rejected() {
                 MatchRules {
                     http: Some(HttpMatch {
                         methods: vec![HttpMethod::Get],
-                        path: "/v1/ws".into(),
+                        path: "/ws/echo".into(),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Append,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Send a WebSocket upgrade request through the data plane.
+    // The mock server has a ws_echo handler at /ws/echo.
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/ws-echo-test/ws/echo")
+        .header("upgrade", "websocket")
+        .header("connection", "Upgrade")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .header("sec-websocket-version", "13")
+        .body(Body::Empty)
+        .unwrap();
+
+    let resp = h
+        .facade()
+        .proxy_request(ctx.clone(), req)
+        .await
+        .expect("WebSocket upgrade should succeed");
+
+    assert_eq!(
+        resp.status(),
+        http::StatusCode::SWITCHING_PROTOCOLS,
+        "expected 101, got {}",
+        resp.status()
+    );
+    assert_eq!(
+        resp.headers().get("upgrade").and_then(|v| v.to_str().ok()),
+        Some("websocket"),
+        "response should contain Upgrade: websocket header"
+    );
+}
+
+// WebSocket E2E: upgrade through real TCP, send text frame, receive echo.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn proxy_websocket_e2e_echo() {
+    use tokio::io::AsyncWriteExt;
+
+    let h = AppHarness::builder().build().await;
+    setup_ws_upstream(&h, "ws-e2e").await;
+    let (addr, server_handle) = start_oagw_server(&h).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    ws_handshake(&mut stream, "/oagw/v1/proxy/ws-e2e/ws/echo").await;
+
+    // Send a masked text frame containing "hello" and read the echo.
+    let frame = build_masked_frame(0x1, b"hello");
+    stream.write_all(&frame).await.unwrap();
+    let (opcode, payload) = read_ws_frame(&mut stream).await.expect("echo frame");
+    assert_eq!(opcode, 0x1, "expected text frame opcode");
+    assert_eq!(payload, b"hello", "echoed payload mismatch");
+
+    // Send a close frame with code 1000 (Normal Closure).
+    let close_frame = build_masked_frame(0x8, &1000u16.to_be_bytes());
+    stream.write_all(&close_frame).await.unwrap();
+    if let Some((op, _)) = read_ws_frame(&mut stream).await {
+        assert_eq!(op, 0x8, "expected close frame opcode");
+    }
+
+    server_handle.abort();
+}
+
+// 14.2: Auth credentials are injected into the outbound WebSocket upgrade request.
+#[tokio::test]
+async fn proxy_websocket_auth_injected_during_handshake() {
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "GET",
+        "/ws/echo",
+        MockResponse {
+            status: 200,
+            headers: vec![("content-type".into(), "application/json".into())],
+            body: MockBody::Json(json!({"ok": true})),
+        },
+    );
+
+    let h = AppHarness::builder()
+        .with_credentials(vec![("cred://ws-key".into(), "sk-ws-secret".into())])
+        .build()
+        .await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("ws-auth-test")
+            .auth(oagw_sdk::AuthConfig {
+                plugin_type: APIKEY_AUTH_PLUGIN_ID.into(),
+                sharing: SharingMode::Private,
+                config: Some(
+                    [
+                        ("header".into(), "authorization".into()),
+                        ("prefix".into(), "Bearer ".into()),
+                        ("secret_ref".into(), "cred://ws-key".into()),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get],
+                        path: guard.path("/ws/echo"),
                         query_allowlist: vec![],
                         path_suffix_mode: PathSuffixMode::Append,
                     }),
@@ -1483,22 +1616,179 @@ async fn proxy_websocket_upgrade_rejected() {
 
     let req = http::Request::builder()
         .method(Method::GET)
-        .uri("/ws-reject-test/v1/ws")
+        .uri(format!("/ws-auth-test{}", guard.path("/ws/echo")))
         .header("upgrade", "websocket")
-        .header("connection", "upgrade")
+        .header("connection", "Upgrade")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .header("sec-websocket-version", "13")
         .body(Body::Empty)
         .unwrap();
 
-    match h.facade().proxy_request(ctx.clone(), req).await {
+    let response = h.facade().proxy_request(ctx, req).await.unwrap();
+    // The mock returns 200 (not 101), which is fine — we're testing auth injection,
+    // not the upgrade itself.
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let recorded = guard.recorded_requests().await;
+    assert_eq!(recorded.len(), 1, "expected exactly 1 recorded request");
+
+    // Verify the auth plugin injected credentials into the upgrade request.
+    let auth_header = recorded[0]
+        .headers
+        .iter()
+        .find(|(k, _)| k == "authorization")
+        .map(|(_, v)| v.as_str())
+        .expect("authorization header missing from upgrade request");
+    assert_eq!(auth_header, "Bearer sk-ws-secret");
+
+    // Verify WebSocket-specific headers were forwarded (not stripped by auth pipeline).
+    let has_upgrade = recorded[0]
+        .headers
+        .iter()
+        .any(|(k, v)| k == "upgrade" && v == "websocket");
+    assert!(has_upgrade, "Upgrade header missing from outbound request");
+
+    let has_ws_key = recorded[0]
+        .headers
+        .iter()
+        .any(|(k, _)| k == "sec-websocket-key");
+    assert!(
+        has_ws_key,
+        "Sec-WebSocket-Key header missing from outbound request"
+    );
+}
+
+// 14.3: Rate limiting applies to WebSocket connection establishment.
+#[tokio::test]
+async fn proxy_websocket_rate_limit_on_handshake() {
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("ws-rate-limit")
+            .rate_limit(RateLimitConfig {
+                sharing: SharingMode::Private,
+                algorithm: RateLimitAlgorithm::TokenBucket,
+                sustained: SustainedRate {
+                    rate: 1,
+                    window: Window::Minute,
+                },
+                burst: Some(BurstConfig { capacity: 1 }),
+                scope: RateLimitScope::Tenant,
+                strategy: RateLimitStrategy::Reject,
+                cost: 1,
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get],
+                        path: "/ws/echo".into(),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Append,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // First WebSocket upgrade should succeed.
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/ws-rate-limit/ws/echo")
+        .header("upgrade", "websocket")
+        .header("connection", "Upgrade")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .header("sec-websocket-version", "13")
+        .body(Body::Empty)
+        .unwrap();
+    let response = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::SWITCHING_PROTOCOLS,
+        "first WS upgrade should succeed with 101"
+    );
+
+    // Second WebSocket upgrade within the rate window should be rejected.
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/ws-rate-limit/ws/echo")
+        .header("upgrade", "websocket")
+        .header("connection", "Upgrade")
+        .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+        .header("sec-websocket-version", "13")
+        .body(Body::Empty)
+        .unwrap();
+    match h.facade().proxy_request(ctx, req).await {
         Err(err) => assert!(
             matches!(
                 err,
-                oagw_sdk::error::ServiceGatewayError::ProtocolError { .. }
+                oagw_sdk::error::ServiceGatewayError::RateLimitExceeded { .. }
             ),
-            "expected ProtocolError for WebSocket upgrade, got: {err:?}"
+            "expected RateLimitExceeded, got: {err:?}"
         ),
-        Ok(_) => panic!("expected error for WebSocket upgrade request"),
+        Ok(resp) => panic!(
+            "expected rate limit error on second WS upgrade, got status {}",
+            resp.status()
+        ),
     }
+}
+
+// 14.4: WebSocket idle timeout — gateway closes the connection after inactivity.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn proxy_websocket_idle_timeout_closes_connection() {
+    use tokio::io::AsyncWriteExt;
+
+    let h = AppHarness::builder()
+        .with_websocket_idle_timeout(std::time::Duration::from_millis(200))
+        .build()
+        .await;
+    setup_ws_upstream(&h, "ws-idle-timeout").await;
+    let (addr, server_handle) = start_oagw_server(&h).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    ws_handshake(&mut stream, "/oagw/v1/proxy/ws-idle-timeout/ws/echo").await;
+
+    // Send a text frame to prove the connection is alive.
+    let frame = build_masked_frame(0x1, b"ping");
+    stream.write_all(&frame).await.unwrap();
+    let (opcode, _) = read_ws_frame(&mut stream).await.expect("echo frame");
+    assert_eq!(opcode, 0x1, "expected text frame opcode");
+
+    // Wait longer than the idle timeout (200ms).
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+    // Expect EOF or close frame indicating gateway closed the connection.
+    if let Some((op, _)) = read_ws_frame(&mut stream).await {
+        // Close frame received; EOF (None) is also valid — gateway closed TCP.
+        assert_eq!(op, 0x8, "expected close frame after idle timeout");
+    }
+
+    server_handle.abort();
 }
 
 // P4 #18: Pingora fail_to_proxy produces valid RFC 9457 Problem body with correct GTS type.
@@ -3502,6 +3792,607 @@ async fn cors_multiple_specific_origins() {
             .is_none(),
         "non-matching origin should not get CORS headers"
     );
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket frame-aware relay integration tests
+// ---------------------------------------------------------------------------
+
+/// Read HTTP response headers from a raw TCP stream until the `\r\n\r\n` terminator.
+/// Returns the complete header block as a String. Panics on timeout or if the
+/// buffer fills without finding the terminator.
+async fn read_http_response_headers(stream: &mut tokio::net::TcpStream) -> String {
+    use tokio::io::AsyncReadExt;
+    let mut buf = vec![0u8; 4096];
+    let mut filled = 0usize;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let n = tokio::time::timeout_at(deadline, stream.read(&mut buf[filled..]))
+            .await
+            .expect("timed out reading HTTP response headers")
+            .expect("read error");
+        assert!(n > 0, "unexpected EOF before header terminator");
+        filled += n;
+        let s = String::from_utf8_lossy(&buf[..filled]);
+        if s.contains("\r\n\r\n") {
+            return s.into_owned();
+        }
+        assert!(
+            filled < buf.len(),
+            "header buffer full without \\r\\n\\r\\n"
+        );
+    }
+}
+
+/// Helper: perform a WebSocket handshake over a raw TCP stream.
+/// Returns the stream positioned after the 101 response headers.
+async fn ws_handshake(stream: &mut tokio::net::TcpStream, uri: &str) {
+    use tokio::io::AsyncWriteExt;
+    let req = format!(
+        "GET {uri} HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         Upgrade: websocket\r\n\
+         Connection: Upgrade\r\n\
+         Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+         Sec-WebSocket-Version: 13\r\n\
+         \r\n"
+    );
+    stream.write_all(req.as_bytes()).await.unwrap();
+    let resp = read_http_response_headers(stream).await;
+    assert!(
+        resp.starts_with("HTTP/1.1 101"),
+        "expected 101 Switching Protocols, got: {resp}"
+    );
+}
+
+/// Helper: build a masked WebSocket frame for sending from a client.
+fn build_masked_frame(opcode: u8, payload: &[u8]) -> Vec<u8> {
+    let mask = [0x37, 0xfa, 0x21, 0x3d];
+    let mut frame = Vec::new();
+    frame.push(0x80 | opcode); // FIN + opcode
+    if payload.len() < 126 {
+        frame.push(0x80 | payload.len() as u8); // MASK + len
+    } else {
+        frame.push(0x80 | 126);
+        frame.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+    }
+    frame.extend_from_slice(&mask);
+    for (i, &byte) in payload.iter().enumerate() {
+        frame.push(byte ^ mask[i % 4]);
+    }
+    frame
+}
+
+/// Helper: read a WebSocket frame from a raw stream.
+/// Returns (opcode, payload) or None on EOF or timeout.
+async fn read_ws_frame(stream: &mut tokio::net::TcpStream) -> Option<(u8, Vec<u8>)> {
+    use tokio::io::AsyncReadExt;
+    let timeout = std::time::Duration::from_secs(5);
+
+    let mut hdr = [0u8; 2];
+    match tokio::time::timeout(timeout, stream.read_exact(&mut hdr)).await {
+        Ok(Ok(_)) => {}
+        _ => return None,
+    }
+    let opcode = hdr[0] & 0x0F;
+    let masked = hdr[1] & 0x80 != 0;
+    let len_byte = (hdr[1] & 0x7F) as u64;
+
+    let payload_len: usize = if len_byte < 126 {
+        len_byte as usize
+    } else if len_byte == 126 {
+        let mut buf = [0u8; 2];
+        tokio::time::timeout(timeout, stream.read_exact(&mut buf))
+            .await
+            .ok()?
+            .ok()?;
+        u16::from_be_bytes(buf) as usize
+    } else {
+        let mut buf = [0u8; 8];
+        tokio::time::timeout(timeout, stream.read_exact(&mut buf))
+            .await
+            .ok()?
+            .ok()?;
+        u64::from_be_bytes(buf) as usize
+    };
+
+    let mask_key = if masked {
+        let mut key = [0u8; 4];
+        tokio::time::timeout(timeout, stream.read_exact(&mut key))
+            .await
+            .ok()?
+            .ok()?;
+        Some(key)
+    } else {
+        None
+    };
+
+    let mut payload = vec![0u8; payload_len];
+    if payload_len > 0 {
+        tokio::time::timeout(timeout, stream.read_exact(&mut payload))
+            .await
+            .ok()?
+            .ok()?;
+    }
+    if let Some(key) = mask_key {
+        for (i, byte) in payload.iter_mut().enumerate() {
+            *byte ^= key[i % 4];
+        }
+    }
+    Some((opcode, payload))
+}
+
+/// Helper: set up an upstream + route pointing at the mock's /ws/echo endpoint.
+async fn setup_ws_upstream(h: &AppHarness, alias: &str) {
+    let ctx = h.security_context().clone();
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias(alias)
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx,
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get],
+                        path: "/ws/echo".into(),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Append,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+}
+
+/// Helper: start an Axum server on a random port and return the address.
+async fn start_oagw_server(h: &AppHarness) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let router = h.router().clone();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router).await.ok();
+    });
+    (addr, handle)
+}
+
+// 14.5: Close frame is forwarded through the gateway with status code preserved.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn proxy_websocket_close_frame_propagated() {
+    let h = AppHarness::builder().build().await;
+    setup_ws_upstream(&h, "ws-close-prop").await;
+    let (addr, server_handle) = start_oagw_server(&h).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    ws_handshake(&mut stream, "/oagw/v1/proxy/ws-close-prop/ws/echo").await;
+
+    // Send a text frame to confirm the connection works.
+    let text_frame = build_masked_frame(0x1, b"alive");
+    tokio::io::AsyncWriteExt::write_all(&mut stream, &text_frame)
+        .await
+        .unwrap();
+    let echo = read_ws_frame(&mut stream).await.unwrap();
+    assert_eq!(echo.0, 0x1); // text opcode
+    assert_eq!(echo.1, b"alive");
+
+    // Send Close 1000 (Normal Closure).
+    let mut close_payload = 1000u16.to_be_bytes().to_vec();
+    close_payload.extend_from_slice(b"Normal");
+    let close_frame = build_masked_frame(0x8, &close_payload);
+    tokio::io::AsyncWriteExt::write_all(&mut stream, &close_frame)
+        .await
+        .unwrap();
+
+    // Should receive Close frame back (echoed by mock upstream through gateway).
+    // The gateway may tear down the TCP connection immediately after the close
+    // handshake, so we may get the Close frame or just EOF.
+    match read_ws_frame(&mut stream).await {
+        Some((opcode, payload)) => {
+            assert_eq!(opcode, 0x8, "expected Close opcode");
+            assert!(
+                payload.len() >= 2,
+                "close payload should contain status code"
+            );
+            let code = u16::from_be_bytes([payload[0], payload[1]]);
+            assert_eq!(code, 1000, "close status code should be 1000");
+        }
+        None => {
+            // EOF after close is acceptable — the close was processed and the
+            // gateway tore down the connection before we could read the response.
+        }
+    }
+
+    server_handle.abort();
+}
+
+// 14.6: Idle timeout sends Close 1001 (Going Away) to the client.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn proxy_websocket_idle_timeout_sends_1001() {
+    let h = AppHarness::builder()
+        .with_websocket_idle_timeout(std::time::Duration::from_millis(200))
+        .build()
+        .await;
+    setup_ws_upstream(&h, "ws-idle-1001").await;
+    let (addr, server_handle) = start_oagw_server(&h).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    ws_handshake(&mut stream, "/oagw/v1/proxy/ws-idle-1001/ws/echo").await;
+
+    // Confirm connection works.
+    let text_frame = build_masked_frame(0x1, b"ping");
+    tokio::io::AsyncWriteExt::write_all(&mut stream, &text_frame)
+        .await
+        .unwrap();
+    let echo = read_ws_frame(&mut stream).await.unwrap();
+    assert_eq!(echo.0, 0x1);
+
+    // Wait for idle timeout to fire.
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+
+    // Should receive Close 1001.
+    let frame = read_ws_frame(&mut stream).await;
+    match frame {
+        Some((opcode, payload)) => {
+            assert_eq!(opcode, 0x8, "expected Close frame after idle timeout");
+            assert!(
+                payload.len() >= 2,
+                "close payload should contain status code"
+            );
+            let code = u16::from_be_bytes([payload[0], payload[1]]);
+            assert_eq!(code, 1001, "idle timeout should send Close 1001 Going Away");
+        }
+        None => {
+            // EOF is acceptable if the connection was torn down before we could read.
+            // The key assertion is that the gateway closed the connection.
+        }
+    }
+
+    server_handle.abort();
+}
+
+// 14.7: Max frame size enforcement sends Close 1009 (Message Too Big).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn proxy_websocket_max_frame_size_sends_1009() {
+    let h = AppHarness::builder()
+        .with_websocket_max_frame_size(50) // 50 bytes max
+        .build()
+        .await;
+    setup_ws_upstream(&h, "ws-maxframe").await;
+    let (addr, server_handle) = start_oagw_server(&h).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    ws_handshake(&mut stream, "/oagw/v1/proxy/ws-maxframe/ws/echo").await;
+
+    // Small frame should work fine.
+    let small_frame = build_masked_frame(0x1, b"ok");
+    tokio::io::AsyncWriteExt::write_all(&mut stream, &small_frame)
+        .await
+        .unwrap();
+    let echo = read_ws_frame(&mut stream).await.unwrap();
+    assert_eq!(echo.0, 0x1);
+    assert_eq!(echo.1, b"ok");
+
+    // Send a frame exceeding the 50-byte limit.
+    let oversized_payload = vec![0x41; 100]; // 100 bytes > 50
+    let oversized_frame = build_masked_frame(0x1, &oversized_payload);
+    tokio::io::AsyncWriteExt::write_all(&mut stream, &oversized_frame)
+        .await
+        .unwrap();
+
+    // Should receive Close 1009 (Message Too Big).
+    // On some platforms (notably Windows) the gateway may tear down the TCP
+    // connection before the Close frame is delivered, so EOF is also acceptable.
+    let frame = read_ws_frame(&mut stream).await;
+    match frame {
+        Some((opcode, payload)) => {
+            assert_eq!(opcode, 0x8, "expected Close frame for oversized message");
+            assert!(
+                payload.len() >= 2,
+                "close payload should contain status code"
+            );
+            let code = u16::from_be_bytes([payload[0], payload[1]]);
+            assert_eq!(code, 1009, "oversized frame should trigger Close 1009");
+        }
+        None => {
+            // EOF / connection reset — the gateway closed the connection after
+            // detecting the oversized frame, which is acceptable behaviour.
+        }
+    }
+
+    server_handle.abort();
+}
+
+// 14.8: Caller disconnect mid-session triggers upstream Close.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn proxy_websocket_caller_disconnect_mid_session() {
+    let h = AppHarness::builder().build().await;
+    setup_ws_upstream(&h, "ws-caller-drop").await;
+    let (addr, server_handle) = start_oagw_server(&h).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    ws_handshake(&mut stream, "/oagw/v1/proxy/ws-caller-drop/ws/echo").await;
+
+    // Confirm connection works.
+    let text_frame = build_masked_frame(0x1, b"alive");
+    tokio::io::AsyncWriteExt::write_all(&mut stream, &text_frame)
+        .await
+        .unwrap();
+    let echo = read_ws_frame(&mut stream).await.unwrap();
+    assert_eq!(echo.0, 0x1);
+    assert_eq!(echo.1, b"alive");
+
+    // Drop the client connection without sending Close — simulates abrupt disconnect.
+    drop(stream);
+
+    // Allow the gateway time to detect the disconnect and clean up.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Verify the gateway didn't crash — open a new connection and perform a
+    // successful handshake on a fresh upstream to confirm the server is healthy.
+    let mut stream2 = tokio::net::TcpStream::connect(addr).await.unwrap();
+    ws_handshake(&mut stream2, "/oagw/v1/proxy/ws-caller-drop/ws/echo").await;
+    let frame = build_masked_frame(0x1, b"still alive");
+    tokio::io::AsyncWriteExt::write_all(&mut stream2, &frame)
+        .await
+        .unwrap();
+    let echo = read_ws_frame(&mut stream2).await.unwrap();
+    assert_eq!(echo.0, 0x1);
+    assert_eq!(echo.1, b"still alive");
+
+    server_handle.abort();
+}
+
+// 14.9: Connection header with multiple upgrade tokens (e.g. "keep-alive, Upgrade")
+// is handled correctly — the WebSocket upgrade is still detected and processed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn proxy_websocket_connection_header_multi_value() {
+    let h = AppHarness::builder().build().await;
+    setup_ws_upstream(&h, "ws-multi-conn").await;
+    let (addr, server_handle) = start_oagw_server(&h).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+
+    // Send handshake with multi-value Connection header: "keep-alive, Upgrade".
+    use tokio::io::AsyncWriteExt;
+    let req = "GET /oagw/v1/proxy/ws-multi-conn/ws/echo HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         Upgrade: websocket\r\n\
+         Connection: keep-alive, Upgrade\r\n\
+         Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+         Sec-WebSocket-Version: 13\r\n\
+         \r\n"
+        .to_string();
+    stream.write_all(req.as_bytes()).await.unwrap();
+    let resp = read_http_response_headers(&mut stream).await;
+    assert!(
+        resp.starts_with("HTTP/1.1 101"),
+        "expected 101 with multi-value Connection header, got: {resp}"
+    );
+
+    // Confirm the connection works — send a text frame and receive echo.
+    let text_frame = build_masked_frame(0x1, b"multi-conn");
+    stream.write_all(&text_frame).await.unwrap();
+    let echo = read_ws_frame(&mut stream).await.unwrap();
+    assert_eq!(echo.0, 0x1);
+    assert_eq!(echo.1, b"multi-conn");
+
+    server_handle.abort();
+}
+
+// 14.10: Ping/Pong frames forwarded through the gateway end-to-end.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn proxy_websocket_ping_pong_forwarded() {
+    let h = AppHarness::builder().build().await;
+    setup_ws_upstream(&h, "ws-pingpong").await;
+    let (addr, server_handle) = start_oagw_server(&h).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    ws_handshake(&mut stream, "/oagw/v1/proxy/ws-pingpong/ws/echo").await;
+
+    // Send a Ping frame (opcode 0x9). The echo mock may or may not reply
+    // with a Pong, but the key assertion is that the frame reaches the
+    // upstream without crashing the gateway.
+    let ping_frame = build_masked_frame(0x9, b"ping");
+    tokio::io::AsyncWriteExt::write_all(&mut stream, &ping_frame)
+        .await
+        .unwrap();
+
+    // After Ping, verify the connection is still functional by sending a
+    // text message and checking the echo.
+    let text_frame = build_masked_frame(0x1, b"after-ping");
+    tokio::io::AsyncWriteExt::write_all(&mut stream, &text_frame)
+        .await
+        .unwrap();
+
+    // Read frames until we get the text echo (may have a Pong in between).
+    loop {
+        let frame = read_ws_frame(&mut stream).await;
+        match frame {
+            Some((0x1, data)) => {
+                assert_eq!(data, b"after-ping");
+                break;
+            }
+            Some((0xA, _)) => continue, // Pong — skip
+            Some((0x9, _)) => continue, // Ping from upstream — skip
+            other => panic!("unexpected frame: {other:?}"),
+        }
+    }
+
+    server_handle.abort();
+}
+
+// 14.11: Binary frames preserve opcode through the gateway end-to-end.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn proxy_websocket_binary_frame_opcode_preserved() {
+    let h = AppHarness::builder().build().await;
+    setup_ws_upstream(&h, "ws-binary-op").await;
+    let (addr, server_handle) = start_oagw_server(&h).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    ws_handshake(&mut stream, "/oagw/v1/proxy/ws-binary-op/ws/echo").await;
+
+    // Send a binary frame (opcode 0x2).
+    let payload: Vec<u8> = (0..=255).collect();
+    let binary_frame = build_masked_frame(0x2, &payload);
+    tokio::io::AsyncWriteExt::write_all(&mut stream, &binary_frame)
+        .await
+        .unwrap();
+
+    // Echo should come back as binary (opcode 0x2), not text.
+    let echo = read_ws_frame(&mut stream).await.unwrap();
+    assert_eq!(
+        echo.0, 0x2,
+        "expected binary opcode 0x2, got 0x{:x}",
+        echo.0
+    );
+    assert_eq!(echo.1, payload);
+
+    server_handle.abort();
+}
+
+// 14.12: Sustained multi-message session with extended-length payloads.
+// Sends 60 frames of varying sizes (including 2-byte and 8-byte extended length
+// encodings) through the full Axum→Pingora→mock→relay→client stack, exercising
+// the relay loop's long-running behavior.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn proxy_websocket_sustained_multi_message_extended_lengths() {
+    let h = AppHarness::builder().build().await;
+    setup_ws_upstream(&h, "ws-sustained").await;
+    let (addr, server_handle) = start_oagw_server(&h).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    ws_handshake(&mut stream, "/oagw/v1/proxy/ws-sustained/ws/echo").await;
+
+    // Mix of payload sizes:
+    // - tiny (< 126 bytes, 1-byte length encoding)
+    // - medium (200–499 bytes, 2-byte extended length encoding)
+    // - large (30 KiB, 2-byte extended length — comfortably within the
+    //   65 KiB DuplexStream bridge buffer; 8-byte encoding is covered by
+    //   unit tests in websocket.rs::extended_length_payloads)
+    let sizes: Vec<usize> = (0..60)
+        .map(|i| match i % 3 {
+            0 => 10 + (i * 7) % 100,   // tiny: 10–109 bytes
+            1 => 200 + (i * 13) % 300, // medium: 200–499 bytes
+            _ => 30_000,               // large: 30 KiB
+        })
+        .collect();
+
+    for (i, &size) in sizes.iter().enumerate() {
+        // Alternate text and binary to exercise opcode preservation.
+        // Text frames must contain valid UTF-8 (the mock's axum WebSocket
+        // validates this), so use ASCII-printable chars for text and raw
+        // bytes for binary.
+        let opcode = if i % 2 == 0 { 0x1 } else { 0x2 };
+        let payload: Vec<u8> = if opcode == 0x1 {
+            // Valid ASCII text: cycle through printable chars (0x20–0x7E).
+            (0..size).map(|j| (0x20 + ((i + j) % 95)) as u8).collect()
+        } else {
+            // Raw binary: full byte range.
+            (0..size).map(|j| ((i + j) % 256) as u8).collect()
+        };
+        let frame = build_masked_frame(opcode, &payload);
+        tokio::io::AsyncWriteExt::write_all(&mut stream, &frame)
+            .await
+            .unwrap();
+
+        let echo = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            read_ws_frame(&mut stream),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("timeout waiting for echo of frame {i} (size {size})"));
+        let (echo_op, echo_data) = echo.unwrap_or_else(|| panic!("EOF on frame {i}"));
+
+        assert_eq!(
+            echo_op, opcode,
+            "frame {i}: opcode mismatch (expected 0x{opcode:x}, got 0x{echo_op:x})"
+        );
+        assert_eq!(echo_data.len(), size, "frame {i}: payload length mismatch");
+        assert_eq!(
+            echo_data, payload,
+            "frame {i}: payload content mismatch (size {size})"
+        );
+    }
+
+    server_handle.abort();
+}
+
+// 14.13: JSON-structured payload with multi-byte UTF-8 survives the proxy.
+// Sends a realistic JSON message containing emoji, CJK, combining characters,
+// and 4-byte UTF-8 sequences to verify the frame relay doesn't corrupt
+// multi-byte boundaries.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn proxy_websocket_json_utf8_payload_integrity() {
+    let h = AppHarness::builder().build().await;
+    setup_ws_upstream(&h, "ws-json-utf8").await;
+    let (addr, server_handle) = start_oagw_server(&h).await;
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    ws_handshake(&mut stream, "/oagw/v1/proxy/ws-json-utf8/ws/echo").await;
+
+    // Realistic JSON payloads with multi-byte UTF-8.
+    let payloads = [
+        // OpenAI Realtime-style event with emoji and CJK
+        r#"{"type":"response.audio_transcript.delta","event_id":"evt_001","delta":"こんにちは世界 🌍🔥 café résumé naïve"}"#,
+        // 4-byte UTF-8: Mathematical Bold Script (U+1D4D0–U+1D503) and emoji
+        r#"{"message":"𝓗𝓮𝓵𝓵𝓸 from 𝕋𝕖𝕤𝕥","emoji":"👨‍👩‍👧‍👦🏳️‍🌈","nulls":null,"nested":{"flag":true}}"#,
+        // Combining characters and zero-width joiners
+        r#"{"text":"e\u0301 n\u0303 o\u0308","zwj":"👩\u200d🔬","count":42}"#,
+        // Large realistic message: chat completion chunk with mixed scripts
+        r#"{"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"Привет мир • مرحبا بالعالم • 你好世界"},"finish_reason":null}]}"#,
+    ];
+
+    for (i, payload_str) in payloads.iter().enumerate() {
+        let payload = payload_str.as_bytes();
+        let frame = build_masked_frame(0x1, payload);
+        tokio::io::AsyncWriteExt::write_all(&mut stream, &frame)
+            .await
+            .unwrap();
+
+        let echo = read_ws_frame(&mut stream)
+            .await
+            .unwrap_or_else(|| panic!("EOF on JSON payload {i}"));
+        assert_eq!(echo.0, 0x1, "payload {i}: expected text opcode");
+        assert_eq!(
+            echo.1, payload,
+            "payload {i}: byte-level mismatch — UTF-8 corruption through proxy"
+        );
+
+        // Also validate that the echoed bytes are valid UTF-8 and round-trip
+        // through serde_json without loss.
+        let echoed_str = std::str::from_utf8(&echo.1).expect("echoed payload is not valid UTF-8");
+        let parsed: serde_json::Value =
+            serde_json::from_str(echoed_str).expect("echoed payload is not valid JSON");
+        let original: serde_json::Value =
+            serde_json::from_str(payload_str).expect("original payload is not valid JSON");
+        assert_eq!(
+            parsed, original,
+            "payload {i}: JSON semantic mismatch after proxy round-trip"
+        );
+    }
+
+    server_handle.abort();
 }
 
 // Response header rules: set/add/remove operations applied to upstream response.

--- a/testing/e2e/modules/oagw/mock_upstream.py
+++ b/testing/e2e/modules/oagw/mock_upstream.py
@@ -7,8 +7,11 @@ fixture so the OAGW service under test can proxy to it.
 Uses only stdlib asyncio — no aiohttp dependency.
 """
 import asyncio
+import hashlib
+import base64
 import json
 import re
+import struct
 from urllib.parse import parse_qs
 import logging
 
@@ -103,10 +106,97 @@ def _bump_count(key: str) -> int:
 
 
 # ---------------------------------------------------------------------------
+# WebSocket helpers (RFC 6455)
+# ---------------------------------------------------------------------------
+
+_WS_MAGIC = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+
+def _ws_accept_key(key: str) -> str:
+    """Compute Sec-WebSocket-Accept from the client's Sec-WebSocket-Key."""
+    digest = hashlib.sha1(key.strip().encode() + _WS_MAGIC).digest()
+    return base64.b64encode(digest).decode()
+
+
+def _ws_upgrade_response(accept_key: str) -> bytes:
+    return (
+        "HTTP/1.1 101 Switching Protocols\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Accept: {accept_key}\r\n"
+        "\r\n"
+    ).encode()
+
+
+async def _ws_read_frame(reader: asyncio.StreamReader) -> tuple[int, bytes] | None:
+    """Read a single WebSocket frame. Returns (opcode, payload) or None on EOF."""
+    hdr = await reader.readexactly(2)
+    opcode = hdr[0] & 0x0F
+    masked = bool(hdr[1] & 0x80)
+    length = hdr[1] & 0x7F
+
+    if length == 126:
+        raw = await reader.readexactly(2)
+        length = struct.unpack("!H", raw)[0]
+    elif length == 127:
+        raw = await reader.readexactly(8)
+        length = struct.unpack("!Q", raw)[0]
+
+    mask_key = await reader.readexactly(4) if masked else b"\x00" * 4
+    payload = bytearray(await reader.readexactly(length))
+    if masked:
+        for i in range(length):
+            payload[i] ^= mask_key[i % 4]
+
+    return opcode, bytes(payload)
+
+
+def _ws_write_frame(opcode: int, payload: bytes) -> bytes:
+    """Build an unmasked WebSocket frame."""
+    frame = bytearray()
+    frame.append(0x80 | opcode)  # FIN + opcode
+    length = len(payload)
+    if length < 126:
+        frame.append(length)
+    elif length < 65536:
+        frame.append(126)
+        frame.extend(struct.pack("!H", length))
+    else:
+        frame.append(127)
+        frame.extend(struct.pack("!Q", length))
+    frame.extend(payload)
+    return bytes(frame)
+
+
+async def _ws_echo_loop(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    """WebSocket echo loop: read frames from client, echo text/binary back."""
+    try:
+        while True:
+            result = await _ws_read_frame(reader)
+            if result is None:
+                break
+            opcode, payload = result
+
+            if opcode == 0x8:  # Close
+                # Echo the close frame back and exit.
+                writer.write(_ws_write_frame(0x8, payload))
+                await writer.drain()
+                break
+            elif opcode == 0x9:  # Ping → Pong
+                writer.write(_ws_write_frame(0xA, payload))
+                await writer.drain()
+            elif opcode in (0x1, 0x2):  # Text or Binary → echo
+                writer.write(_ws_write_frame(opcode, payload))
+                await writer.drain()
+    except (asyncio.IncompleteReadError, ConnectionError):
+        pass
+
+
+# ---------------------------------------------------------------------------
 # Route handlers
 # ---------------------------------------------------------------------------
 
-async def _handle(method: str, path: str, headers: dict, body: bytes, writer: asyncio.StreamWriter) -> None:
+async def _handle(method: str, path: str, headers: dict, body: bytes, writer: asyncio.StreamWriter, reader: asyncio.StreamReader | None = None) -> None:
     # POST /reset-counters — reset all stateful endpoint call counts
     if method == "POST" and path == "/reset-counters":
         _endpoint_call_counts.clear()
@@ -229,6 +319,25 @@ async def _handle(method: str, path: str, headers: dict, body: bytes, writer: as
                 "call_number": call,
             }))
 
+    # GET /ws/echo — WebSocket echo endpoint
+    elif method == "GET" and path == "/ws/echo" and "upgrade" in headers.get("connection", "").lower():
+        upgrade_val = headers.get("upgrade", "").lower()
+        ws_key = headers.get("sec-websocket-key", "")
+        ws_version = headers.get("sec-websocket-version", "")
+        if upgrade_val != "websocket" or not ws_key or not ws_version:
+            writer.write(_json_response(
+                {"error": "invalid WebSocket upgrade: missing required headers"},
+                status=400,
+            ))
+            await writer.drain()
+            return
+        accept = _ws_accept_key(ws_key)
+        writer.write(_ws_upgrade_response(accept))
+        await writer.drain()
+        # Run the echo loop; the caller must keep the connection open.
+        await _ws_echo_loop(reader, writer)
+        return  # Connection fully handled — don't close in _client.
+
     # 404 fallback
     else:
         writer.write(_json_response({"error": "not found"}, status=404))
@@ -250,7 +359,7 @@ class MockUpstreamServer:
         async def _client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
             try:
                 method, path, headers, body = await _read_request(reader)
-                await _handle(method, path, headers, body, writer)
+                await _handle(method, path, headers, body, writer, reader)
                 await writer.drain()
             except (asyncio.CancelledError, GeneratorExit):
                 raise

--- a/testing/e2e/modules/oagw/test_websocket.py
+++ b/testing/e2e/modules/oagw/test_websocket.py
@@ -1,0 +1,433 @@
+"""E2E tests for OAGW WebSocket proxy support.
+
+Verifies that WebSocket upgrade requests are proxied through OAGW to the
+upstream, and that bidirectional frame forwarding works correctly.
+"""
+import asyncio
+
+import pytest
+import websockets
+
+from .helpers import create_route, create_upstream, delete_upstream, unique_alias
+
+
+@pytest.mark.asyncio
+async def test_websocket_echo_text(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """WebSocket text frames are proxied bidirectionally (echo round-trip)."""
+    _ = mock_upstream
+    alias = unique_alias("ws-echo")
+
+    # OAGW management API uses httpx (HTTP), WS client uses websockets library.
+    import httpx
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url, alias=alias,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid,
+            ["GET"], "/ws/echo",
+        )
+
+    # Build WebSocket URL from the OAGW base URL.
+    ws_url = oagw_base_url.replace("http://", "ws://").replace("https://", "wss://")
+    ws_uri = f"{ws_url}/oagw/v1/proxy/{alias}/ws/echo"
+
+    extra_headers = {k: v for k, v in oagw_headers.items()}
+
+    async with websockets.connect(ws_uri, additional_headers=extra_headers) as ws:
+        # Send a text message and verify the echo.
+        await ws.send("hello from e2e")
+        reply = await asyncio.wait_for(ws.recv(), timeout=5.0)
+        assert reply == "hello from e2e", f"unexpected echo: {reply}"
+
+        # Send another message to confirm the connection stays open.
+        await ws.send("second message")
+        reply = await asyncio.wait_for(ws.recv(), timeout=5.0)
+        assert reply == "second message", f"unexpected echo: {reply}"
+
+        # Close cleanly.
+        await ws.close()
+
+    # Cleanup.
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_websocket_echo_binary(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """WebSocket binary frames are proxied bidirectionally."""
+    _ = mock_upstream
+    alias = unique_alias("ws-bin")
+
+    import httpx
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url, alias=alias,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid,
+            ["GET"], "/ws/echo",
+        )
+
+    ws_url = oagw_base_url.replace("http://", "ws://").replace("https://", "wss://")
+    ws_uri = f"{ws_url}/oagw/v1/proxy/{alias}/ws/echo"
+    extra_headers = {k: v for k, v in oagw_headers.items()}
+
+    async with websockets.connect(ws_uri, additional_headers=extra_headers) as ws:
+        payload = bytes(range(256))
+        await ws.send(payload)
+        reply = await asyncio.wait_for(ws.recv(), timeout=5.0)
+        assert reply == payload, f"binary echo mismatch: got {len(reply)} bytes"
+
+        await ws.close()
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_websocket_upgrade_rejected_by_upstream(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """WebSocket upgrade to a non-WS upstream path returns an error."""
+    _ = mock_upstream
+    alias = unique_alias("ws-reject")
+
+    import httpx
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url, alias=alias,
+        )
+        uid = upstream["id"]
+        # Route to /echo (a normal HTTP endpoint, not WebSocket).
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid,
+            ["GET"], "/echo",
+        )
+
+    ws_url = oagw_base_url.replace("http://", "ws://").replace("https://", "wss://")
+    ws_uri = f"{ws_url}/oagw/v1/proxy/{alias}/echo"
+    extra_headers = {k: v for k, v in oagw_headers.items()}
+
+    # The upstream will return a non-101 response (likely 404 or 405),
+    # which should cause the WebSocket handshake to fail.
+    with pytest.raises(websockets.exceptions.InvalidStatus) as exc_info:
+        async with websockets.connect(ws_uri, additional_headers=extra_headers) as ws:
+            pass
+    # The proxy should not return a 101 for a non-WS upstream endpoint.
+    assert exc_info.value.response.status_code != 101
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_websocket_echo_large_payload(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """WebSocket frames larger than the proxy's internal buffer are forwarded correctly."""
+    _ = mock_upstream
+    alias = unique_alias("ws-large")
+
+    import httpx
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url, alias=alias,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid,
+            ["GET"], "/ws/echo",
+        )
+
+    ws_url = oagw_base_url.replace("http://", "ws://").replace("https://", "wss://")
+    ws_uri = f"{ws_url}/oagw/v1/proxy/{alias}/ws/echo"
+    extra_headers = {k: v for k, v in oagw_headers.items()}
+
+    async with websockets.connect(ws_uri, additional_headers=extra_headers) as ws:
+        # 64 KiB payload — exceeds the 8192-byte internal copy buffer,
+        # forcing multiple read/write cycles through the bridge.
+        payload = bytes(i % 256 for i in range(65536))
+        await ws.send(payload)
+        reply = await asyncio.wait_for(ws.recv(), timeout=10.0)
+        assert isinstance(reply, bytes), f"expected binary reply, got {type(reply)}"
+        assert reply == payload, (
+            f"large payload mismatch: sent {len(payload)} bytes, "
+            f"got {len(reply)} bytes"
+        )
+
+        await ws.close()
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_websocket_concurrent_bidirectional(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Multiple messages sent concurrently are all echoed back correctly."""
+    _ = mock_upstream
+    alias = unique_alias("ws-bidir")
+
+    import httpx
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url, alias=alias,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid,
+            ["GET"], "/ws/echo",
+        )
+
+    ws_url = oagw_base_url.replace("http://", "ws://").replace("https://", "wss://")
+    ws_uri = f"{ws_url}/oagw/v1/proxy/{alias}/ws/echo"
+    extra_headers = {k: v for k, v in oagw_headers.items()}
+
+    message_count = 20
+
+    async with websockets.connect(ws_uri, additional_headers=extra_headers) as ws:
+        # Fire all messages without waiting for replies — exercises the
+        # bidirectional copy loop under concurrent read/write pressure.
+        messages = [f"msg-{i}" for i in range(message_count)]
+        for msg in messages:
+            await ws.send(msg)
+
+        # Collect all replies.
+        replies = []
+        for _ in range(message_count):
+            reply = await asyncio.wait_for(ws.recv(), timeout=10.0)
+            replies.append(reply)
+
+        # Echo server preserves order, so replies should match 1:1.
+        assert replies == messages, (
+            f"expected {messages}, got {replies}"
+        )
+
+        await ws.close()
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_websocket_mixed_text_binary_interleaved(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Text and binary frames interleaved in a single session are echoed with correct opcodes."""
+    _ = mock_upstream
+    alias = unique_alias("ws-mixed")
+
+    import httpx
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url, alias=alias,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid,
+            ["GET"], "/ws/echo",
+        )
+
+    ws_url = oagw_base_url.replace("http://", "ws://").replace("https://", "wss://")
+    ws_uri = f"{ws_url}/oagw/v1/proxy/{alias}/ws/echo"
+    extra_headers = {k: v for k, v in oagw_headers.items()}
+
+    async with websockets.connect(ws_uri, additional_headers=extra_headers) as ws:
+        # Interleave text and binary frames — mimics APIs that use text for
+        # JSON control messages and binary for audio/image data.
+        messages = [
+            ("text", '{"type":"control","action":"start"}'),
+            ("binary", bytes(range(256))),
+            ("text", '{"type":"data","seq":1,"content":"こんにちは 🌍"}'),
+            ("binary", b"\x00\xff" * 500),
+            ("text", '{"type":"control","action":"stop"}'),
+            ("binary", bytes(i % 256 for i in range(1024))),
+        ]
+
+        for kind, payload in messages:
+            await ws.send(payload)
+            reply = await asyncio.wait_for(ws.recv(), timeout=5.0)
+
+            if kind == "text":
+                assert isinstance(reply, str), (
+                    f"expected str reply for text frame, got {type(reply)}"
+                )
+                assert reply == payload, f"text mismatch: {reply!r} != {payload!r}"
+            else:
+                assert isinstance(reply, bytes), (
+                    f"expected bytes reply for binary frame, got {type(reply)}"
+                )
+                assert reply == payload, (
+                    f"binary mismatch: {len(reply)} bytes != {len(payload)} bytes"
+                )
+
+        await ws.close()
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_websocket_rapid_small_message_burst(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """150 small messages fired rapidly are all echoed back without loss or reorder."""
+    _ = mock_upstream
+    alias = unique_alias("ws-burst")
+
+    import httpx
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url, alias=alias,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid,
+            ["GET"], "/ws/echo",
+        )
+
+    ws_url = oagw_base_url.replace("http://", "ws://").replace("https://", "wss://")
+    ws_uri = f"{ws_url}/oagw/v1/proxy/{alias}/ws/echo"
+    extra_headers = {k: v for k, v in oagw_headers.items()}
+
+    message_count = 150
+
+    async with websockets.connect(
+        ws_uri, additional_headers=extra_headers, max_size=2**20,
+    ) as ws:
+        # Fire all messages without waiting — exercises the relay loop under
+        # sustained write pressure with small frames (< 100 bytes each).
+        messages = [f'{{"seq":{i},"data":"msg-{i}"}}' for i in range(message_count)]
+        for msg in messages:
+            await ws.send(msg)
+
+        # Collect all replies.
+        replies = []
+        for _ in range(message_count):
+            reply = await asyncio.wait_for(ws.recv(), timeout=15.0)
+            replies.append(reply)
+
+        assert len(replies) == message_count, (
+            f"expected {message_count} replies, got {len(replies)}"
+        )
+        # Echo server preserves order.
+        assert replies == messages, (
+            f"message order/content mismatch at first diff: "
+            f"{next((i, r, m) for i, (r, m) in enumerate(zip(replies, messages, strict=True)) if r != m)}"
+        )
+
+        await ws.close()
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_websocket_utf8_multibyte_integrity(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Multi-byte UTF-8 (emoji, CJK, combining chars) survives the proxy without corruption."""
+    _ = mock_upstream
+    alias = unique_alias("ws-utf8")
+
+    import httpx
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url, alias=alias,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid,
+            ["GET"], "/ws/echo",
+        )
+
+    ws_url = oagw_base_url.replace("http://", "ws://").replace("https://", "wss://")
+    ws_uri = f"{ws_url}/oagw/v1/proxy/{alias}/ws/echo"
+    extra_headers = {k: v for k, v in oagw_headers.items()}
+
+    # JSON payloads with progressively challenging UTF-8 content.
+    payloads = [
+        # CJK + emoji
+        '{"msg":"こんにちは世界 🌍🔥 café résumé naïve"}',
+        # 4-byte UTF-8: mathematical bold script, family emoji with ZWJ
+        '{"msg":"𝓗𝓮𝓵𝓵𝓸 𝕋𝕖𝕤𝕥","emoji":"👨\u200d👩\u200d👧\u200d👦"}',
+        # Mixed scripts: Cyrillic, Arabic, Chinese
+        '{"content":"Привет мир • مرحبا بالعالم • 你好世界","ok":true}',
+        # Combining characters
+        '{"text":"e\u0301 n\u0303 o\u0308","flag":"\U0001f3f3\ufe0f\u200d\U0001f308"}',
+    ]
+
+    async with websockets.connect(ws_uri, additional_headers=extra_headers) as ws:
+        for i, payload in enumerate(payloads):
+            await ws.send(payload)
+            reply = await asyncio.wait_for(ws.recv(), timeout=5.0)
+            assert isinstance(reply, str), f"payload {i}: expected str, got {type(reply)}"
+            assert reply == payload, (
+                f"payload {i}: UTF-8 corruption through proxy\n"
+                f"  sent: {payload!r}\n"
+                f"  got:  {reply!r}"
+            )
+            # Verify JSON round-trip integrity.
+            import json
+            assert json.loads(reply) == json.loads(payload), (
+                f"payload {i}: JSON semantic mismatch"
+            )
+
+        await ws.close()
+
+    # --- Invalid UTF-8 as binary frames (RFC 6455 §5.6: no UTF-8 requirement) ---
+    # These byte sequences are invalid UTF-8 but must pass through cleanly
+    # as binary frames without corruption or rejection.
+    invalid_utf8_payloads = [
+        # Truncated 2-byte sequence (C0 without continuation)
+        b"\xc0",
+        # Truncated 3-byte sequence (E0 80 without final byte)
+        b"\xe0\x80",
+        # Truncated 4-byte sequence (F0 90 80 without final byte)
+        b"\xf0\x90\x80",
+        # Overlong encoding of '/' (0x2F) — forbidden by RFC 3629
+        b"\xc0\xaf",
+        # Surrogate half (U+D800 encoded as CESU-8 — invalid in UTF-8)
+        b"\xed\xa0\x80",
+        # Valid ASCII mixed with invalid continuation bytes
+        b"hello\x80world\xfe\xff",
+        # 0xFE and 0xFF are never valid in UTF-8
+        b"\xfe\xfe\xff\xff",
+        # Mixed: valid JSON envelope wrapping broken bytes
+        b'{"data":"' + b"\xc3\x28\xe2\x82" + b'"}',
+    ]
+
+    async with websockets.connect(ws_uri, additional_headers=extra_headers) as ws:
+        for i, payload in enumerate(invalid_utf8_payloads):
+            await ws.send(payload)
+            reply = await asyncio.wait_for(ws.recv(), timeout=5.0)
+            assert isinstance(reply, bytes), (
+                f"invalid-utf8 payload {i}: expected bytes reply for binary frame, "
+                f"got {type(reply)}"
+            )
+            assert reply == payload, (
+                f"invalid-utf8 payload {i}: binary mismatch through proxy\n"
+                f"  sent: {payload!r}\n"
+                f"  got:  {reply!r}"
+            )
+
+        await ws.close()
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)

--- a/testing/e2e/requirements.txt
+++ b/testing/e2e/requirements.txt
@@ -2,6 +2,7 @@ pytest>=7.0.0
 httpx>=0.28.0  # Previously 0.23.0 minimum for PYSEC-2022-183 fix
 pytest-asyncio
 aiohttp>=3.13.3  # Mock upstream server for OAGW E2E tests
+websockets>=14.0  # WebSocket client for OAGW WebSocket proxy E2E tests
 
 
 h11>=0.16.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full WebSocket proxying: HTTP upgrade handling, 101 Switching Protocols support, bidirectional frame-aware relay, close handshake and idle/close timeouts, optional max-frame-size, and upgrade-aware header sanitization/preservation.

* **Tests**
  * Extensive unit, integration, and end-to-end coverage: raw TCP handshakes, frame parsing/serialization, large/binary payloads, concurrency, timeouts, close/status preservation, rate-limiting, and UTF‑8 integrity.

* **Chores**
  * Test harness and E2E helpers updated; added WebSocket client requirement for E2E tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->