### PR TITLE
fix(oagw): handle CORS preflight without tenant context

### DIFF
--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -111,7 +111,7 @@ modules:
           in_flight: 64
 
       # Authentication Configuration
-      auth_disabled: true
+      auth_disabled: false
       require_auth_by_default: true
 
   # --- Tenant Resolver example (gateway + plugins) ---
@@ -221,7 +221,21 @@ modules:
     config:
       vendor: "hyperspot"
       priority: 100
-      mode: accept_all
+      mode: static_tokens
+      tokens:
+        - token: "e2e-token-tenant-a"
+          identity:
+            subject_id: "11111111-6a88-4768-9dfc-6bcd5187d9ed"
+            subject_tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
+            token_scopes: ["*"]
+        # Nil-tenant token: static-authz denies requests with the nil UUID
+        # tenant, producing a clean 403 Forbidden. Used by
+        # testing/e2e/modules/oagw/test_authz.py::test_proxy_authz_forbidden_nil_tenant
+        - token: "e2e-token-nil-tenant"
+          identity:
+            subject_id: "33333333-6a88-4768-9dfc-6bcd5187d9ed"
+            subject_tenant_id: "00000000-0000-0000-0000-000000000000"
+            token_scopes: ["*"]
       s2s_credentials:
         - client_id: "mini-chat"
           client_secret: "mini-chat-dev-secret"

--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -6591,12 +6591,6 @@
           "allow_credentials": {
             "type": "boolean"
           },
-          "allowed_headers": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
           "allowed_methods": {
             "type": "array",
             "items": {
@@ -6617,11 +6611,6 @@
             "items": {
               "type": "string"
             }
-          },
-          "max_age": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 0
           },
           "sharing": {
             "$ref": "#/components/schemas/SharingMode"

--- a/modules/system/api-gateway/src/middleware/auth.rs
+++ b/modules/system/api-gateway/src/middleware/auth.rs
@@ -201,8 +201,10 @@ pub async fn authn_middleware(
     mut req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
-    // Skip CORS preflight
+    // Skip CORS preflight — insert anonymous SecurityContext so downstream
+    // handlers that extract Extension<SecurityContext> don't panic.
     if is_preflight_request(req.method(), req.headers()) {
+        req.extensions_mut().insert(SecurityContext::anonymous());
         return next.run(req).await;
     }
 

--- a/modules/system/oagw/docs/ADR/0006-cors.md
+++ b/modules/system/oagw/docs/ADR/0006-cors.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 date: 2026-02-03
 decision-makers: OAGW Team
 ---
@@ -79,9 +79,7 @@ CORS is a first-class field in upstream/route configuration:
     "enabled": true,
     "allowed_origins": ["https://app.example.com"],
     "allowed_methods": ["GET", "POST"],
-    "allowed_headers": ["Content-Type", "Authorization"],
     "expose_headers": ["X-Request-ID"],
-    "max_age": 86400,
     "allow_credentials": true
   }
 }
@@ -106,7 +104,7 @@ CORS is a first-class field in upstream/route configuration:
 
 ### Confirmation
 
-Integration tests verify: preflight returns 204 with correct CORS headers, actual requests include CORS headers, rejected origins return 403, `allow_credentials` with wildcard origin is rejected at validation time.
+Integration tests verify: preflight returns permissive 204 with echoed CORS headers, actual requests include CORS response headers for allowed origins, disallowed origins are rejected with 403 on actual requests, disallowed methods are rejected with 403 on actual requests, `allow_credentials` with wildcard origin is rejected at validation time.
 
 ## Pros and Cons of the Options
 
@@ -181,24 +179,11 @@ CORS as first-class feature handled before plugin chain.
         "default": [ "GET", "POST" ],
         "description": "Allowed HTTP methods"
       },
-      "allowed_headers": {
-        "type": "array",
-        "items": { "type": "string" },
-        "default": [ "Content-Type", "Authorization" ],
-        "description": "Allowed request headers (case-insensitive)"
-      },
       "expose_headers": {
         "type": "array",
         "items": { "type": "string" },
         "default": [ ],
         "description": "Headers exposed to browser (beyond CORS-safelisted headers)"
-      },
-      "max_age": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 86400,
-        "default": 86400,
-        "description": "Preflight cache duration in seconds (max 24h)"
       },
       "allow_credentials": {
         "type": "boolean",
@@ -220,9 +205,7 @@ CORS as first-class feature handled before plugin chain.
   "cors": {
     "enabled": true,
     "allowed_origins": [ "*" ],
-    "allowed_methods": [ "GET", "POST" ],
-    "allowed_headers": [ "Content-Type" ],
-    "max_age": 86400
+    "allowed_methods": [ "GET", "POST" ]
   }
 }
 ```
@@ -238,9 +221,7 @@ CORS as first-class feature handled before plugin chain.
       "https://admin.example.com"
     ],
     "allowed_methods": [ "GET", "POST", "PUT", "DELETE" ],
-    "allowed_headers": [ "Content-Type", "Authorization", "X-API-Key" ],
     "expose_headers": [ "X-Request-ID", "X-RateLimit-Remaining" ],
-    "max_age": 3600,
     "allow_credentials": true
   }
 }
@@ -266,6 +247,8 @@ CORS as first-class feature handled before plugin chain.
 
 ### Preflight Request Handling
 
+Browser preflight requests contain no credentials (per WHATWG Fetch spec), so no tenant context is available for upstream resolution. The proxy handler detects preflight and returns a permissive 204 that echoes back the requested origin, method, and headers. Origin and method validation is deferred to the actual request.
+
 ```text
 OPTIONS /api/oagw/v1/proxy/api.example.com/users
 Origin: https://app.example.com
@@ -274,11 +257,9 @@ Access-Control-Request-Headers: Content-Type, Authorization
 
 ↓
 
-1. Check: Is CORS enabled for this upstream/route?
-2. Check: Is origin in allowed_origins?
-3. Check: Is method in allowed_methods?
-4. Check: Are headers in allowed_headers?
-5. Return 204 No Content with CORS headers (or 403 if checks fail)
+1. Handler detects CORS preflight (OPTIONS + Origin + Access-Control-Request-Method)
+2. Return 204 No Content echoing the request's origin, method, and headers
+   (no upstream resolution, no tenant context required)
 ```
 
 **Response headers** (preflight):
@@ -286,12 +267,13 @@ Access-Control-Request-Headers: Content-Type, Authorization
 ```http
 HTTP/1.1 204 No Content
 Access-Control-Allow-Origin: https://app.example.com
-Access-Control-Allow-Methods: GET, POST, PUT, DELETE
+Access-Control-Allow-Methods: POST
 Access-Control-Allow-Headers: Content-Type, Authorization
 Access-Control-Max-Age: 86400
-Access-Control-Allow-Credentials: true
-Vary: Origin
+Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
 ```
+
+Origin enforcement happens on the subsequent actual request — after upstream resolution, the origin is validated against the upstream's CORS config before the request is forwarded. See [Actual Request Handling](#actual-request-handling).
 
 ### Actual Request Handling
 
@@ -302,9 +284,11 @@ Content-Type: application/json
 
 ↓
 
-1. Check: Is origin in allowed_origins?
-2. Forward request to upstream
-3. Add CORS headers to response
+1. Resolve upstream (requires tenant context from authenticated request)
+2. Check: Is origin in allowed_origins? (403 if not)
+3. Check: Is method in allowed_methods? (403 if not)
+4. Forward request to upstream
+5. Add CORS headers to response
 ```
 
 **Response headers** (actual request):
@@ -368,8 +352,8 @@ if config.allow_credentials && config.allowed_origins.iter().any(|o| o == "*") {
 
 **Preflight optimization**:
 
-- Cache preflight responses (client-side via `max_age`)
-- Return 204 No Content (no body)
+- Return permissive 204 No Content at handler level (no upstream resolution, no body)
+- Origin validation happens on the actual request (after upstream resolution, before forwarding)
 - Skip per-request auth/plugin checks for preflight (global/edge rate limiting and WAF/DDoS controls still apply)
 
 **Vary header**:
@@ -399,7 +383,7 @@ With `sharing: enforce`, child cannot add origins.
 
 ## Error Responses
 
-**Preflight rejected** (origin not allowed):
+**Origin not allowed** (actual request — disallowed origin rejected before forwarding to upstream):
 
 ```http
 HTTP/1.1 403 Forbidden
@@ -413,7 +397,7 @@ Content-Type: application/problem+json
 }
 ```
 
-**Method not allowed**:
+**Method not allowed** (actual request — disallowed method rejected before forwarding to upstream):
 
 ```http
 HTTP/1.1 403 Forbidden

--- a/modules/system/oagw/docs/DESIGN.md
+++ b/modules/system/oagw/docs/DESIGN.md
@@ -276,7 +276,7 @@ Multiple per upstream/route. Can reject requests before they reach upstream.
 | Plugin ID | Description |
 |---|---|
 | `gts.x.core.oagw.guard_plugin.v1~x.core.oagw.timeout.v1` | Request timeout enforcement |
-| `gts.x.core.oagw.guard_plugin.v1~x.core.oagw.cors.v1` | CORS preflight validation |
+| `gts.x.core.oagw.guard_plugin.v1~x.core.oagw.cors.v1` | CORS origin validation (actual requests; preflight handled at handler level — see [ADR: CORS](./ADR/0006-cors.md)) |
 
 Circuit breaker is **core functionality** (not a plugin). See [ADR: Circuit Breaker](./ADR/0005-circuit-breaker.md).
 
@@ -497,7 +497,8 @@ Validation rules that can reject requests:
 | Query params | Validate against `match.http.query_allowlist`; reject if unknown |
 | Path suffix | Reject if `path_suffix_mode`: `disabled` and suffix provided |
 | Body | See body validation rules below |
-| CORS | Reject if CORS policy validation fails |
+| CORS origin | Reject if origin is not in upstream's `allowed_origins` (actual cross-origin requests only; preflight returns permissive 204 at handler level — see [ADR: CORS](./ADR/0006-cors.md)) |
+| CORS method | Reject if method is not in upstream's `allowed_methods` (actual cross-origin requests only) |
 
 #### Body Validation Rules
 
@@ -565,7 +566,7 @@ Without appropriate permissions, descendant must use ancestor's configuration as
 - Headers: Well-known headers stripping and validation.
 - Request Validation: Path, query parameters validation against route configuration.
 
-**Cross-Origin Resource Sharing (CORS)**: Built-in, configured per upstream/route. Preflight OPTIONS requests handled locally (no upstream round-trip). See [ADR: CORS](./ADR/0006-cors.md).
+**Cross-Origin Resource Sharing (CORS)**: Built-in, configured per upstream/route. Preflight OPTIONS requests return a permissive 204 at the handler level (no upstream resolution or tenant context required). Origin validation happens on actual requests after upstream resolution, before forwarding. See [ADR: CORS](./ADR/0006-cors.md).
 
 **HTTP Version Negotiation**: OAGW uses adaptive per-host HTTP version detection:
 1. **First request**: Attempt HTTP/2 via ALPN during TLS handshake

--- a/modules/system/oagw/docs/adr-cors.md
+++ b/modules/system/oagw/docs/adr-cors.md
@@ -1,6 +1,6 @@
 # ADR: Cross-Origin Resource Sharing (CORS)
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-02-03
 - **Deciders**: OAGW Team
 
@@ -61,9 +61,7 @@ Implement CORS as a guard plugin. Configurable per upstream/route.
         "config": {
           "allowed_origins": [ "https://app.example.com", "https://admin.example.com" ],
           "allowed_methods": [ "GET", "POST", "PUT", "DELETE" ],
-          "allowed_headers": [ "Content-Type", "Authorization" ],
           "expose_headers": [ "X-Request-ID" ],
-          "max_age": 86400,
           "allow_credentials": true
         }
       }
@@ -100,9 +98,7 @@ CORS as first-class feature in upstream/route configuration. Handled before plug
     "enabled": true,
     "allowed_origins": [ "https://app.example.com" ],
     "allowed_methods": [ "GET", "POST" ],
-    "allowed_headers": [ "Content-Type", "Authorization" ],
     "expose_headers": [ "X-Request-ID" ],
-    "max_age": 86400,
     "allow_credentials": true
   }
 }
@@ -173,24 +169,11 @@ Options 1 and 2 rejected:
         "default": [ "GET", "POST" ],
         "description": "Allowed HTTP methods"
       },
-      "allowed_headers": {
-        "type": "array",
-        "items": { "type": "string" },
-        "default": [ "Content-Type", "Authorization" ],
-        "description": "Allowed request headers (case-insensitive)"
-      },
       "expose_headers": {
         "type": "array",
         "items": { "type": "string" },
         "default": [ ],
         "description": "Headers exposed to browser (beyond CORS-safelisted headers)"
-      },
-      "max_age": {
-        "type": "integer",
-        "minimum": 0,
-        "maximum": 86400,
-        "default": 86400,
-        "description": "Preflight cache duration in seconds (max 24h)"
       },
       "allow_credentials": {
         "type": "boolean",
@@ -212,9 +195,7 @@ Options 1 and 2 rejected:
   "cors": {
     "enabled": true,
     "allowed_origins": [ "*" ],
-    "allowed_methods": [ "GET", "POST" ],
-    "allowed_headers": [ "Content-Type" ],
-    "max_age": 86400
+    "allowed_methods": [ "GET", "POST" ]
   }
 }
 ```
@@ -230,9 +211,7 @@ Options 1 and 2 rejected:
       "https://admin.example.com"
     ],
     "allowed_methods": [ "GET", "POST", "PUT", "DELETE" ],
