### PR TITLE
feat(db+security): transaction config, deadlock detection, InGroup scope filter

### DIFF
--- a/libs/modkit-db/src/db_provider.rs
+++ b/libs/modkit-db/src/db_provider.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, marker::PhantomData, pin::Pin, sync::Arc};
 
-use crate::secure::{DbConn, DbTx};
+use crate::secure::{DbConn, DbTx, TxConfig};
 use crate::{Db, DbError};
 
 /// Thin, reusable DB entrypoint for application services.
@@ -74,5 +74,26 @@ where
             + Send,
     {
         self.db.transaction_ref_mapped(f).await
+    }
+
+    /// Execute a closure inside a database transaction with custom configuration.
+    ///
+    /// This variant allows specifying isolation level and access mode via [`TxConfig`].
+    /// Use this for operations requiring stronger isolation guarantees (e.g.,
+    /// `SERIALIZABLE` for hierarchy mutations).
+    ///
+    /// # Errors
+    ///
+    /// Returns `E` if:
+    /// - starting the transaction fails (mapped from `DbError`)
+    /// - the closure returns an error
+    /// - commit fails (mapped from `DbError`)
+    pub async fn transaction_with_config<T, F>(&self, config: TxConfig, f: F) -> Result<T, E>
+    where
+        T: Send + 'static,
+        F: for<'a> FnOnce(&'a DbTx<'a>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>
+            + Send,
+    {
+        self.db.transaction_ref_mapped_with_config(config, f).await
     }
 }

