### PR TITLE
feat(serverless-runtime): add ADRs for Serverless Workflow Specification and Temporal

### DIFF
--- a/modules/serverless-runtime/docs/ADR/0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md
+++ b/modules/serverless-runtime/docs/ADR/0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md
@@ -1,0 +1,140 @@
+<!--
+Created:  2026-03-30 by Constructor Tech
+Updated:  2026-03-30 by Constructor Tech
+-->
+---
+status: proposed
+date: 2026-03-30
+---
+<!--
+=============================================================================
+ARCHITECTURE DECISION RECORD (ADR) — based on MADR format
+=============================================================================
+PURPOSE: Capture WHY the Serverless Workflow Specification was chosen as the
+workflow definition language for the Serverless Runtime.
+
+RULES:
+- ADRs represent actual decision dilemma and decision state
+- DESIGN is the primary artifact ("what"); ADRs annotate DESIGN with rationale ("why")
+- Use single ADR per decision
+
+STANDARDS ALIGNMENT:
+- MADR (Markdown Any Decision Records)
+- IEEE 42010 (architecture decisions as first-class elements)
+- ISO/IEC 15288 / 12207 (decision analysis process)
+  ==============================================================================
+  -->
+# ADR — Serverless Workflow Specification as Workflow DSL
+
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Option A: Serverless Workflow Specification (CNCF)](#option-a-serverless-workflow-specification-cncf)
+  - [Option B: Amazon States Language (ASL)](#option-b-amazon-states-language-asl)
+  - [Option C: BPMN 2.0](#option-c-bpmn-20)
+  - [Option D: Custom DSL](#option-d-custom-dsl)
+  - [Option E: Code-only (no declarative DSL)](#option-e-code-only-no-declarative-dsl)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+`p1` - **ID**: `cpt-cf-serverless-runtime-adr-workflow-dsl`
+## Context and Problem Statement
+
+The Serverless Runtime needs a workflow definition language that workflow authors use to express orchestration logic — sequential steps, conditional branching, loops, parallel execution, error handling, and sub-workflow composition. This language defines how workflows are authored, validated, and submitted to the platform.
+
+The choice of definition language is separable from the choice of execution engine. The DSL defines the workflow format and validation rules; the engine interprets and executes it. A vendor-neutral DSL allows the workflow format to remain stable even if the execution engine changes.
+
+## Decision Drivers
+
+* The specification language should be vendor-neutral to avoid coupling the workflow format to a specific engine
+* The specification language should use a declarative format (JSON/YAML) for readability and tooling compatibility
+* The specification language must support the control-flow constructs required by the PRD: sequential steps, conditional branching, loops, parallel execution, error handling, and sub-workflow composition (BR-010, BR-104, BR-105). Compensation support (BR-133) must be achievable through task composition
+* The specification must support validation of workflow definitions before execution, with actionable error feedback (BR-011)
+* The format must be interpretable at runtime without compilation, so that workflows can be submitted and modified through an API without code deployments (BR-001)
+* The format must support versioning and schema evolution as workflow capabilities expand
+
+## Considered Options
+
+* **Option A**: Serverless Workflow Specification (CNCF)
+* **Option B**: Amazon States Language (ASL)
+* **Option C**: BPMN 2.0 (Business Process Model and Notation)
+* **Option D**: Custom DSL (platform-specific workflow language)
+* **Option E**: Code-only (no declarative DSL)
+
+## Decision Outcome
+
+Chosen option: **"Option A: Serverless Workflow Specification (CNCF)"**, because it is a vendor-neutral, CNCF-backed standard with a well-defined JSON/YAML schema that covers all required control-flow constructs (sequential, conditional, parallel, error handling, sub-workflows). Compensation patterns can be achieved through task composition (Try/Raise). It decouples the workflow definition format from the execution engine, enabling workflow portability. Its declarative JSON/YAML format supports validation at submission time and is suitable for programmatic generation and visualization.
+
+### Consequences
+
+* Workflow validation is built against the CNCF Serverless Workflow JSON Schema rather than a proprietary format. Workflow definitions are validated at submission time.
+* Workflow definitions are authored in JSON or YAML following the Serverless Workflow Specification. The specification defines 12 task types.
+* The specification is at v1.0.0 (released January 2025). Workflow definitions should declare their specification version for forward compatibility as the specification evolves.
+* Expression evaluation uses jq as the default expression language, as specified by the Serverless Workflow Specification.
+* The DSL supports declarative authentication definitions, enabling workflow authors to declare authentication requirements alongside workflow logic.
+
+### Confirmation
+
+* A sample workflow definition is correctly parsed and validated against the Serverless Workflow Specification schema
+* Validation rejects workflows using unsupported task types with clear error messages identifying the unsupported type
+* jq expressions within workflow definitions are syntactically valid and parseable
+* Workflow definitions round-trip through JSON/YAML serialization without data loss
+
+## Pros and Cons of the Options
+
+### Option A: Serverless Workflow Specification (CNCF)
+
+The Serverless Workflow Specification is a CNCF project that defines a vendor-neutral, declarative workflow language in JSON/YAML. It covers function invocation, event handling, branching, parallel execution, error handling, and sub-workflow composition. Compensation patterns can be implemented through task composition (Try/Raise).
+
+| | Aspect | Note |
+|---|--------|------|
+| Good | Vendor-neutral, CNCF-backed standard | No lock-in to a specific engine; workflows are portable across compliant runtimes |
+| Good | Comprehensive control-flow constructs | Supports all required patterns: sequential (Do), conditional (Switch), parallel (Fork), error handling (Try), sub-workflows, loops (For), event-driven (Listen/Emit) |
+| Good | Declarative JSON/YAML format | Suitable for validation at submission time and programmatic generation |
+| Good | SDKs in major languages | SDKs available for Go, Java, .NET, Python, Rust, TypeScript; project is CNCF-backed with growing adoption |
+| Bad | Relatively new standard (v1.0.0, Jan 2025) | Ecosystem is still growing; fewer production deployments compared to established alternatives |
+
+### Option B: Amazon States Language (ASL)
+
+Amazon States Language is the JSON-based workflow definition format used by AWS Step Functions.
+
+| | Aspect | Note |
+|---|--------|------|
+| Good | Mature ecosystem | Extensive production deployments via AWS Step Functions; well-documented patterns for common orchestration scenarios |
+| Bad | AWS-specific | Tightly coupled to AWS Step Functions; no independent standard body governance |
+| Bad | Limited control-flow | Saga/compensation is achievable via Catch/Retry patterns (AWS publishes official guidance) but is not a first-class construct; error handling (Retry with backoff/jitter, Catch with pattern matching) is capable but less structured than Serverless Workflow Spec's Try task |
+| Bad | No community governance | Amazon controls the specification; no open contribution model |
+
+### Option C: BPMN 2.0
+
+Dismissed early. BPMN is a visual modeling standard — the XML format is generated by graphical editors, not authored by hand or submitted via API. This is a fundamentally different paradigm from a text-based DSL for API-driven workflow registration.
+
+### Option D: Custom DSL
+
+Dismissed early. Building a custom DSL offers perfect fit but requires designing, documenting, and maintaining a language from scratch — with no existing ecosystem, tooling, or portability. The effort is not justified when an existing standard covers the required constructs.
+
+### Option E: Code-only (no declarative DSL)
+
+Dismissed early. Without a declarative DSL, workflows cannot be submitted or modified through an API without code deployments — directly contradicting BR-001. Code-only also couples workflow definitions to the engine SDK, eliminating portability.
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+
+This decision directly addresses the following requirements and design elements:
+
+* `cpt-cf-serverless-runtime-fr-runtime-authoring` — Serverless Workflow Specification provides the declarative format for runtime creation, modification, and registration of workflow definitions with schema-based validation feedback
+* `cpt-cf-serverless-runtime-fr-input-security` — Workflow definitions are validated against defined schemas before execution begins; the DSL's JSON Schema enables structural validation at submission time
+* `cpt-cf-serverless-runtime-fr-advanced-patterns` — DSL supports child workflows (Do with sub-workflow reference), parallel execution (Fork), conditional branching (Switch), loops (For), error handling (Try), and compensation patterns (achievable through Try/Raise composition)
+* `cpt-cf-serverless-runtime-fr-debugging` — Declarative workflow structure supports dry-run validation of definition validity before execution
+* `cpt-cf-serverless-runtime-fr-replay-visualization` — Declarative workflow structure can be parsed to visualize execution blocks and decision branches
+* `cpt-cf-serverless-runtime-principle-impl-agnostic` (DESIGN) — Vendor-neutral DSL ensures workflow definitions are portable across execution engine adapters; workflow format is decoupled from engine choice

--- a/modules/serverless-runtime/docs/ADR/0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md
+++ b/modules/serverless-runtime/docs/ADR/0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md
@@ -3,7 +3,7 @@ Created:  2026-03-30 by Constructor Tech
 Updated:  2026-03-30 by Constructor Tech
 -->
 ---
-status: proposed
+status: accepted
 date: 2026-03-30
 ---
 <!--

--- a/modules/serverless-runtime/docs/ADR/0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md
+++ b/modules/serverless-runtime/docs/ADR/0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md
@@ -45,7 +45,7 @@ STANDARDS ALIGNMENT:
 
 <!-- /toc -->
 
-`p1` - **ID**: `cpt-cf-serverless-runtime-adr-workflow-dsl`
+**ID**: `cpt-cf-serverless-runtime-adr-workflow-dsl`
 ## Context and Problem Statement
 
 The Serverless Runtime needs a workflow definition language that workflow authors use to express orchestration logic — sequential steps, conditional branching, loops, parallel execution, error handling, and sub-workflow composition. This language defines how workflows are authored, validated, and submitted to the platform.

--- a/modules/serverless-runtime/docs/ADR/0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md
+++ b/modules/serverless-runtime/docs/ADR/0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md
@@ -100,6 +100,7 @@ The Serverless Workflow Specification is a CNCF project that defines a vendor-ne
 | Good | Comprehensive control-flow constructs | Supports all required patterns: sequential (Do), conditional (Switch), parallel (Fork), error handling (Try), sub-workflows, loops (For), event-driven (Listen/Emit) |
 | Good | Declarative JSON/YAML format | Suitable for validation at submission time and programmatic generation |
 | Good | SDKs in major languages | SDKs available for Go, Java, .NET, Python, Rust, TypeScript; project is CNCF-backed with growing adoption |
+| Neutral | Declarative verbosity | YAML/JSON definitions are more verbose than code-based alternatives; this is the trade-off for machine-readable validation and tooling support |
 | Bad | Relatively new standard (v1.0.0, Jan 2025) | Ecosystem is still growing; fewer production deployments compared to established alternatives |
 
 ### Option B: Amazon States Language (ASL)

--- a/modules/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
+++ b/modules/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
@@ -89,7 +89,7 @@ The Serverless Runtime domain model defines a pluggable adapter architecture (`c
 
 Chosen option: **"Option A: Temporal"** as the durable execution backend, with a **custom workflow engine layer** built on top using the Temporal Rust SDK.
 
-**Why Temporal**: It is the only option that satisfies all decision drivers — particularly the combination of self-hostable deployment, Rust SDK availability (`temporal-sdk-core` is written in Rust and usable from Rust; standalone `temporalio-sdk` crate is prerelease), proven scale at production users, long-running workflow support (days to years), saga/compensation patterns, and built-in schedule API.
+**Why Temporal**: It is the only option that satisfies all decision drivers — particularly the combination of self-hostable deployment, Rust SDK availability (`temporal-sdk-core` is written in Rust and usable from Rust; standalone `temporalio-sdk` crate is prerelease as of 2026-03-30 — see [sdk-core](https://github.com/temporalio/sdk-core)), proven scale at production users, long-running workflow support (days to years), saga/compensation patterns, and built-in schedule API.
 
 **Why a custom engine layer on top**: Temporal provides durable execution primitives (checkpointing, retry, state persistence, worker management) but does not natively interpret the Serverless Workflow Specification DSL ([ADR-0002](0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md)). A custom engine layer is required to bridge the gap between declarative workflow definitions and Temporal's workflow-as-code model — handling DSL parsing, task execution mapping, expression evaluation, flow control, and data transformation.
 
@@ -119,7 +119,7 @@ Temporal is an open-source durable execution platform that provides workflow orc
 
 | | Aspect | Note |
 |---|--------|------|
-| Good | Rust SDK available (`temporal-sdk-core`) | Written in Rust and usable from Rust; primarily serves as the polyglot core (other language SDKs use it via FFI); standalone `temporalio-sdk` crate is prerelease |
+| Good | Rust SDK available (`temporal-sdk-core`) | Written in Rust and usable from Rust; primarily serves as the polyglot core (other language SDKs use it via FFI); standalone `temporalio-sdk` crate is prerelease (as of 2026-03-30 — see [sdk-core](https://github.com/temporalio/sdk-core)) |
 | Good | Built-in durable execution | Automatic checkpointing, event sourcing, and deterministic replay — workflow state survives infrastructure failures without custom persistence logic |
 | Good | Proven at scale | Production deployments handling high workflow volumes at multiple large-scale users |
 | Good | Long-running workflow support | Workflows can run for days to years with timer-based and event-driven continuation; suspension periods of 30+ days are natively supported |
@@ -134,7 +134,7 @@ Temporal is an open-source durable execution platform that provides workflow orc
 | Bad | Operational complexity | Temporal Server adds infrastructure overhead (server cluster, persistence backend, monitoring) |
 | Bad | Deterministic execution constraints | Engine implementation code must follow Temporal's deterministic replay rules (no side effects in workflow code); this affects engine developers, not workflow authors who write declarative YAML |
 | Bad | Custom engine layer required | Temporal does not natively interpret the Serverless Workflow Specification; a custom DSL interpreter layer adds development and maintenance complexity |
-| Bad | Rust SDK maturity | `temporal-sdk-core` is primarily the polyglot foundation; standalone Rust SDK (`temporalio-sdk`) is prerelease — API stability risk |
+| Bad | Rust SDK maturity | `temporal-sdk-core` is primarily the polyglot foundation; standalone Rust SDK (`temporalio-sdk`) is prerelease (as of 2026-03-30 — see [sdk-core](https://github.com/temporalio/sdk-core)) — API stability risk |
 
 ### Option B: Cadence
 
@@ -210,13 +210,13 @@ Apache Airflow provides DAG-based workflow scheduling and orchestration, primari
 This decision should be revisited if any of the following occur:
 
 * Temporal Rust SDK (`temporal-sdk-core`) is deprecated, archived, or receives no releases for >6 months
-* Temporal Server licensing changes from MIT to a restrictive or commercial-only license
+* Temporal Server licensing changes from MIT (see [LICENSE](https://github.com/temporalio/temporal/blob/main/LICENSE)) to a restrictive or commercial-only license
 * Restate or another engine achieves a production-quality Rust SDK with built-in schedule API and long-running workflow support
 * Operational cost of Temporal Server infrastructure becomes disproportionate to platform infrastructure cost
 
 ### Security Note
 
-Temporal Server adds a network-accessible infrastructure component (gRPC Frontend) that requires security hardening. Temporal supports mTLS and custom authorization plugins; by default no authentication is enforced. Platform security context (`tenant_id`, `user_id`) must be propagated to Temporal via workflow metadata to maintain tenant isolation at the engine level.
+Temporal Server adds a network-accessible infrastructure component (gRPC Frontend) that requires security hardening. Temporal supports mTLS and custom authorization plugins; in self-hosted deployments, no authentication is enforced by default. Platform security context (`tenant_id`, `user_id`) must be propagated to Temporal via workflow metadata to maintain tenant isolation at the engine level.
 
 ## Traceability
 

--- a/modules/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
+++ b/modules/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
@@ -3,7 +3,7 @@ Created:  2026-03-30 by Constructor Tech
 Updated:  2026-03-30 by Constructor Tech
 -->
 ---
-status: proposed
+status: accepted
 date: 2026-03-30
 ---
 <!--

--- a/modules/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
+++ b/modules/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
@@ -49,7 +49,7 @@ STANDARDS ALIGNMENT:
 
 <!-- /toc -->
 
-`p1` - **ID**: `cpt-cf-serverless-runtime-adr-temporal-workflow-engine`
+**ID**: `cpt-cf-serverless-runtime-adr-temporal-workflow-engine`
 ## Context and Problem Statement
 
 The Serverless Runtime domain model defines a pluggable adapter architecture (`cpt-cf-serverless-runtime-principle-pluggable-adapters`) where execution adapters implement the abstract `ServerlessRuntime` trait. The platform needs a workflow engine that:

--- a/modules/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
+++ b/modules/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
@@ -1,0 +1,256 @@
+<!--
+Created:  2026-03-30 by Constructor Tech
+Updated:  2026-03-30 by Constructor Tech
+-->
+---
+status: proposed
+date: 2026-03-30
+---
+<!--
+=============================================================================
+ARCHITECTURE DECISION RECORD (ADR) — based on MADR format
+=============================================================================
+PURPOSE: Capture WHY Temporal was chosen as the durable execution backend
+and WHY a custom workflow engine layer interprets the DSL on top of it.
+
+RULES:
+- ADRs represent actual decision dilemma and decision state
+- DESIGN is the primary artifact ("what"); ADRs annotate DESIGN with rationale ("why")
+- Use single ADR per decision
+
+STANDARDS ALIGNMENT:
+- MADR (Markdown Any Decision Records)
+- IEEE 42010 (architecture decisions as first-class elements)
+- ISO/IEC 15288 / 12207 (decision analysis process)
+  ==============================================================================
+  -->
+# ADR — Temporal-based Workflow Engine
+
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Option A: Temporal](#option-a-temporal)
+  - [Option B: Cadence](#option-b-cadence)
+  - [Option C: Camunda / Zeebe](#option-c-camunda--zeebe)
+  - [Option D: Restate](#option-d-restate)
+  - [Option E: AWS Step Functions](#option-e-aws-step-functions)
+  - [Option F: Apache Airflow](#option-f-apache-airflow)
+- [More Information](#more-information)
+  - [Decision Review Triggers](#decision-review-triggers)
+  - [Security Note](#security-note)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+`p1` - **ID**: `cpt-cf-serverless-runtime-adr-temporal-workflow-engine`
+## Context and Problem Statement
+
+The Serverless Runtime domain model defines a pluggable adapter architecture (`cpt-cf-serverless-runtime-principle-pluggable-adapters`) where execution adapters implement the abstract `ServerlessRuntime` trait. The platform needs a workflow engine that:
+
+1. **Interprets workflow definitions** authored in the Serverless Workflow Specification DSL ([ADR-0002](0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md)) — parsing task definitions, evaluating expressions, managing data flow between steps, and controlling execution flow (branching, loops, error handling).
+2. **Executes workflows durably** — persisting state across service restarts, providing automatic checkpointing, retry, compensation, and long-running workflow support lasting days to months.
+
+
+## Decision Drivers
+
+* The engine must support durable execution with automatic checkpointing, suspend/resume across service restarts, and continuation from the last completed step (BR-003, BR-009)
+* The engine must support long-running workflows lasting days to months, including suspension periods of at least 30 days with event-driven continuation (BR-009)
+* The engine must support durable execution primitives sufficient for saga-style compensation (BR-133)
+* The engine must support idempotency mechanisms including idempotency keys and deduplication windows (BR-134)
+* Multi-tenant isolation is mandatory — one tenant's workflows must not affect another tenant's execution, state, or data (BR-002, BR-036, BR-206)
+* The engine must have a Rust SDK for integration without FFI bridges or sidecar processes (project constraint — the platform is built in Rust)
+* The engine must be self-hostable with no vendor lock-in — the platform must control its own infrastructure (BR-035)
+* The engine must integrate as a standard ModKit plugin module, following the established plugin architecture pattern (DESIGN: `cpt-cf-serverless-runtime-principle-pluggable-adapters`)
+* The engine must implement the `ServerlessRuntime` trait interface (DESIGN: `cpt-cf-serverless-runtime-principle-pluggable-adapters`)
+* The engine must support configurable retry policies with exponential backoff and non-retryable error classification (BR-019)
+* The engine must provide execution visibility — queryable execution status, history, and timeline events (BR-015, BR-130)
+* Schedule-based triggers with cron/interval expressions and missed schedule handling must be supported (BR-022, BR-110)
+* The engine must meet reliability targets: availability >=99.95%, RTO <=30s, RPO <=1min (BR-026)
+* The engine must meet performance targets: start latency p95 <=100ms, step dispatch p95 <=50ms (BR-207)
+* The engine must scale to >=10K concurrent executions, >=1K starts/sec, >=1K tenants (BR-208)
+
+## Considered Options
+
+* **Option A**: Temporal (open-source durable execution platform)
+* **Option B**: Cadence (Uber's original workflow engine, predecessor to Temporal)
+* **Option C**: Camunda / Zeebe (BPMN-based workflow automation)
+* **Option D**: Restate (event-driven durable execution)
+* **Option E**: AWS Step Functions (cloud-native state machine)
+* **Option F**: Apache Airflow (DAG-based workflow orchestration)
+
+## Decision Outcome
+
+Chosen option: **"Option A: Temporal"** as the durable execution backend, with a **custom workflow engine layer** built on top using the Temporal Rust SDK.
+
+**Why Temporal**: It is the only option that satisfies all decision drivers — particularly the combination of self-hostable deployment, Rust SDK availability (`temporal-sdk-core` is written in Rust and usable from Rust; standalone `temporalio-sdk` crate is prerelease), proven scale at production users, long-running workflow support (days to years), saga/compensation patterns, and built-in schedule API.
+
+**Why a custom engine layer on top**: Temporal provides durable execution primitives (checkpointing, retry, state persistence, worker management) but does not natively interpret the Serverless Workflow Specification DSL ([ADR-0002](0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md)). A custom engine layer is required to bridge the gap between declarative workflow definitions and Temporal's workflow-as-code model — handling DSL parsing, task execution mapping, expression evaluation, flow control, and data transformation.
+
+### Consequences
+
+* The workflow engine is implemented as a Temporal worker service that maps DSL task types to Temporal workflows and activities.
+* The engine architecture has two layers: the Temporal SDK layer (durable execution, state persistence, retry, scheduling) and a custom workflow engine layer on top (DSL parsing, task execution, expression evaluation, flow control).
+* A Temporal Server deployment becomes an infrastructure dependency. The engine connects to Temporal Server via the Temporal Rust SDK (`temporal-sdk-core`). Temporal Server itself requires a persistence backend (PostgreSQL, MySQL, or Cassandra).
+* Multi-tenant isolation is achieved at the application layer through `tenant_id`/`user_id` scoping in database queries and ownership checks.
+* Compensation is implemented at the DSL level through Try/Raise task composition (see [ADR-0002](0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md)); the engine provides the durable execution guarantees that make this reliable.
+* Schedule management maps to Temporal's built-in Schedule API.
+* The engine integrates as a standard ModKit plugin module.
+
+### Confirmation
+
+* The engine correctly parses, validates, and executes workflows authored in Serverless Workflow Specification YAML through the full lifecycle: submission → validation → Temporal dispatch → task execution → completion
+* Integration tests verify multi-tenant isolation: workflow created in tenant A is not visible or accessible from tenant B
+* Schedule-based and event-driven triggers create and execute workflows correctly
+* Performance benchmarks validate start latency p95 <=100ms and step dispatch p95 <=50ms under test load
+* Plugin registration works correctly via ModKit plugin pattern
+
+## Pros and Cons of the Options
+
+### Option A: Temporal
+
+Temporal is an open-source durable execution platform that provides workflow orchestration with automatic state persistence, built-in retry/timeout handling, and native support for long-running processes.
+
+| | Aspect | Note |
+|---|--------|------|
+| Good | Rust SDK available (`temporal-sdk-core`) | Written in Rust and usable from Rust; primarily serves as the polyglot core (other language SDKs use it via FFI); standalone `temporalio-sdk` crate is prerelease |
+| Good | Built-in durable execution | Automatic checkpointing, event sourcing, and deterministic replay — workflow state survives infrastructure failures without custom persistence logic |
+| Good | Proven at scale | Production deployments handling high workflow volumes at multiple large-scale users |
+| Good | Long-running workflow support | Workflows can run for days to years with timer-based and event-driven continuation; suspension periods of 30+ days are natively supported |
+| Good | Durable execution for compensation | Temporal's checkpointing and retry guarantees make DSL-level compensation (Try/Raise) reliable across failures |
+| Good | Built-in schedule API | Cron and interval schedules with configurable missed schedule policies, reducing custom schedule infrastructure |
+| Good | Self-hostable, MIT license | No vendor lock-in; full control over infrastructure and data |
+| Good | Workflow visibility API | Built-in query interface for execution status, history, and search — maps to `InvocationRecord` and timeline events |
+| Neutral | Multi-tenancy | Tenant isolation handled at application/DB layer; Temporal namespaces available for additional logical separation if needed |
+| Good | Active community and ecosystem | Regular releases, SDKs in multiple languages, Slack community, conference presence |
+| Neutral | Temporal Server infrastructure | Requires deploying and operating Temporal Server (with its own persistence), but only when the plugin is enabled |
+| Neutral | Worker-based execution model | Per-execution resource limits (memory, CPU) are not enforced at the adapter level — relies on worker pool sizing and Temporal Server rate limiting |
+| Bad | Operational complexity | Temporal Server adds infrastructure overhead (server cluster, persistence backend, monitoring) |
+| Bad | Deterministic execution constraints | Engine implementation code must follow Temporal's deterministic replay rules (no side effects in workflow code); this affects engine developers, not workflow authors who write declarative YAML |
+| Bad | Custom engine layer required | Temporal does not natively interpret the Serverless Workflow Specification; a custom DSL interpreter layer adds development and maintenance complexity |
+| Bad | Rust SDK maturity | `temporal-sdk-core` is primarily the polyglot foundation; standalone Rust SDK (`temporalio-sdk`) is prerelease — API stability risk |
+
+### Option B: Cadence
+
+Cadence is the predecessor to Temporal, originally developed at Uber. It provides similar durable workflow capabilities but development has slowed since the Temporal fork.
+
+| | Aspect | Note |
+|---|--------|------|
+| Good | Proven at Uber scale | Production-tested at massive scale |
+| Good | Similar programming model to Temporal | Workflow-as-code with automatic checkpointing |
+| Good | Self-hostable | Open-source, no vendor lock-in |
+| Bad | No production Rust SDK | Only Go and Java SDKs are production-ready; Rust support would require building from scratch |
+| Bad | Reduced community momentum | Slower release cadence and fewer ecosystem integrations since the Temporal fork |
+| Bad | Feature parity lag | Temporal has added features (advanced visibility, schedule API, Nexus for cross-namespace calls) that Cadence lacks |
+
+### Option C: Camunda / Zeebe
+
+Camunda provides BPMN-based workflow orchestration. Camunda 8 (Zeebe) offers a cloud-native, horizontally scalable engine.
+
+| | Aspect | Note |
+|---|--------|------|
+| Neutral | Strong enterprise governance | Built-in audit trails, user task management, and decision tables |
+| Good | Horizontal scalability | Zeebe's partitioned architecture scales to high throughput |
+| Bad | No Rust SDK | Java/C# SDKs only (Go SDK deprecated); Rust integration requires gRPC client implementation from scratch |
+| Bad | BPMN-centric model | Forces BPMN as the workflow definition format, which conflicts with the chosen Serverless Workflow Specification DSL ([ADR-0002](0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md)) |
+| Bad | Heavier operational footprint | Zeebe requires its own cluster infrastructure with significant memory and storage requirements |
+
+### Option D: Restate
+
+Restate is a newer durable execution framework that uses a distributed log for state management, offering lower-latency step execution.
+
+| | Aspect | Note |
+|---|--------|------|
+| Good | Low-latency step execution | Distributed log architecture reduces per-step overhead |
+| Good | Rust SDK available | Early-stage Rust SDK exists |
+| Good | Simpler operational model | Single binary deployment, lighter infrastructure footprint |
+| Bad | Early-stage maturity | Fewer production deployments and smaller community compared to Temporal |
+| Bad | Less proven long-running workflow support | Supports virtual objects and timers for long-running flows, but fewer production references for multi-day workflows compared to Temporal |
+| Bad | No built-in schedule API | Schedule management would need to be built on top |
+| Bad | Smaller ecosystem | Fewer integrations, patterns, and production-proven recipes |
+
+### Option E: AWS Step Functions
+
+AWS Step Functions provides serverless workflow orchestration using JSON-based state machine definitions (Amazon States Language).
+
+| | Aspect | Note |
+|---|--------|------|
+| Bad | Not self-hostable | Fully managed only — conflicts with on-premises requirement (BR-035) |
+| Neutral | Native AWS integration | Deep integration with AWS services, but creates vendor dependency |
+| Bad | Vendor lock-in | Tightly coupled to AWS; no self-hosted deployment option — violates self-hostability requirement |
+| Bad | No Rust SDK for workflow definition | Workflows defined in JSON (ASL), not via Rust SDK; activities require Lambda or other AWS compute |
+| Bad | Limited compensation support | No native saga pattern; compensation requires manual implementation |
+| Bad | Execution duration limits | Standard Workflows have a 1-year limit; Express Workflows limited to 5 minutes |
+| Bad | Multi-tenant isolation model mismatch | AWS account/IAM boundaries don't align with the platform's GTS-based tenant model |
+
+### Option F: Apache Airflow
+
+Apache Airflow provides DAG-based workflow scheduling and orchestration, primarily designed for data pipeline and ETL workloads.
+
+| | Aspect | Note |
+|---|--------|------|
+| Good | Mature and widely adopted | Large community, extensive operator ecosystem |
+| Good | Strong scheduling capabilities | Advanced cron scheduling with backfill and catch-up |
+| Good | Self-hostable | Open-source, no vendor lock-in |
+| Bad | Python-centric | DAGs defined in Python; no Rust SDK — integration requires REST API wrapper with significant impedance mismatch |
+| Bad | Not designed for durable execution | DAGs are scheduled batch jobs, not event-driven durable workflows; no native suspend/resume or event-waiting |
+| Bad | No saga/compensation support | No built-in compensation pattern; rollback logic must be manually implemented |
+| Bad | High latency per task | Scheduler-based dispatch adds seconds of latency per task, far exceeding the p95 <=50ms step dispatch target |
+
+## More Information
+
+### Decision Review Triggers
+
+This decision should be revisited if any of the following occur:
+
+* Temporal Rust SDK (`temporal-sdk-core`) is deprecated, archived, or receives no releases for >6 months
+* Temporal Server licensing changes from MIT to a restrictive or commercial-only license
+* Restate or another engine achieves a production-quality Rust SDK with built-in schedule API and long-running workflow support
+* Operational cost of Temporal Server infrastructure becomes disproportionate to platform infrastructure cost
+
+### Security Note
+
+Temporal Server adds a network-accessible infrastructure component (gRPC Frontend) that requires security hardening. Temporal supports mTLS and custom authorization plugins; by default no authentication is enforced. Platform security context (`tenant_id`, `user_id`) must be propagated to Temporal via workflow metadata to maintain tenant isolation at the engine level.
+
+## Traceability
+
+- **PRD**: [PRD.md](../PRD.md)
+- **DESIGN**: [DESIGN.md](../DESIGN.md)
+- **Related ADR**: [ADR-0002: Serverless Workflow Specification as Workflow DSL](0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md) — the DSL that this engine interprets and executes
+
+This decision directly addresses the following requirements and design elements:
+
+* `cpt-cf-serverless-runtime-fr-execution-engine` — Durable execution with checkpointing, suspend/resume, long-running workflows
+* `cpt-cf-serverless-runtime-fr-tenant-registry` — Multi-tenant isolation via application-layer tenant scoping
+* `cpt-cf-serverless-runtime-fr-trigger-schedule` — Schedule API for cron/interval triggers with missed schedule policies
+* `cpt-cf-serverless-runtime-fr-runtime-capabilities` — Runtime capabilities exposed as Temporal activities
+* `cpt-cf-serverless-runtime-fr-execution-lifecycle` — Full invocation lifecycle: start, cancel, retry, suspend, resume, compensate
+* `cpt-cf-serverless-runtime-fr-execution-visibility` — Queryable execution status and history via Visibility API
+* `cpt-cf-serverless-runtime-fr-debugging` — Workflow history and replay for execution debugging
+* `cpt-cf-serverless-runtime-fr-advanced-patterns` — Child workflows, parallel execution, saga/compensation, idempotency
+* `cpt-cf-serverless-runtime-fr-governance-sharing` — Publishing governance and access control integration
+* `cpt-cf-serverless-runtime-fr-replay-visualization` — Deterministic replay and history events for timeline visualization
+* `cpt-cf-serverless-runtime-fr-deployment-safety` — Version pinning and task queue routing for blue-green deployment
+* `cpt-cf-serverless-runtime-nfr-security` — Security context propagation, tenant isolation, audit trail; see [Security Note](#security-note)
+* `cpt-cf-serverless-runtime-nfr-resource-governance` — Timeout enforcement, per-tenant quotas, worker pool sizing
+* `cpt-cf-serverless-runtime-nfr-reliability` — Event-sourced execution for RTO/RPO targets
+* `cpt-cf-serverless-runtime-nfr-ops-traceability` — Correlation ID and trace ID propagation via Temporal headers
+* `cpt-cf-serverless-runtime-nfr-observability` — OpenTelemetry integration via SDK interceptors
+* `cpt-cf-serverless-runtime-nfr-retention` — Per-tenant execution history retention
+* `cpt-cf-serverless-runtime-nfr-performance` — Async activity execution for step dispatch latency targets
+* `cpt-cf-serverless-runtime-nfr-scalability` — Horizontal scaling via sharded history/matching services
+* `cpt-cf-serverless-runtime-nfr-tenant-isolation` — Application-layer tenant scoping prevents cross-tenant interference
+* `cpt-cf-serverless-runtime-nfr-composition-deps` — Child workflow and activity dependency management
+* `cpt-cf-serverless-runtime-principle-pluggable-adapters` (DESIGN) — Engine registers as ModKit plugin with GTS adapter type
+* `cpt-cf-serverless-runtime-principle-impl-agnostic` (DESIGN) — Engine is one of multiple possible adapter implementations
+* `cpt-cf-serverless-runtime-principle-gts-identity` (DESIGN) — Temporal workflow IDs derived from GTS instance addresses
+* `cpt-cf-serverless-runtime-principle-unified-function` (DESIGN) — Functions and workflows invoked through the same trait
+* `cpt-cf-serverless-runtime-usecase-resource-provisioning` — Multi-step provisioning with saga rollback
+* `cpt-cf-serverless-runtime-usecase-tenant-onboarding` — Long-running onboarding with signal-based suspension
+* `cpt-cf-serverless-runtime-usecase-subscription-lifecycle` — Scheduled subscription workflows via Schedule API

--- a/modules/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
+++ b/modules/serverless-runtime/docs/ADR/0003-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md
@@ -52,7 +52,7 @@ STANDARDS ALIGNMENT:
 **ID**: `cpt-cf-serverless-runtime-adr-temporal-workflow-engine`
 ## Context and Problem Statement
 
-The Serverless Runtime domain model defines a pluggable adapter architecture (`cpt-cf-serverless-runtime-principle-pluggable-adapters`) where execution adapters implement the abstract `ServerlessRuntime` trait. The platform needs a workflow engine that:
+The Serverless Runtime domain model defines a pluggable adapter architecture (`cpt-cf-serverless-runtime-principle-pluggable-adapters`) where execution adapters implement the abstract `ServerlessRuntime` trait. This ADR covers the **Temporal adapter** — one of multiple possible adapter implementations (others include Starlark, WASM, cloud FaaS). The Temporal adapter needs a workflow engine that:
 
 1. **Interprets workflow definitions** authored in the Serverless Workflow Specification DSL ([ADR-0002](0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md)) — parsing task definitions, evaluating expressions, managing data flow between steps, and controlling execution flow (branching, loops, error handling).
 2. **Executes workflows durably** — persisting state across service restarts, providing automatic checkpointing, retry, compensation, and long-running workflow support lasting days to months.
@@ -134,6 +134,7 @@ Temporal is an open-source durable execution platform that provides workflow orc
 | Bad | Operational complexity | Temporal Server adds infrastructure overhead (server cluster, persistence backend, monitoring) |
 | Bad | Deterministic execution constraints | Engine implementation code must follow Temporal's deterministic replay rules (no side effects in workflow code); this affects engine developers, not workflow authors who write declarative YAML |
 | Bad | Custom engine layer required | Temporal does not natively interpret the Serverless Workflow Specification; a custom DSL interpreter layer adds development and maintenance complexity |
+| Bad | Multi-process architecture | Temporal Server runs as a separate process; all workflow ↔ activity communication requires gRPC serialization/deserialization and IPC, adding latency overhead compared to in-process execution engines |
 | Bad | Rust SDK maturity | `temporal-sdk-core` is primarily the polyglot foundation; standalone Rust SDK (`temporalio-sdk`) is prerelease (as of 2026-03-30 — see [sdk-core](https://github.com/temporalio/sdk-core)) — API stability risk |
 
 ### Option B: Cadence

--- a/modules/serverless-runtime/docs/NEXT_ADR_SCOPE.md
+++ b/modules/serverless-runtime/docs/NEXT_ADR_SCOPE.md
@@ -2,7 +2,7 @@
 
 **Source:** Consistency review of `DESIGN.md` against `PRD.md`
 **Date:** 2026-01-21
-**Updated:** 2026-02-08 (comprehensive consistency and coverage audit)
+**Updated:** 2026-03-30
 
 ---
 
@@ -65,8 +65,15 @@
 ---
 
 ## 2. Next ADR Scope (Recommended)
+### ADR-2 (Completed): Serverless Workflow Specification as Workflow DSL
 
-### ADR-2: Security Model (P0 — Blocker)
+See [ADR-0002](ADR/0002-cpt-cf-serverless-runtime-adr-workflow-dsl.md).
+
+### ADR-3 (Completed): Temporal-based Workflow Engine
+
+See [ADR-0003](ADR/0003-cpt-cf-serverless-runtime-adr-temporal-workflow-engine.md).
+
+### ADR-4 (Next): Security Model (P0 — Blocker)
 
 **Scope:**
 
@@ -85,7 +92,7 @@
 
 **PRD Coverage:** BR-006, BR-013, BR-017, BR-023, BR-024, BR-025, BR-033, BR-034, BR-038, BR-039, BR-127, BR-130, PRD Risks
 
-### ADR-3: Runtime Capabilities SDK (P0 — High Priority)
+### ADR-5: Runtime Capabilities SDK (P0 — High Priority)
 
 **Scope:**
 
@@ -96,7 +103,7 @@
 
 **PRD Coverage:** BR-008, BR-040, BR-136
 
-### ADR-4: Debugging and Observability (P1)
+### ADR-6: Debugging and Observability (P1)
 
 **Scope:**
 
@@ -108,7 +115,7 @@
 
 **PRD Coverage:** BR-101, BR-102, BR-115, BR-120, BR-130
 
-### ADR-5: Advanced Workflow Patterns (P1)
+### ADR-7: Advanced Workflow Patterns (P1)
 
 **Scope:**
 
@@ -122,7 +129,7 @@
 
 **PRD Coverage:** BR-009, BR-026, BR-030, BR-104, BR-105, BR-108, BR-114
 
-### ADR-6: Deployment and Governance (P1)
+### ADR-8: Deployment and Governance (P1)
 
 **Scope:**
 
@@ -134,7 +141,7 @@
 
 **PRD Coverage:** BR-109, BR-117, BR-121, BR-122, BR-123
 
-### ADR-7: Error Taxonomy (P1)
+### ADR-9: Error Taxonomy (P1)
 
 **Scope:**
 


### PR DESCRIPTION
## Summary
  - Add ADR-0002: Serverless Workflow Specification as Workflow DSL — documents the decision to adopt the CNCF Serverless Workflow Specification (v1.0.0) as the declarative workflow definition language
  - Add ADR-0003: Temporal-based Workflow Engine — documents the decision to use Temporal as the durable execution backend with a custom engine layer for DSL interpretation
  - Update NEXT_ADR_SCOPE.md to reflect completed ADR scope

  ## Details
  **ADR-0002** evaluates five options (CNCF Serverless Workflow Spec, ASL, BPMN 2.0, Custom DSL, Code-only) and selects the CNCF spec for its vendor-neutrality, declarative JSON/YAML format, and coverage of all
  required control-flow constructs.

  **ADR-0003** evaluates six options (Temporal, Cadence, Camunda/Zeebe, Restate, AWS Step Functions, Apache Airflow) and selects Temporal for its Rust SDK, durable execution primitives, long-running workflow
  support, built-in schedule API, and self-hostable MIT license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two accepted architecture decision records: one adopting the Serverless Workflow specification as the workflow DSL and one selecting Temporal as the durable workflow execution backend with a custom engine layer.
  * Documented decision drivers, alternatives considered, confirmation criteria, consequences, and traceability to requirements.
  * Updated ADR roadmap: marked those ADRs complete, renumbered subsequent ADRs, and adjusted future ADR scope and dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->