-    "allowed_headers": [ "Content-Type", "Authorization", "X-API-Key" ],
     "expose_headers": [ "X-Request-ID", "X-RateLimit-Remaining" ],
-    "max_age": 3600,
     "allow_credentials": true
   }
 }
@@ -258,6 +237,8 @@ Options 1 and 2 rejected:
 
 ### Preflight Request Handling
 
+Browser preflight requests contain no credentials (per WHATWG Fetch spec), so no tenant context is available for upstream resolution. The proxy handler detects preflight and returns a permissive 204 that echoes back the requested origin, method, and headers. Origin and method validation is deferred to the actual request.
+
 ```
 OPTIONS /api/oagw/v1/proxy/api.example.com/users
 Origin: https://app.example.com
@@ -266,11 +247,9 @@ Access-Control-Request-Headers: Content-Type, Authorization
 
 ↓
 
-1. Check: Is CORS enabled for this upstream/route?
-2. Check: Is origin in allowed_origins?
-3. Check: Is method in allowed_methods?
-4. Check: Are headers in allowed_headers?
-5. Return 204 No Content with CORS headers (or 403 if checks fail)
+1. Handler detects CORS preflight (OPTIONS + Origin + Access-Control-Request-Method)
+2. Return 204 No Content echoing the request's origin, method, and headers
+   (no upstream resolution, no tenant context required)
 ```
 
 **Response headers** (preflight):
@@ -278,12 +257,13 @@ Access-Control-Request-Headers: Content-Type, Authorization
 ```http
 HTTP/1.1 204 No Content
 Access-Control-Allow-Origin: https://app.example.com
-Access-Control-Allow-Methods: GET, POST, PUT, DELETE
+Access-Control-Allow-Methods: POST
 Access-Control-Allow-Headers: Content-Type, Authorization
 Access-Control-Max-Age: 86400
-Access-Control-Allow-Credentials: true
-Vary: Origin
+Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
 ```
+
+Origin enforcement happens on the subsequent actual request — after upstream resolution, the origin is validated against the upstream's CORS config before the request is forwarded. See [Actual Request Handling](#actual-request-handling).
 
 ### Actual Request Handling
 
@@ -294,9 +274,11 @@ Content-Type: application/json
 
 ↓
 
-1. Check: Is origin in allowed_origins?
-2. Forward request to upstream
-3. Add CORS headers to response
+1. Resolve upstream (requires tenant context from authenticated request)
+2. Check: Is origin in allowed_origins? (403 if not)
+3. Check: Is method in allowed_methods? (403 if not)
+4. Forward request to upstream
+5. Add CORS headers to response
 ```
 
 **Response headers** (actual request):
@@ -358,9 +340,9 @@ return Err("Cannot use allow_credentials with wildcard origin");
 
 **Preflight optimization**:
 
-- Cache preflight responses (client-side via `max_age`)
-- Return 204 No Content (no body)
-- Skip auth/rate-limit checks for preflight
+- Return permissive 204 No Content at handler level (no upstream resolution, no body)
+- Origin validation happens on the actual request (after upstream resolution, before forwarding)
+- Skip per-request auth/plugin checks for preflight (global/edge rate limiting and WAF/DDoS controls still apply)
 
 **Vary header**:
 Always include `Vary: Origin` to prevent cache poisoning.
@@ -389,7 +371,7 @@ With `sharing: enforce`, child cannot add origins.
 
 ## Error Responses
 
-**Preflight rejected** (origin not allowed):
+**Origin not allowed** (actual request — disallowed origin rejected before forwarding to upstream):
 
 ```http
 HTTP/1.1 403 Forbidden
@@ -403,7 +385,7 @@ Content-Type: application/problem+json
 }
 ```
 
-**Method not allowed**:
+**Method not allowed** (actual request — disallowed method rejected before forwarding to upstream):
 
 ```http
 HTTP/1.1 403 Forbidden
@@ -436,7 +418,7 @@ HTTP/1.1 403 Forbidden
 
 - CORS only affects browser clients (other clients unaffected)
 - Configuration complexity proportional to security requirements
-- Preflight requests bypass auth/rate-limiting (by design)
+- Preflight requests bypass per-request auth/plugin checks (by design) but still pass through global/edge rate limiting and WAF/DDoS controls
 
 ## Links
 

--- a/modules/system/oagw/docs/features/0004-cpt-cf-oagw-feature-proxy-engine.md
+++ b/modules/system/oagw/docs/features/0004-cpt-cf-oagw-feature-proxy-engine.md
@@ -122,7 +122,7 @@ Design constraints enforced: `cpt-cf-oagw-constraint-body-limit`, `cpt-cf-oagw-c
 14. [x] - `p1` - Execute auth plugin: inject credentials into outbound request - `inst-proxy-14`
 15. [x] - `p1` - **IF** auth plugin fails (secret not found, credential error) - `inst-proxy-15`
     1. [x] - `p1` - **RETURN** 401 AuthenticationFailed or 500 SecretNotFound with `X-OAGW-Error-Source: gateway` - `inst-proxy-15a`
-16. [x] - `p1` - Execute guard plugins: validate method, query params, path suffix, CORS - `inst-proxy-16`
+16. [x] - `p1` - Execute guard plugins: validate method, query params, path suffix, CORS origin (actual requests only; preflight returns permissive 204 at handler level — see [ADR: CORS](../ADR/0006-cors.md)) - `inst-proxy-16`
 17. [x] - `p1` - **IF** any guard rejects - `inst-proxy-17`
     1. [x] - `p1` - **RETURN** guard-specific error code with `X-OAGW-Error-Source: gateway` - `inst-proxy-17a`
 18. [x] - `p1` - Execute transform plugins: `on_request` phase — mutate outbound request - `inst-proxy-18`

--- a/modules/system/oagw/docs/features/0008-cpt-cf-oagw-feature-observability.md
+++ b/modules/system/oagw/docs/features/0008-cpt-cf-oagw-feature-observability.md
@@ -17,7 +17,7 @@
 - [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
   - [Metrics Collection Pipeline](#metrics-collection-pipeline)
   - [Audit Log Emission](#audit-log-emission)
-  - [CORS Preflight Handler](#cors-preflight-handler)
+  - [CORS Handler](#cors-handler)
   - [SSRF Protection Validation](#ssrf-protection-validation)
   - [HTTP Smuggling Prevention](#http-smuggling-prevention)
   - [Multi-Layer Config Cache](#multi-layer-config-cache)
@@ -80,7 +80,7 @@ Operators need full visibility into outbound API traffic patterns, errors, and p
 | CP L2 cache TTL | 300s | Yes | `OagwConfig` |
 | Redis operation timeout | 50ms | Yes | `OagwConfig` |
 | Audit log sampling rate | 1/100 | Yes | Per-route configurable |
-| CORS max_age default | 86400s | Yes | Per-upstream/route |
+| CORS max_age | 86400s | No | Hardcoded in handler |
 
 ### 1.7 Non-Applicable Domains
 
@@ -108,7 +108,7 @@ Operators need full visibility into outbound API traffic patterns, errors, and p
 **Steps**:
 1. [ ] - `p2` - Operator submits upstream/route update with CORS configuration via Management API - `inst-cors-1`
 2. [ ] - `p2` - API: PUT /api/oagw/v1/upstreams/{id} or PUT /api/oagw/v1/routes/{id} (cors field in request body) - `inst-cors-2`
-3. [ ] - `p2` - Validate CORS configuration: allowed_origins, allowed_methods, allowed_headers, max_age - `inst-cors-3`
+3. [ ] - `p2` - Validate CORS configuration: allowed_origins, allowed_methods - `inst-cors-3`
 4. [ ] - `p2` - **IF** validation fails - `inst-cors-4`
    1. [ ] - `p2` - **RETURN** 400 ValidationError with details - `inst-cors-4a`
 5. [ ] - `p2` - **ELSE** - `inst-cors-5`
@@ -198,36 +198,38 @@ Operators need full visibility into outbound API traffic patterns, errors, and p
 8. [ ] - `p2` - Emit to stdout - `inst-al-8`
 9. [ ] - `p2` - **RETURN** void - `inst-al-9`
 
-### CORS Preflight Handler
+### CORS Handler
+
+Preflight returns a permissive 204 at the handler level (no upstream resolution). Origin validation happens on actual requests after upstream resolution. See [ADR: CORS](../ADR/0006-cors.md).
 
 - [ ] `p2` - **ID**: `cpt-cf-oagw-algo-obs-cors-handler`
 
-**Input**: Inbound HTTP request, resolved upstream/route CORS configuration
+**Input**: Inbound HTTP request (preflight or actual), upstream/route CORS configuration (actual requests only)
 
 **Output**: CORS preflight response (for OPTIONS) or CORS headers added to proxy response
 
 **Steps**:
-1. [ ] - `p2` - **IF** no CORS configuration on upstream or route - `inst-cors-h-1`
-   1. [ ] - `p2` - Skip CORS processing; CORS is disabled by default (secure default) - `inst-cors-h-1a`
-   2. [ ] - `p2` - **RETURN** request unchanged - `inst-cors-h-1b`
-2. [ ] - `p2` - Extract `Origin` header from inbound request - `inst-cors-h-2`
-3. [ ] - `p2` - **IF** Origin header absent - `inst-cors-h-3`
-   1. [ ] - `p2` - Skip CORS processing (not a cross-origin request) - `inst-cors-h-3a`
-   2. [ ] - `p2` - **RETURN** request unchanged - `inst-cors-h-3b`
-4. [ ] - `p2` - Match Origin against configured `allowed_origins` patterns - `inst-cors-h-4`
-5. [ ] - `p2` - **IF** Origin not in allowed list - `inst-cors-h-5`
-   1. [ ] - `p2` - **RETURN** 403 with CORS violation error (no CORS headers) - `inst-cors-h-5a`
-6. [ ] - `p2` - **IF** request method is OPTIONS (preflight) - `inst-cors-h-6`
-   1. [ ] - `p2` - Validate `Access-Control-Request-Method` against `allowed_methods` - `inst-cors-h-6a`
-   2. [ ] - `p2` - Validate `Access-Control-Request-Headers` against `allowed_headers` - `inst-cors-h-6b`
-   3. [ ] - `p2` - **IF** validation fails - `inst-cors-h-6c`
-      1. [ ] - `p2` - **RETURN** 403 with CORS preflight rejection - `inst-cors-h-6c1`
-   4. [ ] - `p2` - Build preflight response: `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, `Access-Control-Max-Age` - `inst-cors-h-6d`
-   5. [ ] - `p2` - **RETURN** 204 No Content with CORS headers (no upstream round-trip) - `inst-cors-h-6e`
-7. [ ] - `p2` - **ELSE** (actual cross-origin request) - `inst-cors-h-7`
-   1. [ ] - `p2` - Add `Access-Control-Allow-Origin` to response headers after upstream call - `inst-cors-h-7a`
-   2. [ ] - `p2` - Add `Access-Control-Expose-Headers` if configured - `inst-cors-h-7b`
-   3. [ ] - `p2` - **RETURN** response with CORS headers - `inst-cors-h-7c`
+
+**Preflight path** (handler level, no upstream resolution):
+1. [ ] - `p2` - **IF** request is CORS preflight (OPTIONS + Origin + Access-Control-Request-Method) - `inst-cors-h-1`
+   1. [ ] - `p2` - Return permissive 204 echoing the request's origin, method, and headers - `inst-cors-h-1a`
+   2. [ ] - `p2` - **RETURN** 204 No Content with permissive CORS headers (no upstream resolution, no tenant context required) - `inst-cors-h-1b`
+
+**Actual request path** (after upstream resolution in Data Plane service):
+2. [ ] - `p2` - **IF** no CORS configuration on upstream or route - `inst-cors-h-2`
+   1. [ ] - `p2` - Skip CORS processing; CORS is disabled by default (secure default) - `inst-cors-h-2a`
+   2. [ ] - `p2` - **RETURN** request unchanged - `inst-cors-h-2b`
+3. [ ] - `p2` - Extract `Origin` header from inbound request - `inst-cors-h-3`
+4. [ ] - `p2` - **IF** Origin header absent - `inst-cors-h-4`
+   1. [ ] - `p2` - Skip CORS processing (not a cross-origin request) - `inst-cors-h-4a`
+   2. [ ] - `p2` - **RETURN** request unchanged - `inst-cors-h-4b`
+5. [ ] - `p2` - Match Origin against configured `allowed_origins` - `inst-cors-h-5`
+6. [ ] - `p2` - **IF** Origin not in allowed list - `inst-cors-h-6`
+   1. [ ] - `p2` - **RETURN** 403 with CORS origin not allowed error (request not forwarded to upstream) - `inst-cors-h-6a`
+7. [ ] - `p2` - Forward request to upstream - `inst-cors-h-7`
+8. [ ] - `p2` - Add `Access-Control-Allow-Origin` to response headers after upstream call - `inst-cors-h-8`
+   1. [ ] - `p2` - Add `Access-Control-Expose-Headers` if configured - `inst-cors-h-8a`
+   2. [ ] - `p2` - **RETURN** response with CORS headers - `inst-cors-h-8b`
 
 ### SSRF Protection Validation
 
