### PR TITLE
feat(minichat): add vLLM Responses API provider with think-tag parsing plus nextest for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
 
+      - name: Install nextest
+        uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
+        with:
+          tool: nextest
+
       # Cache Cargo registry/git + target/ across platforms.
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
@@ -108,6 +113,11 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
+
+      - name: Install nextest
+        uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
+        with:
+          tool: nextest
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
@@ -162,7 +172,7 @@ jobs:
 
       # Install tools via prebuilt binaries for speed.
       - name: Install cargo-deny
-        uses: taiki-e/install-action@30eab0fabba9ea3f522099957e668b21876aa39e # v2.66.6
+        uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
         with:
           tool: cargo-deny
 
@@ -201,9 +211,9 @@ jobs:
           shared-key: pr-${{ runner.os }}-nightly-${{ env.RUSTUP_TOOLCHAIN }}-llvm-cov
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@30eab0fabba9ea3f522099957e668b21876aa39e # v2.66.6
+        uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov, nextest
 
       # Generate lcov.info for upload. Customize flags/features as needed.
       - name: Coverage (lcov)
@@ -213,7 +223,7 @@ jobs:
           CARGO_LLVM_COV_BUILD_DIR: llvm-cov-build
         run: |
           cargo llvm-cov clean --workspace
-          cargo llvm-cov --workspace --lcov --output-path lcov.info
+          cargo llvm-cov nextest --workspace --lcov --output-path lcov.info
 
       # Upload to Codecov; do not fail CI if Codecov is down/misconfigured.
       - name: Upload to Codecov
@@ -238,15 +248,15 @@ jobs:
           toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
           components: llvm-tools-preview,rustc-dev
 
+      - name: Install dylint-link and nextest
+        uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
+        with:
+          tool: cargo-dylint,dylint-link, nextest
+
       - name: Install protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install dylint-link
-        uses: taiki-e/install-action@30eab0fabba9ea3f522099957e668b21876aa39e # v2.66.6
-        with:
-          tool: cargo-dylint,dylint-link
 
       - name: Run dylint tests
         working-directory: dylint_lints

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -178,6 +178,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
 
+      - name: Install nextest
+        uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
+        with:
+          tool: nextest
+
       - name: cargo test (workspace)
         run: make test-no-macros
 

--- a/Makefile
+++ b/Makefile
@@ -189,9 +189,12 @@ gts-docs-vendor-release:
 		--exclude "*/helm/*/templates/*" \
 		docs modules libs examples
 
+install-tools:
+	@command -v cargo-nextest >/dev/null 2>&1 || cargo install cargo-nextest
+
 ## Run tests for GTS documentation validator
-gts-docs-test:
-	cargo test -p gts-docs-validator
+gts-docs-test: install-tools
+	cargo nextest run -p gts-docs-validator
 
 ## List all custom project compliance lints (see dylint_lints/README.md)
 dylint-list:
@@ -207,8 +210,8 @@ dylint-list:
 	done
 
 ## Test dylint lints on UI test cases (compile and verify violations)
-dylint-test:
-	@cd dylint_lints && cargo test
+dylint-test: install-tools
+	@cd dylint_lints && cargo nextest run
 
 # Run project compliance dylint lints on the workspace (see `make dylint-list`)
 dylint:
@@ -268,8 +271,8 @@ openapi:
 .PHONY: dev dev-fmt dev-clippy dev-test
 
 ## Run tests in development mode
-dev-test:
-	cargo test --workspace
+dev-test: install-tools
+	cargo nextest run --workspace
 
 ## Auto-fix code formatting
 dev-fmt:
@@ -287,35 +290,35 @@ dev: dev-fmt dev-clippy dev-test
 .PHONY: test test-no-macros test-macros test-sqlite test-pg test-mysql test-db test-users-info-pg
 
 # Run all tests
-test:
-	cargo test --workspace
+test: install-tools
+	cargo nextest run --workspace
 
-test-no-macros:
-	cargo test --workspace --exclude cf-modkit-macros-tests --exclude cf-modkit-db-macros
+test-no-macros: install-tools
+	cargo nextest run --workspace --exclude cf-modkit-macros-tests --exclude cf-modkit-db-macros
 
-test-macros:
-	cargo test -p cf-modkit-db-macros
-	cargo test -p cf-modkit-macros-tests
+test-macros: install-tools
+	cargo nextest run -p cf-modkit-db-macros
+	cargo nextest run -p cf-modkit-macros-tests
 
 ## Run SQLite integration tests
-test-sqlite:
-	cargo test -p cf-modkit-db --features sqlite,integration,preview-outbox
+test-sqlite: install-tools
+	cargo nextest run -p cf-modkit-db --features sqlite,integration,preview-outbox
 	cargo build -p cf-modkit-db --examples --features sqlite,preview-outbox
 
 ## Run PostgreSQL integration tests
-test-pg:
-	cargo test -p cf-modkit-db --features pg,integration,preview-outbox
+test-pg: install-tools
+	cargo nextest run -p cf-modkit-db --features pg,integration,preview-outbox
 
 ## Run MySQL integration tests
-test-mysql:
-	cargo test -p cf-modkit-db --features mysql,integration,preview-outbox
+test-mysql: install-tools
+	cargo nextest run -p cf-modkit-db --features mysql,integration,preview-outbox
 
 # Run all database integration tests
 test-db: test-sqlite test-pg test-mysql
 
 ## Run users-info module integration tests
-test-users-info-pg:
-	cargo test -p users-info --features "integration" -- --nocapture
+test-users-info-pg: install-tools
+	cargo nextest run -p users-info --features "integration"
 
 # -------- Benchmarks --------
 
@@ -387,7 +390,7 @@ MINI_CHAT_FEATURES = mini-chat,static-authn,static-authz,single-tenant,static-cr
 MINI_CHAT_K8S_FEATURES = $(MINI_CHAT_FEATURES),k8s
 
 MINI_CHAT_IMAGE ?= hyperspot-mini-chat
-MINI_CHAT_TAG   ?= latest
+MINI_CHAT_TAG   ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo latest)
 
 ## Run mini-chat E2E tests (separate binary with mini-chat features)
 e2e-mini-chat:
@@ -506,16 +509,17 @@ mini-chat-helm: mini-chat-docker
 	@if command -v k3s >/dev/null 2>&1; then \
 		docker save $(MINI_CHAT_IMAGE):$(MINI_CHAT_TAG) | sudo k3s ctr images import -; \
 	elif command -v minikube >/dev/null 2>&1; then \
+		minikube ssh "docker rmi -f $(MINI_CHAT_IMAGE):$(MINI_CHAT_TAG) 2>/dev/null" || true; \
 		minikube image load $(MINI_CHAT_IMAGE):$(MINI_CHAT_TAG); \
 	else \
 		echo "ERROR: k3s or minikube required"; exit 1; \
 	fi
 	helm upgrade --install mini-chat modules/mini-chat/deploy/helm/mini-chat/ \
+		--set image.tag="$(MINI_CHAT_TAG)" \
 		--set secrets.azureOpenaiApiKey="$${AZURE_OPENAI_API_KEY}" \
 		--set secrets.azureOpenaiApiHost="$${AZURE_OPENAI_API_HOST}" \
 		--set postgres.host="$${PG_HOST:-postgres.default.svc.cluster.local}" \
 		--set postgres.password="$${PG_PASSWORD}"
-	@# Force pod restart so it picks up the freshly-loaded image
 	kubectl rollout restart deployment/mini-chat
 	kubectl rollout status deployment/mini-chat --timeout=120s
 
@@ -543,6 +547,7 @@ mini-chat-up:
 	@if docker image inspect $(MINI_CHAT_IMAGE):$(MINI_CHAT_TAG) >/dev/null 2>&1; then \
 		echo "Loading image $(MINI_CHAT_IMAGE):$(MINI_CHAT_TAG) into cluster..."; \
 		if command -v minikube >/dev/null 2>&1; then \
+			minikube ssh "docker rmi -f $(MINI_CHAT_IMAGE):$(MINI_CHAT_TAG) 2>/dev/null" || true; \
 			minikube image load $(MINI_CHAT_IMAGE):$(MINI_CHAT_TAG); \
 		else \
 			docker save $(MINI_CHAT_IMAGE):$(MINI_CHAT_TAG) | sudo k3s ctr images import -; \
@@ -557,11 +562,11 @@ mini-chat-up:
 		echo "  export AZURE_OPENAI_API_KEY=... AZURE_OPENAI_API_HOST=..."; \
 	fi
 	helm upgrade --install mini-chat modules/mini-chat/deploy/helm/mini-chat/ \
+		--set image.tag="$(MINI_CHAT_TAG)" \
 		--set secrets.azureOpenaiApiKey="$${AZURE_OPENAI_API_KEY}" \
 		--set secrets.azureOpenaiApiHost="$${AZURE_OPENAI_API_HOST}" \
 		--set postgres.host="$${PG_HOST:-postgres.default.svc.cluster.local}" \
 		--set postgres.password="$${PG_PASSWORD}"
-	@# --- 4. Rollout restart to guarantee the latest image is used ---
 	kubectl rollout restart deployment/mini-chat
 	kubectl rollout status deployment/mini-chat --timeout=120s
 	@echo ""

