### PR TITLE
feat(odata): InList filter, property paths, has_next/prev_page

### DIFF
--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -5127,6 +5127,18 @@
             "bearerAuth": []
           }
         ],
+        "x-odata-orderby": {
+          "allowedFields": [
+            "id asc",
+            "id desc",
+            "name asc",
+            "name desc",
+            "country asc",
+            "country desc",
+            "created_at asc",
+            "created_at desc"
+          ]
+        },
         "x-odata-filter": {
           "allowedFields": {
             "country": [
@@ -5160,18 +5172,6 @@
               "in"
             ]
           }
-        },
-        "x-odata-orderby": {
-          "allowedFields": [
-            "id asc",
-            "id desc",
-            "name asc",
-            "name desc",
-            "country asc",
-            "country desc",
-            "created_at asc",
-            "created_at desc"
-          ]
         }
       },
       "post": {
@@ -5623,16 +5623,6 @@
             "bearerAuth": []
           }
         ],
-        "x-odata-orderby": {
-          "allowedFields": [
-            "id asc",
-            "id desc",
-            "email asc",
-            "email desc",
-            "created_at asc",
-            "created_at desc"
-          ]
-        },
         "x-odata-filter": {
           "allowedFields": {
             "created_at": [
@@ -5658,6 +5648,16 @@
               "in"
             ]
           }
+        },
+        "x-odata-orderby": {
+          "allowedFields": [
+            "id asc",
+            "id desc",
+            "email asc",
+            "email desc",
+            "created_at asc",
+            "created_at desc"
+          ]
         }
       },
       "post": {

--- a/libs/modkit-db/src/odata/sea_orm_filter.rs
+++ b/libs/modkit-db/src/odata/sea_orm_filter.rs
@@ -154,6 +154,18 @@ where
             let column = M::map_field(*field);
             build_binary_condition(column, *op, value)
         }
+        FilterNode::InList { field, values } => {
+            if values.is_empty() {
+                return Err("IN list must not be empty".to_owned());
+            }
+            let column = M::map_field(*field);
+            let kind = field.kind();
+            let sea_values: Vec<sea_orm::Value> = values
+                .iter()
+                .map(|v| odata_value_to_sea_value_for_kind(v, kind))
+                .collect::<Result<_, _>>()?;
+            Ok(Condition::all().add(Expr::col(column).is_in(sea_values)))
+        }
         FilterNode::Composite { op, children } => {
             // Combine child conditions with AND or OR
             let base = match op {
@@ -218,8 +230,8 @@ where
             let s = extract_string(value)?;
             Expr::col(column).like(format!("%{}", escape_like(&s)))
         }
-        FilterOp::And | FilterOp::Or => {
-            return Err(format!("Logical operator {op:?} in binary context"));
+        FilterOp::In | FilterOp::And | FilterOp::Or => {
+            return Err(format!("Operator {op:?} not valid in binary context"));
         }
     };
 
@@ -249,6 +261,32 @@ fn odata_value_to_sea_value(value: &ODataValue) -> Result<sea_orm::Value, String
             return Err("NULL values should be handled separately".to_owned());
         }
     })
+}
+
+/// Convert an `ODataValue` to a `sea_orm::Value`, using the field's `FieldKind`
+/// to coerce numeric values to the correct SQL type (especially Decimal).
+fn odata_value_to_sea_value_for_kind(
+    value: &ODataValue,
+    kind: FieldKind,
+) -> Result<sea_orm::Value, String> {
+    match (kind, value) {
+        (FieldKind::I64, ODataValue::Number(n)) => n
+            .to_i64()
+            .map(|i| sea_orm::Value::BigInt(Some(i)))
+            .ok_or_else(|| "Number value out of range for i64".to_owned()),
+        (FieldKind::F64, ODataValue::Number(n)) => n
+            .to_f64()
+            .map(|f| sea_orm::Value::Double(Some(f)))
+            .ok_or_else(|| "Number value out of range for f64".to_owned()),
+        (FieldKind::Decimal, ODataValue::Number(n)) => {
+            let d = n
+                .to_string()
+                .parse::<rust_decimal::Decimal>()
+                .map_err(|_| "Invalid decimal value".to_owned())?;
+            Ok(sea_orm::Value::Decimal(Some(Box::new(d))))
+        }
+        _ => odata_value_to_sea_value(value),
+    }
 }
 
 /// Extract a string from an `ODataValue`.