@@ -359,7 +361,7 @@ Log retention is an infrastructure concern (centralized logging system). This fe
 
 The system **MUST** provide built-in CORS handling configurable per upstream and per route. Preflight OPTIONS requests **MUST** be handled locally without upstream round-trip. CORS **MUST** be disabled by default (secure default); only configured origins are allowed.
 
-Configuration **MUST** support: `allowed_origins`, `allowed_methods`, `allowed_headers`, `max_age`. Origin matching **MUST** reject unrecognized origins with no CORS headers in the response.
+Configuration **MUST** support: `allowed_origins`, `allowed_methods`. Origin matching **MUST** reject unrecognized origins with no CORS headers in the response.
 
 **Implements**:
 - `cpt-cf-oagw-algo-obs-cors-handler`
@@ -433,9 +435,9 @@ When Redis (CP L2) is unavailable, the system **MUST** degrade gracefully by ski
 - [ ] Audit logs never contain request/response bodies, query parameters, API keys, tokens, or credentials
 - [ ] Log levels follow policy: INFO for success, WARN for rate limit/circuit breaker, ERROR for failures
 - [ ] High-frequency route sampling reduces log volume without losing visibility
-- [ ] CORS preflight OPTIONS requests return 204 without upstream round-trip
+- [ ] CORS preflight OPTIONS requests return permissive 204 at handler level without upstream resolution (see [ADR: CORS](../ADR/0006-cors.md))
 - [ ] CORS is disabled by default; only explicitly configured origins are allowed
-- [ ] Unrecognized origins receive no CORS headers in the response
+- [ ] Unrecognized origins on actual requests are rejected with 403 before reaching the upstream
 - [ ] HTTPS-only scheme enforcement blocks non-HTTPS upstream connections
 - [ ] DNS results resolving to private/reserved IP ranges are rejected (unless explicitly allowed)
 - [ ] Internal forwarding headers are stripped from outbound requests

--- a/modules/system/oagw/docs/schemas/route.v1.schema.json
+++ b/modules/system/oagw/docs/schemas/route.v1.schema.json
@@ -195,7 +195,13 @@
         },
         "allowed_origins": {
           "type": "array",
-          "items": { "type": "string", "format": "uri" },
+          "items": {
+            "type": "string",
+            "oneOf": [
+              { "const": "*" },
+              { "format": "uri" }
+            ]
+          },
           "description": "Allowed origins. Use ['*'] for any origin (not recommended with credentials)."
         },
         "allowed_methods": {
@@ -204,24 +210,11 @@
           "default": [ "GET", "POST" ],
           "description": "Allowed HTTP methods."
         },
-        "allowed_headers": {
-          "type": "array",
-          "items": { "type": "string" },
-          "default": [ "Content-Type", "Authorization" ],
-          "description": "Allowed request headers (case-insensitive)."
-        },
         "expose_headers": {
           "type": "array",
           "items": { "type": "string" },
           "default": [ ],
           "description": "Headers exposed to browser (beyond CORS-safelisted headers)."
-        },
-        "max_age": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 86400,
-          "default": 86400,
-          "description": "Preflight cache duration in seconds (max 24h)."
         },
         "allow_credentials": {
           "type": "boolean",
@@ -229,7 +222,20 @@
           "description": "Allow credentials (cookies, auth headers). Requires specific origins (not '*')."
         }
       },
-      "required": [ "enabled" ]
+      "required": [ "enabled" ],
+      "if": {
+        "properties": {
+          "allow_credentials": { "const": true }
+        },
+        "required": [ "allow_credentials" ]
+      },
+      "then": {
+        "not": {
+          "properties": {
+            "allowed_origins": { "contains": { "const": "*" } }
+          }
+        }
+      }
     }
   }
 }

--- a/modules/system/oagw/docs/schemas/upstream.v1.schema.json
+++ b/modules/system/oagw/docs/schemas/upstream.v1.schema.json
@@ -297,24 +297,11 @@
           "default": [ "GET", "POST" ],
           "description": "Allowed HTTP methods."
         },