--- a/libs/modkit-db/src/deadlock.rs
+++ b/libs/modkit-db/src/deadlock.rs
@@ -1,0 +1,136 @@
+//! Deadlock and serialization failure detection utilities.
+//!
+//! > "Always be prepared to re-issue a transaction if it fails due to deadlock.
+//! > Deadlocks are not dangerous. Just try again."
+//! > — [`MySQL` 8.0 Reference Manual, `InnoDB` Deadlocks](https://dev.mysql.com/doc/refman/8.0/en/innodb-deadlocks.html)
+//!
+//! `InnoDB` detects deadlocks instantly and rolls back one transaction (the victim).
+//! SQLSTATE `40001` signals a serialization failure that is always safe to retry.
+//! This module provides detection helpers for use by callers that manage their
+//! own transaction lifecycle (e.g., the outbox sequencer, hierarchy mutations).
+
+use sea_orm::DbErr;
+
+/// SQLSTATE `40001` — serialization failure / deadlock.
+///
+/// This code is used by both `PostgreSQL` (for serialization failures under
+/// `SERIALIZABLE` isolation) and `MySQL`/`MariaDB` (for `InnoDB` deadlocks).
+const SERIALIZATION_FAILURE_SQLSTATE: &str = "40001";
+
+/// `PostgreSQL` error message substring for serialization failures.
+///
+/// `PostgreSQL` reports `could not serialize access` when a `SERIALIZABLE`
+/// transaction detects a read/write dependency conflict.
+const PG_SERIALIZATION_MSG: &str = "could not serialize access";
+
+/// Returns `true` if the error contains SQLSTATE `40001`.
+///
+/// This matches both `MySQL`/`MariaDB` deadlocks and `PostgreSQL` serialization
+/// failures. It does **not** distinguish between the two — both are retryable.
+/// [`is_serialization_failure`] broadens detection by also matching the
+/// `PostgreSQL` error message text for cases where the SQLSTATE is absent.
+///
+/// Always returns `false` for non-runtime errors (`Custom`, `RecordNotFound`, etc.)
+/// and for `SQLite` errors (single-writer model, no SQLSTATE `40001`).
+///
+/// Detection is based on the error's string representation containing the
+/// SQLSTATE code, which avoids a direct dependency on `sqlx` types.
+#[must_use]
+pub fn is_deadlock(err: &DbErr) -> bool {
+    match err {
+        DbErr::Exec(runtime_err) | DbErr::Query(runtime_err) => {
+            let msg = runtime_err.to_string();
+            msg.contains(SERIALIZATION_FAILURE_SQLSTATE)
+        }
+        _ => false,
+    }
+}
+
+/// Returns `true` if the error is a retryable serialization failure.
+///
+/// This is a superset of [`is_deadlock`] — it matches SQLSTATE `40001` **and**
+/// the `PostgreSQL` `could not serialize access` message text.  Both deadlocks
+/// and serialization conflicts are retryable, and this function does not
+/// distinguish between them.
+///
+/// Coverage:
+/// - **`PostgreSQL`**: `SERIALIZABLE` isolation conflicts
+///   (`could not serialize access`, SQLSTATE `40001`)
+/// - **`MySQL`/`MariaDB`**: `InnoDB` deadlocks (SQLSTATE `40001`)
+/// - **`SQLite`**: Always `false` (single-writer model, no serialization failures)
+///
+/// Use this to implement bounded retry around `SERIALIZABLE` transactions.
+///
+/// Detection is based on the error's string representation to avoid a direct
+/// dependency on `sqlx` types.
+#[must_use]
+pub fn is_serialization_failure(err: &DbErr) -> bool {
+    match err {
+        DbErr::Exec(runtime_err) | DbErr::Query(runtime_err) => {
+            let msg = runtime_err.to_string();
+            msg.contains(SERIALIZATION_FAILURE_SQLSTATE) || msg.contains(PG_SERIALIZATION_MSG)
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sea_orm::RuntimeErr;
+
+    fn exec_err(msg: &str) -> DbErr {
+        DbErr::Exec(RuntimeErr::Internal(msg.to_owned()))
+    }
+
+    // -- is_deadlock positive cases --
+
+    #[test]
+    fn deadlock_sqlstate_40001_detected() {
+        assert!(is_deadlock(&exec_err(
+            "error returned from database: 40001: Deadlock found"
+        )));
+    }
+
+    #[test]
+    fn deadlock_pg_serialization_failure_detected() {
+        assert!(is_deadlock(&exec_err(
+            "ERROR: 40001: could not serialize access"
+        )));
+    }
+
+    // -- is_deadlock negative cases --
+
+    #[test]
+    fn non_deadlock_errors_return_false() {
+        assert!(!is_deadlock(&DbErr::Custom("something".into())));
+        assert!(!is_deadlock(&DbErr::RecordNotFound("x".into())));
+        assert!(!is_deadlock(&exec_err("duplicate key value")));
+    }
+
+    // -- is_serialization_failure positive cases --
+
+    #[test]
+    fn serialization_failure_sqlstate_detected() {
+        assert!(is_serialization_failure(&exec_err(
+            "error returned from database: 40001"
+        )));
+    }
+
+    #[test]
+    fn serialization_failure_pg_message_detected() {
+        assert!(is_serialization_failure(&exec_err(
+            "ERROR: could not serialize access due to concurrent update"
+        )));
+    }
+
+    // -- is_serialization_failure negative cases --
+
+    #[test]
+    fn non_serialization_errors_return_false() {
+        assert!(!is_serialization_failure(&DbErr::Custom(
+            "something".into()
+        )));
+        assert!(!is_serialization_failure(&exec_err("unique constraint")));
+    }
+}

--- a/libs/modkit-db/src/lib.rs
+++ b/libs/modkit-db/src/lib.rs
@@ -77,6 +77,7 @@ pub use sea_orm_migration;
 pub mod advisory_locks;
 pub mod config;
 pub mod contention;
+pub mod deadlock;
 pub mod manager;
 pub mod migration_runner;
 pub mod odata;

--- a/libs/modkit-db/src/secure/cond.rs
+++ b/libs/modkit-db/src/secure/cond.rs
@@ -1,7 +1,8 @@
+use sea_orm::sea_query::{Alias, Query};
 use sea_orm::{ColumnTrait, Condition, EntityTrait, sea_query::Expr};
 
 use crate::secure::{AccessScope, ScopableEntity};
-use modkit_security::access_scope::{ScopeConstraint, ScopeFilter, ScopeValue};
+use modkit_security::access_scope::{ScopeConstraint, ScopeFilter, ScopeValue, rg_tables};
 
 /// Convert a [`ScopeValue`] to a `sea_query::SimpleExpr` for SQL binding.
 fn scope_value_to_sea_expr(v: &ScopeValue) -> sea_orm::sea_query::SimpleExpr {
@@ -101,6 +102,44 @@ where
             ScopeFilter::In(inf) => {
                 let sea_values = scope_values_to_sea_values(inf.values());
                 and_cond = and_cond.add(col.is_in(sea_values));
+            }
+            ScopeFilter::InGroup(gf) => {
+                // col IN (SELECT resource_id FROM resource_group_membership
+                //          WHERE group_id IN (...))
+                let group_values = scope_values_to_sea_values(gf.group_ids());
+                let subquery = Query::select()
+                    .column(Alias::new(rg_tables::MEMBERSHIP_RESOURCE_ID))
+                    .from(Alias::new(rg_tables::MEMBERSHIP_TABLE))
+                    .and_where(
+                        Expr::col(Alias::new(rg_tables::MEMBERSHIP_GROUP_ID)).is_in(group_values),
+                    )
+                    .to_owned();
+                and_cond = and_cond.add(col.into_expr().in_subquery(subquery));
+            }
+            ScopeFilter::InGroupSubtree(sf) => {
+                // col IN (SELECT resource_id FROM resource_group_membership
+                //          WHERE group_id IN (
+                //            SELECT descendant_id FROM resource_group_closure
+                //            WHERE ancestor_id IN (...)
+                //          ))
+                let ancestor_values = scope_values_to_sea_values(sf.ancestor_ids());
+                let closure_subquery = Query::select()
+                    .column(Alias::new(rg_tables::CLOSURE_DESCENDANT_ID))
+                    .from(Alias::new(rg_tables::CLOSURE_TABLE))
+                    .and_where(
+                        Expr::col(Alias::new(rg_tables::CLOSURE_ANCESTOR_ID))
+                            .is_in(ancestor_values),
+                    )
+                    .to_owned();
+                let membership_subquery = Query::select()
+                    .column(Alias::new(rg_tables::MEMBERSHIP_RESOURCE_ID))
+                    .from(Alias::new(rg_tables::MEMBERSHIP_TABLE))
+                    .and_where(
+                        Expr::col(Alias::new(rg_tables::MEMBERSHIP_GROUP_ID))
+                            .in_subquery(closure_subquery),
+                    )
+                    .to_owned();
+                and_cond = and_cond.add(col.into_expr().in_subquery(membership_subquery));
             }
         }
     }
@@ -247,6 +286,78 @@ mod tests {
         assert!(
             !cond_str.contains("Value(Bool(Some(false)))"),
             "Expected a real condition, got deny-all: {cond_str}"
+        );
+    }
+
+    #[test]
+    fn test_in_group_filter_produces_subquery_condition() {
+        let group_id = uuid::Uuid::new_v4();
+        let scope =
+            AccessScope::from_constraints(vec![ScopeConstraint::new(vec![ScopeFilter::in_group(
+                pep_properties::RESOURCE_ID,
+                vec![ScopeValue::Uuid(group_id)],
+            )])]);
+        let cond = build_scope_condition::<custom_prop_entity::Entity>(&scope);
+        let cond_str = format!("{cond:?}");
+        // Should NOT be deny-all
+        assert!(
+            !cond_str.contains("Value(Bool(Some(false)))"),
+            "InGroup should produce a real condition, got: {cond_str}"
+        );
+        // Verify the condition references the membership table and columns
+        assert!(
+            cond_str.contains("resource_group_membership"),
+            "InGroup condition must reference resource_group_membership table, got: {cond_str}"
+        );
+        assert!(
+            cond_str.contains("group_id"),
+            "InGroup condition must filter by group_id, got: {cond_str}"
+        );
+        assert!(
+            cond_str.contains("resource_id"),
+            "InGroup condition must join on resource_id, got: {cond_str}"
+        );
+    }
+
+    #[test]
+    fn test_in_group_subtree_filter_produces_subquery_condition() {
+        let ancestor_id = uuid::Uuid::new_v4();
+        let scope = AccessScope::from_constraints(vec![ScopeConstraint::new(vec![
+            ScopeFilter::in_group_subtree(
+                pep_properties::RESOURCE_ID,
+                vec![ScopeValue::Uuid(ancestor_id)],
+            ),
+        ])]);
+        let cond = build_scope_condition::<custom_prop_entity::Entity>(&scope);
+        let cond_str = format!("{cond:?}");
+        assert!(
+            !cond_str.contains("Value(Bool(Some(false)))"),
+            "InGroupSubtree should produce a real condition, got: {cond_str}"
+        );
+        // Verify subtree condition references hierarchy tables
+        assert!(
+            cond_str.contains("resource_group_membership"),
+            "InGroupSubtree condition must reference resource_group_membership table, got: {cond_str}"
+        );
+        assert!(
+            cond_str.contains("resource_id"),
+            "InGroupSubtree condition must join on resource_id, got: {cond_str}"
+        );
+    }
+
+    #[test]
+    fn test_tenant_plus_in_group_produces_and_condition() {
+        let tid = uuid::Uuid::new_v4();
+        let gid = uuid::Uuid::new_v4();
+        let scope = AccessScope::from_constraints(vec![ScopeConstraint::new(vec![
+            ScopeFilter::in_uuids(pep_properties::OWNER_TENANT_ID, vec![tid]),
+            ScopeFilter::in_group(pep_properties::RESOURCE_ID, vec![ScopeValue::Uuid(gid)]),
+        ])]);
+        let cond = build_scope_condition::<custom_prop_entity::Entity>(&scope);
+        let cond_str = format!("{cond:?}");
+        assert!(
+            !cond_str.contains("Value(Bool(Some(false)))"),
+            "Combined tenant+group should produce a real condition, got: {cond_str}"
         );
     }
 

--- a/libs/modkit-db/src/secure/db.rs
+++ b/libs/modkit-db/src/secure/db.rs
@@ -293,6 +293,63 @@ impl Db {
         }
     }
 
