### PR TITLE
refactor(oagw): derive error instances from request URIs

### DIFF
--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service_test.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service_test.rs
@@ -691,7 +691,6 @@ async fn test_upload_provider_failure_sets_failed() {
     let oagw =
         MockOagwGateway::single_error(oagw_sdk::error::ServiceGatewayError::ConnectionTimeout {
             detail: "mock timeout".to_owned(),
-            instance: String::new(),
         });
 
     let outbox = Arc::new(NoopOutboxEnqueuer);
@@ -1036,7 +1035,6 @@ async fn test_upload_vector_store_indexing_fails() {
         Ok(vector_store_create_response("vs-idx-fail")),
         Err(oagw_sdk::error::ServiceGatewayError::ConnectionTimeout {
             detail: "indexing timeout".to_owned(),
-            instance: String::new(),
         }),
     ]);
 
@@ -1089,7 +1087,6 @@ async fn test_create_vector_store_failure_cleans_up_placeholder_row() {
         Ok(file_upload_response("file-vs-fail")),
         Err(oagw_sdk::error::ServiceGatewayError::ConnectionTimeout {
             detail: "VS create timeout".to_owned(),
-            instance: String::new(),
         }),
     ]);
 
@@ -1148,7 +1145,6 @@ async fn test_vector_store_failure_sets_attachment_failed() {
         Ok(file_upload_response("file-vs-fail-2")),
         Err(oagw_sdk::error::ServiceGatewayError::ConnectionTimeout {
             detail: "VS create timeout".to_owned(),
-            instance: String::new(),
         }),
         Ok(serde_json::json!({"deleted": true})), // fire-and-forget file delete
     ]);

