### PR TITLE
feat(minichat): Persist web_search/code_interpreter completed counts in chat_turns

### DIFF
--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -5127,18 +5127,6 @@
             "bearerAuth": []
           }
         ],
-        "x-odata-orderby": {
-          "allowedFields": [
-            "id asc",
-            "id desc",
-            "name asc",
-            "name desc",
-            "country asc",
-            "country desc",
-            "created_at asc",
-            "created_at desc"
-          ]
-        },
         "x-odata-filter": {
           "allowedFields": {
             "country": [
@@ -5172,6 +5160,18 @@
               "in"
             ]
           }
+        },
+        "x-odata-orderby": {
+          "allowedFields": [
+            "id asc",
+            "id desc",
+            "name asc",
+            "name desc",
+            "country asc",
+            "country desc",
+            "created_at asc",
+            "created_at desc"
+          ]
         }
       },
       "post": {
@@ -5623,6 +5623,16 @@
             "bearerAuth": []
           }
         ],
+        "x-odata-orderby": {
+          "allowedFields": [
+            "id asc",
+            "id desc",
+            "email asc",
+            "email desc",
+            "created_at asc",
+            "created_at desc"
+          ]
+        },
         "x-odata-filter": {
           "allowedFields": {
             "created_at": [
@@ -5648,16 +5658,6 @@
               "in"
             ]
           }
-        },
-        "x-odata-orderby": {
-          "allowedFields": [
-            "id asc",
-            "id desc",
-            "email asc",
-            "email desc",
-            "created_at asc",
-            "created_at desc"
-          ]
         }
       },
       "post": {
@@ -8284,14 +8284,15 @@
           "type",
           "title",
           "status",
-          "detail",
-          "instance",
-          "code"
+          "detail"
         ],
         "properties": {
           "code": {
             "type": "string",
             "description": "Optional machine-readable error code defined by the application."
+          },
+          "context": {
+            "description": "Optional structured context (e.g. `resource_type`, `resource_name`)."
           },
           "detail": {
             "type": "string",

--- a/modules/mini-chat/mini-chat/src/domain/model/finalization.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/finalization.rs
@@ -119,4 +119,8 @@ pub struct OrphanFinalizationInput {
     pub minimal_generation_floor_applied: Option<i32>,
     /// `started_at` — used to derive `period_starts` for quota settlement.
     pub started_at: OffsetDateTime,
+    /// Completed web search tool calls persisted from the DB (0 if pod crashed before increment).
+    pub web_search_completed_count: u32,
+    /// Completed code interpreter tool calls persisted from the DB (0 if pod crashed before increment).
+    pub code_interpreter_completed_count: u32,
 }

--- a/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
@@ -32,7 +32,8 @@ pub(crate) use quota_usage_repo::{IncrementReserveParams, QuotaUsageRepository, 
 pub(crate) use reaction_repo::{ReactionRepository, UpsertReactionParams};
 pub(crate) use thread_summary_repo::{ThreadSummaryModel, ThreadSummaryRepository};
 pub(crate) use turn_repo::{
-    CasCompleteParams, CasTerminalParams, CreateTurnParams, TurnRepository, UpdatePreflightParams,
+    CasCompleteParams, CasTerminalParams, CreateTurnParams, ToolCallType, TurnRepository,
+    UpdatePreflightParams,
 };
 pub(crate) use user_limits_provider::UserLimitsProvider;
 pub(crate) use vector_store_repo::{InsertVectorStoreParams, VectorStoreRepository};

--- a/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/turn_repo.rs
@@ -69,6 +69,14 @@ pub struct UpdatePreflightParams {
     pub minimal_generation_floor_applied: i32,
 }
 
+/// Identifies which completed tool call counter to increment.
+#[domain_model]
+#[derive(Debug, Clone, Copy)]
+pub enum ToolCallType {
+    WebSearch,
+    CodeInterpreter,
+}
+
 /// Repository trait for turn persistence operations.
 #[async_trait]
 #[allow(dead_code)]
@@ -212,4 +220,16 @@ pub trait TurnRepository: Send + Sync {
         scope: &AccessScope,
         params: UpdatePreflightParams,
     ) -> Result<u64, DomainError>;
+
+    /// Atomically increment the completed tool call counter for a turn.
+    ///
+    /// Called from the streaming task on `ToolPhase::Done`. Best-effort:
+    /// callers are expected to log and swallow errors.
+    async fn increment_tool_calls<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        turn_id: Uuid,
+        tool: ToolCallType,
+    ) -> Result<(), DomainError>;
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
@@ -518,8 +518,8 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
                                 .unwrap_or(0),
                             settlement_path: SettlementPath::Estimated,
                             period_starts,
-                            web_search_calls: 0,
-                            code_interpreter_calls: 0,
+                            web_search_calls: input.web_search_completed_count,
+                            code_interpreter_calls: input.code_interpreter_completed_count,
                         };
 
                         let scope = modkit_security::AccessScope::allow_all();
@@ -571,8 +571,8 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
                         actual_credits_micro,
                         settlement_method: settlement_method_str.to_owned(),
                         policy_version_applied: input.policy_version_applied.unwrap_or(0),
-                        web_search_calls: 0,
-                        code_interpreter_calls: 0,
+                        web_search_calls: input.web_search_completed_count,
+                        code_interpreter_calls: input.code_interpreter_completed_count,
                         timestamp: now,
                     };
                     outbox_enqueuer