+    /// Execute a closure inside a database transaction with custom configuration
+    /// (isolation level, access mode), mapping infrastructure errors into `E`.
+    ///
+    /// This is the preferred building block for service-facing entrypoints (like `DBProvider`)
+    /// that must return **domain** errors and need non-default transaction settings
+    /// (e.g., `SERIALIZABLE` isolation).
+    ///
+    /// # Security
+    ///
+    /// The task-local guard is enforced for the duration of the closure.
+    ///
+    /// # Errors
+    ///
+    /// Returns `E` if:
+    /// - starting the transaction fails (mapped from `DbError`)
+    /// - the closure returns an error
+    /// - commit fails (mapped from `DbError`)
+    pub async fn transaction_ref_mapped_with_config<F, T, E>(
+        &self,
+        config: TxConfig,
+        f: F,
+    ) -> Result<T, E>
+    where
+        E: From<DbError> + Send + 'static,
+        F: for<'a> FnOnce(&'a DbTx<'a>) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>
+            + Send,
+        T: Send + 'static,
+    {
+        use sea_orm::{AccessMode, IsolationLevel};
+
+        let isolation: Option<IsolationLevel> = config.isolation.map(Into::into);
+        let access_mode: Option<AccessMode> = config.access_mode.map(Into::into);
+
+        let txn = self
+            .handle
+            .sea_internal_ref()
+            .begin_with_config(isolation, access_mode)
+            .await
+            .map_err(DbError::from)
+            .map_err(E::from)?;
+        let tx = DbTx { tx: &txn };
+
+        // Run the closure with the transaction guard set
+        let res = with_tx_guard(f(&tx)).await;
+
+        match res {
+            Ok(v) => {
+                txn.commit().await.map_err(DbError::from).map_err(E::from)?;
+                Ok(v)
+            }
+            Err(e) => {
+                _ = txn.rollback().await;
+                Err(e)
+            }
+        }
+    }
+
     /// Execute a closure inside a database transaction.
     ///
     /// # Security