-        "allowed_headers": {
-          "type": "array",
-          "items": { "type": "string" },
-          "default": [ "Content-Type", "Authorization" ],
-          "description": "Allowed request headers (case-insensitive)."
-        },
         "expose_headers": {
           "type": "array",
           "items": { "type": "string" },
           "default": [ ],
           "description": "Headers exposed to browser (beyond CORS-safelisted headers)."
-        },
-        "max_age": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 86400,
-          "default": 86400,
-          "description": "Preflight cache duration in seconds (max 24h)."
         },
         "allow_credentials": {
           "type": "boolean",

--- a/modules/system/oagw/oagw-sdk/src/models.rs
+++ b/modules/system/oagw/oagw-sdk/src/models.rs
@@ -231,9 +231,7 @@ pub struct CorsConfig {
     pub enabled: bool,
     pub allowed_origins: Vec<String>,
     pub allowed_methods: Vec<CorsHttpMethod>,
-    pub allowed_headers: Vec<String>,
     pub expose_headers: Vec<String>,
-    pub max_age: u32,
     pub allow_credentials: bool,
 }
 

--- a/modules/system/oagw/oagw/src/api/rest/dto.rs
+++ b/modules/system/oagw/oagw/src/api/rest/dto.rs
@@ -207,10 +207,6 @@ pub enum CorsHttpMethod {
     Options,
 }
 
-fn default_max_age() -> u32 {
-    86400
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct CorsConfig {
     #[serde(default)]
@@ -222,11 +218,7 @@ pub struct CorsConfig {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub allowed_methods: Vec<CorsHttpMethod>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub allowed_headers: Vec<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub expose_headers: Vec<String>,
-    #[serde(default = "default_max_age")]
-    pub max_age: u32,
     #[serde(default)]
     pub allow_credentials: bool,
 }
@@ -633,9 +625,7 @@ impl From<CorsConfig> for domain::CorsConfig {
             enabled: v.enabled,
             allowed_origins: v.allowed_origins,
             allowed_methods: v.allowed_methods.into_iter().map(Into::into).collect(),
-            allowed_headers: v.allowed_headers,
             expose_headers: v.expose_headers,
-            max_age: v.max_age,
             allow_credentials: v.allow_credentials,
         }
     }
@@ -898,9 +888,7 @@ impl From<domain::CorsConfig> for CorsConfig {
             enabled: v.enabled,
             allowed_origins: v.allowed_origins,
             allowed_methods: v.allowed_methods.into_iter().map(Into::into).collect(),
-            allowed_headers: v.allowed_headers,
             expose_headers: v.expose_headers,
-            max_age: v.max_age,
             allow_credentials: v.allow_credentials,
         }
     }

--- a/modules/system/oagw/oagw/src/api/rest/error.rs
+++ b/modules/system/oagw/oagw/src/api/rest/error.rs
@@ -37,8 +37,6 @@ pub(crate) const ERR_CORS_ORIGIN_NOT_ALLOWED: &str =
     "gts.x.core.errors.err.v1~x.oagw.cors.origin_not_allowed.v1";
 pub(crate) const ERR_CORS_METHOD_NOT_ALLOWED: &str =
     "gts.x.core.errors.err.v1~x.oagw.cors.method_not_allowed.v1";
-pub(crate) const ERR_CORS_HEADER_NOT_ALLOWED: &str =
-    "gts.x.core.errors.err.v1~x.oagw.cors.header_not_allowed.v1";
 pub(crate) const ERR_STREAM_ABORTED: &str = "gts.x.core.errors.err.v1~x.oagw.stream.aborted.v1";
 pub(crate) const ERR_LINK_UNAVAILABLE: &str = "gts.x.core.errors.err.v1~x.oagw.link.unavailable.v1";
 pub(crate) const ERR_CIRCUIT_BREAKER_OPEN: &str =
@@ -75,7 +73,6 @@ fn gts_type(err: &DomainError) -> &str {
         DomainError::GuardRejected { .. } => ERR_GUARD_REJECTED,
         DomainError::CorsOriginNotAllowed { .. } => ERR_CORS_ORIGIN_NOT_ALLOWED,
         DomainError::CorsMethodNotAllowed { .. } => ERR_CORS_METHOD_NOT_ALLOWED,
-        DomainError::CorsHeaderNotAllowed { .. } => ERR_CORS_HEADER_NOT_ALLOWED,
         DomainError::StreamAborted { .. } => ERR_STREAM_ABORTED,
         DomainError::LinkUnavailable { .. } => ERR_LINK_UNAVAILABLE,
         DomainError::CircuitBreakerOpen { .. } => ERR_CIRCUIT_BREAKER_OPEN,
@@ -116,9 +113,9 @@ fn http_status_code(err: &DomainError) -> StatusCode {
             .ok()
             .filter(|code| code.is_client_error() || code.is_server_error())
             .unwrap_or(StatusCode::BAD_REQUEST),
-        DomainError::CorsOriginNotAllowed { .. }
-        | DomainError::CorsMethodNotAllowed { .. }
-        | DomainError::CorsHeaderNotAllowed { .. } => StatusCode::FORBIDDEN,
+        DomainError::CorsOriginNotAllowed { .. } | DomainError::CorsMethodNotAllowed { .. } => {
+            StatusCode::FORBIDDEN
+        }
         DomainError::Forbidden { .. } => StatusCode::FORBIDDEN,
     }
 }
@@ -143,7 +140,6 @@ fn error_title(err: &DomainError) -> &str {
         DomainError::GuardRejected { .. } => "Guard Rejected",
         DomainError::CorsOriginNotAllowed { .. } => "CORS Origin Not Allowed",
         DomainError::CorsMethodNotAllowed { .. } => "CORS Method Not Allowed",
-        DomainError::CorsHeaderNotAllowed { .. } => "CORS Header Not Allowed",
         DomainError::StreamAborted { .. } => "Stream Aborted",
         DomainError::LinkUnavailable { .. } => "Link Unavailable",
         DomainError::CircuitBreakerOpen { .. } => "Circuit Breaker Open",
@@ -171,7 +167,6 @@ fn error_instance(err: &DomainError) -> &str {
         | DomainError::GuardRejected { instance, .. }
         | DomainError::CorsOriginNotAllowed { instance, .. }
         | DomainError::CorsMethodNotAllowed { instance, .. }
-        | DomainError::CorsHeaderNotAllowed { instance, .. }
         | DomainError::StreamAborted { instance, .. }
         | DomainError::LinkUnavailable { instance, .. }
         | DomainError::CircuitBreakerOpen { instance, .. }
@@ -373,10 +368,6 @@ mod tests {
             },
             DomainError::CorsMethodNotAllowed {
                 method: "DELETE".into(),
-                instance: "/test".into(),
-            },
-            DomainError::CorsHeaderNotAllowed {
-                header: "x-custom".into(),
                 instance: "/test".into(),
             },
             DomainError::StreamAborted {

--- a/modules/system/oagw/oagw/src/api/rest/handlers/proxy.rs
+++ b/modules/system/oagw/oagw/src/api/rest/handlers/proxy.rs
@@ -27,6 +27,47 @@ pub async fn proxy_handler(
     Extension(ctx): Extension<SecurityContext>,
     req: Request,
 ) -> Result<Response, Response> {
+    // Short-circuit CORS preflight — return permissive 204 without upstream resolution.
+    // The actual request validates the origin against the upstream's CORS config.
+    if req.method() == http::Method::OPTIONS
+        && req.headers().contains_key(http::header::ORIGIN)
+        && req
+            .headers()
+            .contains_key(http::header::ACCESS_CONTROL_REQUEST_METHOD)
+    {
+        let origin = req
+            .headers()
+            .get(http::header::ORIGIN)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("*");
+
+        let requested_method = req
+            .headers()
+            .get(http::header::ACCESS_CONTROL_REQUEST_METHOD)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        let requested_headers = req
+            .headers()
+            .get(http::header::ACCESS_CONTROL_REQUEST_HEADERS)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        return Ok(Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .header("access-control-allow-origin", origin)
+            .header("access-control-allow-methods", requested_method)
+            .header("access-control-allow-headers", requested_headers)
+            .header("access-control-allow-credentials", "true")
+            .header("access-control-max-age", "86400")
+            .header(
+                "vary",
+                "Origin, Access-Control-Request-Method, Access-Control-Request-Headers",
+            )
+            .body(Body::empty())
+            .unwrap());
+    }
+
     let max_body_size = state.config.max_body_size_bytes;
     let (mut parts, body) = req.into_parts();
 

--- a/modules/system/oagw/oagw/src/domain/cors.rs
+++ b/modules/system/oagw/oagw/src/domain/cors.rs
@@ -5,9 +5,6 @@
 use super::error::DomainError;
 use super::model::{CorsConfig, CorsHttpMethod};
 
-/// Maximum allowed value for `max_age` (24 hours in seconds).
-const MAX_AGE_LIMIT: u32 = 86400;
-
 // ---------------------------------------------------------------------------
 // CorsHttpMethod helpers
 // ---------------------------------------------------------------------------
@@ -54,14 +51,6 @@ pub fn validate_cors_config(config: &CorsConfig) -> Result<(), DomainError> {
     if config.allow_credentials && config.allowed_origins.iter().any(|o| o == "*") {
         return Err(DomainError::Validation {
             detail: "allow_credentials cannot be true when allowed_origins contains '*'".into(),
-            instance: String::new(),
-        });
-    }
-
-    // max_age must not exceed 24 hours.
-    if config.max_age > MAX_AGE_LIMIT {
-        return Err(DomainError::Validation {
-            detail: format!("max_age must not exceed {MAX_AGE_LIMIT} seconds"),
             instance: String::new(),
         });
     }
@@ -136,136 +125,12 @@ fn is_valid_origin(origin: &str) -> bool {
 }
 
 // ---------------------------------------------------------------------------
-// Preflight detection
+// Actual request CORS enforcement
 // ---------------------------------------------------------------------------
 
-/// Check whether an inbound request is a CORS preflight.
-///
-/// A CORS preflight is an OPTIONS request with both `Origin` and
-/// `Access-Control-Request-Method` headers present.
-#[must_use]
-pub fn is_cors_preflight(method: &str, headers: &[(String, String)]) -> bool {
-    if !method.eq_ignore_ascii_case("OPTIONS") {
-        return false;
-    }
-
-    let has_origin = headers
-        .iter()
-        .any(|(k, _)| k.eq_ignore_ascii_case("origin"));
-    let has_request_method = headers
-        .iter()
-        .any(|(k, _)| k.eq_ignore_ascii_case("access-control-request-method"));
-
-    has_origin && has_request_method
-}
-
-// ---------------------------------------------------------------------------
-// Preflight handler
-// ---------------------------------------------------------------------------
-
-/// Handle a CORS preflight request.
-///
-/// Validates the origin, requested method, and requested headers against the
-/// CORS configuration. Returns the CORS response headers on success, or a
-/// `DomainError` on validation failure.
-pub fn handle_cors_preflight(
-    config: &CorsConfig,
-    origin: &str,
-    request_method: &str,
-    request_headers: &[String],
-    instance: &str,
-) -> Result<Vec<(String, String)>, DomainError> {
-    // 1. Validate origin.
-    if !is_origin_allowed(config, origin) {
-        return Err(DomainError::CorsOriginNotAllowed {
-            origin: origin.to_string(),
-            instance: instance.to_string(),
-        });
-    }
-
-    // 2. Validate request method.
-    let method = CorsHttpMethod::from_str_loose(request_method).ok_or_else(|| {
-        DomainError::CorsMethodNotAllowed {
-            method: request_method.to_string(),
-            instance: instance.to_string(),
-        }
-    })?;
-    if !config.allowed_methods.contains(&method) {
-        return Err(DomainError::CorsMethodNotAllowed {
-            method: request_method.to_string(),
-            instance: instance.to_string(),
-        });
-    }
-
-    // 3. Validate request headers (case-insensitive).
-    for header in request_headers {
-        let header_lower = header.trim().to_ascii_lowercase();
-        if header_lower.is_empty() {
-            continue;
-        }
-        let allowed = config
-            .allowed_headers
-            .iter()
-            .any(|h| h.eq_ignore_ascii_case(&header_lower));
-        if !allowed {
-            return Err(DomainError::CorsHeaderNotAllowed {
-                header: header.trim().to_string(),
-                instance: instance.to_string(),
-            });
-        }
-    }
-
-    // 4. Build response headers.
-    let mut resp_headers = Vec::new();
-
-    // Reflect origin (not wildcard) when credentials are allowed.
-    let allow_origin = if config.allow_credentials {
-        origin.to_string()
-    } else if config.allowed_origins.iter().any(|o| o == "*") {
-        "*".to_string()
-    } else {
-        origin.to_string()
-    };
-    resp_headers.push(("access-control-allow-origin".to_string(), allow_origin));
-
-    // Allowed methods.
-    let methods_str: String = config
-        .allowed_methods
-        .iter()
-        .map(CorsHttpMethod::as_str)
-        .collect::<Vec<_>>()
-        .join(", ");
-    resp_headers.push(("access-control-allow-methods".to_string(), methods_str));
-
-    // Allowed headers.
-    if !config.allowed_headers.is_empty() {
-        resp_headers.push((
-            "access-control-allow-headers".to_string(),
-            config.allowed_headers.join(", "),
-        ));
-    }
-
-    // Max-Age.
-    resp_headers.push((
-        "access-control-max-age".to_string(),
-        config.max_age.to_string(),
-    ));
-
-    // Credentials.
-    if config.allow_credentials {
-        resp_headers.push((
-            "access-control-allow-credentials".to_string(),
-            "true".to_string(),
-        ));
-    }
-
-    // Vary (prevent cache poisoning).
-    resp_headers.push((
-        "vary".to_string(),
-        "Origin, Access-Control-Request-Method, Access-Control-Request-Headers".to_string(),
-    ));
-
-    Ok(resp_headers)
+/// Check whether the request method is in the `allowed_methods` list.
+pub fn is_method_allowed(config: &CorsConfig, method: &str) -> bool {
+    CorsHttpMethod::from_str_loose(method).is_some_and(|m| config.allowed_methods.contains(&m))
 }
 
 // ---------------------------------------------------------------------------
@@ -323,7 +188,7 @@ pub fn apply_cors_headers(config: &CorsConfig, origin: &str) -> Vec<(String, Str
 /// Check whether the given origin is in the `allowed_origins` list.
 ///
 /// Supports exact string match and the wildcard `"*"`.
-fn is_origin_allowed(config: &CorsConfig, origin: &str) -> bool {
+pub fn is_origin_allowed(config: &CorsConfig, origin: &str) -> bool {
     config
         .allowed_origins
         .iter()
@@ -345,9 +210,7 @@ mod tests {
             enabled: true,
             allowed_origins: vec!["https://example.com".to_string()],
             allowed_methods: vec![CorsHttpMethod::Get, CorsHttpMethod::Post],
-            allowed_headers: vec!["content-type".to_string(), "authorization".to_string()],
             expose_headers: vec!["x-request-id".to_string()],
-            max_age: 3600,
             allow_credentials: false,
         }
     }
@@ -372,16 +235,6 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_max_age_boundary() {
-        let mut config = make_config();
-        config.max_age = MAX_AGE_LIMIT;
-        assert!(validate_cors_config(&config).is_ok());
-
-        config.max_age = MAX_AGE_LIMIT + 1;
-        assert!(validate_cors_config(&config).is_err());
-    }
-
-    #[test]
     fn test_validate_invalid_origin_rejected() {
         let config = CorsConfig {
             allowed_origins: vec!["not-a-url".to_string()],
@@ -397,83 +250,6 @@ mod tests {
             ..make_config()
         };
         assert!(validate_cors_config(&config).is_ok());
-    }
-
-    // -- is_cors_preflight --
-
-    #[test]
-    fn test_is_cors_preflight_true() {
-        let headers = vec![
-            ("origin".to_string(), "https://example.com".to_string()),
-            (
-                "access-control-request-method".to_string(),
-                "POST".to_string(),
-            ),
-        ];
-        assert!(is_cors_preflight("OPTIONS", &headers));
-    }
-
-    #[test]
-    fn test_is_cors_preflight_wrong_method() {
-        let headers = vec![
-            ("origin".to_string(), "https://example.com".to_string()),
-            (
-                "access-control-request-method".to_string(),
-                "POST".to_string(),
-            ),
-        ];
-        assert!(!is_cors_preflight("GET", &headers));
-    }
-
-    #[test]
-    fn test_is_cors_preflight_missing_origin() {
-        let headers = vec![(
-            "access-control-request-method".to_string(),
-            "POST".to_string(),
-        )];
-        assert!(!is_cors_preflight("OPTIONS", &headers));
-    }
-
-    // -- handle_cors_preflight --
-
-    #[test]
-    fn test_preflight_valid_origin_returns_headers() {
-        let config = make_config();
-        let result =
-            handle_cors_preflight(&config, "https://example.com", "GET", &[], "/test").unwrap();
-        let origin_header = result
-            .iter()
-            .find(|(k, _)| k == "access-control-allow-origin")
-            .unwrap();
-        assert_eq!(origin_header.1, "https://example.com");
-
-        let vary = result.iter().find(|(k, _)| k == "vary").unwrap();
-        assert!(vary.1.contains("Origin"));
-    }
-
-    #[test]
-    fn test_preflight_invalid_origin_returns_error() {
-        let config = make_config();
-        let err =
-            handle_cors_preflight(&config, "https://evil.com", "GET", &[], "/test").unwrap_err();
-        assert!(matches!(err, DomainError::CorsOriginNotAllowed { .. }));
-    }
-
-    #[test]
-    fn test_preflight_invalid_method_returns_error() {
-        let config = make_config();
-        let err = handle_cors_preflight(&config, "https://example.com", "DELETE", &[], "/test")
-            .unwrap_err();
-        assert!(matches!(err, DomainError::CorsMethodNotAllowed { .. }));
-    }
-
-    #[test]
-    fn test_preflight_invalid_header_returns_error() {
-        let config = make_config();
-        let headers = vec!["x-custom-header".to_string()];
-        let err = handle_cors_preflight(&config, "https://example.com", "GET", &headers, "/test")
-            .unwrap_err();
-        assert!(matches!(err, DomainError::CorsHeaderNotAllowed { .. }));
     }
 
     // -- apply_cors_headers --

--- a/modules/system/oagw/oagw/src/domain/error.rs
+++ b/modules/system/oagw/oagw/src/domain/error.rs
@@ -72,13 +72,9 @@ pub enum DomainError {
     #[error("CORS origin not allowed: {origin}")]
     CorsOriginNotAllowed { origin: String, instance: String },
 
-    /// CORS: the preflight request method is not in the allowed methods list.
+    /// CORS: the request method is not in the allowed methods list.
     #[error("CORS method not allowed: {method}")]
     CorsMethodNotAllowed { method: String, instance: String },
-
-    /// CORS: a preflight request header is not in the allowed headers list.
-    #[error("CORS header not allowed: {header}")]
-    CorsHeaderNotAllowed { header: String, instance: String },
 
     #[error("{detail}")]
     StreamAborted { detail: String, instance: String },

--- a/modules/system/oagw/oagw/src/domain/model.rs
+++ b/modules/system/oagw/oagw/src/domain/model.rs
@@ -228,9 +228,7 @@ pub struct CorsConfig {
     pub enabled: bool,
     pub allowed_origins: Vec<String>,
     pub allowed_methods: Vec<CorsHttpMethod>,
-    pub allowed_headers: Vec<String>,
     pub expose_headers: Vec<String>,
-    pub max_age: u32,
     pub allow_credentials: bool,
 }
 

--- a/modules/system/oagw/oagw/src/domain/services/client.rs
+++ b/modules/system/oagw/oagw/src/domain/services/client.rs
@@ -269,11 +269,6 @@ fn domain_err_to_sdk(err: DomainError) -> ServiceGatewayError {
         } => ServiceGatewayError::Forbidden {
             detail: format!("CORS method not allowed: {method} (instance: {instance})"),
         },
-        DomainError::CorsHeaderNotAllowed {
-            header, instance, ..
-        } => ServiceGatewayError::Forbidden {
-            detail: format!("CORS header not allowed: {header} (instance: {instance})"),
-        },
         DomainError::StreamAborted { detail, instance } => {
             ServiceGatewayError::StreamAborted { detail, instance }
         }
@@ -507,9 +502,7 @@ fn cors_config_to_domain(v: oagw_sdk::CorsConfig) -> model::CorsConfig {
             .into_iter()
             .map(cors_http_method_to_domain)
             .collect(),
-        allowed_headers: v.allowed_headers,
         expose_headers: v.expose_headers,
-        max_age: v.max_age,
         allow_credentials: v.allow_credentials,
     }
 }
@@ -702,9 +695,7 @@ fn cors_config_to_sdk(v: model::CorsConfig) -> oagw_sdk::CorsConfig {
             .into_iter()
             .map(cors_http_method_to_sdk)
             .collect(),
-        allowed_headers: v.allowed_headers,
         expose_headers: v.expose_headers,
-        max_age: v.max_age,
         allow_credentials: v.allow_credentials,
     }
 }

--- a/modules/system/oagw/oagw/src/domain/services/management.rs
+++ b/modules/system/oagw/oagw/src/domain/services/management.rs
@@ -2923,9 +2923,7 @@ mod tests {
             enabled: true,
             allowed_origins: origins.into_iter().map(String::from).collect(),
             allowed_methods: vec![CorsHttpMethod::Get, CorsHttpMethod::Post],
-            allowed_headers: vec!["content-type".into()],
             expose_headers: vec![],
-            max_age: 3600,
             allow_credentials: false,
         }
     }
@@ -3083,9 +3081,7 @@ mod tests {
             enabled: true,
             allowed_origins: vec!["*".into()],
             allowed_methods: vec![CorsHttpMethod::Get],
-            allowed_headers: vec![],
             expose_headers: vec![],
-            max_age: 3600,
             allow_credentials: false,
         });
         let mut child = make_upstream(t, "api", None, None, None, vec![]);
@@ -3094,9 +3090,7 @@ mod tests {
             enabled: true,
             allowed_origins: vec!["https://child.com".into()],
             allowed_methods: vec![CorsHttpMethod::Get],
-            allowed_headers: vec![],
             expose_headers: vec![],
-            max_age: 3600,
             allow_credentials: true,
         });
 
@@ -3116,9 +3110,7 @@ mod tests {
             enabled: true,
             allowed_origins: vec!["*".into()],
             allowed_methods: vec![CorsHttpMethod::Get],
-            allowed_headers: vec![],
             expose_headers: vec![],
-            max_age: 3600,
             allow_credentials: false,
         });
 
@@ -3142,9 +3134,7 @@ mod tests {
                 enabled: true,
                 allowed_origins: vec!["https://route.com".into()],
                 allowed_methods: vec![CorsHttpMethod::Get],
-                allowed_headers: vec![],
                 expose_headers: vec![],
-                max_age: 3600,
                 allow_credentials: true,
             }),
             tags: vec![],
@@ -3177,9 +3167,7 @@ mod tests {
             enabled: true,
             allowed_origins: vec!["https://locked.com".into()],
             allowed_methods: vec![CorsHttpMethod::Get],
-            allowed_headers: vec![],
             expose_headers: vec![],
-            max_age: 3600,
             allow_credentials: false,
         });
         svc.create_upstream(&root_ctx, req).await.unwrap();

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -401,26 +401,16 @@ impl DataPlaneService for DataPlaneServiceImpl {
             Body::Stream(s) => (Bytes::new(), Some(s)),
         };
 
-        // For CORS preflight, resolve the route using the intended method
-        // (from Access-Control-Request-Method) instead of OPTIONS, which has
-        // no matching HttpMethod variant and would fail route resolution.
-        let resolve_method = if method.as_ref().eq_ignore_ascii_case("OPTIONS") {
-            req_headers
-                .get("access-control-request-method")
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or(method.as_ref())
-        } else {
-            method.as_ref()
-        };
-
         // 1+2. Resolve upstream + route in one pass (single hierarchy walk).
         let (upstream, route) = self
             .cp
-            .resolve_proxy_target(&ctx, &alias, resolve_method, &path_suffix)
+            .resolve_proxy_target(&ctx, &alias, method.as_ref(), &path_suffix)
             .await?;
 
-        // 1c. CORS: use effective config (already merged by compute_effective_config)
-        // and handle preflight short-circuit.
+        // 1c. CORS origin enforcement for actual cross-origin requests.
+        // Preflight is handled permissively at the handler level (no upstream resolution).
+        // Here we validate the Origin against the upstream's CORS config and reject
+        // disallowed origins before the request reaches the upstream.
         let effective_cors = upstream.cors.clone();
         let request_origin = req_headers
             .get(http::header::ORIGIN)
@@ -429,46 +419,20 @@ impl DataPlaneService for DataPlaneServiceImpl {
 
         if let Some(ref cors_config) = effective_cors
             && cors_config.enabled
+            && let Some(ref origin) = request_origin
         {
-            let header_vec: Vec<(String, String)> = headers::header_map_to_vec(&req_headers);
-            if crate::domain::cors::is_cors_preflight(method.as_ref(), &header_vec) {
-                let origin = request_origin.as_deref().unwrap_or("");
-                let request_method = req_headers
-                    .get("access-control-request-method")
-                    .and_then(|v| v.to_str().ok())
-                    .unwrap_or("");
-                let request_headers_list: Vec<String> = req_headers
-                    .get("access-control-request-headers")
-                    .and_then(|v| v.to_str().ok())
-                    .map(|s| s.split(',').map(|h| h.trim().to_string()).collect())
-                    .unwrap_or_default();
+            if !crate::domain::cors::is_origin_allowed(cors_config, origin) {
+                return Err(DomainError::CorsOriginNotAllowed {
+                    origin: origin.clone(),
+                    instance: instance_uri,
+                });
+            }
 
-                let cors_headers = crate::domain::cors::handle_cors_preflight(
-                    cors_config,
-                    origin,
-                    request_method,
-                    &request_headers_list,
-                    &instance_uri,
-                )?;
-
-                let mut response = http::Response::builder()
-                    .status(http::StatusCode::NO_CONTENT)
-                    .body(Body::Empty)
-                    .map_err(|e| DomainError::Internal {
-                        message: format!("failed to build CORS preflight response: {e}"),
-                    })?;
-                for (name, value) in cors_headers {
-                    if let Ok(v) = HeaderValue::from_str(&value)
-                        && let Ok(n) = http::header::HeaderName::from_bytes(name.as_bytes())
-                    {
-                        if n == http::header::VARY {
-                            response.headers_mut().append(n, v);
-                        } else {
-                            response.headers_mut().insert(n, v);
-                        }
-                    }
-                }
-                return Ok(response);
+            if !crate::domain::cors::is_method_allowed(cors_config, method.as_ref()) {
+                return Err(DomainError::CorsMethodNotAllowed {
+                    method: method.to_string(),
+                    instance: instance_uri,
+                });
             }
         }
 
@@ -1298,9 +1262,7 @@ fn domain_error_status(err: &DomainError) -> u16 {
         DomainError::PluginNotFound { .. } => 404,
         DomainError::PluginInUse { .. } => 409,
         DomainError::GuardRejected { status, .. } => *status,
-        DomainError::CorsOriginNotAllowed { .. }
-        | DomainError::CorsMethodNotAllowed { .. }
-        | DomainError::CorsHeaderNotAllowed { .. } => 403,
+        DomainError::CorsOriginNotAllowed { .. } | DomainError::CorsMethodNotAllowed { .. } => 403,
     }
 }
 
@@ -1326,7 +1288,6 @@ fn domain_error_type_name(err: &DomainError) -> &'static str {
         DomainError::GuardRejected { .. } => "GuardRejected",
         DomainError::CorsOriginNotAllowed { .. } => "CorsOriginNotAllowed",
         DomainError::CorsMethodNotAllowed { .. } => "CorsMethodNotAllowed",
-        DomainError::CorsHeaderNotAllowed { .. } => "CorsHeaderNotAllowed",
         DomainError::StreamAborted { .. } => "StreamAborted",
         DomainError::LinkUnavailable { .. } => "LinkUnavailable",
         DomainError::CircuitBreakerOpen { .. } => "CircuitBreakerOpen",

--- a/modules/system/oagw/oagw/src/infra/type_provisioning.rs
+++ b/modules/system/oagw/oagw/src/infra/type_provisioning.rs
@@ -228,17 +228,9 @@ struct CorsConfig {
     #[serde(default)]
     allowed_methods: Vec<CorsHttpMethod>,
     #[serde(default)]
-    allowed_headers: Vec<String>,
-    #[serde(default)]
     expose_headers: Vec<String>,
-    #[serde(default = "default_max_age")]
-    max_age: u32,
     #[serde(default)]
     allow_credentials: bool,
-}
-
-fn default_max_age() -> u32 {
-    86400
 }
 
 #[derive(Deserialize)]
@@ -535,9 +527,7 @@ impl From<CorsConfig> for domain::CorsConfig {
             enabled: v.enabled,
             allowed_origins: v.allowed_origins,
             allowed_methods: v.allowed_methods.into_iter().map(Into::into).collect(),
-            allowed_headers: v.allowed_headers,
             expose_headers: v.expose_headers,
-            max_age: v.max_age,
             allow_credentials: v.allow_credentials,
         }
     }

--- a/modules/system/oagw/oagw/tests/proxy_integration.rs
+++ b/modules/system/oagw/oagw/tests/proxy_integration.rs
@@ -3215,9 +3215,7 @@ fn test_cors_config() -> CorsConfig {
         enabled: true,
         allowed_origins: vec!["https://example.com".to_string()],
         allowed_methods: vec![CorsHttpMethod::Get, CorsHttpMethod::Post],
-        allowed_headers: vec!["content-type".to_string(), "authorization".to_string()],
         expose_headers: vec!["x-request-id".to_string()],
-        max_age: 3600,
         allow_credentials: false,
     }
 }
@@ -3371,133 +3369,6 @@ async fn cors_actual_request_includes_headers() {
     assert!(
         headers.get(http::header::VARY).is_some(),
         "Vary header must be present"
-    );
-}
-
-// CORS: Actual request with disallowed origin gets no CORS headers.
-#[tokio::test]
-async fn cors_actual_request_disallowed_origin_no_cors_headers() {
-    let mut guard = MockGuard::new();
-    guard.mock(
-        "GET",
-        "/api/data",
-        MockResponse {
-            status: 200,
-            headers: vec![("content-type".into(), "application/json".into())],
-            body: MockBody::Json(json!({"ok": true})),
-        },
-    );
-
-    let h = AppHarness::builder().build().await;
-    setup_cors_upstream(&h, &guard, "cors-bad-origin", Some(test_cors_config())).await;
-
-    let req = http::Request::builder()
-        .method(Method::GET)
-        .uri(format!("/cors-bad-origin{}", guard.path("/api/data")))
-        .header("origin", "https://evil.com")
-        .body(Body::Empty)
-        .unwrap();
-
-    let response = h
-        .facade()
-        .proxy_request(h.security_context().clone(), req)
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-    assert!(
-        response
-            .headers()
-            .get("access-control-allow-origin")
-            .is_none(),
-        "disallowed origin should not receive CORS headers"
-    );
-}
-
-// CORS: Preflight with allowed origin/method returns 204 with CORS headers.
-#[tokio::test]
-async fn cors_preflight_allowed_returns_204() {
-    let guard = MockGuard::new();
-
-    let h = AppHarness::builder().build().await;
-    setup_cors_upstream(&h, &guard, "cors-preflight", Some(test_cors_config())).await;
-
-    let req = http::Request::builder()
-        .method(Method::OPTIONS)
-        .uri(format!("/cors-preflight{}", guard.path("/api/data")))
-        .header("origin", "https://example.com")
-        .header("access-control-request-method", "POST")
-        .body(Body::Empty)
-        .unwrap();
-
-    let response = h
-        .facade()
-        .proxy_request(h.security_context().clone(), req)
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::NO_CONTENT);
-
-    let headers = response.headers();
-    assert_eq!(
-        headers.get("access-control-allow-origin").unwrap(),
-        "https://example.com"
-    );
-    assert!(
-        headers.get("access-control-allow-methods").is_some(),
-        "preflight must include allow-methods"
-    );
-    assert_eq!(headers.get("access-control-max-age").unwrap(), "3600");
-    assert!(
-        headers.get(http::header::VARY).is_some(),
-        "preflight must include Vary"
-    );
-}
-
-// CORS: Preflight with disallowed origin returns 403.
-#[tokio::test]
-async fn cors_preflight_rejected_origin_returns_403() {
-    let guard = MockGuard::new();
-
-    let h = AppHarness::builder().build().await;
-    setup_cors_upstream(&h, &guard, "cors-pf-bad-origin", Some(test_cors_config())).await;
-
-    let req = http::Request::builder()
-        .method(Method::OPTIONS)
-        .uri(format!("/cors-pf-bad-origin{}", guard.path("/api/data")))
-        .header("origin", "https://evil.com")
-        .header("access-control-request-method", "GET")
-        .body(Body::Empty)
-        .unwrap();
-
-    let response = h
-        .facade()
-        .proxy_request(h.security_context().clone(), req)
-        .await;
-    assert!(response.is_err(), "rejected preflight should return error");
-}
-
-// CORS: Preflight with disallowed method returns 403.
-#[tokio::test]
-async fn cors_preflight_rejected_method_returns_403() {
-    let guard = MockGuard::new();
-
-    let h = AppHarness::builder().build().await;
-    setup_cors_upstream(&h, &guard, "cors-pf-bad-method", Some(test_cors_config())).await;
-
-    let req = http::Request::builder()
-        .method(Method::OPTIONS)
-        .uri(format!("/cors-pf-bad-method{}", guard.path("/api/data")))
-        .header("origin", "https://example.com")
-        .header("access-control-request-method", "DELETE")
-        .body(Body::Empty)
-        .unwrap();
-
-    let response = h
-        .facade()
-        .proxy_request(h.security_context().clone(), req)
-        .await;
-    assert!(
-        response.is_err(),
-        "preflight with disallowed method should return error"
     );
 }
 
@@ -3717,9 +3588,7 @@ async fn cors_route_inherit_merges_origins() {
         enabled: true,
         allowed_origins: vec!["https://other.com".to_string()],
         allowed_methods: vec![CorsHttpMethod::Get, CorsHttpMethod::Post],
-        allowed_headers: vec!["content-type".to_string(), "authorization".to_string()],
         expose_headers: vec!["x-request-id".to_string()],
-        max_age: 3600,
         allow_credentials: false,
     };
 
@@ -3783,20 +3652,19 @@ async fn cors_route_inherit_merges_origins() {
     );
 }
 