@@ -1758,6 +1758,8 @@ mod tests {
             policy_version_applied: Some(1),
             minimal_generation_floor_applied: Some(10),
             started_at: time::OffsetDateTime::now_utc(),
+            web_search_completed_count: 0,
+            code_interpreter_completed_count: 0,
         };
 
         let result = svc.finalize_orphan_turn(input, 60).await.unwrap();
@@ -1800,6 +1802,56 @@ mod tests {
             outbox.flush_count(),
             1,
             "flush should be called after CAS win"
+        );
+    }
+
+    #[tokio::test]
+    async fn finalize_orphan_tool_counts_propagate_to_usage_event() {
+        let db = mock_db_provider(inmem_db().await);
+        let (svc, outbox) = build_finalization_service(Arc::clone(&db));
+
+        let tenant_id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let turn_id = Uuid::new_v4();
+        let request_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+
+        insert_test_chat(&db, tenant_id, chat_id, user_id).await;
+        insert_running_turn(&db, tenant_id, chat_id, turn_id, request_id).await;
+
+        let conn = db.conn().unwrap();
+        backdate_turn_progress(&conn, turn_id).await;
+
+        let input = crate::domain::model::finalization::OrphanFinalizationInput {
+            turn_id,
+            tenant_id,
+            chat_id,
+            request_id,
+            user_id: Some(user_id),
+            requester_type: mini_chat_sdk::RequesterType::User,
+            effective_model: Some("gpt-5.2".to_owned()),
+            reserve_tokens: Some(100),
+            max_output_tokens_applied: Some(4096),
+            reserved_credits_micro: Some(1000),
+            policy_version_applied: Some(1),
+            minimal_generation_floor_applied: Some(10),
+            started_at: time::OffsetDateTime::now_utc(),
+            web_search_completed_count: 3,
+            code_interpreter_completed_count: 2,
+        };
+
+        let result = svc.finalize_orphan_turn(input, 60).await.unwrap();
+        assert!(result, "should be CAS winner");
+
+        let usage_events = outbox.usage_events.lock().unwrap();
+        assert_eq!(usage_events.len(), 1);
+        assert_eq!(
+            usage_events[0].web_search_calls, 3,
+            "web_search_calls must reflect persisted count"
+        );
+        assert_eq!(
+            usage_events[0].code_interpreter_calls, 2,
+            "code_interpreter_calls must reflect persisted count"
         );
     }
 
@@ -1852,6 +1904,8 @@ mod tests {
             policy_version_applied: Some(1),
             minimal_generation_floor_applied: Some(10),
             started_at: time::OffsetDateTime::now_utc(),
+            web_search_completed_count: 0,
+            code_interpreter_completed_count: 0,
         };
 
         let result = svc.finalize_orphan_turn(input, 60).await.unwrap();
@@ -1901,6 +1955,8 @@ mod tests {
             policy_version_applied: Some(1),
             minimal_generation_floor_applied: Some(10),
             started_at: time::OffsetDateTime::now_utc(),
+            web_search_completed_count: 0,
+            code_interpreter_completed_count: 0,
         };
 
         let result = svc.finalize_orphan_turn(input, 60).await.unwrap();