--- a/modules/mini-chat/deploy/helm/mini-chat/templates/configmap.yaml
+++ b/modules/mini-chat/deploy/helm/mini-chat/templates/configmap.yaml
@@ -115,6 +115,8 @@ data:
           secrets:
             - key: "azure-openai-key"
               value: "${AZURE_OPENAI_API_KEY}"
+            - key: "vllm-local-key"
+              value: "local-dev-key"
 
       file-parser:
         config:
@@ -139,6 +141,19 @@ data:
                 header: "api-key"
                 prefix: ""
                 secret_ref: "azure-openai-key"
+            vllm_local:
+              kind: vllm_responses
+              storage_kind: openai
+              host: "127.0.0.1"
+              port: 8000
+              use_http: true
+              upstream_alias: "vllm-local"
+              api_path: "/v1/responses"
+              auth_plugin_type: "gts.x.core.oagw.auth_plugin.v1~x.core.oagw.apikey.v1"
+              auth_config:
+                header: "Authorization"
+                prefix: "Bearer "
+                secret_ref: "vllm-local-key"
 
       static-mini-chat-audit-plugin:
         config:
@@ -321,9 +336,96 @@ data:
                 is_default: false
                 sort_order: 1
 
+            - model_id: "qwen3-0.6b"
+              provider_model_id: "Qwen/Qwen3-0.6B"
+              display_name: "Qwen3 0.6B (vLLM local)"
+              description: "Local vLLM model for development"
+              version: "3.0"
+              provider_id: "vllm_local"
+              provider_display_name: "vLLM Local"
+              icon: ""
+              tier: Standard
+              enabled: true
+              system_prompt: "You are a helpful, concise assistant. Answer clearly and directly."
+              multimodal_capabilities: []
+              context_window: 40960
+              max_output_tokens: 4096
+              max_input_tokens: 40960
+              input_tokens_credit_multiplier_micro: 0
+              output_tokens_credit_multiplier_micro: 0
+              multiplier_display: "0x"
+              estimation_budgets:
+                bytes_per_token_conservative: 4
+                fixed_overhead_tokens: 100
+                safety_margin_pct: 10
+                image_token_budget: 0
+                tool_surcharge_tokens: 0
+                web_search_surcharge_tokens: 0
+                code_interpreter_surcharge_tokens: 0
+                minimal_generation_floor: 50
+              max_retrieved_chunks_per_turn: 0
+              max_tool_calls: 0
+              general_config:
+                type: ""
+                tier: "standard"
+                available_from: "1970-01-01T00:00:00Z"
+                max_file_size_mb: 0
+                api_params:
+                  temperature: 0.2
+                  top_p: 1.0
+                  frequency_penalty: 0.0
+                  presence_penalty: 0.0
+                  stop: []
+                features:
+                  streaming: true
+                  function_calling: false
+                  structured_output: false
+                  fine_tuning: false
+                  distillation: false
+                  fim_completion: false
+                  chat_prefix_completion: false
+                input_type:
+                  text: true
+                  image: false
+                  audio: false
+                  video: false
+                tool_support:
+                  web_search: false
+                  file_search: false
+                  image_generation: false
+                  code_interpreter: false
+                  computer_use: false
+                  mcp: false
+                supported_endpoints:
+                  chat_completions: true
+                  responses: true
+                  realtime: false
+                  assistants: false
+                  batch_api: false
+                  fine_tuning: false
+                  embeddings: false
+                  videos: false
+                  image_generation: false
+                  image_edit: false
+                  audio_speech_generation: false
+                  audio_transcription: false
+                  audio_translation: false
+                  moderations: false
+                  completions: false
+                token_policy:
+                  input_tokens_credit_multiplier: 0.0
+                  output_tokens_credit_multiplier: 0.0
+                performance:
+                  response_latency_ms: 200
+                  speed_tokens_per_second: 200
+              preference:
+                is_default: false
+                sort_order: 2
+
       oagw:
         config:
           proxy_timeout_secs: 60
+          allow_http_upstream: true
 
     opentelemetry:
       tracing:

--- a/modules/mini-chat/mini-chat-sdk/src/lib.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/lib.rs
@@ -12,8 +12,8 @@ pub use audit_models::{
 pub use error::{MiniChatAuditPluginError, MiniChatModelPolicyPluginError, PublishError};
 pub use gts::{MiniChatAuditPluginSpecV1, MiniChatModelPolicyPluginSpecV1};
 pub use models::{
-    EstimationBudgets, KillSwitches, ModelCatalogEntry, ModelGeneralConfig, ModelPreference,
-    ModelTier, ModelToolSupport, PolicySnapshot, PolicyVersionInfo, TierLimits, UsageEvent,
-    UsageTokens, UserLicenseStatus, UserLimits,
+    EstimationBudgets, KillSwitches, ModelApiParams, ModelCatalogEntry, ModelGeneralConfig,
+    ModelPreference, ModelTier, ModelToolSupport, PolicySnapshot, PolicyVersionInfo, TierLimits,
+    UsageEvent, UsageTokens, UserLicenseStatus, UserLimits,
 };
 pub use plugin_api::{MiniChatAuditPluginClientV1, MiniChatModelPolicyPluginClientV1};

--- a/modules/mini-chat/mini-chat-sdk/src/models.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/models.rs
@@ -146,6 +146,11 @@ pub struct ModelApiParams {
     pub frequency_penalty: f64,
     pub presence_penalty: f64,
     pub stop: Vec<String>,
+    /// Provider-specific extra body parameters (e.g. vLLM `top_k`,
+    /// `chat_template_kwargs`). Providers that support it will place this
+    /// value under the `"extra_body"` key in the request payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_body: Option<serde_json::Value>,
 }
 
 /// Feature capability flags (API: `PolicyModelFeatures`).
@@ -404,6 +409,7 @@ mod tests {
                 frequency_penalty: 0.0,
                 presence_penalty: 0.0,
                 stop: vec![],
+                extra_body: None,
             },
             features: ModelFeatures {
                 streaming: true,

--- a/modules/mini-chat/mini-chat/src/domain/model/quota.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/quota.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 use crate::config::EstimationBudgets;
 use crate::infra::db::entity::quota_usage::PeriodType;
-use mini_chat_sdk::ModelToolSupport;
+use mini_chat_sdk::{ModelApiParams, ModelToolSupport};
 
 /// Result of preflight reserve evaluation.
 #[domain_model]
@@ -32,6 +32,8 @@ pub enum PreflightDecision {
         max_tool_calls: u32,
         /// Tool support flags of the effective model.
         tool_support: ModelToolSupport,
+        /// LLM API inference parameters (temperature, `top_p`, etc.).
+        api_params: ModelApiParams,
     },
     Downgrade {
         effective_model: String,
@@ -58,6 +60,8 @@ pub enum PreflightDecision {
         max_tool_calls: u32,
         /// Tool support flags of the effective model.
         tool_support: ModelToolSupport,
+        /// LLM API inference parameters (temperature, `top_p`, etc.).
+        api_params: ModelApiParams,
     },
     Reject {
         error_code: String,

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
@@ -715,6 +715,7 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                                         .max_retrieved_chunks_per_turn,
                                     max_tool_calls: eff_entry.max_tool_calls,
                                     tool_support: eff_entry.general_config.tool_support.clone(),
+                                    api_params: eff_entry.general_config.api_params.clone(),
                                 },
                                 CascadeDecision::Downgrade {
                                     downgrade_from,
@@ -740,6 +741,7 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                                         .max_retrieved_chunks_per_turn,
                                     max_tool_calls: eff_entry.max_tool_calls,
                                     tool_support: eff_entry.general_config.tool_support.clone(),
+                                    api_params: eff_entry.general_config.api_params.clone(),
                                 },
                                 CascadeDecision::Reject => unreachable!(),
                             };

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/mod.rs
@@ -531,22 +531,25 @@ impl<
         emit_stream_started(&tx, request_id, message_id).await;
 
         Ok(provider_task::spawn_provider_task(
-            resolved_provider.adapter,
-            proxy_path,
             ctx,
-            assembled.messages,
-            assembled.system_instructions,
-            assembled.tools,
-            model,
-            effective_provider_model_id,
-            pf.max_output_tokens_applied.cast_unsigned(),
-            pf.max_tool_calls,
-            self.quota.web_search_max_calls_per_message(),
-            self.quota.code_interpreter_max_calls_per_message(),
+            provider_task::ProviderTaskConfig {
+                llm: resolved_provider.adapter,
+                upstream_alias: proxy_path,
+                messages: assembled.messages,
+                system_instructions: assembled.system_instructions,
+                tools: assembled.tools,
+                model: pf.effective_model,
+                provider_model_id: effective_provider_model_id,
+                max_output_tokens: pf.max_output_tokens_applied.cast_unsigned(),
+                max_tool_calls: pf.max_tool_calls,
+                web_search_max_calls: self.quota.web_search_max_calls_per_message(),
+                code_interpreter_max_calls: self.quota.code_interpreter_max_calls_per_message(),
+                api_params: pf.api_params,
+                provider_file_id_map,
+            },
             cancel,
             tx,
             Some(finalization_ctx),
-            provider_file_id_map,
         ))
     }
 
@@ -1207,22 +1210,25 @@ impl<
         emit_stream_started(&tx, request_id, message_id).await;
 
         Ok(provider_task::spawn_provider_task(
-            resolved_provider.adapter,
-            proxy_path,
             ctx,
-            assembled.messages,
-            assembled.system_instructions,
-            assembled.tools,
-            pf.effective_model,
-            effective_provider_model_id,
-            pf.max_output_tokens_applied.cast_unsigned(),
-            pf.max_tool_calls,
-            self.quota.web_search_max_calls_per_message(),
-            self.quota.code_interpreter_max_calls_per_message(),
+            provider_task::ProviderTaskConfig {
+                llm: resolved_provider.adapter,
+                upstream_alias: proxy_path,
+                messages: assembled.messages,
+                system_instructions: assembled.system_instructions,
+                tools: assembled.tools,
+                model: pf.effective_model,
+                provider_model_id: effective_provider_model_id,
+                max_output_tokens: pf.max_output_tokens_applied.cast_unsigned(),
+                max_tool_calls: pf.max_tool_calls,
+                web_search_max_calls: self.quota.web_search_max_calls_per_message(),
+                code_interpreter_max_calls: self.quota.code_interpreter_max_calls_per_message(),
+                api_params: pf.api_params,
+                provider_file_id_map,
+            },
             cancel,
             tx,
             Some(finalization_ctx),
-            provider_file_id_map,
         ))
     }
 }