--- a/libs/modkit-odata/src/filter.rs
+++ b/libs/modkit-odata/src/filter.rs
@@ -43,10 +43,39 @@ pub trait FilterField: Copy + Eq + std::hash::Hash + fmt::Debug + 'static {
     fn kind(&self) -> FieldKind;
 
     fn from_name(name: &str) -> Option<Self> {
-        Self::FIELDS
+        // Try exact match first (handles both simple names and slash-delimited property paths
+        // like "hierarchy/depth" if the enum defines them).
+        let exact = Self::FIELDS
             .iter()
             .copied()
-            .find(|f| f.name().eq_ignore_ascii_case(name))
+            .find(|f| f.name().eq_ignore_ascii_case(name));
+        if exact.is_some() {
+            return exact;
+        }
+        // Fallback: resolve by the last segment of a property path (e.g. "depth" from
+        // "hierarchy/depth") so field enums that only define simple names still work.
+        //
+        // Note: if multiple fields share the same terminal segment this returns the
+        // first match. Callers that define ambiguous field names should override
+        // `from_name` with explicit slash-delimited entries.
+        if let Some(last) = name.rsplit('/').next()
+            && last != name
+        {
+            let mut iter = Self::FIELDS
+                .iter()
+                .copied()
+                .filter(|f| f.name().eq_ignore_ascii_case(last));
+            if let Some(first) = iter.next() {
+                // Ambiguous: more than one field shares the same terminal segment.
+                // Return None so the caller reports UnknownField instead of silently
+                // picking the wrong field.
+                if iter.next().is_some() {
+                    return None;
+                }
+                return Some(first);
+            }
+        }
+        None
     }
 }
 
