### PR TITLE
feat(minichat): implement orphan turn detection and finalization

### DIFF
--- a/modules/mini-chat/mini-chat/src/background_workers.rs
+++ b/modules/mini-chat/mini-chat/src/background_workers.rs
@@ -5,8 +5,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::config::OrphanWatchdogConfig;
+use crate::domain::repos::{MessageRepository, TurnRepository};
 use crate::infra::leader::LeaderElector;
 use crate::infra::workers::WorkerHandles;
+use crate::infra::workers::orphan_watchdog::OrphanWatchdogDeps;
 
 /// Worker configs captured in `init()` and consumed by `start()`.
 pub struct WorkerConfigs {
@@ -33,11 +35,16 @@ pub async fn prepare_worker_runtime(
 
 /// Spawn all background workers, returning their handles and a cancellation
 /// token that can be used to request shutdown.
-pub fn spawn_workers(
+pub fn spawn_workers<TR, MR>(
     configs: &WorkerConfigs,
     parent_cancel: &CancellationToken,
     leader_elector: Option<&Arc<dyn LeaderElector>>,
-) -> anyhow::Result<(WorkerHandles, CancellationToken)> {
+    orphan_deps: Option<OrphanWatchdogDeps<TR, MR>>,
+) -> anyhow::Result<(WorkerHandles, CancellationToken)>
+where
+    TR: TurnRepository + 'static,
+    MR: MessageRepository + 'static,
+{
     let worker_cancel = parent_cancel.child_token();
     let mut handles = WorkerHandles::new();
 
@@ -46,6 +53,8 @@ pub fn spawn_workers(
             leader_elector
                 .ok_or_else(|| anyhow::anyhow!("leader elector required for orphan_watchdog"))?,
         );
+        let deps = orphan_deps
+            .ok_or_else(|| anyhow::anyhow!("orphan watchdog deps required when enabled"))?;
         let cancel = worker_cancel.child_token();
         handles.spawn(
             "orphan_watchdog",
@@ -53,6 +62,7 @@ pub fn spawn_workers(
             crate::infra::workers::orphan_watchdog::run(
                 elector,
                 configs.orphan_watchdog.clone(),
+                deps,
                 cancel,
             ),
         );
@@ -70,6 +80,10 @@ fn leader_workers_enabled(configs: &WorkerConfigs) -> bool {
 ///
 /// When built with `k8s`, mini-chat requires Kubernetes runtime support:
 /// `POD_NAMESPACE`, `POD_NAME`, and kube client access must all be available.
+#[allow(
+    clippy::unused_async,
+    reason = "async needed when k8s feature is enabled"
+)]
 async fn create_leader_elector() -> anyhow::Result<Arc<dyn LeaderElector>> {
     #[cfg(feature = "k8s")]
     {
@@ -111,8 +125,11 @@ mod tests {
         assert!(elector.is_none());
 
         let parent_cancel = CancellationToken::new();
-        let (handles, worker_cancel) =
-            spawn_workers(&configs, &parent_cancel, elector.as_ref()).unwrap();
+        let (handles, worker_cancel) = spawn_workers::<
+            crate::infra::db::repo::turn_repo::TurnRepository,
+            crate::infra::db::repo::message_repo::MessageRepository,
+        >(&configs, &parent_cancel, elector.as_ref(), None)
+        .unwrap();
         assert_eq!(handles.len(), 0);
 
         worker_cancel.cancel();

--- a/modules/mini-chat/mini-chat/src/config/background.rs
+++ b/modules/mini-chat/mini-chat/src/config/background.rs
@@ -12,7 +12,8 @@ pub struct OrphanWatchdogConfig {
     #[serde(default = "default_orphan_scan_interval")]
     pub scan_interval_secs: u64,
     /// A `running` turn with `last_progress_at` older than this is orphan-eligible.
-    /// Valid range: 60–3600. Default: 300 (5 min).
+    /// Valid range: 90–3600. Default: 300 (5 min).
+    /// Minimum 90s = 3× `PROGRESS_UPDATE_INTERVAL` (30s) to avoid false orphaning.
     #[serde(default = "default_orphan_timeout")]
     pub timeout_secs: u64,
 }
@@ -28,10 +29,15 @@ impl Default for OrphanWatchdogConfig {
 }
 
 impl OrphanWatchdogConfig {
+    /// Minimum timeout to avoid false orphaning under normal jitter.
+    /// `PROGRESS_UPDATE_INTERVAL` is 30s; 90s gives 3 heartbeat windows of headroom.
+    const MIN_TIMEOUT_SECS: u64 = 90;
+
     pub fn validate(&self) -> Result<(), String> {
-        if !(60..=3600).contains(&self.timeout_secs) {
+        if !(Self::MIN_TIMEOUT_SECS..=3600).contains(&self.timeout_secs) {
             return Err(format!(
-                "orphan_watchdog.timeout_secs must be 60-3600, got {}",
+                "orphan_watchdog.timeout_secs must be {}-3600, got {}",
+                Self::MIN_TIMEOUT_SECS,
                 self.timeout_secs
             ));
         }

--- a/modules/mini-chat/mini-chat/src/domain/model/finalization.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/finalization.rs
@@ -1,6 +1,7 @@
 use mini_chat_sdk::RequesterType;
 use modkit_macros::domain_model;
 use modkit_security::AccessScope;
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::domain::llm::Usage;
@@ -96,4 +97,26 @@ pub fn settlement_path_from_billing(
         SettlementMethod::Estimated => SettlementPath::Estimated,
         SettlementMethod::Released => SettlementPath::Released,
     }
+}
+
+/// Simplified input for orphan finalization.
+/// Built from the turn row — no streaming context available.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct OrphanFinalizationInput {
+    pub turn_id: Uuid,
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    pub request_id: Uuid,
+    /// From `requester_user_id`. Nullable because some turns may have system requesters.
+    pub user_id: Option<Uuid>,
+    pub requester_type: RequesterType,
+    pub effective_model: Option<String>,
+    pub reserve_tokens: Option<i64>,
+    pub max_output_tokens_applied: Option<i32>,
+    pub reserved_credits_micro: Option<i64>,
+    pub policy_version_applied: Option<i64>,
+    pub minimal_generation_floor_applied: Option<i32>,
+    /// `started_at` — used to derive `period_starts` for quota settlement.
+    pub started_at: OffsetDateTime,
 }

--- a/modules/mini-chat/mini-chat/src/domain/ports/metric_labels.rs
+++ b/modules/mini-chat/mini-chat/src/domain/ports/metric_labels.rs
@@ -95,6 +95,12 @@ pub mod cleanup_state {
     pub const FAILED: &str = "failed";
 }
 
+/// Orphan watchdog reason labels (`reason` label).
+pub mod reason {
+    #[allow(dead_code)] // declared ahead of call site (watchdog uses string literals)
+    pub const STALE_PROGRESS: &str = "stale_progress";
+}
+
 /// Cancel / abort trigger labels (`trigger` label).
 pub mod trigger {
     #[allow(dead_code)] // declared ahead of call site (deferred metrics)

--- a/modules/mini-chat/mini-chat/src/domain/ports/metrics.rs
+++ b/modules/mini-chat/mini-chat/src/domain/ports/metrics.rs
@@ -165,6 +165,19 @@ pub trait MiniChatMetricsPort: Send + Sync {
     /// `{prefix}_cleanup_vector_store_with_failed_attachments` — counter
     fn record_cleanup_vs_with_failed_attachments(&self);
 
+    // ── P1: Orphan Watchdog (3 metrics) ─────────────────────────────────
+
+    /// `{prefix}_orphan_detected` — counter
+    /// `reason`: `stale_progress`
+    fn record_orphan_detected(&self, reason: &str);
+
+    /// `{prefix}_orphan_finalized` — counter
+    /// `reason`: `stale_progress`
+    fn record_orphan_finalized(&self, reason: &str);
+
+    /// `{prefix}_orphan_scan_duration_seconds` — histogram
+    fn record_orphan_scan_duration_seconds(&self, seconds: f64);
+
     // ── P2: Tool Call Counters (1 metric) ────────────────────────────
 
     /// `{prefix}_code_interpreter_calls` — counter
@@ -206,6 +219,9 @@ impl MiniChatMetricsPort for NoopMetrics {
     fn increment_attachments_pending(&self) {}
     fn decrement_attachments_pending(&self) {}
     fn record_image_inputs_per_turn(&self, _: u32) {}
+    fn record_orphan_detected(&self, _: &str) {}
+    fn record_orphan_finalized(&self, _: &str) {}
+    fn record_orphan_scan_duration_seconds(&self, _: f64) {}
     fn record_code_interpreter_calls(&self, _: &str, _: u32) {}
     fn record_cleanup_completed(&self, _: &str) {}
     fn record_cleanup_failed(&self, _: &str) {}

--- a/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
@@ -32,7 +32,7 @@ pub(crate) use quota_usage_repo::{IncrementReserveParams, QuotaUsageRepository, 
 pub(crate) use reaction_repo::{ReactionRepository, UpsertReactionParams};
 pub(crate) use thread_summary_repo::{ThreadSummaryModel, ThreadSummaryRepository};
 pub(crate) use turn_repo::{
-    CasCompleteParams, CasTerminalParams, CreateTurnParams, TurnRepository,
+    CasCompleteParams, CasTerminalParams, CreateTurnParams, TurnRepository, UpdatePreflightParams,
 };
 pub(crate) use user_limits_provider::UserLimitsProvider;
 pub(crate) use vector_store_repo::{InsertVectorStoreParams, VectorStoreRepository};

--- a/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
@@ -52,6 +52,22 @@ pub struct CasTerminalParams {
     pub provider_response_id: Option<String>,
 }
 
+/// Preflight fields to backfill on a mutation turn after quota evaluation.
+///
+/// The mutation path creates turns with NULL quota fields; this struct carries
+/// the computed preflight values so they can be persisted before the provider
+/// task spawns (ensuring the orphan watchdog has complete data).
+#[domain_model]
+pub struct UpdatePreflightParams {
+    pub turn_id: Uuid,
+    pub reserve_tokens: i64,
+    pub max_output_tokens_applied: i32,
+    pub reserved_credits_micro: i64,
+    pub policy_version_applied: i64,
+    pub effective_model: String,
+    pub minimal_generation_floor_applied: i32,
+}
+
 /// Repository trait for turn persistence operations.
 #[async_trait]
 #[allow(dead_code)]
@@ -129,6 +145,46 @@ pub trait TurnRepository: Send + Sync {
         chat_id: Uuid,
     ) -> Result<Option<TurnModel>, DomainError>;
 
+    /// Update `last_progress_at = now()` for a running turn.
+    ///
+    /// Called from the streaming task which passes the request-scoped `AccessScope`
+    /// for defense-in-depth tenant scoping.
+    ///
+    /// Returns `rows_affected` (0 if turn is no longer running — benign, no error).
+    async fn update_progress_at<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        turn_id: Uuid,
+    ) -> Result<u64, DomainError>;
+
+    /// Find running turns with stale progress (orphan candidates).
+    ///
+    /// No `AccessScope` — system-level background worker query under leader election.
+    /// Returns at most `limit` rows ordered by oldest progress first.
+    async fn find_orphan_candidates<C: DBRunner>(
+        &self,
+        runner: &C,
+        timeout_secs: u64,
+        limit: u32,
+    ) -> Result<Vec<TurnModel>, DomainError>;
+
+    /// CAS update for orphan finalization with full predicate re-check.
+    ///
+    /// The terminal UPDATE re-checks ALL orphan predicates:
+    /// `state = 'running' AND deleted_at IS NULL AND last_progress_at <= now() - timeout`.
+    /// This prevents "false orphan finalization after renewed progress" (DESIGN.md P1 invariant).
+    ///
+    /// Returns `rows_affected`:
+    /// - `0`: turn is no longer orphan-eligible (already finalized, soft-deleted, or progress renewed)
+    /// - `1`: turn transitioned to `Failed` with `error_code = 'orphan_timeout'`
+    async fn cas_finalize_orphan<C: DBRunner>(
+        &self,
+        runner: &C,
+        turn_id: Uuid,
+        timeout_secs: u64,
+    ) -> Result<u64, DomainError>;
+
     /// SELECT the most recent non-deleted turn for a chat with `FOR UPDATE` row lock.
     /// Used within mutation transactions to serialize concurrent retry/edit/delete.
     async fn find_latest_for_update<C: DBRunner>(
@@ -137,4 +193,22 @@ pub trait TurnRepository: Send + Sync {
         scope: &AccessScope,
         chat_id: Uuid,
     ) -> Result<Option<TurnModel>, DomainError>;
+
+    /// Backfill preflight quota fields on a running turn.
+    ///
+    /// The mutation path (`mutate_for_stream`) creates the turn with NULL quota
+    /// fields because preflight runs after the mutation transaction. This method
+    /// persists the computed preflight values so the orphan watchdog can settle
+    /// quota correctly if the pod crashes after preflight.
+    ///
+    /// Only updates the row if `state = 'running'` (CAS guard prevents writing
+    /// to already-finalized turns).
+    ///
+    /// Returns `rows_affected` (0 if turn is no longer running).
+    async fn update_preflight_fields<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: UpdatePreflightParams,
+    ) -> Result<u64, DomainError>;
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/attachment_service.rs
@@ -865,8 +865,10 @@ impl<
         //    generate a thumbnail after the upload completes.
         let structured_name = structured_filename(chat_id, attachment_id, validated_mime);
 
-        // Arc<Mutex> is required because the stream closure must be Send + 'static;
-        // in practice the stream is consumed sequentially so contention never occurs.
+        // Arc<Mutex<Option<Vec>>> bridges two ownership scopes: the stream
+        // closure (writes chunks during upload) and the post-upload thumbnail
+        // path (reads the buffer).  The stream is consumed sequentially so no
+        // real contention occurs; Arc<Mutex> is needed only to satisfy Send + 'static.
         let image_buffer: std::sync::Arc<std::sync::Mutex<Option<Vec<u8>>>> =
             std::sync::Arc::new(std::sync::Mutex::new(if is_document {
                 None
@@ -887,7 +889,8 @@ impl<
                     if let Some(ref mut v) = *guard {
                         // Stop buffering if we exceed decode limit — thumbnail
                         // generation will be skipped, but upload continues.
-                        if v.len() + bytes.len() <= max_buf {
+                        // saturating_add avoids overflow when both values are large.
+                        if v.len().saturating_add(bytes.len()) <= max_buf {
                             v.extend_from_slice(bytes);
                         } else {
                             *guard = None;

--- a/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use super::current_otel_trace_id;
 use modkit_macros::domain_model;
 use tracing::{debug, error, warn};
+use uuid::Uuid;
 
 use mini_chat_sdk::{
     AuditUsageTokens, LatencyMs, PolicyDecisions, QuotaDecision, TurnAuditEvent,
@@ -431,6 +432,219 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
             metrics.record_streams_aborted(abort_trigger);
         }
     }
+
+    /// Finalize an orphan turn within a single database transaction.
+    ///
+    /// Uses the orphan-specific CAS guard that re-checks all predicates
+    /// (`state`=running, `deleted_at` IS NULL, `last_progress_at` <= cutoff).
+    /// Reuses billing derivation, quota settlement, and outbox enqueue.
+    ///
+    /// Returns `Ok(true)` if CAS won (turn finalized), `Ok(false)` if CAS lost.
+    pub(crate) async fn finalize_orphan_turn(
+        &self,
+        input: crate::domain::model::finalization::OrphanFinalizationInput,
+        timeout_secs: u64,
+    ) -> Result<bool, DomainError> {
+        use crate::domain::model::billing_outcome::{
+            BillingDerivationInput, derive_billing_outcome,
+        };
+        use crate::domain::model::quota::SettlementPath;
+        use crate::infra::db::entity::quota_usage::PeriodType;
+        let start = std::time::Instant::now();
+        let turn_repo = Arc::clone(&self.turn_repo);
+        let quota_settler = Arc::clone(&self.quota_settler);
+        let outbox_enqueuer = Arc::clone(&self.outbox_enqueuer);
+
+        let tx_result = self
+            .db
+            .transaction(|tx| {
+                Box::pin(async move {
+                    // 1. CAS finalize orphan (re-checks all predicates)
+                    let rows = turn_repo
+                        .cas_finalize_orphan(tx, input.turn_id, timeout_secs)
+                        .await
+                        .map_err(to_db)?;
+
+                    if rows == 0 {
+                        debug!(
+                            turn_id = %input.turn_id,
+                            "orphan CAS loser: turn already finalized or progress renewed"
+                        );
+                        return Ok(false);
+                    }
+
+                    // 2. Derive billing outcome (pure function)
+                    let billing = derive_billing_outcome(&BillingDerivationInput {
+                        terminal_state: TurnState::Failed,
+                        error_code: Some("orphan_timeout".to_owned()),
+                        has_usage: false,
+                    });
+
+                    // 3. Settle quota if all required fields are present.
+                    let quota_fields = input
+                        .effective_model
+                        .as_ref()
+                        .zip(input.user_id)
+                        .zip(input.reserve_tokens)
+                        .zip(input.policy_version_applied)
+                        .map(|(((em, uid), rt), pv)| (em.clone(), uid, rt, pv));
+
+                    let settlement_outcome = if let Some((
+                        effective_model,
+                        user_id_val,
+                        reserve_tokens,
+                        policy_version_applied,
+                    )) = quota_fields
+                    {
+                        let day = input.started_at.date();
+                        // replace_day(1) is infallible for any valid Date, but the
+                        // `time` crate returns Result so we propagate defensively.
+                        let month_start = day
+                            .replace_day(1)
+                            .map_err(|e| to_db(DomainError::internal(e.to_string())))?;
+                        let period_starts =
+                            vec![(PeriodType::Daily, day), (PeriodType::Monthly, month_start)];
+
+                        let settlement_input = SettlementInput {
+                            tenant_id: input.tenant_id,
+                            user_id: user_id_val,
+                            effective_model,
+                            policy_version_applied,
+                            reserve_tokens,
+                            max_output_tokens_applied: input.max_output_tokens_applied.unwrap_or(0),
+                            reserved_credits_micro: input.reserved_credits_micro.unwrap_or(0),
+                            minimal_generation_floor_applied: input
+                                .minimal_generation_floor_applied
+                                .unwrap_or(0),
+                            settlement_path: SettlementPath::Estimated,
+                            period_starts,
+                            web_search_calls: 0,
+                            code_interpreter_calls: 0,
+                        };
+
+                        let scope = modkit_security::AccessScope::allow_all();
+                        let outcome = quota_settler
+                            .settle_in_tx(tx, &scope, settlement_input)
+                            .await
+                            .map_err(to_db)?;
+                        Some(outcome)
+                    } else {
+                        warn!(
+                            turn_id = %input.turn_id,
+                            "orphan turn missing quota fields, skipping settlement"
+                        );
+                        None
+                    };
+
+                    // 4. Build and enqueue usage event
+                    let now = time::OffsetDateTime::now_utc();
+                    let effective_model_str = input.effective_model.clone().unwrap_or_default();
+                    // Nil UUID for system requesters or turns without a user — the turn
+                    // row may have NULL requester_user_id for system-initiated turns.
+                    // Acceptable because billing settles by tenant, not user.
+                    let user_id = input.user_id.unwrap_or(Uuid::nil());
+
+                    let settlement_method_str =
+                        settlement_outcome.as_ref().map_or("estimated", |s| {
+                            match s.settlement_method {
+                                SettlementMethod::Actual => "actual",
+                                SettlementMethod::Estimated => "estimated",
+                                SettlementMethod::Released => "released",
+                            }
+                        });
+
+                    let actual_credits_micro = settlement_outcome
+                        .as_ref()
+                        .map_or(0, |s| s.actual_credits_micro);
+
+                    let usage_event = UsageEvent {
+                        tenant_id: input.tenant_id,
+                        user_id,
+                        chat_id: input.chat_id,
+                        turn_id: input.turn_id,
+                        request_id: input.request_id,
+                        effective_model: effective_model_str.clone(),
+                        selected_model: effective_model_str.clone(),
+                        terminal_state: "failed".to_owned(),
+                        billing_outcome: billing.outcome.as_str().to_owned(),
+                        usage: None,
+                        actual_credits_micro,
+                        settlement_method: settlement_method_str.to_owned(),
+                        policy_version_applied: input.policy_version_applied.unwrap_or(0),
+                        web_search_calls: 0,
+                        code_interpreter_calls: 0,
+                        timestamp: now,
+                    };
+                    outbox_enqueuer
+                        .enqueue_usage_event(tx, usage_event)
+                        .await
+                        .map_err(to_db)?;
+
+                    // 5. Build and enqueue audit event
+                    let audit_event = AuditEnvelope::Turn(TurnAuditEvent {
+                        event_type: TurnAuditEventType::TurnFailed,
+                        timestamp: now,
+                        tenant_id: input.tenant_id,
+                        requester_type: input.requester_type,
+                        trace_id: None,
+                        user_id,
+                        chat_id: input.chat_id,
+                        turn_id: input.turn_id,
+                        request_id: input.request_id,
+                        selected_model: effective_model_str.clone(),
+                        effective_model: effective_model_str.clone(),
+                        policy_version_applied: input
+                            .policy_version_applied
+                            .map(i64::cast_unsigned),
+                        usage: AuditUsageTokens {
+                            input_tokens: 0,
+                            output_tokens: 0,
+                            model: Some(effective_model_str),
+                            cache_read_input_tokens: Some(0),
+                            cache_write_input_tokens: Some(0),
+                            reasoning_tokens: Some(0),
+                        },
+                        latency_ms: LatencyMs {
+                            ttft_ms: None,
+                            total_ms: None,
+                        },
+                        policy_decisions: PolicyDecisions {
+                            license: None,
+                            quota: QuotaDecision {
+                                decision: "unknown".to_owned(),
+                                quota_scope: None,
+                                downgrade_from: None,
+                                downgrade_reason: None,
+                            },
+                        },
+                        error_code: Some("orphan_timeout".to_owned()),
+                        prompt: None,
+                        response: None,
+                        attachments: Vec::new(),
+                        tool_calls: None,
+                    });
+                    outbox_enqueuer
+                        .enqueue_audit_event(tx, audit_event)
+                        .await
+                        .map_err(to_db)?;
+
+                    Ok(true)
+                })
+            })
+            .await
+            .map_err(DomainError::from)?;
+
+        // Post-commit side effects (outside transaction).
+        if tx_result {
+            self.outbox_enqueuer.flush();
+            let ms = start.elapsed().as_secs_f64() * 1000.0;
+            self.metrics.record_audit_emit(result_label::OK);
+            self.metrics.record_finalization_latency_ms(ms);
+            self.metrics.record_streams_aborted(trigger::ORPHAN_TIMEOUT);
+        }
+
+        Ok(tx_result)
+    }
 }
 
 fn build_turn_audit_envelope(input: &FinalizationInput, trace_id: Option<String>) -> AuditEnvelope {
@@ -792,6 +1006,25 @@ mod tests {
             ttft_ms: None,
             total_ms: None,
         }
+    }
+
+    /// Backdate `last_progress_at` on a turn to 10 minutes ago, making it orphan-eligible.
+    async fn backdate_turn_progress(runner: &impl modkit_db::secure::DBRunner, turn_id: Uuid) {
+        use crate::infra::db::entity::chat_turn::{Column, Entity as TurnEntity};
+        use modkit_db::secure::SecureUpdateExt;
+        use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, sea_query::Expr};
+        use time::OffsetDateTime;
+
+        let past = OffsetDateTime::now_utc() - time::Duration::seconds(600);
+        let scope = AccessScope::allow_all();
+        TurnEntity::update_many()
+            .col_expr(Column::LastProgressAt, Expr::value(Some(past)))
+            .filter(Column::Id.eq(turn_id))
+            .secure()
+            .scope_with(&scope)
+            .exec(runner)
+            .await
+            .expect("backdate last_progress_at");
     }
 
     // ── 3.6: CAS winner executes full atomic finalization ──
@@ -1488,5 +1721,208 @@ mod tests {
             }
             other => panic!("expected Turn event, got: {other:?}"),
         }
+    }
+
+    // ── Orphan finalization tests ──
+
+    #[tokio::test]
+    async fn finalize_orphan_cas_winner() {
+        let db = mock_db_provider(inmem_db().await);
+        let (svc, outbox) = build_finalization_service(Arc::clone(&db));
+
+        let tenant_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        insert_test_chat(&db, tenant_id, chat_id, user_id).await;
+        insert_running_turn(&db, tenant_id, chat_id, turn_id, request_id).await;
+
+        // Make the turn stale by backdating last_progress_at
+        let conn = db.conn().unwrap();
+        backdate_turn_progress(&conn, turn_id).await;
+
+        let input = crate::domain::model::finalization::OrphanFinalizationInput {
+            turn_id,
+            tenant_id,
+            chat_id,
+            request_id,
+            user_id: Some(user_id),
+            requester_type: mini_chat_sdk::RequesterType::User,
+            effective_model: Some("gpt-5.2".to_owned()),
+            reserve_tokens: Some(100),
+            max_output_tokens_applied: Some(4096),
+            reserved_credits_micro: Some(1000),
+            policy_version_applied: Some(1),
+            minimal_generation_floor_applied: Some(10),
+            started_at: time::OffsetDateTime::now_utc(),
+        };
+
+        let result = svc.finalize_orphan_turn(input, 60).await.unwrap();
+        assert!(result, "should be CAS winner");
+
+        // Verify turn state
+        let scope = AccessScope::allow_all();
+        let turn_repo = TurnRepo;
+        let turn = turn_repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .unwrap()
+            .expect("turn should exist");
+        assert_eq!(turn.state, TurnState::Failed);
+        assert_eq!(turn.error_code.as_deref(), Some("orphan_timeout"));
+
+        // Verify usage event enqueued
+        let usage_events = outbox.usage_events.lock().unwrap();
+        assert_eq!(usage_events.len(), 1, "should have one usage event");
+        assert_eq!(usage_events[0].terminal_state, "failed");
+        assert_eq!(usage_events[0].billing_outcome, "aborted");
+        drop(usage_events);
+
+        // Verify audit event enqueued
+        let audit_events = outbox.audit_events();
+        assert_eq!(audit_events.len(), 1, "should have one audit event");
+        match &audit_events[0] {
+            AuditEnvelope::Turn(evt) => {
+                assert_eq!(
+                    evt.event_type,
+                    mini_chat_sdk::TurnAuditEventType::TurnFailed
+                );
+                assert_eq!(evt.error_code.as_deref(), Some("orphan_timeout"));
+            }
+            other => panic!("expected Turn event, got: {other:?}"),
+        }
+
+        // Verify flush was called
+        assert_eq!(
+            outbox.flush_count(),
+            1,
+            "flush should be called after CAS win"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_orphan_cas_loser() {
+        let db = mock_db_provider(inmem_db().await);
+        let (svc, outbox) = build_finalization_service(Arc::clone(&db));
+
+        let tenant_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        insert_test_chat(&db, tenant_id, chat_id, user_id).await;
+        insert_running_turn(&db, tenant_id, chat_id, turn_id, request_id).await;
+
+        // Finalize normally first (CAS update to failed — avoids FK constraint on assistant_message_id)
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let turn_repo = TurnRepo;
+        turn_repo
+            .cas_update_state(
+                &conn,
+                &scope,
+                crate::domain::repos::CasTerminalParams {
+                    turn_id,
+                    state: TurnState::Failed,
+                    error_code: Some("test_error".to_owned()),
+                    error_detail: None,
+                    assistant_message_id: None,
+                    provider_response_id: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Now try orphan finalization — should be CAS loser
+        let input = crate::domain::model::finalization::OrphanFinalizationInput {
+            turn_id,
+            tenant_id,
+            chat_id,
+            request_id,
+            user_id: Some(user_id),
+            requester_type: mini_chat_sdk::RequesterType::User,
+            effective_model: Some("gpt-5.2".to_owned()),
+            reserve_tokens: Some(100),
+            max_output_tokens_applied: Some(4096),
+            reserved_credits_micro: Some(1000),
+            policy_version_applied: Some(1),
+            minimal_generation_floor_applied: Some(10),
+            started_at: time::OffsetDateTime::now_utc(),
+        };
+
+        let result = svc.finalize_orphan_turn(input, 60).await.unwrap();
+        assert!(!result, "should be CAS loser");
+
+        // Verify no usage or audit events were enqueued
+        let usage_events = outbox.usage_events.lock().unwrap();
+        assert!(usage_events.is_empty(), "no usage events for CAS loser");
+        drop(usage_events);
+
+        let audit_events = outbox.audit_events();
+        assert!(audit_events.is_empty(), "no audit events for CAS loser");
+
+        assert_eq!(outbox.flush_count(), 0, "no flush for CAS loser");
+    }
+
+    #[tokio::test]
+    async fn finalize_orphan_missing_quota_fields() {
+        let db = mock_db_provider(inmem_db().await);
+        let (svc, outbox) = build_finalization_service(Arc::clone(&db));
+
+        let tenant_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        insert_test_chat(&db, tenant_id, chat_id, user_id).await;
+        insert_running_turn(&db, tenant_id, chat_id, turn_id, request_id).await;
+
+        // Make the turn stale by backdating last_progress_at
+        let conn = db.conn().unwrap();
+        backdate_turn_progress(&conn, turn_id).await;
+
+        // Build input with effective_model = None → settlement will be skipped
+        let input = crate::domain::model::finalization::OrphanFinalizationInput {
+            turn_id,
+            tenant_id,
+            chat_id,
+            request_id,
+            user_id: Some(user_id),
+            requester_type: mini_chat_sdk::RequesterType::User,
+            effective_model: None, // missing
+            reserve_tokens: Some(100),
+            max_output_tokens_applied: Some(4096),
+            reserved_credits_micro: Some(1000),
+            policy_version_applied: Some(1),
+            minimal_generation_floor_applied: Some(10),
+            started_at: time::OffsetDateTime::now_utc(),
+        };
+
+        let result = svc.finalize_orphan_turn(input, 60).await.unwrap();
+        assert!(result, "CAS should succeed even with missing quota fields");
+
+        // Verify turn is failed
+        let scope = AccessScope::allow_all();
+        let turn_repo = TurnRepo;
+        let turn = turn_repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .unwrap()
+            .expect("turn should exist");
+        assert_eq!(turn.state, TurnState::Failed);
+        assert_eq!(turn.error_code.as_deref(), Some("orphan_timeout"));
+
+        // Usage event should still be enqueued (settlement skipped, but event still sent)
+        let usage_events = outbox.usage_events.lock().unwrap();
+        assert_eq!(
+            usage_events.len(),
+            1,
+            "usage event should be enqueued even without settlement"
+        );
+        drop(usage_events);
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/replay.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/replay.rs
@@ -291,6 +291,7 @@ mod tests {
             deleted_at: None,
             replaced_by_request_id: None,
             started_at: OffsetDateTime::now_utc(),
+            last_progress_at: None,
             completed_at: Some(OffsetDateTime::now_utc()),
             updated_at: OffsetDateTime::now_utc(),
         }

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/mod.rs
@@ -1,478 +1,37 @@
+pub(super) mod provider_task;
+mod types;
+
+pub use types::{StreamError, StreamOutcome};
+
 use std::sync::Arc;
 
 use authz_resolver_sdk::PolicyEnforcer;
-use futures::StreamExt;
 use modkit_macros::domain_model;
 use modkit_security::{AccessScope, SecurityContext};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, info, warn};
+use tracing::warn;
 use uuid::Uuid;
-
-use mini_chat_sdk::RequesterType;
 
 use crate::config::{ContextConfig, StreamingConfig};
 use crate::domain::error::DomainError;
-use crate::domain::llm::{ToolPhase, Usage};
 use crate::domain::models::ResolvedModel;
 use crate::domain::ports::MiniChatMetricsPort;
-use crate::domain::ports::metric_labels::{decision, period, stage, trigger};
+use crate::domain::ports::metric_labels::{decision, period};
 use crate::domain::repos::{
     AttachmentRepository, CasTerminalParams, ChatRepository, CreateTurnParams,
     InsertUserMessageParams, MessageAttachmentRepository, MessageRepository, QuotaUsageRepository,
     SnapshotBoundary, ThreadSummaryRepository, TurnRepository, VectorStoreRepository,
 };
-use crate::domain::stream_events::{DoneData, ErrorData, StreamEvent, StreamStartedData};
-use crate::infra::db::entity::chat_turn::{Model as TurnModel, TurnState};
-use crate::infra::llm::{
-    ClientSseEvent, FeatureFlag, LlmMessage, LlmProvider, LlmProviderError, LlmRequestBuilder,
-    LlmTool, RequestMetadata, RequestType, TerminalOutcome, provider_resolver::ProviderResolver,
-};
+use crate::domain::stream_events::{StreamEvent, StreamStartedData};
+use crate::infra::db::entity::chat_turn::TurnState;
+use crate::infra::llm::provider_resolver::ProviderResolver;
 
 use super::{DbProvider, actions, resources};
-
-// ── RAII guard for active_streams gauge ──────────────────────────────────
-
-/// Ensures `decrement_active_streams` is always called when the guard is
-/// dropped, even if a new exit path is added without an explicit decrement.
-#[domain_model]
-struct ActiveStreamGuard(Arc<dyn MiniChatMetricsPort>);
-
-impl Drop for ActiveStreamGuard {
-    fn drop(&mut self) {
-        self.0.decrement_active_streams();
-    }
-}
-
-// ── Typed error for attachment validation inside TX boundary ─────────────
-
-#[allow(de0309_must_have_domain_model)]
-#[derive(Debug, thiserror::Error)]
-#[error("invalid attachment: {message}")]
-struct InvalidAttachmentError {
-    message: String,
-}
-
-fn attachment_err(message: impl Into<String>) -> modkit_db::DbError {
-    modkit_db::DbError::Other(anyhow::Error::new(InvalidAttachmentError {
-        message: message.into(),
-    }))
-}
-
-/// Collects [`FeatureFlag`]s from the tools attached to a request, used to
-/// populate [`RequestMetadata`] for observability.
-fn determine_features(tools: &[LlmTool]) -> Vec<FeatureFlag> {
-    let mut flags = Vec::new();
-    if tools
-        .iter()
-        .any(|t| matches!(t, LlmTool::FileSearch { .. }))
-    {
-        flags.push(FeatureFlag::FileSearch);
-    }
-    if tools.iter().any(|t| matches!(t, LlmTool::WebSearch { .. })) {
-        flags.push(FeatureFlag::WebSearch);
-    }
-    if tools
-        .iter()
-        .any(|t| matches!(t, LlmTool::CodeInterpreter { .. }))
-    {
-        flags.push(FeatureFlag::CodeInterpreter);
-    }
-    flags
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// StreamTerminal — service-level terminal classification
-// ════════════════════════════════════════════════════════════════════════════
-
-/// How the stream ended at the service level.
-///
-/// Maps from the provider-level [`TerminalOutcome`] with an additional
-/// `Cancelled` variant for client/server-initiated cancellation.
-#[domain_model]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StreamTerminal {
-    /// Provider completed successfully — full response received.
-    Completed,
-    /// Provider stopped early (e.g. `max_output_tokens` hit).
-    Incomplete,
-    /// Provider or stream-level error.
-    Failed,
-    /// Cancelled (client disconnect or server-initiated).
-    Cancelled,
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// StreamOutcome — returned from run_stream()
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Summary of a finished stream, returned from [`StreamService::run_stream()`].
-///
-/// Used by P1 for logging and metrics, and by P4 for CAS finalization.
-#[domain_model]
-#[derive(Debug)]
-#[allow(dead_code)]
-pub struct StreamOutcome {
-    /// How the stream ended.
-    pub terminal: StreamTerminal,
-    /// Accumulated assistant text from delta events.
-    pub accumulated_text: String,
-    /// Token usage from the provider (if available).
-    pub usage: Option<Usage>,
-    /// The model actually used by the provider.
-    pub effective_model: String,
-    /// Normalized error code (e.g. `rate_limited`, `provider_timeout`).
-    pub error_code: Option<String>,
-    /// Provider response ID (e.g. `OpenAI` `response_id`).
-    pub provider_response_id: Option<String>,
-    /// Whether usage was from a partial/incomplete provider response.
-    pub provider_partial_usage: bool,
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// StreamError — pre-stream error before SSE connection opens
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Pre-stream error — returned from [`StreamService::run_stream()`] before
-/// the SSE connection opens. The handler maps these to JSON error responses.
-#[domain_model]
-#[derive(Debug)]
-#[allow(dead_code)]
-pub enum StreamError {
-    /// Idempotent replay: a turn with this `request_id` already exists.
-    Replay { turn: Box<TurnModel> },
-    /// Conflict: another turn is already running for this chat.
-    Conflict { code: String, message: String },
-    /// Turn creation or pre-stream DB operation failed.
-    TurnCreationFailed { source: DomainError },
-    /// Authorization failed (enforcer denied access).
-    AuthorizationFailed { source: DomainError },
-    /// Chat does not exist or is not visible to the caller.
-    ChatNotFound { chat_id: Uuid },
-    /// Quota exhausted — preflight rejected the request.
-    QuotaExhausted {
-        error_code: String,
-        http_status: u16,
-        quota_scope: String,
-    },
-    /// Web search is disabled via kill switch but was requested.
-    WebSearchDisabled,
-    /// Images are disabled via kill switch but image attachments were included.
-    ImagesDisabled,
-    /// Too many image attachments in one message (`max_images_per_message` exceeded).
-    TooManyImages { count: u32, max: u32 },
-    /// Model does not support image input (missing `VISION_INPUT` capability).
-    UnsupportedMedia,
-    /// One or more attachment IDs are invalid (not found, wrong status, wrong chat, etc.).
-    InvalidAttachment { code: String, message: String },
-    /// Context budget exceeded — mandatory items don't fit in the token budget.
-    ContextBudgetExceeded {
-        required_tokens: u64,
-        available_tokens: u64,
-    },
-    /// User message content exceeds the model's maximum input token limit.
-    InputTooLong {
-        estimated_tokens: u64,
-        max_input_tokens: u32,
-    },
-}
-
-impl From<authz_resolver_sdk::EnforcerError> for StreamError {
-    fn from(e: authz_resolver_sdk::EnforcerError) -> Self {
-        match e {
-            e @ authz_resolver_sdk::EnforcerError::Denied { .. } => Self::AuthorizationFailed {
-                source: DomainError::from(e),
-            },
-            e @ (authz_resolver_sdk::EnforcerError::EvaluationFailed(_)
-            | authz_resolver_sdk::EnforcerError::CompileFailed(_)) => Self::TurnCreationFailed {
-                source: DomainError::from(e),
-            },
-        }
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// FinalizationCtx — bundled context for atomic finalization in the spawned task
-// ════════════════════════════════════════════════════════════════════════════
-
-/// All context needed to call `FinalizationService::finalize_turn_cas()`
-/// from the spawned provider task. Replaces the old `PersistenceCtx`.
-///
-/// Assembled in `run_stream()` after preflight commits, from `PreflightDecision`
-/// fields + request context. `None` in unit tests (no DB).
-#[domain_model]
-struct FinalizationCtx<TR: TurnRepository + 'static, MR: MessageRepository + 'static> {
-    finalization_svc:
-        Arc<crate::domain::service::finalization_service::FinalizationService<TR, MR>>,
-    scope: AccessScope,
-    turn_id: Uuid,
-    tenant_id: Uuid,
-    chat_id: Uuid,
-    request_id: Uuid,
-    user_id: Uuid,
-    requester_type: RequesterType,
-    /// Pre-generated assistant message ID, sent in `StreamStartedData` (`stream_started` event).
-    message_id: Uuid,
-    // ── Quota/preflight fields (from PreflightDecision) ──
-    effective_model: String,
-    selected_model: String,
-    reserve_tokens: i64,
-    max_output_tokens_applied: i32,
-    reserved_credits_micro: i64,
-    policy_version_applied: i64,
-    minimal_generation_floor_applied: i32,
-    quota_decision: String,
-    downgrade_from: Option<String>,
-    downgrade_reason: Option<String>,
-    period_starts: Vec<(
-        crate::infra::db::entity::quota_usage::PeriodType,
-        time::Date,
-    )>,
-    /// Provider ID for metrics labels.
-    provider_id: String,
-    /// Metrics port for recording stream metrics in the spawned task.
-    metrics: Arc<dyn MiniChatMetricsPort>,
-    /// Quota warnings provider for computing `quota_warnings` in the `done` event.
-    quota_warnings_provider: Arc<dyn crate::domain::service::quota_settler::QuotaWarningsProvider>,
-}
-
-impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> FinalizationCtx<TR, MR> {
-    /// Build a [`FinalizationInput`] from this context and stream outcome data.
-    #[allow(clippy::too_many_arguments)]
-    fn to_finalization_input(
-        &self,
-        terminal_state: TurnState,
-        accumulated_text: &str,
-        usage: Option<Usage>,
-        error_code: Option<String>,
-        error_detail: Option<String>,
-        provider_response_id: Option<String>,
-        web_search_calls: u32,
-        code_interpreter_calls: u32,
-        ttft_ms: Option<u64>,
-        total_ms: Option<u64>,
-    ) -> crate::domain::model::finalization::FinalizationInput {
-        crate::domain::model::finalization::FinalizationInput {
-            turn_id: self.turn_id,
-            tenant_id: self.tenant_id,
-            chat_id: self.chat_id,
-            request_id: self.request_id,
-            user_id: self.user_id,
-            requester_type: self.requester_type,
-            scope: self.scope.clone(),
-            message_id: self.message_id,
-            terminal_state,
-            error_code,
-            error_detail,
-            accumulated_text: accumulated_text.to_owned(),
-            usage,
-            provider_response_id,
-            effective_model: self.effective_model.clone(),
-            selected_model: self.selected_model.clone(),
-            reserve_tokens: self.reserve_tokens,
-            max_output_tokens_applied: self.max_output_tokens_applied,
-            reserved_credits_micro: self.reserved_credits_micro,
-            policy_version_applied: self.policy_version_applied,
-            minimal_generation_floor_applied: self.minimal_generation_floor_applied,
-            quota_decision: self.quota_decision.clone(),
-            downgrade_from: self.downgrade_from.clone(),
-            downgrade_reason: self.downgrade_reason.clone(),
-            period_starts: self.period_starts.clone(),
-            web_search_calls,
-            code_interpreter_calls,
-            ttft_ms,
-            total_ms,
-        }
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// Input token validation
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Estimate text-only tokens for `content` and return `Err(InputTooLong)` if
-/// the estimate exceeds the model's `max_input_tokens`.
-///
-/// Surcharges (images, tools, web search, code interpreter) are intentionally
-/// excluded: this is a fast pre-flight guard on the raw message text, not a
-/// full context budget check.
-fn check_input_token_limit(content: &str, pf: &PreflightResult) -> Result<(), StreamError> {
-    let estimate = super::token_estimator::estimate_tokens(
-        &super::token_estimator::EstimationInput {
-            utf8_bytes: content.len() as u64,
-            num_images: 0,
-            tools_enabled: false,
-            web_search_enabled: false,
-            code_interpreter_enabled: false,
-        },
-        &pf.estimation_budgets,
-    );
-    if estimate.estimated_input_tokens > u64::from(pf.max_input_tokens) {
-        return Err(StreamError::InputTooLong {
-            estimated_tokens: estimate.estimated_input_tokens,
-            max_input_tokens: pf.max_input_tokens,
-        });
-    }
-    Ok(())
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// Error normalization
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Map an optional subject-type string from [`SecurityContext`] to [`RequesterType`].
-fn requester_type_from_str(s: Option<&str>) -> RequesterType {
-    match s {
-        Some("system") => RequesterType::System,
-        _ => RequesterType::User,
-    }
-}
-
-/// Normalize an [`LlmProviderError`] to a `(code, message)` pair for the SSE
-/// error event. Messages are already sanitized by the infra layer.
-fn normalize_error(err: &LlmProviderError) -> (String, String) {
-    match err {
-        LlmProviderError::RateLimited { .. } => (
-            "rate_limited".to_owned(),
-            "Rate limited by provider".to_owned(),
-        ),
-        LlmProviderError::Timeout => (
-            "provider_timeout".to_owned(),
-            "Provider request timed out".to_owned(),
-        ),
-        LlmProviderError::ProviderError { message, .. } => {
-            ("provider_error".to_owned(), message.clone())
-        }
-        LlmProviderError::InvalidResponse { detail } => (
-            "provider_error".to_owned(),
-            crate::infra::llm::sanitize_provider_message(detail),
-        ),
-        LlmProviderError::ProviderUnavailable => (
-            "provider_error".to_owned(),
-            "Provider is currently unavailable".to_owned(),
-        ),
-        LlmProviderError::StreamError(e) => (
-            "provider_error".to_owned(),
-            crate::infra::llm::sanitize_provider_message(&e.to_string()),
-        ),
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════════
-// PreflightResult — flattened preflight outcome for run_stream()
-// ════════════════════════════════════════════════════════════════════════════
-
-/// Flattened preflight fields used by `run_stream()` after `preflight_reserve()`.
-#[domain_model]
-struct PreflightResult {
-    effective_model: String,
-    effective_provider_model_id: String,
-    reserve_tokens: i64,
-    max_output_tokens_applied: i32,
-    reserved_credits_micro: i64,
-    policy_version_applied: i64,
-    minimal_generation_floor_applied: i32,
-    quota_decision: String,
-    downgrade_from: Option<String>,
-    downgrade_reason: Option<String>,
-    system_prompt: String,
-    context_window: u32,
-    max_input_tokens: u32,
-    estimation_budgets: crate::config::EstimationBudgets,
-    max_retrieved_chunks_per_turn: u32,
-    max_tool_calls: u32,
-    tool_support: mini_chat_sdk::ModelToolSupport,
-}
-
-/// Convert a `PreflightDecision` into a flat `PreflightResult` or a `StreamError`.
-fn flatten_preflight(
-    decision: crate::domain::model::quota::PreflightDecision,
-) -> Result<PreflightResult, StreamError> {
-    use crate::domain::model::quota::PreflightDecision;
-    match decision {
-        PreflightDecision::Allow {
-            effective_model,
-            effective_provider_model_id,
-            reserve_tokens,
-            max_output_tokens_applied,
-            reserved_credits_micro,
-            policy_version_applied,
-            minimal_generation_floor_applied,
-            system_prompt,
-            context_window,
-            max_input_tokens,
-            estimation_budgets,
-            max_retrieved_chunks_per_turn,
-            max_tool_calls,
-            tool_support,
-            ..
-        } => Ok(PreflightResult {
-            effective_model,
-            effective_provider_model_id,
-            reserve_tokens,
-            max_output_tokens_applied,
-            reserved_credits_micro,
-            policy_version_applied,
-            minimal_generation_floor_applied,
-            quota_decision: "allow".to_owned(),
-            downgrade_from: None,
-            downgrade_reason: None,
-            system_prompt,
-            context_window,
-            max_input_tokens,
-            estimation_budgets,
-            max_retrieved_chunks_per_turn,
-            max_tool_calls,
-            tool_support,
-        }),
-        PreflightDecision::Downgrade {
-            effective_model,
-            effective_provider_model_id,
-            reserve_tokens,
-            max_output_tokens_applied,
-            reserved_credits_micro,
-            policy_version_applied,
-            minimal_generation_floor_applied,
-            downgrade_from,
-            downgrade_reason,
-            system_prompt,
-            context_window,
-            max_input_tokens,
-            estimation_budgets,
-            max_retrieved_chunks_per_turn,
-            max_tool_calls,
-            tool_support,
-            ..
-        } => Ok(PreflightResult {
-            effective_model,
-            effective_provider_model_id,
-            reserve_tokens,
-            max_output_tokens_applied,
-            reserved_credits_micro,
-            policy_version_applied,
-            minimal_generation_floor_applied,
-            quota_decision: "downgrade".to_owned(),
-            downgrade_from: Some(downgrade_from),
-            downgrade_reason: Some(downgrade_reason.as_str().to_owned()),
-            system_prompt,
-            context_window,
-            max_input_tokens,
-            estimation_budgets,
-            max_retrieved_chunks_per_turn,
-            max_tool_calls,
-            tool_support,
-        }),
-        PreflightDecision::Reject {
-            error_code,
-            http_status,
-            quota_scope,
-        } => Err(StreamError::QuotaExhausted {
-            error_code,
-            http_status,
-            quota_scope,
-        }),
-    }
-}
+use types::{
+    FinalizationCtx, InvalidAttachmentError, PreflightResult, attachment_err,
+    check_input_token_limit, flatten_preflight, requester_type_from_str,
+};
 
 // ════════════════════════════════════════════════════════════════════════════
 // StreamService
@@ -894,6 +453,8 @@ impl<
 
         let finalization_ctx = FinalizationCtx {
             finalization_svc: Arc::clone(&self.finalization),
+            db: Arc::clone(&self.db),
+            turn_repo: Arc::clone(&self.turn_repo),
             scope,
             turn_id,
             tenant_id,
@@ -968,7 +529,7 @@ impl<
 
         emit_stream_started(&tx, request_id, message_id).await;
 
-        Ok(spawn_provider_task(
+        Ok(provider_task::spawn_provider_task(
             resolved_provider.adapter,
             proxy_path,
             ctx,
@@ -1440,15 +1001,36 @@ impl<
         let file_search_disabled = computed.kill_switches.disable_file_search;
         let disable_code_interpreter = computed.kill_switches.disable_code_interpreter;
 
-        // ── Write quota reserves ────────────────────────────────────────
+        // ── Persist preflight fields + write quota reserves atomically ──
+        // Both must be visible together so the orphan watchdog can settle
+        // quota correctly if the pod crashes after this point.
         let quota_repo = Arc::clone(&self.quota.repo);
+        let turn_repo_tx = Arc::clone(&self.turn_repo);
         let computed_for_tx = computed;
+        let has_reserves = !computed_for_tx.buckets.is_empty();
+        let preflight_params = crate::domain::repos::UpdatePreflightParams {
+            turn_id,
+            reserve_tokens: pf.reserve_tokens,
+            max_output_tokens_applied: pf.max_output_tokens_applied,
+            reserved_credits_micro: pf.reserved_credits_micro,
+            policy_version_applied: pf.policy_version_applied,
+            effective_model: pf.effective_model.clone(),
+            minimal_generation_floor_applied: pf.minimal_generation_floor_applied,
+        };
+        let scope_for_tx = scope.clone();
 
-        if !computed_for_tx.buckets.is_empty() {
+        {
             self.db
                 .transaction(|txn| {
                     use crate::domain::repos::IncrementReserveParams;
                     Box::pin(async move {
+                        // 1. Backfill preflight fields on the turn row.
+                        turn_repo_tx
+                            .update_preflight_fields(txn, &scope_for_tx, preflight_params)
+                            .await
+                            .map_err(|e| modkit_db::DbError::Other(anyhow::Error::new(e)))?;
+
+                        // 2. Write quota reserves.
                         let reserve_scope = AccessScope::for_tenant(computed_for_tx.tenant_id);
                         for bucket in &computed_for_tx.buckets {
                             for (period_type, period_start) in &computed_for_tx.periods {
@@ -1479,13 +1061,17 @@ impl<
                     source: DomainError::database(e.to_string()),
                 })?;
 
-            // Metrics: quota reserve committed (one per period)
-            for (period_type, _) in &period_starts {
-                let label = match period_type {
-                    crate::infra::db::entity::quota_usage::PeriodType::Daily => period::DAILY,
-                    crate::infra::db::entity::quota_usage::PeriodType::Monthly => period::MONTHLY,
-                };
-                self.metrics.record_quota_reserve(label);
+            // Metrics: quota reserve committed (one per period, only when reserves exist)
+            if has_reserves {
+                for (period_type, _) in &period_starts {
+                    let label = match period_type {
+                        crate::infra::db::entity::quota_usage::PeriodType::Daily => period::DAILY,
+                        crate::infra::db::entity::quota_usage::PeriodType::Monthly => {
+                            period::MONTHLY
+                        }
+                    };
+                    self.metrics.record_quota_reserve(label);
+                }
             }
         }
 
@@ -1547,6 +1133,8 @@ impl<
 
         let finalization_ctx = FinalizationCtx {
             finalization_svc: Arc::clone(&self.finalization),
+            db: Arc::clone(&self.db),
+            turn_repo: Arc::clone(&self.turn_repo),
             scope: scope.clone(),
             turn_id,
             tenant_id,
@@ -1615,7 +1203,7 @@ impl<
 
         emit_stream_started(&tx, request_id, message_id).await;
 
-        Ok(spawn_provider_task(
+        Ok(provider_task::spawn_provider_task(
             resolved_provider.adapter,
             proxy_path,
             ctx,
@@ -1636,10 +1224,6 @@ impl<
     }
 }
 
-/// Core provider task: reads from the LLM, translates events, and returns
-/// a [`StreamOutcome`]. After the stream ends, atomically finalizes the turn
-/// via `FinalizationService::finalize_turn_cas()` if a context is provided.
-///
 /// Emit `stream_started` before handing `tx` to the provider task (D3).
 async fn emit_stream_started(tx: &mpsc::Sender<StreamEvent>, request_id: Uuid, message_id: Uuid) {
     if tx
@@ -1655,847 +1239,12 @@ async fn emit_stream_started(tx: &mpsc::Sender<StreamEvent>, request_id: Uuid, m
     }
 }
 
-/// All five terminal paths (provider done, incomplete, provider error,
-/// client disconnect, pre-stream error) route through `finalize_turn_cas()`.
-/// SSE terminal events (Done/Error) are emitted only after the CAS winner
-/// commits the transaction (D3).
-#[allow(
-    clippy::too_many_arguments,
-    clippy::too_many_lines,
-    clippy::cognitive_complexity,
-    clippy::let_underscore_must_use,
-    clippy::cast_possible_truncation
-)]
-fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'static>(
-    llm: Arc<dyn LlmProvider>,
-    upstream_alias: String,
-    ctx: SecurityContext,
-    messages: Vec<LlmMessage>,
-    system_instructions: Option<String>,
-    tools: Vec<LlmTool>,
-    model: String,
-    provider_model_id: String,
-    max_output_tokens: u32,
-    max_tool_calls: u32,
-    web_search_max_calls: u32,
-    code_interpreter_max_calls: u32,
-    cancel: CancellationToken,
-    tx: mpsc::Sender<StreamEvent>,
-    fin_ctx: Option<FinalizationCtx<TR, MR>>,
-    provider_file_id_map: std::collections::HashMap<String, crate::domain::llm::AttachmentRef>,
-) -> tokio::task::JoinHandle<StreamOutcome> {
-    let span = if let Some(ref fctx) = fin_ctx {
-        tracing::info_span!(
-            "provider_stream",
-            chat_id = %fctx.chat_id,
-            turn_request_id = %fctx.request_id,
-            turn_id = %fctx.turn_id,
-            model = %model,
-        )
-    } else {
-        tracing::info_span!("provider_stream", model = %model)
-    };
-
-    tokio::spawn(async move {
-        let stream_start = std::time::Instant::now();
-        let mut first_token_time: Option<std::time::Duration> = None;
-
-        // ── Metrics: stream started + active gauge ──
-        // ActiveStreamGuard ensures decrement on every exit path (Drop-based).
-        let _stream_guard = if let Some(ref fctx) = fin_ctx {
-            fctx.metrics
-                .record_stream_started(&fctx.provider_id, &fctx.effective_model);
-            fctx.metrics.increment_active_streams();
-            Some(ActiveStreamGuard(Arc::clone(&fctx.metrics)))
-        } else {
-            None
-        };
-
-        // Build the LLM request using provider_model_id (the actual provider-facing name)
-        let mut builder = LlmRequestBuilder::new(&provider_model_id)
-            .messages(messages)
-            .max_output_tokens(u64::from(max_output_tokens))
-            .max_tool_calls(max_tool_calls);
-        if let Some(instructions) = system_instructions {
-            builder = builder.system_instructions(instructions);
-        }
-        let features = determine_features(&tools);
-        for tool in tools {
-            builder = builder.tool(tool);
-        }
-        let metadata = RequestMetadata {
-            tenant_id: ctx.subject_tenant_id().to_string(),
-            user_id: ctx.subject_id().to_string(),
-            chat_id: fin_ctx
-                .as_ref()
-                .map_or_else(String::new, |f| f.chat_id.to_string()),
-            request_type: RequestType::Chat,
-            features,
-        };
-        builder = builder.metadata(metadata);
-        let request = builder.build_streaming();
-
-        // Call the provider to start streaming
-        let stream_result = llm
-            .stream(ctx, request, &upstream_alias, cancel.clone())
-            .await;
-
-        let mut provider_stream = match stream_result {
-            Ok(s) => s,
-            Err(e) => {
-                // Provider failed before any events — finalize first, then emit error.
-                warn!(
-                    error = %e,
-                    raw_detail = e.raw_detail().unwrap_or(""),
-                    "LLM provider failed before stream start"
-                );
-                let (code, message) = normalize_error(&e);
-
-                if let Some(ref fctx) = fin_ctx {
-                    let input = fctx.to_finalization_input(
-                        TurnState::Failed,
-                        "",
-                        None,
-                        Some(code.clone()),
-                        None,
-                        None,
-                        0,
-                        0,
-                        None,
-                        None,
-                    );
-                    match fctx.finalization_svc.finalize_turn_cas(input).await {
-                        Ok(outcome) if outcome.won_cas => {
-                            let _ = tx
-                                .send(StreamEvent::Error(ErrorData {
-                                    code: code.clone(),
-                                    message,
-                                }))
-                                .await;
-                        }
-                        Ok(_) => { /* CAS loser — no SSE emission */ }
-                        Err(fe) => {
-                            warn!(error = %fe, "finalization failed on pre-stream error");
-                            // Still emit error so client isn't left hanging
-                            let _ = tx
-                                .send(StreamEvent::Error(ErrorData {
-                                    code: code.clone(),
-                                    message,
-                                }))
-                                .await;
-                        }
-                    }
-                } else {
-                    let _ = tx
-                        .send(StreamEvent::Error(ErrorData {
-                            code: code.clone(),
-                            message,
-                        }))
-                        .await;
-                }
-
-                // Metrics: pre-stream failure
-                if let Some(ref fctx) = fin_ctx {
-                    let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
-                    fctx.metrics.record_stream_failed(&fctx.provider_id, &fctx.effective_model, &code);
-                    fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
-                }
-
-                return StreamOutcome {
-                    terminal: StreamTerminal::Failed,
-                    accumulated_text: String::new(),
-                    usage: None,
-                    effective_model: model,
-                    error_code: Some(code),
-                    provider_response_id: None,
-                    provider_partial_usage: false,
-                };
-            }
-        };
-
-        // Read events from provider, translate and forward through channel
-        let mut accumulated_text = String::new();
-        let mut cancelled = false;
-        let mut web_search_call_count: u32 = 0;
-        // TODO(P2): web_search_call_count (Start) is used for enforcement,
-        // web_search_completed_count (Done) is used for settlement. If a search
-        // starts but never completes (provider error between Start/Done), the
-        // daily quota under-counts by one. Acceptable for P1 since OpenAI always
-        // pairs searching→completed; revisit if we add providers that don't.
-        let mut web_search_completed_count: u32 = 0;
-        let mut code_interpreter_call_count: u32 = 0;
-        let mut code_interpreter_completed_count: u32 = 0;
-
-        loop {
-            tokio::select! {
-                biased;
-
-                () = cancel.cancelled() => {
-                    debug!("stream cancelled, aborting provider");
-                    if let Some(ref fctx) = fin_ctx {
-                        fctx.metrics.record_cancel_requested(trigger::DISCONNECT);
-                        let disconnect_stage = if first_token_time.is_none() {
-                            stage::BEFORE_FIRST_TOKEN
-                        } else {
-                            stage::MID_STREAM
-                        };
-                        fctx.metrics.record_stream_disconnected(disconnect_stage);
-                    }
-                    provider_stream.cancel();
-                    cancelled = true;
-                    break;
-                }
-
-                event = provider_stream.next() => {
-                    match event {
-                        Some(Ok(client_event)) => {
-                            let is_first_token = matches!(client_event, ClientSseEvent::Delta { .. })
-                                && first_token_time.is_none();
-
-                            if let ClientSseEvent::Delta { ref content, .. } = client_event {
-                                if first_token_time.is_none() {
-                                    let ttft = stream_start.elapsed();
-                                    first_token_time = Some(ttft);
-                                    info!(
-                                        time_to_first_token_ms = ttft.as_millis() as u64,
-                                        "first token received"
-                                    );
-                                    if let Some(ref fctx) = fin_ctx {
-                                        let ms = ttft.as_secs_f64() * 1000.0;
-                                        fctx.metrics.record_ttft_provider_ms(&fctx.provider_id, &fctx.effective_model, ms);
-                                    }
-                                }
-                                accumulated_text.push_str(content);
-                            }
-
-                            // Track web search tool calls for per-message limit
-                            if let ClientSseEvent::Tool { ref phase, name, .. } = client_event
-                                && name == "web_search"
-                            {
-                                match phase {
-                                    ToolPhase::Start => {
-                                        web_search_call_count += 1;
-                                        if web_search_call_count > web_search_max_calls {
-                                            warn!(
-                                                web_search_call_count,
-                                                limit = web_search_max_calls,
-                                                "web search per-message limit exceeded"
-                                            );
-                                            let code = "web_search_calls_exceeded".to_owned();
-                                            let message = "Web search calls exceeded for this message".to_owned();
-
-                                            // Finalize as failed, then emit error (D3)
-                                            if let Some(ref fctx) = fin_ctx {
-                                                let input = fctx.to_finalization_input(
-                                                    TurnState::Failed,
-                                                    &accumulated_text,
-                                                    None,
-                                                    Some(code.clone()),
-                                                    None,
-                                                    None,
-                                                    web_search_completed_count,
-                                                    code_interpreter_completed_count,
-                                                    None,
-                                                    None,
-                                                );
-                                                match fctx.finalization_svc.finalize_turn_cas(input).await {
-                                                    Ok(outcome) if outcome.won_cas => {
-                                                        let _ = tx.send(StreamEvent::Error(ErrorData {
-                                                            code: code.clone(),
-                                                            message,
-                                                        })).await;
-                                                    }
-                                                    Ok(_) => {}
-                                                    Err(fe) => {
-                                                        warn!(error = %fe, "finalization failed on ws limit exceeded");
-                                                        let _ = tx.send(StreamEvent::Error(ErrorData {
-                                                            code: code.clone(),
-                                                            message,
-                                                        })).await;
-                                                    }
-                                                }
-                                            } else {
-                                                let _ = tx.send(StreamEvent::Error(ErrorData {
-                                                    code: code.clone(),
-                                                    message,
-                                                })).await;
-                                            }
-
-                                            provider_stream.cancel();
-
-                                            // Metrics: web search limit exceeded
-                                            if let Some(ref fctx) = fin_ctx {
-                                                let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
-                                                fctx.metrics.record_stream_failed(
-                                                    &fctx.provider_id,
-                                                    &fctx.effective_model,
-                                                    &code,
-                                                );
-                                                fctx.metrics.record_stream_total_latency_ms(
-                                                    &fctx.provider_id,
-                                                    &fctx.effective_model,
-                                                    ms,
-                                                );
-                                            }
-
-                                            let has_partial = !accumulated_text.is_empty();
-                                            return StreamOutcome {
-                                                terminal: StreamTerminal::Failed,
-                                                accumulated_text,
-                                                usage: None,
-                                                effective_model: model,
-                                                error_code: Some(code),
-                                                provider_response_id: None,
-                                                provider_partial_usage: has_partial,
-                                            };
-                                        }
-                                    }
-                                    ToolPhase::Done => {
-                                        web_search_completed_count += 1;
-                                    }
-                                }
-                            }
-
-                            // Track code interpreter tool calls
-                            if let ClientSseEvent::Tool { ref phase, name, .. } = client_event
-                                && name == "code_interpreter"
-                            {
-                                match phase {
-                                    ToolPhase::Start => {
-                                        code_interpreter_call_count += 1;
-                                        if code_interpreter_call_count > code_interpreter_max_calls {
-                                            warn!(
-                                                code_interpreter_call_count,
-                                                limit = code_interpreter_max_calls,
-                                                "code interpreter per-message limit exceeded"
-                                            );
-                                            let code = "code_interpreter_calls_exceeded".to_owned();
-                                            let message = "Code interpreter calls exceeded for this message".to_owned();
-
-                                            if let Some(ref fctx) = fin_ctx {
-                                                let input = fctx.to_finalization_input(
-                                                    TurnState::Failed,
-                                                    &accumulated_text,
-                                                    None,
-                                                    Some(code.clone()),
-                                                    None,
-                                                    None,
-                                                    web_search_completed_count,
-                                                    code_interpreter_completed_count,
-                                                    None,
-                                                    None,
-                                                );
-                                                match fctx.finalization_svc.finalize_turn_cas(input).await {
-                                                    Ok(outcome) if outcome.won_cas => {
-                                                        let _ = tx.send(StreamEvent::Error(ErrorData {
-                                                            code: code.clone(),
-                                                            message,
-                                                        })).await;
-                                                    }
-                                                    Ok(_) => {}
-                                                    Err(fe) => {
-                                                        warn!(error = %fe, "finalization failed on ci limit exceeded");
-                                                        let _ = tx.send(StreamEvent::Error(ErrorData {
-                                                            code: code.clone(),
-                                                            message,
-                                                        })).await;
-                                                    }
-                                                }
-                                            } else {
-                                                let _ = tx.send(StreamEvent::Error(ErrorData {
-                                                    code: code.clone(),
-                                                    message,
-                                                })).await;
-                                            }
-
-                                            provider_stream.cancel();
-
-                                            if let Some(ref fctx) = fin_ctx {
-                                                let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
-                                                fctx.metrics.record_stream_failed(
-                                                    &fctx.provider_id,
-                                                    &fctx.effective_model,
-                                                    &code,
-                                                );
-                                                fctx.metrics.record_stream_total_latency_ms(
-                                                    &fctx.provider_id,
-                                                    &fctx.effective_model,
-                                                    ms,
-                                                );
-                                            }
-
-                                            let has_partial = !accumulated_text.is_empty();
-                                            return StreamOutcome {
-                                                terminal: StreamTerminal::Failed,
-                                                accumulated_text,
-                                                usage: None,
-                                                effective_model: model,
-                                                error_code: Some(code),
-                                                provider_response_id: None,
-                                                provider_partial_usage: has_partial,
-                                            };
-                                        }
-                                    }
-                                    ToolPhase::Done => {
-                                        code_interpreter_completed_count += 1;
-                                    }
-                                }
-                            }
-
-                            let stream_event = StreamEvent::from(client_event);
-                            if tx.send(stream_event).await.is_err() {
-                                // Receiver dropped (client disconnect handled by relay)
-                                info!("channel closed (client disconnect), exiting provider task");
-                                break;
-                            }
-
-                            // TTFT overhead: time from provider first-byte to channel send.
-                            if is_first_token
-                                && let (Some(fctx), Some(provider_ttft)) =
-                                    (&fin_ctx, first_token_time)
-                                {
-                                    let total = stream_start.elapsed().as_secs_f64() * 1000.0;
-                                    let provider_ms = provider_ttft.as_secs_f64() * 1000.0;
-                                    fctx.metrics.record_ttft_overhead_ms(
-                                        &fctx.provider_id,
-                                        &fctx.effective_model,
-                                        total - provider_ms,
-                                    );
-                                }
-                        }
-                        Some(Err(e)) => {
-                            warn!(error = %e, "provider stream error");
-                            let (code, message) =
-                                normalize_error(&LlmProviderError::StreamError(e));
-
-                            // Finalize first, emit error only if CAS winner (D3)
-                            if let Some(ref fctx) = fin_ctx {
-                                let mid_elapsed = stream_start.elapsed();
-                                let input = fctx.to_finalization_input(
-                                    TurnState::Failed,
-                                    &accumulated_text,
-                                    None,
-                                    Some(code.clone()),
-                                    None,
-                                    None,
-                                    web_search_completed_count,
-                                    code_interpreter_completed_count,
-                                    first_token_time.map(|d| d.as_millis() as u64),
-                                    Some(mid_elapsed.as_millis() as u64),
-                                );
-                                match fctx.finalization_svc.finalize_turn_cas(input).await {
-                                    Ok(outcome) if outcome.won_cas => {
-                                        let _ = tx
-                                            .send(StreamEvent::Error(ErrorData {
-                                                code: code.clone(),
-                                                message,
-                                            }))
-                                            .await;
-                                    }
-                                    Ok(_) => {}
-                                    Err(fe) => {
-                                        warn!(error = %fe, "finalization failed on stream error");
-                                        let _ = tx
-                                            .send(StreamEvent::Error(ErrorData {
-                                                code: code.clone(),
-                                                message,
-                                            }))
-                                            .await;
-                                    }
-                                }
-                            } else {
-                                let _ = tx
-                                    .send(StreamEvent::Error(ErrorData {
-                                        code: code.clone(),
-                                        message,
-                                    }))
-                                    .await;
-                            }
-
-                            // Metrics: mid-stream failure
-                            if let Some(ref fctx) = fin_ctx {
-                                let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
-                                fctx.metrics.record_stream_failed(&fctx.provider_id, &fctx.effective_model, &code);
-                                fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
-                            }
-
-                            provider_stream.cancel();
-                            let has_partial = !accumulated_text.is_empty();
-                            return StreamOutcome {
-                                terminal: StreamTerminal::Failed,
-                                accumulated_text,
-                                usage: None,
-                                effective_model: model,
-                                error_code: Some(code),
-                                provider_response_id: None,
-                                provider_partial_usage: has_partial,
-                            };
-                        }
-                        None => {
-                            // Stream ended — terminal captured by ProviderStream
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        if cancelled {
-            let elapsed = stream_start.elapsed();
-            info!(
-                terminal = "cancelled",
-                duration_ms = elapsed.as_millis() as u64,
-                "stream cancelled"
-            );
-
-            // Finalize cancelled turn — no SSE emission (stream already disconnected) (D3)
-            if let Some(ref fctx) = fin_ctx {
-                let input = fctx.to_finalization_input(
-                    TurnState::Cancelled,
-                    &accumulated_text,
-                    None,
-                    None,
-                    None,
-                    None,
-                    web_search_completed_count,
-                    code_interpreter_completed_count,
-                    first_token_time.map(|d| d.as_millis() as u64),
-                    Some(elapsed.as_millis() as u64),
-                );
-                if let Err(e) = fctx.finalization_svc.finalize_turn_cas(input).await {
-                    warn!(error = %e, "finalization failed on cancelled stream");
-                }
-
-                // Metrics: cancelled stream
-                let ms = elapsed.as_secs_f64() * 1000.0;
-                fctx.metrics.record_cancel_effective(trigger::DISCONNECT);
-                fctx.metrics.record_time_to_abort_ms(trigger::DISCONNECT, ms);
-                fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
-            }
-
-            return StreamOutcome {
-                terminal: StreamTerminal::Cancelled,
-                accumulated_text,
-                usage: None,
-                effective_model: model,
-                error_code: None,
-                provider_response_id: None,
-                provider_partial_usage: false,
-            };
-        }
-
-        // Extract the terminal outcome from the provider stream
-        let terminal = provider_stream.into_outcome().await;
-
-        match terminal {
-            TerminalOutcome::Completed {
-                usage,
-                content: _,
-                citations,
-                response_id,
-                ..
-            } => {
-                let elapsed = stream_start.elapsed();
-                info!(
-                    terminal = "completed",
-                    input_tokens = usage.input_tokens,
-                    output_tokens = usage.output_tokens,
-                    duration_ms = elapsed.as_millis() as u64,
-                    "stream completed"
-                );
-
-                // Finalize first, then emit Done only if CAS winner (D3)
-                if let Some(ref fctx) = fin_ctx {
-                    let input = fctx.to_finalization_input(
-                        TurnState::Completed,
-                        &accumulated_text,
-                        Some(usage),
-                        None,
-                        None,
-                        Some(response_id.clone()),
-                        web_search_completed_count,
-                        code_interpreter_completed_count,
-                        first_token_time.map(|d| d.as_millis() as u64),
-                        Some(elapsed.as_millis() as u64),
-                    );
-                    match fctx.finalization_svc.finalize_turn_cas(input).await {
-                        Ok(outcome) if outcome.won_cas => {
-                            // P4-2: Map provider file_ids to internal UUIDs
-                            let mapped = crate::domain::citation_mapping::map_citation_ids(
-                                citations,
-                                &provider_file_id_map,
-                            );
-                            if !mapped.is_empty() {
-                                let _ = tx
-                                    .send(StreamEvent::Citations(
-                                        crate::domain::stream_events::CitationsData {
-                                            items: mapped,
-                                        },
-                                    ))
-                                    .await;
-                            }
-                            // Compute quota warnings post-commit (advisory, best-effort)
-                            let quota_warnings = match fctx
-                                .quota_warnings_provider
-                                .get_quota_warnings(&fctx.scope, fctx.tenant_id, fctx.user_id)
-                                .await
-                            {
-                                Ok(w) => Some(w),
-                                Err(e) => {
-                                    warn!(error = %e, "failed to compute quota_warnings");
-                                    None
-                                }
-                            };
-                            let _ = tx
-                                .send(StreamEvent::Done(Box::new(DoneData {
-                                    usage: Some(usage),
-                                    effective_model: fctx.effective_model.clone(),
-                                    selected_model: fctx.selected_model.clone(),
-                                    quota_decision: fctx.quota_decision.clone(),
-                                    downgrade_from: fctx.downgrade_from.clone(),
-                                    downgrade_reason: fctx.downgrade_reason.clone(),
-                                    quota_warnings,
-                                })))
-                                .await;
-                        }
-                        Ok(_) => { /* CAS loser — no SSE emission */ }
-                        Err(fe) => {
-                            warn!(error = %fe, "finalization failed on completed stream");
-                            // Emit Done anyway so client isn't left hanging
-                            let _ = tx
-                                .send(StreamEvent::Done(Box::new(DoneData {
-                                    usage: Some(usage),
-                                    effective_model: fctx.effective_model.clone(),
-                                    selected_model: fctx.selected_model.clone(),
-                                    quota_decision: "allow".into(),
-                                    downgrade_from: None,
-                                    downgrade_reason: None,
-                                    quota_warnings: None,
-                                })))
-                                .await;
-                        }
-                    }
-                } else {
-                    // No finalization context (unit tests) — emit directly
-                    let mapped = crate::domain::citation_mapping::map_citation_ids(
-                        citations,
-                        &provider_file_id_map,
-                    );
-                    if !mapped.is_empty() {
-                        let _ = tx
-                            .send(StreamEvent::Citations(
-                                crate::domain::stream_events::CitationsData { items: mapped },
-                            ))
-                            .await;
-                    }
-                    let _ = tx
-                        .send(StreamEvent::Done(Box::new(DoneData {
-                            usage: Some(usage),
-                            effective_model: model.clone(),
-                            selected_model: model.clone(),
-                            quota_decision: "allow".into(),
-                            downgrade_from: None,
-                            downgrade_reason: None,
-                            quota_warnings: None,
-                        })))
-                        .await;
-                }
-
-                // Metrics: completed stream
-                if let Some(ref fctx) = fin_ctx {
-                    let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
-                    fctx.metrics.record_stream_completed(&fctx.provider_id, &fctx.effective_model);
-                    fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
-                }
-
-                StreamOutcome {
-                    terminal: StreamTerminal::Completed,
-                    accumulated_text,
-                    usage: Some(usage),
-                    effective_model: model,
-                    error_code: None,
-                    provider_response_id: Some(response_id),
-                    provider_partial_usage: false,
-                }
-            }
-            TerminalOutcome::Incomplete { usage, reason, .. } => {
-                let elapsed = stream_start.elapsed();
-                warn!(
-                    terminal = "incomplete",
-                    reason = %reason,
-                    duration_ms = elapsed.as_millis() as u64,
-                    "stream incomplete"
-                );
-
-                // Incomplete maps to Completed in DB — provider finished but hit
-                // max_output_tokens. From billing/persistence perspective this is
-                // a completed turn with truncated content (see design D10).
-                if let Some(ref fctx) = fin_ctx {
-                    let input = fctx.to_finalization_input(
-                        TurnState::Completed,
-                        &accumulated_text,
-                        Some(usage),
-                        None,
-                        None,
-                        None,
-                        web_search_completed_count,
-                        code_interpreter_completed_count,
-                        first_token_time.map(|d| d.as_millis() as u64),
-                        Some(elapsed.as_millis() as u64),
-                    );
-                    match fctx.finalization_svc.finalize_turn_cas(input).await {
-                        Ok(outcome) if outcome.won_cas => {
-                            let quota_warnings = match fctx
-                                .quota_warnings_provider
-                                .get_quota_warnings(&fctx.scope, fctx.tenant_id, fctx.user_id)
-                                .await
-                            {
-                                Ok(w) => Some(w),
-                                Err(e) => {
-                                    warn!(error = %e, "failed to compute quota_warnings");
-                                    None
-                                }
-                            };
-                            let _ = tx
-                                .send(StreamEvent::Done(Box::new(DoneData {
-                                    usage: Some(usage),
-                                    effective_model: fctx.effective_model.clone(),
-                                    selected_model: fctx.selected_model.clone(),
-                                    quota_decision: fctx.quota_decision.clone(),
-                                    downgrade_from: fctx.downgrade_from.clone(),
-                                    downgrade_reason: fctx.downgrade_reason.clone(),
-                                    quota_warnings,
-                                })))
-                                .await;
-                        }
-                        Ok(_) => {}
-                        Err(fe) => {
-                            warn!(error = %fe, "finalization failed on incomplete stream");
-                            let _ = tx
-                                .send(StreamEvent::Done(Box::new(DoneData {
-                                    usage: Some(usage),
-                                    effective_model: fctx.effective_model.clone(),
-                                    selected_model: fctx.selected_model.clone(),
-                                    quota_decision: "allow".into(),
-                                    downgrade_from: None,
-                                    downgrade_reason: None,
-                                    quota_warnings: None,
-                                })))
-                                .await;
-                        }
-                    }
-                } else {
-                    let _ = tx
-                        .send(StreamEvent::Done(Box::new(DoneData {
-                            usage: Some(usage),
-                            effective_model: model.clone(),
-                            selected_model: model.clone(),
-                            quota_decision: "allow".into(),
-                            downgrade_from: None,
-                            downgrade_reason: None,
-                            quota_warnings: None,
-                        })))
-                        .await;
-                }
-
-                // Metrics: incomplete stream
-                if let Some(ref fctx) = fin_ctx {
-                    let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
-                    fctx.metrics.record_stream_incomplete(&fctx.provider_id, &fctx.effective_model, &reason);
-                    fctx.metrics.record_stream_completed(&fctx.provider_id, &fctx.effective_model);
-                    fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
-                }
-
-                StreamOutcome {
-                    terminal: StreamTerminal::Incomplete,
-                    accumulated_text,
-                    usage: Some(usage),
-                    effective_model: model,
-                    error_code: Some(format!("incomplete:{reason}")),
-                    provider_response_id: None,
-                    provider_partial_usage: false,
-                }
-            }
-            TerminalOutcome::Failed { error, usage, .. } => {
-                let raw_detail = error.raw_detail().map(ToOwned::to_owned);
-                let (code, message) = normalize_error(&error);
-                let elapsed = stream_start.elapsed();
-                warn!(
-                    terminal = "failed",
-                    error_code = %code,
-                    raw_detail = raw_detail.as_deref().unwrap_or(""),
-                    duration_ms = elapsed.as_millis() as u64,
-                    "stream failed"
-                );
-
-                // Finalize first, emit error only if CAS winner (D3)
-                if let Some(ref fctx) = fin_ctx {
-                    let input = fctx.to_finalization_input(
-                        TurnState::Failed,
-                        &accumulated_text,
-                        usage,
-                        Some(code.clone()),
-                        None,
-                        None,
-                        web_search_completed_count,
-                        code_interpreter_completed_count,
-                        first_token_time.map(|d| d.as_millis() as u64),
-                        Some(elapsed.as_millis() as u64),
-                    );
-                    match fctx.finalization_svc.finalize_turn_cas(input).await {
-                        Ok(outcome) if outcome.won_cas => {
-                            let _ = tx
-                                .send(StreamEvent::Error(ErrorData {
-                                    code: code.clone(),
-                                    message,
-                                }))
-                                .await;
-                        }
-                        Ok(_) => {}
-                        Err(fe) => {
-                            warn!(error = %fe, "finalization failed on failed stream");
-                            let _ = tx
-                                .send(StreamEvent::Error(ErrorData {
-                                    code: code.clone(),
-                                    message,
-                                }))
-                                .await;
-                        }
-                    }
-                } else {
-                    let _ = tx
-                        .send(StreamEvent::Error(ErrorData {
-                            code: code.clone(),
-                            message,
-                        }))
-                        .await;
-                }
-
-                // Metrics: failed stream (post-provider)
-                if let Some(ref fctx) = fin_ctx {
-                    let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
-                    fctx.metrics.record_stream_failed(&fctx.provider_id, &fctx.effective_model, &code);
-                    fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
-                }
-
-                StreamOutcome {
-                    terminal: StreamTerminal::Failed,
-                    accumulated_text,
-                    usage,
-                    effective_model: model,
-                    error_code: Some(code),
-                    provider_response_id: None,
-                    provider_partial_usage: usage.is_some(),
-                }
-            }
-        }
-    }.instrument(span))
-}
-
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use super::types::{StreamTerminal, normalize_error};
     use super::*;
+    use crate::domain::llm::{ToolPhase, Usage};
     use crate::domain::repos::CasTerminalParams;
     use crate::infra::db::repo::attachment_repo::AttachmentRepository as OrmAttachmentRepo;
     use crate::infra::db::repo::chat_repo::ChatRepository as OrmChatRepo;
@@ -2504,10 +1253,12 @@ mod tests {
     use crate::infra::db::repo::turn_repo::TurnRepository as TurnRepo;
     use crate::infra::db::repo::vector_store_repo::VectorStoreRepository as OrmVectorStoreRepo;
     use crate::infra::llm::{
-        Citation, CitationSource, LlmRequest, NonStreaming, ProviderStream, ResponseResult,
-        Streaming, TranslatedEvent,
+        Citation, CitationSource, ClientSseEvent, LlmMessage, LlmProvider, LlmProviderError,
+        LlmRequest, NonStreaming, ProviderStream, ResponseResult, Streaming, TerminalOutcome,
+        TranslatedEvent,
     };
-    use futures::stream;
+    use futures::{StreamExt, stream};
+    use mini_chat_sdk::RequesterType;
     use oagw_sdk::error::StreamingError;
 
     // ── Noop OutboxEnqueuer ──
@@ -2853,7 +1604,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
         let cancel = CancellationToken::new();
 
-        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+        let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
@@ -2905,7 +1656,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
         let cancel = CancellationToken::new();
 
-        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+        let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
@@ -2950,7 +1701,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
         let cancel = CancellationToken::new();
 
-        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+        let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
@@ -3044,7 +1795,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
         let cancel = CancellationToken::new();
 
-        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+        let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
@@ -4280,6 +3031,8 @@ mod tests {
 
         let fctx = FinalizationCtx {
             finalization_svc,
+            db: Arc::clone(&db),
+            turn_repo: Arc::clone(&turn_repo_arc),
             scope,
             turn_id,
             tenant_id,
@@ -4308,7 +3061,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
         let cancel = CancellationToken::new();
 
-        let handle = spawn_provider_task(
+        let handle = provider_task::spawn_provider_task(
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
@@ -5062,7 +3815,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
         let cancel = CancellationToken::new();
 
-        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+        let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
@@ -5108,7 +3861,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
         let cancel = CancellationToken::new();
 
-        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+        let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
@@ -5164,7 +3917,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
         let cancel = CancellationToken::new();
 
-        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+        let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
@@ -5207,7 +3960,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
         let cancel = CancellationToken::new();
 
-        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+        let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
@@ -5252,7 +4005,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
         let cancel = CancellationToken::new();
 
-        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+        let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
@@ -5308,7 +4061,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel::<StreamEvent>(32);
         let cancel = CancellationToken::new();
 
-        let handle = spawn_provider_task::<TurnRepo, MsgRepo>(
+        let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
             provider,
             "test-alias".to_owned(),
             mock_ctx(),
@@ -5937,6 +4690,7 @@ mod tests {
             deleted_at: Set(None),
             replaced_by_request_id: Set(None),
             started_at: Set(now),
+            last_progress_at: Set(Some(now)),
             completed_at: Set(None),
             updated_at: Set(now),
         };
@@ -6362,6 +5116,9 @@ mod tests {
         fn increment_attachments_pending(&self) {}
         fn decrement_attachments_pending(&self) {}
         fn record_image_inputs_per_turn(&self, _: u32) {}
+        fn record_orphan_detected(&self, _: &str) {}
+        fn record_orphan_finalized(&self, _: &str) {}
+        fn record_orphan_scan_duration_seconds(&self, _: f64) {}
         fn record_code_interpreter_calls(&self, _: &str, _: u32) {}
         fn record_cleanup_completed(&self, _: &str) {}
         fn record_cleanup_failed(&self, _: &str) {}

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/provider_task.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/provider_task.rs
@@ -1,0 +1,887 @@
+use std::sync::Arc;
+
+use futures::StreamExt;
+use modkit_security::SecurityContext;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{Instrument, debug, info, warn};
+
+use crate::domain::llm::ToolPhase;
+use crate::domain::ports::metric_labels::{stage, trigger};
+use crate::domain::repos::{MessageRepository, TurnRepository};
+use crate::domain::stream_events::{DoneData, ErrorData, StreamEvent};
+use crate::infra::db::entity::chat_turn::TurnState;
+use crate::infra::llm::{
+    ClientSseEvent, LlmMessage, LlmProvider, LlmProviderError, LlmRequestBuilder, LlmTool,
+    RequestMetadata, RequestType, TerminalOutcome,
+};
+
+use super::types::{
+    ActiveStreamGuard, FinalizationCtx, PROGRESS_UPDATE_INTERVAL, StreamOutcome, StreamTerminal,
+    determine_features, normalize_error,
+};
+
+/// All five terminal paths (provider done, incomplete, provider error,
+/// client disconnect, pre-stream error) route through `finalize_turn_cas()`.
+/// SSE terminal events (Done/Error) are emitted only after the CAS winner
+/// commits the transaction (D3).
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::cognitive_complexity,
+    clippy::let_underscore_must_use,
+    clippy::cast_possible_truncation
+)]
+pub(super) fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'static>(
+    llm: Arc<dyn LlmProvider>,
+    upstream_alias: String,
+    ctx: SecurityContext,
+    messages: Vec<LlmMessage>,
+    system_instructions: Option<String>,
+    tools: Vec<LlmTool>,
+    model: String,
+    provider_model_id: String,
+    max_output_tokens: u32,
+    max_tool_calls: u32,
+    web_search_max_calls: u32,
+    code_interpreter_max_calls: u32,
+    cancel: CancellationToken,
+    tx: mpsc::Sender<StreamEvent>,
+    fin_ctx: Option<FinalizationCtx<TR, MR>>,
+    provider_file_id_map: std::collections::HashMap<String, crate::domain::llm::AttachmentRef>,
+) -> tokio::task::JoinHandle<StreamOutcome> {
+    let span = if let Some(ref fctx) = fin_ctx {
+        tracing::info_span!(
+            "provider_stream",
+            chat_id = %fctx.chat_id,
+            turn_request_id = %fctx.request_id,
+            turn_id = %fctx.turn_id,
+            model = %model,
+        )
+    } else {
+        tracing::info_span!("provider_stream", model = %model)
+    };
+
+    tokio::spawn(async move {
+        let stream_start = std::time::Instant::now();
+        let mut first_token_time: Option<std::time::Duration> = None;
+
+        // ── Metrics: stream started + active gauge ──
+        // ActiveStreamGuard ensures decrement on every exit path (Drop-based).
+        let _stream_guard = if let Some(ref fctx) = fin_ctx {
+            fctx.metrics
+                .record_stream_started(&fctx.provider_id, &fctx.effective_model);
+            fctx.metrics.increment_active_streams();
+            Some(ActiveStreamGuard(Arc::clone(&fctx.metrics)))
+        } else {
+            None
+        };
+
+        // Build the LLM request using provider_model_id (the actual provider-facing name)
+        let mut builder = LlmRequestBuilder::new(&provider_model_id)
+            .messages(messages)
+            .max_output_tokens(u64::from(max_output_tokens))
+            .max_tool_calls(max_tool_calls);
+        if let Some(instructions) = system_instructions {
+            builder = builder.system_instructions(instructions);
+        }
+        let features = determine_features(&tools);
+        for tool in tools {
+            builder = builder.tool(tool);
+        }
+        let metadata = RequestMetadata {
+            tenant_id: ctx.subject_tenant_id().to_string(),
+            user_id: ctx.subject_id().to_string(),
+            chat_id: fin_ctx
+                .as_ref()
+                .map_or_else(String::new, |f| f.chat_id.to_string()),
+            request_type: RequestType::Chat,
+            features,
+        };
+        builder = builder.metadata(metadata);
+        let request = builder.build_streaming();
+
+        // Call the provider to start streaming
+        let stream_result = llm
+            .stream(ctx, request, &upstream_alias, cancel.clone())
+            .await;
+
+        let mut provider_stream = match stream_result {
+            Ok(s) => s,
+            Err(e) => {
+                // Provider failed before any events — finalize first, then emit error.
+                warn!(
+                    error = %e,
+                    raw_detail = e.raw_detail().unwrap_or(""),
+                    "LLM provider failed before stream start"
+                );
+                let (code, message) = normalize_error(&e);
+
+                if let Some(ref fctx) = fin_ctx {
+                    let input = fctx.to_finalization_input(
+                        TurnState::Failed,
+                        "",
+                        None,
+                        Some(code.clone()),
+                        None,
+                        None,
+                        0,
+                        0,
+                        None,
+                        None,
+                    );
+                    match fctx.finalization_svc.finalize_turn_cas(input).await {
+                        Ok(outcome) if outcome.won_cas => {
+                            let _ = tx
+                                .send(StreamEvent::Error(ErrorData {
+                                    code: code.clone(),
+                                    message,
+                                }))
+                                .await;
+                        }
+                        Ok(_) => { /* CAS loser — no SSE emission */ }
+                        Err(fe) => {
+                            warn!(error = %fe, "finalization failed on pre-stream error");
+                            // Still emit error so client isn't left hanging
+                            let _ = tx
+                                .send(StreamEvent::Error(ErrorData {
+                                    code: code.clone(),
+                                    message,
+                                }))
+                                .await;
+                        }
+                    }
+                } else {
+                    let _ = tx
+                        .send(StreamEvent::Error(ErrorData {
+                            code: code.clone(),
+                            message,
+                        }))
+                        .await;
+                }
+
+                // Metrics: pre-stream failure
+                if let Some(ref fctx) = fin_ctx {
+                    let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
+                    fctx.metrics.record_stream_failed(&fctx.provider_id, &fctx.effective_model, &code);
+                    fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
+                }
+
+                return StreamOutcome {
+                    terminal: StreamTerminal::Failed,
+                    accumulated_text: String::new(),
+                    usage: None,
+                    effective_model: model,
+                    error_code: Some(code),
+                    provider_response_id: None,
+                    provider_partial_usage: false,
+                };
+            }
+        };
+
+        // Read events from provider, translate and forward through channel
+        let mut accumulated_text = String::new();
+        let mut cancelled = false;
+        let mut last_progress_update = std::time::Instant::now();
+        let mut web_search_call_count: u32 = 0;
+        // TODO(P2): web_search_call_count (Start) is used for enforcement,
+        // web_search_completed_count (Done) is used for settlement. If a search
+        // starts but never completes (provider error between Start/Done), the
+        // daily quota under-counts by one. Acceptable for P1 since OpenAI always
+        // pairs searching→completed; revisit if we add providers that don't.
+        let mut web_search_completed_count: u32 = 0;
+        let mut code_interpreter_call_count: u32 = 0;
+        let mut code_interpreter_completed_count: u32 = 0;
+
+        loop {
+            tokio::select! {
+                biased;
+
+                () = cancel.cancelled() => {
+                    debug!("stream cancelled, aborting provider");
+                    if let Some(ref fctx) = fin_ctx {
+                        fctx.metrics.record_cancel_requested(trigger::DISCONNECT);
+                        let disconnect_stage = if first_token_time.is_none() {
+                            stage::BEFORE_FIRST_TOKEN
+                        } else {
+                            stage::MID_STREAM
+                        };
+                        fctx.metrics.record_stream_disconnected(disconnect_stage);
+                    }
+                    provider_stream.cancel();
+                    cancelled = true;
+                    break;
+                }
+
+                event = provider_stream.next() => {
+                    match event {
+                        Some(Ok(client_event)) => {
+                            let is_first_token = matches!(client_event, ClientSseEvent::Delta { .. })
+                                && first_token_time.is_none();
+
+                            if let ClientSseEvent::Delta { ref content, .. } = client_event {
+                                if first_token_time.is_none() {
+                                    let ttft = stream_start.elapsed();
+                                    first_token_time = Some(ttft);
+                                    info!(
+                                        time_to_first_token_ms = ttft.as_millis() as u64,
+                                        "first token received"
+                                    );
+                                    if let Some(ref fctx) = fin_ctx {
+                                        let ms = ttft.as_secs_f64() * 1000.0;
+                                        fctx.metrics.record_ttft_provider_ms(&fctx.provider_id, &fctx.effective_model, ms);
+                                    }
+                                }
+                                accumulated_text.push_str(content);
+
+                                // Throttled progress timestamp update for orphan detection.
+                                // Timer resets only on success — retry sooner on transient
+                                // failures to avoid stale last_progress_at triggering false
+                                // orphan detection.
+                                if let Some(ref fctx) = fin_ctx
+                                    && last_progress_update.elapsed() >= PROGRESS_UPDATE_INTERVAL
+                                {
+                                    let ok = match fctx.db.conn() {
+                                        Ok(conn) => {
+                                            match fctx.turn_repo.update_progress_at(&conn, &fctx.scope, fctx.turn_id).await {
+                                                Ok(_) => true,
+                                                Err(e) => {
+                                                    warn!(turn_id = %fctx.turn_id, error = %e, "failed to update progress timestamp");
+                                                    false
+                                                }
+                                            }
+                                        }
+                                        Err(e) => {
+                                            warn!(turn_id = %fctx.turn_id, error = %e, "failed to get DB connection for progress update");
+                                            false
+                                        }
+                                    };
+                                    if ok {
+                                        last_progress_update = std::time::Instant::now();
+                                    }
+                                }
+                            }
+
+                            // Track web search tool calls for per-message limit
+                            if let ClientSseEvent::Tool { ref phase, name, .. } = client_event
+                                && name == "web_search"
+                            {
+                                match phase {
+                                    ToolPhase::Start => {
+                                        web_search_call_count += 1;
+                                        if web_search_call_count > web_search_max_calls {
+                                            warn!(
+                                                web_search_call_count,
+                                                limit = web_search_max_calls,
+                                                "web search per-message limit exceeded"
+                                            );
+                                            let code = "web_search_calls_exceeded".to_owned();
+                                            let message = "Web search calls exceeded for this message".to_owned();
+
+                                            // Finalize as failed, then emit error (D3)
+                                            if let Some(ref fctx) = fin_ctx {
+                                                let input = fctx.to_finalization_input(
+                                                    TurnState::Failed,
+                                                    &accumulated_text,
+                                                    None,
+                                                    Some(code.clone()),
+                                                    None,
+                                                    None,
+                                                    web_search_completed_count,
+                                                    code_interpreter_completed_count,
+                                                    None,
+                                                    None,
+                                                );
+                                                match fctx.finalization_svc.finalize_turn_cas(input).await {
+                                                    Ok(outcome) if outcome.won_cas => {
+                                                        let _ = tx.send(StreamEvent::Error(ErrorData {
+                                                            code: code.clone(),
+                                                            message,
+                                                        })).await;
+                                                    }
+                                                    Ok(_) => {}
+                                                    Err(fe) => {
+                                                        warn!(error = %fe, "finalization failed on ws limit exceeded");
+                                                        let _ = tx.send(StreamEvent::Error(ErrorData {
+                                                            code: code.clone(),
+                                                            message,
+                                                        })).await;
+                                                    }
+                                                }
+                                            } else {
+                                                let _ = tx.send(StreamEvent::Error(ErrorData {
+                                                    code: code.clone(),
+                                                    message,
+                                                })).await;
+                                            }
+
+                                            provider_stream.cancel();
+
+                                            // Metrics: web search limit exceeded
+                                            if let Some(ref fctx) = fin_ctx {
+                                                let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
+                                                fctx.metrics.record_stream_failed(
+                                                    &fctx.provider_id,
+                                                    &fctx.effective_model,
+                                                    &code,
+                                                );
+                                                fctx.metrics.record_stream_total_latency_ms(
+                                                    &fctx.provider_id,
+                                                    &fctx.effective_model,
+                                                    ms,
+                                                );
+                                            }
+
+                                            let has_partial = !accumulated_text.is_empty();
+                                            return StreamOutcome {
+                                                terminal: StreamTerminal::Failed,
+                                                accumulated_text,
+                                                usage: None,
+                                                effective_model: model,
+                                                error_code: Some(code),
+                                                provider_response_id: None,
+                                                provider_partial_usage: has_partial,
+                                            };
+                                        }
+                                    }
+                                    ToolPhase::Done => {
+                                        web_search_completed_count += 1;
+                                    }
+                                }
+                            }
+
+                            // Track code interpreter tool calls
+                            if let ClientSseEvent::Tool { ref phase, name, .. } = client_event
+                                && name == "code_interpreter"
+                            {
+                                match phase {
+                                    ToolPhase::Start => {
+                                        code_interpreter_call_count += 1;
+                                        if code_interpreter_call_count > code_interpreter_max_calls {
+                                            warn!(
+                                                code_interpreter_call_count,
+                                                limit = code_interpreter_max_calls,
+                                                "code interpreter per-message limit exceeded"
+                                            );
+                                            let code = "code_interpreter_calls_exceeded".to_owned();
+                                            let message = "Code interpreter calls exceeded for this message".to_owned();
+
+                                            if let Some(ref fctx) = fin_ctx {
+                                                let input = fctx.to_finalization_input(
+                                                    TurnState::Failed,
+                                                    &accumulated_text,
+                                                    None,
+                                                    Some(code.clone()),
+                                                    None,
+                                                    None,
+                                                    web_search_completed_count,
+                                                    code_interpreter_completed_count,
+                                                    None,
+                                                    None,
+                                                );
+                                                match fctx.finalization_svc.finalize_turn_cas(input).await {
+                                                    Ok(outcome) if outcome.won_cas => {
+                                                        let _ = tx.send(StreamEvent::Error(ErrorData {
+                                                            code: code.clone(),
+                                                            message,
+                                                        })).await;
+                                                    }
+                                                    Ok(_) => {}
+                                                    Err(fe) => {
+                                                        warn!(error = %fe, "finalization failed on ci limit exceeded");
+                                                        let _ = tx.send(StreamEvent::Error(ErrorData {
+                                                            code: code.clone(),
+                                                            message,
+                                                        })).await;
+                                                    }
+                                                }
+                                            } else {
+                                                let _ = tx.send(StreamEvent::Error(ErrorData {
+                                                    code: code.clone(),
+                                                    message,
+                                                })).await;
+                                            }
+
+                                            provider_stream.cancel();
+
+                                            if let Some(ref fctx) = fin_ctx {
+                                                let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
+                                                fctx.metrics.record_stream_failed(
+                                                    &fctx.provider_id,
+                                                    &fctx.effective_model,
+                                                    &code,
+                                                );
+                                                fctx.metrics.record_stream_total_latency_ms(
+                                                    &fctx.provider_id,
+                                                    &fctx.effective_model,
+                                                    ms,
+                                                );
+                                            }
+
+                                            let has_partial = !accumulated_text.is_empty();
+                                            return StreamOutcome {
+                                                terminal: StreamTerminal::Failed,
+                                                accumulated_text,
+                                                usage: None,
+                                                effective_model: model,
+                                                error_code: Some(code),
+                                                provider_response_id: None,
+                                                provider_partial_usage: has_partial,
+                                            };
+                                        }
+                                    }
+                                    ToolPhase::Done => {
+                                        code_interpreter_completed_count += 1;
+                                    }
+                                }
+                            }
+
+                            let stream_event = StreamEvent::from(client_event);
+                            if tx.send(stream_event).await.is_err() {
+                                // Receiver dropped (client disconnect handled by relay)
+                                info!("channel closed (client disconnect), exiting provider task");
+                                break;
+                            }
+
+                            // TTFT overhead: time from provider first-byte to channel send.
+                            if is_first_token
+                                && let (Some(fctx), Some(provider_ttft)) =
+                                    (&fin_ctx, first_token_time)
+                                {
+                                    let total = stream_start.elapsed().as_secs_f64() * 1000.0;
+                                    let provider_ms = provider_ttft.as_secs_f64() * 1000.0;
+                                    fctx.metrics.record_ttft_overhead_ms(
+                                        &fctx.provider_id,
+                                        &fctx.effective_model,
+                                        total - provider_ms,
+                                    );
+                                }
+                        }
+                        Some(Err(e)) => {
+                            warn!(error = %e, "provider stream error");
+                            let (code, message) =
+                                normalize_error(&LlmProviderError::StreamError(e));
+
+                            // Finalize first, emit error only if CAS winner (D3)
+                            if let Some(ref fctx) = fin_ctx {
+                                let mid_elapsed = stream_start.elapsed();
+                                let input = fctx.to_finalization_input(
+                                    TurnState::Failed,
+                                    &accumulated_text,
+                                    None,
+                                    Some(code.clone()),
+                                    None,
+                                    None,
+                                    web_search_completed_count,
+                                    code_interpreter_completed_count,
+                                    first_token_time.map(|d| d.as_millis() as u64),
+                                    Some(mid_elapsed.as_millis() as u64),
+                                );
+                                match fctx.finalization_svc.finalize_turn_cas(input).await {
+                                    Ok(outcome) if outcome.won_cas => {
+                                        let _ = tx
+                                            .send(StreamEvent::Error(ErrorData {
+                                                code: code.clone(),
+                                                message,
+                                            }))
+                                            .await;
+                                    }
+                                    Ok(_) => {}
+                                    Err(fe) => {
+                                        warn!(error = %fe, "finalization failed on stream error");
+                                        let _ = tx
+                                            .send(StreamEvent::Error(ErrorData {
+                                                code: code.clone(),
+                                                message,
+                                            }))
+                                            .await;
+                                    }
+                                }
+                            } else {
+                                let _ = tx
+                                    .send(StreamEvent::Error(ErrorData {
+                                        code: code.clone(),
+                                        message,
+                                    }))
+                                    .await;
+                            }
+
+                            // Metrics: mid-stream failure
+                            if let Some(ref fctx) = fin_ctx {
+                                let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
+                                fctx.metrics.record_stream_failed(&fctx.provider_id, &fctx.effective_model, &code);
+                                fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
+                            }
+
+                            provider_stream.cancel();
+                            let has_partial = !accumulated_text.is_empty();
+                            return StreamOutcome {
+                                terminal: StreamTerminal::Failed,
+                                accumulated_text,
+                                usage: None,
+                                effective_model: model,
+                                error_code: Some(code),
+                                provider_response_id: None,
+                                provider_partial_usage: has_partial,
+                            };
+                        }
+                        None => {
+                            // Stream ended — terminal captured by ProviderStream
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if cancelled {
+            let elapsed = stream_start.elapsed();
+            info!(
+                terminal = "cancelled",
+                duration_ms = elapsed.as_millis() as u64,
+                "stream cancelled"
+            );
+
+            // Finalize cancelled turn — no SSE emission (stream already disconnected) (D3)
+            if let Some(ref fctx) = fin_ctx {
+                let input = fctx.to_finalization_input(
+                    TurnState::Cancelled,
+                    &accumulated_text,
+                    None,
+                    None,
+                    None,
+                    None,
+                    web_search_completed_count,
+                    code_interpreter_completed_count,
+                    first_token_time.map(|d| d.as_millis() as u64),
+                    Some(elapsed.as_millis() as u64),
+                );
+                if let Err(e) = fctx.finalization_svc.finalize_turn_cas(input).await {
+                    warn!(error = %e, "finalization failed on cancelled stream");
+                }
+
+                // Metrics: cancelled stream
+                let ms = elapsed.as_secs_f64() * 1000.0;
+                fctx.metrics.record_cancel_effective(trigger::DISCONNECT);
+                fctx.metrics.record_time_to_abort_ms(trigger::DISCONNECT, ms);
+                fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
+            }
+
+            return StreamOutcome {
+                terminal: StreamTerminal::Cancelled,
+                accumulated_text,
+                usage: None,
+                effective_model: model,
+                error_code: None,
+                provider_response_id: None,
+                provider_partial_usage: false,
+            };
+        }
+
+        // Extract the terminal outcome from the provider stream
+        let terminal = provider_stream.into_outcome().await;
+
+        match terminal {
+            TerminalOutcome::Completed {
+                usage,
+                content: _,
+                citations,
+                response_id,
+                ..
+            } => {
+                let elapsed = stream_start.elapsed();
+                info!(
+                    terminal = "completed",
+                    input_tokens = usage.input_tokens,
+                    output_tokens = usage.output_tokens,
+                    duration_ms = elapsed.as_millis() as u64,
+                    "stream completed"
+                );
+
+                // Finalize first, then emit Done only if CAS winner (D3)
+                if let Some(ref fctx) = fin_ctx {
+                    let input = fctx.to_finalization_input(
+                        TurnState::Completed,
+                        &accumulated_text,
+                        Some(usage),
+                        None,
+                        None,
+                        Some(response_id.clone()),
+                        web_search_completed_count,
+                        code_interpreter_completed_count,
+                        first_token_time.map(|d| d.as_millis() as u64),
+                        Some(elapsed.as_millis() as u64),
+                    );
+                    match fctx.finalization_svc.finalize_turn_cas(input).await {
+                        Ok(outcome) if outcome.won_cas => {
+                            // P4-2: Map provider file_ids to internal UUIDs
+                            let mapped = crate::domain::citation_mapping::map_citation_ids(
+                                citations,
+                                &provider_file_id_map,
+                            );
+                            if !mapped.is_empty() {
+                                let _ = tx
+                                    .send(StreamEvent::Citations(
+                                        crate::domain::stream_events::CitationsData {
+                                            items: mapped,
+                                        },
+                                    ))
+                                    .await;
+                            }
+                            // Compute quota warnings post-commit (advisory, best-effort)
+                            let quota_warnings = match fctx
+                                .quota_warnings_provider
+                                .get_quota_warnings(&fctx.scope, fctx.tenant_id, fctx.user_id)
+                                .await
+                            {
+                                Ok(w) => Some(w),
+                                Err(e) => {
+                                    warn!(error = %e, "failed to compute quota_warnings");
+                                    None
+                                }
+                            };
+                            let _ = tx
+                                .send(StreamEvent::Done(Box::new(DoneData {
+                                    usage: Some(usage),
+                                    effective_model: fctx.effective_model.clone(),
+                                    selected_model: fctx.selected_model.clone(),
+                                    quota_decision: fctx.quota_decision.clone(),
+                                    downgrade_from: fctx.downgrade_from.clone(),
+                                    downgrade_reason: fctx.downgrade_reason.clone(),
+                                    quota_warnings,
+                                })))
+                                .await;
+                        }
+                        Ok(_) => { /* CAS loser — no SSE emission */ }
+                        Err(fe) => {
+                            warn!(error = %fe, "finalization failed on completed stream");
+                            // Emit Done anyway so client isn't left hanging
+                            let _ = tx
+                                .send(StreamEvent::Done(Box::new(DoneData {
+                                    usage: Some(usage),
+                                    effective_model: fctx.effective_model.clone(),
+                                    selected_model: fctx.selected_model.clone(),
+                                    quota_decision: "allow".into(),
+                                    downgrade_from: None,
+                                    downgrade_reason: None,
+                                    quota_warnings: None,
+                                })))
+                                .await;
+                        }
+                    }
+                } else {
+                    // No finalization context (unit tests) — emit directly
+                    let mapped = crate::domain::citation_mapping::map_citation_ids(
+                        citations,
+                        &provider_file_id_map,
+                    );
+                    if !mapped.is_empty() {
+                        let _ = tx
+                            .send(StreamEvent::Citations(
+                                crate::domain::stream_events::CitationsData { items: mapped },
+                            ))
+                            .await;
+                    }
+                    let _ = tx
+                        .send(StreamEvent::Done(Box::new(DoneData {
+                            usage: Some(usage),
+                            effective_model: model.clone(),
+                            selected_model: model.clone(),
+                            quota_decision: "allow".into(),
+                            downgrade_from: None,
+                            downgrade_reason: None,
+                            quota_warnings: None,
+                        })))
+                        .await;
+                }
+
+                // Metrics: completed stream
+                if let Some(ref fctx) = fin_ctx {
+                    let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
+                    fctx.metrics.record_stream_completed(&fctx.provider_id, &fctx.effective_model);
+                    fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
+                }
+
+                StreamOutcome {
+                    terminal: StreamTerminal::Completed,
+                    accumulated_text,
+                    usage: Some(usage),
+                    effective_model: model,
+                    error_code: None,
+                    provider_response_id: Some(response_id),
+                    provider_partial_usage: false,
+                }
+            }
+            TerminalOutcome::Incomplete { usage, reason, .. } => {
+                let elapsed = stream_start.elapsed();
+                warn!(
+                    terminal = "incomplete",
+                    reason = %reason,
+                    duration_ms = elapsed.as_millis() as u64,
+                    "stream incomplete"
+                );
+
+                // Incomplete maps to Completed in DB — provider finished but hit
+                // max_output_tokens. From billing/persistence perspective this is
+                // a completed turn with truncated content (see design D10).
+                if let Some(ref fctx) = fin_ctx {
+                    let input = fctx.to_finalization_input(
+                        TurnState::Completed,
+                        &accumulated_text,
+                        Some(usage),
+                        None,
+                        None,
+                        None,
+                        web_search_completed_count,
+                        code_interpreter_completed_count,
+                        first_token_time.map(|d| d.as_millis() as u64),
+                        Some(elapsed.as_millis() as u64),
+                    );
+                    match fctx.finalization_svc.finalize_turn_cas(input).await {
+                        Ok(outcome) if outcome.won_cas => {
+                            let quota_warnings = match fctx
+                                .quota_warnings_provider
+                                .get_quota_warnings(&fctx.scope, fctx.tenant_id, fctx.user_id)
+                                .await
+                            {
+                                Ok(w) => Some(w),
+                                Err(e) => {
+                                    warn!(error = %e, "failed to compute quota_warnings");
+                                    None
+                                }
+                            };
+                            let _ = tx
+                                .send(StreamEvent::Done(Box::new(DoneData {
+                                    usage: Some(usage),
+                                    effective_model: fctx.effective_model.clone(),
+                                    selected_model: fctx.selected_model.clone(),
+                                    quota_decision: fctx.quota_decision.clone(),
+                                    downgrade_from: fctx.downgrade_from.clone(),
+                                    downgrade_reason: fctx.downgrade_reason.clone(),
+                                    quota_warnings,
+                                })))
+                                .await;
+                        }
+                        Ok(_) => {}
+                        Err(fe) => {
+                            warn!(error = %fe, "finalization failed on incomplete stream");
+                            let _ = tx
+                                .send(StreamEvent::Done(Box::new(DoneData {
+                                    usage: Some(usage),
+                                    effective_model: fctx.effective_model.clone(),
+                                    selected_model: fctx.selected_model.clone(),
+                                    quota_decision: "allow".into(),
+                                    downgrade_from: None,
+                                    downgrade_reason: None,
+                                    quota_warnings: None,
+                                })))
+                                .await;
+                        }
+                    }
+                } else {
+                    let _ = tx
+                        .send(StreamEvent::Done(Box::new(DoneData {
+                            usage: Some(usage),
+                            effective_model: model.clone(),
+                            selected_model: model.clone(),
+                            quota_decision: "allow".into(),
+                            downgrade_from: None,
+                            downgrade_reason: None,
+                            quota_warnings: None,
+                        })))
+                        .await;
+                }
+
+                // Metrics: incomplete stream
+                if let Some(ref fctx) = fin_ctx {
+                    let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
+                    fctx.metrics.record_stream_incomplete(&fctx.provider_id, &fctx.effective_model, &reason);
+                    fctx.metrics.record_stream_completed(&fctx.provider_id, &fctx.effective_model);
+                    fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
+                }
+
+                StreamOutcome {
+                    terminal: StreamTerminal::Incomplete,
+                    accumulated_text,
+                    usage: Some(usage),
+                    effective_model: model,
+                    error_code: Some(format!("incomplete:{reason}")),
+                    provider_response_id: None,
+                    provider_partial_usage: false,
+                }
+            }
+            TerminalOutcome::Failed { error, usage, .. } => {
+                let raw_detail = error.raw_detail().map(ToOwned::to_owned);
+                let (code, message) = normalize_error(&error);
+                let elapsed = stream_start.elapsed();
+                warn!(
+                    terminal = "failed",
+                    error_code = %code,
+                    raw_detail = raw_detail.as_deref().unwrap_or(""),
+                    duration_ms = elapsed.as_millis() as u64,
+                    "stream failed"
+                );
+
+                // Finalize first, emit error only if CAS winner (D3)
+                if let Some(ref fctx) = fin_ctx {
+                    let input = fctx.to_finalization_input(
+                        TurnState::Failed,
+                        &accumulated_text,
+                        usage,
+                        Some(code.clone()),
+                        None,
+                        None,
+                        web_search_completed_count,
+                        code_interpreter_completed_count,
+                        first_token_time.map(|d| d.as_millis() as u64),
+                        Some(elapsed.as_millis() as u64),
+                    );
+                    match fctx.finalization_svc.finalize_turn_cas(input).await {
+                        Ok(outcome) if outcome.won_cas => {
+                            let _ = tx
+                                .send(StreamEvent::Error(ErrorData {
+                                    code: code.clone(),
+                                    message,
+                                }))
+                                .await;
+                        }
+                        Ok(_) => {}
+                        Err(fe) => {
+                            warn!(error = %fe, "finalization failed on failed stream");
+                            let _ = tx
+                                .send(StreamEvent::Error(ErrorData {
+                                    code: code.clone(),
+                                    message,
+                                }))
+                                .await;
+                        }
+                    }
+                } else {
+                    let _ = tx
+                        .send(StreamEvent::Error(ErrorData {
+                            code: code.clone(),
+                            message,
+                        }))
+                        .await;
+                }
+
+                // Metrics: failed stream (post-provider)
+                if let Some(ref fctx) = fin_ctx {
+                    let ms = stream_start.elapsed().as_secs_f64() * 1000.0;
+                    fctx.metrics.record_stream_failed(&fctx.provider_id, &fctx.effective_model, &code);
+                    fctx.metrics.record_stream_total_latency_ms(&fctx.provider_id, &fctx.effective_model, ms);
+                }
+
+                StreamOutcome {
+                    terminal: StreamTerminal::Failed,
+                    accumulated_text,
+                    usage,
+                    effective_model: model,
+                    error_code: Some(code),
+                    provider_response_id: None,
+                    provider_partial_usage: usage.is_some(),
+                }
+            }
+        }
+    }.instrument(span))
+}

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/types.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/types.rs
@@ -1,0 +1,470 @@
+use std::sync::Arc;
+
+use modkit_macros::domain_model;
+use modkit_security::AccessScope;
+use uuid::Uuid;
+
+use mini_chat_sdk::RequesterType;
+
+use crate::domain::error::DomainError;
+use crate::domain::llm::Usage;
+use crate::domain::ports::MiniChatMetricsPort;
+use crate::domain::repos::{MessageRepository, TurnRepository};
+use crate::infra::db::entity::chat_turn::TurnState;
+use crate::infra::llm::{FeatureFlag, LlmProviderError, LlmTool};
+
+use super::super::DbProvider;
+
+// ── RAII guard for active_streams gauge ──────────────────────────────────
+
+/// Ensures `decrement_active_streams` is always called when the guard is
+/// dropped, even if a new exit path is added without an explicit decrement.
+#[domain_model]
+pub(super) struct ActiveStreamGuard(pub(super) Arc<dyn MiniChatMetricsPort>);
+
+impl Drop for ActiveStreamGuard {
+    fn drop(&mut self) {
+        self.0.decrement_active_streams();
+    }
+}
+
+// ── Typed error for attachment validation inside TX boundary ─────────────
+
+#[allow(de0309_must_have_domain_model)]
+#[derive(Debug, thiserror::Error)]
+#[error("invalid attachment: {message}")]
+pub(super) struct InvalidAttachmentError {
+    pub(super) message: String,
+}
+
+pub(super) fn attachment_err(message: impl Into<String>) -> modkit_db::DbError {
+    modkit_db::DbError::Other(anyhow::Error::new(InvalidAttachmentError {
+        message: message.into(),
+    }))
+}
+
+/// Collects [`FeatureFlag`]s from the tools attached to a request, used to
+/// populate [`RequestMetadata`] for observability.
+pub(super) fn determine_features(tools: &[LlmTool]) -> Vec<FeatureFlag> {
+    let mut flags = Vec::new();
+    if tools
+        .iter()
+        .any(|t| matches!(t, LlmTool::FileSearch { .. }))
+    {
+        flags.push(FeatureFlag::FileSearch);
+    }
+    if tools.iter().any(|t| matches!(t, LlmTool::WebSearch { .. })) {
+        flags.push(FeatureFlag::WebSearch);
+    }
+    if tools
+        .iter()
+        .any(|t| matches!(t, LlmTool::CodeInterpreter { .. }))
+    {
+        flags.push(FeatureFlag::CodeInterpreter);
+    }
+    flags
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// StreamTerminal — service-level terminal classification
+// ════════════════════════════════════════════════════════════════════════════
+
+/// How the stream ended at the service level.
+///
+/// Maps from the provider-level [`TerminalOutcome`] with an additional
+/// `Cancelled` variant for client/server-initiated cancellation.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamTerminal {
+    /// Provider completed successfully — full response received.
+    Completed,
+    /// Provider stopped early (e.g. `max_output_tokens` hit).
+    Incomplete,
+    /// Provider or stream-level error.
+    Failed,
+    /// Cancelled (client disconnect or server-initiated).
+    Cancelled,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// StreamOutcome — returned from run_stream()
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Summary of a finished stream, returned from [`StreamService::run_stream()`].
+///
+/// Used by P1 for logging and metrics, and by P4 for CAS finalization.
+#[domain_model]
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct StreamOutcome {
+    /// How the stream ended.
+    pub terminal: StreamTerminal,
+    /// Accumulated assistant text from delta events.
+    pub accumulated_text: String,
+    /// Token usage from the provider (if available).
+    pub usage: Option<Usage>,
+    /// The model actually used by the provider.
+    pub effective_model: String,
+    /// Normalized error code (e.g. `rate_limited`, `provider_timeout`).
+    pub error_code: Option<String>,
+    /// Provider response ID (e.g. `OpenAI` `response_id`).
+    pub provider_response_id: Option<String>,
+    /// Whether usage was from a partial/incomplete provider response.
+    pub provider_partial_usage: bool,
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// StreamError — pre-stream error before SSE connection opens
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Pre-stream error — returned from [`StreamService::run_stream()`] before
+/// the SSE connection opens. The handler maps these to JSON error responses.
+#[domain_model]
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum StreamError {
+    /// Idempotent replay: a turn with this `request_id` already exists.
+    Replay {
+        turn: Box<crate::infra::db::entity::chat_turn::Model>,
+    },
+    /// Conflict: another turn is already running for this chat.
+    Conflict { code: String, message: String },
+    /// Turn creation or pre-stream DB operation failed.
+    TurnCreationFailed { source: DomainError },
+    /// Authorization failed (enforcer denied access).
+    AuthorizationFailed { source: DomainError },
+    /// Chat does not exist or is not visible to the caller.
+    ChatNotFound { chat_id: Uuid },
+    /// Quota exhausted — preflight rejected the request.
+    QuotaExhausted {
+        error_code: String,
+        http_status: u16,
+        quota_scope: String,
+    },
+    /// Web search is disabled via kill switch but was requested.
+    WebSearchDisabled,
+    /// Images are disabled via kill switch but image attachments were included.
+    ImagesDisabled,
+    /// Too many image attachments in one message (`max_images_per_message` exceeded).
+    TooManyImages { count: u32, max: u32 },
+    /// Model does not support image input (missing `VISION_INPUT` capability).
+    UnsupportedMedia,
+    /// One or more attachment IDs are invalid (not found, wrong status, wrong chat, etc.).
+    InvalidAttachment { code: String, message: String },
+    /// Context budget exceeded — mandatory items don't fit in the token budget.
+    ContextBudgetExceeded {
+        required_tokens: u64,
+        available_tokens: u64,
+    },
+    /// User message content exceeds the model's maximum input token limit.
+    InputTooLong {
+        estimated_tokens: u64,
+        max_input_tokens: u32,
+    },
+}
+
+impl From<authz_resolver_sdk::EnforcerError> for StreamError {
+    fn from(e: authz_resolver_sdk::EnforcerError) -> Self {
+        match e {
+            e @ authz_resolver_sdk::EnforcerError::Denied { .. } => Self::AuthorizationFailed {
+                source: DomainError::from(e),
+            },
+            e @ (authz_resolver_sdk::EnforcerError::EvaluationFailed(_)
+            | authz_resolver_sdk::EnforcerError::CompileFailed(_)) => Self::TurnCreationFailed {
+                source: DomainError::from(e),
+            },
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// FinalizationCtx — bundled context for atomic finalization in the spawned task
+// ════════════════════════════════════════════════════════════════════════════
+
+/// All context needed to call `FinalizationService::finalize_turn_cas()`
+/// from the spawned provider task. Replaces the old `PersistenceCtx`.
+///
+/// Assembled in `run_stream()` after preflight commits, from `PreflightDecision`
+/// fields + request context. `None` in unit tests (no DB).
+#[domain_model]
+pub(super) struct FinalizationCtx<TR: TurnRepository + 'static, MR: MessageRepository + 'static> {
+    pub(super) finalization_svc:
+        Arc<crate::domain::service::finalization_service::FinalizationService<TR, MR>>,
+    pub(super) db: Arc<DbProvider>,
+    pub(super) turn_repo: Arc<TR>,
+    pub(super) scope: AccessScope,
+    pub(super) turn_id: Uuid,
+    pub(super) tenant_id: Uuid,
+    pub(super) chat_id: Uuid,
+    pub(super) request_id: Uuid,
+    pub(super) user_id: Uuid,
+    pub(super) requester_type: RequesterType,
+    /// Pre-generated assistant message ID, sent in `StreamStartedData` (`stream_started` event).
+    pub(super) message_id: Uuid,
+    // ── Quota/preflight fields (from PreflightDecision) ──
+    pub(super) effective_model: String,
+    pub(super) selected_model: String,
+    pub(super) reserve_tokens: i64,
+    pub(super) max_output_tokens_applied: i32,
+    pub(super) reserved_credits_micro: i64,
+    pub(super) policy_version_applied: i64,
+    pub(super) minimal_generation_floor_applied: i32,
+    pub(super) quota_decision: String,
+    pub(super) downgrade_from: Option<String>,
+    pub(super) downgrade_reason: Option<String>,
+    pub(super) period_starts: Vec<(
+        crate::infra::db::entity::quota_usage::PeriodType,
+        time::Date,
+    )>,
+    /// Provider ID for metrics labels.
+    pub(super) provider_id: String,
+    /// Metrics port for recording stream metrics in the spawned task.
+    pub(super) metrics: Arc<dyn MiniChatMetricsPort>,
+    /// Quota warnings provider for computing `quota_warnings` in the `done` event.
+    pub(super) quota_warnings_provider:
+        Arc<dyn crate::domain::service::quota_settler::QuotaWarningsProvider>,
+}
+
+impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> FinalizationCtx<TR, MR> {
+    /// Build a [`FinalizationInput`] from this context and stream outcome data.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn to_finalization_input(
+        &self,
+        terminal_state: TurnState,
+        accumulated_text: &str,
+        usage: Option<Usage>,
+        error_code: Option<String>,
+        error_detail: Option<String>,
+        provider_response_id: Option<String>,
+        web_search_calls: u32,
+        code_interpreter_calls: u32,
+        ttft_ms: Option<u64>,
+        total_ms: Option<u64>,
+    ) -> crate::domain::model::finalization::FinalizationInput {
+        crate::domain::model::finalization::FinalizationInput {
+            turn_id: self.turn_id,
+            tenant_id: self.tenant_id,
+            chat_id: self.chat_id,
+            request_id: self.request_id,
+            user_id: self.user_id,
+            requester_type: self.requester_type,
+            scope: self.scope.clone(),
+            message_id: self.message_id,
+            terminal_state,
+            error_code,
+            error_detail,
+            accumulated_text: accumulated_text.to_owned(),
+            usage,
+            provider_response_id,
+            effective_model: self.effective_model.clone(),
+            selected_model: self.selected_model.clone(),
+            reserve_tokens: self.reserve_tokens,
+            max_output_tokens_applied: self.max_output_tokens_applied,
+            reserved_credits_micro: self.reserved_credits_micro,
+            policy_version_applied: self.policy_version_applied,
+            minimal_generation_floor_applied: self.minimal_generation_floor_applied,
+            quota_decision: self.quota_decision.clone(),
+            downgrade_from: self.downgrade_from.clone(),
+            downgrade_reason: self.downgrade_reason.clone(),
+            period_starts: self.period_starts.clone(),
+            web_search_calls,
+            code_interpreter_calls,
+            ttft_ms,
+            total_ms,
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Input token validation
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Estimate text-only tokens for `content` and return `Err(InputTooLong)` if
+/// the estimate exceeds the model's `max_input_tokens`.
+///
+/// Surcharges (images, tools, web search, code interpreter) are intentionally
+/// excluded: this is a fast pre-flight guard on the raw message text, not a
+/// full context budget check.
+pub(super) fn check_input_token_limit(
+    content: &str,
+    pf: &PreflightResult,
+) -> Result<(), StreamError> {
+    let estimate = super::super::token_estimator::estimate_tokens(
+        &super::super::token_estimator::EstimationInput {
+            utf8_bytes: content.len() as u64,
+            num_images: 0,
+            tools_enabled: false,
+            web_search_enabled: false,
+            code_interpreter_enabled: false,
+        },
+        &pf.estimation_budgets,
+    );
+    if estimate.estimated_input_tokens > u64::from(pf.max_input_tokens) {
+        return Err(StreamError::InputTooLong {
+            estimated_tokens: estimate.estimated_input_tokens,
+            max_input_tokens: pf.max_input_tokens,
+        });
+    }
+    Ok(())
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Error normalization
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Map an optional subject-type string from [`SecurityContext`] to [`RequesterType`].
+pub(super) fn requester_type_from_str(s: Option<&str>) -> RequesterType {
+    match s {
+        Some("system") => RequesterType::System,
+        _ => RequesterType::User,
+    }
+}
+
+/// Normalize an [`LlmProviderError`] to a `(code, message)` pair for the SSE
+/// error event. Messages are already sanitized by the infra layer.
+pub(super) fn normalize_error(err: &LlmProviderError) -> (String, String) {
+    match err {
+        LlmProviderError::RateLimited { .. } => (
+            "rate_limited".to_owned(),
+            "Rate limited by provider".to_owned(),
+        ),
+        LlmProviderError::Timeout => (
+            "provider_timeout".to_owned(),
+            "Provider request timed out".to_owned(),
+        ),
+        LlmProviderError::ProviderError { message, .. } => {
+            ("provider_error".to_owned(), message.clone())
+        }
+        LlmProviderError::InvalidResponse { detail } => (
+            "provider_error".to_owned(),
+            crate::infra::llm::sanitize_provider_message(detail),
+        ),
+        LlmProviderError::ProviderUnavailable => (
+            "provider_error".to_owned(),
+            "Provider is currently unavailable".to_owned(),
+        ),
+        LlmProviderError::StreamError(e) => (
+            "provider_error".to_owned(),
+            crate::infra::llm::sanitize_provider_message(&e.to_string()),
+        ),
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// PreflightResult — flattened preflight outcome for run_stream()
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Flattened preflight fields used by `run_stream()` after `preflight_reserve()`.
+#[domain_model]
+pub(super) struct PreflightResult {
+    pub(super) effective_model: String,
+    pub(super) effective_provider_model_id: String,
+    pub(super) reserve_tokens: i64,
+    pub(super) max_output_tokens_applied: i32,
+    pub(super) reserved_credits_micro: i64,
+    pub(super) policy_version_applied: i64,
+    pub(super) minimal_generation_floor_applied: i32,
+    pub(super) quota_decision: String,
+    pub(super) downgrade_from: Option<String>,
+    pub(super) downgrade_reason: Option<String>,
+    pub(super) system_prompt: String,
+    pub(super) context_window: u32,
+    pub(super) max_input_tokens: u32,
+    pub(super) estimation_budgets: crate::config::EstimationBudgets,
+    pub(super) max_retrieved_chunks_per_turn: u32,
+    pub(super) max_tool_calls: u32,
+    pub(super) tool_support: mini_chat_sdk::ModelToolSupport,
+}
+
+/// Convert a `PreflightDecision` into a flat `PreflightResult` or a `StreamError`.
+pub(super) fn flatten_preflight(
+    decision: crate::domain::model::quota::PreflightDecision,
+) -> Result<PreflightResult, StreamError> {
+    use crate::domain::model::quota::PreflightDecision;
+    match decision {
+        PreflightDecision::Allow {
+            effective_model,
+            effective_provider_model_id,
+            reserve_tokens,
+            max_output_tokens_applied,
+            reserved_credits_micro,
+            policy_version_applied,
+            minimal_generation_floor_applied,
+            system_prompt,
+            context_window,
+            max_input_tokens,
+            estimation_budgets,
+            max_retrieved_chunks_per_turn,
+            max_tool_calls,
+            tool_support,
+            ..
+        } => Ok(PreflightResult {
+            effective_model,
+            effective_provider_model_id,
+            reserve_tokens,
+            max_output_tokens_applied,
+            reserved_credits_micro,
+            policy_version_applied,
+            minimal_generation_floor_applied,
+            quota_decision: "allow".to_owned(),
+            downgrade_from: None,
+            downgrade_reason: None,
+            system_prompt,
+            context_window,
+            max_input_tokens,
+            estimation_budgets,
+            max_retrieved_chunks_per_turn,
+            max_tool_calls,
+            tool_support,
+        }),
+        PreflightDecision::Downgrade {
+            effective_model,
+            effective_provider_model_id,
+            reserve_tokens,
+            max_output_tokens_applied,
+            reserved_credits_micro,
+            policy_version_applied,
+            minimal_generation_floor_applied,
+            downgrade_from,
+            downgrade_reason,
+            system_prompt,
+            context_window,
+            max_input_tokens,
+            estimation_budgets,
+            max_retrieved_chunks_per_turn,
+            max_tool_calls,
+            tool_support,
+            ..
+        } => Ok(PreflightResult {
+            effective_model,
+            effective_provider_model_id,
+            reserve_tokens,
+            max_output_tokens_applied,
+            reserved_credits_micro,
+            policy_version_applied,
+            minimal_generation_floor_applied,
+            quota_decision: "downgrade".to_owned(),
+            downgrade_from: Some(downgrade_from),
+            downgrade_reason: Some(downgrade_reason.as_str().to_owned()),
+            system_prompt,
+            context_window,
+            max_input_tokens,
+            estimation_budgets,
+            max_retrieved_chunks_per_turn,
+            max_tool_calls,
+            tool_support,
+        }),
+        PreflightDecision::Reject {
+            error_code,
+            http_status,
+            quota_scope,
+        } => Err(StreamError::QuotaExhausted {
+            error_code,
+            http_status,
+            quota_scope,
+        }),
+    }
+}
+
+/// Interval between progress timestamp updates for orphan detection.
+pub(super) const PROGRESS_UPDATE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -1285,6 +1285,9 @@ impl crate::domain::ports::MiniChatMetricsPort for TestMetrics {
         self.attachments_pending.fetch_add(-1, Ordering::Relaxed);
     }
     fn record_image_inputs_per_turn(&self, _count: u32) {}
+    fn record_orphan_detected(&self, _: &str) {}
+    fn record_orphan_finalized(&self, _: &str) {}
+    fn record_orphan_scan_duration_seconds(&self, _: f64) {}
     fn record_code_interpreter_calls(&self, _: &str, _: u32) {
         self.code_interpreter_calls.fetch_add(1, Ordering::Relaxed);
     }

--- a/modules/mini-chat/mini-chat/src/domain/service/thumbnail.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/thumbnail.rs
@@ -27,12 +27,15 @@ pub struct Thumbnail {
 /// `img_thumbnail = null`."*
 #[allow(clippy::cognitive_complexity)]
 pub fn generate(cfg: &ThumbnailConfig, raw: &[u8]) -> Option<Thumbnail> {
-    // Pre-screen: reject obviously oversized payloads before decoding.
+    // Pre-screen: reject oversized compressed payloads before decoding.
+    // max_decode_bytes is the memory budget for the decoded bitmap; using it as
+    // an input-size guard too is intentionally conservative — a compressed file
+    // larger than the decoded budget will always exceed it once decoded.
     if raw.len() > cfg.max_decode_bytes {
         tracing::debug!(
             raw_len = raw.len(),
             max = cfg.max_decode_bytes,
-            "thumbnail skipped: source exceeds max_decode_bytes"
+            "thumbnail skipped: compressed input exceeds max_decode_bytes"
         );
         return None;
     }

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/chat_turn.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/chat_turn.rs
@@ -32,6 +32,7 @@ pub struct Model {
     pub deleted_at: Option<OffsetDateTime>,
     pub replaced_by_request_id: Option<Uuid>,
     pub started_at: OffsetDateTime,
+    pub last_progress_at: Option<OffsetDateTime>,
     pub completed_at: Option<OffsetDateTime>,
     pub updated_at: OffsetDateTime,
 }

--- a/modules/mini-chat/mini-chat/src/infra/db/migrations/m20260329_000001_add_last_progress_at.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/migrations/m20260329_000001_add_last_progress_at.rs
@@ -1,0 +1,61 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::ConnectionTrait;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+        let conn = manager.get_connection();
+
+        let sql = match backend {
+            sea_orm::DatabaseBackend::Postgres => POSTGRES_UP,
+            sea_orm::DatabaseBackend::Sqlite => SQLITE_UP,
+            sea_orm::DatabaseBackend::MySql => {
+                return Err(DbErr::Migration("MySQL not supported for mini-chat".into()));
+            }
+        };
+
+        conn.execute_unprepared(sql).await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.execute_unprepared(DOWN).await?;
+        Ok(())
+    }
+}
+
+const POSTGRES_UP: &str = r"
+ALTER TABLE chat_turns ADD COLUMN last_progress_at TIMESTAMPTZ;
+
+UPDATE chat_turns
+   SET last_progress_at = started_at
+ WHERE last_progress_at IS NULL
+   AND state = 'running';
+
+CREATE INDEX IF NOT EXISTS idx_chat_turns_orphan_scan
+    ON chat_turns (last_progress_at)
+    WHERE state = 'running' AND deleted_at IS NULL;
+";
+
+const SQLITE_UP: &str = r"
+ALTER TABLE chat_turns ADD COLUMN last_progress_at TEXT;
+
+UPDATE chat_turns
+   SET last_progress_at = started_at
+ WHERE last_progress_at IS NULL
+   AND state = 'running';
+
+CREATE INDEX IF NOT EXISTS idx_chat_turns_orphan_scan
+    ON chat_turns (last_progress_at)
+    WHERE state = 'running' AND deleted_at IS NULL;
+";
+
+const DOWN: &str = r"
+DROP INDEX IF EXISTS idx_chat_turns_orphan_scan;
+ALTER TABLE chat_turns DROP COLUMN last_progress_at;
+";

--- a/modules/mini-chat/mini-chat/src/infra/db/migrations/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/migrations/mod.rs
@@ -1,12 +1,16 @@
 use sea_orm_migration::prelude::*;
 
 mod m20260302_000001_initial;
+mod m20260329_000001_add_last_progress_at;
 
 pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20260302_000001_initial::Migration)]
+        vec![
+            Box::new(m20260302_000001_initial::Migration),
+            Box::new(m20260329_000001_add_last_progress_at::Migration),
+        ]
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
@@ -48,6 +48,7 @@ impl crate::domain::repos::TurnRepository for TurnRepository {
             deleted_at: Set(None),
             replaced_by_request_id: Set(None),
             started_at: Set(now),
+            last_progress_at: Set(Some(now)),
             completed_at: Set(None),
             updated_at: Set(now),
         };
@@ -215,6 +216,84 @@ impl crate::domain::repos::TurnRepository for TurnRepository {
         Ok(())
     }
 
+    async fn update_progress_at<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        turn_id: Uuid,
+    ) -> Result<u64, DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let result = TurnEntity::update_many()
+            .col_expr(Column::LastProgressAt, Expr::value(Some(now)))
+            .col_expr(Column::UpdatedAt, Expr::value(now))
+            .filter(
+                Condition::all()
+                    .add(Column::Id.eq(turn_id))
+                    .add(Column::State.eq(TurnState::Running)),
+            )
+            .secure()
+            .scope_with(scope)
+            .exec(runner)
+            .await?;
+        Ok(result.rows_affected)
+    }
+
+    async fn find_orphan_candidates<C: DBRunner>(
+        &self,
+        runner: &C,
+        timeout_secs: u64,
+        limit: u32,
+    ) -> Result<Vec<TurnModel>, DomainError> {
+        let cutoff =
+            OffsetDateTime::now_utc() - time::Duration::seconds(timeout_secs.cast_signed());
+        let scope = AccessScope::allow_all();
+        Ok(TurnEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::State.eq(TurnState::Running))
+                    .add(Column::DeletedAt.is_null())
+                    .add(Column::LastProgressAt.is_not_null())
+                    .add(Column::LastProgressAt.lte(cutoff)),
+            )
+            .secure()
+            .scope_with(&scope)
+            .order_by(Column::LastProgressAt, Order::Asc)
+            .limit(u64::from(limit))
+            .all(runner)
+            .await?)
+    }
+
+    async fn cas_finalize_orphan<C: DBRunner>(
+        &self,
+        runner: &C,
+        turn_id: Uuid,
+        timeout_secs: u64,
+    ) -> Result<u64, DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let cutoff = now - time::Duration::seconds(timeout_secs.cast_signed());
+        let scope = AccessScope::allow_all();
+        let result = TurnEntity::update_many()
+            .col_expr(Column::State, Expr::value(TurnState::Failed.into_value()))
+            .col_expr(
+                Column::ErrorCode,
+                Expr::value(Some("orphan_timeout".to_owned())),
+            )
+            .col_expr(Column::CompletedAt, Expr::value(now))
+            .col_expr(Column::UpdatedAt, Expr::value(now))
+            .filter(
+                Condition::all()
+                    .add(Column::Id.eq(turn_id))
+                    .add(Column::State.eq(TurnState::Running))
+                    .add(Column::DeletedAt.is_null())
+                    .add(Column::LastProgressAt.lte(cutoff)),
+            )
+            .secure()
+            .scope_with(&scope)
+            .exec(runner)
+            .await?;
+        Ok(result.rows_affected)
+    }
+
     async fn find_latest_turn<C: DBRunner>(
         &self,
         runner: &C,
@@ -253,5 +332,355 @@ impl crate::domain::repos::TurnRepository for TurnRepository {
             .order_by(Column::Id, Order::Desc)
             .one(runner)
             .await?)
+    }
+
+    async fn update_preflight_fields<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        params: crate::domain::repos::UpdatePreflightParams,
+    ) -> Result<u64, DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let result = TurnEntity::update_many()
+            .col_expr(
+                Column::ReserveTokens,
+                Expr::value(Some(params.reserve_tokens)),
+            )
+            .col_expr(
+                Column::MaxOutputTokensApplied,
+                Expr::value(Some(params.max_output_tokens_applied)),
+            )
+            .col_expr(
+                Column::ReservedCreditsMicro,
+                Expr::value(Some(params.reserved_credits_micro)),
+            )
+            .col_expr(
+                Column::PolicyVersionApplied,
+                Expr::value(Some(params.policy_version_applied)),
+            )
+            .col_expr(
+                Column::EffectiveModel,
+                Expr::value(Some(params.effective_model)),
+            )
+            .col_expr(
+                Column::MinimalGenerationFloorApplied,
+                Expr::value(Some(params.minimal_generation_floor_applied)),
+            )
+            .col_expr(Column::UpdatedAt, Expr::value(now))
+            .filter(
+                Condition::all()
+                    .add(Column::Id.eq(params.turn_id))
+                    .add(Column::State.eq(TurnState::Running)),
+            )
+            .secure()
+            .scope_with(scope)
+            .exec(runner)
+            .await?;
+        Ok(result.rows_affected)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use crate::domain::repos::{CreateTurnParams, TurnRepository as TurnRepoTrait};
+    use crate::domain::service::test_helpers::{inmem_db, insert_chat, mock_db_provider};
+    use crate::infra::db::entity::chat_turn::TurnState;
+    use modkit_security::AccessScope;
+    use uuid::Uuid;
+
+    /// Helper: backdate `last_progress_at` via `SeaORM` `update_many`.
+    async fn backdate_progress(runner: &impl modkit_db::secure::DBRunner, turn_id: Uuid) {
+        let past = OffsetDateTime::now_utc() - time::Duration::seconds(600);
+        let scope = AccessScope::allow_all();
+        TurnEntity::update_many()
+            .col_expr(
+                Column::LastProgressAt,
+                sea_orm::sea_query::Expr::value(Some(past)),
+            )
+            .filter(Column::Id.eq(turn_id))
+            .secure()
+            .scope_with(&scope)
+            .exec(runner)
+            .await
+            .expect("backdate last_progress_at");
+    }
+
+    /// Helper: insert a running turn with standard params.
+    async fn setup_running_turn(
+        db: &std::sync::Arc<modkit_db::DBProvider<modkit_db::DbError>>,
+    ) -> (Uuid, Uuid, Uuid, Uuid) {
+        let tenant_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+
+        insert_chat(db, tenant_id, chat_id).await;
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let repo = TurnRepository;
+        repo.create_turn(
+            &conn,
+            &scope,
+            CreateTurnParams {
+                id: turn_id,
+                tenant_id,
+                chat_id,
+                request_id,
+                requester_type: "user".to_owned(),
+                requester_user_id: Some(Uuid::new_v4()),
+                reserve_tokens: Some(100),
+                max_output_tokens_applied: Some(4096),
+                reserved_credits_micro: Some(1000),
+                policy_version_applied: Some(1),
+                effective_model: Some("gpt-5.2".to_owned()),
+                minimal_generation_floor_applied: Some(10),
+            },
+        )
+        .await
+        .expect("create turn");
+
+        (tenant_id, chat_id, turn_id, request_id)
+    }
+
+    // ── Phase 1: create_turn_sets_last_progress_at ──
+
+    #[tokio::test]
+    async fn create_turn_sets_last_progress_at() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, chat_id, _, request_id) = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let repo = TurnRepository;
+        let turn = repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .unwrap()
+            .expect("turn should exist");
+
+        assert!(
+            turn.last_progress_at.is_some(),
+            "last_progress_at should be set on creation"
+        );
+        let elapsed = (OffsetDateTime::now_utc() - turn.last_progress_at.unwrap()).whole_seconds();
+        assert!(
+            elapsed.abs() < 5,
+            "last_progress_at should be approximately now (delta={elapsed}s)"
+        );
+    }
+
+    // ── Phase 2: update_progress_at ──
+
+    #[tokio::test]
+    async fn update_progress_at_updates_running_turn() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, chat_id, turn_id, request_id) = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let repo = TurnRepository;
+
+        // Record initial last_progress_at
+        let before = repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let initial = before.last_progress_at.unwrap();
+
+        // Briefly sleep to ensure timestamp changes
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        let rows = repo
+            .update_progress_at(&conn, &scope, turn_id)
+            .await
+            .unwrap();
+        assert_eq!(rows, 1, "should update one row");
+
+        let after = repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .unwrap()
+            .unwrap();
+        // SQLite may not advance subsecond, so >= is the strongest
+        // portable check. The rows_affected == 1 assertion above proves
+        // the UPDATE executed.
+        assert!(
+            after.last_progress_at.unwrap() >= initial,
+            "last_progress_at must not go backwards"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_progress_at_noop_on_terminal() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, _, turn_id, _) = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let repo = TurnRepository;
+
+        // Finalize the turn to Failed
+        repo.cas_update_state(
+            &conn,
+            &scope,
+            crate::domain::repos::CasTerminalParams {
+                turn_id,
+                state: TurnState::Failed,
+                error_code: Some("test".to_owned()),
+                error_detail: None,
+                assistant_message_id: None,
+                provider_response_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let rows = repo
+            .update_progress_at(&conn, &scope, turn_id)
+            .await
+            .unwrap();
+        assert_eq!(rows, 0, "should not update a terminal turn");
+    }
+
+    // ── Phase 3: find_orphan_candidates ──
+
+    #[tokio::test]
+    async fn find_orphan_candidates_returns_stale_running() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, _, turn_id, _) = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        backdate_progress(&conn, turn_id).await;
+
+        let repo = TurnRepository;
+        let candidates = repo.find_orphan_candidates(&conn, 60, 100).await.unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].id, turn_id);
+    }
+
+    #[tokio::test]
+    async fn find_orphan_candidates_excludes_recent_progress() {
+        let db = mock_db_provider(inmem_db().await);
+        let _ = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        let repo = TurnRepository;
+        let candidates = repo.find_orphan_candidates(&conn, 60, 100).await.unwrap();
+        assert!(
+            candidates.is_empty(),
+            "recent turn should not be an orphan candidate"
+        );
+    }
+
+    #[tokio::test]
+    async fn find_orphan_candidates_excludes_terminal() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, _, turn_id, _) = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let repo = TurnRepository;
+
+        // Finalize to Failed
+        repo.cas_update_state(
+            &conn,
+            &scope,
+            crate::domain::repos::CasTerminalParams {
+                turn_id,
+                state: TurnState::Failed,
+                error_code: Some("test".to_owned()),
+                error_detail: None,
+                assistant_message_id: None,
+                provider_response_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Make it look old
+        backdate_progress(&conn, turn_id).await;
+
+        let candidates = repo.find_orphan_candidates(&conn, 60, 100).await.unwrap();
+        assert!(
+            candidates.is_empty(),
+            "terminal turn should not be an orphan candidate"
+        );
+    }
+
+    // ── Phase 3: cas_finalize_orphan ──
+
+    #[tokio::test]
+    async fn cas_finalize_orphan_transitions_to_failed() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, chat_id, turn_id, request_id) = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        // Make it stale
+        backdate_progress(&conn, turn_id).await;
+
+        let repo = TurnRepository;
+        let rows = repo.cas_finalize_orphan(&conn, turn_id, 60).await.unwrap();
+        assert_eq!(rows, 1, "CAS should succeed for stale running turn");
+
+        let scope = AccessScope::allow_all();
+        let turn = repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .unwrap()
+            .expect("turn should exist");
+        assert_eq!(turn.state, TurnState::Failed);
+        assert_eq!(turn.error_code.as_deref(), Some("orphan_timeout"));
+        assert!(turn.completed_at.is_some(), "completed_at should be set");
+    }
+
+    #[tokio::test]
+    async fn cas_finalize_orphan_noop_if_progress_renewed() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, _, turn_id, _) = setup_running_turn(&db).await;
+
+        // last_progress_at is fresh (just created) — CAS should fail
+        let conn = db.conn().unwrap();
+        let repo = TurnRepository;
+        let rows = repo.cas_finalize_orphan(&conn, turn_id, 60).await.unwrap();
+        assert_eq!(
+            rows, 0,
+            "CAS should fail when progress was renewed (P1 safety invariant)"
+        );
+    }
+
+    #[tokio::test]
+    async fn cas_finalize_orphan_noop_if_already_terminal() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, _, turn_id, _) = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let repo = TurnRepository;
+
+        // Finalize normally first
+        repo.cas_update_state(
+            &conn,
+            &scope,
+            crate::domain::repos::CasTerminalParams {
+                turn_id,
+                state: TurnState::Failed,
+                error_code: Some("test".to_owned()),
+                error_detail: None,
+                assistant_message_id: None,
+                provider_response_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Make it look old
+        backdate_progress(&conn, turn_id).await;
+
+        let rows = repo.cas_finalize_orphan(&conn, turn_id, 60).await.unwrap();
+        assert_eq!(rows, 0, "CAS should fail for already terminal turn");
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/metrics.rs
+++ b/modules/mini-chat/mini-chat/src/infra/metrics.rs
@@ -184,9 +184,10 @@ pub struct MiniChatMetricsMeter {
     #[allow(dead_code)]
     image_turns: Counter<u64>,
 
-    // ── P2: Orphan watchdog (deferred: watchdog not implemented) ──
-    #[allow(dead_code)]
-    orphan_turn: Counter<u64>,
+    // ── P1: Orphan Watchdog ──────────────────────────────────────────────
+    orphan_detected: Counter<u64>,
+    orphan_finalized: Counter<u64>,
+    orphan_scan_duration: Histogram<f64>,
 
     // ── Low-priority deferred ──────────────────────────────────────────
     #[allow(dead_code)]
@@ -557,10 +558,18 @@ impl MiniChatMetricsMeter {
                 .with_description("Turns that included >=1 image")
                 .build(),
 
-            // deferred: orphan watchdog not implemented
-            orphan_turn: meter
-                .u64_counter(format!("{prefix}_orphan_turn"))
+            // ── P1: Orphan Watchdog ──────────────────────────────────────
+            orphan_detected: meter
+                .u64_counter(format!("{prefix}_orphan_detected"))
                 .with_description("Orphan turns detected by watchdog")
+                .build(),
+            orphan_finalized: meter
+                .u64_counter(format!("{prefix}_orphan_finalized"))
+                .with_description("Orphan turns finalized by watchdog (CAS won)")
+                .build(),
+            orphan_scan_duration: meter
+                .f64_histogram(format!("{prefix}_orphan_scan_duration_seconds"))
+                .with_description("Watchdog scan execution duration")
                 .build(),
 
             // deferred: low-priority
@@ -802,6 +811,22 @@ impl MiniChatMetricsPort for MiniChatMetricsMeter {
             u64::from(count),
             &[KeyValue::new(key::MODEL, model.to_owned())],
         );
+    }
+
+    // ── P1: Orphan Watchdog ───────────────────────────────────────────
+
+    fn record_orphan_detected(&self, reason: &str) {
+        self.orphan_detected
+            .add(1, &[KeyValue::new(key::REASON, reason.to_owned())]);
+    }
+
+    fn record_orphan_finalized(&self, reason: &str) {
+        self.orphan_finalized
+            .add(1, &[KeyValue::new(key::REASON, reason.to_owned())]);
+    }
+
+    fn record_orphan_scan_duration_seconds(&self, seconds: f64) {
+        self.orphan_scan_duration.record(seconds, &[]);
     }
 
     // ── P1: Cleanup ──────────────────────────────────────────────────

--- a/modules/mini-chat/mini-chat/src/infra/workers/orphan_watchdog.rs
+++ b/modules/mini-chat/mini-chat/src/infra/workers/orphan_watchdog.rs
@@ -1,26 +1,44 @@
 //! Orphan watchdog — detects and finalizes turns abandoned by crashed pods.
 //!
 //! Requires leader election: exactly one active watchdog instance per environment.
-//!
-//! **P1 stub**: runs the periodic loop, logs each tick, but performs no actual
-//! scan or finalization. Real logic will be added when domain services and
-//! repository access are wired in.
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{debug, error, info, warn};
 
 use crate::config::OrphanWatchdogConfig;
+use mini_chat_sdk::RequesterType;
+
+use crate::domain::model::finalization::OrphanFinalizationInput;
+use crate::domain::ports::MiniChatMetricsPort;
+use crate::domain::repos::{MessageRepository, TurnRepository};
+use crate::domain::service::DbProvider;
+use crate::domain::service::finalization_service::FinalizationService;
+use crate::infra::db::entity::chat_turn::Model as TurnModel;
 use crate::infra::leader::{LeaderElector, work_fn};
+
+/// Dependencies for the orphan watchdog scan-finalize loop.
+pub struct OrphanWatchdogDeps<TR: TurnRepository + 'static, MR: MessageRepository + 'static> {
+    pub finalization_svc: Arc<FinalizationService<TR, MR>>,
+    pub turn_repo: Arc<TR>,
+    pub db: Arc<DbProvider>,
+    /// Metrics port for recording orphan detection/finalization metrics.
+    /// Wired in Phase 6 when orphan-specific metric methods are added to `MiniChatMetricsPort`.
+    pub metrics: Arc<dyn MiniChatMetricsPort>,
+}
+
+/// Maximum number of orphan candidates to process per scan tick.
+const BATCH_LIMIT: u32 = 100;
 
 /// Run the orphan watchdog under leader election.
 ///
 /// Returns when `cancel` fires (module shutdown) or on unrecoverable error.
-pub async fn run(
+pub async fn run<TR: TurnRepository + 'static, MR: MessageRepository + 'static>(
     elector: Arc<dyn LeaderElector>,
     config: OrphanWatchdogConfig,
+    deps: OrphanWatchdogDeps<TR, MR>,
     cancel: CancellationToken,
 ) -> anyhow::Result<()> {
     if !config.enabled {
@@ -35,6 +53,7 @@ pub async fn run(
     );
 
     let interval = Duration::from_secs(config.scan_interval_secs);
+    let deps = Arc::new(deps);
 
     elector
         .run_role(
@@ -42,6 +61,8 @@ pub async fn run(
             cancel,
             work_fn(move |cancel| {
                 let interval = interval;
+                let deps = Arc::clone(&deps);
+                let config = config.clone();
                 async move {
                     let mut ticker = tokio::time::interval(interval);
                     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -49,7 +70,24 @@ pub async fn run(
                     loop {
                         tokio::select! {
                             _ = ticker.tick() => {
-                                info!("orphan_watchdog: tick (stub -- no scan yet)");
+                                let scan_start = std::time::Instant::now();
+
+                                let result = scan_and_finalize(&deps, &config, &cancel).await;
+
+                                // Always record scan duration — even on error — so
+                                // dashboards detect silent watchdog failures.
+                                deps.metrics.record_orphan_scan_duration_seconds(
+                                    scan_start.elapsed().as_secs_f64(),
+                                );
+
+                                if let Err(()) = result {
+                                    // scan_and_finalize already logged the error.
+                                    continue;
+                                }
+                                if result == Ok(true) {
+                                    // Shutdown requested mid-scan.
+                                    return Ok(());
+                                }
                             }
                             () = cancel.cancelled() => {
                                 info!("orphan_watchdog: shutting down");
@@ -61,6 +99,110 @@ pub async fn run(
             }),
         )
         .await
+}
+
+#[allow(
+    clippy::cognitive_complexity,
+    reason = "linear scan-finalize loop, complexity from match arms"
+)]
+/// Run one scan-finalize cycle. Returns:
+/// - `Ok(false)` — scan completed normally
+/// - `Ok(true)` — shutdown requested mid-scan
+/// - `Err(())` — scan failed (already logged)
+async fn scan_and_finalize<TR: TurnRepository + 'static, MR: MessageRepository + 'static>(
+    deps: &OrphanWatchdogDeps<TR, MR>,
+    config: &OrphanWatchdogConfig,
+    cancel: &CancellationToken,
+) -> Result<bool, ()> {
+    let conn = deps.db.conn().map_err(|e| {
+        error!(error = %e, "orphan_watchdog: failed to get DB connection");
+    })?;
+
+    let candidates = deps
+        .turn_repo
+        .find_orphan_candidates(&conn, config.timeout_secs, BATCH_LIMIT)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "orphan_watchdog: scan query failed");
+        })?;
+
+    if candidates.is_empty() {
+        debug!("orphan_watchdog: scan completed, no candidates");
+    } else {
+        info!(count = candidates.len(), "orphan_watchdog: scan completed");
+    }
+
+    for turn in &candidates {
+        if cancel.is_cancelled() {
+            info!("orphan_watchdog: shutting down mid-scan");
+            return Ok(true);
+        }
+
+        deps.metrics.record_orphan_detected("stale_progress");
+
+        let input = orphan_input_from_turn(turn);
+        match deps
+            .finalization_svc
+            .finalize_orphan_turn(input, config.timeout_secs)
+            .await
+        {
+            Ok(true) => {
+                deps.metrics.record_orphan_finalized("stale_progress");
+                info!(
+                    turn_id = %turn.id,
+                    tenant_id = %turn.tenant_id,
+                    chat_id = %turn.chat_id,
+                    "orphan_watchdog: finalized orphan turn"
+                );
+            }
+            Ok(false) => {
+                debug!(
+                    turn_id = %turn.id,
+                    "orphan_watchdog: CAS lost (already finalized or progress renewed)"
+                );
+            }
+            Err(e) => {
+                error!(
+                    turn_id = %turn.id,
+                    error = %e,
+                    "orphan_watchdog: finalization error"
+                );
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+/// Build [`OrphanFinalizationInput`] from an infra entity.
+/// Lives in the infra layer to avoid domain→infra coupling.
+fn orphan_input_from_turn(turn: &TurnModel) -> OrphanFinalizationInput {
+    let requester_type = match turn.requester_type.as_str() {
+        "system" => RequesterType::System,
+        "user" => RequesterType::User,
+        other => {
+            warn!(
+                requester_type = other,
+                "orphan_watchdog: unknown requester_type, defaulting to User"
+            );
+            RequesterType::User
+        }
+    };
+    OrphanFinalizationInput {
+        turn_id: turn.id,
+        tenant_id: turn.tenant_id,
+        chat_id: turn.chat_id,
+        request_id: turn.request_id,
+        user_id: turn.requester_user_id,
+        requester_type,
+        effective_model: turn.effective_model.clone(),
+        reserve_tokens: turn.reserve_tokens,
+        max_output_tokens_applied: turn.max_output_tokens_applied,
+        reserved_credits_micro: turn.reserved_credits_micro,
+        policy_version_applied: turn.policy_version_applied,
+        minimal_generation_floor_applied: turn.minimal_generation_floor_applied,
+        started_at: turn.started_at,
+    }
 }
 
 #[cfg(test)]
@@ -75,7 +217,8 @@ mod tests {
             enabled: false,
             ..Default::default()
         };
-        let result = run(elector, config, cancel).await;
+        let deps = test_deps().await;
+        let result = run(elector, config, deps, cancel).await;
         assert!(result.is_ok());
     }
 
@@ -84,14 +227,105 @@ mod tests {
         let elector = crate::infra::leader::noop();
         let cancel = CancellationToken::new();
         let config = OrphanWatchdogConfig::default();
+        let deps = test_deps().await;
 
         let c = cancel.clone();
-        let handle = tokio::spawn(async move { run(elector, config, c).await });
+        let handle = tokio::spawn(async move { run(elector, config, deps, c).await });
 
         tokio::time::sleep(Duration::from_millis(50)).await;
         cancel.cancel();
 
         let result = tokio::time::timeout(Duration::from_secs(2), handle).await;
         assert!(matches!(result, Ok(Ok(Ok(())))));
+    }
+
+    /// Build minimal test deps using the concrete infra repos and an in-memory `SQLite` DB.
+    async fn test_deps() -> OrphanWatchdogDeps<
+        crate::infra::db::repo::turn_repo::TurnRepository,
+        crate::infra::db::repo::message_repo::MessageRepository,
+    > {
+        use crate::domain::ports::metrics::NoopMetrics;
+        use crate::domain::service::test_helpers::{inmem_db, mock_db_provider};
+        use crate::infra::db::repo::message_repo::MessageRepository as MsgRepo;
+        use crate::infra::db::repo::turn_repo::TurnRepository as TurnRepo;
+
+        let db = mock_db_provider(inmem_db().await);
+        let turn_repo = Arc::new(TurnRepo);
+        let message_repo = Arc::new(MsgRepo::new(modkit_db::odata::LimitCfg {
+            default: 20,
+            max: 100,
+        }));
+
+        let finalization_svc = Arc::new(FinalizationService::new(
+            Arc::clone(&db),
+            Arc::clone(&turn_repo),
+            Arc::clone(&message_repo),
+            Arc::new(NoopQuotaSettler)
+                as Arc<dyn crate::domain::service::quota_settler::QuotaSettler>,
+            Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
+            Arc::new(NoopMetrics),
+        ));
+
+        OrphanWatchdogDeps {
+            finalization_svc,
+            turn_repo,
+            db,
+            metrics: Arc::new(NoopMetrics),
+        }
+    }
+
+    struct NoopQuotaSettler;
+
+    #[async_trait::async_trait]
+    impl crate::domain::service::quota_settler::QuotaSettler for NoopQuotaSettler {
+        async fn settle_in_tx(
+            &self,
+            _tx: &modkit_db::secure::DbTx<'_>,
+            _scope: &modkit_security::AccessScope,
+            _input: crate::domain::model::quota::SettlementInput,
+        ) -> Result<crate::domain::model::quota::SettlementOutcome, crate::domain::error::DomainError>
+        {
+            Ok(crate::domain::model::quota::SettlementOutcome {
+                settlement_method: crate::domain::model::quota::SettlementMethod::Estimated,
+                actual_credits_micro: 0,
+                charged_tokens: 0,
+                overshoot_capped: false,
+            })
+        }
+    }
+
+    struct NoopOutboxEnqueuer;
+
+    #[async_trait::async_trait]
+    impl crate::domain::repos::OutboxEnqueuer for NoopOutboxEnqueuer {
+        async fn enqueue_usage_event(
+            &self,
+            _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+            _event: mini_chat_sdk::UsageEvent,
+        ) -> Result<(), crate::domain::error::DomainError> {
+            Ok(())
+        }
+        async fn enqueue_attachment_cleanup(
+            &self,
+            _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+            _event: crate::domain::repos::AttachmentCleanupEvent,
+        ) -> Result<(), crate::domain::error::DomainError> {
+            Ok(())
+        }
+        async fn enqueue_chat_cleanup(
+            &self,
+            _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+            _event: crate::domain::repos::ChatCleanupEvent,
+        ) -> Result<(), crate::domain::error::DomainError> {
+            Ok(())
+        }
+        async fn enqueue_audit_event(
+            &self,
+            _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+            _event: crate::domain::model::audit_envelope::AuditEnvelope,
+        ) -> Result<(), crate::domain::error::DomainError> {
+            Ok(())
+        }
+        fn flush(&self) {}
     }
 }

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -540,8 +540,25 @@ impl RunnableCapability for MiniChatModule {
             info!("Outbox pipeline started (OAGW ready)");
         }
 
+        let orphan_deps = if wc.orphan_watchdog.enabled {
+            let services = self.service.get().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "{} not initialized - init() must run before start()",
+                    Self::MODULE_NAME
+                )
+            })?;
+            Some(crate::infra::workers::orphan_watchdog::OrphanWatchdogDeps {
+                finalization_svc: Arc::clone(&services.finalization),
+                turn_repo: Arc::clone(&services.turn_repo),
+                db: Arc::clone(&services.db),
+                metrics: Arc::clone(&services.metrics),
+            })
+        } else {
+            None
+        };
+
         let (handles, worker_cancel) =
-            background_workers::spawn_workers(wc, &cancel, leader_elector.as_ref())?;
+            background_workers::spawn_workers(wc, &cancel, leader_elector.as_ref(), orphan_deps)?;
         self.store_worker_runtime(handles, worker_cancel).await?;
 
         Ok(())

--- a/testing/e2e/modules/mini_chat/config/base.yaml
+++ b/testing/e2e/modules/mini_chat/config/base.yaml
@@ -115,6 +115,12 @@ modules:
       # Default (4) spawns too many concurrent writers for a single SQLite file.
       outbox:
         num_partitions: 2
+      # Orphan watchdog: use minimum allowed timeout (90s) and frequent scans
+      # to make e2e orphan detection tests feasible (default 300s is too slow).
+      orphan_watchdog:
+        enabled: true
+        scan_interval_secs: 2
+        timeout_secs: 90
       # S2S credentials for obtaining SecurityContext
       # that will be used for communication with other modules.
       client_credentials:

--- a/testing/e2e/modules/mini_chat/test_cleanup.py
+++ b/testing/e2e/modules/mini_chat/test_cleanup.py
@@ -201,13 +201,20 @@ class TestCleanup:
         assert att_resp.status_code == 404
 
     def test_orphan_watchdog_detects_stuck_turn(self, chat, mock_provider):
-        # TODO: Requires waiting for orphan timeout (5 min default). Too slow
-        # for regular e2e tests. This test uses disconnect detection (faster)
-        # as a proxy for orphan watchdog behavior.
+        # This test verifies that a disconnected streaming turn reaches a
+        # terminal state. With the test config (orphan_watchdog.timeout_secs=60,
+        # scan_interval_secs=2), the orphan watchdog will detect and finalize
+        # any truly stuck turn within ~62s. However, the server's disconnect
+        # detection (via SSE channel closure) usually finalizes the turn as
+        # "cancelled" much faster. Both paths produce a correct terminal state.
+        #
+        # The orphan watchdog is the safety net for cases where disconnect
+        # detection fails (e.g., pod crash). That path is covered by the
+        # unit tests in turn_repo.rs and finalization_service.rs.
         chat_id = chat["id"]
         request_id = str(uuid.uuid4())
 
-        # Very slow scenario
+        # Very slow scenario — ensures the mock provider doesn't finish naturally
         many_deltas = [
             MockEvent("response.output_text.delta", {"delta": f"w{i} "})
             for i in range(30)
@@ -220,7 +227,7 @@ class TestCleanup:
         url = f"{API_PREFIX}/chats/{chat_id}/messages:stream"
         body = {"content": "Stuck turn test.", "request_id": request_id}
 
-        # Start stream and disconnect immediately
+        # Start stream and disconnect immediately — turn stays running
         with httpx.stream(
             "POST", url, json=body,
             headers={"Accept": "text/event-stream"},
@@ -229,13 +236,29 @@ class TestCleanup:
             assert resp.status_code == 200
             # disconnect immediately
 
-        # Poll until turn reaches terminal state
+        # Poll until turn reaches terminal state.
+        # Disconnect detection should resolve this within a few seconds.
+        # The orphan watchdog is the fallback (60s+ timeout).
         turn = poll_turn_terminal(chat_id, request_id, timeout=30.0)
-        assert turn["state"] in ("cancelled", "error"), f"Expected cancelled/error for orphan, got {turn['state']}"
+        assert turn["state"] in ("cancelled", "error"), (
+            f"Expected cancelled (disconnect) or error (orphan), got {turn['state']}"
+        )
+        # If the orphan watchdog resolved it, error_code will be "orphan_timeout".
+        # If disconnect detection resolved it, state will be "cancelled".
+        if turn["state"] == "error":
+            assert turn.get("error_code") == "orphan_timeout", (
+                f"Expected orphan_timeout error_code, got {turn.get('error_code')}"
+            )
 
     def test_orphan_settlement_estimated(self, chat, mock_provider):
-        # TODO: Timing dependent on orphan watchdog interval. This test
-        # uses disconnect detection as a proxy.
+        # Verify that quota reserves are released after an orphan-like turn
+        # terminates. Both disconnect detection (cancel -> estimated settlement)
+        # and orphan watchdog (failed -> estimated settlement) release reserves.
+        #
+        # This test uses disconnect-as-proxy because true orphan detection
+        # requires the minimum 60s timeout, which is too slow for regular CI.
+        # The settlement path is identical — both derive BillingOutcome::Aborted
+        # and use SettlementPath::Estimated.
         chat_id = chat["id"]
         request_id = str(uuid.uuid4())
 
@@ -261,10 +284,13 @@ class TestCleanup:
             for _ in resp.iter_bytes(chunk_size=256):
                 break
 
-        # Wait for resolution
+        # Wait for terminal state
         turn = poll_turn_terminal(chat_id, request_id, timeout=30.0)
-        assert turn["state"] in ("cancelled", "error"), f"Expected cancelled/error for orphan, got {turn['state']}"
+        assert turn["state"] in ("cancelled", "error"), (
+            f"Expected cancelled (disconnect) or error (orphan), got {turn['state']}"
+        )
 
+        # Verify no stuck reserves — settlement should have released them
         time.sleep(0.5)
         assert not has_stuck_reserves(), (
             "Stuck reserves after orphan-like turn settlement"


### PR DESCRIPTION
Add orphan watchdog that detects stuck running turns (stale last_progress_at) and finalizes them with error_code='orphan_timeout' via CAS-guarded transaction.

- Add `last_progress_at` column to chat_turns with migration and partial index
- Throttled progress heartbeat (30s) during SSE streaming
- Repository methods: update_progress_at, find_orphan_candidates, cas_finalize_orphan
- Orphan finalization in FinalizationService with billing/quota/audit/outbox
- Wire OrphanWatchdogDeps into background worker and module startup
- Orphan-specific metrics: detected, finalized, scan_duration_seconds
- stream_service.rs (~7KLOC) is split for several files
- Unit tests for repo, finalization (CAS winner/loser/missing fields), watchdog
- Update e2e config and test_cleanup assertions for orphan watchdog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orphan watchdog: periodic scans detect and finalize stuck turns (marked as orphan_timeout); streaming now updates progress timestamps to support detection.
  * Streaming: improved provider task with tool-call limits, guarded terminal emissions, and stronger finalization handling.

* **Database**
  * Migration and model change to persist last-progress timestamps and index running turns.

* **Metrics**
  * New orphan metrics: detected, finalized, and scan-duration.

* **Refactor**
  * Stream service split into clearer modules and shared finalization context.

* **Tests**
  * Expanded unit and e2e coverage for orphan flows, CAS outcomes, settlement, and progress updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->