-// CORS: Preflight with disallowed request header returns error.
+// CORS: Disallowed origin is rejected before reaching upstream.
 #[tokio::test]
-async fn cors_preflight_rejected_header_returns_error() {
+async fn cors_actual_request_disallowed_origin_rejected_before_upstream() {
     let guard = MockGuard::new();
+    // No mock registered — if the upstream is called, the request will fail differently.
 
     let h = AppHarness::builder().build().await;
-    setup_cors_upstream(&h, &guard, "cors-pf-bad-hdr", Some(test_cors_config())).await;
+    setup_cors_upstream(&h, &guard, "cors-reject-origin", Some(test_cors_config())).await;
 
     let req = http::Request::builder()
-        .method(Method::OPTIONS)
-        .uri(format!("/cors-pf-bad-hdr{}", guard.path("/api/data")))
-        .header("origin", "https://example.com")
-        .header("access-control-request-method", "GET")
-        .header("access-control-request-headers", "x-custom-forbidden")
+        .method(Method::GET)
+        .uri(format!("/cors-reject-origin{}", guard.path("/api/data")))
+        .header("origin", "https://evil.com")
         .body(Body::Empty)
         .unwrap();
 
@@ -3806,7 +3674,76 @@ async fn cors_preflight_rejected_header_returns_error() {
         .await;
     assert!(
         response.is_err(),
-        "preflight with disallowed request header should return error"
+        "disallowed origin on actual request should be rejected before reaching upstream"
+    );
+}
+
+// CORS: Disallowed method is rejected before reaching upstream.
+#[tokio::test]
+async fn cors_actual_request_disallowed_method_rejected_before_upstream() {
+    let guard = MockGuard::new();
+    // No mock registered — if the upstream is called, the request will fail differently.
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    // Route allows DELETE but CORS config only allows GET and POST.
+    let cors = test_cors_config(); // allowed_methods: [Get, Post]
+
+    let mut builder = CreateUpstreamRequest::builder(
+        Server {
+            endpoints: vec![Endpoint {
+                scheme: Scheme::Http,
+                host: "127.0.0.1".into(),
+                port: h.mock_port(),
+            }],
+        },
+        "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+    )
+    .alias("cors-reject-method");
+    builder = builder.cors(cors);
+
+    let upstream = h
+        .facade()
+        .create_upstream(ctx.clone(), builder.build())
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get, HttpMethod::Post, HttpMethod::Delete],
+                        path: guard.path("/api/data"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Disabled,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // DELETE is allowed by the route but not by CORS — should be rejected.
+    let req = http::Request::builder()
+        .method(Method::DELETE)
+        .uri(format!("/cors-reject-method{}", guard.path("/api/data")))
+        .header("origin", "https://example.com")
+        .body(Body::Empty)
+        .unwrap();
+
+    let response = h
+        .facade()
+        .proxy_request(h.security_context().clone(), req)
+        .await;
+    assert!(
+        response.is_err(),
+        "disallowed method on actual request should be rejected before reaching upstream"
     );
 }
 
@@ -3856,7 +3793,7 @@ async fn cors_multiple_specific_origins() {
         "https://beta.com"
     );
 
-    // Non-matching origin gets no CORS headers.
+    // Non-matching origin is rejected before reaching upstream.
     let req = http::Request::builder()
         .method(Method::GET)
         .uri(format!("/cors-multi{}", guard.path("/api/data")))
@@ -3867,15 +3804,10 @@ async fn cors_multiple_specific_origins() {
     let response = h
         .facade()
         .proxy_request(h.security_context().clone(), req)
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+        .await;
     assert!(
-        response
-            .headers()
-            .get("access-control-allow-origin")
-            .is_none(),
-        "non-matching origin should not get CORS headers"
+        response.is_err(),
+        "non-matching origin should be rejected with 403"
     );
 }
 

--- a/modules/system/oagw/scenarios/INDEX.md
+++ b/modules/system/oagw/scenarios/INDEX.md
@@ -67,7 +67,7 @@ Call your external service through OAGW's proxy endpoint: `{METHOD} /api/oagw/v1
 
 - [Token bucket rate limiting](rate-limiting/positive-18.1-token-bucket-sustained-burst.md) — see [Rate limiting](#rate-limiting)
 - [Request path rewrite](plugins/transforms/positive-11.1-request-path-rewrite-transform.md) — see [Transform plugins](#transform-plugins)
-- [Custom Starlark guard](plugins/guards/positive-10.2-built-cors-handling.md) — see [Guard plugins](#guard-plugins)
+- [Built-in CORS handling](plugins/guards/positive-10.2-built-cors-handling.md) — see [Guard plugins](#guard-plugins)
 - [Tags for discovery](management-api/upstreams/positive-2.9-tags-support-discovery-filtering.md) — see [Upstream management](#upstream-management)
 
 ---
@@ -356,13 +356,9 @@ Call your external service through OAGW's proxy endpoint: `{METHOD} /api/oagw/v1
 
 ### CORS
 
-#### Built-in CORS handling (preflight)
+#### Built-in CORS handling (preflight + actual request)
 - **Scenario**: [positive-10.2-built-cors-handling.md](plugins/guards/positive-10.2-built-cors-handling.md)
-- **Mechanism**: OPTIONS preflight handled locally (`204` with correct `Access-Control-*`). Preflight bypasses upstream call.
-
-#### Actual request adds CORS headers on response
-- **Scenario**: *Section 21.1 — no separate file. Behavior verified as part of HTTP passthrough and guard plugin scenarios.*
-- **Mechanism**: Response includes `Access-Control-Allow-Origin` (specific origin, not `*` when credentials). Includes `Vary: Origin`.
+- **Mechanism**: OPTIONS preflight returns permissive `204` at handler level (no upstream resolution). Origin enforcement happens on actual requests after upstream resolution — disallowed origins are rejected with `403` before reaching the upstream. Allowed origins receive CORS response headers (`Access-Control-Allow-Origin`, `Vary: Origin`, etc.).
 
 #### Hierarchical merge/union for CORS allowed origins
 - **Scenario**: *Covered within hierarchical configuration scenarios.*
@@ -374,7 +370,7 @@ Call your external service through OAGW's proxy endpoint: `{METHOD} /api/oagw/v1
 
 > **Flow reference**: [Plugin Execution](flows/plugin-execution.md)
 
-*Note: CORS preflight guard is covered in [CORS](#cors) above. Timeout and Starlark guard rejection scenarios are in [Guardrails → Guard rejections](#guard-rejections).*
+*Note: CORS origin validation is covered in [CORS](#cors) above. Timeout and Starlark guard rejection scenarios are in [Guardrails → Guard rejections](#guard-rejections).*
 
 ---
 

--- a/modules/system/oagw/scenarios/flows/plugin-execution.md
+++ b/modules/system/oagw/scenarios/flows/plugin-execution.md
@@ -137,8 +137,7 @@ Execution order: upstream guards, then route guards.
 
 **Actions**:
 1. Check `Origin` header: `https://example.com`
-2. Validate against allowed origins
-3. Not a preflight (not OPTIONS) → skip preflight logic
+2. Validate against allowed origins (preflight never reaches plugins — handled at handler level)
 
 **Output**: `GuardDecision::Allow`
 

--- a/modules/system/oagw/scenarios/plugins/guards/negative-10.3-cors-credentials-wildcard-rejected-config-validation.md
+++ b/modules/system/oagw/scenarios/plugins/guards/negative-10.3-cors-credentials-wildcard-rejected-config-validation.md
@@ -21,7 +21,7 @@ Expected:
 
 ## Scenario B: reject at request time (if config validation allows storing)
 
-If configuration is accepted, preflight or actual request must be rejected.
+If configuration is accepted, the actual request must be rejected.
 
 Expected:
 - `403 Forbidden`

--- a/modules/system/oagw/scenarios/plugins/guards/positive-10.2-built-cors-handling.md
+++ b/modules/system/oagw/scenarios/plugins/guards/positive-10.2-built-cors-handling.md
@@ -1,4 +1,4 @@
-# Built-in CORS handling (preflight)
+# Built-in CORS handling (preflight + actual request)
 
 ## Setup
 
@@ -10,8 +10,6 @@ Enable CORS on upstream or route:
     "enabled": true,
     "allowed_origins": ["https://app.example.com"],
     "allowed_methods": ["GET", "POST"],
-    "allowed_headers": ["Content-Type", "Authorization"],
-    "max_age": 3600,
     "allow_credentials": true
   }
 }
@@ -27,17 +25,31 @@ Access-Control-Request-Method: POST
 Access-Control-Request-Headers: Content-Type, Authorization
 ```
 
-## Expected response
+## Expected preflight response
 
 - `204 No Content`
-- Includes CORS headers:
+- Permissive CORS headers echoed from the request (not validated against upstream config):
   - `Access-Control-Allow-Origin: https://app.example.com`
-  - `Access-Control-Allow-Methods: GET, POST`
+  - `Access-Control-Allow-Methods: POST`
   - `Access-Control-Allow-Headers: Content-Type, Authorization`
-  - `Access-Control-Max-Age: 3600`
-  - `Access-Control-Allow-Credentials: true`
-  - `Vary: Origin`
+  - `Access-Control-Max-Age: 86400`
+  - `Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers`
+
+## Actual request with disallowed origin
+
+```http
+POST /api/oagw/v1/proxy/<alias>/resource HTTP/1.1
+Host: oagw.example.com
+Origin: https://evil.com
+Authorization: Bearer <token>
+```
+
+## Expected actual request response
+
+- `403 Forbidden` — origin rejected before reaching upstream.
 
 ## What to check
 
-- Preflight is handled locally (no upstream call).
+- Preflight is handled at the handler level (no upstream resolution, no tenant context required).
+- Origin enforcement happens on the actual request after upstream resolution.
+- Disallowed origins never reach the upstream.

--- a/testing/e2e/conftest.py
+++ b/testing/e2e/conftest.py
@@ -18,14 +18,15 @@ def base_url():
 def auth_headers():
     """
     Build Authorization headers using E2E_AUTH_TOKEN env var.
-    
+
+    Falls back to a dummy token suitable for the static-authn-plugin
+    running in ``accept_all`` mode (any non-empty Bearer token is accepted).
+
     Returns:
-        dict: Headers dict with Authorization header if token is set, empty dict otherwise.
+        dict: Headers dict with Authorization header.
     """
-    token = os.getenv("E2E_AUTH_TOKEN")
-    if token:
-        return {"Authorization": f"Bearer {token}"}
-    return {}
+    token = os.getenv("E2E_AUTH_TOKEN", "e2e-token-tenant-a")
+    return {"Authorization": f"Bearer {token}"}
 
 
 @pytest.fixture

--- a/testing/e2e/modules/file_parser/generate_file_parser_golden.py
+++ b/testing/e2e/modules/file_parser/generate_file_parser_golden.py
@@ -26,11 +26,9 @@ def get_base_url():
 
 
 def get_auth_headers():
-    """Get authorization headers if token is set."""
-    token = os.getenv("E2E_AUTH_TOKEN")
-    if token:
-        return {"Authorization": f"Bearer {token}"}
-    return {}
+    """Get authorization headers (defaults to dummy token for accept_all mode)."""
+    token = os.getenv("E2E_AUTH_TOKEN", "e2e-token-tenant-a")
+    return {"Authorization": f"Bearer {token}"}
 
 
 def find_input_files(testdata_dir):

--- a/testing/e2e/modules/oagw/conftest.py
+++ b/testing/e2e/modules/oagw/conftest.py
@@ -26,19 +26,12 @@ def mock_upstream_url():
 
 
 @pytest.fixture
-def tenant_id():
-    """Fixed tenant UUID for test isolation."""
-    return "00000000-df51-5b42-9538-d2b56b7ee953"
-
-
-@pytest.fixture
-def oagw_headers(tenant_id):
-    """Standard headers for OAGW requests (tenant + optional auth)."""
-    headers = {"x-tenant-id": tenant_id}
-    token = os.getenv("E2E_AUTH_TOKEN")
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
+def oagw_headers():
+    """Standard headers for OAGW requests (auth only — tenant comes from the token)."""
+    token = os.getenv("E2E_AUTH_TOKEN", "e2e-token-tenant-a")
+    return {
+        "Authorization": f"Bearer {token}",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -100,8 +93,7 @@ def _check_oagw_reachable():
     """Skip all OAGW tests if the service is not reachable."""
     url = os.getenv("E2E_OAGW_BASE_URL", "http://localhost:8086")
     try:
-        resp = httpx.get(f"{url}/oagw/v1/upstreams", timeout=5.0,
-                         headers={"x-tenant-id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"})
+        resp = httpx.get(f"{url}/oagw/v1/upstreams", timeout=5.0)
         # Any response (even 401/403) means the service is up.
     except httpx.ConnectError:
         pytest.skip(f"OAGW service not running at {url}", allow_module_level=True)

--- a/testing/e2e/modules/oagw/test_authz.py
+++ b/testing/e2e/modules/oagw/test_authz.py
@@ -6,8 +6,6 @@ import pytest
 
 from .helpers import create_route, create_upstream, delete_upstream, unique_alias
 
-NIL_TENANT_ID = "00000000-0000-0000-0000-000000000000"
-
 
 @pytest.mark.asyncio
 async def test_proxy_authz_allowed(
@@ -39,9 +37,18 @@ async def test_proxy_authz_allowed(
 async def test_proxy_authz_forbidden_nil_tenant(
     oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
 ):
-    """Nil tenant UUID is denied by authz with 403 and Problem Details body."""
+    """Nil tenant UUID is denied by authz with 403 and Problem Details body.
+
+    The static-authz plugin denies requests when the token's subject_tenant_id
+    is the nil UUID (00000000-0000-0000-0000-000000000000). The authz check
+    runs before upstream resolution, so this produces a clean 403.
+    The tenant is extracted from the token by the auth middleware — there is
+    no x-tenant-id header.
+    """
     _ = mock_upstream
     alias = unique_alias("authz-deny")
+    # Use a token whose subject_tenant_id is the nil UUID.
+    nil_tenant_token = os.getenv("E2E_AUTH_TOKEN_NIL_TENANT", "e2e-token-nil-tenant")
     async with httpx.AsyncClient(timeout=10.0) as client:
         upstream = await create_upstream(
             client, oagw_base_url, oagw_headers, mock_upstream_url, alias=alias,
@@ -52,10 +59,9 @@ async def test_proxy_authz_forbidden_nil_tenant(
                 client, oagw_base_url, oagw_headers, uid, ["GET"], "/v1/models",
             )
 
-            denied_headers = {"x-tenant-id": NIL_TENANT_ID}
-            token = os.getenv("E2E_AUTH_TOKEN")
-            if token:
-                denied_headers["Authorization"] = f"Bearer {token}"
+            denied_headers = {
+                "Authorization": f"Bearer {nil_tenant_token}",
+            }
 
             resp = await client.get(
                 f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
@@ -64,12 +70,14 @@ async def test_proxy_authz_forbidden_nil_tenant(
 
             if resp.status_code == 401:
                 pytest.skip(
-                    "Server requires JWT auth; set E2E_AUTH_TOKEN to a token with nil tenant"
+                    "Token rejected by auth; ensure a nil-tenant token is configured"
                 )
             if resp.status_code == 200:
                 pytest.skip("AuthZ not enforced in this environment")
 
-            assert resp.status_code == 403
+            assert resp.status_code == 403, (
+                f"Expected 403, got {resp.status_code}: {resp.text[:500]}"
+            )
             assert resp.headers.get("x-oagw-error-source") == "gateway"
             body = resp.json()
             assert body["status"] == 403

--- a/testing/e2e/modules/oagw/test_body_validation.py
+++ b/testing/e2e/modules/oagw/test_body_validation.py
@@ -47,7 +47,7 @@ async def test_invalid_content_length_returns_400(
         host = parsed.hostname or "127.0.0.1"
         port = parsed.port or 80
 
-        header_lines = [f"x-tenant-id: {oagw_headers['x-tenant-id']}"]
+        header_lines = []
         if "Authorization" in oagw_headers:
             header_lines.append(f"Authorization: {oagw_headers['Authorization']}")
 
@@ -91,7 +91,7 @@ async def test_body_exceeding_limit_returns_413(
         host = parsed.hostname or "127.0.0.1"
         port = parsed.port or 80
 
-        header_lines = [f"x-tenant-id: {oagw_headers['x-tenant-id']}"]
+        header_lines = []
         if "Authorization" in oagw_headers:
             header_lines.append(f"Authorization: {oagw_headers['Authorization']}")
 

--- a/testing/e2e/modules/oagw/test_cors.py
+++ b/testing/e2e/modules/oagw/test_cors.py
@@ -9,9 +9,7 @@ CORS_CONFIG = {
     "enabled": True,
     "allowed_origins": ["https://app.example.com"],
     "allowed_methods": ["GET", "POST"],
-    "allowed_headers": ["content-type", "authorization"],
     "expose_headers": ["x-request-id"],
-    "max_age": 3600,
     "allow_credentials": False,
 }
 
@@ -22,12 +20,17 @@ CORS_CONFIG = {
 
 
 @pytest.mark.asyncio
-async def test_cors_preflight_allowed_origin(
+async def test_cors_preflight_fully_permissive(
     oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
 ):
-    """Preflight with allowed origin returns 204 with CORS headers."""
+    """Preflight with no auth headers returns fully permissive 204.
+
+    The permissive preflight echoes origin, method, headers, enables
+    credentials, and sets a long max-age — all without upstream resolution.
+    The actual-request path enforces the real CORS policy.
+    """
     _ = mock_upstream
-    alias = unique_alias("cors-pre-ok")
+    alias = unique_alias("cors-pre-noauth")
     async with httpx.AsyncClient(timeout=10.0) as client:
         upstream = await create_upstream(
             client, oagw_base_url, oagw_headers, mock_upstream_url,
@@ -38,11 +41,11 @@ async def test_cors_preflight_allowed_origin(
             client, oagw_base_url, oagw_headers, uid, ["POST"], "/echo",
         )
 
+        # Send preflight with ONLY Origin + ACRM — no Authorization, no tenant headers.
         resp = await client.request(
             "OPTIONS",
             f"{oagw_base_url}/oagw/v1/proxy/{alias}/echo",
             headers={
-                **oagw_headers,
                 "origin": "https://app.example.com",
                 "access-control-request-method": "POST",
                 "access-control-request-headers": "content-type",
@@ -54,53 +57,20 @@ async def test_cors_preflight_allowed_origin(
         assert resp.headers["access-control-allow-origin"] == "https://app.example.com"
         assert "POST" in resp.headers["access-control-allow-methods"]
         assert "content-type" in resp.headers.get("access-control-allow-headers", "")
-        assert resp.headers.get("access-control-max-age") == "3600"
+        assert resp.headers.get("access-control-allow-credentials") == "true"
+        assert resp.headers.get("access-control-max-age") == "86400"
         assert "Origin" in resp.headers.get("vary", "")
 
         await delete_upstream(client, oagw_base_url, oagw_headers, uid)
 
 
 @pytest.mark.asyncio
-async def test_cors_preflight_rejected_origin(
+async def test_cors_preflight_permissive_echoes_any_method(
     oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
 ):
-    """Preflight with disallowed origin returns 403."""
+    """Preflight with method not in upstream CORS config still returns 204."""
     _ = mock_upstream
-    alias = unique_alias("cors-pre-bad")
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        upstream = await create_upstream(
-            client, oagw_base_url, oagw_headers, mock_upstream_url,
-            alias=alias, cors=CORS_CONFIG,
-        )
-        uid = upstream["id"]
-        await create_route(
-            client, oagw_base_url, oagw_headers, uid, ["POST"], "/echo",
-        )
-
-        resp = await client.request(
-            "OPTIONS",
-            f"{oagw_base_url}/oagw/v1/proxy/{alias}/echo",
-            headers={
-                **oagw_headers,
-                "origin": "https://evil.com",
-                "access-control-request-method": "POST",
-            },
-        )
-        assert resp.status_code == 403, (
-            f"Expected 403, got {resp.status_code}: {resp.text[:500]}"
-        )
-        assert "access-control-allow-origin" not in resp.headers
-
-        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
-
-
-@pytest.mark.asyncio
-async def test_cors_preflight_rejected_method(
-    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
-):
-    """Preflight with disallowed method returns 403."""
-    _ = mock_upstream
-    alias = unique_alias("cors-pre-meth")
+    alias = unique_alias("cors-pre-any")
     async with httpx.AsyncClient(timeout=10.0) as client:
         upstream = await create_upstream(
             client, oagw_base_url, oagw_headers, mock_upstream_url,
@@ -120,82 +90,10 @@ async def test_cors_preflight_rejected_method(
                 "access-control-request-method": "DELETE",
             },
         )
-        assert resp.status_code == 403, (
-            f"Expected 403, got {resp.status_code}: {resp.text[:500]}"
-        )
-
-        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
-
-
-@pytest.mark.asyncio
-async def test_cors_preflight_rejected_header(
-    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
-):
-    """Preflight with disallowed request header returns 403."""
-    _ = mock_upstream
-    alias = unique_alias("cors-pre-hdr")
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        upstream = await create_upstream(
-            client, oagw_base_url, oagw_headers, mock_upstream_url,
-            alias=alias, cors=CORS_CONFIG,  # only content-type, authorization allowed
-        )
-        uid = upstream["id"]
-        await create_route(
-            client, oagw_base_url, oagw_headers, uid, ["POST"], "/echo",
-        )
-
-        resp = await client.request(
-            "OPTIONS",
-            f"{oagw_base_url}/oagw/v1/proxy/{alias}/echo",
-            headers={
-                **oagw_headers,
-                "origin": "https://app.example.com",
-                "access-control-request-method": "POST",
-                "access-control-request-headers": "x-custom-secret",
-            },
-        )
-        assert resp.status_code == 403, (
-            f"Expected 403, got {resp.status_code}: {resp.text[:500]}"
-        )
-
-        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
-
-
-@pytest.mark.asyncio
-async def test_cors_preflight_with_credentials(
-    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
-):
-    """Preflight with allow_credentials reflects origin and includes credentials header."""
-    _ = mock_upstream
-    alias = unique_alias("cors-pre-cred")
-    cors_with_creds = {
-        **CORS_CONFIG,
-        "allow_credentials": True,
-    }
-    async with httpx.AsyncClient(timeout=10.0) as client:
-        upstream = await create_upstream(
-            client, oagw_base_url, oagw_headers, mock_upstream_url,
-            alias=alias, cors=cors_with_creds,
-        )
-        uid = upstream["id"]
-        await create_route(
-            client, oagw_base_url, oagw_headers, uid, ["POST"], "/echo",
-        )
-
-        resp = await client.request(
-            "OPTIONS",
-            f"{oagw_base_url}/oagw/v1/proxy/{alias}/echo",
-            headers={
-                **oagw_headers,
-                "origin": "https://app.example.com",
-                "access-control-request-method": "POST",
-            },
-        )
         assert resp.status_code == 204, (
-            f"Expected 204, got {resp.status_code}: {resp.text[:500]}"
+            f"Expected 204 (permissive), got {resp.status_code}: {resp.text[:500]}"
         )
-        assert resp.headers["access-control-allow-origin"] == "https://app.example.com"
-        assert resp.headers.get("access-control-allow-credentials") == "true"
+        assert "DELETE" in resp.headers["access-control-allow-methods"]
 
         await delete_upstream(client, oagw_base_url, oagw_headers, uid)
 
@@ -242,10 +140,10 @@ async def test_cors_actual_request_includes_headers(
 
 
 @pytest.mark.asyncio
-async def test_cors_actual_request_disallowed_origin_no_headers(
+async def test_cors_actual_request_disallowed_origin_rejected(
     oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
 ):
-    """Actual request with disallowed origin gets no CORS headers (browser blocks)."""
+    """Actual request with disallowed origin is rejected with 403 before reaching upstream."""
     _ = mock_upstream
     alias = unique_alias("cors-actual-bad")
     async with httpx.AsyncClient(timeout=10.0) as client:
@@ -267,11 +165,9 @@ async def test_cors_actual_request_disallowed_origin_no_headers(
             },
             json={"test": "cors"},
         )
-        # Request still succeeds (upstream proxied), but no CORS headers
-        assert resp.status_code == 200, (
-            f"Expected 200, got {resp.status_code}: {resp.text[:500]}"
+        assert resp.status_code == 403, (
+            f"Expected 403, got {resp.status_code}: {resp.text[:500]}"
         )
-        assert "access-control-allow-origin" not in resp.headers
 
         await delete_upstream(client, oagw_base_url, oagw_headers, uid)
 


### PR DESCRIPTION
Browser preflight (OPTIONS) requests carry no credentials, so upstream resolution fails. Preflight now returns a permissive 204 at the handler level; origin and method enforcement moves to the actual request path after upstream resolution. Removes allowed_headers and max_age from CorsConfig (max_age hardcoded to 86400, header validation unnecessary with permissive preflight).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication enabled by default for the API gateway.
  * Preflight (OPTIONS) handled at the handler, returning permissive 204 that echoes request CORS headers.

* **Bug Fixes**
  * CORS origin and method validation now run on actual requests and reject disallowed origins/methods with 403 before proxying.

* **Refactor**
  * Removed CORS config options allowed_headers and max_age; public models and API schemas updated.

* **Documentation**
  * ADRs, design docs, examples and scenarios updated for the new CORS flow.

* **Tests / Chores**
  * E2E fixtures always send Authorization (default test tokens); tests adjusted; tenant header removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->