### PR TITLE
refactor(modkit): split required and defaulted module config loading

### DIFF
--- a/docs/MODKIT_PLUGINS.md
+++ b/docs/MODKIT_PLUGINS.md
@@ -327,7 +327,7 @@ pub struct MyModule {
 #[async_trait]
 impl Module for MyModule {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: ModuleConfig = ctx.config()?;
+        let cfg: ModuleConfig = ctx.config_or_default()?;
 
         // === SCHEMA REGISTRATION ===
         // The main module is responsible for registering the plugin SCHEMA.
@@ -471,7 +471,7 @@ pub struct VendorAPlugin {
 #[async_trait]
 impl Module for VendorAPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: PluginConfig = ctx.config()?;
+        let cfg: PluginConfig = ctx.config_or_default()?;
 
         // 1. Generate stable GTS instance ID
         let instance_id = MyModulePluginSpecV1::gts_make_instance_id("vendor_a.pkg_b.my_module.plugin.v1");
@@ -503,6 +503,9 @@ impl Module for VendorAPlugin {
     }
 }
 ```
+
+Use `ctx.config()` only for required module configuration. When the module or plugin can start
+with `Default` values, prefer `ctx.config_or_default()`.
 
 The plugin service implements the plugin API:
 

--- a/docs/modkit_unified_system/03_clienthub_and_plugins.md
+++ b/docs/modkit_unified_system/03_clienthub_and_plugins.md
@@ -195,7 +195,7 @@ pub struct MyModule { /* ... */ }
 #[async_trait]
 impl Module for MyModule {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: ModuleConfig = ctx.config()?;
+        let cfg: ModuleConfig = ctx.config_or_default()?;
 
         // Register plugin SCHEMA in types-registry
         let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
@@ -230,7 +230,7 @@ pub struct VendorAPlugin { /* ... */ }
 #[async_trait]
 impl Module for VendorAPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: PluginConfig = ctx.config()?;
+        let cfg: PluginConfig = ctx.config_or_default()?;
 
         let instance_id = MyModulePluginSpecV1::gts_make_instance_id("vendor_a.pkg.my_module.plugin.v1");
 
@@ -256,6 +256,9 @@ impl Module for VendorAPlugin {
     }
 }
 ```
+
+Use `ctx.config()` only when startup must fail if `modules.<name>.config` is absent. For
+modules and plugins with defaults, use `ctx.config_or_default()` instead.
 
 ### Step 5: Main Module Resolves Plugin
 

--- a/docs/modkit_unified_system/10_checklists_and_templates.md
+++ b/docs/modkit_unified_system/10_checklists_and_templates.md
@@ -14,6 +14,7 @@ This section provides minimal checklists and code templates for common ModKit ta
 - [ ] Add `#[derive(Scopable)]` on SeaORM entities (import `modkit_db_macros::Scopable`)
 - [ ] Use `SecureConn` + `SecurityContext` for all DB operations
 - [ ] Register client in `init()`: `ctx.client_hub().register::<dyn MyModuleApi>(api)`
+- [ ] Pick the right config loader: `ctx.config()` is strict; `ctx.config_or_default()` is lenient
 - [ ] Export SDK types from module crate `lib.rs`
 - [ ] Add module to `Cargo.toml` workspace and `main.rs` type_name check
 

--- a/docs/modkit_unified_system/README.md
+++ b/docs/modkit_unified_system/README.md
@@ -37,6 +37,7 @@ This folder contains the ModKit developer documentation, split by topic for focu
 - **Secure-by-default DB access**: Use `SecureConn` + `AccessScope`. Modules cannot access raw database connections.
 - **RFC-9457 errors everywhere**: Use `Problem` (implements `IntoResponse`). Do not use `ProblemResponse`.
 - **Type-safe REST**: Use `OperationBuilder` with `.authenticated()` and `.standard_errors()`.
+- **Config loading is explicit**: `ctx.config()` / `ctx.config_expanded()` require `modules.<name>.config`; use `ctx.config_or_default()` / `ctx.config_expanded_or_default()` only when missing config should fall back to `Default`.
 - **OData macros are in `modkit-odata-macros`**: Use `modkit_odata_macros::ODataFilterable`.
 - **ClientHub registration**: `ctx.client_hub().register::<dyn MyModuleApi>(api)`; `ctx.client_hub().get::<dyn MyModuleApi>()?`.
 - **Cancellation**: Pass `CancellationToken` to background tasks for cooperative shutdown.

--- a/examples/modkit/users-info/users-info/src/module.rs
+++ b/examples/modkit/users-info/users-info/src/module.rs
@@ -62,7 +62,7 @@ impl Default for UsersInfo {
 impl Module for UsersInfo {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         // Load module configuration using new API
-        let cfg: UsersInfoConfig = ctx.config()?;
+        let cfg: UsersInfoConfig = ctx.config_or_default()?;
         debug!(
             "Loaded users_info config: default_page_size={}, max_page_size={}",
             cfg.default_page_size, cfg.max_page_size

--- a/libs/modkit/src/context.rs
+++ b/libs/modkit/src/context.rs
@@ -4,7 +4,10 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 // Import configuration types from the config module
-use crate::config::{ConfigError, ConfigProvider, module_config_or_default};
+use crate::{
+    config::{ConfigError, ConfigProvider, module_config_or_default},
+    module_config_required,
+};
 
 // Note: runtime-dependent features are conditionally compiled
 
@@ -208,6 +211,17 @@ impl ModuleCtx {
         })
     }
 
+    /// Deserialize the module's config section into `T`.
+    ///
+    /// This reads the `modules.<name>.config` object for the current module and
+    /// deserializes it into the requested type.
+    ///
+    /// # Errors
+    /// Returns `ConfigError` if the module config is missing or deserialization fails.
+    pub fn config<T: DeserializeOwned>(&self) -> Result<T, ConfigError> {
+        module_config_required(self.config_provider.as_ref(), &self.module_name)
+    }
+
     /// Deserialize the module's config section into T, or use defaults if missing.
     ///
     /// This method uses lenient configuration loading: if the module is not present in config,
@@ -225,20 +239,40 @@ impl ModuleCtx {
     ///     timeout_ms: u64,
     /// }
     ///
-    /// let config: MyConfig = ctx.config()?;
+    /// let config: MyConfig = ctx.config_or_default()?;
     /// ```
     ///
     /// # Errors
     /// Returns `ConfigError` if deserialization fails.
-    pub fn config<T: DeserializeOwned + Default>(&self) -> Result<T, ConfigError> {
+    pub fn config_or_default<T: DeserializeOwned + Default>(&self) -> Result<T, ConfigError> {
         module_config_or_default(self.config_provider.as_ref(), &self.module_name)
     }
 
     /// Like [`config()`](Self::config), but additionally expands `${VAR}` placeholders
+    /// in fields marked with `#[expand_vars]`.
+    ///
+    /// # Errors
+    /// Returns `ConfigError` if the module config is missing, deserialization fails,
+    /// or environment variable expansion fails.
+    pub fn config_expanded<T>(&self) -> Result<T, ConfigError>
+    where
+        T: DeserializeOwned + crate::var_expand::ExpandVars,
+    {
+        let mut cfg: T = self.config()?;
+        cfg.expand_vars().map_err(|e| ConfigError::VarExpand {
+            module: self.module_name.to_string(),
+            source: e,
+        })?;
+        Ok(cfg)
+    }
+
+    /// Like [`config_or_default()`](Self::config_or_default), but additionally expands `${VAR}`
+    /// placeholders
     /// in fields marked with `#[expand_vars]` (requires `#[derive(ExpandVars)]` on the config
     /// struct).
     ///
-    /// Modules that do not need environment variable expansion should use [`config()`](Self::config).
+    /// Modules that do not need environment variable expansion should use
+    /// [`config_or_default()`](Self::config_or_default).
     ///
     /// # Example
     ///
@@ -250,16 +284,16 @@ impl ModuleCtx {
     ///     timeout_ms: u64,
     /// }
     ///
-    /// let config: MyConfig = ctx.config_expanded()?;
+    /// let config: MyConfig = ctx.config_expanded_or_default()?;
     /// ```
     ///
     /// # Errors
     /// Returns `ConfigError` if deserialization fails or if environment variable expansion fails.
-    pub fn config_expanded<T>(&self) -> Result<T, ConfigError>
+    pub fn config_expanded_or_default<T>(&self) -> Result<T, ConfigError>
     where
         T: DeserializeOwned + Default + crate::var_expand::ExpandVars,
     {
-        let mut cfg: T = self.config()?;
+        let mut cfg: T = self.config_or_default()?;
         cfg.expand_vars().map_err(|e| ConfigError::VarExpand {
             module: self.module_name.to_string(),
             source: e,
@@ -374,7 +408,7 @@ mod tests {
     }
 
     #[test]
-    fn test_module_ctx_config_returns_default_for_missing_module() {
+    fn test_module_ctx_config_returns_error_for_missing_module() {
         let provider = Arc::new(MockConfigProvider::new());
         let ctx = ModuleCtx::new(
             "nonexistent_module",
@@ -386,6 +420,25 @@ mod tests {
         );
 
         let result: Result<TestConfig, ConfigError> = ctx.config();
+        assert!(matches!(
+            result,
+            Err(ConfigError::ModuleNotFound { ref module }) if module == "nonexistent_module"
+        ));
+    }
+
+    #[test]
+    fn test_module_ctx_config_or_default_returns_default_for_missing_module() {
+        let provider = Arc::new(MockConfigProvider::new());
+        let ctx = ModuleCtx::new(
+            "nonexistent_module",
+            Uuid::new_v4(),
+            provider,
+            Arc::new(crate::client_hub::ClientHub::default()),
+            CancellationToken::new(),
+            None,
+        );
+
+        let result: Result<TestConfig, ConfigError> = ctx.config_or_default();
         assert!(result.is_ok());
 
         let config = result.unwrap();
@@ -502,9 +555,19 @@ mod tests {
     }
 
     #[test]
-    fn config_expanded_falls_back_to_default_when_missing() {
+    fn config_expanded_returns_error_when_missing() {
         let ctx = make_ctx("missing_mod", json!({}));
-        let cfg: ExpandableConfig = ctx.config_expanded().unwrap();
+        let err = ctx.config_expanded::<ExpandableConfig>().unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::MissingConfigSection { ref module } if module == "missing_mod"
+        ));
+    }
+
+    #[test]
+    fn config_expanded_or_default_falls_back_to_default_when_missing() {
+        let ctx = make_ctx("missing_mod", json!({}));
+        let cfg: ExpandableConfig = ctx.config_expanded_or_default().unwrap();
         assert_eq!(cfg, ExpandableConfig::default());
     }
 

--- a/modules/credstore/credstore/src/module.rs
+++ b/modules/credstore/credstore/src/module.rs
@@ -40,7 +40,7 @@ impl Default for CredStoreModule {
 impl Module for CredStoreModule {
     #[tracing::instrument(skip_all, fields(vendor))]
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: CredStoreConfig = ctx.config()?;
+        let cfg: CredStoreConfig = ctx.config_or_default()?;
         tracing::Span::current().record("vendor", cfg.vendor.as_str());
         info!(vendor = %cfg.vendor);
 

--- a/modules/credstore/plugins/static-credstore-plugin/src/module.rs
+++ b/modules/credstore/plugins/static-credstore-plugin/src/module.rs
@@ -35,7 +35,7 @@ impl Default for StaticCredStorePlugin {
 impl Module for StaticCredStorePlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         // Load configuration
-        let cfg: StaticCredStorePluginConfig = ctx.config_expanded()?;
+        let cfg: StaticCredStorePluginConfig = ctx.config_expanded_or_default()?;
 
         info!(
             vendor = %cfg.vendor,

--- a/modules/file-parser/src/config.rs
+++ b/modules/file-parser/src/config.rs
@@ -13,21 +13,7 @@ pub struct FileParserConfig {
     /// files under this directory (after symlink resolution / canonicalization)
     /// are allowed.  The module will fail to start if this field is missing or
     /// the path cannot be resolved.
-    ///
-    /// Wrapped in `Option` because the `ModKit` config loader requires `Default`,
-    /// but `init()` treats `None` as a hard startup error.
-    #[serde(default)]
-    pub allowed_local_base_dir: Option<PathBuf>,
-}
-
-impl Default for FileParserConfig {
-    fn default() -> Self {
-        Self {
-            max_file_size_mb: default_max_file_size_mb(),
-            // None here — init() will reject this with a clear error message.
-            allowed_local_base_dir: None,
-        }
-    }
+    pub allowed_local_base_dir: PathBuf,
 }
 
 fn default_max_file_size_mb() -> u64 {

--- a/modules/file-parser/src/module.rs
+++ b/modules/file-parser/src/module.rs
@@ -56,19 +56,11 @@ impl Module for FileParserModule {
 
         info!("Registered {} parser backends", parsers.len());
 
-        // allowed_local_base_dir is mandatory — fail fast if missing.
-        let raw_base = cfg.allowed_local_base_dir.ok_or_else(|| {
-            anyhow::anyhow!(
-                "file-parser: 'allowed_local_base_dir' is required but not set. \
-                 Add it to your config under modules.file-parser.config."
-            )
-        })?;
-
         // Canonicalize at startup so we only do it once.
-        let allowed_local_base_dir = raw_base.canonicalize().map_err(|e| {
+        let allowed_local_base_dir = cfg.allowed_local_base_dir.canonicalize().map_err(|e| {
             anyhow::anyhow!(
                 "allowed_local_base_dir '{}' cannot be resolved: {e}",
-                raw_base.display()
+                cfg.allowed_local_base_dir.display()
             )
         })?;
         if !allowed_local_base_dir.is_dir() {

--- a/modules/mini-chat/mini-chat/src/infra/plugins/static_audit/module.rs
+++ b/modules/mini-chat/mini-chat/src/infra/plugins/static_audit/module.rs
@@ -40,7 +40,7 @@ impl Default for StaticMiniChatAuditPlugin {
 #[async_trait]
 impl Module for StaticMiniChatAuditPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: StaticMiniChatAuditPluginConfig = ctx.config()?;
+        let cfg: StaticMiniChatAuditPluginConfig = ctx.config_or_default()?;
         info!(
             enabled = cfg.enabled,
             "Loaded static mini-chat audit plugin configuration"

--- a/modules/mini-chat/mini-chat/src/infra/plugins/static_model_policy/module.rs
+++ b/modules/mini-chat/mini-chat/src/infra/plugins/static_model_policy/module.rs
@@ -34,7 +34,7 @@ impl Default for StaticMiniChatModelPolicyPlugin {
 #[async_trait]
 impl Module for StaticMiniChatModelPolicyPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: StaticMiniChatPolicyPluginConfig = ctx.config()?;
+        let cfg: StaticMiniChatPolicyPluginConfig = ctx.config_or_default()?;
         info!(
             vendor = %cfg.vendor,
             priority = cfg.priority,

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -116,7 +116,7 @@ impl Module for MiniChatModule {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         info!("Initializing {} module", Self::MODULE_NAME);
 
-        let mut cfg: crate::config::MiniChatConfig = ctx.config_expanded()?;
+        let mut cfg: crate::config::MiniChatConfig = ctx.config_expanded_or_default()?;
         cfg.streaming
             .validate()
             .map_err(|e| anyhow::anyhow!("streaming config: {e}"))?;

--- a/modules/simple-user-settings/simple-user-settings/src/module.rs
+++ b/modules/simple-user-settings/simple-user-settings/src/module.rs
@@ -49,7 +49,7 @@ impl modkit::contracts::DatabaseCapability for SettingsModule {
 #[async_trait]
 impl Module for SettingsModule {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: SettingsConfig = ctx.config()?;
+        let cfg: SettingsConfig = ctx.config_or_default()?;
 
         let db: Arc<DBProvider<DbError>> = Arc::new(ctx.db_required()?);
 

--- a/modules/system/api-gateway/src/module.rs
+++ b/modules/system/api-gateway/src/module.rs
@@ -644,7 +644,7 @@ impl ApiGateway {
 #[async_trait]
 impl modkit::Module for ApiGateway {
     async fn init(&self, ctx: &modkit::context::ModuleCtx) -> anyhow::Result<()> {
-        let cfg = ctx.config::<crate::config::ApiGatewayConfig>()?;
+        let cfg = ctx.config_or_default::<crate::config::ApiGatewayConfig>()?;
         self.config.store(Arc::new(cfg.clone()));
 
         debug!(

--- a/modules/system/authn-resolver/authn-resolver/src/module.rs
+++ b/modules/system/authn-resolver/authn-resolver/src/module.rs
@@ -48,7 +48,7 @@ impl SystemCapability for AuthNResolver {}
 impl Module for AuthNResolver {
     #[tracing::instrument(skip_all, fields(vendor))]
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: AuthNResolverConfig = ctx.config()?;
+        let cfg: AuthNResolverConfig = ctx.config_or_default()?;
         tracing::Span::current().record("vendor", cfg.vendor.as_str());
         info!(vendor = %cfg.vendor);
 

--- a/modules/system/authn-resolver/plugins/static-authn-plugin/src/module.rs
+++ b/modules/system/authn-resolver/plugins/static-authn-plugin/src/module.rs
@@ -42,7 +42,7 @@ impl Default for StaticAuthNPlugin {
 impl Module for StaticAuthNPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         // Load configuration
-        let cfg: StaticAuthNPluginConfig = ctx.config()?;
+        let cfg: StaticAuthNPluginConfig = ctx.config_or_default()?;
         if matches!(cfg.mode, crate::config::AuthNMode::AcceptAll) {
             tracing::warn!(
                 "Static AuthN plugin is running in `accept_all` mode - \

--- a/modules/system/authz-resolver/authz-resolver/src/module.rs
+++ b/modules/system/authz-resolver/authz-resolver/src/module.rs
@@ -48,7 +48,7 @@ impl SystemCapability for AuthZResolver {}
 impl Module for AuthZResolver {
     #[tracing::instrument(skip_all, fields(vendor))]
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: AuthZResolverConfig = ctx.config()?;
+        let cfg: AuthZResolverConfig = ctx.config_or_default()?;
         tracing::Span::current().record("vendor", cfg.vendor.as_str());
         info!(vendor = %cfg.vendor);
 

--- a/modules/system/authz-resolver/plugins/static-authz-plugin/src/module.rs
+++ b/modules/system/authz-resolver/plugins/static-authz-plugin/src/module.rs
@@ -34,7 +34,7 @@ impl Default for StaticAuthZPlugin {
 #[async_trait]
 impl Module for StaticAuthZPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: StaticAuthZPluginConfig = ctx.config()?;
+        let cfg: StaticAuthZPluginConfig = ctx.config_or_default()?;
         info!(
             vendor = %cfg.vendor,
             priority = cfg.priority,

--- a/modules/system/grpc-hub/src/module.rs
+++ b/modules/system/grpc-hub/src/module.rs
@@ -539,7 +539,7 @@ impl modkit::contracts::GrpcHubCapability for GrpcHub {
 impl Module for GrpcHub {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         // Load typed configuration
-        let cfg: GrpcHubConfig = ctx.config()?;
+        let cfg: GrpcHubConfig = ctx.config_or_default()?;
         tracing::debug!(listen_addr = %cfg.listen_addr, "Loaded gRPC hub configuration");
 
         // Parse listen_addr into appropriate transport type

--- a/modules/system/module-orchestrator/src/module.rs
+++ b/modules/system/module-orchestrator/src/module.rs
@@ -22,7 +22,11 @@ use crate::server;
 
 /// Configuration for the module orchestrator
 #[derive(Clone, Debug, Default, serde::Deserialize)]
-pub struct ModuleOrchestratorConfig;
+#[allow(
+    clippy::empty_structs_with_brackets,
+    reason = "empty struct is required for config deserialization"
+)]
+pub struct ModuleOrchestratorConfig {}
 
 /// Module Orchestrator - system module for service discovery
 ///
@@ -46,7 +50,7 @@ pub struct ModuleOrchestrator {
 impl Default for ModuleOrchestrator {
     fn default() -> Self {
         Self {
-            config: RwLock::new(ModuleOrchestratorConfig),
+            config: RwLock::new(ModuleOrchestratorConfig {}),
             directory_api: OnceLock::new(),
             module_manager: OnceLock::new(),
             modules_service: OnceLock::new(),
@@ -68,7 +72,7 @@ impl SystemCapability for ModuleOrchestrator {
 impl modkit::Module for ModuleOrchestrator {
     async fn init(&self, ctx: &ModuleCtx) -> Result<()> {
         // Load configuration if present
-        let cfg = ctx.config::<ModuleOrchestratorConfig>().unwrap_or_default();
+        let cfg = ctx.config_or_default::<ModuleOrchestratorConfig>()?;
         *self.config.write().await = cfg;
 
         // Use the injected ModuleManager to create the DirectoryClient

--- a/modules/system/oagw/oagw/src/module.rs
+++ b/modules/system/oagw/oagw/src/module.rs
@@ -59,7 +59,7 @@ impl Default for OutboundApiGatewayModule {
 #[async_trait]
 impl Module for OutboundApiGatewayModule {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: OagwConfig = ctx.config()?;
+        let cfg: OagwConfig = ctx.config_or_default()?;
         cfg.validate()
             .map_err(|e| anyhow::anyhow!("invalid OAGW config: {e}"))?;
         info!("OAGW config: proxy_timeout_secs={}", cfg.proxy_timeout_secs);

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/src/module.rs
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/src/module.rs
@@ -42,7 +42,7 @@ impl Default for StaticTrPlugin {
 impl Module for StaticTrPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         // Load configuration
-        let cfg: StaticTrPluginConfig = ctx.config()?;
+        let cfg: StaticTrPluginConfig = ctx.config_or_default()?;
         info!(
             vendor = %cfg.vendor,
             priority = cfg.priority,

--- a/modules/system/tenant-resolver/tenant-resolver/src/module.rs
+++ b/modules/system/tenant-resolver/tenant-resolver/src/module.rs
@@ -48,7 +48,7 @@ impl SystemCapability for TenantResolver {}
 impl Module for TenantResolver {
     #[tracing::instrument(skip_all, fields(vendor))]
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: TenantResolverConfig = ctx.config()?;
+        let cfg: TenantResolverConfig = ctx.config_or_default()?;
         tracing::Span::current().record("vendor", cfg.vendor.as_str());
         info!(vendor = %cfg.vendor);
 

--- a/modules/system/types-registry/types-registry/src/module.rs
+++ b/modules/system/types-registry/types-registry/src/module.rs
@@ -47,7 +47,7 @@ impl Default for TypesRegistryModule {
 #[async_trait]
 impl Module for TypesRegistryModule {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
-        let cfg: TypesRegistryConfig = ctx.config()?;
+        let cfg: TypesRegistryConfig = ctx.config_or_default()?;
         debug!(
             "Loaded types_registry config: entity_id_fields={:?}, schema_id_fields={:?}",
             cfg.entity_id_fields, cfg.schema_id_fields


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Many modules and plugins now start with default configs when explicit config is absent, improving startup resilience.

* **Improvements**
  * Added distinct strict vs lenient config-loading and refined environment-variable expansion semantics.
  * Reordered API operation extension metadata for chats.

* **Breaking Changes**
  * File parser now requires an explicit base directory in its config.
  * Problem schema: `instance` and `code` no longer required; added optional `context`.

* **Documentation**
  * Docs, examples and checklists updated with config-loading guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->