--- a/modules/mini-chat/mini-chat/src/domain/service/replay.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/replay.rs
@@ -289,6 +289,8 @@ mod tests {
             effective_model,
             minimal_generation_floor_applied: Some(10),
             web_search_enabled: false,
+            web_search_completed_count: 0,
+            code_interpreter_completed_count: 0,
             deleted_at: None,
             replaced_by_request_id: None,
             started_at: OffsetDateTime::now_utc(),

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/mod.rs
@@ -4829,6 +4829,8 @@ mod tests {
             effective_model: Set(None),
             minimal_generation_floor_applied: Set(None),
             web_search_enabled: Set(false),
+            web_search_completed_count: Set(0),
+            code_interpreter_completed_count: Set(0),
             deleted_at: Set(None),
             replaced_by_request_id: Set(None),
             started_at: Set(now),

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/provider_task.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/provider_task.rs
@@ -8,7 +8,7 @@ use tracing::{Instrument, debug, info, warn};
 
 use crate::domain::llm::ToolPhase;
 use crate::domain::ports::metric_labels::{stage, trigger};
-use crate::domain::repos::{MessageRepository, TurnRepository};
+use crate::domain::repos::{MessageRepository, ToolCallType, TurnRepository};
 use crate::domain::stream_events::{DoneData, ErrorData, StreamEvent};
 use crate::infra::db::entity::chat_turn::TurnState;
 use crate::infra::llm::{
@@ -394,6 +394,18 @@ pub(super) fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepos
                                     }
                                     ToolPhase::Done => {
                                         web_search_completed_count += 1;
+                                        if let Some(ref fctx) = fin_ctx {
+                                            match fctx.db.conn() {
+                                                Ok(conn) => {
+                                                    if let Err(e) = fctx.turn_repo.increment_tool_calls(&conn, &fctx.scope, fctx.turn_id, ToolCallType::WebSearch).await {
+                                                        warn!(turn_id = %fctx.turn_id, error = %e, "failed to persist web_search_completed_count");
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    warn!(turn_id = %fctx.turn_id, error = %e, "failed to acquire DB connection for web_search_completed_count");
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -480,6 +492,18 @@ pub(super) fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepos
                                     }
                                     ToolPhase::Done => {
                                         code_interpreter_completed_count += 1;
+                                        if let Some(ref fctx) = fin_ctx {
+                                            match fctx.db.conn() {
+                                                Ok(conn) => {
+                                                    if let Err(e) = fctx.turn_repo.increment_tool_calls(&conn, &fctx.scope, fctx.turn_id, ToolCallType::CodeInterpreter).await {
+                                                        warn!(turn_id = %fctx.turn_id, error = %e, "failed to persist code_interpreter_completed_count");
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    warn!(turn_id = %fctx.turn_id, error = %e, "failed to acquire DB connection for code_interpreter_completed_count");
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/chat_turn.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/chat_turn.rs
@@ -30,6 +30,8 @@ pub struct Model {
     pub effective_model: Option<String>,
     pub minimal_generation_floor_applied: Option<i32>,
     pub web_search_enabled: bool,
+    pub web_search_completed_count: i32,
+    pub code_interpreter_completed_count: i32,
     pub deleted_at: Option<OffsetDateTime>,
     pub replaced_by_request_id: Option<Uuid>,
     pub started_at: OffsetDateTime,

--- a/modules/mini-chat/mini-chat/src/infra/db/migrations/m20260402_000003_add_tool_counts_to_turns.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/migrations/m20260402_000003_add_tool_counts_to_turns.rs
@@ -1,0 +1,32 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::ConnectionTrait;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.execute_unprepared(
+            "ALTER TABLE chat_turns ADD COLUMN web_search_completed_count INT NOT NULL DEFAULT 0",
+        )
+        .await?;
+        conn.execute_unprepared(
+            "ALTER TABLE chat_turns ADD COLUMN code_interpreter_completed_count INT NOT NULL DEFAULT 0",
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        conn.execute_unprepared("ALTER TABLE chat_turns DROP COLUMN web_search_completed_count")
+            .await?;
+        conn.execute_unprepared(
+            "ALTER TABLE chat_turns DROP COLUMN code_interpreter_completed_count",
+        )
+        .await?;
+        Ok(())
+    }
+}

--- a/modules/mini-chat/mini-chat/src/infra/db/migrations/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/migrations/mod.rs
@@ -3,6 +3,7 @@ use sea_orm_migration::prelude::*;
 mod m20260302_000001_initial;
 mod m20260329_000001_add_last_progress_at;
 mod m20260330_000002_add_web_search_enabled_to_turns;
+mod m20260402_000003_add_tool_counts_to_turns;
 
 pub struct Migrator;
 
@@ -13,6 +14,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260302_000001_initial::Migration),
             Box::new(m20260329_000001_add_last_progress_at::Migration),
             Box::new(m20260330_000002_add_web_search_enabled_to_turns::Migration),
+            Box::new(m20260402_000003_add_tool_counts_to_turns::Migration),
         ]
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/turn_repo.rs
@@ -10,7 +10,7 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::domain::error::DomainError;
-use crate::domain::repos::{CasCompleteParams, CasTerminalParams, CreateTurnParams};
+use crate::domain::repos::{CasCompleteParams, CasTerminalParams, CreateTurnParams, ToolCallType};
 use crate::infra::db::entity::chat_turn::{
     ActiveModel, Column, Entity as TurnEntity, Model as TurnModel, TurnState,
 };
@@ -46,6 +46,8 @@ impl crate::domain::repos::TurnRepository for TurnRepository {
             effective_model: Set(params.effective_model),
             minimal_generation_floor_applied: Set(params.minimal_generation_floor_applied),
             web_search_enabled: Set(params.web_search_enabled),
+            web_search_completed_count: Set(0),
+            code_interpreter_completed_count: Set(0),
             deleted_at: Set(None),
             replaced_by_request_id: Set(None),
             started_at: Set(now),
@@ -379,6 +381,32 @@ impl crate::domain::repos::TurnRepository for TurnRepository {
             .await?;
         Ok(result.rows_affected)
     }
+
+    async fn increment_tool_calls<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        turn_id: Uuid,
+        tool: ToolCallType,
+    ) -> Result<(), DomainError> {
+        let col = match tool {
+            ToolCallType::WebSearch => Column::WebSearchCompletedCount,
+            ToolCallType::CodeInterpreter => Column::CodeInterpreterCompletedCount,
+        };
+        TurnEntity::update_many()
+            .col_expr(col, Expr::col(col).add(1i32))
+            .filter(
+                Condition::all()
+                    .add(Column::Id.eq(turn_id))
+                    .add(Column::State.eq(TurnState::Running))
+                    .add(Column::DeletedAt.is_null()),
+            )
+            .secure()
+            .scope_with(scope)
+            .exec(runner)
+            .await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -684,5 +712,105 @@ mod tests {
 
         let rows = repo.cas_finalize_orphan(&conn, turn_id, 60).await.unwrap();
         assert_eq!(rows, 0, "CAS should fail for already terminal turn");
+    }
+
+    // ── Phase 4: increment_tool_calls ──
+
+    #[tokio::test]
+    async fn create_turn_zeros_tool_counts() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, chat_id, _, request_id) = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let repo = TurnRepository;
+        let turn = repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .unwrap()
+            .expect("turn should exist");
+
+        assert_eq!(turn.web_search_completed_count, 0);
+        assert_eq!(turn.code_interpreter_completed_count, 0);
+    }
+
+    #[tokio::test]
+    async fn increment_tool_calls_web_search() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, chat_id, turn_id, request_id) = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let repo = TurnRepository;
+
+        repo.increment_tool_calls(&conn, &scope, turn_id, ToolCallType::WebSearch)
+            .await
+            .expect("increment should succeed");
+
+        let turn = repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .unwrap()
+            .expect("turn should exist");
+
+        assert_eq!(turn.web_search_completed_count, 1);
+        assert_eq!(
+            turn.code_interpreter_completed_count, 0,
+            "unrelated counter must not change"
+        );
+    }
+
+    #[tokio::test]
+    async fn increment_tool_calls_code_interpreter() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, chat_id, turn_id, request_id) = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let repo = TurnRepository;
+
+        repo.increment_tool_calls(&conn, &scope, turn_id, ToolCallType::CodeInterpreter)
+            .await
+            .expect("increment should succeed");
+
+        let turn = repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .unwrap()
+            .expect("turn should exist");
+
+        assert_eq!(turn.code_interpreter_completed_count, 1);
+        assert_eq!(
+            turn.web_search_completed_count, 0,
+            "unrelated counter must not change"
+        );
+    }
+
+    #[tokio::test]
+    async fn increment_tool_calls_accumulates() {
+        let db = mock_db_provider(inmem_db().await);
+        let (_, chat_id, turn_id, request_id) = setup_running_turn(&db).await;
+
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::allow_all();
+        let repo = TurnRepository;
+
+        for _ in 0..3 {
+            repo.increment_tool_calls(&conn, &scope, turn_id, ToolCallType::WebSearch)
+                .await
+                .expect("increment should succeed");
+        }
+        repo.increment_tool_calls(&conn, &scope, turn_id, ToolCallType::CodeInterpreter)
+            .await
+            .expect("increment should succeed");
+
+        let turn = repo
+            .find_by_chat_and_request_id(&conn, &scope, chat_id, request_id)
+            .await
+            .unwrap()
+            .expect("turn should exist");
+
+        assert_eq!(turn.web_search_completed_count, 3);
+        assert_eq!(turn.code_interpreter_completed_count, 1);
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/workers/orphan_watchdog.rs
+++ b/modules/mini-chat/mini-chat/src/infra/workers/orphan_watchdog.rs
@@ -202,12 +202,23 @@ fn orphan_input_from_turn(turn: &TurnModel) -> OrphanFinalizationInput {
         policy_version_applied: turn.policy_version_applied,
         minimal_generation_floor_applied: turn.minimal_generation_floor_applied,
         started_at: turn.started_at,
+        web_search_completed_count: u32::try_from(turn.web_search_completed_count)
+            .unwrap_or_else(|_| {
+                warn!(turn_id = %turn.id, value = turn.web_search_completed_count, "negative web_search_completed_count in DB, defaulting to 0");
+                0
+            }),
+        code_interpreter_completed_count: u32::try_from(turn.code_interpreter_completed_count)
+            .unwrap_or_else(|_| {
+                warn!(turn_id = %turn.id, value = turn.code_interpreter_completed_count, "negative code_interpreter_completed_count in DB, defaulting to 0");
+                0
+            }),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
 
     #[tokio::test]
     async fn disabled_returns_immediately() {
@@ -327,5 +338,65 @@ mod tests {
             Ok(())
         }
         fn flush(&self) {}
+    }
+
+    // ── orphan_input_from_turn ──
+
+    fn stub_turn(
+        web_search_completed_count: i32,
+        code_interpreter_completed_count: i32,
+    ) -> TurnModel {
+        use crate::infra::db::entity::chat_turn::TurnState;
+        TurnModel {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            chat_id: Uuid::new_v4(),
+            request_id: Uuid::new_v4(),
+            requester_type: "user".to_owned(),
+            requester_user_id: Some(Uuid::new_v4()),
+            state: TurnState::Running,
+            provider_name: None,
+            provider_response_id: None,
+            assistant_message_id: None,
+            error_code: None,
+            error_detail: None,
+            reserve_tokens: None,
+            max_output_tokens_applied: None,
+            reserved_credits_micro: None,
+            policy_version_applied: None,
+            effective_model: None,
+            minimal_generation_floor_applied: None,
+            web_search_enabled: false,
+            web_search_completed_count,
+            code_interpreter_completed_count,
+            deleted_at: None,
+            replaced_by_request_id: None,
+            started_at: time::OffsetDateTime::now_utc(),
+            last_progress_at: None,
+            completed_at: None,
+            updated_at: time::OffsetDateTime::now_utc(),
+        }
+    }
+
+    #[test]
+    fn orphan_input_maps_tool_counts() {
+        let turn = stub_turn(3, 5);
+        let input = orphan_input_from_turn(&turn);
+        assert_eq!(input.web_search_completed_count, 3);
+        assert_eq!(input.code_interpreter_completed_count, 5);
+    }
+
+    #[test]
+    fn orphan_input_clamps_negative_web_search_count() {
+        let turn = stub_turn(-1, 0);
+        let input = orphan_input_from_turn(&turn);
+        assert_eq!(input.web_search_completed_count, 0);
+    }
+
+    #[test]
+    fn orphan_input_clamps_negative_code_interpreter_count() {
+        let turn = stub_turn(0, -2);
+        let input = orphan_input_from_turn(&turn);
+        assert_eq!(input.code_interpreter_completed_count, 0);
     }
 }


### PR DESCRIPTION
Tool call counts (`web_search_completed_count`, `code_interpreter_completed_count`) were tracked only in-memory in `provider_task.rs` and lost on pod crash. The orphan watchdog therefore always billed zero tool calls when recovering abandoned turns.

**Changes:**
- Migration `m20260402_000003` adds both columns to `chat_turns` (`INT NOT NULL DEFAULT 0`)
- `TurnRepository::increment_tool_calls` atomically increments the relevant counter on each `ToolPhase::Done` (best-effort; errors are logged and swallowed)
- `orphan_input_from_turn` reads the persisted counts so orphan finalization bills correctly
- Normal finalization path is unchanged — it continues to use in-memory counters

Closes #1362.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-turn tracking and persistence of completed web-search and code-interpreter calls; counts are recorded when tools finish and included in finalization and usage events.

* **Bug Fixes**
  * Negative stored counters are clamped to zero with a warning to avoid invalid values during processing.

* **Chores**
  * Database migration added to store the new counters; creation flows initialize them.

* **Tests**
  * Updated and added tests covering initialization, incrementing, propagation, and clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->