### PR TITLE
[do not merge] experiment: recreate security context error with OPTIONS request in oagw

### DIFF
--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -111,7 +111,7 @@ modules:
           in_flight: 64
 
       # Authentication Configuration
-      auth_disabled: true
+      auth_disabled: false
       require_auth_by_default: true
 
   # --- Tenant Resolver example (gateway + plugins) ---
@@ -221,7 +221,18 @@ modules:
     config:
       vendor: "hyperspot"
       priority: 100
-      mode: accept_all
+      mode: static_tokens
+      tokens:
+        - token: "e2e-token-tenant-a"
+          identity:
+            subject_id: "11111111-6a88-4768-9dfc-6bcd5187d9ed"
+            subject_tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
+            token_scopes: ["*"]
+        - token: "e2e-token-tenant-b"
+          identity:
+            subject_id: "22222222-6a88-4768-9dfc-6bcd5187d9ed"
+            subject_tenant_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+            token_scopes: ["*"]
       s2s_credentials:
         - client_id: "mini-chat"
           client_secret: "mini-chat-dev-secret"

--- a/testing/e2e/conftest.py
+++ b/testing/e2e/conftest.py
@@ -18,14 +18,15 @@ def base_url():
 def auth_headers():
     """
     Build Authorization headers using E2E_AUTH_TOKEN env var.
-    
+
+    Falls back to a dummy token suitable for the static-authn-plugin
+    running in ``accept_all`` mode (any non-empty Bearer token is accepted).
+
     Returns:
-        dict: Headers dict with Authorization header if token is set, empty dict otherwise.
+        dict: Headers dict with Authorization header.
     """
-    token = os.getenv("E2E_AUTH_TOKEN")
-    if token:
-        return {"Authorization": f"Bearer {token}"}
-    return {}
+    token = os.getenv("E2E_AUTH_TOKEN", "e2e-token-tenant-a")
+    return {"Authorization": f"Bearer {token}"}
 
 
 @pytest.fixture

--- a/testing/e2e/modules/file_parser/generate_file_parser_golden.py
+++ b/testing/e2e/modules/file_parser/generate_file_parser_golden.py
@@ -26,11 +26,9 @@ def get_base_url():
 
 
 def get_auth_headers():
-    """Get authorization headers if token is set."""
-    token = os.getenv("E2E_AUTH_TOKEN")
-    if token:
-        return {"Authorization": f"Bearer {token}"}
-    return {}
+    """Get authorization headers (defaults to dummy token for accept_all mode)."""
+    token = os.getenv("E2E_AUTH_TOKEN", "e2e-token-tenant-a")
+    return {"Authorization": f"Bearer {token}"}
 
 
 def find_input_files(testdata_dir):

--- a/testing/e2e/modules/oagw/conftest.py
+++ b/testing/e2e/modules/oagw/conftest.py
@@ -33,12 +33,12 @@ def tenant_id():
 
 @pytest.fixture
 def oagw_headers(tenant_id):
-    """Standard headers for OAGW requests (tenant + optional auth)."""
-    headers = {"x-tenant-id": tenant_id}
-    token = os.getenv("E2E_AUTH_TOKEN")
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
+    """Standard headers for OAGW requests (tenant + auth)."""
+    token = os.getenv("E2E_AUTH_TOKEN", "e2e-token-tenant-a")
+    return {
+        "x-tenant-id": tenant_id,
+        "Authorization": f"Bearer {token}",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/testing/e2e/modules/oagw/test_authz.py
+++ b/testing/e2e/modules/oagw/test_authz.py
@@ -52,10 +52,11 @@ async def test_proxy_authz_forbidden_nil_tenant(
                 client, oagw_base_url, oagw_headers, uid, ["GET"], "/v1/models",
             )
 
-            denied_headers = {"x-tenant-id": NIL_TENANT_ID}
-            token = os.getenv("E2E_AUTH_TOKEN")
-            if token:
-                denied_headers["Authorization"] = f"Bearer {token}"
+            token = os.getenv("E2E_AUTH_TOKEN", "e2e-token-tenant-a")
+            denied_headers = {
+                "x-tenant-id": NIL_TENANT_ID,
+                "Authorization": f"Bearer {token}",
+            }
 
             resp = await client.get(
                 f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled authentication validation for the API gateway (previously disabled).
  * Updated authentication configuration to enforce static token validation instead of accept-all mode.
  * Updated test infrastructure and fixtures to provide authentication tokens by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->