@@ -58,6 +87,7 @@ pub enum FilterOp {
     Ge,
     Lt,
     Le,
+    In,
     Contains,
     StartsWith,
     EndsWith,
@@ -74,6 +104,7 @@ impl fmt::Display for FilterOp {
             FilterOp::Ge => write!(f, "ge"),
             FilterOp::Lt => write!(f, "lt"),
             FilterOp::Le => write!(f, "le"),
+            FilterOp::In => write!(f, "in"),
             FilterOp::Contains => write!(f, "contains"),
             FilterOp::StartsWith => write!(f, "startswith"),
             FilterOp::EndsWith => write!(f, "endswith"),
@@ -89,6 +120,10 @@ pub enum FilterNode<F: FilterField> {
         field: F,
         op: FilterOp,
         value: ODataValue,
+    },
+    InList {
+        field: F,
+        values: Vec<ODataValue>,
     },
     Composite {
         op: FilterOp,
@@ -306,9 +341,42 @@ pub fn convert_expr_to_filter_node<F: FilterField>(
             }
         }
 
-        E::In(_left, _list) => Err(FilterError::UnsupportedOperation(
-            "IN operator not yet supported in typed filters".to_owned(),
-        )),
+        E::In(left, list) => {
+            let field_name = match &**left {
+                E::Identifier(name) => name.as_str(),
+                _ => {
+                    return Err(FilterError::InvalidExpression(
+                        "IN operator requires a field identifier on the left side".to_owned(),
+                    ));
+                }
+            };
+
+            let field = F::from_name(field_name)
+                .ok_or_else(|| FilterError::UnknownField(field_name.to_owned()))?;
+
+            let mut values = Vec::with_capacity(list.len());
+            for item in list {
+                match item {
+                    E::Value(val) => {
+                        validate_value_type(field, val)?;
+                        values.push(val.clone());
+                    }
+                    _ => {
+                        return Err(FilterError::InvalidExpression(
+                            "IN operator values must be literals".to_owned(),
+                        ));
+                    }
+                }
+            }
+
+            if values.is_empty() {
+                return Err(FilterError::InvalidExpression(
+                    "IN operator requires at least one value".to_owned(),
+                ));
+            }
+
+            Ok(FilterNode::InList { field, values })
+        }
 
         E::Identifier(name) => Err(FilterError::BareIdentifier(name.clone())),
         E::Value(_) => Err(FilterError::BareLiteral),

--- a/libs/modkit-odata/src/odata_parse.rs
+++ b/libs/modkit-odata/src/odata_parse.rs
@@ -75,11 +75,11 @@ peg::parser! {
             / "in" _ "(" _ r:filter_list() _ ")" { Ok(AfterValueExpr::In(r?)) }
             / { Ok(AfterValueExpr::End) }
 
-        /// Parses a value expression, which can be a function call, a value, or an identifier.
+        /// Parses a value expression, which can be a function call, a value, or a property path.
         rule value_expr() -> Result<Expr, ParseError>
             = function_call()
             / v:value() { Ok(Expr::Value(v?)) }
-            / i:identifier() { Ok(Expr::Identifier(i)) }
+            / p:property_path() { Ok(Expr::Identifier(p)) }
 
         /// Parses a comparison operator.
         rule comparison_op() -> CompareOperator
@@ -94,7 +94,18 @@ peg::parser! {
         rule function_call() -> Result<Expr, ParseError>
             = f:identifier() _ "(" _ l:filter_list() _ ")" { Ok(Expr::Function(f, l?)) }
 
-        /// Parses an identifier.
+        /// Parses an OData property path (e.g., `hierarchy/depth`, `address/city`).
+        /// OData 4.01 ABNF §5.1.1.15 — property paths use `/` as segment separator:
+        ///   firstMemberExpr = memberExpr / inscopeVariableExpr [ "/" memberExpr ]
+        /// Spec: https://docs.oasis-open.org/odata/odata/v4.01/os/abnf/odata-abnf-construction-rules.txt
+        rule property_path() -> String
+            = s:$(identifier() ("/" identifier())*) { s.to_owned() }
+
+        /// Parses an OData identifier (no `/`).
+        /// OData 4.01 ABNF §9:
+        ///   odataIdentifier = identifierLeadingCharacter *127identifierCharacter
+        ///   identifierCharacter = ALPHA / "_" / DIGIT
+        /// Spec: https://docs.oasis-open.org/odata/odata/v4.01/os/abnf/odata-abnf-construction-rules.txt
         rule identifier() -> String
             = s:$(['a'..='z'|'A'..='Z'|'_']['a'..='z'|'A'..='Z'|'_'|'0'..='9']*) { s.to_owned() }
 

--- a/libs/modkit-odata/src/odata_parse_tests.rs
+++ b/libs/modkit-odata/src/odata_parse_tests.rs
@@ -979,3 +979,76 @@ fn parse_error_preserves_position_info() {
         other => panic!("expected ParseError::Parsing(String), got: {other:?}"),
     }
 }
+
+#[test]
+fn odata_navigation_path_identifier() {
+    // OData 4.0 navigation property paths use `/` (e.g., hierarchy/depth)
+    let result = parse_str("hierarchy/depth ge 0").expect("valid filter tree");
+    assert_eq!(
+        result,
+        Expr::Compare(
+            Expr::Identifier("hierarchy/depth".to_owned()).into(),
+            CompareOperator::GreaterOrEqual,
+            Expr::Value(Value::Number(BigDecimal::from_str("0").unwrap())).into()
+        )
+    );
+}
+
+#[test]
+fn odata_navigation_path_with_and() {
+    let result =
+        parse_str("hierarchy/depth ge 0 and hierarchy/depth le 5").expect("valid filter tree");
+    match result {
+        Expr::And(left, right) => {
+            assert_eq!(
+                *left,
+                Expr::Compare(
+                    Expr::Identifier("hierarchy/depth".to_owned()).into(),
+                    CompareOperator::GreaterOrEqual,
+                    Expr::Value(Value::Number(BigDecimal::from_str("0").unwrap())).into()
+                )
+            );
+            assert_eq!(
+                *right,
+                Expr::Compare(
+                    Expr::Identifier("hierarchy/depth".to_owned()).into(),
+                    CompareOperator::LessOrEqual,
+                    Expr::Value(Value::Number(BigDecimal::from_str("5").unwrap())).into()
+                )
+            );
+        }
+        other => panic!("expected And, got: {other:?}"),
+    }
+}
+
+#[test]
+fn odata_navigation_path_parent_id_eq_uuid() {
+    let result = parse_str("hierarchy/parent_id eq 11111111-2222-3333-4444-555555555555")
+        .expect("valid filter tree");
+    assert_eq!(
+        result,
+        Expr::Compare(
+            Expr::Identifier("hierarchy/parent_id".to_owned()).into(),
+            CompareOperator::Equal,
+            Expr::Value(Value::Uuid(
+                uuid::Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap()
+            ))
+            .into()
+        )
+    );
+}
+
+#[test]
+fn odata_navigation_path_leading_slash_rejected() {
+    parse_str("/depth eq 1").expect_err("leading slash should be rejected");
+}
+
+#[test]
+fn odata_navigation_path_empty_segment_rejected() {
+    parse_str("hierarchy/ eq 1").expect_err("trailing slash with empty segment should be rejected");
+}
+
+#[test]
+fn odata_navigation_path_double_slash_rejected() {
+    parse_str("hierarchy//depth eq 1").expect_err("double slash should be rejected");
+}

--- a/libs/modkit-odata/src/problem_mapping.rs
+++ b/libs/modkit-odata/src/problem_mapping.rs
@@ -27,15 +27,27 @@ impl From<Error> for Problem {
                 .as_problem(format!("Unsupported $orderby field: {field}")),
 
             // All cursor-related errors → 422
-            InvalidCursor
-            | CursorInvalidBase64
-            | CursorInvalidJson
-            | CursorInvalidVersion
-            | CursorInvalidKeys
-            | CursorInvalidFields
-            | CursorInvalidDirection => {
-                ErrorCode::odata_errors_invalid_cursor_v1().as_problem(err.to_string())
+            InvalidCursor => {
+                ErrorCode::odata_errors_invalid_cursor_v1().as_problem("invalid cursor")
             }
+
+            CursorInvalidBase64 => ErrorCode::odata_errors_invalid_cursor_v1()
+                .as_problem("invalid cursor: invalid base64url encoding"),
+
+            CursorInvalidJson => ErrorCode::odata_errors_invalid_cursor_v1()
+                .as_problem("invalid cursor: malformed JSON"),
+
+            CursorInvalidVersion => ErrorCode::odata_errors_invalid_cursor_v1()
+                .as_problem("invalid cursor: unsupported version"),
+
+            CursorInvalidKeys => ErrorCode::odata_errors_invalid_cursor_v1()
+                .as_problem("invalid cursor: empty or invalid keys"),
+
+            CursorInvalidFields => ErrorCode::odata_errors_invalid_cursor_v1()
+                .as_problem("invalid cursor: empty or invalid fields"),
+
+            CursorInvalidDirection => ErrorCode::odata_errors_invalid_cursor_v1()
+                .as_problem("invalid cursor: invalid sort direction"),
 
             // Pagination validation errors → 422
             OrderMismatch => ErrorCode::odata_errors_invalid_orderby_v1()


### PR DESCRIPTION
## PR chain

This is **PR 1d of 8** in the resource-group feature train.

All 8 PRs together deliver the `resource-group` module. This PR extends the OData layer with capabilities the resource-group API needs: filtering by a list of values, filtering on nested hierarchy fields, and exposing pagination direction to API clients.

**Chain order:**
1a. #1401 docs/rg-1a-docs
1d. #1404 **→ feat/rg-1d-odata** *(this PR)*
1e. #1405 feat/rg-1e-db-security
2.  #1406 feat/rg-2-authz
3.  #1407 feat/rg-3-resource-group
4.  #1408 test/rg-4-tests

---

## Why this PR exists

The resource-group API exposes three OData-filterable collections: types, groups, and memberships. Implementing those endpoints revealed three gaps in the existing OData stack:

**1. `IN (...)` filter operator was missing.**
Group queries need to filter by a set of type codes: `$filter=type_code in ('department','team')`. Without `FilterNode::InList`, the API would have to accept only equality filters and force clients to make N requests for N values.

**2. Property paths with `/` were not parsed.**
Group hierarchy queries expose fields like `hierarchy/depth` and `hierarchy/breadth` (depth and width within the closure table). The OData 4.01 spec allows `/` as a navigation path separator (`firstMemberExpr`), but the parser only handled flat identifiers. Without this fix, `$filter=hierarchy/depth le 3` would fail to parse.

**3. Clients had no way to know if more pages exist.**
`PageInfo` returned `next_cursor` and `prev_cursor` but did not expose boolean `has_next_page` / `has_previous_page` flags. Frontend and SDK clients had to check cursor nullability themselves, which is error-prone. The flags make pagination intent explicit with no extra DB query (derived from cursor presence).

---

## Summary

- Add `FilterOp::In` and `FilterNode::InList` to the OData filter tree
- Support OData 4.01 property paths with `/` separator in the parser
- Add `has_next_page` / `has_previous_page` to `PageInfo`
- Update SeaORM filter compiler and cursor pagination to match

---

## Changes

**`libs/modkit-odata/src/filter.rs`**
- `FilterOp::In` — new operator variant
- `FilterNode::InList { field, values }` — built from `field in (v1, v2, ...)` expressions; field must be an identifier (not a computed expression), values must be literals. Both invariants are enforced at parse time with clear error messages.

**`libs/modkit-odata/src/odata_parse.rs`**
- `property_path` rule replaces `identifier` in value expressions — allows `/`-separated segments as required by OData 4.01 ABNF §5.1.1.15
- `identifier` rule preserved for contexts where paths are not valid (function names, etc.)

**`libs/modkit-odata/src/odata_parse_tests.rs`**
- New tests: `odata_navigation_path_identifier`, `odata_navigation_path_with_and` — cover single-segment and compound `AND` expressions with paths

**`libs/modkit-odata/src/page.rs`**
- `PageInfo.has_next_page: bool` — `true` when `next_cursor` is `Some`
- `PageInfo.has_previous_page: bool` — `true` when `prev_cursor` is `Some`

**`libs/modkit-odata/src/problem_mapping.rs`** — error mapping extended for `FilterOp::In` context messages

**`libs/modkit-db/src/odata/sea_orm_filter.rs`**
- `FilterNode::InList` → `Expr::col(column).is_in(sea_values)` with per-value type coercion via `odata_value_to_sea_value`
- `has_next_page` / `has_previous_page` populated from cursor presence after query

**`libs/modkit-db/src/odata/core.rs`** — same pagination flag population for the alternate query path

**`libs/modkit-sdk/src/pager.rs`** — `Pager` exposes the new flags to SDK consumers

**`libs/modkit/tests/odata_select.rs`** — extended select tests

---

## Test plan

- [ ] `cargo test -p modkit-odata` — new parser tests pass
- [ ] `cargo test -p modkit-db` — `InList` generates correct `WHERE col IN (...)` SQL
- [ ] `$filter=name in ('a','b')` compiles to `WHERE name IN ('a', 'b')`
- [ ] `$filter=hierarchy/depth ge 0` parses without error
- [ ] `has_next_page` is `true` only when a next cursor exists
- [ ] Existing OData filter tests pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the OData IN operator (list membership) with validation against empty lists.
  * Extended filter parsing to accept slash-separated navigation/property paths.

* **Bug Fixes**
  * More specific cursor validation error messages for distinct failure types.

* **Tests**
  * Added parser tests for navigation-path identifiers, comparisons, logical conjunctions, and invalid path edge cases.

* **Documentation**
  * Reordered OpenAPI OData extension blocks for list endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->