--- a/modules/mini-chat/mini-chat/src/infra/llm/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/mod.rs
@@ -510,7 +510,6 @@ mod tests {
     fn gateway_rate_limit_maps_to_rate_limited() {
         let err = ServiceGatewayError::RateLimitExceeded {
             detail: "too many requests".into(),
-            instance: "/test".into(),
             retry_after_secs: Some(60),
         };
         let mapped: LlmProviderError = err.into();
@@ -526,7 +525,6 @@ mod tests {
     fn gateway_connection_timeout_maps_to_timeout() {
         let err = ServiceGatewayError::ConnectionTimeout {
             detail: "timed out".into(),
-            instance: "/test".into(),
         };
         let mapped: LlmProviderError = err.into();
         assert!(matches!(mapped, LlmProviderError::Timeout));
@@ -536,7 +534,6 @@ mod tests {
     fn gateway_request_timeout_maps_to_timeout() {
         let err = ServiceGatewayError::RequestTimeout {
             detail: "timed out".into(),
-            instance: "/test".into(),
         };
         let mapped: LlmProviderError = err.into();
         assert!(matches!(mapped, LlmProviderError::Timeout));
@@ -546,7 +543,6 @@ mod tests {
     fn gateway_upstream_disabled_maps_to_unavailable() {
         let err = ServiceGatewayError::UpstreamDisabled {
             detail: "disabled".into(),
-            instance: "/test".into(),
         };
         let mapped: LlmProviderError = err.into();
         assert!(matches!(mapped, LlmProviderError::ProviderUnavailable));
@@ -556,7 +552,6 @@ mod tests {
     fn gateway_downstream_error_maps_to_provider_error() {
         let err = ServiceGatewayError::DownstreamError {
             detail: "resp_xyz789 failed at https://api.example.com".into(),
-            instance: "/test".into(),
         };
         let mapped: LlmProviderError = err.into();
         match mapped {

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
@@ -2352,7 +2352,6 @@ mod tests {
     async fn oagw_rate_limit_error() {
         let gw = MockGateway::returning_error(ServiceGatewayError::RateLimitExceeded {
             detail: "too many requests".into(),
-            instance: "/test".into(),
             retry_after_secs: Some(30),
         });
         let provider = OpenAiResponsesProvider::new(gw);
@@ -2375,7 +2374,6 @@ mod tests {
     async fn oagw_connection_timeout_error() {
         let gw = MockGateway::returning_error(ServiceGatewayError::ConnectionTimeout {
             detail: "timed out".into(),
-            instance: "/test".into(),
         });
         let provider = OpenAiResponsesProvider::new(gw);
 
@@ -2392,7 +2390,6 @@ mod tests {
     async fn oagw_upstream_disabled_error() {
         let gw = MockGateway::returning_error(ServiceGatewayError::UpstreamDisabled {
             detail: "disabled".into(),
-            instance: "/test".into(),
         });
         let provider = OpenAiResponsesProvider::new(gw);
 

--- a/modules/system/oagw/oagw-sdk/src/error.rs
+++ b/modules/system/oagw/oagw-sdk/src/error.rs
@@ -2,53 +2,52 @@
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ServiceGatewayError {
     #[error("{detail}")]
-    ValidationError { detail: String, instance: String },
+    ValidationError { detail: String },
 
     #[error("target host header required for multi-endpoint upstream")]
-    MissingTargetHost { instance: String },
+    MissingTargetHost,
 
     #[error("invalid target host header format")]
-    InvalidTargetHost { instance: String },
+    InvalidTargetHost,
 
     #[error("{detail}")]
-    UnknownTargetHost { detail: String, instance: String },
+    UnknownTargetHost { detail: String },
 
     #[error("{detail}")]
-    AuthenticationFailed { detail: String, instance: String },
+    AuthenticationFailed { detail: String },
 
-    #[error("{entity} not found")]
-    NotFound { entity: String, instance: String },
+    #[error("{entity}/{id} not found")]
+    NotFound { entity: String, id: String },
 
     #[error("no matching route found")]
-    RouteNotFound { instance: String },
+    RouteNotFound,
 
     #[error("{detail}")]
-    PayloadTooLarge { detail: String, instance: String },
+    PayloadTooLarge { detail: String },
 
     #[error("{detail}")]
     RateLimitExceeded {
         detail: String,
-        instance: String,
         retry_after_secs: Option<u64>,
     },
 
     #[error("{detail}")]
-    SecretNotFound { detail: String, instance: String },
+    SecretNotFound { detail: String },
 
     #[error("{detail}")]
-    DownstreamError { detail: String, instance: String },
+    DownstreamError { detail: String },
 
     #[error("{detail}")]
-    ProtocolError { detail: String, instance: String },
+    ProtocolError { detail: String },
 
     #[error("{detail}")]
-    UpstreamDisabled { detail: String, instance: String },
+    UpstreamDisabled { detail: String },
 
     #[error("{detail}")]
-    ConnectionTimeout { detail: String, instance: String },
+    ConnectionTimeout { detail: String },
 
     #[error("{detail}")]
-    RequestTimeout { detail: String, instance: String },
+    RequestTimeout { detail: String },
 
     /// A guard plugin rejected the request.
     #[error("guard rejected: {detail}")]
@@ -56,20 +55,19 @@ pub enum ServiceGatewayError {
         status: u16,
         error_code: String,
         detail: String,
-        instance: String,
     },
 
     #[error("{detail}")]
-    StreamAborted { detail: String, instance: String },
+    StreamAborted { detail: String },
 
     #[error("{detail}")]
-    LinkUnavailable { detail: String, instance: String },
+    LinkUnavailable { detail: String },
 
     #[error("{detail}")]
-    CircuitBreakerOpen { detail: String, instance: String },
+    CircuitBreakerOpen { detail: String },
 
     #[error("{detail}")]
-    IdleTimeout { detail: String, instance: String },
+    IdleTimeout { detail: String },
 
     #[error("plugin not found: {detail}")]
     PluginNotFound { detail: String },

--- a/modules/system/oagw/oagw/src/api/rest/error.rs
+++ b/modules/system/oagw/oagw/src/api/rest/error.rs
@@ -3,6 +3,7 @@ use http::{HeaderValue, StatusCode};
 use modkit::api::problem::Problem;
 
 use crate::domain::error::DomainError;
+use crate::request_instance::RequestInstance;
 use oagw_sdk::api::ErrorSource;
 
 // ---------------------------------------------------------------------------
@@ -54,8 +55,8 @@ fn gts_type(err: &DomainError) -> &str {
     match err {
         DomainError::Validation { .. } => ERR_VALIDATION,
         DomainError::Conflict { .. } => ERR_CONFLICT,
-        DomainError::MissingTargetHost { .. } => ERR_MISSING_TARGET_HOST,
-        DomainError::InvalidTargetHost { .. } => ERR_INVALID_TARGET_HOST,
+        DomainError::MissingTargetHost => ERR_MISSING_TARGET_HOST,
+        DomainError::InvalidTargetHost => ERR_INVALID_TARGET_HOST,
         DomainError::UnknownTargetHost { .. } => ERR_UNKNOWN_TARGET_HOST,
         DomainError::AuthenticationFailed { .. } => ERR_AUTH_FAILED,
         DomainError::NotFound {
@@ -86,8 +87,8 @@ fn gts_type(err: &DomainError) -> &str {
 fn http_status_code(err: &DomainError) -> StatusCode {
     match err {
         DomainError::Validation { .. }
-        | DomainError::MissingTargetHost { .. }
-        | DomainError::InvalidTargetHost { .. }
+        | DomainError::MissingTargetHost
+        | DomainError::InvalidTargetHost
         | DomainError::UnknownTargetHost { .. } => StatusCode::BAD_REQUEST,
         DomainError::Conflict { .. } => StatusCode::CONFLICT,
         DomainError::AuthenticationFailed { .. } => StatusCode::UNAUTHORIZED,
@@ -124,8 +125,8 @@ fn error_title(err: &DomainError) -> &str {
     match err {
         DomainError::Validation { .. } => "Validation Error",
         DomainError::Conflict { .. } => "Conflict",
-        DomainError::MissingTargetHost { .. } => "Missing Target Host",
-        DomainError::InvalidTargetHost { .. } => "Invalid Target Host",
+        DomainError::MissingTargetHost => "Missing Target Host",
+        DomainError::InvalidTargetHost => "Invalid Target Host",
         DomainError::UnknownTargetHost { .. } => "Unknown Target Host",
         DomainError::AuthenticationFailed { .. } => "Authentication Failed",
         DomainError::NotFound { .. } => "Not Found",
@@ -150,72 +151,25 @@ fn error_title(err: &DomainError) -> &str {
     }
 }
 
-fn error_instance(err: &DomainError) -> &str {
-    match err {
-        DomainError::Validation { instance, .. }
-        | DomainError::MissingTargetHost { instance, .. }
-        | DomainError::InvalidTargetHost { instance, .. }
-        | DomainError::UnknownTargetHost { instance, .. }
-        | DomainError::AuthenticationFailed { instance, .. }
-        | DomainError::PayloadTooLarge { instance, .. }
-        | DomainError::RateLimitExceeded { instance, .. }
-        | DomainError::SecretNotFound { instance, .. }
-        | DomainError::DownstreamError { instance, .. }
-        | DomainError::ProtocolError { instance, .. }
-        | DomainError::ConnectionTimeout { instance, .. }
-        | DomainError::RequestTimeout { instance, .. }
-        | DomainError::GuardRejected { instance, .. }
-        | DomainError::CorsOriginNotAllowed { instance, .. }
-        | DomainError::CorsMethodNotAllowed { instance, .. }
-        | DomainError::StreamAborted { instance, .. }
-        | DomainError::LinkUnavailable { instance, .. }
-        | DomainError::CircuitBreakerOpen { instance, .. }
-        | DomainError::IdleTimeout { instance, .. } => instance,
-        DomainError::NotFound { .. }
-        | DomainError::Conflict { .. }
-        | DomainError::UpstreamDisabled { .. }
-        | DomainError::Internal { .. }
-        | DomainError::PluginNotFound { .. }
-        | DomainError::PluginInUse { .. }
-        | DomainError::Forbidden { .. } => "",
-    }
-}
-
-// ---------------------------------------------------------------------------
-// From<DomainError> for Problem
-// ---------------------------------------------------------------------------
-
-impl From<DomainError> for Problem {
-    fn from(err: DomainError) -> Self {
-        let gts = gts_type(&err).to_string();
-        let inst = error_instance(&err).to_string();
-        let status = http_status_code(&err);
-        let t = error_title(&err).to_string();
-        let detail = err.to_string();
-
-        Problem::new(status, t, detail)
-            .with_type(gts)
-            .with_instance(inst)
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Convenience functions for handlers
 // ---------------------------------------------------------------------------
 
-/// Convert a `DomainError` into a `Problem`, filling in `instance` for
-/// variants that don't carry their own. Used by management API handlers.
-pub(crate) fn domain_error_to_problem(err: DomainError, instance: &str) -> Problem {
-    let mut p = Problem::from(err);
-    if p.instance.is_empty() {
-        p.instance = instance.to_string();
-    }
-    p
+/// Convert a `DomainError` into a `Problem` using the request-derived `instance`.
+pub(crate) fn domain_error_to_problem(err: DomainError, instance: RequestInstance) -> Problem {
+    let gts = gts_type(&err).to_string();
+    let status = http_status_code(&err);
+    let title = error_title(&err).to_string();
+    let detail = err.to_string();
+
+    Problem::new(status, title, detail)
+        .with_type(gts)
+        .with_instance(instance)
 }
 
 /// Convert a `DomainError` into an axum `Response` with the
 /// `x-oagw-error-source: gateway` header. Used by the proxy handler.
-pub fn error_response(err: DomainError) -> Response {
+pub(crate) fn error_response(err: DomainError, instance: RequestInstance) -> Response {
     let retry_after = match &err {
         DomainError::RateLimitExceeded {
             retry_after_secs: Some(secs),
@@ -224,7 +178,7 @@ pub fn error_response(err: DomainError) -> Response {
         _ => None,
     };
 
-    let problem: Problem = err.into();
+    let problem = domain_error_to_problem(err, instance);
     let mut response = problem.into_response();
 
     response.headers_mut().insert(
@@ -249,9 +203,8 @@ mod tests {
     fn validation_error_produces_correct_problem() {
         let err = DomainError::Validation {
             detail: "missing required field 'server'".into(),
-            instance: "/oagw/v1/upstreams".into(),
         };
-        let p: Problem = err.into();
+        let p = domain_error_to_problem(err, RequestInstance::from_trusted("/oagw/v1/upstreams"));
         assert_eq!(p.status, StatusCode::BAD_REQUEST);
         assert_eq!(p.type_url, ERR_VALIDATION);
         assert_eq!(p.title, "Validation Error");
@@ -264,7 +217,7 @@ mod tests {
         let err = DomainError::Conflict {
             detail: "alias already exists".into(),
         };
-        let p: Problem = err.into();
+        let p = domain_error_to_problem(err, RequestInstance::from_trusted("/oagw/v1/upstreams"));
         assert_eq!(p.status, StatusCode::CONFLICT);
         assert_eq!(p.type_url, ERR_CONFLICT);
         assert_eq!(p.title, "Conflict");
@@ -274,10 +227,12 @@ mod tests {
     fn rate_limit_exceeded_produces_429() {
         let err = DomainError::RateLimitExceeded {
             detail: "rate limit exceeded for upstream".into(),
-            instance: "/oagw/v1/proxy/api.openai.com/v1/chat/completions".into(),
             retry_after_secs: Some(30),
         };
-        let p: Problem = err.into();
+        let p = domain_error_to_problem(
+            err,
+            RequestInstance::from_trusted("/oagw/v1/proxy/api.openai.com/v1/chat/completions"),
+        );
         assert_eq!(p.status, StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(p.type_url, ERR_RATE_LIMIT_EXCEEDED);
     }
@@ -288,34 +243,28 @@ mod tests {
             entity: "route",
             id: uuid::Uuid::nil(),
         };
-        let p: Problem = err.into();
+        let p = domain_error_to_problem(err, RequestInstance::from_trusted("/oagw/v1/routes/123"));
         assert_eq!(p.status, StatusCode::NOT_FOUND);
         assert_eq!(p.type_url, ERR_ROUTE_NOT_FOUND);
     }
 
     #[test]
     fn all_error_types_produce_valid_json() {
+        let request_instance = RequestInstance::from_trusted("/test");
         let errors: Vec<DomainError> = vec![
             DomainError::Validation {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::Conflict {
                 detail: "test".into(),
             },
-            DomainError::MissingTargetHost {
-                instance: "/test".into(),
-            },
-            DomainError::InvalidTargetHost {
-                instance: "/test".into(),
-            },
+            DomainError::MissingTargetHost,
+            DomainError::InvalidTargetHost,
             DomainError::UnknownTargetHost {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::AuthenticationFailed {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::NotFound {
                 entity: "route",
@@ -323,35 +272,28 @@ mod tests {
             },
             DomainError::PayloadTooLarge {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::RateLimitExceeded {
                 detail: "test".into(),
-                instance: "/test".into(),
                 retry_after_secs: None,
             },
             DomainError::SecretNotFound {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::DownstreamError {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::ProtocolError {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::UpstreamDisabled {
                 alias: "test".into(),
             },
             DomainError::ConnectionTimeout {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::RequestTimeout {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::Internal {
                 message: "test".into(),
@@ -360,31 +302,24 @@ mod tests {
                 status: 400,
                 error_code: "MISSING_HEADER".into(),
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::CorsOriginNotAllowed {
                 origin: "https://evil.com".into(),
-                instance: "/test".into(),
             },
             DomainError::CorsMethodNotAllowed {
                 method: "DELETE".into(),
-                instance: "/test".into(),
             },
             DomainError::StreamAborted {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::LinkUnavailable {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::CircuitBreakerOpen {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::IdleTimeout {
                 detail: "test".into(),
-                instance: "/test".into(),
             },
             DomainError::PluginNotFound {
                 detail: "test".into(),
@@ -397,7 +332,7 @@ mod tests {
             },
         ];
         for err in errors {
-            let p: Problem = err.into();
+            let p = domain_error_to_problem(err, request_instance.clone());
             let json = serde_json::to_string(&p).unwrap();
             let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
             assert!(parsed.get("type").is_some());
@@ -408,23 +343,16 @@ mod tests {
     }
 
     #[test]
-    fn domain_error_to_problem_fills_missing_instance() {
+    fn domain_error_to_problem_uses_request_instance() {
         let err = DomainError::NotFound {
             entity: "upstream",
             id: uuid::Uuid::nil(),
         };
-        let p = domain_error_to_problem(err, "/oagw/v1/upstreams/123");
-        assert_eq!(p.instance, "/oagw/v1/upstreams/123");
-    }
-
-    #[test]
-    fn domain_error_to_problem_preserves_existing_instance() {
-        let err = DomainError::Validation {
-            detail: "bad input".into(),
-            instance: "/oagw/v1/upstreams".into(),
-        };
-        let p = domain_error_to_problem(err, "/fallback");
-        assert_eq!(p.instance, "/oagw/v1/upstreams");
+        let p = domain_error_to_problem(
+            err,
+            RequestInstance::from_trusted("/oagw/v1/upstreams/123?include=routes"),
+        );
+        assert_eq!(p.instance, "/oagw/v1/upstreams/123?include=routes");
     }
 
     #[test]
@@ -433,9 +361,8 @@ mod tests {
             status: 403,
             error_code: "FORBIDDEN".into(),
             detail: "test".into(),
-            instance: "/test".into(),
         };
-        let p: Problem = err.into();
+        let p = domain_error_to_problem(err, RequestInstance::from_trusted("/test"));
         assert_eq!(p.status, StatusCode::FORBIDDEN);
     }
 
@@ -445,9 +372,8 @@ mod tests {
             status: 503,
             error_code: "UNAVAILABLE".into(),
             detail: "test".into(),
-            instance: "/test".into(),
         };
-        let p: Problem = err.into();
+        let p = domain_error_to_problem(err, RequestInstance::from_trusted("/test"));
         assert_eq!(p.status, StatusCode::SERVICE_UNAVAILABLE);
     }
 
@@ -457,9 +383,8 @@ mod tests {
             status: 200,
             error_code: "OK".into(),
             detail: "test".into(),
-            instance: "/test".into(),
         };
-        let p: Problem = err.into();
+        let p = domain_error_to_problem(err, RequestInstance::from_trusted("/test"));
         assert_eq!(p.status, StatusCode::BAD_REQUEST);
     }
 
@@ -469,9 +394,8 @@ mod tests {
             status: 301,
             error_code: "REDIRECT".into(),
             detail: "test".into(),
-            instance: "/test".into(),
         };
-        let p: Problem = err.into();
+        let p = domain_error_to_problem(err, RequestInstance::from_trusted("/test"));
         assert_eq!(p.status, StatusCode::BAD_REQUEST);
     }
 
@@ -481,9 +405,8 @@ mod tests {
             status: 999,
             error_code: "INVALID".into(),
             detail: "test".into(),
-            instance: "/test".into(),
         };
-        let p: Problem = err.into();
+        let p = domain_error_to_problem(err, RequestInstance::from_trusted("/test"));
         assert_eq!(p.status, StatusCode::BAD_REQUEST);
     }
 
@@ -493,7 +416,7 @@ mod tests {
             entity: "route",
             id: uuid::Uuid::nil(),
         };
-        let resp = error_response(err);
+        let resp = error_response(err, RequestInstance::from_trusted("/test"));
         assert_eq!(
             resp.headers().get("x-oagw-error-source").unwrap(),
             "gateway"

--- a/modules/system/oagw/oagw/src/api/rest/extractors.rs
+++ b/modules/system/oagw/oagw/src/api/rest/extractors.rs
@@ -1,24 +1,19 @@
-use modkit::api::problem::Problem;
 use uuid::Uuid;
 
+use crate::domain::error::DomainError;
 use crate::domain::gts_helpers;
 use crate::domain::model::ListQuery;
 
 /// Parse a GTS identifier, verifying that its schema prefix matches
 /// `expected_schema` (e.g. `UPSTREAM_SCHEMA`). Returns a validation
-/// `Problem` if the prefix does not match.
-#[allow(clippy::result_large_err)]
-pub fn parse_gts_id(gts_str: &str, expected_schema: &str, instance: &str) -> Result<Uuid, Problem> {
-    let (schema, uuid) = gts_helpers::parse_resource_gts(gts_str).map_err(Problem::from)?;
+/// `DomainError` if the prefix does not match.
+pub fn parse_gts_id(gts_str: &str, expected_schema: &str) -> Result<Uuid, DomainError> {
+    let (schema, uuid) = gts_helpers::parse_resource_gts(gts_str)?;
     let expected_prefix = expected_schema.trim_end_matches('~');
     if schema != expected_prefix {
-        return Err(Problem::new(
-            http::StatusCode::BAD_REQUEST,
-            "Validation Error",
-            format!("expected GTS schema '{expected_schema}' but got '{schema}~'"),
-        )
-        .with_type("gts.x.core.errors.err.v1~x.oagw.validation.error.v1")
-        .with_instance(instance));
+        return Err(DomainError::validation(format!(
+            "expected GTS schema '{expected_schema}' but got '{schema}~'"
+        )));
     }
     Ok(uuid)
 }

--- a/modules/system/oagw/oagw/src/api/rest/handlers/proxy.rs
+++ b/modules/system/oagw/oagw/src/api/rest/handlers/proxy.rs
@@ -13,6 +13,7 @@ use tracing::Instrument;
 
 use crate::api::rest::error::error_response;
 use crate::module::AppState;
+use crate::request_instance::RequestInstance;
 
 /// Proxy handler for `/oagw/v1/proxy/{alias}/{path:.*}`.
 ///
@@ -70,6 +71,7 @@ pub async fn proxy_handler(
 
     let max_body_size = state.config.max_body_size_bytes;
     let (mut parts, body) = req.into_parts();
+    let request_instance = RequestInstance::from_uri(&parts.uri);
 
     // Detect WebSocket upgrade and extract the hyper upgrade handle.
     // This must happen before body consumption — the OnUpgrade future is
@@ -78,20 +80,19 @@ pub async fn proxy_handler(
 
     // RFC 6455 §4.1: WebSocket upgrade MUST be GET with no body.
     if is_upgrade {
-        let path = parts.uri.path().to_string();
         if parts.method != http::Method::GET {
-            return Err(error_response(DomainError::Validation {
-                detail: "WebSocket upgrade requires GET method".into(),
-                instance: path,
-            }));
+            return Err(error_response(
+                DomainError::validation("WebSocket upgrade requires GET method"),
+                request_instance,
+            ));
         }
         if parts.headers.contains_key(http::header::CONTENT_LENGTH)
             || parts.headers.contains_key(http::header::TRANSFER_ENCODING)
         {
-            return Err(error_response(DomainError::Validation {
-                detail: "WebSocket upgrade request must not contain a body".into(),
-                instance: path,
-            }));
+            return Err(error_response(
+                DomainError::validation("WebSocket upgrade request must not contain a body"),
+                request_instance,
+            ));
         }
     }
 
@@ -104,43 +105,47 @@ pub async fn proxy_handler(
     // Parse alias from the URI to validate it's present.
     let path = parts.uri.path();
     let prefix = "/oagw/v1/proxy/";
-    let remaining = path.strip_prefix(prefix).ok_or_else(|| {
-        error_response(DomainError::Validation {
-            detail: "invalid proxy path".into(),
-            instance: path.to_string(),
-        })
-    })?;
+    let Some(remaining) = path.strip_prefix(prefix) else {
+        return Err(error_response(
+            DomainError::validation("invalid proxy path"),
+            request_instance,
+        ));
+    };
 
     // Validate alias is not empty.
     let alias_end = remaining.find('/').unwrap_or(remaining.len());
     if alias_end == 0 {
-        return Err(error_response(DomainError::Validation {
-            detail: "missing alias in proxy path".into(),
-            instance: path.to_string(),
-        }));
+        return Err(error_response(
+            DomainError::validation("missing alias in proxy path"),
+            request_instance,
+        ));
     }
 
     // Validate Content-Length if present (skip for WebSocket — no body).
     if !is_upgrade && let Some(cl) = parts.headers.get(http::header::CONTENT_LENGTH) {
-        let cl_str = cl.to_str().map_err(|_| {
-            error_response(DomainError::Validation {
-                detail: "invalid Content-Length header".into(),
-                instance: path.to_string(),
-            })
-        })?;
-        let cl_val: usize = cl_str.parse().map_err(|_| {
-            error_response(DomainError::Validation {
-                detail: format!("Content-Length is not a valid integer: '{cl_str}'"),
-                instance: path.to_string(),
-            })
-        })?;
+        let Ok(cl_str) = cl.to_str() else {
+            return Err(error_response(
+                DomainError::validation("invalid Content-Length header"),
+                request_instance,
+            ));
+        };
+        let Ok(cl_val) = cl_str.parse::<usize>() else {
+            return Err(error_response(
+                DomainError::validation(format!(
+                    "Content-Length is not a valid integer: '{cl_str}'"
+                )),
+                request_instance,
+            ));
+        };
         if cl_val > max_body_size {
-            return Err(error_response(DomainError::PayloadTooLarge {
-                detail: format!(
-                    "request body of {cl_val} bytes exceeds maximum of {max_body_size} bytes"
-                ),
-                instance: path.to_string(),
-            }));
+            return Err(error_response(
+                DomainError::PayloadTooLarge {
+                    detail: format!(
+                        "request body of {cl_val} bytes exceeds maximum of {max_body_size} bytes"
+                    ),
+                },
+                request_instance,
+            ));
         }
     }
 
@@ -149,14 +154,16 @@ pub async fn proxy_handler(
     let body_bytes = if is_upgrade {
         Bytes::new()
     } else {
-        axum::body::to_bytes(body, max_body_size)
-            .await
-            .map_err(|_| {
-                error_response(DomainError::PayloadTooLarge {
+        let Ok(bb) = axum::body::to_bytes(body, max_body_size).await else {
+            return Err(error_response(
+                DomainError::PayloadTooLarge {
                     detail: format!("request body exceeds maximum of {max_body_size} bytes"),
-                    instance: path.to_string(),
-                })
-            })?
+                },
+                request_instance,
+            ));
+        };
+
+        bb
     };
 
     // Strip the proxy prefix from the URI so the DP receives /{alias}/{path}?query.
@@ -165,46 +172,56 @@ pub async fn proxy_handler(
     } else {
         format!("/{remaining}")
     };
-    parts.uri = new_uri_str.parse().map_err(|_| {
-        error_response(DomainError::Validation {
-            detail: "failed to parse proxy URI".into(),
-            instance: path.to_string(),
-        })
-    })?;
+
+    match new_uri_str.parse() {
+        Ok(uri) => parts.uri = uri,
+        Err(_) => {
+            return Err(error_response(
+                DomainError::validation("failed to parse proxy URI"),
+                request_instance,
+            ));
+        }
+    };
 
     // Build http::Request<Body> for the DP service.
     let sdk_body = oagw_sdk::Body::from(body_bytes);
     let proxy_req = http::Request::from_parts(parts, sdk_body);
 
     // Execute proxy pipeline.
-    let proxy_resp = state
+    let proxy_resp = match state
         .dp
-        .proxy_request(ctx, proxy_req)
+        .proxy_request(ctx, proxy_req, request_instance.clone())
         .await
-        .map_err(error_response)?;
+    {
+        Ok(proxy_resp) => proxy_resp,
+        Err(err) => return Err(error_response(err, request_instance)),
+    };
 
     // Convert http::Response<oagw_sdk::Body> to axum Response.
     let (mut resp_parts, sdk_body) = proxy_resp.into_parts();
 
     // Handle WebSocket 101 Switching Protocols.
     if resp_parts.status == StatusCode::SWITCHING_PROTOCOLS {
-        let bridge = resp_parts
+        let Some(bridge) = resp_parts
             .extensions
             .remove::<WebSocketBridgeHandle>()
             .and_then(|h| h.take())
-            .ok_or_else(|| {
-                error_response(DomainError::Internal {
-                    message: "101 Switching Protocols but WebSocket bridge handle is missing"
-                        .into(),
-                })
-            })?;
-        let on_upgrade = on_upgrade.ok_or_else(|| {
-            error_response(DomainError::ProtocolError {
-                detail: "WebSocket upgrade requested but connection does not support upgrades"
-                    .into(),
-                instance: String::new(),
-            })
-        })?;
+        else {
+            return Err(error_response(
+                DomainError::internal(
+                    "101 Switching Protocols but WebSocket bridge handle is missing",
+                ),
+                request_instance,
+            ));
+        };
+        let Some(on_upgrade) = on_upgrade else {
+            return Err(error_response(
+                DomainError::protocol(
+                    "WebSocket upgrade requested but connection does not support upgrades",
+                ),
+                request_instance,
+            ));
+        };
 
         // Build the 101 response to return to hyper (triggers the upgrade).
         let mut builder = Response::builder().status(StatusCode::SWITCHING_PROTOCOLS);
@@ -214,9 +231,10 @@ pub async fn proxy_handler(
         // Data now originates from upstream — consistent with the non-upgrade path.
         builder = builder.header("x-oagw-error-source", ErrorSource::Upstream.as_str());
         let response = builder.body(Body::empty()).map_err(|e| {
-            error_response(DomainError::Internal {
-                message: format!("failed to build WebSocket upgrade response: {e}"),
-            })
+            error_response(
+                DomainError::internal(format!("failed to build WebSocket upgrade response: {e}")),
+                request_instance,
+            )
         })?;
 
         // Spawn the bidirectional bridge task. It awaits the upgrade
@@ -261,10 +279,12 @@ pub async fn proxy_handler(
     let body = Body::from_stream(sdk_body.into_stream());
 
     builder.body(body).map_err(|e| {
-        error_response(DomainError::DownstreamError {
-            detail: format!("failed to build response: {e}"),
-            instance: String::new(),
-        })
+        error_response(
+            DomainError::DownstreamError {
+                detail: format!("failed to build response: {e}"),
+            },
+            request_instance,
+        )
     })
 }
 

--- a/modules/system/oagw/oagw/src/api/rest/handlers/route.rs
+++ b/modules/system/oagw/oagw/src/api/rest/handlers/route.rs
@@ -11,6 +11,7 @@ use crate::api::rest::extractors::parse_gts_id;
 use crate::domain::gts_helpers as gts;
 use crate::domain::model::Route;
 use crate::module::AppState;
+use crate::request_instance::RequestInstance;
 
 fn to_response(r: Route) -> RouteResponse {
     RouteResponse {
@@ -30,30 +31,36 @@ fn to_response(r: Route) -> RouteResponse {
 pub async fn create_route(
     Extension(state): Extension<AppState>,
     Extension(ctx): Extension<SecurityContext>,
+    request_instance: RequestInstance,
     Json(req): Json<CreateRouteRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    let instance = "/oagw/v1/routes";
-    let upstream_uuid = parse_gts_id(&req.upstream_id, gts::UPSTREAM_SCHEMA, instance)?;
+    let upstream_uuid = match parse_gts_id(&req.upstream_id, gts::UPSTREAM_SCHEMA) {
+        Ok(uuid) => uuid,
+        Err(e) => return Err(domain_error_to_problem(e, request_instance)),
+    };
     let route = state
         .cp
         .create_route(&ctx, (upstream_uuid, req).into())
         .await
-        .map_err(|e| domain_error_to_problem(e, instance))?;
+        .map_err(|e| domain_error_to_problem(e, request_instance))?;
     Ok((StatusCode::CREATED, Json(to_response(route))))
 }
 
 pub async fn get_route(
     Extension(state): Extension<AppState>,
     Extension(ctx): Extension<SecurityContext>,
+    request_instance: RequestInstance,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, Problem> {
-    let instance = format!("/oagw/v1/routes/{id}");
-    let uuid = parse_gts_id(&id, gts::ROUTE_SCHEMA, &instance)?;
+    let uuid = match parse_gts_id(&id, gts::ROUTE_SCHEMA) {
+        Ok(uuid) => uuid,
+        Err(e) => return Err(domain_error_to_problem(e, request_instance)),
+    };
     let route = state
         .cp
         .get_route(&ctx, uuid)
         .await
-        .map_err(|e| domain_error_to_problem(e, &instance))?;
+        .map_err(|e| domain_error_to_problem(e, request_instance))?;
     Ok(Json(to_response(route)))
 }
 
@@ -76,14 +83,18 @@ fn default_limit() -> u32 {
 pub async fn list_routes(
     Extension(state): Extension<AppState>,
     Extension(ctx): Extension<SecurityContext>,
+    request_instance: RequestInstance,
     Query(params): Query<ListRoutesQuery>,
 ) -> Result<impl IntoResponse, Problem> {
-    let instance = "/oagw/v1/routes";
-    let upstream_uuid = params
+    let upstream_uuid = match params
         .upstream_id
         .as_deref()
-        .map(|id| parse_gts_id(id, gts::UPSTREAM_SCHEMA, instance))
-        .transpose()?;
+        .map(|id| parse_gts_id(id, gts::UPSTREAM_SCHEMA))
+        .transpose()
+    {
+        Ok(uuid) => uuid,
+        Err(e) => return Err(domain_error_to_problem(e, request_instance)),
+    };
     let query = crate::domain::model::ListQuery {
         top: params.limit.min(100),
         skip: params.offset,
@@ -92,7 +103,7 @@ pub async fn list_routes(
         .cp
         .list_routes(&ctx, upstream_uuid, &query)
         .await
-        .map_err(|e| domain_error_to_problem(e, instance))?;
+        .map_err(|e| domain_error_to_problem(e, request_instance))?;
     let response: Vec<RouteResponse> = routes.into_iter().map(to_response).collect();
     Ok(Json(response))
 }
@@ -100,31 +111,37 @@ pub async fn list_routes(
 pub async fn update_route(
     Extension(state): Extension<AppState>,
     Extension(ctx): Extension<SecurityContext>,
+    request_instance: RequestInstance,
     Path(id): Path<String>,
     Json(req): Json<UpdateRouteRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    let instance = format!("/oagw/v1/routes/{id}");
-    let uuid = parse_gts_id(&id, gts::ROUTE_SCHEMA, &instance)?;
+    let uuid = match parse_gts_id(&id, gts::ROUTE_SCHEMA) {
+        Ok(uuid) => uuid,
+        Err(e) => return Err(domain_error_to_problem(e, request_instance)),
+    };
     let route = state
         .cp
         .update_route(&ctx, uuid, req.into())
         .await
-        .map_err(|e| domain_error_to_problem(e, &instance))?;
+        .map_err(|e| domain_error_to_problem(e, request_instance))?;
     Ok(Json(to_response(route)))
 }
 
 pub async fn delete_route(
     Extension(state): Extension<AppState>,
     Extension(ctx): Extension<SecurityContext>,
+    request_instance: RequestInstance,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, Problem> {
-    let instance = format!("/oagw/v1/routes/{id}");
-    let uuid = parse_gts_id(&id, gts::ROUTE_SCHEMA, &instance)?;
+    let uuid = match parse_gts_id(&id, gts::ROUTE_SCHEMA) {
+        Ok(uuid) => uuid,
+        Err(e) => return Err(domain_error_to_problem(e, request_instance)),
+    };
     state
         .cp
         .delete_route(&ctx, uuid)
         .await
-        .map_err(|e| domain_error_to_problem(e, &instance))?;
+        .map_err(|e| domain_error_to_problem(e, request_instance))?;
     state.dp.remove_rate_limit_key(&format!("route:{uuid}"));
     Ok(StatusCode::NO_CONTENT)
 }

--- a/modules/system/oagw/oagw/src/api/rest/handlers/upstream.rs
+++ b/modules/system/oagw/oagw/src/api/rest/handlers/upstream.rs
@@ -11,6 +11,7 @@ use crate::api::rest::extractors::{PaginationQuery, parse_gts_id};
 use crate::domain::gts_helpers as gts;
 use crate::domain::model::Upstream;
 use crate::module::AppState;
+use crate::request_instance::RequestInstance;
 
 fn to_response(u: Upstream) -> UpstreamResponse {
     UpstreamResponse {
@@ -32,13 +33,14 @@ fn to_response(u: Upstream) -> UpstreamResponse {
 pub async fn create_upstream(
     Extension(state): Extension<AppState>,
     Extension(ctx): Extension<SecurityContext>,
+    request_instance: RequestInstance,
     Json(req): Json<CreateUpstreamRequest>,
 ) -> Result<impl IntoResponse, Problem> {
     let upstream = state
         .cp
         .create_upstream(&ctx, req.into())
         .await
-        .map_err(|e| domain_error_to_problem(e, "/oagw/v1/upstreams"))?;
+        .map_err(|e| domain_error_to_problem(e, request_instance))?;
     // Defensive no-op: new IDs have no cache entry, but keeps CRUD handlers uniform.
     state.backend_selector.invalidate(upstream.id);
     Ok((StatusCode::CREATED, Json(to_response(upstream))))
@@ -47,21 +49,25 @@ pub async fn create_upstream(
 pub async fn get_upstream(
     Extension(state): Extension<AppState>,
     Extension(ctx): Extension<SecurityContext>,
+    request_instance: RequestInstance,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, Problem> {
-    let instance = format!("/oagw/v1/upstreams/{id}");
-    let uuid = parse_gts_id(&id, gts::UPSTREAM_SCHEMA, &instance)?;
+    let uuid = match parse_gts_id(&id, gts::UPSTREAM_SCHEMA) {
+        Ok(uuid) => uuid,
+        Err(e) => return Err(domain_error_to_problem(e, request_instance)),
+    };
     let upstream = state
         .cp
         .get_upstream(&ctx, uuid)
         .await
-        .map_err(|e| domain_error_to_problem(e, &instance))?;
+        .map_err(|e| domain_error_to_problem(e, request_instance))?;
     Ok(Json(to_response(upstream)))
 }
 
 pub async fn list_upstreams(
     Extension(state): Extension<AppState>,
     Extension(ctx): Extension<SecurityContext>,
+    request_instance: RequestInstance,
     Query(pagination): Query<PaginationQuery>,
 ) -> Result<impl IntoResponse, Problem> {
     let query = pagination.to_list_query();
@@ -69,7 +75,7 @@ pub async fn list_upstreams(
         .cp
         .list_upstreams(&ctx, &query)
         .await
-        .map_err(|e| domain_error_to_problem(e, "/oagw/v1/upstreams"))?;
+        .map_err(|e| domain_error_to_problem(e, request_instance))?;
     let response: Vec<UpstreamResponse> = upstreams.into_iter().map(to_response).collect();
     Ok(Json(response))
 }
@@ -77,16 +83,19 @@ pub async fn list_upstreams(
 pub async fn update_upstream(
     Extension(state): Extension<AppState>,
     Extension(ctx): Extension<SecurityContext>,
+    request_instance: RequestInstance,
     Path(id): Path<String>,
     Json(req): Json<UpdateUpstreamRequest>,
 ) -> Result<impl IntoResponse, Problem> {
-    let instance = format!("/oagw/v1/upstreams/{id}");
-    let uuid = parse_gts_id(&id, gts::UPSTREAM_SCHEMA, &instance)?;
+    let uuid = match parse_gts_id(&id, gts::UPSTREAM_SCHEMA) {
+        Ok(uuid) => uuid,
+        Err(e) => return Err(domain_error_to_problem(e, request_instance)),
+    };
     let upstream = state
         .cp
         .update_upstream(&ctx, uuid, req.into())
         .await
-        .map_err(|e| domain_error_to_problem(e, &instance))?;
+        .map_err(|e| domain_error_to_problem(e, request_instance))?;
     state.backend_selector.invalidate(upstream.id);
     Ok(Json(to_response(upstream)))
 }
@@ -94,15 +103,19 @@ pub async fn update_upstream(
 pub async fn delete_upstream(
     Extension(state): Extension<AppState>,
     Extension(ctx): Extension<SecurityContext>,
+    request_instance: RequestInstance,
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, Problem> {
-    let instance = format!("/oagw/v1/upstreams/{id}");
-    let uuid = parse_gts_id(&id, gts::UPSTREAM_SCHEMA, &instance)?;
+    let uuid = match parse_gts_id(&id, gts::UPSTREAM_SCHEMA) {
+        Ok(uuid) => uuid,
+        Err(e) => return Err(domain_error_to_problem(e, request_instance)),
+    };
+
     state
         .cp
         .delete_upstream(&ctx, uuid)
         .await
-        .map_err(|e| domain_error_to_problem(e, &instance))?;
+        .map_err(|e| domain_error_to_problem(e, request_instance))?;
     state.backend_selector.invalidate(uuid);
     state.dp.remove_rate_limit_key(&format!("upstream:{uuid}"));
     Ok(StatusCode::NO_CONTENT)

--- a/modules/system/oagw/oagw/src/domain/cors.rs
+++ b/modules/system/oagw/oagw/src/domain/cors.rs
@@ -51,7 +51,6 @@ pub fn validate_cors_config(config: &CorsConfig) -> Result<(), DomainError> {
     if config.allow_credentials && config.allowed_origins.iter().any(|o| o == "*") {
         return Err(DomainError::Validation {
             detail: "allow_credentials cannot be true when allowed_origins contains '*'".into(),
-            instance: String::new(),
         });
     }
 
@@ -66,7 +65,6 @@ pub fn validate_cors_config(config: &CorsConfig) -> Result<(), DomainError> {
                 detail: format!(
                     "invalid origin '{origin}': must be '*' or a valid origin (e.g. https://example.com)"
                 ),
-                instance: String::new(),
             });
         }
     }

--- a/modules/system/oagw/oagw/src/domain/error.rs
+++ b/modules/system/oagw/oagw/src/domain/error.rs
@@ -1,4 +1,5 @@
 use modkit_macros::domain_model;
+use oagw_sdk::error::ServiceGatewayError;
 use uuid::Uuid;
 
 use super::repo::RepositoryError;
@@ -14,7 +15,7 @@ pub enum DomainError {
     Conflict { detail: String },
 
     #[error("validation: {detail}")]
-    Validation { detail: String, instance: String },
+    Validation { detail: String },
 
     #[error("upstream '{alias}' is disabled")]
     UpstreamDisabled { alias: String },
@@ -23,41 +24,40 @@ pub enum DomainError {
     Internal { message: String },
 
     #[error("target host header required for multi-endpoint upstream")]
-    MissingTargetHost { instance: String },
+    MissingTargetHost,
 
     #[error("invalid target host header format")]
-    InvalidTargetHost { instance: String },
+    InvalidTargetHost,
 
     #[error("{detail}")]
-    UnknownTargetHost { detail: String, instance: String },
+    UnknownTargetHost { detail: String },
 
     #[error("{detail}")]
-    AuthenticationFailed { detail: String, instance: String },
+    AuthenticationFailed { detail: String },
 
     #[error("{detail}")]
-    PayloadTooLarge { detail: String, instance: String },
+    PayloadTooLarge { detail: String },
 
     #[error("{detail}")]
     RateLimitExceeded {
         detail: String,
-        instance: String,
         retry_after_secs: Option<u64>,
     },
 
     #[error("{detail}")]
-    SecretNotFound { detail: String, instance: String },
+    SecretNotFound { detail: String },
 
     #[error("{detail}")]
-    DownstreamError { detail: String, instance: String },
+    DownstreamError { detail: String },
 
     #[error("{detail}")]
-    ProtocolError { detail: String, instance: String },
+    ProtocolError { detail: String },
 
     #[error("{detail}")]
-    ConnectionTimeout { detail: String, instance: String },
+    ConnectionTimeout { detail: String },
 
     #[error("{detail}")]
-    RequestTimeout { detail: String, instance: String },
+    RequestTimeout { detail: String },
 
     /// A guard plugin rejected the request with a specific status and error code.
     #[error("guard rejected: {detail}")]
@@ -65,28 +65,27 @@ pub enum DomainError {
         status: u16,
         error_code: String,
         detail: String,
-        instance: String,
     },
 
     /// CORS: the request origin is not in the allowed origins list.
     #[error("CORS origin not allowed: {origin}")]
-    CorsOriginNotAllowed { origin: String, instance: String },
+    CorsOriginNotAllowed { origin: String },
 
     /// CORS: the request method is not in the allowed methods list.
     #[error("CORS method not allowed: {method}")]
-    CorsMethodNotAllowed { method: String, instance: String },
+    CorsMethodNotAllowed { method: String },
 
     #[error("{detail}")]
-    StreamAborted { detail: String, instance: String },
+    StreamAborted { detail: String },
 
     #[error("{detail}")]
-    LinkUnavailable { detail: String, instance: String },
+    LinkUnavailable { detail: String },
 
     #[error("{detail}")]
-    CircuitBreakerOpen { detail: String, instance: String },
+    CircuitBreakerOpen { detail: String },
 
     #[error("{detail}")]
-    IdleTimeout { detail: String, instance: String },
+    IdleTimeout { detail: String },
 
     #[error("plugin not found: {detail}")]
     PluginNotFound { detail: String },
@@ -116,7 +115,6 @@ impl DomainError {
     pub fn validation(detail: impl Into<String>) -> Self {
         Self::Validation {
             detail: detail.into(),
-            instance: String::new(),
         }
     }
 
@@ -139,6 +137,91 @@ impl DomainError {
     pub fn forbidden(detail: impl Into<String>) -> Self {
         Self::Forbidden {
             detail: detail.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn protocol(detail: impl Into<String>) -> Self {
+        Self::ProtocolError {
+            detail: detail.into(),
+        }
+    }
+}
+
+impl From<DomainError> for ServiceGatewayError {
+    fn from(e: DomainError) -> Self {
+        match e {
+            DomainError::NotFound { entity, id } => ServiceGatewayError::NotFound {
+                entity: entity.to_string(),
+                id: id.to_string(),
+            },
+            DomainError::Conflict { detail } => ServiceGatewayError::ValidationError { detail },
+            DomainError::Validation { detail } => ServiceGatewayError::ValidationError { detail },
+            DomainError::UpstreamDisabled { alias } => ServiceGatewayError::UpstreamDisabled {
+                detail: format!("upstream '{alias}' is disabled"),
+            },
+            DomainError::Internal { message } => {
+                ServiceGatewayError::DownstreamError { detail: message }
+            }
+            DomainError::MissingTargetHost => ServiceGatewayError::MissingTargetHost,
+            DomainError::InvalidTargetHost => ServiceGatewayError::InvalidTargetHost,
+            DomainError::UnknownTargetHost { detail } => {
+                ServiceGatewayError::UnknownTargetHost { detail }
+            }
+            DomainError::AuthenticationFailed { detail } => {
+                ServiceGatewayError::AuthenticationFailed { detail }
+            }
+            DomainError::PayloadTooLarge { detail } => {
+                ServiceGatewayError::PayloadTooLarge { detail }
+            }
+            DomainError::RateLimitExceeded {
+                detail,
+                retry_after_secs,
+            } => ServiceGatewayError::RateLimitExceeded {
+                detail,
+                retry_after_secs,
+            },
+            DomainError::SecretNotFound { detail } => {
+                ServiceGatewayError::SecretNotFound { detail }
+            }
+            DomainError::DownstreamError { detail } => {
+                ServiceGatewayError::DownstreamError { detail }
+            }
+            DomainError::ProtocolError { detail } => ServiceGatewayError::ProtocolError { detail },
+            DomainError::ConnectionTimeout { detail } => {
+                ServiceGatewayError::ConnectionTimeout { detail }
+            }
+            DomainError::RequestTimeout { detail } => {
+                ServiceGatewayError::RequestTimeout { detail }
+            }
+            DomainError::GuardRejected {
+                status,
+                error_code,
+                detail,
+            } => ServiceGatewayError::GuardRejected {
+                status,
+                error_code,
+                detail,
+            },
+            DomainError::CorsOriginNotAllowed { origin, .. } => ServiceGatewayError::Forbidden {
+                detail: format!("CORS origin not allowed: {origin}"),
+            },
+            DomainError::CorsMethodNotAllowed { method, .. } => ServiceGatewayError::Forbidden {
+                detail: format!("CORS method not allowed: {method}"),
+            },
+            DomainError::StreamAborted { detail } => ServiceGatewayError::StreamAborted { detail },
+            DomainError::LinkUnavailable { detail } => {
+                ServiceGatewayError::LinkUnavailable { detail }
+            }
+            DomainError::CircuitBreakerOpen { detail } => {
+                ServiceGatewayError::CircuitBreakerOpen { detail }
+            }
+            DomainError::IdleTimeout { detail } => ServiceGatewayError::IdleTimeout { detail },
+            DomainError::PluginNotFound { detail } => {
+                ServiceGatewayError::PluginNotFound { detail }
+            }
+            DomainError::PluginInUse { detail } => ServiceGatewayError::PluginInUse { detail },
+            DomainError::Forbidden { detail } => ServiceGatewayError::Forbidden { detail },
         }
     }
 }

--- a/modules/system/oagw/oagw/src/domain/gts_helpers.rs
+++ b/modules/system/oagw/oagw/src/domain/gts_helpers.rs
@@ -64,18 +64,15 @@ pub fn parse_resource_gts(s: &str) -> Result<(String, Uuid), DomainError> {
     // Validate the full GTS identifier (anonymous UUID segments supported since 0.8.4).
     gts::GtsID::new(s).map_err(|e| DomainError::Validation {
         detail: format!("invalid GTS identifier: {e}"),
-        instance: s.to_string(),
     })?;
 
     let tilde_pos = s.rfind('~').ok_or_else(|| DomainError::Validation {
         detail: "missing '~' separator in GTS identifier".into(),
-        instance: s.to_string(),
     })?;
 
     let instance = &s[tilde_pos + 1..];
     let uuid = Uuid::parse_str(instance).map_err(|e| DomainError::Validation {
         detail: format!("invalid UUID in GTS instance: {e}"),
-        instance: s.to_string(),
     })?;
 
     Ok((s[..tilde_pos].to_string(), uuid))

--- a/modules/system/oagw/oagw/src/domain/rate_limit.rs
+++ b/modules/system/oagw/oagw/src/domain/rate_limit.rs
@@ -99,12 +99,7 @@ impl RateLimiter {
     ///
     /// # Errors
     /// Returns `DomainError::RateLimitExceeded` with Retry-After seconds when exhausted.
-    pub fn try_consume(
-        &self,
-        key: &str,
-        config: &RateLimitConfig,
-        instance_uri: &str,
-    ) -> Result<(), DomainError> {
+    pub fn try_consume(&self, key: &str, config: &RateLimitConfig) -> Result<(), DomainError> {
         let cost = config.cost as f64;
         let mut bucket = self
             .buckets
@@ -117,7 +112,6 @@ impl RateLimiter {
             let retry_after = bucket.retry_after_secs(cost);
             Err(DomainError::RateLimitExceeded {
                 detail: format!("rate limit exceeded for key: {key}"),
-                instance: instance_uri.to_string(),
                 retry_after_secs: Some(retry_after),
             })
         }
@@ -149,7 +143,7 @@ mod tests {
         let limiter = RateLimiter::new();
         let config = make_config(10, Window::Second, None);
         for _ in 0..10 {
-            assert!(limiter.try_consume("test", &config, "/test").is_ok());
+            assert!(limiter.try_consume("test", &config).is_ok());
         }
     }
 
@@ -157,9 +151,9 @@ mod tests {
     fn denies_when_exhausted() {
         let limiter = RateLimiter::new();
         let config = make_config(2, Window::Second, None);
-        assert!(limiter.try_consume("test", &config, "/test").is_ok());
-        assert!(limiter.try_consume("test", &config, "/test").is_ok());
-        let err = limiter.try_consume("test", &config, "/test").unwrap_err();
+        assert!(limiter.try_consume("test", &config).is_ok());
+        assert!(limiter.try_consume("test", &config).is_ok());
+        let err = limiter.try_consume("test", &config).unwrap_err();
         assert!(matches!(err, DomainError::RateLimitExceeded { .. }));
     }
 
@@ -167,8 +161,8 @@ mod tests {
     fn retry_after_is_calculated() {
         let limiter = RateLimiter::new();
         let config = make_config(1, Window::Minute, None);
-        assert!(limiter.try_consume("test", &config, "/test").is_ok());
-        match limiter.try_consume("test", &config, "/test") {
+        assert!(limiter.try_consume("test", &config).is_ok());
+        match limiter.try_consume("test", &config) {
             Err(DomainError::RateLimitExceeded {
                 retry_after_secs, ..
             }) => {
@@ -185,28 +179,28 @@ mod tests {
         let limiter = RateLimiter::new();
         let config = make_config(1, Window::Second, Some(5));
         for _ in 0..5 {
-            assert!(limiter.try_consume("test", &config, "/test").is_ok());
+            assert!(limiter.try_consume("test", &config).is_ok());
         }
-        assert!(limiter.try_consume("test", &config, "/test").is_err());
+        assert!(limiter.try_consume("test", &config).is_err());
     }
 
     #[test]
     fn separate_keys_independent() {
         let limiter = RateLimiter::new();
         let config = make_config(1, Window::Second, None);
-        assert!(limiter.try_consume("key-a", &config, "/test").is_ok());
-        assert!(limiter.try_consume("key-b", &config, "/test").is_ok());
-        assert!(limiter.try_consume("key-a", &config, "/test").is_err());
-        assert!(limiter.try_consume("key-b", &config, "/test").is_err());
+        assert!(limiter.try_consume("key-a", &config).is_ok());
+        assert!(limiter.try_consume("key-b", &config).is_ok());
+        assert!(limiter.try_consume("key-a", &config).is_err());
+        assert!(limiter.try_consume("key-b", &config).is_err());
     }
 
     #[test]
     fn purge_removes_stale_entries() {
         let limiter = RateLimiter::new();
         let config = make_config(10, Window::Second, None);
-        limiter.try_consume("a", &config, "/test").unwrap();
-        limiter.try_consume("b", &config, "/test").unwrap();
-        limiter.try_consume("c", &config, "/test").unwrap();
+        limiter.try_consume("a", &config).unwrap();
+        limiter.try_consume("b", &config).unwrap();
+        limiter.try_consume("c", &config).unwrap();
 
         let active: HashSet<String> = ["a", "c"].iter().map(|s| (*s).into()).collect();
         limiter.purge_keys(&active);
@@ -221,10 +215,8 @@ mod tests {
     fn remove_key_deletes_single_bucket() {
         let limiter = RateLimiter::new();
         let config = make_config(10, Window::Second, None);
-        limiter
-            .try_consume("upstream:aaa", &config, "/test")
-            .unwrap();
-        limiter.try_consume("route:bbb", &config, "/test").unwrap();
+        limiter.try_consume("upstream:aaa", &config).unwrap();
+        limiter.try_consume("route:bbb", &config).unwrap();
 
         limiter.remove_key("upstream:aaa");
 
@@ -244,8 +236,8 @@ mod tests {
     fn purge_with_empty_set_removes_all() {
         let limiter = RateLimiter::new();
         let config = make_config(10, Window::Second, None);
-        limiter.try_consume("x", &config, "/test").unwrap();
-        limiter.try_consume("y", &config, "/test").unwrap();
+        limiter.try_consume("x", &config).unwrap();
+        limiter.try_consume("y", &config).unwrap();
 
         limiter.purge_keys(&HashSet::new());
 

--- a/modules/system/oagw/oagw/src/domain/services/client.rs
+++ b/modules/system/oagw/oagw/src/domain/services/client.rs
@@ -9,8 +9,8 @@ use oagw_sdk::error::ServiceGatewayError;
 use uuid::Uuid;
 
 use super::{ControlPlaneService, DataPlaneService};
-use crate::domain::error::DomainError;
 use crate::domain::model;
+use crate::request_instance::RequestInstance;
 
 /// Facade that implements the public `ServiceGatewayClientV1` trait by
 /// delegating to the internal CP and DP services.
@@ -35,7 +35,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
     ) -> Result<oagw_sdk::Upstream, ServiceGatewayError> {
         let internal_req = sdk_create_upstream_to_domain(req);
         let result = self.cp.create_upstream(&ctx, internal_req).await;
-        result.map(upstream_to_sdk).map_err(domain_err_to_sdk)
+        result.map(upstream_to_sdk).map_err(Into::into)
     }
 
     async fn get_upstream(
@@ -47,7 +47,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
             .get_upstream(&ctx, id)
             .await
             .map(upstream_to_sdk)
-            .map_err(domain_err_to_sdk)
+            .map_err(Into::into)
     }
 
     async fn list_upstreams(
@@ -63,7 +63,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
             .list_upstreams(&ctx, &q)
             .await
             .map(|v| v.into_iter().map(upstream_to_sdk).collect())
-            .map_err(domain_err_to_sdk)
+            .map_err(Into::into)
     }
 
     async fn update_upstream(
@@ -77,7 +77,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
             .update_upstream(&ctx, id, internal_req)
             .await
             .map(upstream_to_sdk)
-            .map_err(domain_err_to_sdk)
+            .map_err(Into::into)
     }
 
     async fn delete_upstream(
@@ -85,10 +85,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
         ctx: SecurityContext,
         id: Uuid,
     ) -> Result<(), ServiceGatewayError> {
-        self.cp
-            .delete_upstream(&ctx, id)
-            .await
-            .map_err(domain_err_to_sdk)
+        self.cp.delete_upstream(&ctx, id).await.map_err(Into::into)
     }
 
     async fn create_route(
@@ -101,7 +98,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
             .create_route(&ctx, internal_req)
             .await
             .map(route_to_sdk)
-            .map_err(domain_err_to_sdk)
+            .map_err(Into::into)
     }
 
     async fn get_route(
@@ -113,7 +110,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
             .get_route(&ctx, id)
             .await
             .map(route_to_sdk)
-            .map_err(domain_err_to_sdk)
+            .map_err(Into::into)
     }
 
     async fn list_routes(
@@ -130,7 +127,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
             .list_routes(&ctx, upstream_id, &q)
             .await
             .map(|v| v.into_iter().map(route_to_sdk).collect())
-            .map_err(domain_err_to_sdk)
+            .map_err(Into::into)
     }
 
     async fn update_route(
@@ -144,7 +141,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
             .update_route(&ctx, id, internal_req)
             .await
             .map(route_to_sdk)
-            .map_err(domain_err_to_sdk)
+            .map_err(Into::into)
     }
 
     async fn delete_route(
@@ -152,10 +149,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
         ctx: SecurityContext,
         id: Uuid,
     ) -> Result<(), ServiceGatewayError> {
-        self.cp
-            .delete_route(&ctx, id)
-            .await
-            .map_err(domain_err_to_sdk)
+        self.cp.delete_route(&ctx, id).await.map_err(Into::into)
     }
 
     async fn resolve_proxy_target(
@@ -169,7 +163,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
             .resolve_proxy_target(&ctx, alias, method, path)
             .await
             .map(|(u, r)| (upstream_to_sdk(u), route_to_sdk(r)))
-            .map_err(domain_err_to_sdk)
+            .map_err(Into::into)
     }
 
     async fn proxy_request(
@@ -177,113 +171,12 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
         ctx: SecurityContext,
         req: http::Request<Body>,
     ) -> Result<http::Response<Body>, ServiceGatewayError> {
+        let request_instance = RequestInstance::from_uri(req.uri());
+
         self.dp
-            .proxy_request(ctx, req)
+            .proxy_request(ctx, req, request_instance.clone())
             .await
-            .map_err(domain_err_to_sdk)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// DomainError → ServiceGatewayError
-// ---------------------------------------------------------------------------
-
-fn domain_err_to_sdk(err: DomainError) -> ServiceGatewayError {
-    match err {
-        DomainError::NotFound { entity, id } => ServiceGatewayError::NotFound {
-            entity: entity.to_string(),
-            instance: format!("{entity}/{id}"),
-        },
-        DomainError::Conflict { detail } => ServiceGatewayError::ValidationError {
-            detail,
-            instance: String::new(),
-        },
-        DomainError::Validation { detail, instance } => {
-            ServiceGatewayError::ValidationError { detail, instance }
-        }
-        DomainError::UpstreamDisabled { alias } => ServiceGatewayError::UpstreamDisabled {
-            detail: format!("upstream '{alias}' is disabled"),
-            instance: String::new(),
-        },
-        DomainError::Internal { message } => ServiceGatewayError::DownstreamError {
-            detail: message,
-            instance: String::new(),
-        },
-        DomainError::MissingTargetHost { instance } => {
-            ServiceGatewayError::MissingTargetHost { instance }
-        }
-        DomainError::InvalidTargetHost { instance } => {
-            ServiceGatewayError::InvalidTargetHost { instance }
-        }
-        DomainError::UnknownTargetHost { detail, instance } => {
-            ServiceGatewayError::UnknownTargetHost { detail, instance }
-        }
-        DomainError::AuthenticationFailed { detail, instance } => {
-            ServiceGatewayError::AuthenticationFailed { detail, instance }
-        }
-        DomainError::PayloadTooLarge { detail, instance } => {
-            ServiceGatewayError::PayloadTooLarge { detail, instance }
-        }
-        DomainError::RateLimitExceeded {
-            detail,
-            instance,
-            retry_after_secs,
-        } => ServiceGatewayError::RateLimitExceeded {
-            detail,
-            instance,
-            retry_after_secs,
-        },
-        DomainError::SecretNotFound { detail, instance } => {
-            ServiceGatewayError::SecretNotFound { detail, instance }
-        }
-        DomainError::DownstreamError { detail, instance } => {
-            ServiceGatewayError::DownstreamError { detail, instance }
-        }
-        DomainError::ProtocolError { detail, instance } => {
-            ServiceGatewayError::ProtocolError { detail, instance }
-        }
-        DomainError::ConnectionTimeout { detail, instance } => {
-            ServiceGatewayError::ConnectionTimeout { detail, instance }
-        }
-        DomainError::RequestTimeout { detail, instance } => {
-            ServiceGatewayError::RequestTimeout { detail, instance }
-        }
-        DomainError::GuardRejected {
-            status,
-            error_code,
-            detail,
-            instance,
-        } => ServiceGatewayError::GuardRejected {
-            status,
-            error_code,
-            detail,
-            instance,
-        },
-        DomainError::CorsOriginNotAllowed {
-            origin, instance, ..
-        } => ServiceGatewayError::Forbidden {
-            detail: format!("CORS origin not allowed: {origin} (instance: {instance})"),
-        },
-        DomainError::CorsMethodNotAllowed {
-            method, instance, ..
-        } => ServiceGatewayError::Forbidden {
-            detail: format!("CORS method not allowed: {method} (instance: {instance})"),
-        },
-        DomainError::StreamAborted { detail, instance } => {
-            ServiceGatewayError::StreamAborted { detail, instance }
-        }
-        DomainError::LinkUnavailable { detail, instance } => {
-            ServiceGatewayError::LinkUnavailable { detail, instance }
-        }
-        DomainError::CircuitBreakerOpen { detail, instance } => {
-            ServiceGatewayError::CircuitBreakerOpen { detail, instance }
-        }
-        DomainError::IdleTimeout { detail, instance } => {
-            ServiceGatewayError::IdleTimeout { detail, instance }
-        }
-        DomainError::PluginNotFound { detail } => ServiceGatewayError::PluginNotFound { detail },
-        DomainError::PluginInUse { detail } => ServiceGatewayError::PluginInUse { detail },
-        DomainError::Forbidden { detail } => ServiceGatewayError::Forbidden { detail },
+            .map_err(Into::into)
     }
 }
 
@@ -740,6 +633,8 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    use crate::domain::error::DomainError;
+
     #[test]
     fn auth_config_hashmap_round_trips() {
         let mut config = HashMap::new();
@@ -813,7 +708,7 @@ mod tests {
             entity: "upstream",
             id: Uuid::nil(),
         };
-        let sdk_err = domain_err_to_sdk(err);
+        let sdk_err = err.into();
         assert!(matches!(
             sdk_err,
             ServiceGatewayError::NotFound { ref entity, .. } if entity == "upstream"
@@ -824,9 +719,8 @@ mod tests {
     fn domain_err_validation_maps_to_sdk() {
         let err = DomainError::Validation {
             detail: "bad input".into(),
-            instance: "/test".into(),
         };
-        let sdk_err = domain_err_to_sdk(err);
+        let sdk_err = err.into();
         assert!(matches!(
             sdk_err,
             ServiceGatewayError::ValidationError { .. }
@@ -837,10 +731,9 @@ mod tests {
     fn domain_err_rate_limit_maps_to_sdk() {
         let err = DomainError::RateLimitExceeded {
             detail: "too fast".into(),
-            instance: "/api".into(),
             retry_after_secs: Some(30),
         };
-        let sdk_err = domain_err_to_sdk(err);
+        let sdk_err = err.into();
         match sdk_err {
             ServiceGatewayError::RateLimitExceeded {
                 retry_after_secs, ..
@@ -853,9 +746,8 @@ mod tests {
     fn domain_err_timeout_maps_to_sdk() {
         let err = DomainError::RequestTimeout {
             detail: "timed out".into(),
-            instance: "/slow".into(),
         };
-        let sdk_err = domain_err_to_sdk(err);
+        let sdk_err = err.into();
         assert!(matches!(
             sdk_err,
             ServiceGatewayError::RequestTimeout { .. }

--- a/modules/system/oagw/oagw/src/domain/services/mod.rs
+++ b/modules/system/oagw/oagw/src/domain/services/mod.rs
@@ -17,6 +17,7 @@ use crate::domain::model::{
     CreateRouteRequest, CreateUpstreamRequest, Endpoint, ListQuery, Route, UpdateRouteRequest,
     UpdateUpstreamRequest, Upstream,
 };
+use crate::request_instance::RequestInstance;
 
 /// Result of endpoint selection: the domain endpoint plus an optional
 /// pre-resolved socket address from the load balancer's DNS cache.
@@ -105,6 +106,7 @@ pub(crate) trait DataPlaneService: Send + Sync {
         &self,
         ctx: SecurityContext,
         req: http::Request<Body>,
+        request_instance: RequestInstance,
     ) -> Result<http::Response<Body>, DomainError>;
 
     /// Remove a rate-limit bucket by key (e.g. `"upstream:{id}"` or `"route:{id}"`).

--- a/modules/system/oagw/oagw/src/infra/proxy/pingora_proxy.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/pingora_proxy.rs
@@ -19,10 +19,11 @@ use tokio::sync::watch;
 use tracing::{info, warn};
 use uuid::Uuid;
 
+use crate::api::rest::error::domain_error_to_problem;
 use crate::domain::error::DomainError;
 use crate::domain::model::{Endpoint, Scheme};
 use crate::domain::services::{EndpointSelector, SelectedEndpoint};
-use modkit::api::Problem;
+use crate::request_instance::RequestInstance;
 
 // ---------------------------------------------------------------------------
 // Internal header names (D9)
@@ -417,7 +418,7 @@ impl EndpointSelector for PingoraEndpointSelector {
 
 pub struct ProxyCtx {
     endpoint: Endpoint,
-    instance_uri: String,
+    instance_uri: Option<RequestInstance>,
     /// Upstream that owns this endpoint (for diagnostic logs).
     upstream_id: Option<Uuid>,
     /// Pre-resolved socket address from the load balancer's DNS cache.
@@ -450,7 +451,7 @@ impl ProxyCtx {
             };
         }
         if let Some(v) = headers.get(H_INSTANCE_URI).and_then(|v| v.to_str().ok()) {
-            self.instance_uri = v.to_string();
+            self.instance_uri = Some(RequestInstance::from_trusted(v.to_string()));
         }
         if let Some(v) = headers.get(H_UPSTREAM_ID).and_then(|v| v.to_str().ok()) {
             self.upstream_id = v.parse().ok();
@@ -469,7 +470,7 @@ impl Default for ProxyCtx {
                 host: String::new(),
                 port: 443,
             },
-            instance_uri: String::new(),
+            instance_uri: None,
             upstream_id: None,
             resolved_addr: None,
         }
@@ -696,11 +697,13 @@ impl ProxyHttp for PingoraProxy {
         e: &pingora_core::Error,
         ctx: &mut Self::CTX,
     ) -> pingora_proxy::FailToProxy {
-        let instance = ctx.instance_uri.clone();
+        let request_instance = ctx
+            .instance_uri
+            .clone()
+            .unwrap_or_else(|| RequestInstance::from_uri(&session.req_header().uri));
         let domain_err = match &e.etype {
             pingora_core::ErrorType::ConnectTimedout => DomainError::ConnectionTimeout {
                 detail: "upstream connection timed out".into(),
-                instance,
             },
             pingora_core::ErrorType::ReadTimedout | pingora_core::ErrorType::WriteTimedout => {
                 DomainError::RequestTimeout {
@@ -712,7 +715,6 @@ impl ProxyHttp for PingoraProxy {
                             "write"
                         }
                     ),
-                    instance,
                 }
             }
             pingora_core::ErrorType::H2Error | pingora_core::ErrorType::H2Downgrade => {
@@ -722,7 +724,6 @@ impl ProxyHttp for PingoraProxy {
                 self.protocol_cache.evict(&ctx.endpoint);
                 DomainError::ProtocolError {
                     detail: "upstream HTTP/2 error".into(),
-                    instance,
                 }
             }
             pingora_core::ErrorType::ReadError | pingora_core::ErrorType::WriteError => {
@@ -735,7 +736,6 @@ impl ProxyHttp for PingoraProxy {
                             "write"
                         }
                     ),
-                    instance,
                 }
             }
             pingora_core::ErrorType::ConnectNoRoute
@@ -749,7 +749,6 @@ impl ProxyHttp for PingoraProxy {
                     _ => "upstream connection error",
                 }
                 .into(),
-                instance,
             },
             _ => DomainError::DownstreamError {
                 detail: match &e.etype {
@@ -765,11 +764,10 @@ impl ProxyHttp for PingoraProxy {
                     _ => "upstream error",
                 }
                 .into(),
-                instance,
             },
         };
 
-        let problem: Problem = domain_err.into();
+        let problem = domain_error_to_problem(domain_err, request_instance);
         let status = problem.status.as_u16();
         let body_bytes = Bytes::from(serde_json::to_vec(&problem).unwrap_or_default());
 
@@ -802,7 +800,7 @@ impl ProxyHttp for PingoraProxy {
         info!(
             reused,
             peer = %peer,
-            instance = %ctx.instance_uri,
+            instance = ctx.instance_uri.as_ref().map_or("", RequestInstance::as_str),
             "Connected to upstream"
         );
         Ok(())
@@ -1249,7 +1247,10 @@ mod tests {
         assert_eq!(ctx.endpoint.host, "api.example.com");
         assert_eq!(ctx.endpoint.port, 8443);
         assert_eq!(ctx.endpoint.scheme, Scheme::Https);
-        assert_eq!(ctx.instance_uri, "/test/instance");
+        assert_eq!(
+            ctx.instance_uri.as_ref().map(RequestInstance::as_str),
+            Some("/test/instance")
+        );
         assert_eq!(ctx.upstream_id, Some(upstream_id));
         let expected: std::net::SocketAddr = "93.184.216.34:8443".parse().unwrap();
         assert_eq!(ctx.resolved_addr, Some(expected));

--- a/modules/system/oagw/oagw/src/infra/proxy/request_builder.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/request_builder.rs
@@ -20,7 +20,6 @@ pub fn build_upstream_url(
         Scheme::Grpc => {
             return Err(DomainError::Validation {
                 detail: "gRPC scheme is not supported for HTTP proxy".into(),
-                instance: String::new(),
             });
         }
     };

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -30,6 +30,7 @@ use crate::domain::services::{
 };
 use crate::infra::plugin::{AuthPluginRegistry, GuardPluginRegistry, TransformPluginRegistry};
 use crate::infra::proxy::{actions, resources};
+use crate::request_instance::RequestInstance;
 
 use super::headers;
 use super::pingora_proxy::{
@@ -166,7 +167,6 @@ impl DataPlaneServiceImpl {
         status: http::StatusCode,
         resp_headers: HeaderMap,
         resp_body_stream: BodyStream,
-        instance_uri: String,
     ) -> Result<http::Response<Body>, DomainError> {
         execute_guard_responses(
             &self.guard_registry,
@@ -175,7 +175,6 @@ impl DataPlaneServiceImpl {
             &resp_headers,
             pipeline.method,
             pipeline.path_suffix,
-            &instance_uri,
             pipeline.ctx,
         )
         .await?;
@@ -226,7 +225,7 @@ impl DataPlaneServiceImpl {
             resp_body_stream
         };
 
-        build_proxy_response(status, resp_headers, resp_body_stream, instance_uri)
+        build_proxy_response(status, resp_headers, resp_body_stream)
     }
 
     /// Two-tier endpoint selection (D1):
@@ -236,14 +235,12 @@ impl DataPlaneServiceImpl {
         &self,
         upstream: &Upstream,
         req_headers: &http::HeaderMap,
-        instance_uri: &str,
     ) -> Result<SelectedEndpoint, DomainError> {
         let endpoints = &upstream.server.endpoints;
 
         if endpoints.is_empty() {
             return Err(DomainError::DownstreamError {
                 detail: "upstream has no endpoints".into(),
-                instance: instance_uri.to_string(),
             });
         }
 
@@ -259,9 +256,7 @@ impl DataPlaneServiceImpl {
                     .bytes()
                     .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_'))
             {
-                return Err(DomainError::InvalidTargetHost {
-                    instance: instance_uri.to_string(),
-                });
+                return Err(DomainError::InvalidTargetHost);
             }
 
             // Find matching endpoint by host (no LB — no resolved addr).
@@ -282,7 +277,6 @@ impl DataPlaneServiceImpl {
                             "X-OAGW-Target-Host '{}' does not match any configured endpoint",
                             target_host
                         ),
-                        instance: instance_uri.to_string(),
                     }
                 })?;
             return Ok(SelectedEndpoint {
@@ -309,7 +303,6 @@ impl DataPlaneServiceImpl {
             .await
             .ok_or_else(|| DomainError::DownstreamError {
                 detail: "all backends are unhealthy".into(),
-                instance: instance_uri.to_string(),
             })
     }
 }
@@ -320,8 +313,9 @@ impl DataPlaneService for DataPlaneServiceImpl {
         &self,
         ctx: SecurityContext,
         req: http::Request<Body>,
+        request_instance: RequestInstance,
     ) -> Result<http::Response<Body>, DomainError> {
-        let instance_uri = req.uri().to_string();
+        let instance_uri = request_instance.as_str();
 
         self.policy_enforcer
             .access_scope_with(
@@ -370,7 +364,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
         if !headers::is_valid_content_type(&req_headers) {
             return Err(DomainError::Validation {
                 detail: "Content-Type header is not a recognized MIME type".into(),
-                instance: instance_uri,
             });
         }
 
@@ -378,7 +371,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
         if !headers::is_valid_transfer_encoding(&req_headers) {
             return Err(DomainError::Validation {
                 detail: "unsupported Transfer-Encoding; only chunked is accepted".into(),
-                instance: instance_uri,
             });
         }
 
@@ -393,7 +385,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
                             "request body of {} bytes exceeds maximum of {max_body} bytes",
                             b.len()
                         ),
-                        instance: instance_uri,
                     });
                 }
                 (b, None)
@@ -424,14 +415,12 @@ impl DataPlaneService for DataPlaneServiceImpl {
             if !crate::domain::cors::is_origin_allowed(cors_config, origin) {
                 return Err(DomainError::CorsOriginNotAllowed {
                     origin: origin.clone(),
-                    instance: instance_uri,
                 });
             }
 
             if !crate::domain::cors::is_method_allowed(cors_config, method.as_ref()) {
                 return Err(DomainError::CorsMethodNotAllowed {
                     method: method.to_string(),
-                    instance: instance_uri,
                 });
             }
         }
@@ -447,7 +436,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
                             "query parameter '{}' is not in the route's query_allowlist",
                             key
                         ),
-                        instance: instance_uri,
                     });
                 }
             }
@@ -465,7 +453,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
                         "path suffix not allowed: route path_suffix_mode is disabled but request has extra path '{}'",
                         extra
                     ),
-                    instance: instance_uri,
                 });
             }
         }
@@ -515,7 +502,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
             let plugin = self.auth_registry.resolve(&auth.plugin_type).map_err(|e| {
                 DomainError::AuthenticationFailed {
                     detail: e.to_string(),
-                    instance: instance_uri.clone(),
                 }
             })?;
             let mut auth_ctx = AuthContext {
@@ -528,23 +514,18 @@ impl DataPlaneService for DataPlaneServiceImpl {
                 .await
                 .map_err(|e| match e {
                     crate::domain::plugin::PluginError::SecretNotFound(ref s) => {
-                        DomainError::SecretNotFound {
-                            detail: s.clone(),
-                            instance: instance_uri.clone(),
-                        }
+                        DomainError::SecretNotFound { detail: s.clone() }
                     }
                     crate::domain::plugin::PluginError::Rejected(ref msg)
                     | crate::domain::plugin::PluginError::InvalidConfig(ref msg) => {
                         DomainError::Validation {
                             detail: msg.clone(),
-                            instance: instance_uri.clone(),
                         }
                     }
                     crate::domain::plugin::PluginError::AuthFailed(_)
                     | crate::domain::plugin::PluginError::Internal(_) => {
                         DomainError::AuthenticationFailed {
                             detail: e.to_string(),
-                            instance: instance_uri.clone(),
                         }
                     }
                 })?;
@@ -593,7 +574,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
                         status,
                         error_code,
                         detail,
-                        instance: instance_uri,
                     });
                 }
                 Err(e) => {
@@ -667,16 +647,13 @@ impl DataPlaneService for DataPlaneServiceImpl {
         }
 
         // 5a. Endpoint selection (D1 — two-tier).
-        let selected = self
-            .select_endpoint(&upstream, &req_headers, &instance_uri)
-            .await?;
+        let selected = self.select_endpoint(&upstream, &req_headers).await?;
         let endpoint = &selected.endpoint;
 
         // 5b. Enforce HTTPS-only constraint (cpt-cf-oagw-constraint-https-only).
         if !self.allow_http_upstream && matches!(endpoint.scheme, Scheme::Http) {
             return Err(DomainError::Validation {
                 detail: "upstream endpoint uses HTTP; only HTTPS endpoints are permitted".into(),
-                instance: instance_uri,
             });
         }
 
@@ -685,11 +662,11 @@ impl DataPlaneService for DataPlaneServiceImpl {
         // 6. Check rate limit (upstream then route).
         if let Some(ref rl) = upstream.rate_limit {
             let key = format!("upstream:{}", upstream.id);
-            self.rate_limiter.try_consume(&key, rl, &instance_uri)?;
+            self.rate_limiter.try_consume(&key, rl)?;
         }
         if let Some(ref rl) = route.rate_limit {
             let key = format!("route:{}", route.id);
-            self.rate_limiter.try_consume(&key, rl, &instance_uri)?;
+            self.rate_limiter.try_consume(&key, rl)?;
         }
 
         // 7. Build URL.
@@ -726,7 +703,7 @@ impl DataPlaneService for DataPlaneServiceImpl {
             outbound_headers.insert(H_ENDPOINT_PORT, v);
         }
         outbound_headers.insert(H_ENDPOINT_SCHEME, HeaderValue::from_static(scheme_str));
-        if let Ok(v) = HeaderValue::from_str(&instance_uri) {
+        if let Ok(v) = HeaderValue::from_str(instance_uri) {
             outbound_headers.insert(H_INSTANCE_URI, v);
         }
         if let Some(addr) = selected.resolved_addr
@@ -771,7 +748,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
                 .await
                 .map_err(|e| DomainError::DownstreamError {
                     detail: format!("failed to write upgrade request to proxy bridge: {e}"),
-                    instance: instance_uri.clone(),
                 })?;
 
             // Parse only the response headers (IO stays intact for bidirectional copy).
@@ -783,17 +759,14 @@ impl DataPlaneService for DataPlaneServiceImpl {
             .await
             .map_err(|_| DomainError::RequestTimeout {
                 detail: format!("WebSocket upgrade to {url} timed out after {upgrade_timeout:?}"),
-                instance: instance_uri.clone(),
             })?
             .map_err(|e| DomainError::DownstreamError {
                 detail: format!("proxy bridge error during WebSocket upgrade: {e}"),
-                instance: instance_uri.clone(),
             })?;
 
             if status != http::StatusCode::SWITCHING_PROTOCOLS {
                 return Err(DomainError::ProtocolError {
                     detail: format!("upstream rejected WebSocket upgrade with status {status}"),
-                    instance: instance_uri,
                 });
             }
 
@@ -805,7 +778,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
                 &resp_headers,
                 pipeline.method,
                 pipeline.path_suffix,
-                &instance_uri,
                 pipeline.ctx,
             )
             .await?;
@@ -865,7 +837,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
             client_write.write_all(&header_bytes).await.map_err(|e| {
                 DomainError::DownstreamError {
                     detail: format!("failed to write to proxy bridge: {e}"),
-                    instance: instance_uri.clone(),
                 }
             })?;
 
@@ -875,7 +846,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
             // fast instead of waiting for the full request timeout.
             let (limit_tx, limit_rx) = tokio::sync::oneshot::channel::<usize>();
             let (abort_tx, abort_rx) = tokio::sync::oneshot::channel::<String>();
-            let body_instance_uri = instance_uri.clone();
             tokio::spawn(async move {
                 let mut total_bytes: usize = 0;
                 let mut exceeded = false;
@@ -949,31 +919,26 @@ impl DataPlaneService for DataPlaneServiceImpl {
                         detail: format!(
                             "streaming request body of {total} bytes exceeds maximum of {max_body} bytes"
                         ),
-                        instance: body_instance_uri,
                     })
                 }
                 Ok(reason) = abort_rx => {
                     Err(DomainError::DownstreamError {
                         detail: format!("streaming request body failed mid-stream: {reason}"),
-                        instance: body_instance_uri,
                     })
                 }
                 result = resp_future => {
                     let (status, resp_headers, resp_body_stream) = result
                         .map_err(|_| DomainError::RequestTimeout {
                             detail: format!("request to {url} timed out after {timeout:?}"),
-                            instance: instance_uri.clone(),
                         })?
                         .map_err(|e| DomainError::DownstreamError {
                             detail: format!("proxy bridge error: {e}"),
-                            instance: instance_uri.clone(),
                         })?;
                     self.finalize_response(
                         &pipeline,
                         status,
                         resp_headers,
                         resp_body_stream,
-                        instance_uri,
                     )
                     .await
                 }
@@ -992,7 +957,6 @@ impl DataPlaneService for DataPlaneServiceImpl {
                 .await
                 .map_err(|e| DomainError::DownstreamError {
                     detail: format!("failed to write to proxy bridge: {e}"),
-                    instance: instance_uri.clone(),
                 })?;
             // Do NOT shutdown the write side — Pingora uses Content-Length to
             // determine the request boundary, and an early write-close is
@@ -1004,21 +968,13 @@ impl DataPlaneService for DataPlaneServiceImpl {
                     .await
                     .map_err(|_| DomainError::RequestTimeout {
                         detail: format!("request to {url} timed out after {timeout:?}"),
-                        instance: instance_uri.clone(),
                     })?
                     .map_err(|e| DomainError::DownstreamError {
                         detail: format!("proxy bridge error: {e}"),
-                        instance: instance_uri.clone(),
                     })?;
 
-            self.finalize_response(
-                &pipeline,
-                status,
-                resp_headers,
-                resp_body_stream,
-                instance_uri,
-            )
-            .await
+            self.finalize_response(&pipeline, status, resp_headers, resp_body_stream)
+                .await
         };
 
         // 9d. Execute transform error plugins on upstream failures.
@@ -1072,7 +1028,6 @@ async fn execute_guard_responses(
     resp_headers: &HeaderMap,
     method: &str,
     path: &str,
-    instance_uri: &str,
     security_context: &SecurityContext,
 ) -> Result<(), DomainError> {
     let resp_header_map = headers::header_map_to_vec(resp_headers);
@@ -1108,7 +1063,6 @@ async fn execute_guard_responses(
                     status,
                     error_code,
                     detail,
-                    instance: instance_uri.to_string(),
                 });
             }
             Err(e) => {
@@ -1241,8 +1195,8 @@ async fn execute_transform_errors(
 fn domain_error_status(err: &DomainError) -> u16 {
     match err {
         DomainError::Validation { .. }
-        | DomainError::MissingTargetHost { .. }
-        | DomainError::InvalidTargetHost { .. }
+        | DomainError::MissingTargetHost
+        | DomainError::InvalidTargetHost
         | DomainError::UnknownTargetHost { .. } => 400,
         DomainError::AuthenticationFailed { .. } => 401,
         DomainError::Forbidden { .. } => 403,
@@ -1271,8 +1225,8 @@ fn domain_error_type_name(err: &DomainError) -> &'static str {
     match err {
         DomainError::Validation { .. } => "ValidationError",
         DomainError::Conflict { .. } => "Conflict",
-        DomainError::MissingTargetHost { .. } => "MissingTargetHost",
-        DomainError::InvalidTargetHost { .. } => "InvalidTargetHost",
+        DomainError::MissingTargetHost => "MissingTargetHost",
+        DomainError::InvalidTargetHost => "InvalidTargetHost",
         DomainError::UnknownTargetHost { .. } => "UnknownTargetHost",
         DomainError::AuthenticationFailed { .. } => "AuthenticationFailed",
         DomainError::NotFound { .. } => "NotFound",
@@ -1304,7 +1258,6 @@ fn build_proxy_response(
     status: http::StatusCode,
     mut resp_headers: HeaderMap,
     body_stream: BodyStream,
-    instance_uri: String,
 ) -> Result<http::Response<Body>, DomainError> {
     let error_source = headers::extract_error_source(&resp_headers);
     headers::sanitize_response_headers(&mut resp_headers);
@@ -1314,7 +1267,6 @@ fn build_proxy_response(
         .body(Body::Stream(body_stream))
         .map_err(|e| DomainError::DownstreamError {
             detail: format!("failed to build response: {e}"),
-            instance: instance_uri,
         })?;
     *resp.headers_mut() = resp_headers;
     resp.extensions_mut().insert(error_source);
@@ -1630,7 +1582,7 @@ mod tests {
         }]);
         let headers = HeaderMap::new();
 
-        let err = svc.select_endpoint(&upstream, &headers, "/test").await;
+        let err = svc.select_endpoint(&upstream, &headers).await;
 
         // select_endpoint itself doesn't enforce HTTPS — the check is in proxy_request
         // after select_endpoint returns. Verify the endpoint is returned here (enforcement
@@ -1649,10 +1601,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-oagw-target-host", "a.com".parse().unwrap());
 
-        let result = svc
-            .select_endpoint(&upstream, &headers, "/test")
-            .await
-            .unwrap();
+        let result = svc.select_endpoint(&upstream, &headers).await.unwrap();
         assert_eq!(result.endpoint.host, "a.com");
         assert_eq!(selector.calls(), 0, "BackendSelector should not be called");
     }
@@ -1666,10 +1615,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-oagw-target-host", "evil.com".parse().unwrap());
 
-        let err = svc
-            .select_endpoint(&upstream, &headers, "/test")
-            .await
-            .unwrap_err();
+        let err = svc.select_endpoint(&upstream, &headers).await.unwrap_err();
         assert!(
             matches!(err, DomainError::UnknownTargetHost { .. }),
             "expected UnknownTargetHost, got: {err:?}"
@@ -1693,12 +1639,9 @@ mod tests {
         ] {
             let mut headers = HeaderMap::new();
             headers.insert("x-oagw-target-host", bad_value.parse().unwrap());
-            let err = svc
-                .select_endpoint(&upstream, &headers, "/test")
-                .await
-                .unwrap_err();
+            let err = svc.select_endpoint(&upstream, &headers).await.unwrap_err();
             assert!(
-                matches!(err, DomainError::InvalidTargetHost { .. }),
+                matches!(err, DomainError::InvalidTargetHost),
                 "expected InvalidTargetHost for '{bad_value}', got: {err:?}"
             );
         }
@@ -1707,12 +1650,9 @@ mod tests {
         // allows empty strings while .parse() does not.
         let mut headers = HeaderMap::new();
         headers.insert("x-oagw-target-host", HeaderValue::from_static(""));
-        let err = svc
-            .select_endpoint(&upstream, &headers, "/test")
-            .await
-            .unwrap_err();
+        let err = svc.select_endpoint(&upstream, &headers).await.unwrap_err();
         assert!(
-            matches!(err, DomainError::InvalidTargetHost { .. }),
+            matches!(err, DomainError::InvalidTargetHost),
             "expected InvalidTargetHost for empty header, got: {err:?}"
         );
     }
@@ -1725,14 +1665,8 @@ mod tests {
         let upstream = upstream_with(vec![ep("a.com", 443), ep("b.com", 443)]);
         let headers = HeaderMap::new();
 
-        let ep1 = svc
-            .select_endpoint(&upstream, &headers, "/test")
-            .await
-            .unwrap();
-        let ep2 = svc
-            .select_endpoint(&upstream, &headers, "/test")
-            .await
-            .unwrap();
+        let ep1 = svc.select_endpoint(&upstream, &headers).await.unwrap();
+        let ep2 = svc.select_endpoint(&upstream, &headers).await.unwrap();
 
         assert_eq!(
             selector.calls(),
@@ -1752,10 +1686,7 @@ mod tests {
         let upstream = upstream_with(vec![ep("only.com", 443)]);
         let headers = HeaderMap::new();
 
-        let result = svc
-            .select_endpoint(&upstream, &headers, "/test")
-            .await
-            .unwrap();
+        let result = svc.select_endpoint(&upstream, &headers).await.unwrap();
         assert_eq!(result.endpoint.host, "only.com");
         assert_eq!(
             selector.calls(),
@@ -1773,19 +1704,13 @@ mod tests {
         // Valid header matching the single endpoint → OK.
         let mut headers = HeaderMap::new();
         headers.insert("x-oagw-target-host", "a.com".parse().unwrap());
-        let result = svc
-            .select_endpoint(&upstream, &headers, "/test")
-            .await
-            .unwrap();
+        let result = svc.select_endpoint(&upstream, &headers).await.unwrap();
         assert_eq!(result.endpoint.host, "a.com");
 
         // Invalid header not matching → UnknownTargetHost.
         let mut headers = HeaderMap::new();
         headers.insert("x-oagw-target-host", "b.com".parse().unwrap());
-        let err = svc
-            .select_endpoint(&upstream, &headers, "/test")
-            .await
-            .unwrap_err();
+        let err = svc.select_endpoint(&upstream, &headers).await.unwrap_err();
         assert!(
             matches!(err, DomainError::UnknownTargetHost { .. }),
             "expected UnknownTargetHost for mismatched header on single-endpoint upstream"

--- a/modules/system/oagw/oagw/src/lib.rs
+++ b/modules/system/oagw/oagw/src/lib.rs
@@ -15,6 +15,7 @@ pub mod api;
 pub mod config;
 pub(crate) mod domain;
 pub(crate) mod infra;
+pub(crate) mod request_instance;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_support;

--- a/modules/system/oagw/oagw/src/request_instance.rs
+++ b/modules/system/oagw/oagw/src/request_instance.rs
@@ -1,0 +1,80 @@
+use std::convert::Infallible;
+
+use axum::extract::FromRequestParts;
+use http::{Uri, request::Parts};
+
+/// RFC 9457 `instance` value derived from an HTTP request target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RequestInstance(String);
+
+impl RequestInstance {
+    #[must_use]
+    pub(crate) fn from_uri(uri: &Uri) -> Self {
+        Self(
+            uri.path_and_query()
+                .map_or_else(|| uri.path().to_string(), |pq| pq.as_str().to_string()),
+        )
+    }
+
+    /// Trusted constructor for values already derived from an inbound request URI.
+    #[must_use]
+    pub(crate) fn from_trusted(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    #[must_use]
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<RequestInstance> for String {
+    fn from(instance: RequestInstance) -> Self {
+        instance.0
+    }
+}
+
+impl AsRef<str> for RequestInstance {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<S: Sync> FromRequestParts<S> for RequestInstance {
+    type Rejection = Infallible;
+
+    async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        Ok(RequestInstance::from_uri(&parts.uri))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_uri_uses_path_when_query_absent() {
+        let uri: Uri = "/oagw/v1/upstreams".parse().unwrap();
+        let instance = RequestInstance::from_uri(&uri);
+        assert_eq!(instance.as_str(), "/oagw/v1/upstreams");
+    }
+
+    #[test]
+    fn from_uri_preserves_query_string() {
+        let uri: Uri = "/oagw/v1/routes?limit=10&offset=20".parse().unwrap();
+        let instance = RequestInstance::from_uri(&uri);
+        assert_eq!(instance.as_str(), "/oagw/v1/routes?limit=10&offset=20");
+    }
+
+    #[test]
+    fn from_uri_preserves_proxy_wildcard_query() {
+        let uri: Uri = "/oagw/v1/proxy/api.openai.com/v1/chat/completions?model=gpt-4"
+            .parse()
+            .unwrap();
+        let instance = RequestInstance::from_uri(&uri);
+        assert_eq!(
+            instance.as_str(),
+            "/oagw/v1/proxy/api.openai.com/v1/chat/completions?model=gpt-4"
+        );
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized how request "instance" values are derived and propagated, removing redundant instance fields and producing more consistent error responses (NotFound messages now include "entity/id not found") across proxy, routing, and service flows.

* **Tests**
  * Updated unit and integration tests to match the refined error shapes and new instance-handling behavior across providers, LLM integration, proxy, and routing components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->