@@ -1608,22 +1614,32 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
-            provider,
-            "test-alias".to_owned(),
             mock_ctx(),
-            vec![LlmMessage::user("hi")],
-            None,
-            vec![],
-            "test-model".into(),
-            "test-model".into(),
-            4096,
-            2, // max_tool_calls
-            2, // web_search_max_calls
-            2, // code_interpreter_max_calls
+            provider_task::ProviderTaskConfig {
+                llm: provider,
+                upstream_alias: "test-alias".to_owned(),
+                messages: vec![LlmMessage::user("hi")],
+                system_instructions: None,
+                tools: vec![],
+                model: "test-model".into(),
+                provider_model_id: "test-model".into(),
+                max_output_tokens: 4096,
+                max_tool_calls: 2,
+                web_search_max_calls: 2,
+                code_interpreter_max_calls: 2,
+                api_params: mini_chat_sdk::ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                    extra_body: None,
+                },
+                provider_file_id_map: std::collections::HashMap::new(),
+            },
             cancel,
             tx,
             None,
-            std::collections::HashMap::new(),
         );
 
         // Collect all events from the channel
@@ -1660,22 +1676,32 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
-            provider,
-            "test-alias".to_owned(),
             mock_ctx(),
-            vec![LlmMessage::user("hi")],
-            None,
-            vec![],
-            "test-model".into(),
-            "test-model".into(),
-            4096,
-            2, // max_tool_calls
-            2, // web_search_max_calls
-            2, // code_interpreter_max_calls
+            provider_task::ProviderTaskConfig {
+                llm: provider,
+                upstream_alias: "test-alias".to_owned(),
+                messages: vec![LlmMessage::user("hi")],
+                system_instructions: None,
+                tools: vec![],
+                model: "test-model".into(),
+                provider_model_id: "test-model".into(),
+                max_output_tokens: 4096,
+                max_tool_calls: 2,
+                web_search_max_calls: 2,
+                code_interpreter_max_calls: 2,
+                api_params: mini_chat_sdk::ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                    extra_body: None,
+                },
+                provider_file_id_map: std::collections::HashMap::new(),
+            },
             cancel,
             tx,
             None,
-            std::collections::HashMap::new(),
         );
 
         let mut events = Vec::new();
@@ -1705,22 +1731,32 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
-            provider,
-            "test-alias".to_owned(),
             mock_ctx(),
-            vec![LlmMessage::user("hi")],
-            None,
-            vec![],
-            "test-model".into(),
-            "test-model".into(),
-            4096,
-            2, // max_tool_calls
-            2, // web_search_max_calls
-            2, // code_interpreter_max_calls
+            provider_task::ProviderTaskConfig {
+                llm: provider,
+                upstream_alias: "test-alias".to_owned(),
+                messages: vec![LlmMessage::user("hi")],
+                system_instructions: None,
+                tools: vec![],
+                model: "test-model".into(),
+                provider_model_id: "test-model".into(),
+                max_output_tokens: 4096,
+                max_tool_calls: 2,
+                web_search_max_calls: 2,
+                code_interpreter_max_calls: 2,
+                api_params: mini_chat_sdk::ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                    extra_body: None,
+                },
+                provider_file_id_map: std::collections::HashMap::new(),
+            },
             cancel,
             tx,
             None,
-            std::collections::HashMap::new(),
         );
 
         let mut events = Vec::new();
@@ -1799,22 +1835,32 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
-            provider,
-            "test-alias".to_owned(),
             mock_ctx(),
-            vec![LlmMessage::user("hi")],
-            None,
-            vec![],
-            "test-model".into(),
-            "test-model".into(),
-            4096,
-            2, // max_tool_calls
-            2, // web_search_max_calls
-            2, // code_interpreter_max_calls
+            provider_task::ProviderTaskConfig {
+                llm: provider,
+                upstream_alias: "test-alias".to_owned(),
+                messages: vec![LlmMessage::user("hi")],
+                system_instructions: None,
+                tools: vec![],
+                model: "test-model".into(),
+                provider_model_id: "test-model".into(),
+                max_output_tokens: 4096,
+                max_tool_calls: 2,
+                web_search_max_calls: 2,
+                code_interpreter_max_calls: 2,
+                api_params: mini_chat_sdk::ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                    extra_body: None,
+                },
+                provider_file_id_map: std::collections::HashMap::new(),
+            },
             cancel.clone(),
             tx,
             None,
-            std::collections::HashMap::new(),
         );
 
         // Read the first delta
@@ -2491,6 +2537,14 @@ mod tests {
                 computer_use: false,
                 mcp: false,
             },
+            api_params: mini_chat_sdk::ModelApiParams {
+                temperature: 0.7,
+                top_p: 1.0,
+                frequency_penalty: 0.0,
+                presence_penalty: 0.0,
+                stop: vec![],
+                extra_body: None,
+            },
         };
 
         let result = flatten_preflight(decision).expect("Allow should produce Ok");
@@ -2527,6 +2581,14 @@ mod tests {
                 code_interpreter: false,
                 computer_use: false,
                 mcp: false,
+            },
+            api_params: mini_chat_sdk::ModelApiParams {
+                temperature: 0.7,
+                top_p: 1.0,
+                frequency_penalty: 0.0,
+                presence_penalty: 0.0,
+                stop: vec![],
+                extra_body: None,
             },
         };
 
@@ -3071,22 +3133,32 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let handle = provider_task::spawn_provider_task(
-            provider,
-            "test-alias".to_owned(),
             mock_ctx(),
-            vec![LlmMessage::user("hi")],
-            None,
-            vec![],
-            "gpt-4o-mini".into(), // effective_model passed as the model param
-            "gpt-4o-mini".into(),
-            4096,
-            2, // max_tool_calls
-            2, // web_search_max_calls
-            2, // code_interpreter_max_calls
+            provider_task::ProviderTaskConfig {
+                llm: provider,
+                upstream_alias: "test-alias".to_owned(),
+                messages: vec![LlmMessage::user("hi")],
+                system_instructions: None,
+                tools: vec![],
+                model: "gpt-4o-mini".into(), // effective_model passed as the model param
+                provider_model_id: "gpt-4o-mini".into(),
+                max_output_tokens: 4096,
+                max_tool_calls: 2,
+                web_search_max_calls: 2,
+                code_interpreter_max_calls: 2,
+                api_params: mini_chat_sdk::ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                    extra_body: None,
+                },
+                provider_file_id_map: std::collections::HashMap::new(),
+            },
             cancel,
             tx,
             Some(fctx),
-            std::collections::HashMap::new(),
         );
 
         // Collect events
@@ -3825,22 +3897,32 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
-            provider,
-            "test-alias".to_owned(),
             mock_ctx(),
-            vec![LlmMessage::user("hi")],
-            None,
-            vec![],
-            "test-model".into(),
-            "test-model".into(),
-            4096,
-            2, // max_tool_calls
-            2, // web_search_max_calls
-            2, // code_interpreter_max_calls
+            provider_task::ProviderTaskConfig {
+                llm: provider,
+                upstream_alias: "test-alias".to_owned(),
+                messages: vec![LlmMessage::user("hi")],
+                system_instructions: None,
+                tools: vec![],
+                model: "test-model".into(),
+                provider_model_id: "test-model".into(),
+                max_output_tokens: 4096,
+                max_tool_calls: 2,
+                web_search_max_calls: 2,
+                code_interpreter_max_calls: 2,
+                api_params: mini_chat_sdk::ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                    extra_body: None,
+                },
+                provider_file_id_map: std::collections::HashMap::new(),
+            },
             cancel,
             tx,
             None,
-            std::collections::HashMap::new(),
         );
 
         let mut events = Vec::new();
@@ -3871,22 +3953,32 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
-            provider,
-            "test-alias".to_owned(),
             mock_ctx(),