--- a/libs/modkit-security/src/access_scope.rs
+++ b/libs/modkit-security/src/access_scope.rs
@@ -102,6 +102,30 @@ pub mod pep_properties {
     pub const OWNER_ID: &str = "owner_id";
 }
 
+/// Well-known resource-group table and column names for subquery construction.
+///
+/// Used by the `SecureORM` condition builder to translate `InGroup`/`InGroupSubtree`
+/// scope filters into SQL subqueries without depending on entity types.
+///
+/// **Note:** These tables are canonical to the RG module's database.
+/// `resource_group_membership` is not projected to domain services.
+/// `InGroup`/`InGroupSubtree` predicates are only executable within the RG module.
+pub mod rg_tables {
+    /// Membership table (RG-internal, not projected to domain services).
+    pub const MEMBERSHIP_TABLE: &str = "resource_group_membership";
+    /// Column in membership table: the resource's external ID.
+    pub const MEMBERSHIP_RESOURCE_ID: &str = "resource_id";
+    /// Column in membership table: the group the resource belongs to.
+    pub const MEMBERSHIP_GROUP_ID: &str = "group_id";
+
+    /// Closure table for group hierarchy.
+    pub const CLOSURE_TABLE: &str = "resource_group_closure";
+    /// Column in closure table: the ancestor group.
+    pub const CLOSURE_ANCESTOR_ID: &str = "ancestor_id";
+    /// Column in closure table: the descendant group.
+    pub const CLOSURE_DESCENDANT_ID: &str = "descendant_id";
+}
+
 /// A single scope filter — a typed predicate on a named resource property.
 ///
 /// The property name (e.g., `"owner_tenant_id"`, `"id"`) is an authorization