-            vec![LlmMessage::user("hi")],
-            None,
-            vec![],
-            "test-model".into(),
-            "test-model".into(),
-            4096,
-            2, // max_tool_calls
-            2, // web_search_max_calls
-            2, // code_interpreter_max_calls
+            provider_task::ProviderTaskConfig {
+                llm: provider,
+                upstream_alias: "test-alias".to_owned(),
+                messages: vec![LlmMessage::user("hi")],
+                system_instructions: None,
+                tools: vec![],
+                model: "test-model".into(),
+                provider_model_id: "test-model".into(),
+                max_output_tokens: 4096,
+                max_tool_calls: 2,
+                web_search_max_calls: 2,
+                code_interpreter_max_calls: 2,
+                api_params: mini_chat_sdk::ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                    extra_body: None,
+                },
+                provider_file_id_map: std::collections::HashMap::new(),
+            },
             cancel,
             tx,
             None,
-            std::collections::HashMap::new(),
         );
 
         let mut events = Vec::new();
@@ -3927,22 +4019,32 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
-            provider,
-            "test-alias".to_owned(),
             mock_ctx(),
-            vec![LlmMessage::user("hi")],
-            None,
-            vec![],
-            "test-model".into(),
-            "test-model".into(),
-            4096,
-            2, // max_tool_calls
-            2, // web_search_max_calls
-            2, // code_interpreter_max_calls
+            provider_task::ProviderTaskConfig {
+                llm: provider,
+                upstream_alias: "test-alias".to_owned(),
+                messages: vec![LlmMessage::user("hi")],
+                system_instructions: None,
+                tools: vec![],
+                model: "test-model".into(),
+                provider_model_id: "test-model".into(),
+                max_output_tokens: 4096,
+                max_tool_calls: 2,
+                web_search_max_calls: 2,
+                code_interpreter_max_calls: 2,
+                api_params: mini_chat_sdk::ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                    extra_body: None,
+                },
+                provider_file_id_map: std::collections::HashMap::new(),
+            },
             cancel,
             tx,
             None,
-            std::collections::HashMap::new(),
         );
 
         let mut events = Vec::new();
@@ -3970,22 +4072,32 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
-            provider,
-            "test-alias".to_owned(),
             mock_ctx(),
-            vec![LlmMessage::user("hi")],
-            None,
-            vec![],
-            "test-model".into(),
-            "test-model".into(),
-            4096,
-            2, // max_tool_calls
-            2, // web_search_max_calls
-            2, // code_interpreter_max_calls
+            provider_task::ProviderTaskConfig {
+                llm: provider,
+                upstream_alias: "test-alias".to_owned(),
+                messages: vec![LlmMessage::user("hi")],
+                system_instructions: None,
+                tools: vec![],
+                model: "test-model".into(),
+                provider_model_id: "test-model".into(),
+                max_output_tokens: 4096,
+                max_tool_calls: 2,
+                web_search_max_calls: 2,
+                code_interpreter_max_calls: 2,
+                api_params: mini_chat_sdk::ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                    extra_body: None,
+                },
+                provider_file_id_map: std::collections::HashMap::new(),
+            },
             cancel,
             tx,
             None,
-            std::collections::HashMap::new(),
         );
 
         let mut events = Vec::new();
@@ -4015,22 +4127,32 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
-            provider,
-            "test-alias".to_owned(),
             mock_ctx(),
-            vec![LlmMessage::user("hi")],
-            None,
-            vec![],
-            "test-model".into(),
-            "test-model".into(),
-            4096,
-            2, // max_tool_calls
-            2, // web_search_max_calls
-            2, // code_interpreter_max_calls
+            provider_task::ProviderTaskConfig {
+                llm: provider,
+                upstream_alias: "test-alias".to_owned(),
+                messages: vec![LlmMessage::user("hi")],
+                system_instructions: None,
+                tools: vec![],
+                model: "test-model".into(),
+                provider_model_id: "test-model".into(),
+                max_output_tokens: 4096,
+                max_tool_calls: 2,
+                web_search_max_calls: 2,
+                code_interpreter_max_calls: 2,
+                api_params: mini_chat_sdk::ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                    extra_body: None,
+                },
+                provider_file_id_map: std::collections::HashMap::new(),
+            },
             cancel,
             tx,
             None,
-            std::collections::HashMap::new(),
         );
 
         let mut events = Vec::new();
@@ -4071,22 +4193,32 @@ mod tests {
         let cancel = CancellationToken::new();
 
         let handle = provider_task::spawn_provider_task::<TurnRepo, MsgRepo>(
-            provider,
-            "test-alias".to_owned(),
             mock_ctx(),
-            vec![LlmMessage::user("hi")],
-            None,
-            vec![],
-            "test-model".into(),
-            "test-model".into(),
-            4096,
-            2, // max_tool_calls
-            2, // web_search_max_calls
-            2, // code_interpreter_max_calls
+            provider_task::ProviderTaskConfig {
+                llm: provider,
+                upstream_alias: "test-alias".to_owned(),
+                messages: vec![LlmMessage::user("hi")],
+                system_instructions: None,
+                tools: vec![],
+                model: "test-model".into(),
+                provider_model_id: "test-model".into(),
+                max_output_tokens: 4096,
+                max_tool_calls: 2,
+                web_search_max_calls: 2,
+                code_interpreter_max_calls: 2,
+                api_params: mini_chat_sdk::ModelApiParams {
+                    temperature: 0.7,
+                    top_p: 1.0,
+                    frequency_penalty: 0.0,
+                    presence_penalty: 0.0,
+                    stop: vec![],
+                    extra_body: None,
+                },
+                provider_file_id_map: std::collections::HashMap::new(),
+            },
             cancel,
             tx,
             None,
-            std::collections::HashMap::new(),
         );
 
         let mut events = Vec::new();

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/provider_task.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/provider_task.rs
@@ -16,40 +16,64 @@ use crate::infra::llm::{
     RequestMetadata, RequestType, TerminalOutcome,
 };
 
+use modkit_macros::domain_model;
+
 use super::types::{
     ActiveStreamGuard, FinalizationCtx, PROGRESS_UPDATE_INTERVAL, StreamOutcome, StreamTerminal,
     determine_features, normalize_error,
 };
+
+/// Model and provider configuration for a single provider task invocation.
+#[domain_model]
+pub(super) struct ProviderTaskConfig {
+    pub llm: Arc<dyn LlmProvider>,
+    pub upstream_alias: String,
+    pub messages: Vec<LlmMessage>,
+    pub system_instructions: Option<String>,
+    pub tools: Vec<LlmTool>,
+    pub model: String,
+    pub provider_model_id: String,
+    pub max_output_tokens: u32,
+    pub max_tool_calls: u32,
+    pub web_search_max_calls: u32,
+    pub code_interpreter_max_calls: u32,
+    pub api_params: mini_chat_sdk::ModelApiParams,
+    pub provider_file_id_map: std::collections::HashMap<String, crate::domain::llm::AttachmentRef>,
+}
 
 /// All five terminal paths (provider done, incomplete, provider error,
 /// client disconnect, pre-stream error) route through `finalize_turn_cas()`.
 /// SSE terminal events (Done/Error) are emitted only after the CAS winner
 /// commits the transaction (D3).
 #[allow(
-    clippy::too_many_arguments,
     clippy::too_many_lines,
     clippy::cognitive_complexity,
     clippy::let_underscore_must_use,
     clippy::cast_possible_truncation
 )]
 pub(super) fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepository + 'static>(
-    llm: Arc<dyn LlmProvider>,
-    upstream_alias: String,
     ctx: SecurityContext,
-    messages: Vec<LlmMessage>,
-    system_instructions: Option<String>,
-    tools: Vec<LlmTool>,
-    model: String,
-    provider_model_id: String,
-    max_output_tokens: u32,
-    max_tool_calls: u32,
-    web_search_max_calls: u32,
-    code_interpreter_max_calls: u32,
+    config: ProviderTaskConfig,
     cancel: CancellationToken,
     tx: mpsc::Sender<StreamEvent>,
     fin_ctx: Option<FinalizationCtx<TR, MR>>,
-    provider_file_id_map: std::collections::HashMap<String, crate::domain::llm::AttachmentRef>,
 ) -> tokio::task::JoinHandle<StreamOutcome> {
+    let ProviderTaskConfig {
+        llm,
+        upstream_alias,
+        messages,
+        system_instructions,
+        tools,
+        model,
+        provider_model_id,
+        max_output_tokens,
+        max_tool_calls,
+        web_search_max_calls,
+        code_interpreter_max_calls,
+        api_params,
+        provider_file_id_map,
+    } = config;
+
     let span = if let Some(ref fctx) = fin_ctx {
         tracing::info_span!(
             "provider_stream",
@@ -99,6 +123,25 @@ pub(super) fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepos
             features,
         };
         builder = builder.metadata(metadata);
+
+        // Forward model-policy API params (temperature, top_p, etc.) to the
+        // provider adapter via the generic `additional_params` escape hatch.
+        {
+            let mut params = serde_json::json!({
+                "temperature": api_params.temperature,
+                "top_p": api_params.top_p,
+                "frequency_penalty": api_params.frequency_penalty,
+                "presence_penalty": api_params.presence_penalty,
+            });
+            if !api_params.stop.is_empty() {
+                params["stop"] = serde_json::json!(api_params.stop);
+            }
+            if let Some(extra_body) = api_params.extra_body {
+                params["extra_body"] = extra_body;
+            }
+            builder = builder.additional_params(params);
+        }
+
         let request = builder.build_streaming();
 
         // Call the provider to start streaming
@@ -219,7 +262,7 @@ pub(super) fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepos
                             let is_first_token = matches!(client_event, ClientSseEvent::Delta { .. })
                                 && first_token_time.is_none();
 
-                            if let ClientSseEvent::Delta { ref content, .. } = client_event {
+                            if let ClientSseEvent::Delta { r#type, ref content } = client_event {
                                 if first_token_time.is_none() {
                                     let ttft = stream_start.elapsed();
                                     first_token_time = Some(ttft);
@@ -232,7 +275,12 @@ pub(super) fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepos
                                         fctx.metrics.record_ttft_provider_ms(&fctx.provider_id, &fctx.effective_model, ms);
                                     }
                                 }
-                                accumulated_text.push_str(content);
+                                // Only accumulate visible text for DB storage;
+                                // reasoning deltas are streamed to the client
+                                // but excluded from the persisted content.
+                                if r#type == "text" {
+                                    accumulated_text.push_str(content);
+                                }
 
                                 // Throttled progress timestamp update for orphan detection.
                                 // Timer resets only on success — retry sooner on transient

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/types.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/types.rs
@@ -374,6 +374,7 @@ pub(super) struct PreflightResult {
     pub(super) max_retrieved_chunks_per_turn: u32,
     pub(super) max_tool_calls: u32,
     pub(super) tool_support: mini_chat_sdk::ModelToolSupport,
+    pub(super) api_params: mini_chat_sdk::ModelApiParams,
 }
 
 /// Convert a `PreflightDecision` into a flat `PreflightResult` or a `StreamError`.
@@ -397,6 +398,7 @@ pub(super) fn flatten_preflight(
             max_retrieved_chunks_per_turn,
             max_tool_calls,
             tool_support,
+            api_params,
             ..
         } => Ok(PreflightResult {
             effective_model,
@@ -416,6 +418,7 @@ pub(super) fn flatten_preflight(
             max_retrieved_chunks_per_turn,
             max_tool_calls,
             tool_support,
+            api_params,
         }),
         PreflightDecision::Downgrade {
             effective_model,
@@ -434,6 +437,7 @@ pub(super) fn flatten_preflight(
             max_retrieved_chunks_per_turn,
             max_tool_calls,
             tool_support,
+            api_params,
             ..
         } => Ok(PreflightResult {
             effective_model,
@@ -453,6 +457,7 @@ pub(super) fn flatten_preflight(
             max_retrieved_chunks_per_turn,
             max_tool_calls,
             tool_support,
+            api_params,
         }),
         PreflightDecision::Reject {
             error_code,

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -458,9 +458,9 @@ pub fn test_catalog_entry(params: TestCatalogEntryParams) -> ModelCatalogEntry {
                 temperature: 0.7,
                 top_p: 1.0,
                 frequency_penalty: 0.0,
-
                 presence_penalty: 0.0,
                 stop: vec![],
+                extra_body: None,
             },
             features: ModelFeatures {
                 streaming: true,

--- a/modules/mini-chat/mini-chat/src/infra/llm/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/mod.rs
@@ -366,8 +366,12 @@ impl Stream for ProviderStream {
         loop {
             match this.inner.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(TranslatedEvent::Sse(event)))) => {
-                    // Accumulate delta text for fallback partial_content
-                    if let ClientSseEvent::Delta { ref content, .. } = event {
+                    // Accumulate only visible text (not reasoning) for DB content.
+                    if let ClientSseEvent::Delta {
+                        r#type: "text",
+                        ref content,
+                    } = event
+                    {
                         this.accumulated_text.push_str(content);
                     }
                     return Poll::Ready(Some(Ok(event)));

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/mod.rs
@@ -12,6 +12,7 @@ pub mod openai_file_storage;
 pub mod openai_responses;
 pub mod openai_vector_store;
 pub mod rag_http_client;
+pub mod vllm_responses;
 
 use std::sync::Arc;
 
@@ -20,6 +21,7 @@ use serde::{Deserialize, Serialize};
 
 pub use openai_chat::OpenAiChatProvider;
 pub use openai_responses::OpenAiResponsesProvider;
+pub use vllm_responses::VllmResponsesProvider;
 
 // ════════════════════════════════════════════════════════════════════════════
 // Provider selection
@@ -34,6 +36,9 @@ pub enum ProviderKind {
     /// `OpenAI` Chat Completions API (`/v1/chat/completions`).
     #[serde(rename = "openai_chat_completions")]
     OpenAiChatCompletions,
+    /// vLLM Responses API (`/v1/responses`).
+    #[serde(rename = "vllm_responses")]
+    VllmResponses,
 }
 
 /// Create a provider adapter from a [`ProviderKind`].
@@ -48,5 +53,6 @@ pub fn create_provider(
     match kind {
         ProviderKind::OpenAiResponses => Arc::new(OpenAiResponsesProvider::new(gateway)),
         ProviderKind::OpenAiChatCompletions => Arc::new(OpenAiChatProvider::new(gateway)),
+        ProviderKind::VllmResponses => Arc::new(VllmResponsesProvider::new(gateway)),
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
@@ -32,7 +32,7 @@ const MAX_CODE_INTERPRETER_OUTPUT_CHARS: usize = 8_192;
 
 /// Raw provider SSE event from the Responses API.
 #[derive(Debug, Clone)]
-enum ProviderEvent {
+pub(super) enum ProviderEvent {
     ResponseOutputTextDelta {
         delta: String,
     },
@@ -101,9 +101,28 @@ pub struct RawUsage {
     output_tokens_details: Option<OutputTokensDetails>,
 }
 
+impl RawUsage {
+    /// Convert to the domain [`Usage`] type.
+    pub(super) fn to_usage(&self) -> Usage {
+        Usage {
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            cache_read_input_tokens: self
+                .input_tokens_details
+                .as_ref()
+                .map_or(0, |d| d.cached_tokens),
+            cache_write_input_tokens: 0,
+            reasoning_tokens: self
+                .output_tokens_details
+                .as_ref()
+                .map_or(0, |d| d.reasoning_tokens),
+        }
+    }
+}
+
 /// Provider error payload from `response.failed` event.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-struct ProviderErrorPayload {
+pub(super) struct ProviderErrorPayload {
     #[serde(default)]
     code: String,
     #[serde(default)]
@@ -118,7 +137,7 @@ struct ProviderErrorEnvelope {
 
 /// Parse an error response body, handling both `{"error":{...}}` (`OpenAI`)
 /// and flat `{"code":"...","message":"..."}` shapes.
-fn parse_error_response(bytes: &[u8]) -> LlmProviderError {
+pub(super) fn parse_error_response(bytes: &[u8]) -> LlmProviderError {
     // Try OpenAI envelope first: {"error": {"message": "...", "code": "..."}}
     if let Ok(envelope) = serde_json::from_slice::<ProviderErrorEnvelope>(bytes) {
         let raw = envelope.error.message.clone();
@@ -412,7 +431,10 @@ impl FromServerEvent for ProviderEvent {
 // ════════════════════════════════════════════════════════════════════════════
 
 /// Translate a raw Responses API event into the shared contract.
-fn translate_provider_event(event: &ProviderEvent, accumulated_text: &str) -> TranslatedEvent {
+pub(super) fn translate_provider_event(
+    event: &ProviderEvent,
+    accumulated_text: &str,
+) -> TranslatedEvent {
     match event {
         ProviderEvent::ResponseOutputTextDelta { delta } => {
             TranslatedEvent::Sse(ClientSseEvent::Delta {
@@ -475,21 +497,7 @@ fn translate_provider_event(event: &ProviderEvent, accumulated_text: &str) -> Tr
 
         ProviderEvent::ResponseCompleted { response } => {
             let citations = extract_citations(response, accumulated_text);
-            let usage = Usage {
-                input_tokens: response.usage.input_tokens,
-                output_tokens: response.usage.output_tokens,
-                cache_read_input_tokens: response
-                    .usage
-                    .input_tokens_details
-                    .as_ref()
-                    .map_or(0, |d| d.cached_tokens),
-                cache_write_input_tokens: 0,
-                reasoning_tokens: response
-                    .usage
-                    .output_tokens_details
-                    .as_ref()
-                    .map_or(0, |d| d.reasoning_tokens),
-            };
+            let usage = response.usage.to_usage();
             let raw = serde_json::to_value(response).unwrap_or_default();
             TranslatedEvent::Terminal(TerminalOutcome::Completed {
                 usage,
@@ -530,7 +538,10 @@ fn translate_provider_event(event: &ProviderEvent, accumulated_text: &str) -> Tr
 }
 
 /// Extract citations from a `ResponseCompleted`'s output annotations.
-fn extract_citations(response: &ResponseObject, accumulated_text: &str) -> Vec<Citation> {
+pub(super) fn extract_citations(
+    response: &ResponseObject,
+    accumulated_text: &str,
+) -> Vec<Citation> {
     let mut citations = Vec::new();
 
     for output_item in &response.output {
@@ -905,21 +916,7 @@ impl crate::infra::llm::LlmProvider for OpenAiResponsesProvider {
         // ever is, map_citation_ids() must be applied by the caller.
         let citations = extract_citations(&response_obj, &content);
 
-        let usage = Usage {
-            input_tokens: response_obj.usage.input_tokens,
-            output_tokens: response_obj.usage.output_tokens,
-            cache_read_input_tokens: response_obj
-                .usage
-                .input_tokens_details
-                .as_ref()
-                .map_or(0, |d| d.cached_tokens),
-            cache_write_input_tokens: 0,
-            reasoning_tokens: response_obj
-                .usage
-                .output_tokens_details
-                .as_ref()
-                .map_or(0, |d| d.reasoning_tokens),
-        };
+        let usage = response_obj.usage.to_usage();
 
         let raw = serde_json::to_value(&response_obj).unwrap_or_default();
 

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/vllm_responses.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/vllm_responses.rs
@@ -1,0 +1,751 @@
+//! vLLM Responses API adapter (`/v1/responses`).
+//!
+//! Implements [`LlmProvider`] for vLLM's OpenAI-compatible Responses API.
+//! vLLM supports the same SSE event format as `OpenAI` but has stricter input
+//! validation: assistant messages must use plain string content (not the
+//! `output_text` array format), and tool-related fields are omitted.
+//!
+//! ## `<think>` tag handling
+//!
+//! Models like Qwen3 emit `<think>…</think>` blocks for chain-of-thought
+//! reasoning. This provider parses those tags out of the delta stream and
+//! emits them as `"reasoning"` deltas (instead of `"text"`), allowing the
+//! UI to render a collapsible "Thinking" panel.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::StreamExt;
+use modkit_security::SecurityContext;
+use oagw_sdk::error::StreamingError;
+use oagw_sdk::sse::{ServerEventsResponse, ServerEventsStream};
+use oagw_sdk::{Body, ServiceGatewayClientV1};
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+use crate::infra::llm::request::ContentPart as MessageContentPart;
+use crate::infra::llm::{
+    ClientSseEvent, LlmProviderError, LlmRequest, NonStreaming, ProviderStream, ResponseResult,
+    Streaming, TranslatedEvent,
+};
+
+use super::openai_responses::{
+    ProviderEvent, ResponseObject, extract_citations, parse_error_response,
+    translate_provider_event,
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// Think-tag state machine
+// ════════════════════════════════════════════════════════════════════════════
+
+const THINK_OPEN: &str = "<think>";
+const THINK_CLOSE: &str = "</think>";
+
+/// Tracks whether the stream is inside a `<think>…</think>` block.
+///
+/// Handles tags split across multiple deltas by buffering partial matches.
+#[derive(Debug)]
+struct ThinkState {
+    inside: bool,
+    /// Holds characters that *might* be the start of a tag but haven't been
+    /// fully matched yet (e.g. `"<thi"` waiting for `"nk>"`).
+    pending: String,
+}
+
+/// A chunk of text with its resolved delta type.
+struct Chunk {
+    delta_type: &'static str,
+    text: String,
+}
+
+impl ThinkState {
+    fn new() -> Self {
+        Self {
+            inside: false,
+            pending: String::new(),
+        }
+    }
+
+    /// Feed a raw delta string and return zero or more typed chunks.
+    ///
+    /// The state machine scans character-by-character, looking for `<think>`
+    /// and `</think>` boundaries. Characters that are *not* part of a tag
+    /// are grouped into chunks tagged as either `"reasoning"` (inside) or
+    /// `"text"` (outside).
+    fn feed(&mut self, delta: &str) -> Vec<Chunk> {
+        let mut chunks: Vec<Chunk> = Vec::new();
+        self.pending.push_str(delta);
+
+        // Work on the pending buffer (which may contain leftovers from the
+        // previous delta that partially matched a tag).
+        let buf = std::mem::take(&mut self.pending);
+        let mut pos = 0;
+
+        while pos < buf.len() {
+            let remainder = &buf[pos..];
+            if remainder.starts_with('<') {
+                // Try to match a tag starting at `pos`.
+                let tag = if self.inside { THINK_CLOSE } else { THINK_OPEN };
+
+                if remainder.len() >= tag.len() {
+                    if remainder.starts_with(tag) {
+                        // Full tag matched — toggle state, skip tag.
+                        self.inside = !self.inside;
+                        pos += tag.len();
+                        continue;
+                    }
+                    // Not a tag — emit the `<` as content and advance.
+                    push_char(&mut chunks, self.delta_type(), '<');
+                    pos += 1;
+                } else if tag.starts_with(remainder) {
+                    // Partial tag at the end of buffer — stash for next delta.
+                    remainder.clone_into(&mut self.pending);
+                    return chunks;
+                } else {
+                    // Not a tag prefix — emit the `<` as content.
+                    push_char(&mut chunks, self.delta_type(), '<');
+                    pos += 1;
+                }
+            } else {
+                // Advance by one full Unicode character.
+                // SAFETY: `remainder` is non-empty because `pos < buf.len()`.
+                #[allow(clippy::expect_used)]
+                let ch = remainder.chars().next().expect("non-empty remainder");
+                push_char(&mut chunks, self.delta_type(), ch);
+                pos += ch.len_utf8();
+            }
+        }
+
+        chunks
+    }
+
+    /// Flush any remaining pending buffer (called when the stream ends or
+    /// on terminal events).
+    fn flush(&mut self) -> Vec<Chunk> {
+        if self.pending.is_empty() {
+            return Vec::new();
+        }
+        let leftover = std::mem::take(&mut self.pending);
+        let dt = self.delta_type();
+        vec![Chunk {
+            delta_type: dt,
+            text: leftover,
+        }]
+    }
+
+    fn delta_type(&self) -> &'static str {
+        if self.inside { "reasoning" } else { "text" }
+    }
+}
+
+/// Append a character to the last chunk if its type matches, or start a new one.
+fn push_char(chunks: &mut Vec<Chunk>, delta_type: &'static str, ch: char) {
+    if let Some(last) = chunks.last_mut()
+        && last.delta_type == delta_type
+    {
+        last.text.push(ch);
+        return;
+    }
+    chunks.push(Chunk {
+        delta_type,
+        text: ch.to_string(),
+    });
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Think-aware event translation
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Translate a provider event, splitting `<think>` blocks into `"reasoning"`
+/// deltas and normal text into `"text"` deltas.
+///
+/// For non-delta events, delegates to [`translate_provider_event`].
+fn translate_with_think(
+    event: &ProviderEvent,
+    accumulated_text: &str,
+    think: &mut ThinkState,
+) -> Vec<Result<TranslatedEvent, StreamingError>> {
+    match event {
+        ProviderEvent::ResponseOutputTextDelta { delta } => {
+            let chunks = think.feed(delta);
+            chunks
+                .into_iter()
+                .filter(|c| !c.text.is_empty())
+                .map(|c| {
+                    Ok(TranslatedEvent::Sse(ClientSseEvent::Delta {
+                        r#type: c.delta_type,
+                        content: c.text,
+                    }))
+                })
+                .collect()
+        }
+        other => {
+            // Flush any buffered partial-tag text before terminal events
+            // so it isn't silently dropped.
+            let mut events: Vec<Result<TranslatedEvent, StreamingError>> = think
+                .flush()
+                .into_iter()
+                .filter(|c| !c.text.is_empty())
+                .map(|c| {
+                    Ok(TranslatedEvent::Sse(ClientSseEvent::Delta {
+                        r#type: c.delta_type,
+                        content: c.text,
+                    }))
+                })
+                .collect();
+
+            // Strip think tags from accumulated text so terminal outcomes
+            // (Completed.content, Failed.partial_content) contain only
+            // visible text.
+            let clean_text = strip_think_tags(accumulated_text);
+            events.push(Ok(translate_provider_event(other, &clean_text)));
+            events
+        }
+    }
+}
+
+/// Strip `<think>…</think>` from the final non-streaming response content.
+fn strip_think_tags(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find(THINK_OPEN) {
+        result.push_str(&rest[..start]);
+        match rest[start..].find(THINK_CLOSE) {
+            Some(end) => rest = &rest[start + end + THINK_CLOSE.len()..],
+            None => {
+                // Unclosed tag — drop the rest as reasoning
+                return result;
+            }
+        }
+    }
+    result.push_str(rest);
+    result
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Request body construction
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Build the vLLM Responses API JSON body from an [`LlmRequest`].
+///
+/// Compared to the `OpenAI` variant, this:
+/// - Uses plain string `content` for assistant messages (vLLM rejects the
+///   `output_text` array format).
+/// - Omits tool definitions (`file_search`, `web_search`, `code_interpreter`).
+/// - Omits `metadata` and `max_tool_calls`.
+fn build_request_body<M>(request: &LlmRequest<M>, stream: bool) -> serde_json::Value {
+    let mut body = serde_json::json!({
+        "stream": stream,
+        "store": false,
+    });
+
+    body["model"] = serde_json::json!(&request.model);
+
+    let input: Vec<serde_json::Value> = request
+        .messages
+        .iter()
+        .filter(|msg| msg.role != crate::infra::llm::request::Role::System)
+        .map(|msg| {
+            let role = match msg.role {
+                crate::infra::llm::request::Role::User => "user",
+                crate::infra::llm::request::Role::Assistant => "assistant",
+                crate::infra::llm::request::Role::System => unreachable!(),
+            };
+
+            // vLLM requires assistant content as a plain string.
+            if role == "assistant" {
+                let text = msg
+                    .content
+                    .iter()
+                    .filter_map(|part| match part {
+                        MessageContentPart::Text { text } => Some(text.as_str()),
+                        MessageContentPart::Image { .. } => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("");
+                return serde_json::json!({
+                    "type": "message",
+                    "role": "assistant",
+                    "content": text
+                });
+            }
+
+            // User messages keep the structured content array.
+            let content: Vec<serde_json::Value> = msg
+                .content
+                .iter()
+                .map(|part| match part {
+                    MessageContentPart::Text { text } => serde_json::json!({
+                        "type": "input_text",
+                        "text": text
+                    }),
+                    MessageContentPart::Image { file_id } => serde_json::json!({
+                        "type": "input_image",
+                        "file_id": file_id
+                    }),
+                })
+                .collect();
+            serde_json::json!({
+                "type": "message",
+                "role": role,
+                "content": content
+            })
+        })
+        .collect();
+
+    if !input.is_empty() {
+        body["input"] = serde_json::Value::Array(input);
+    }
+
+    if let Some(ref instructions) = request.system_instructions {
+        body["instructions"] = serde_json::json!(instructions);
+    }
+
+    if let Some(max_tokens) = request.max_output_tokens {
+        body["max_output_tokens"] = serde_json::json!(max_tokens);
+    }
+
+    if let Some(ref identity) = request.user_identity {
+        body["user"] = serde_json::json!(format!("{}:{}", identity.tenant_id, identity.user_id));
+    }
+
+    // Merge additional provider-specific params (temperature, top_p, etc.).
+    if let Some(ref extra) = request.additional_params
+        && let (Some(body_obj), Some(extra_obj)) = (body.as_object_mut(), extra.as_object())
+    {
+        for (k, v) in extra_obj {
+            body_obj.insert(k.clone(), v.clone());
+        }
+    }
+
+    body
+}
+
+/// Serialize a request body to `Body::Bytes`.
+#[allow(clippy::expect_used)]
+fn body_to_bytes(body: &serde_json::Value) -> Body {
+    let json = serde_json::to_vec(body).expect("serde_json::Value always serializes");
+    Body::Bytes(Bytes::from(json))
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// VllmResponsesProvider
+// ════════════════════════════════════════════════════════════════════════════
+
+/// vLLM Responses API adapter. Routes all calls through OAGW.
+///
+/// Parses `<think>…</think>` tags in the response stream and emits them as
+/// `"reasoning"` deltas, enabling the UI to show a "Thinking" panel.
+#[derive(Clone)]
+pub struct VllmResponsesProvider {
+    gateway: Arc<dyn ServiceGatewayClientV1>,
+}
+
+impl VllmResponsesProvider {
+    #[must_use]
+    pub fn new(gateway: Arc<dyn ServiceGatewayClientV1>) -> Self {
+        Self { gateway }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::infra::llm::LlmProvider for VllmResponsesProvider {
+    #[tracing::instrument(
+        skip(self, ctx, request, upstream_alias, cancel),
+        fields(model = %request.model(), upstream = %upstream_alias)
+    )]
+    async fn stream(
+        &self,
+        ctx: SecurityContext,
+        request: LlmRequest<Streaming>,
+        upstream_alias: &str,
+        cancel: CancellationToken,
+    ) -> Result<ProviderStream, LlmProviderError> {
+        let body = build_request_body(&request, true);
+        let uri = format!("/{upstream_alias}");
+
+        let http_request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(&uri)
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .header(http::header::ACCEPT, "text/event-stream")
+            .body(body_to_bytes(&body))
+            .map_err(|e| LlmProviderError::InvalidResponse {
+                detail: format!("failed to build HTTP request: {e}"),
+            })?;
+
+        debug!(uri = %uri, "sending streaming request to provider");
+
+        let response = self.gateway.proxy_request(ctx, http_request).await?;
+
+        match ServerEventsStream::from_response::<ProviderEvent>(response) {
+            ServerEventsResponse::Events(event_stream) => {
+                // Scan state: (accumulated_text, think_state_machine).
+                let translated = event_stream
+                    .scan(
+                        (String::new(), ThinkState::new()),
+                        |(accumulated, think), result| {
+                            let output: Vec<Result<TranslatedEvent, StreamingError>> = match result
+                            {
+                                Ok(event) => {
+                                    if let ProviderEvent::ResponseOutputTextDelta { ref delta } =
+                                        event
+                                    {
+                                        accumulated.push_str(delta);
+                                    }
+                                    translate_with_think(&event, accumulated, think)
+                                }
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "provider SSE stream error");
+                                    vec![Err(e)]
+                                }
+                            };
+                            async move { Some(futures::stream::iter(output)) }
+                        },
+                    )
+                    .flatten();
+
+                Ok(ProviderStream::new(translated, cancel))
+            }
+            ServerEventsResponse::Response(resp) => {
+                let (parts, body) = resp.into_parts();
+                tracing::warn!(status = %parts.status, "provider returned non-SSE response");
+                match body.into_bytes().await {
+                    Ok(bytes) => {
+                        let body_preview = crate::infra::llm::sanitize_provider_message(
+                            &String::from_utf8_lossy(&bytes)
+                                .chars()
+                                .take(200)
+                                .collect::<String>(),
+                        );
+                        debug!(body = %body_preview, "non-SSE response body");
+                        Err(parse_error_response(&bytes))
+                    }
+                    Err(e) => Err(LlmProviderError::InvalidResponse {
+                        detail: format!("failed to read response body: {e}"),
+                    }),
+                }
+            }
+        }
+    }
+
+    #[tracing::instrument(
+        skip(self, ctx, request, upstream_alias),
+        fields(model = %request.model(), upstream = %upstream_alias)
+    )]
+    async fn complete(
+        &self,
+        ctx: SecurityContext,
+        request: LlmRequest<NonStreaming>,
+        upstream_alias: &str,
+    ) -> Result<ResponseResult, LlmProviderError> {
+        let body = build_request_body(&request, false);
+        let uri = format!("/{upstream_alias}");
+
+        let http_request = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(&uri)
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .header(http::header::ACCEPT, "application/json")
+            .body(body_to_bytes(&body))
+            .map_err(|e| LlmProviderError::InvalidResponse {
+                detail: format!("failed to build HTTP request: {e}"),
+            })?;
+
+        let response = self.gateway.proxy_request(ctx, http_request).await?;
+
+        let (parts, resp_body) = response.into_parts();
+        let bytes =
+            resp_body
+                .into_bytes()
+                .await
+                .map_err(|e| LlmProviderError::InvalidResponse {
+                    detail: format!("failed to read response body: {e}"),
+                })?;
+
+        if !parts.status.is_success() {
+            return Err(parse_error_response(&bytes));
+        }
+
+        let response_obj: ResponseObject =
+            serde_json::from_slice(&bytes).map_err(|_| parse_error_response(&bytes))?;
+
+        let raw_content = response_obj
+            .output
+            .iter()
+            .flat_map(|item| &item.content)
+            .filter(|part| part.r#type == "output_text")
+            .map(|part| part.text.as_str())
+            .collect::<Vec<_>>()
+            .join("");
+
+        // Strip think tags from non-streaming response.
+        let content = strip_think_tags(&raw_content);
+
+        let citations = extract_citations(&response_obj, &content);
+        let usage = response_obj.usage.to_usage();
+
+        let raw = serde_json::to_value(&response_obj).unwrap_or_default();
+
+        Ok(ResponseResult {
+            content,
+            usage,
+            response_id: response_obj.id,
+            citations,
+            raw_response: raw,
+        })
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Tests
+// ════════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+#[allow(clippy::non_ascii_literal)]
+mod tests {
+    use super::*;
+    use crate::infra::llm::{LlmMessage, llm_request};
+
+    // ── ThinkState unit tests ────────────────────────────────────────────
+
+    #[test]
+    fn think_tags_in_single_delta() {
+        let mut state = ThinkState::new();
+        let chunks = state.feed("<think>reasoning here</think>actual text");
+        let types: Vec<_> = chunks
+            .iter()
+            .map(|c| (c.delta_type, c.text.as_str()))
+            .collect();
+        assert_eq!(
+            types,
+            vec![("reasoning", "reasoning here"), ("text", "actual text")]
+        );
+    }
+
+    #[test]
+    fn think_tags_split_across_deltas() {
+        let mut state = ThinkState::new();
+
+        let c1 = state.feed("<think>start of thought");
+        assert_eq!(c1.len(), 1);
+        assert_eq!(c1[0].delta_type, "reasoning");
+        assert_eq!(c1[0].text, "start of thought");
+
+        let c2 = state.feed(" continued</think>visible");
+        let types: Vec<_> = c2.iter().map(|c| (c.delta_type, c.text.as_str())).collect();
+        assert_eq!(
+            types,
+            vec![("reasoning", " continued"), ("text", "visible")]
+        );
+    }
+
+    #[test]
+    fn partial_tag_across_deltas() {
+        let mut state = ThinkState::new();
+
+        // Delta ends mid-tag: "<thi"
+        let c1 = state.feed("<thi");
+        assert!(c1.is_empty(), "partial tag should be buffered");
+
+        // Next delta completes the tag
+        let c2 = state.feed("nk>inside");
+        assert_eq!(c2.len(), 1);
+        assert_eq!(c2[0].delta_type, "reasoning");
+        assert_eq!(c2[0].text, "inside");
+    }
+
+    #[test]
+    fn no_think_tags_passes_through() {
+        let mut state = ThinkState::new();
+        let chunks = state.feed("just normal text");
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].delta_type, "text");
+        assert_eq!(chunks[0].text, "just normal text");
+    }
+
+    #[test]
+    fn angle_bracket_not_a_tag() {
+        let mut state = ThinkState::new();
+        let chunks = state.feed("5 < 10 and 10 > 5");
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].delta_type, "text");
+        assert_eq!(chunks[0].text, "5 < 10 and 10 > 5");
+    }
+
+    #[test]
+    fn empty_think_block() {
+        let mut state = ThinkState::new();
+        let chunks = state.feed("<think></think>answer");
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].delta_type, "text");
+        assert_eq!(chunks[0].text, "answer");
+    }
+
+    #[test]
+    fn flush_emits_pending() {
+        let mut state = ThinkState::new();
+        let c1 = state.feed("<thi");
+        assert!(c1.is_empty());
+
+        let flushed = state.flush();
+        assert_eq!(flushed.len(), 1);
+        assert_eq!(flushed[0].text, "<thi");
+        assert_eq!(flushed[0].delta_type, "text");
+    }
+
+    #[test]
+    fn newlines_after_think_tag_stripped() {
+        let mut state = ThinkState::new();
+        let chunks = state.feed("<think>\nreasoning\n</think>\ntext");
+        let types: Vec<_> = chunks
+            .iter()
+            .map(|c| (c.delta_type, c.text.as_str()))
+            .collect();
+        assert_eq!(
+            types,
+            vec![("reasoning", "\nreasoning\n"), ("text", "\ntext")]
+        );
+    }
+
+    #[test]
+    fn cyrillic_text_preserved() {
+        let mut state = ThinkState::new();
+        let chunks = state.feed("<think>Нека помислим</think>Здравей свят!");
+        let types: Vec<_> = chunks
+            .iter()
+            .map(|c| (c.delta_type, c.text.as_str()))
+            .collect();
+        assert_eq!(
+            types,
+            vec![("reasoning", "Нека помислим"), ("text", "Здравей свят!"),]
+        );
+    }
+
+    #[test]
+    fn multibyte_chars_not_corrupted() {
+        let mut state = ThinkState::new();
+        // Emoji, CJK, Bulgarian in a single delta
+        let chunks = state.feed("🦀 Rust は素晴らしい и прекрасен");
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].text, "🦀 Rust は素晴らしい и прекрасен");
+    }
+
+    // ── strip_think_tags ─────────────────────────────────────────────────
+
+    #[test]
+    fn strip_think_basic() {
+        assert_eq!(strip_think_tags("<think>reasoning</think>answer"), "answer");
+    }
+
+    #[test]
+    fn strip_think_no_tags() {
+        assert_eq!(strip_think_tags("plain text"), "plain text");
+    }
+
+    #[test]
+    fn strip_think_unclosed() {
+        assert_eq!(strip_think_tags("before<think>reasoning"), "before");
+    }
+
+    #[test]
+    fn strip_think_multiple() {
+        assert_eq!(strip_think_tags("<think>a</think>b<think>c</think>d"), "bd");
+    }
+
+    // ── build_request_body ───────────────────────────────────────────────
+
+    #[test]
+    fn assistant_content_is_plain_string() {
+        let request = llm_request("test-model")
+            .message(LlmMessage::user("Hello"))
+            .message(LlmMessage::assistant("Hi there!"))
+            .message(LlmMessage::user("How are you?"))
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+        let input = body["input"].as_array().unwrap();
+
+        assert_eq!(input[0]["role"], "user");
+        assert!(input[0]["content"].is_array());
+
+        assert_eq!(input[1]["role"], "assistant");
+        assert!(input[1]["content"].is_string());
+        assert_eq!(input[1]["content"], "Hi there!");
+
+        assert_eq!(input[2]["role"], "user");
+        assert!(input[2]["content"].is_array());
+    }
+
+    #[test]
+    fn tools_are_omitted_even_when_set() {
+        use crate::domain::llm::{LlmTool, WebSearchContextSize};
+
+        let request = llm_request("test-model")
+            .message(LlmMessage::user("Search"))
+            .tool(LlmTool::WebSearch {
+                search_context_size: WebSearchContextSize::Medium,
+            })
+            .tool(LlmTool::FileSearch {
+                vector_store_ids: vec!["vs-1".into()],
+                filters: None,
+                max_num_results: None,
+            })
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+        assert!(body.get("tools").is_none());
+    }
+
+    #[test]
+    fn metadata_and_max_tool_calls_omitted_even_when_set() {
+        use crate::infra::llm::request::{RequestMetadata, RequestType};
+
+        let request = llm_request("test-model")
+            .message(LlmMessage::user("Hello"))
+            .metadata(RequestMetadata {
+                tenant_id: "t1".into(),
+                user_id: "u1".into(),
+                chat_id: "c1".into(),
+                request_type: RequestType::Chat,
+                features: vec![],
+            })
+            .max_tool_calls(5)
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+        assert!(body.get("metadata").is_none());
+        assert!(body.get("max_tool_calls").is_none());
+        assert!(body.get("previous_response_id").is_none());
+    }
+
+    #[test]
+    fn system_messages_become_instructions() {
+        let request = llm_request("test-model")
+            .system_instructions("Be helpful")
+            .message(LlmMessage::user("Hello"))
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+        assert_eq!(body["instructions"], "Be helpful");
+
+        let input = body["input"].as_array().unwrap();
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "user");
+    }
+
+    #[test]
+    fn additional_params_are_merged() {
+        let request = llm_request("test-model")
+            .message(LlmMessage::user("Hello"))
+            .additional_params(serde_json::json!({
+                "temperature": 0.5,
+                "top_p": 0.9
+            }))
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+        assert_eq!(body["temperature"], 0.5);
+        assert_eq!(body["top_p"], 0.9);
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/plugins/static_model_policy/tests.rs
+++ b/modules/mini-chat/mini-chat/src/infra/plugins/static_model_policy/tests.rs
@@ -44,6 +44,7 @@ fn make_entry(model_id: &str, tier: ModelTier) -> ModelCatalogEntry {
                 frequency_penalty: 0.0,
                 presence_penalty: 0.0,
                 stop: vec![],
+                extra_body: None,
             },
             features: ModelFeatures {
                 streaming: true,

--- a/scripts/lib/prereq.py
+++ b/scripts/lib/prereq.py
@@ -528,9 +528,56 @@ class PrereqCargoLlvmCov(Prereq):
             return PRECHECK_ERROR
 
 
+class PrereqCargoNextest(Prereq):
+    def __init__(self):
+        super().__init__(
+            name="cargo-nextest is installed",
+            remediation=(
+                "Install cargo-nextest using "
+                "'cargo install cargo-nextest'"
+            )
+        )
+
+    def check(self):
+        try:
+            subprocess.check_output(
+                ["cargo", "nextest", "--version"], stderr=subprocess.DEVNULL
+            )
+            return PRECHECK_OK
+        except subprocess.CalledProcessError:
+            try:
+                subprocess.check_call(
+                    ["cargo", "install", "--locked", "cargo-nextest"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                subprocess.check_output(
+                    ["cargo", "nextest", "--version"],
+                    stderr=subprocess.DEVNULL,
+                )
+                return PRECHECK_OK
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                logging.error(
+                    "cargo-nextest is not installed or could not be installed"
+                )
+                logging.error(f"Possible remediation: {self.remediation}")
+                return PRECHECK_ERROR
+        except FileNotFoundError:
+            logging.error(
+                "'cargo' command not found"
+            )
+            logging.error(
+                "Possible remediation: Install Rust and cargo from "
+                "https://rustup.rs/ or using a package manager like "
+                "Homebrew: 'brew install rust'"
+            )
+            return PRECHECK_ERROR
+
+
 # Core prerequisites needed for basic testing
 CORE_PREREQS = [
     PrereqCargo,
+    PrereqCargoNextest,
     PrereqProtoc,
     PrereqPython,
     PrereqPytest,


### PR DESCRIPTION
Introduce a dedicated vLLM provider (`vllm_responses`) that handles vLLM's stricter Responses API validation and parses `<think>…</think>` reasoning blocks into separate SSE delta types.
  - Streaming state machine splits deltas into `type: "reasoning"` and `type: "text"`, enabling UI to render a "Thinking" panel
  - Non-streaming path strips think tags from response content
  - Handles multi-byte UTF-8 correctly in tag boundary parsing
- Expose shared types from openai_responses (ProviderEvent, translate, extract_citations, parse_error_response) via pub(super) + RawUsage::to_usage()
- Makefile: use git SHA image tags and force-remove stale minikube images before loading to prevent stale-cache deployment issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local vLLM provider support added and Qwen3-0.6b exposed as an available model; HTTP upstreams enabled for local providers.

* **Improvements**
  * Streaming now separates plain text from internal "reasoning", strips tags from outputs, and improves usage accounting; added tests for streaming/tagging behavior.
  * Per-model API parameters supported in model configuration.

* **Infrastructure**
  * Test tooling and CI updated to use nextest; added local tool install/prereqs and switched image tagging to short git SHA by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->