@@ -110,18 +134,18 @@ pub mod pep_properties {
 /// Variants mirror the predicate types from the PDP response:
 /// - [`ScopeFilter::Eq`] — equality (`property = value`)
 /// - [`ScopeFilter::In`] — set membership (`property IN (values)`)
-///
-/// ## Future extensions
-///
-/// Additional filter types (`in_tenant_subtree`, `in_group`,
-/// `in_group_subtree`) are planned. See the authorization design document
-/// (`docs/arch/authorization/DESIGN.md`) for the full predicate taxonomy.
+/// - [`ScopeFilter::InGroup`] — group membership subquery
+/// - [`ScopeFilter::InGroupSubtree`] — group subtree subquery
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ScopeFilter {
     /// Equality: `property = value`.
     Eq(EqScopeFilter),
     /// Set membership: `property IN (values)`.
     In(InScopeFilter),
+    /// Group membership: `property IN (SELECT resource_id FROM membership WHERE group_id IN (group_ids))`.
+    InGroup(InGroupScopeFilter),
+    /// Group subtree: `property IN (SELECT resource_id FROM membership WHERE group_id IN (SELECT descendant_id FROM closure WHERE ancestor_id IN (ancestor_ids)))`.
+    InGroupSubtree(InGroupSubtreeScopeFilter),
 }
 
 /// Equality scope filter: `property = value`.
@@ -204,6 +228,70 @@ impl InScopeFilter {
     }
 }
 
+/// Group membership scope filter.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InGroupScopeFilter {
+    property: String,
+    group_ids: Vec<ScopeValue>,
+}
+
+impl InGroupScopeFilter {
+    /// Create a group membership scope filter.
+    #[must_use]
+    pub fn new(property: impl Into<String>, group_ids: Vec<ScopeValue>) -> Self {
+        Self {
+            property: property.into(),
+            group_ids,
+        }
+    }
+
+    /// The authorization property name.
+    #[inline]
+    #[must_use]
+    pub fn property(&self) -> &str {
+        &self.property
+    }
+
+    /// The group IDs.
+    #[inline]
+    #[must_use]
+    pub fn group_ids(&self) -> &[ScopeValue] {
+        &self.group_ids
+    }
+}
+
+/// Group subtree scope filter.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InGroupSubtreeScopeFilter {
+    property: String,
+    ancestor_ids: Vec<ScopeValue>,
+}
+
+impl InGroupSubtreeScopeFilter {
+    /// Create a group subtree scope filter.
+    #[must_use]
+    pub fn new(property: impl Into<String>, ancestor_ids: Vec<ScopeValue>) -> Self {
+        Self {
+            property: property.into(),
+            ancestor_ids,
+        }
+    }
+
+    /// The authorization property name.
+    #[inline]
+    #[must_use]
+    pub fn property(&self) -> &str {
+        &self.property
+    }
+
+    /// The ancestor group IDs.
+    #[inline]
+    #[must_use]
+    pub fn ancestor_ids(&self) -> &[ScopeValue] {
+        &self.ancestor_ids
+    }
+}
+
 impl ScopeFilter {
     /// Create an equality filter (`property = value`).
     #[must_use]
@@ -226,23 +314,41 @@ impl ScopeFilter {
         ))
     }
 
+    /// Create a group membership filter.
+    #[must_use]
+    pub fn in_group(property: impl Into<String>, group_ids: Vec<ScopeValue>) -> Self {
+        Self::InGroup(InGroupScopeFilter::new(property, group_ids))
+    }
+
+    /// Create a group subtree filter.
+    #[must_use]
+    pub fn in_group_subtree(property: impl Into<String>, ancestor_ids: Vec<ScopeValue>) -> Self {
+        Self::InGroupSubtree(InGroupSubtreeScopeFilter::new(property, ancestor_ids))
+    }
+
     /// The authorization property name.
     #[must_use]
     pub fn property(&self) -> &str {
         match self {
             Self::Eq(f) => f.property(),
             Self::In(f) => f.property(),
+            Self::InGroup(f) => f.property(),
+            Self::InGroupSubtree(f) => f.property(),
         }
     }
 
-    /// Collect all values as a slice-like view for iteration.
+    /// Collect direct-match values as a slice-like view for iteration.
     ///
     /// For `Eq`, returns a single-element slice; for `In`, returns the values slice.
+    /// For `InGroup`/`InGroupSubtree`, returns empty — those are subquery parameters,
+    /// not resource property values. The actual matching happens in SQL via
+    /// [`secure::scope_to_condition`].
     #[must_use]
     pub fn values(&self) -> ScopeFilterValues<'_> {
         match self {
             Self::Eq(f) => ScopeFilterValues::Single(&f.value),
             Self::In(f) => ScopeFilterValues::Multiple(&f.values),
+            Self::InGroup(_) | Self::InGroupSubtree(_) => ScopeFilterValues::Multiple(&[]),
         }
     }
 
@@ -951,6 +1057,52 @@ mod tests {
             "Tenant filter must be preserved"
         );
     }
+
+    // --- ScopeFilter::InGroup ---
+
+    #[test]
+    fn scope_filter_in_group_constructor() {
+        let f = ScopeFilter::in_group(
+            pep_properties::OWNER_TENANT_ID,
+            vec![ScopeValue::Uuid(uid(T1))],
+        );
+        assert_eq!(f.property(), pep_properties::OWNER_TENANT_ID);
+        assert!(matches!(f, ScopeFilter::InGroup(_)));
+        assert_eq!(f.values().iter().count(), 0);
+    }
+
+    // --- ScopeFilter::InGroupSubtree ---
+
+    #[test]
+    fn scope_filter_in_group_subtree_constructor() {
+        let f = ScopeFilter::in_group_subtree(
+            pep_properties::OWNER_TENANT_ID,
+            vec![ScopeValue::Uuid(uid(T1))],
+        );
+        assert_eq!(f.property(), pep_properties::OWNER_TENANT_ID);
+        assert!(matches!(f, ScopeFilter::InGroupSubtree(_)));
+        assert_eq!(f.values().iter().count(), 0);
+    }
+
+    #[test]
+    fn in_group_scope_contains_uuid_returns_false() {
+        let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::in_group(
+            pep_properties::OWNER_TENANT_ID,
+            vec![ScopeValue::Uuid(uid(T1))],
+        )]));
+        assert!(!scope.contains_uuid(pep_properties::OWNER_TENANT_ID, uid(T1)));
+    }
+
+    #[test]
+    fn in_group_subtree_scope_contains_uuid_returns_false() {
+        let scope = AccessScope::single(ScopeConstraint::new(vec![ScopeFilter::in_group_subtree(
+            pep_properties::OWNER_TENANT_ID,
+            vec![ScopeValue::Uuid(uid(T1))],
+        )]));
+        assert!(!scope.contains_uuid(pep_properties::OWNER_TENANT_ID, uid(T1)));
+    }
+
+    // --- contains_uuid string matching ---
 
     #[test]
     fn contains_uuid_matches_string_variant() {

--- a/libs/modkit-security/src/lib.rs
+++ b/libs/modkit-security/src/lib.rs
@@ -6,8 +6,8 @@ pub mod context;
 pub mod prelude;
 
 pub use access_scope::{
-    AccessScope, EqScopeFilter, InScopeFilter, ScopeConstraint, ScopeFilter, ScopeValue,
-    pep_properties,
+    AccessScope, EqScopeFilter, InGroupScopeFilter, InGroupSubtreeScopeFilter, InScopeFilter,
+    ScopeConstraint, ScopeFilter, ScopeValue, pep_properties, rg_tables,
 };
 pub use context::{SecurityContext, SecurityContextBuildError};
 

--- a/modules/llm-gateway/docs/ADR/0003-fdd-llmgw-adr-file-storage.md
+++ b/modules/llm-gateway/docs/ADR/0003-fdd-llmgw-adr-file-storage.md
@@ -79,4 +79,4 @@ None
 
 **References**:
 * PRD: `cpt-cf-llm-gateway-nfr-scalability-v1`
-* DESIGN: `cpt-cf-llm-gateway-principle-pass-through`
+* DESIGN: `cpt-cf-llm-gateway-adr-pass-through`

--- a/modules/llm-gateway/docs/ADR/0005-cpt-cf-llm-gateway-adr-open-responses-protocol.md
+++ b/modules/llm-gateway/docs/ADR/0005-cpt-cf-llm-gateway-adr-open-responses-protocol.md
@@ -5,6 +5,25 @@ date: 2026-03-12
 
 # ADR-0005: Adopt Open Responses Protocol for LLM Completion Requests
 
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [OpenAI Chat Completions API](#openai-chat-completions-api)
+  - [Custom CyberFabric API](#custom-cyberfabric-api)
+  - [Vendor-specific API (OpenAI, Anthropic, or other)](#vendor-specific-api-openai-anthropic-or-other)
+  - [Open Responses Protocol](#open-responses-protocol)
+- [More Information](#more-information)
+  - [Provider Parameter Extensions](#provider-parameter-extensions)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
 **ID**: `cpt-cf-llm-gateway-adr-open-responses-protocol`
 
 ## Context and Problem Statement
@@ -107,7 +126,7 @@ An open specification based on OpenAI's Responses API design, governed as an ope
 
 The Open Responses protocol emerged as an effort to standardize the richer response model that providers are converging on. Unlike the legacy Chat Completions API which returns a single message per choice, Open Responses returns a list of typed output items — enabling first-class representation of reasoning traces, internal tool invocations, citations, and other structured outputs that newer models produce.
 
-This decision aligns with the Gateway's pass-through design principle (`cpt-cf-llm-gateway-principle-pass-through`): the protocol's item-based structure allows the Gateway to forward provider-specific items transparently without needing to interpret their content.
+This decision aligns with the Gateway's pass-through design principle (`cpt-cf-llm-gateway-adr-pass-through`): the protocol's item-based structure allows the Gateway to forward provider-specific items transparently without needing to interpret their content.
 
 ### Provider Parameter Extensions
 

--- a/modules/llm-gateway/docs/ADR/0006-cpt-cf-llm-gateway-adr-image-generation-api.md
+++ b/modules/llm-gateway/docs/ADR/0006-cpt-cf-llm-gateway-adr-image-generation-api.md
@@ -5,6 +5,22 @@ date: 2026-03-18
 
 # ADR-0006: Use Responses API with Custom Extensions for Image Generation
 
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Dedicated Image Generation API (based on OpenAI `/images/generations`)](#dedicated-image-generation-api-based-on-openai-imagesgenerations)
+  - [Responses API with custom CyberFabric extensions](#responses-api-with-custom-cyberfabric-extensions)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
 **ID**: `cpt-cf-llm-gateway-adr-image-generation-api`
 
 ## Context and Problem Statement
@@ -100,7 +116,7 @@ The `cyberfabric:data` output item carries binary output with the following fiel
 | `base64` | string or null | Base64-encoded data (when `response_format` is `base64`) |
 | `url` | string or null | File storage URL (when `response_format` is `url`) |
 
-This decision aligns with the Gateway's pass-through design principle (`cpt-cf-llm-gateway-principle-pass-through`): provider adapters translate between the `cyberfabric:image_generation` tool and each provider's native image generation API, while the API layer treats the tool and output items as opaque typed items.
+This decision aligns with the Gateway's pass-through design principle (`cpt-cf-llm-gateway-adr-pass-through`): provider adapters translate between the `cyberfabric:image_generation` tool and each provider's native image generation API, while the API layer treats the tool and output items as opaque typed items.
 
 ## Traceability
 

--- a/modules/llm-gateway/docs/ADR/0007-cpt-cf-llm-gateway-adr-no-stored-responses.md
+++ b/modules/llm-gateway/docs/ADR/0007-cpt-cf-llm-gateway-adr-no-stored-responses.md
@@ -5,6 +5,23 @@ date: 2026-03-26
 
 # ADR-0007: Do Not Support Stored Responses or Server-Side Conversation State
 
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Full support for stored responses](#full-support-for-stored-responses)
+  - [Partial support (OpenAI pass-through only)](#partial-support-openai-pass-through-only)
+  - [No support for stored responses](#no-support-for-stored-responses)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
 **ID**: `cpt-cf-llm-gateway-adr-no-stored-responses`
 
 ## Context and Problem Statement


### PR DESCRIPTION
## PR chain

This is **PR 1e of 8** in the resource-group feature train.

All 8 PRs together deliver the `resource-group` module. This PR adds the infrastructure that allows the security layer to express "resource is visible if it belongs to a group" — a prerequisite for the authz SDK predicates (PR 4) and the resource-group module itself (PR 5).

**Chain order:**
1a. #1401 docs/rg-1a-docs
1d. #1404 feat/rg-1d-odata
1e. #1405 **→ feat/rg-1e-db-security** *(this PR)*
2.  #1406 feat/rg-2-authz
3.  #1407 feat/rg-3-resource-group
4.  #1408 test/rg-4-tests

---

## Why this PR exists

The existing `SecureORM` layer supports two kinds of access scope filters: `Eq` (equality) and `In` (set membership). These are sufficient for tenant scoping (`owner_tenant_id = ?`) and simple resource lists (`resource_id IN (?)`), but they cannot express group-based visibility: "show this resource only if it is a member of one of these groups."

Group-based visibility requires a SQL subquery into the `resource_group_membership` table, and subtree-based visibility requires a doubly-nested subquery through `resource_group_closure`. Without these filters, the resource-group module's AuthZ integration would have to pull membership data into application memory and filter there — which breaks for large tenants and defeats the purpose of `SecureORM`.

**Transaction isolation for hierarchy mutations** is addressed in the same PR because `TxConfig` is defined in `db_provider.rs` and referenced by `secure/db.rs` — they are in the same crate and must compile together. The closure table (parent/ancestor/descendant edges) is mutated under concurrent writes; without `SERIALIZABLE` isolation, two concurrent group moves can produce a corrupted hierarchy. The `deadlock` module provides detection helpers so the service layer can safely retry on SQLSTATE `40001`.

---

## Summary

- Add `ScopeFilter::InGroup` and `ScopeFilter::InGroupSubtree` to `modkit-security` — new scope filter variants for group-based resource visibility
- Implement SQL subquery compilation for the new filters in `modkit-db/secure`
- Add `transaction_with_config` to `DBProvider` — enables `SERIALIZABLE` isolation for closure table mutations
- Add `deadlock` module — SQLSTATE `40001` detection for MySQL/MariaDB and PostgreSQL

---

## Changes

**`libs/modkit-security/src/access_scope.rs`**

Two new `ScopeFilter` variants:

- `ScopeFilter::InGroup(InGroupScopeFilter)` — a resource is visible if its ID appears in `resource_group_membership` for any of the given `group_ids`. Used when the caller knows exactly which groups to check (e.g. the user's direct group memberships).
- `ScopeFilter::InGroupSubtree(InGroupSubtreeScopeFilter)` — a resource is visible if its ID appears in `resource_group_membership` for any group that descends from any of the given `ancestor_ids` in `resource_group_closure`. Used for hierarchical visibility: "everything owned by this department and all its sub-departments."

Constructor helpers: `ScopeFilter::in_group(property, group_ids)`, `ScopeFilter::in_group_subtree(property, ancestor_ids)`.

**`libs/modkit-db/src/secure/cond.rs`**

SQL compilation for the new filters. `ScopeFilter::InGroup` compiles to:
```sql
col IN (
  SELECT resource_id FROM resource_group_membership
  WHERE group_id IN (...)
)
```

`ScopeFilter::InGroupSubtree` compiles to:
```sql
col IN (
  SELECT resource_id FROM resource_group_membership
  WHERE group_id IN (
    SELECT descendant_id FROM resource_group_closure
    WHERE ancestor_id IN (...)
  )
)
```

The `ScopeFilter` match is exhaustive — both new variants are handled in this PR to avoid a compile error.

**`libs/modkit-db/src/db_provider.rs`**

`DBProvider::transaction_with_config(config: TxConfig, f)` — a companion to the existing `transaction` method that lets callers specify isolation level (`SERIALIZABLE`) and access mode (`READ WRITE`). The resource-group `GroupService` uses this for closure table mutations to prevent phantom reads under concurrent group moves.

**`libs/modkit-db/src/deadlock.rs`** *(new file)*

- `is_deadlock(err: &DbErr) -> bool` — detects MySQL/MariaDB InnoDB deadlocks via SQLSTATE `40001`
- `is_serialization_failure(err: &DbErr) -> bool` — detects PostgreSQL serialization failures (`could not serialize access`)

Services that run under `SERIALIZABLE` are expected to catch these and retry. The helpers normalize across MySQL and PostgreSQL so the retry logic in the service layer is engine-agnostic.

**`libs/modkit-db/src/secure/db.rs`**

Uses `TxConfig` (same crate as `db_provider.rs`) — compiled together.

---

## Test plan

- [ ] `cargo test -p modkit-security` — new `ScopeFilter` variant construction and serialization tests
- [ ] `cargo test -p modkit-db` — subquery SQL generation tests in `cond.rs`
- [ ] `ScopeFilter::InGroup` generates correct single-level subquery
- [ ] `ScopeFilter::InGroupSubtree` generates correct nested subquery
- [ ] `is_deadlock` returns `true` for SQLSTATE `40001`, `false` for other errors
- [ ] `is_serialization_failure` returns `true` for PostgreSQL serialization failure message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transactions can be run with custom configuration options.
  * Deadlock and serialization-failure detection utilities added.
  * Group-based and group-subtree scope filters introduced for resource authorization.

* **Tests**
  * Unit tests added to validate deadlock/serialization detection and new scope-filter behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->