### PR TITLE
feat(minichat): implement thread summary worker (transactional outbox)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ testing/e2e/.env.e2e
 testing/e2e/.env.e2e.*
 testing/e2e/.venv/
 testing/e2e/logs/
+.docker-stage

--- a/Makefile
+++ b/Makefile
@@ -497,12 +497,33 @@ fips:
 mini-chat:
 	cargo run --bin hyperspot-server --features mini-chat,static-authn,static-authz,single-tenant,static-credstore,otel -- --config config/mini-chat.yaml run
 
-## Build mini-chat Docker image for K8s
+## Build mini-chat Docker image for K8s (dev build by default, RELEASE=1 for optimized)
+## On linux: builds on host (reuses local target/), then packages the binary.
+## On other OS: full multi-stage Docker build with BuildKit caching.
+MINI_CHAT_PROFILE = $(if $(RELEASE),release,dev)
+MINI_CHAT_CARGO_RELEASE_FLAG = $(if $(RELEASE),--release,)
+MINI_CHAT_TARGET_DIR = $(or $(CARGO_TARGET_DIR),target)/$(if $(RELEASE),release,debug)
+
 mini-chat-docker:
-	docker build \
+ifeq ($(shell uname -s),Linux)
+	@echo "==> Linux host: building on host, packaging into image"
+	cargo build $(MINI_CHAT_CARGO_RELEASE_FLAG) --bin hyperspot-server --package=hyperspot-server \
+		--features "$(MINI_CHAT_K8S_FEATURES)"
+	@mkdir -p .docker-stage
+	@cp $(MINI_CHAT_TARGET_DIR)/hyperspot-server .docker-stage/hyperspot-server
+	DOCKER_BUILDKIT=1 docker build \
+		-f modules/mini-chat/deploy/docker/mini-chat-prebuilt.Dockerfile \
+		--build-arg BINARY_PATH=".docker-stage/hyperspot-server" \
+		-t $(MINI_CHAT_IMAGE):$(MINI_CHAT_TAG) .
+	@rm -rf .docker-stage
+else
+	@echo "==> Non-linux host: full Docker build"
+	DOCKER_BUILDKIT=1 docker build \
 		-f modules/mini-chat/deploy/docker/mini-chat.Dockerfile \
 		--build-arg CARGO_FEATURES="$(MINI_CHAT_K8S_FEATURES)" \
+		--build-arg BUILD_PROFILE="$(MINI_CHAT_PROFILE)" \
 		-t $(MINI_CHAT_IMAGE):$(MINI_CHAT_TAG) .
+endif
 
 ## Deploy mini-chat Helm chart to local K8s cluster (build + load + install)
 mini-chat-helm: mini-chat-docker

--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -44,7 +44,7 @@ modules:
     config:
       bind_addr: "127.0.0.1:8087"
       enable_docs: true
-      cors_enabled: false
+      cors_enabled: true
       openapi:
         title: "Mini-Chat Dev API"
         version: "0.1.0"
@@ -115,6 +115,9 @@ modules:
       server: "sqlite_mini_chat"
       file: "mini_chat.db"
     config:
+      orphan_watchdog:
+        scan_interval_secs: 10
+        timeout_secs: 90
       # S2S credentials for obtaining SecurityContext
       # that will be used for communication with other modules.
       client_credentials:
@@ -122,6 +125,11 @@ modules:
         client_secret: "mini-chat-dev-secret"
       # Provider registry. Key = provider_id (matches ModelCatalogEntry.provider_id).
       # `upstream_alias` is optional — defaults to `host` when omitted.
+      thread_summary_worker:
+        enabled: true
+        summary_model_id: "gpt-4.1-mini"
+        compression_threshold_pct: 80
+        summary_system_prompt: "You are a conversation summarizer. Given a conversation (and optionally an existing summary), produce a detailed structured summary. Respond with an <analysis> block (your reasoning) followed by a <summary> block (the final summary). Only the <summary> content will be stored. Do not invent information not present in the conversation."
       providers:
         azure_openai:
           kind: openai_responses
@@ -197,11 +205,8 @@ modules:
           icon: ""
           tier: Premium
           enabled: true
-          # System prompt sent as `instructions` in every LLM request for this model.
-          # Omit or leave empty for no system instructions.
           system_prompt: "You are a helpful, concise assistant. Answer clearly and directly."
-          # Prompt template for thread summary generation (future use).
-          # thread_summary_prompt: "Summarize the key points of this conversation."
+          thread_summary_prompt: ""
           multimodal_capabilities: ["VISION_INPUT"]
           context_window: 1047576
           max_output_tokens: 32768
@@ -289,6 +294,7 @@ modules:
           tier: Standard
           enabled: true
           system_prompt: "You are a helpful, concise assistant. Answer clearly and directly."
+          thread_summary_prompt: ""
           multimodal_capabilities: ["VISION_INPUT"]
           context_window: 1047576
           max_output_tokens: 32768
@@ -363,6 +369,96 @@ modules:
           preference:
             is_default: false
             sort_order: 1
+
+        # ── GPT-4.1 Mini with tiny context (E2E thread summary testing) ──
+        # Same provider model as gpt-4.1-mini but with context_window=4096
+        # so the 80% compression threshold (~3200 tokens) is reachable in ~3 turns.
+        - model_id: "gpt-4.1-mini-tiny-ctx"
+          provider_model_id: "gpt-4.1-mini"
+          display_name: "GPT-4.1 Mini (Tiny Context - E2E)"
+          description: "E2E testing model with small context for thread summary trigger"
+          version: "4.1"
+          provider_id: "azure_openai"
+          provider_display_name: "Azure OpenAI"
+          icon: ""
+          tier: Standard
+          enabled: true
+          system_prompt: "You are a helpful assistant. Be verbose - write detailed, long responses with explanations."
+          thread_summary_prompt: ""
+          multimodal_capabilities: ["VISION_INPUT"]
+          context_window: 4096
+          max_output_tokens: 1024
+          max_input_tokens: 3072
+          input_tokens_credit_multiplier_micro: 1000000
+          output_tokens_credit_multiplier_micro: 3000000
+          multiplier_display: "1x"
+          estimation_budgets:
+            bytes_per_token_conservative: 4
+            fixed_overhead_tokens: 100
+            safety_margin_pct: 10
+            image_token_budget: 1000
+            tool_surcharge_tokens: 500
+            web_search_surcharge_tokens: 500
+            code_interpreter_surcharge_tokens: 1000
+            minimal_generation_floor: 50
+          max_retrieved_chunks_per_turn: 5
+          max_tool_calls: 10
+          general_config:
+            type: ""
+            tier: "standard"
+            available_from: "1970-01-01T00:00:00Z"
+            max_file_size_mb: 25
+            api_params:
+              temperature: 0.7
+              top_p: 1.0
+              frequency_penalty: 0.0
+              presence_penalty: 0.0
+              stop: []
+            features:
+              streaming: true
+              function_calling: true
+              structured_output: true
+              fine_tuning: false
+              distillation: false
+              fim_completion: false
+              chat_prefix_completion: false
+            input_type:
+              text: true
+              image: true
+              audio: false
+              video: false
+            tool_support:
+              web_search: false
+              file_search: false
+              image_generation: false
+              code_interpreter: false
+              computer_use: false
+              mcp: false
+            supported_endpoints:
+              chat_completions: true
+              responses: true
+              realtime: false
+              assistants: false
+              batch_api: false
+              fine_tuning: false
+              embeddings: false
+              videos: false
+              image_generation: false
+              image_edit: false
+              audio_speech_generation: false
+              audio_transcription: false
+              audio_translation: false
+              moderations: false
+              completions: false
+            token_policy:
+              input_tokens_credit_multiplier: 1.0
+              output_tokens_credit_multiplier: 3.0
+            performance:
+              response_latency_ms: 400
+              speed_tokens_per_second: 150
+          preference:
+            is_default: false
+            sort_order: 99
 
   oagw:
     config:

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -768,8 +768,27 @@ impl HostRuntime {
         // 9. Wait for cancellation
         self.cancel.cancelled().await;
 
-        // 10. Stop phase
+        // 10. Stop phase with hard timeout.
+        //     Blocking syscalls (e.g. libc getaddrinfo in tokio spawn_blocking)
+        //     can saturate all tokio worker threads, preventing tokio timers
+        //     from firing. Use an OS thread so the watchdog works even when
+        //     the tokio runtime is fully blocked.
+        let stop_timeout = std::time::Duration::from_secs(15);
+        let disarm = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let disarm_clone = std::sync::Arc::clone(&disarm);
+        std::thread::spawn(move || {
+            std::thread::sleep(stop_timeout);
+            if !disarm_clone.load(std::sync::atomic::Ordering::Relaxed) {
+                tracing::warn!(
+                    timeout_secs = stop_timeout.as_secs(),
+                    "shutdown: stop phase timed out, force exiting"
+                );
+                std::process::exit(1);
+            }
+        });
+
         self.run_stop_phase().await?;
+        disarm.store(true, std::sync::atomic::Ordering::Relaxed);
 
         Ok(())
     }

--- a/modules/mini-chat/deploy/docker/mini-chat-prebuilt.Dockerfile
+++ b/modules/mini-chat/deploy/docker/mini-chat-prebuilt.Dockerfile
@@ -1,0 +1,22 @@
+# Packaging-only Dockerfile — expects a pre-built binary at build context.
+# Used by `make mini-chat-docker` on linux when the host cargo target is reusable.
+ARG BINARY_PATH=target/debug/hyperspot-server
+
+FROM debian:13.3-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ARG BINARY_PATH
+COPY ${BINARY_PATH} /app/hyperspot-server
+COPY config /app/config
+
+EXPOSE 8087
+
+RUN useradd -U -u 1000 appuser && \
+    chown -R 1000:1000 /app
+USER 1000
+CMD ["/app/hyperspot-server", "--config", "/app/config/mini-chat.yaml", "run"]

--- a/modules/mini-chat/deploy/docker/mini-chat.Dockerfile
+++ b/modules/mini-chat/deploy/docker/mini-chat.Dockerfile
@@ -2,8 +2,9 @@
 # Stage 1: Builder
 FROM rust:1.92-bookworm@sha256:e90e846de4124376164ddfbaab4b0774c7bdeef5e738866295e5a90a34a307a2 AS builder
 
-# Build arguments for cargo features
+# Build arguments
 ARG CARGO_FEATURES=mini-chat,static-authn,static-authz,single-tenant,static-credstore,k8s
+ARG BUILD_PROFILE=dev
 
 # Install protobuf-compiler for prost-build
 RUN apt-get update && \
@@ -25,12 +26,25 @@ COPY examples ./examples
 COPY config ./config
 COPY proto ./proto
 
-# Build the hyperspot-server binary in release mode
-RUN if [ -n "$CARGO_FEATURES" ]; then \
-        cargo build --release --bin hyperspot-server --package=hyperspot-server --features "$CARGO_FEATURES"; \
+# Build the hyperspot-server binary.
+# BUILD_PROFILE: "dev" (default, fast compile) or "release" (optimized).
+# BuildKit cache mounts persist cargo registry + target dir across builds.
+# On linux hosts (same triple as the container), this reuses compiled deps.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/build/target,sharing=locked \
+    RELEASE_FLAG="" && \
+    OUTPUT_DIR="debug" && \
+    if [ "$BUILD_PROFILE" = "release" ]; then \
+        RELEASE_FLAG="--release"; \
+        OUTPUT_DIR="release"; \
+    fi && \
+    if [ -n "$CARGO_FEATURES" ]; then \
+        cargo build $RELEASE_FLAG --bin hyperspot-server --package=hyperspot-server --features "$CARGO_FEATURES"; \
     else \
-        cargo build --release --bin hyperspot-server --package=hyperspot-server; \
-    fi
+        cargo build $RELEASE_FLAG --bin hyperspot-server --package=hyperspot-server; \
+    fi && \
+    cp /build/target/$OUTPUT_DIR/hyperspot-server /tmp/hyperspot-server
 
 # Stage 2: Runtime
 FROM debian:13.3-slim
@@ -41,8 +55,8 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-# Copy the built binary from builder stage
-COPY --from=builder /build/target/release/hyperspot-server /app/hyperspot-server
+# Copy the built binary from builder stage (via /tmp because target/ is a cache mount)
+COPY --from=builder /tmp/hyperspot-server /app/hyperspot-server
 # Copy config
 COPY --from=builder /build/config /app/config
 

--- a/modules/mini-chat/deploy/helm/mini-chat/templates/configmap.yaml
+++ b/modules/mini-chat/deploy/helm/mini-chat/templates/configmap.yaml
@@ -129,6 +129,11 @@ data:
           client_credentials:
             client_id: "mini-chat"
             client_secret: "mini-chat-dev-secret"
+          thread_summary_worker:
+            enabled: true
+            summary_model_id: "gpt-4.1-mini"
+            compression_threshold_pct: 80
+            summary_system_prompt: "You are a conversation summarizer. Given a conversation (and optionally an existing summary), produce a detailed structured summary. Respond with an <analysis> block (your reasoning) followed by a <summary> block (the final summary). Only the <summary> content will be stored. Do not invent information not present in the conversation."
           providers:
             azure_openai:
               kind: openai_responses
@@ -175,6 +180,7 @@ data:
               tier: Premium
               enabled: true
               system_prompt: "You are a helpful, concise assistant. Answer clearly and directly."
+              thread_summary_prompt: ""
               multimodal_capabilities: ["VISION_INPUT"]
               context_window: 1047576
               max_output_tokens: 32768
@@ -261,6 +267,7 @@ data:
               tier: Standard
               enabled: true
               system_prompt: "You are a helpful, concise assistant. Answer clearly and directly."
+              thread_summary_prompt: ""
               multimodal_capabilities: ["VISION_INPUT"]
               context_window: 1047576
               max_output_tokens: 32768
@@ -347,6 +354,7 @@ data:
               tier: Standard
               enabled: true
               system_prompt: "You are a helpful, concise assistant. Answer clearly and directly."
+              thread_summary_prompt: ""
               multimodal_capabilities: []
               context_window: 40960
               max_output_tokens: 4096
@@ -421,6 +429,94 @@ data:
               preference:
                 is_default: false
                 sort_order: 2
+
+            # ── GPT-4.1 Mini with tiny context (E2E thread summary testing) ──
+            - model_id: "gpt-4.1-mini-tiny-ctx"
+              provider_model_id: "gpt-4.1-mini"
+              display_name: "GPT-4.1 Mini (Tiny Context - E2E)"
+              description: "E2E testing model with small context for thread summary trigger"
+              version: "4.1"
+              provider_id: "azure_openai"
+              provider_display_name: "Azure OpenAI"
+              icon: ""
+              tier: Standard
+              enabled: true
+              system_prompt: "You are a helpful assistant. Be verbose - write detailed, long responses with explanations."
+              thread_summary_prompt: ""
+              multimodal_capabilities: ["VISION_INPUT"]
+              context_window: 4096
+              max_output_tokens: 1024
+              max_input_tokens: 3072
+              input_tokens_credit_multiplier_micro: 1000000
+              output_tokens_credit_multiplier_micro: 3000000
+              multiplier_display: "1x"
+              estimation_budgets:
+                bytes_per_token_conservative: 4
+                fixed_overhead_tokens: 100
+                safety_margin_pct: 10
+                image_token_budget: 1000
+                tool_surcharge_tokens: 500
+                web_search_surcharge_tokens: 500
+                code_interpreter_surcharge_tokens: 1000
+                minimal_generation_floor: 50
+              max_retrieved_chunks_per_turn: 5
+              max_tool_calls: 10
+              general_config:
+                type: ""
+                tier: "standard"
+                available_from: "1970-01-01T00:00:00Z"
+                max_file_size_mb: 25
+                api_params:
+                  temperature: 0.7
+                  top_p: 1.0
+                  frequency_penalty: 0.0
+                  presence_penalty: 0.0
+                  stop: []
+                features:
+                  streaming: true
+                  function_calling: true
+                  structured_output: true
+                  fine_tuning: false
+                  distillation: false
+                  fim_completion: false
+                  chat_prefix_completion: false
+                input_type:
+                  text: true
+                  image: true
+                  audio: false
+                  video: false
+                tool_support:
+                  web_search: false
+                  file_search: false
+                  image_generation: false
+                  code_interpreter: false
+                  computer_use: false
+                  mcp: false
+                supported_endpoints:
+                  chat_completions: true
+                  responses: true
+                  realtime: false
+                  assistants: false
+                  batch_api: false
+                  fine_tuning: false
+                  embeddings: false
+                  videos: false
+                  image_generation: false
+                  image_edit: false
+                  audio_speech_generation: false
+                  audio_transcription: false
+                  audio_translation: false
+                  moderations: false
+                  completions: false
+                token_policy:
+                  input_tokens_credit_multiplier: 1.0
+                  output_tokens_credit_multiplier: 3.0
+                performance:
+                  response_latency_ms: 400
+                  speed_tokens_per_second: 150
+              preference:
+                is_default: false
+                sort_order: 99
 
       oagw:
         config:

--- a/modules/mini-chat/deploy/helm/mini-chat/values.yaml
+++ b/modules/mini-chat/deploy/helm/mini-chat/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 3
+replicaCount: 1
 
 image:
   repository: hyperspot-mini-chat

--- a/modules/mini-chat/docs/DESIGN.md
+++ b/modules/mini-chat/docs/DESIGN.md
@@ -218,7 +218,7 @@ Where:
 - `effective_model_context_window` — from model catalog entry for the resolved effective_model (see `context_window` field)
 - `reserved_output_tokens` — `max_output_tokens` configured for the request (persisted as `chat_turns.max_output_tokens_applied`)
 
-When context exceeds the budget, the system truncates in reverse priority: retrieval excerpts first, then document summaries, then old messages (not summary). Thread summary and system prompt are never truncated.
+When context exceeds the budget, the system truncates in reverse priority: retrieval excerpts first, then document summaries, then old messages, then thread summary (droppable). System prompt and current user message are never truncated.
 
 The budget MUST be computed after `resolve_effective_model()` (i.e., after quota downgrade), because a downgraded model may have a smaller context window than the selected_model.
 
@@ -362,11 +362,11 @@ graph TB
 
   **Tier availability rule**: a tier is considered **available** only if it has remaining quota in **ALL** configured periods for that tier. If **ANY** period is exhausted, the tier is treated as exhausted and the downgrade cascade continues to the next tier. When all tiers are exhausted, the system rejects with `quota_exceeded`.
 
-  - **Phase 1 - Preflight (reserve) estimate** (on request start, before any streaming begins and before outbound call): estimate token usage from `ContextPlan` size + `max_output_tokens` (persisted as `max_output_tokens_applied`), convert to reserved credits using model multipliers (section 5.4.1), and reserve credits for quota enforcement. Decision: allow at requested tier / downgrade to next tier / reject if all tiers exhausted.
+  - **Phase 1 - Preflight (reserve) estimate** (on request start, before any streaming begins and before outbound call): estimate token usage from current message size + `prior_context_tokens` (actual `input_tokens + output_tokens` from the last completed turn, representing the conversation history that will be re-sent) + `max_output_tokens` (persisted as `max_output_tokens_applied`), convert to reserved credits using model multipliers (section 5.4.1), and reserve credits for quota enforcement. Decision: allow at requested tier / downgrade to next tier / reject if all tiers exhausted.
     - Reserve MUST prevent parallel requests from overspending remaining tier quota.
-    - Reserve SHOULD be keyed by `(user_id, period_type, period_start, bucket)` and reconciled on terminal outcome. Reserves MUST be checked across all configured period types (`daily`, `monthly`) and all required buckets for the current tier; if any period or bucket is exhausted, the tier is considered exhausted and the cascade proceeds to the next tier.
+    - Reserve MUST be keyed by `(tenant_id, user_id, period_type, period_start, bucket)` and reconciled on terminal outcome. Reserves MUST be checked across all configured period types (`daily`, `monthly`) and all required buckets for the current tier; if any period or bucket is exhausted, the tier is considered exhausted and the cascade proceeds to the next tier.
   - **Phase 2 - Commit actual** (on `event: done`): reconcile the reserve to actual provider usage (`response.usage.input_tokens` + `response.usage.output_tokens`), compute actual credits via model multipliers, and commit actual credits to `quota_usage`. If actual exceeds estimate (overshoot), the completed response is never retroactively cancelled, but guardrails apply:
-    - Commit MUST be atomic per `(user_id, period_type, period_start, bucket)` row (avoid race conditions under parallel streams)
+    - Commit MUST be atomic per `(tenant_id, user_id, period_type, period_start, bucket)` row (avoid race conditions under parallel streams)
     - If the remaining quota for a tier is below a configured negative threshold, preflight MUST downgrade new requests to the next tier in the cascade. The negative threshold is a configurable absolute credit value defined in quota configuration.
     - `max_output_tokens` and an explicit input budget MUST bound the maximum cost per request
   - **Streaming constraint**: quota check is preflight-only. Mid-stream abort due to quota is NOT supported (would produce broken UX and partial content). Mid-stream abort is only triggered by: user cancel, provider error, or infrastructure limits.
@@ -1543,9 +1543,14 @@ Thread summary generation MUST be driven by the estimated token size of the asse
 
 Before each LLM call, the system already constructs a `ContextPlan` and computes an estimated input token size for the final request payload (system prompt, current thread summary, recent messages, retrieval/document context, tools, and the new user message).
 
-The thread summary trigger MUST evaluate this assembled request estimate.
+The thread summary trigger MUST evaluate the `assembled_context_tokens` value computed during context assembly (which reflects the real conversation size: system prompt + thread summary + history messages + current user message).
 
-A summary SHOULD be triggered when the estimated assembled request input reaches a configurable compression threshold.
+A summary SHOULD be triggered under either of these conditions (OR):
+
+1. **Proactive (first summary):** `assembled_context_tokens >= compression_threshold_pct% of effective_budget` AND no existing summary. Default threshold: **80%**.
+2. **Urgent (re-summarize):** Context assembly had to truncate (drop) older messages (`messages_truncated = true`). This means the existing summary is stale and the conversation is losing context.
+
+When a summary already exists and context assembly is not truncating messages, the trigger MUST NOT fire — the existing summary is still effective.
 
 The default compression threshold SHOULD be **80% of the effective input token budget**.
 
@@ -1553,7 +1558,7 @@ The effective input token budget is defined as:
 
 `token_budget = min(configured_max_input_tokens, model_context_window - reserved_output_tokens)`
 
-If the estimated assembled request tokens exceed the compression threshold, the system SHOULD enqueue durable thread-summary work in the transaction that durably persists or finalizes the causing turn.
+If the trigger conditions above are met (proactive or urgent), the system MUST enqueue durable thread-summary work in the transaction that durably persists or finalizes the causing turn.
 
 **Heuristic triggers**
 
@@ -1582,6 +1587,9 @@ Such heuristics MUST NOT be used as the sole correctness criterion for summary g
 - A handler attempt MUST bind itself to the frozen target frontier carried by the durable outbox message.
 - The handler MUST load exactly the non-deleted, non-compressed messages whose order key is in `(base_frontier, frozen_target_frontier]`.
 - Messages appended after `frozen_target_frontier` MUST be excluded from the current run. They MUST NOT cancel, widen, or invalidate the in-flight run and are eligible only for a future summary cycle.
+- If the LLM call fails with a context-length-exceeded error (prompt too large for the summary model), the handler SHOULD retry by dropping the oldest messages from the prompt (up to 2 retries, dropping ~20% of messages each time). This PTL retry mechanism ensures summaries can be generated even for very long conversations.
+
+**Context assembly filtering**: when building the `ContextPlan` for a user turn, message queries (`recent_for_context`, `recent_after_boundary`) MUST filter `is_compressed = false` to exclude messages already covered by the thread summary. The `is_compressed` rows remain in the database for UI rendering (chat history display) but MUST NOT be sent to the LLM.
 
 4. **CAS-protected commit**
 
@@ -2161,13 +2169,13 @@ If the chat is soft-deleted before vector store creation completes, the creation
   - If the turn ran on premium tier (bucket `tier:premium`): `reserved_credits_micro -= turn_reserved_credits_micro; spent_credits_micro += turn_actual_credits_micro; calls += 1`.
   - Token telemetry counters (`input_tokens`, `output_tokens`) are updated only in bucket `total`.
 
-Both operations MUST target the correct `(user_id, period_type, period_start, bucket)` row(s) within the finalization transaction. Image accounting: on each turn that includes images, increment `image_inputs` by the number of images in the request on the `total` bucket row. On each image upload, increment `image_upload_bytes` by the uploaded file size on the `total` bucket row. Preflight checks MUST validate `image_upload_bytes` caps on upload requests and MUST validate `image_inputs` caps on send-message requests (plus any optional per-turn byte caps computed from attachment metadata).
+Both operations MUST target the correct `(tenant_id, user_id, period_type, period_start, bucket)` row(s) within the finalization transaction. Image accounting: on each turn that includes images, increment `image_inputs` by the number of images in the request on the `total` bucket row. On each image upload, increment `image_upload_bytes` by the uploaded file size on the `total` bucket row. Preflight checks MUST validate `image_upload_bytes` caps on upload requests and MUST validate `image_inputs` caps on send-message requests (plus any optional per-turn byte caps computed from attachment metadata).
 
 **PK**: `id`
 
-**Constraints**: UNIQUE on `(user_id, period_type, period_start, bucket)`.
+**Constraints**: UNIQUE on `(tenant_id, user_id, period_type, period_start, bucket)`.
 
-**Indexes**: `(user_id, period_type, period_start, bucket)` for quota lookups
+**Indexes**: `(tenant_id, user_id, period_type, period_start, bucket)` for quota lookups
 
 **Secure ORM**: `#[secure(tenant_col = "tenant_id", owner_col = "user_id", resource_col = "id", no_type)]`
 
@@ -2710,9 +2718,9 @@ On each user message, the domain service assembles a `ContextPlan` in this norma
 | Priority (highest first) | Item |
 |--------------------------|------|
 | 1 (never truncated) | System prompt + tool guard instructions |
-| 2 (never truncated) | Thread summary |
-| 3 | User message + image attachments (current turn) |
-| 4 | Recent messages |
+| 2 (never truncated) | User message + image attachments (current turn) |
+| 3 (droppable) | Thread summary — dropped if it doesn't fit after mandatory items |
+| 4 | Recent messages (oldest dropped first) |
 | 5 | Document summaries |
 | 6 (truncated first) | Retrieval excerpts |
 
@@ -2734,8 +2742,9 @@ token_budget = min(configured_max_input_tokens, effective_model.context_window -
 
 | Category | Items | Rule |
 |----------|-------|------|
-| Never truncated | System prompt + tool guard instructions, thread summary | Always included. If these alone exceed the budget, the turn is rejected at preflight. |
-| Truncatable | User message + image attachments, recent messages, document summaries, retrieval excerpts | Removed in reverse priority order (lowest priority first, per the table above). |
+| Never truncated | System prompt + tool guard instructions, user message + image attachments | Always included. If these alone exceed the budget, the turn is rejected at preflight. |
+| Droppable | Thread summary | Dropped if it doesn't fit after mandatory items. |
+| Truncatable | Recent messages, document summaries, retrieval excerpts | Removed in reverse priority order (lowest priority first, per the table above). |
 
 **Algorithm** (step by step):
 
@@ -2746,8 +2755,8 @@ token_budget = min(configured_max_input_tokens, effective_model.context_window -
    a. **Retrieval excerpts**: drop lowest-ranked chunks first, then reduce `retrieval_k` until retrieval is empty or budget is met.
    b. **Document summaries**: drop document summaries starting from the least relevant.
    c. **Recent messages**: drop oldest conversation turns first, preserving the most recent turns.
-   d. **User message**: never truncated. If the plan still exceeds the budget after steps a-c, reject at preflight with an oversize error.
-5. Thread summary is never truncated. If the system prompt + thread summary + user message alone exceed the budget, the turn MUST be rejected before any outbound call.
+   d. **Thread summary**: dropped entirely if it doesn't fit after steps a-c.
+   e. **User message**: never truncated. If the plan still exceeds the budget after steps a-d, reject at preflight with an oversize error.
 
 **Determinism note**: given identical inputs (same message history, same retrieval results, same model context window), the truncation algorithm MUST produce the same `ContextPlan`. This property is important for debugging and idempotent retry scenarios. Determinism applies to truncation and ordering logic given identical retrieval inputs. Retrieval results themselves may vary depending on provider behavior.
 
@@ -6895,7 +6904,9 @@ Concrete deployment keys for these parameters are integration-specific, but thei
 | `thread_summary.enabled` | `bool` | `true` | **ConfigMap** |
 | `thread_summary.queue_name` | `string` | implementation-defined | **ConfigMap** |
 | `thread_summary.partition_count` | `integer` | implementation-defined (e.g. 8) | **ConfigMap** |
-| `thread_summary.compression_threshold_pct` | — | `80` | **ConfigMap** |
+| `thread_summary.compression_threshold_pct` | `integer` | `80` | **ConfigMap** |
+| `thread_summary.message_content_limit` | `integer` | `4000` | **ConfigMap** |
+| `thread_summary.summary_model_id` | `string` | `""` (chat's model) | **ConfigMap** |
 | User turn interval trigger | — | `15` | **ConfigMap** |
 | `summary_quality.min_length` | — | — | **ConfigMap** |
 | `summary_quality.min_entropy` | — | — | **ConfigMap** |

--- a/modules/mini-chat/docs/openapi.json
+++ b/modules/mini-chat/docs/openapi.json
@@ -46,7 +46,9 @@
     "/v1/chats": {
       "post": {
         "operationId": "createChat",
-        "tags": ["chats"],
+        "tags": [
+          "chats"
+        ],
         "summary": "Create a new chat",
         "description": "Creates a chat for the authenticated user. The optional `model` field selects a model from the deployment model catalog; if omitted, the default model is resolved: the is_default premium model, or the first enabled premium model, or the first enabled standard model. The model is locked for the chat lifetime.",
         "requestBody": {
@@ -112,7 +114,9 @@
       },
       "get": {
         "operationId": "listChats",
-        "tags": ["chats"],
+        "tags": [
+          "chats"
+        ],
         "summary": "List chats for the current user",
         "description": "Returns chats for the authenticated user ordered by most recent activity (`updated_at` DESC, `id` DESC tiebreaker). Supports cursor-based pagination via `limit` and `cursor` parameters.\n\n**OData support**:\n- `$filter`: `title` — string functions `contains(title, '...')`, `startswith(title, '...')`, `endswith(title, '...')`; comparison operators `eq`, `ne`. Also supports `updated_at` (eq, ne, gt, ge, lt, le) and `id` (eq, ne).",
         "parameters": [
@@ -174,7 +178,9 @@
       ],
       "get": {
         "operationId": "getChat",
-        "tags": ["chats"],
+        "tags": [
+          "chats"
+        ],
         "summary": "Get chat metadata",
         "description": "Returns chat metadata (including selected model) and message_count. Does NOT embed messages; use `GET /v1/chats/{id}/messages` to load conversation history with cursor pagination.",
         "responses": {
@@ -230,7 +236,9 @@
       },
       "delete": {
         "operationId": "deleteChat",
-        "tags": ["chats"],
+        "tags": [
+          "chats"
+        ],
         "summary": "Delete a chat",
         "description": "Soft-deletes the chat and marks attachments for asynchronous cleanup. External provider resources (files, chat vector stores) are removed by a background cleanup worker with idempotent retries.",
         "responses": {
@@ -260,7 +268,9 @@
       },
       "patch": {
         "operationId": "updateChatTitle",
-        "tags": ["chats"],
+        "tags": [
+          "chats"
+        ],
         "summary": "Update chat title",
         "description": "Partial update — P1 allows updating only the `title` field. The title is trimmed; strings consisting entirely of whitespace are rejected. On success, `updated_at` is set to the current time. Does not affect messages, attachments, model, or is_temporary.",
         "requestBody": {
@@ -336,7 +346,9 @@
       ],
       "post": {
         "operationId": "sendMessage",
-        "tags": ["messages"],
+        "tags": [
+          "messages"
+        ],
         "summary": "Send message and receive streamed AI response",
         "description": "Sends a user message and opens an SSE stream for the assistant response. If `request_id` matches an active generation, returns 409 Conflict (JSON, no SSE). If `request_id` matches a completed generation, replays the response as SSE (side-effect-free: no new quota reserve, no billing events).\n\nThe optional `web_search` parameter enables web search for this turn (disabled by default, backward compatible).\n\n**Attachment fields**: `attachment_ids` identifies attachments explicitly attached to this message (persisted into `message_attachments`, returned in message `attachments[]`; images included in multimodal input for the current turn). In P1, retrieval always covers all documents in the chat vector store — `attachment_ids` does not scope or filter retrieval. `file_search` is only included when the chat has at least one ready document attachment.\n\n**SSE event ordering**: `stream_started ping* (delta | tool)* citations? (done | error)`. `delta` and `tool` may interleave; at most one `citations` event, emitted after all `delta` events and before the terminal event.\n\nExactly one terminal event (`done` or `error`) ends the stream.\n\n**SSE event types and payloads**:\n- `event: stream_started` — first event, carries `request_id`, assistant `message_id`, and `is_new_turn` flag. Payload: `SseStreamStartedEvent`.\n- `event: ping` — keepalive, payload: `{}`. Clients MUST ignore.\n- `event: delta` — incremental text. Payload: `SseDeltaEvent`.\n- `event: tool` — tool activity (file_search, web_search at P1). Payload: `SseToolEvent`.\n- `event: citations` — source references (file and web). Payload: `SseCitationsEvent`.\n- `event: done` — terminal success with usage and quota_decision. Emitted for both full completions and truncated-but-successful completions (provider `response.incomplete`). Payload: `SseDoneEvent`.\n- `event: error` — terminal failure. Payload: `SseErrorEvent`.\n\nSee component schemas for payload definitions.\n\n**Pre-stream errors**: If validation, authorization, or quota preflight fails before streaming, a JSON error response with the appropriate HTTP status is returned and no SSE stream is opened.\n\n**Cancellation**: If the client disconnects mid-stream, the server cancels the in-flight provider request and applies a bounded best-effort debit for quota. No SSE error event is emitted (the stream is already broken). The Turn Status API is authoritative for final state after disconnect.",
         "requestBody": {
@@ -377,12 +389,24 @@
                 "schema": {
                   "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `stream_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
                   "oneOf": [
-                    { "$ref": "#/components/schemas/SseStreamStartedEvent" },
-                    { "$ref": "#/components/schemas/SseDeltaEvent" },
-                    { "$ref": "#/components/schemas/SseToolEvent" },
-                    { "$ref": "#/components/schemas/SseCitationsEvent" },
-                    { "$ref": "#/components/schemas/SseDoneEvent" },
-                    { "$ref": "#/components/schemas/SseErrorEvent" }
+                    {
+                      "$ref": "#/components/schemas/SseStreamStartedEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseDeltaEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseToolEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseCitationsEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseDoneEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseErrorEvent"
+                    }
                   ]
                 }
               }
@@ -512,7 +536,9 @@
       ],
       "post": {
         "operationId": "uploadAttachment",
-        "tags": ["attachments"],
+        "tags": [
+          "attachments"
+        ],
         "summary": "Upload a document or image to a chat",
         "description": "Uploads a file as an attachment. MIME type determines `kind`: `image/png`, `image/jpeg`, `image/webp` produce `image` attachments; all other supported types produce `document` attachments. Documents are indexed in the chat's dedicated vector store and optionally summarized. Images are stored via the provider Files API but NOT indexed in vector stores. Returns immediately with `status: pending`; transitions to `ready` or `failed` asynchronously.\n\n**MIME inference**: When the browser sends `application/octet-stream` (common for `.md` and other text files), the server infers the actual MIME type from the file extension. Supported extensions include `.pdf`, `.md`, `.txt`, `.html`, `.docx`, `.pptx`, `.json`, `.csv`, and others.\n\n**CSV support**: `text/csv` files are accepted and internally remapped to `text/plain` for indexing compatibility. This behavior is controlled by server configuration (`allow_csv_upload`, default: true).",
         "requestBody": {
@@ -521,7 +547,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -635,7 +663,9 @@
       ],
       "get": {
         "operationId": "listMessages",
-        "tags": ["messages"],
+        "tags": [
+          "messages"
+        ],
         "summary": "List messages with cursor pagination",
         "description": "Returns paginated messages for a chat using cursor-based pagination with OData query support. Default ordering is `created_at asc` (chronological). Use `$orderby` and `$filter` for advanced queries.\n\n**OData support**:\n- `$orderby`: `created_at asc|desc`, `id asc|desc`\n- `$filter`: `created_at` (eq, ne, gt, ge, lt, le), `role` (eq, ne, in), `id` (eq, ne, in)",
         "parameters": [
@@ -653,15 +683,36 @@
           }
         ],
         "x-odata-orderby": {
-          "supported_fields": ["created_at", "id"],
-          "supported_directions": ["asc", "desc"],
+          "supported_fields": [
+            "created_at",
+            "id"
+          ],
+          "supported_directions": [
+            "asc",
+            "desc"
+          ],
           "default": "created_at asc"
         },
         "x-odata-filter": {
           "supported_fields": {
-            "created_at": ["eq", "ne", "gt", "ge", "lt", "le"],
-            "role": ["eq", "ne", "in"],
-            "id": ["eq", "ne", "in"]
+            "created_at": [
+              "eq",
+              "ne",
+              "gt",
+              "ge",
+              "lt",
+              "le"
+            ],
+            "role": [
+              "eq",
+              "ne",
+              "in"
+            ],
+            "id": [
+              "eq",
+              "ne",
+              "in"
+            ]
           }
         },
         "responses": {
@@ -759,7 +810,9 @@
       ],
       "get": {
         "operationId": "getAttachment",
-        "tags": ["attachments"],
+        "tags": [
+          "attachments"
+        ],
         "summary": "Get attachment status and metadata",
         "description": "Returns the current status and metadata of an attachment. Use this endpoint to poll for processing completion after upload (status transitions: `pending` -> `ready` or `pending` -> `failed`). The `doc_summary` field is populated asynchronously by a server background task and is null until processing completes (always null for images).",
         "responses": {
@@ -835,7 +888,9 @@
       },
       "delete": {
         "operationId": "deleteAttachment",
-        "tags": ["attachments"],
+        "tags": [
+          "attachments"
+        ],
         "summary": "Delete an attachment from the chat",
         "description": "Deletes an attachment if it is not referenced by any submitted message. If the attachment is referenced by a submitted message, the operation is rejected with 409 Conflict (attachment_locked). For eligible attachments, the attachment is soft-deleted locally and immediately removed from future retrieval and chat metadata. Provider-side file deletion and vector-store cleanup are performed asynchronously via background workers and are not required to complete before the API returns 204 No Content. Re-deleting an already-deleted attachment is idempotent and returns 204.",
         "responses": {
@@ -885,7 +940,9 @@
       ],
       "get": {
         "operationId": "getTurnStatus",
-        "tags": ["turns"],
+        "tags": [
+          "turns"
+        ],
         "summary": "Get authoritative turn status",
         "description": "Returns the authoritative server-side turn state for a given request_id. Used by the UI for disconnect recovery. Internal states map to API states: running->running, completed->done, failed->error, cancelled->cancelled. Includes error_code (when state is 'error') and assistant_message_id (when state is 'done') so clients can resolve lifecycle uncertainty after disconnect without listing or scanning message history. Retrieving the assistant message content itself may require one follow-up request. Billing outcome and provider internals are not exposed.",
         "responses": {
@@ -929,7 +986,9 @@
       },
       "patch": {
         "operationId": "editTurn",
-        "tags": ["turns"],
+        "tags": [
+          "turns"
+        ],
         "summary": "Edit the last user turn and regenerate response",
         "description": "Replaces the content of the last user message and generates a new assistant response via SSE. The previous turn is soft-deleted with `replaced_by_request_id` set. The server generates a new `request_id` for the new turn; the old `request_id` becomes replay-only (a completed `request_id` always returns the previously stored result). Original attachment associations from `attachment_ids` are preserved (copied to the new user message via `message_attachments`). Retrieval for the edited turn operates over the entire chat vector store (P1). Only the most recent non-deleted turn in a terminal state may be edited.",
         "requestBody": {
@@ -953,12 +1012,24 @@
                 "schema": {
                   "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `stream_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
                   "oneOf": [
-                    { "$ref": "#/components/schemas/SseStreamStartedEvent" },
-                    { "$ref": "#/components/schemas/SseDeltaEvent" },
-                    { "$ref": "#/components/schemas/SseToolEvent" },
-                    { "$ref": "#/components/schemas/SseCitationsEvent" },
-                    { "$ref": "#/components/schemas/SseDoneEvent" },
-                    { "$ref": "#/components/schemas/SseErrorEvent" }
+                    {
+                      "$ref": "#/components/schemas/SseStreamStartedEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseDeltaEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseToolEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseCitationsEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseDoneEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseErrorEvent"
+                    }
                   ]
                 }
               }
@@ -1027,7 +1098,9 @@
       },
       "delete": {
         "operationId": "deleteTurn",
-        "tags": ["turns"],
+        "tags": [
+          "turns"
+        ],
         "summary": "Delete the last turn",
         "description": "Soft-deletes the most recent turn (user message + assistant response). Only the latest non-deleted turn in a terminal state may be deleted. No replacement turn is created.",
         "responses": {
@@ -1087,7 +1160,9 @@
       ],
       "post": {
         "operationId": "retryTurn",
-        "tags": ["turns"],
+        "tags": [
+          "turns"
+        ],
         "summary": "Retry the last turn",
         "description": "Soft-deletes the previous turn and re-submits the original user message (including any attachment associations from `attachment_ids`, copied to the new user message via `message_attachments`) for a new assistant response via SSE. The server generates a new `request_id` for the new turn; the old `request_id` becomes replay-only (a completed `request_id` always returns the previously stored result). Retrieval for the retried turn operates over the entire chat vector store (P1). Only the most recent non-deleted turn in a terminal state may be retried. No request body is required; the original user message content and attachment associations are reused automatically.",
         "requestBody": {
@@ -1102,12 +1177,24 @@
                 "schema": {
                   "description": "Server-Sent Events stream. Each line is `event: <type>\\ndata: <JSON>\\n\\n`. Event ordering: `stream_started ping* (delta | tool)* citations? (done | error)`. Exactly one terminal event ends the stream.",
                   "oneOf": [
-                    { "$ref": "#/components/schemas/SseStreamStartedEvent" },
-                    { "$ref": "#/components/schemas/SseDeltaEvent" },
-                    { "$ref": "#/components/schemas/SseToolEvent" },
-                    { "$ref": "#/components/schemas/SseCitationsEvent" },
-                    { "$ref": "#/components/schemas/SseDoneEvent" },
-                    { "$ref": "#/components/schemas/SseErrorEvent" }
+                    {
+                      "$ref": "#/components/schemas/SseStreamStartedEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseDeltaEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseToolEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseCitationsEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseDoneEvent"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SseErrorEvent"
+                    }
                   ]
                 }
               }
@@ -1186,7 +1273,9 @@
       ],
       "put": {
         "operationId": "setReaction",
-        "tags": ["reactions"],
+        "tags": [
+          "reactions"
+        ],
         "summary": "Set like/dislike on an assistant message",
         "description": "Upserts a binary reaction on an assistant message. Only assistant messages may receive reactions. Idempotent: replaces any existing reaction for this user on this message.",
         "requestBody": {
@@ -1258,7 +1347,9 @@
       },
       "delete": {
         "operationId": "removeReaction",
-        "tags": ["reactions"],
+        "tags": [
+          "reactions"
+        ],
         "summary": "Remove reaction from an assistant message",
         "description": "Removes the current user's reaction from an assistant message. Idempotent: returns 204 whether or not a reaction existed.",
         "responses": {
@@ -1297,7 +1388,9 @@
     "/v1/models": {
       "get": {
         "operationId": "listModels",
-        "tags": ["models"],
+        "tags": [
+          "models"
+        ],
         "summary": "List models visible to the current user",
         "description": "Returns all models that are globally enabled in the policy catalog AND user-enabled for this user (allow-by-default semantics). Disabled models are never returned. The catalog is sourced from `minichat-policy-plugin` and cached in memory.",
         "responses": {
@@ -1333,7 +1426,9 @@
     "/v1/models/{model_id}": {
       "get": {
         "operationId": "getModel",
-        "tags": ["models"],
+        "tags": [
+          "models"
+        ],
         "summary": "Get a single model by ID",
         "description": "Returns the model only if it is visible to the current user (globally enabled AND user-enabled). Returns 404 if the model is globally disabled, user-disabled, or does not exist — to avoid leaking catalog details.",
         "parameters": [
@@ -1377,7 +1472,9 @@
     "/v1/quota/status": {
       "get": {
         "operationId": "getQuotaStatus",
-        "tags": ["quota"],
+        "tags": [
+          "quota"
+        ],
         "summary": "Get quota status for the authenticated user",
         "description": "Returns per-tier, per-period quota usage, remaining credits, warning flags, and the configured warning threshold. Useful for at-rest quota queries outside of a streaming turn.",
         "responses": {
@@ -1610,8 +1707,15 @@
     "schemas": {
       "ErrorResponse": {
         "type": "object",
-        "required": ["type", "title", "status", "detail", "instance", "code"],
-        "description": "Problem Details error envelope returned by mini-chat JSON errors and SSE terminal error events. Matches the runtime `Problem` serialization. In current handlers, the stable application error token is often carried in `title`; `code` may be an empty string unless explicitly populated. Error text MUST NOT contain provider-scoped identifiers (provider_file_id, vector_store_id, deployment names, upstream error bodies).",
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "instance",
+          "code"
+        ],
+        "description": "Problem Details error envelope (RFC 9457). Returned by all JSON error responses and SSE terminal `error` events.\n\n**Error codes** (in `code` field):\n\n| Code | HTTP | Description |\n|------|------|-------------|\n| `invalid_request` | 400 | Validation error (empty content, bad model, etc.) |\n| `web_search_disabled` | 400 | Web search disabled via kill switch |\n| `web_search_calls_exceeded` | 400 | Per-turn web search call limit reached |\n| `document_limit_exceeded` | 400 | Per-chat document count limit reached |\n| `storage_limit_exceeded` | 400 | Per-chat storage size limit reached |\n| `model_not_found` | 404 | Requested model not in catalog |\n| `unsupported_file_type` | 415 | Upload MIME type not allowed |\n| `file_too_large` | 413 | Upload exceeds size limit |\n| `quota_exhausted` | 429 | All quota tiers exhausted |\n| `generation_in_progress` | 409 | Another turn is already running in this chat |\n| `not_latest_turn` | 409 | Retry/edit/delete only allowed on the latest turn |\n| `invalid_turn_state` | 400 | Turn in wrong state for requested mutation |\n| `input_too_long` | 400 | User message exceeds model's max_input_tokens |\n| `rate_limited` | 429 | Provider rate limit (SSE error event) |\n| `provider_timeout` | 504 | Provider request timed out (SSE error event) |\n| `provider_error` | 502 | Provider returned an error (SSE error event) |\n| `provider_unavailable` | 502 | Provider unreachable (SSE error event) |\n| `service_unavailable` | 503 | Internal service unavailable |\n\nError text MUST NOT contain provider-scoped identifiers (provider_file_id, vector_store_id, response_id).",
         "properties": {
           "type": {
             "type": "string",
@@ -1638,11 +1742,17 @@
             "description": "Machine-readable application code. Always present in the payload; may be an empty string when the handler does not populate it explicitly."
           },
           "trace_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Trace identifier useful for correlating server logs."
           },
           "errors": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "description": "Optional list of validation violations for validation-style errors.",
             "items": {
               "$ref": "#/components/schemas/ValidationViolation"
@@ -1652,7 +1762,10 @@
       },
       "ValidationViolation": {
         "type": "object",
-        "required": ["field", "message"],
+        "required": [
+          "field",
+          "message"
+        ],
         "description": "Single validation violation entry included in `ErrorResponse.errors` when field-level validation details are available.",
         "properties": {
           "field": {
@@ -1664,14 +1777,23 @@
             "description": "Human-readable message describing the validation error."
           },
           "code": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Optional machine-readable validation code for this violation."
           }
         }
       },
       "Chat": {
         "type": "object",
-        "required": ["id", "model", "is_temporary", "created_at", "updated_at"],
+        "required": [
+          "id",
+          "model",
+          "is_temporary",
+          "created_at",
+          "updated_at"
+        ],
         "description": "Chat metadata. Returned by create, list, and as part of chat detail.",
         "properties": {
           "id": {
@@ -1683,7 +1805,10 @@
             "description": "Model identifier from the deployment model catalog. Locked at creation for the chat lifetime."
           },
           "title": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "maxLength": 255
           },
           "is_temporary": {
@@ -1709,7 +1834,9 @@
           },
           {
             "type": "object",
-            "required": ["message_count"],
+            "required": [
+              "message_count"
+            ],
             "properties": {
               "message_count": {
                 "type": "integer",
@@ -1722,7 +1849,15 @@
       },
       "Message": {
         "type": "object",
-        "required": ["id", "request_id", "role", "content", "attachments", "my_reaction", "created_at"],
+        "required": [
+          "id",
+          "request_id",
+          "role",
+          "content",
+          "attachments",
+          "my_reaction",
+          "created_at"
+        ],
         "description": "A single message in a chat (user, assistant, or system).",
         "properties": {
           "id": {
@@ -1736,21 +1871,34 @@
           },
           "role": {
             "type": "string",
-            "enum": ["user", "assistant", "system"]
+            "enum": [
+              "user",
+              "assistant",
+              "system"
+            ]
           },
           "content": {
             "type": "string"
           },
           "model": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Effective model used. Present on assistant messages; null on user/system messages."
           },
           "input_tokens": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "Actual input tokens. Present on assistant messages."
           },
           "output_tokens": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "description": "Actual output tokens. Present on assistant messages."
           },
           "attachments": {
@@ -1761,8 +1909,15 @@
             "description": "Always-present list of attachment summaries associated with this message. Contains lightweight metadata sufficient for UI rendering (kind, filename, status, thumbnail). Empty array when no attachments. Full attachment details (doc_summary, size_bytes, content_type, error_code) are available via GET /v1/chats/{id}/attachments/{attachment_id}."
           },
           "my_reaction": {
-            "type": ["string", "null"],
-            "enum": ["like", "dislike", null],
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "like",
+              "dislike",
+              null
+            ],
             "description": "The requesting user's reaction on this message. Null when no reaction exists or when the message role is not assistant (only assistant messages support reactions)."
           },
           "created_at": {
@@ -1773,7 +1928,15 @@
       },
       "Attachment": {
         "type": "object",
-        "required": ["id", "status", "kind", "filename", "content_type", "size_bytes", "created_at"],
+        "required": [
+          "id",
+          "status",
+          "kind",
+          "filename",
+          "content_type",
+          "size_bytes",
+          "created_at"
+        ],
         "description": "File attachment (document or image) on a chat.",
         "properties": {
           "id": {
@@ -1783,12 +1946,19 @@
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "ready", "failed"],
+            "enum": [
+              "pending",
+              "ready",
+              "failed"
+            ],
             "description": "Processing status. Transitions: pending -> ready or pending -> failed."
           },
           "kind": {
             "type": "string",
-            "enum": ["document", "image"],
+            "enum": [
+              "document",
+              "image"
+            ],
             "description": "Derived from MIME type. image/png, image/jpeg, image/webp -> image; all other supported types -> document."
           },
           "filename": {
@@ -1804,22 +1974,35 @@
             "format": "int64"
           },
           "doc_summary": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Server-generated document summary (asynchronous background task). Null until processing completes; always null for images. Never provided by the client."
           },
           "img_thumbnail": {
             "oneOf": [
-              { "$ref": "#/components/schemas/ImgThumbnail" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/ImgThumbnail"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "Server-generated preview thumbnail for image attachments. Null when kind is 'document', when kind is 'image' but thumbnail generation failed or was skipped, or when status is not 'ready'. Maximum decoded size (raw bytes before base64): 128 KiB by default (configurable via `thumbnail_max_bytes`). Stored internally in Mini Chat database only; never uploaded to provider. No provider identifiers. Never provided by the client."
           },
           "error_code": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Stable internal error code when status is 'failed' (e.g. 'index_failed', 'provider_upload_failed'). Null when status is 'pending' or 'ready'. No provider identifiers in this field."
           },
           "summary_updated_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "description": "Timestamp of summary generation."
           },
@@ -1831,7 +2014,11 @@
       },
       "TurnStatus": {
         "type": "object",
-        "required": ["request_id", "state", "updated_at"],
+        "required": [
+          "request_id",
+          "state",
+          "updated_at"
+        ],
         "description": "Authoritative server-side turn state for lifecycle resolution and disconnect recovery. Internal-to-API state mapping: running->running, completed->done, failed->error, cancelled->cancelled. Terminal states (done, error, cancelled) are immutable — once reached, the state never changes. Exactly one terminal outcome exists per (chat_id, request_id) pair. All terminal states indicate that quota settlement has been finalized atomically with the state transition. A state of 'done' guarantees that the full assistant message content is durably persisted and available for idempotent replay. Optional fields (error_code, assistant_message_id) provide actionable context so clients can resolve lifecycle uncertainty after disconnect without listing or scanning message history; retrieving the assistant message content may require one follow-up request. Billing outcome and provider internals are not exposed. chat_id is not included in the response body because it is already present in the URL path.",
         "properties": {
           "request_id": {
@@ -1840,7 +2027,12 @@
           },
           "state": {
             "type": "string",
-            "enum": ["running", "done", "error", "cancelled"],
+            "enum": [
+              "running",
+              "done",
+              "error",
+              "cancelled"
+            ],
             "description": "Turn state. 'done', 'error', 'cancelled' are terminal and immutable. 'error' indicates the turn failed — check error_code to determine if it was a provider failure (provider_error, provider_timeout) or a system timeout (orphan_timeout). 'cancelled' indicates client disconnect or internal abort — no SSE error event was emitted. Use this endpoint to resolve state after disconnect. IMPORTANT: error_code='orphan_timeout' means stream ended without provider terminal event (system timeout, NOT provider error); display 'Request timed out' to users, NOT 'Provider error'."
           },
           "error_code": {
@@ -1862,7 +2054,11 @@
       },
       "ReactionResponse": {
         "type": "object",
-        "required": ["message_id", "reaction", "created_at"],
+        "required": [
+          "message_id",
+          "reaction",
+          "created_at"
+        ],
         "properties": {
           "message_id": {
             "type": "string",
@@ -1870,7 +2066,10 @@
           },
           "reaction": {
             "type": "string",
-            "enum": ["like", "dislike"]
+            "enum": [
+              "like",
+              "dislike"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -1895,7 +2094,9 @@
       },
       "UpdateChatTitleRequest": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "description": "Request body for updating a chat title. Only `title` is updatable in P1.",
         "properties": {
           "title": {
@@ -1908,7 +2109,9 @@
       },
       "SendMessageRequest": {
         "type": "object",
-        "required": ["content"],
+        "required": [
+          "content"
+        ],
         "description": "Request body for sending a message. Opens an SSE stream on success. `attachment_ids` identifies attachments explicitly attached to this message (persisted, returned in message attachments array). In P1, retrieval always covers all documents in the chat vector store — `attachment_ids` does not scope or filter retrieval.",
         "properties": {
           "content": {
@@ -1937,7 +2140,9 @@
       },
       "EditTurnRequest": {
         "type": "object",
-        "required": ["content"],
+        "required": [
+          "content"
+        ],
         "description": "Request body for editing the last user turn. Original attachment associations from `attachment_ids` are preserved automatically (copied via message_attachments). Retrieval for the edited turn operates over the entire chat vector store (P1).",
         "properties": {
           "content": {
@@ -1948,17 +2153,26 @@
       },
       "SetReactionRequest": {
         "type": "object",
-        "required": ["reaction"],
+        "required": [
+          "reaction"
+        ],
         "properties": {
           "reaction": {
             "type": "string",
-            "enum": ["like", "dislike"]
+            "enum": [
+              "like",
+              "dislike"
+            ]
           }
         }
       },
       "SseStreamStartedEvent": {
         "type": "object",
-        "required": ["request_id", "message_id", "is_new_turn"],
+        "required": [
+          "request_id",
+          "message_id",
+          "is_new_turn"
+        ],
         "description": "SSE `event: stream_started` payload. First event in every SSE stream (both new generations and replays). Carries the server-assigned request_id, assistant message_id, and is_new_turn flag.",
         "properties": {
           "request_id": {
@@ -1974,18 +2188,27 @@
           "is_new_turn": {
             "type": "boolean",
             "description": "true for a live generation (new turn); false when the stream replays an already-completed turn (idempotent replay)."
+          },
+          "thread_summary_applied": {
+            "$ref": "#/components/schemas/ThreadSummaryInfo",
+            "description": "Present when a thread summary is included in the context window. Absent (not serialized) when no summary exists. UI can display an informational indicator (e.g. 'Conversation summarized')."
           }
         }
       },
       "SseDeltaEvent": {
         "type": "object",
-        "required": ["type", "content"],
+        "required": [
+          "type",
+          "content"
+        ],
         "description": "SSE `event: delta` payload. Streams incremental assistant text output.",
         "properties": {
           "type": {
             "type": "string",
             "description": "Content type. P1: always \"text\". Reserved for future: \"markdown\", \"structured\".",
-            "enum": ["text"]
+            "enum": [
+              "text"
+            ]
           },
           "content": {
             "type": "string",
@@ -1995,12 +2218,19 @@
       },
       "SseToolEvent": {
         "type": "object",
-        "required": ["phase", "name"],
+        "required": [
+          "phase",
+          "name"
+        ],
         "description": "SSE `event: tool` payload. Reports tool call activity (P1: file_search, web_search).",
         "properties": {
           "phase": {
             "type": "string",
-            "enum": ["start", "progress", "done"]
+            "enum": [
+              "start",
+              "progress",
+              "done"
+            ]
           },
           "name": {
             "type": "string",
@@ -2021,7 +2251,9 @@
       },
       "SseCitationsEvent": {
         "type": "object",
-        "required": ["items"],
+        "required": [
+          "items"
+        ],
         "description": "SSE `event: citations` payload. Delivers source references used in the answer. MAY include items from file_search (source=file) and/or web_search (source=web). Image inputs do not produce citations. Emitted at most once near stream completion before the terminal event (P1).",
         "properties": {
           "items": {
@@ -2034,12 +2266,19 @@
       },
       "CitationItem": {
         "type": "object",
-        "required": ["source", "title", "snippet"],
+        "required": [
+          "source",
+          "title",
+          "snippet"
+        ],
         "description": "A single citation reference. When source=\"file\", attachment_id is required. When source=\"web\", url is required.",
         "properties": {
           "source": {
             "type": "string",
-            "enum": ["file", "web"],
+            "enum": [
+              "file",
+              "web"
+            ],
             "description": "Citation source type. P1: \"file\" and \"web\" (when web search is enabled)."
           },
           "title": {
@@ -2060,8 +2299,12 @@
             "type": "object",
             "description": "Reserved for mapping citations to character positions in final assistant text.",
             "properties": {
-              "start": { "type": "integer" },
-              "end": { "type": "integer" }
+              "start": {
+                "type": "integer"
+              },
+              "end": {
+                "type": "integer"
+              }
             }
           },
           "snippet": {
@@ -2076,24 +2319,41 @@
           }
         },
         "if": {
-          "properties": { "source": { "const": "file" } }
+          "properties": {
+            "source": {
+              "const": "file"
+            }
+          }
         },
         "then": {
-          "required": ["attachment_id"]
+          "required": [
+            "attachment_id"
+          ]
         },
         "else": {
-          "required": ["url"]
+          "required": [
+            "url"
+          ]
         }
       },
       "SseDoneEvent": {
         "type": "object",
-        "required": ["usage", "effective_model", "selected_model", "quota_decision"],
+        "required": [
+          "usage",
+          "effective_model",
+          "selected_model",
+          "quota_decision"
+        ],
         "description": "SSE `event: done` payload. Terminal event finalizing the stream with usage and model selection metadata. Used for both full completions and truncated-but-successful completions (provider `response.incomplete`). The assistant message_id is provided in the preceding `stream_started` event.",
         "properties": {
           "usage": {
             "nullable": true,
             "description": "Token usage for this turn. Null when usage is unavailable (e.g. provider error before any tokens were consumed).",
-            "allOf": [{ "$ref": "#/components/schemas/SseUsage" }]
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SseUsage"
+              }
+            ]
           },
           "effective_model": {
             "type": "string",
@@ -2105,7 +2365,10 @@
           },
           "quota_decision": {
             "type": "string",
-            "enum": ["allow", "downgrade"],
+            "enum": [
+              "allow",
+              "downgrade"
+            ],
             "description": "Indicates whether the selected model was used as-is (allow) or a quota-driven downgrade occurred (downgrade). Always present."
           },
           "downgrade_from": {
@@ -2114,7 +2377,12 @@
           },
           "downgrade_reason": {
             "type": "string",
-            "enum": ["premium_quota_exhausted", "force_standard_tier", "disable_premium_tier", "model_disabled"],
+            "enum": [
+              "premium_quota_exhausted",
+              "force_standard_tier",
+              "disable_premium_tier",
+              "model_disabled"
+            ],
             "description": "Why downgrade occurred. Present only when quota_decision=\"downgrade\". Values: premium_quota_exhausted (user quota exhausted); force_standard_tier (operator kill switch: premium tier forcibly disabled for this tenant); disable_premium_tier (operator kill switch: premium tier globally disabled); model_disabled (operator kill switch: selected model global_enabled=false)."
           },
           "quota_warnings": {
@@ -2134,31 +2402,49 @@
             ]
           },
           "completion_signal": {
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "description": "Non-fatal completion signal. Null for normal completion. For truncated responses (provider `response.incomplete`) contains the truncation reason. Not an error indicator — the turn outcome is still `completed`.",
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["incomplete"]
+                "enum": [
+                  "incomplete"
+                ]
               },
               "reason": {
                 "type": "string",
                 "description": "Truncation reason from the canonical CompletionSignalReason enum (e.g. \"max_tokens\", \"content_filter\")."
               }
             },
-            "required": ["kind"]
+            "required": [
+              "kind"
+            ]
           }
         },
         "if": {
-          "properties": { "quota_decision": { "const": "downgrade" } }
+          "properties": {
+            "quota_decision": {
+              "const": "downgrade"
+            }
+          }
         },
         "then": {
-          "required": ["downgrade_from", "downgrade_reason"]
+          "required": [
+            "downgrade_from",
+            "downgrade_reason"
+          ]
         }
       },
       "SseUsage": {
         "type": "object",
-        "required": ["input_tokens", "output_tokens", "model"],
+        "required": [
+          "input_tokens",
+          "output_tokens",
+          "model"
+        ],
         "description": "Token usage reported in the terminal done event.",
         "properties": {
           "input_tokens": {
@@ -2192,7 +2478,9 @@
       },
       "PageInfo": {
         "type": "object",
-        "required": ["limit"],
+        "required": [
+          "limit"
+        ],
         "description": "Cursor-based pagination metadata following the platform OData-style convention.",
         "properties": {
           "limit": {
@@ -2200,18 +2488,27 @@
             "description": "The limit that was applied for this page."
           },
           "next_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Opaque cursor for fetching the next page. Null when there are no more results."
           },
           "prev_cursor": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Opaque cursor for fetching the previous page. Null on the first page."
           }
         }
       },
       "ChatsPage": {
         "type": "object",
-        "required": ["items", "page_info"],
+        "required": [
+          "items",
+          "page_info"
+        ],
         "description": "Paginated list of chats following the platform Page + PageInfo convention. Default ordering: `updated_at desc`, `id desc` (tiebreaker).",
         "properties": {
           "items": {
@@ -2227,7 +2524,10 @@
       },
       "MessagesPage": {
         "type": "object",
-        "required": ["items", "page_info"],
+        "required": [
+          "items",
+          "page_info"
+        ],
         "description": "Paginated list of messages following the platform Page + PageInfo convention.",
         "properties": {
           "items": {
@@ -2243,7 +2543,12 @@
       },
       "AttachmentSummary": {
         "type": "object",
-        "required": ["attachment_id", "kind", "filename", "status"],
+        "required": [
+          "attachment_id",
+          "kind",
+          "filename",
+          "status"
+        ],
         "description": "Lightweight attachment metadata embedded in Message objects. Contains only the fields needed for UI rendering of message history. Full details (doc_summary, size_bytes, content_type, error_code, etc.) are available via GET /v1/chats/{id}/attachments/{attachment_id}.",
         "properties": {
           "attachment_id": {
@@ -2252,7 +2557,10 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["document", "image"],
+            "enum": [
+              "document",
+              "image"
+            ],
             "description": "Attachment type. Derived from MIME type on upload."
           },
           "filename": {
@@ -2262,13 +2570,21 @@
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "ready", "failed"],
+            "enum": [
+              "pending",
+              "ready",
+              "failed"
+            ],
             "description": "Processing status."
           },
           "img_thumbnail": {
             "oneOf": [
-              { "$ref": "#/components/schemas/ImgThumbnail" },
-              { "type": "null" }
+              {
+                "$ref": "#/components/schemas/ImgThumbnail"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "Server-generated preview thumbnail. Present only when kind=image and status=ready. Null for documents and when thumbnail generation failed or was skipped."
           }
@@ -2276,12 +2592,19 @@
       },
       "ImgThumbnail": {
         "type": "object",
-        "required": ["content_type", "width", "height", "data_base64"],
+        "required": [
+          "content_type",
+          "width",
+          "height",
+          "data_base64"
+        ],
         "description": "Server-generated preview thumbnail for an image attachment. Produced during image upload processing using the Rust `image` crate. The thumbnail fits inside configured WxH dimensions (aspect ratio preserved, no cropping). Maximum decoded size (raw bytes before base64): 128 KiB by default (configurable via `thumbnail_max_bytes`). Stored internally in Mini Chat database only; never uploaded to provider Files API or external storage. No provider identifiers.",
         "properties": {
           "content_type": {
             "type": "string",
-            "enum": ["image/webp"],
+            "enum": [
+              "image/webp"
+            ],
             "description": "MIME type of the thumbnail image. P1: always image/webp."
           },
           "width": {
@@ -2304,7 +2627,10 @@
       },
       "QuotaDecision": {
         "type": "string",
-        "enum": ["allow", "downgrade"],
+        "enum": [
+          "allow",
+          "downgrade"
+        ],
         "description": "Deprecated as standalone schema — fields are now inlined on SseDoneEvent. Retained for backward reference only."
       },
       "MultimodalCapability": {
@@ -2313,7 +2639,14 @@
       },
       "Model": {
         "type": "object",
-        "required": ["model_id", "display_name", "tier", "multiplier_display", "multimodal_capabilities", "context_window"],
+        "required": [
+          "model_id",
+          "display_name",
+          "tier",
+          "multiplier_display",
+          "multimodal_capabilities",
+          "context_window"
+        ],
         "description": "A model visible to the current user. Does NOT expose provider, provider deployment IDs, credit multipliers, policy_version, max_output, or is_default.",
         "properties": {
           "model_id": {
@@ -2326,7 +2659,10 @@
           },
           "tier": {
             "type": "string",
-            "enum": ["standard", "premium"],
+            "enum": [
+              "standard",
+              "premium"
+            ],
             "description": "Rate-limit tier."
           },
           "multiplier_display": {
@@ -2352,7 +2688,9 @@
       },
       "ModelList": {
         "type": "object",
-        "required": ["items"],
+        "required": [
+          "items"
+        ],
         "description": "List of models visible to the current user.",
         "properties": {
           "items": {
@@ -2365,7 +2703,10 @@
       },
       "QuotaStatusResponse": {
         "type": "object",
-        "required": ["tiers", "warning_threshold_pct"],
+        "required": [
+          "tiers",
+          "warning_threshold_pct"
+        ],
         "description": "Full quota status for the authenticated user, broken down by tier and period.",
         "properties": {
           "tiers": {
@@ -2386,7 +2727,10 @@
       },
       "QuotaTierStatus": {
         "type": "object",
-        "required": ["tier", "periods"],
+        "required": [
+          "tier",
+          "periods"
+        ],
         "description": "Quota status for a single tier.",
         "properties": {
           "tier": {
@@ -2403,7 +2747,16 @@
       },
       "QuotaPeriodStatus": {
         "type": "object",
-        "required": ["period", "limit_credits_micro", "used_credits_micro", "remaining_credits_micro", "remaining_percentage", "next_reset", "warning", "exhausted"],
+        "required": [
+          "period",
+          "limit_credits_micro",
+          "used_credits_micro",
+          "remaining_credits_micro",
+          "remaining_percentage",
+          "next_reset",
+          "warning",
+          "exhausted"
+        ],
         "description": "Quota details for a single period within a tier.",
         "properties": {
           "period": {
@@ -2448,17 +2801,29 @@
       },
       "QuotaTier": {
         "type": "string",
-        "enum": ["premium", "total"],
+        "enum": [
+          "premium",
+          "total"
+        ],
         "description": "Quota tier classification."
       },
       "QuotaPeriod": {
         "type": "string",
-        "enum": ["daily", "monthly"],
+        "enum": [
+          "daily",
+          "monthly"
+        ],
         "description": "Quota period classification."
       },
       "QuotaWarning": {
         "type": "object",
-        "required": ["tier", "period", "remaining_percentage", "warning", "exhausted"],
+        "required": [
+          "tier",
+          "period",
+          "remaining_percentage",
+          "warning",
+          "exhausted"
+        ],
         "description": "Per-tier, per-period quota warning entry included in the SSE done event.",
         "properties": {
           "tier": {
@@ -2481,6 +2846,14 @@
           "exhausted": {
             "type": "boolean",
             "description": "True when remaining_percentage is 0."
+          },
+          "next_reset": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "RFC 3339 timestamp of the next quota period reset. Null when not applicable."
           }
         },
         "example": {
@@ -2489,6 +2862,21 @@
           "remaining_percentage": 8,
           "warning": true,
           "exhausted": false
+        }
+      },
+      "ThreadSummaryInfo": {
+        "type": "object",
+        "description": "Metadata about a thread summary applied to the current turn's context. Present in `stream_started` when the conversation has an active thread summary from a previous compression cycle.",
+        "required": [
+          "token_estimate"
+        ],
+        "properties": {
+          "token_estimate": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0,
+            "description": "Estimated token cost of the summary in the context window."
+          }
         }
       }
     }

--- a/modules/mini-chat/docs/plans/cleanup-worker/README.md
+++ b/modules/mini-chat/docs/plans/cleanup-worker/README.md
@@ -1,0 +1,60 @@
+# Cleanup Worker Implementation Plan
+
+Implements `cpt-cf-mini-chat-fr-chat-deletion-cleanup` (P1) from DESIGN.md.
+
+## Context
+
+Two distinct cleanup paths exist per design:
+
+1. **Per-attachment cleanup** — triggered by `DELETE /v1/chats/{chat_id}/attachments/{id}`.
+   Already enqueues `AttachmentCleanupEvent` into `mini-chat.attachment_cleanup` queue.
+   Handler (`AttachmentCleanupHandler`) is a P1 stub returning `Retry`.
+
+2. **Chat-deletion cleanup** — triggered by `DELETE /v1/chats/{id}`.
+   Currently only soft-deletes the chat row. Does NOT mark attachments as `pending`,
+   does NOT enqueue any cleanup event, and no `ChatCleanupEvent` type exists yet.
+
+Both paths converge on the same attachment cleanup state machine (`pending` → `done` | `failed`)
+and the vector-store ordering invariant (all attachments terminal before vector-store delete).
+
+## Architecture Decisions
+
+- **Outbox-driven, no module-local polling** — per design MUST.
+- **Per-attachment handler** deletes a single provider file (simple, one event = one file).
+- **Chat-level handler** receives a chat-scoped event, iterates pending attachments, then deletes vector store.
+- **Two separate outbox queues** — attachment cleanup partitioned by `tenant_id`, chat cleanup partitioned by `chat_id`.
+- **RagHttpClient.delete()** is already best-effort (no status check, 404 = success). Fits the idempotency requirement.
+- **SecurityContext for OAGW calls** — handler needs a way to construct/obtain a system-level security context for provider calls (no user session in background workers).
+
+## Rust Guidelines Applied (M-* from Microsoft Pragmatic Rust Guidelines)
+
+- **M-ERRORS-CANONICAL-STRUCTS**: cleanup errors use `FileStorageError` variants, mapped to `HandlerResult`.
+- **M-LOG-STRUCTURED**: structured tracing with named fields (tenant_id, chat_id, attachment_id, cleanup_status).
+- **M-PANIC-ON-BUG**: payload deserialization failure → `Reject` (dead-letter), not panic.
+- **M-CONCISE-NAMES**: `ChatCleanupHandler`, not `ChatCleanupManagerService`.
+- **M-SERVICES-CLONE**: handler structs hold `Arc<T>` deps, are `Send + Sync`.
+- **M-STATIC-VERIFICATION**: clippy clean, no `#[allow]` without `reason`.
+
+## Phases
+
+| Phase | File | Summary |
+|-------|------|---------|
+| 1 | [phase-1-repo-layer.md](phase-1-repo-layer.md) | Attachment & vector-store repo methods for cleanup queries/updates |
+| 2 | [phase-2-chat-cleanup-event.md](phase-2-chat-cleanup-event.md) | `ChatCleanupEvent`, outbox enqueuer, `delete_chat` transaction |
+| 3 | [phase-3-attachment-handler.md](phase-3-attachment-handler.md) | Implement `AttachmentCleanupHandler` (per-attachment file delete) |
+| 4 | [phase-4-chat-handler.md](phase-4-chat-handler.md) | Implement `ChatCleanupHandler` (chat-scoped batch + vector store) |
+| 5 | [phase-5-observability.md](phase-5-observability.md) | Prometheus metrics per design |
+| 6 | [phase-6-tests.md](phase-6-tests.md) | Unit + integration tests |
+
+## Dependency Graph
+
+```
+Phase 1 ──┬──► Phase 3 (uses repo methods)
+           │
+           └──► Phase 2 ──► Phase 4 (uses event + repo methods)
+                               │
+Phase 5 ◄─────────────────────┘ (metrics wired into handlers)
+Phase 6 depends on all above
+```
+
+Phases 2 and 3 can be developed in parallel after Phase 1.

--- a/modules/mini-chat/docs/plans/cleanup-worker/phase-1-repo-layer.md
+++ b/modules/mini-chat/docs/plans/cleanup-worker/phase-1-repo-layer.md
@@ -1,0 +1,112 @@
+# Phase 1: Repository Layer for Cleanup
+
+## Goal
+
+Add query and update methods to `AttachmentRepository` and `VectorStoreRepository` that the cleanup handlers need. No handler logic yet — pure data access.
+
+## Current State
+
+- `AttachmentRepository` trait (`domain/repos/attachment_repo.rs`) has no cleanup-related methods.
+- Entity (`infra/db/entity/attachment.rs`) already has columns: `cleanup_status`, `cleanup_attempts`, `last_cleanup_error`, `cleanup_updated_at`.
+- Migration already has `idx_attachments_cleanup` partial index on `cleanup_status WHERE cleanup_status IS NOT NULL AND deleted_at IS NULL`.
+- `VectorStoreRepository` has `find_by_chat()` and `delete()` — sufficient for Phase 4, but `delete()` uses AccessScope which is problematic for background workers (no user session).
+
+## Tasks
+
+### 1.1 Add `AttachmentRepository` trait methods
+
+File: `src/domain/repos/attachment_repo.rs`
+
+```rust
+/// Load all attachments for a soft-deleted chat that still need provider cleanup.
+/// `chat_id` is a globally unique UUID — no tenant scoping needed.
+async fn find_pending_cleanup_by_chat<C: DBRunner>(
+    &self,
+    runner: &C,
+    chat_id: Uuid,
+) -> Result<Vec<AttachmentModel>, DomainError>;
+
+/// Mark a single attachment's cleanup as done.
+/// Sets cleanup_status = 'done', cleanup_updated_at = now().
+/// Returns rows affected (0 if already terminal — idempotent).
+async fn mark_cleanup_done<C: DBRunner>(
+    &self,
+    runner: &C,
+    attachment_id: Uuid,
+) -> Result<u64, DomainError>;
+
+/// Record a retryable cleanup failure.
+/// Increments cleanup_attempts, sets last_cleanup_error, cleanup_updated_at = now().
+/// If cleanup_attempts >= max_attempts, transitions to 'failed' instead.
+/// Returns the new cleanup_status ('pending' or 'failed').
+async fn record_cleanup_attempt<C: DBRunner>(
+    &self,
+    runner: &C,
+    attachment_id: Uuid,
+    error: &str,
+    max_attempts: u32,
+) -> Result<String, DomainError>;
+
+/// Bulk-set cleanup_status = 'pending' for all non-deleted attachments of a chat
+/// that don't already have a cleanup_status set.
+/// Used in the chat-deletion transaction (Phase 2).
+/// Returns count of rows updated.
+async fn mark_attachments_pending_for_chat<C: DBRunner>(
+    &self,
+    runner: &C,
+    chat_id: Uuid,
+) -> Result<u64, DomainError>;
+```
+
+Design notes:
+- These methods do NOT take `AccessScope` — background workers have no user session. This is safe because the outbox message was originally enqueued within a scoped transaction.
+- No `tenant_id` in signatures — `chat_id` is a globally unique UUID, sufficient for all queries. Workers operate without authorization context.
+- `record_cleanup_attempt` encapsulates the state machine: if `attempts + 1 >= max_attempts`, it sets `cleanup_status = 'failed'`; otherwise keeps `'pending'`.
+- `find_pending_cleanup_by_chat` filters: `chat_id = $1 AND cleanup_status = 'pending' AND deleted_at IS NOT NULL` (attachments must be soft-deleted to be cleanup-eligible).
+
+### 1.2 Implement in infra layer
+
+File: `src/infra/db/repo/attachment_repo.rs`
+
+- `find_pending_cleanup_by_chat`: SeaORM `find()` with filter on `chat_id`, `cleanup_status = 'pending'`, `deleted_at IS NOT NULL`.
+- `mark_cleanup_done`: `update_many()` with CAS guard `cleanup_status = 'pending'`, set `cleanup_status = 'done'`, `cleanup_updated_at = now()`.
+- `record_cleanup_attempt`: Raw SQL or SeaORM expression update — `SET cleanup_attempts = cleanup_attempts + 1, last_cleanup_error = $error, cleanup_updated_at = now()` + conditional `cleanup_status = CASE WHEN cleanup_attempts + 1 >= $max THEN 'failed' ELSE 'pending' END` with CAS guard `cleanup_status = 'pending'`. Return the resulting status via `RETURNING cleanup_status` or a follow-up read.
+- `mark_attachments_pending_for_chat`: `update_many()` filter `chat_id = $1 AND cleanup_status IS NULL AND deleted_at IS NULL`, set `cleanup_status = 'pending'`, `cleanup_updated_at = now()`. (Note: `deleted_at IS NULL` because at this point in the TX the chat is being soft-deleted but individual attachments haven't been soft-deleted yet — they get `cleanup_status = 'pending'` as the marker.)
+
+### 1.3 Add `VectorStoreRepository` system-scoped methods
+
+File: `src/domain/repos/vector_store_repo.rs`
+
+The existing `find_by_chat()` and `delete()` require `AccessScope`. Background workers don't have one. Add unscoped variants:
+
+```rust
+/// Find vector store row for a chat (system context, no access scope).
+/// `chat_id` is globally unique — no tenant scoping needed.
+async fn find_by_chat_system<C: DBRunner>(
+    &self,
+    runner: &C,
+    chat_id: Uuid,
+) -> Result<Option<VectorStoreModel>, DomainError>;
+
+/// Hard-delete vector store row (system context, no access scope).
+async fn delete_system<C: DBRunner>(
+    &self,
+    runner: &C,
+    id: Uuid,
+) -> Result<u64, DomainError>;
+```
+
+Implementation: Same as existing methods but without `.secure().scope_with(scope)` — filter by `chat_id` (or `id`) directly.
+
+### 1.4 Test helper updates
+
+File: `src/domain/service/test_helpers.rs`
+
+Add mock implementations for the new trait methods in `MockAttachmentRepository` and `MockVectorStoreRepository` (or whichever mock pattern is used).
+
+## Acceptance Criteria
+
+- [ ] All new trait methods compile and have infra implementations
+- [ ] Unit tests for each repo method (SQLite in-memory)
+- [ ] CAS guards prevent double-transitions (e.g., marking `done` twice is idempotent, returns 0)
+- [ ] `record_cleanup_attempt` correctly transitions to `failed` at threshold

--- a/modules/mini-chat/docs/plans/cleanup-worker/phase-2-chat-cleanup-event.md
+++ b/modules/mini-chat/docs/plans/cleanup-worker/phase-2-chat-cleanup-event.md
@@ -1,0 +1,141 @@
+# Phase 2: Chat Cleanup Event & Enqueue
+
+## Goal
+
+Define the `ChatCleanupEvent`, add it to the outbox enqueuer, register a new outbox queue, and update `delete_chat` to atomically soft-delete + mark attachments pending + enqueue the cleanup event.
+
+## Current State
+
+- `delete_chat` in `chat_service.rs:247-267` only calls `chat_repo.soft_delete()`. No outbox event.
+- `OutboxEnqueuer` trait has no `enqueue_chat_cleanup` method.
+- `OutboxConfig` has no `chat_cleanup_queue_name`.
+- No `ChatCleanupEvent` type exists.
+
+## Tasks
+
+### 2.1 Define `ChatCleanupEvent` and `CleanupReason` enum
+
+File: `src/domain/repos/outbox_enqueuer.rs`
+
+Per DESIGN.md (line 1758), the payload must contain `tenant_id`, `chat_id`, `system_request_id`, `reason`, `chat_deleted_at`.
+
+```rust
+/// Why provider cleanup was triggered.
+/// Enum ensures exhaustive match in the handler and prevents typo-driven bugs
+/// (M-STRONG-TYPES).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CleanupReason {
+    /// Chat was explicitly soft-deleted by the user.
+    ChatSoftDelete,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatCleanupEvent {
+    pub reason: CleanupReason,
+    pub chat_id: Uuid,
+    pub system_request_id: Uuid,         // Stable UUID v4, persisted at enqueue, reused across retries
+    pub chat_deleted_at: OffsetDateTime,
+}
+```
+
+**`tenant_id` is included** per DESIGN.md line 1758 (MUST). Workers don't use it for DB queries (chat_id is globally unique), but it's required for structured logging and traceability.
+
+**Why no `event_type: String`?** The existing `AttachmentCleanupEvent` uses a `String` `event_type` field. For the new event, `CleanupReason` enum replaces this — stronger typing catches mismatches at compile time (M-STRONG-TYPES). Consider also migrating `AttachmentCleanupEvent.event_type` to an enum in a follow-up.
+
+### 2.2 Add `enqueue_chat_cleanup` to `OutboxEnqueuer` trait
+
+File: `src/domain/repos/outbox_enqueuer.rs`
+
+```rust
+async fn enqueue_chat_cleanup(
+    &self,
+    runner: &(dyn DBRunner + Sync),
+    event: ChatCleanupEvent,
+) -> Result<(), DomainError>;
+```
+
+### 2.3 Add queue name to config
+
+File: `src/config.rs` — `OutboxConfig` struct
+
+```rust
+/// Queue name for chat-deletion cleanup events.
+#[serde(default = "default_chat_cleanup_queue_name")]
+pub chat_cleanup_queue_name: String,
+```
+
+Default: `"mini-chat.chat_cleanup"`.
+
+Update `validate()` to check non-empty. Update `Default` impl.
+
+### 2.4 Implement `enqueue_chat_cleanup` in infra
+
+File: `src/infra/outbox.rs` — `InfraOutboxEnqueuer`
+
+- Store `chat_cleanup_queue_name` field.
+- Partition by `chat_id` — per design: "queue SHOULD partition by chat_id so that all cleanup messages for the same chat are assigned to the same partition and processed sequentially". Different chats clean up in parallel across partitions.
+- Reuse the same hash-modulo approach as `partition_for()` but keyed on `chat_id`.
+
+```rust
+async fn enqueue_chat_cleanup(
+    &self,
+    runner: &(dyn DBRunner + Sync),
+    event: ChatCleanupEvent,
+) -> Result<(), DomainError> {
+    let partition = self.partition_for(event.chat_id); // hash chat_id → partition
+    let payload = serde_json::to_vec(&event)...;
+    self.outbox.enqueue(runner, &self.chat_cleanup_queue_name, partition, payload, "application/json").await...;
+    Ok(())
+}
+```
+
+### 2.5 Update `delete_chat` service method
+
+File: `src/domain/service/chat_service.rs`
+
+The current flow:
+1. Resolve access scope
+2. `chat_repo.soft_delete()`
+
+New flow (single transaction):
+1. Resolve access scope
+2. Start transaction
+3. `chat_repo.soft_delete()` — sets `chats.deleted_at`
+4. `attachment_repo.mark_attachments_pending_for_chat()` — sets `cleanup_status = 'pending'` on all chat attachments (from Phase 1)
+5. `outbox_enqueuer.enqueue_chat_cleanup()` — enqueues `ChatCleanupEvent`
+6. Commit transaction
+7. `outbox_enqueuer.flush()` — notify outbox sequencer
+
+The `system_request_id` is `Uuid::new_v4()` generated once at enqueue time.
+
+**Important**: The service currently uses `self.db.conn()` (not a transaction). This must change to `self.db.transaction()` to ensure atomicity of all three operations.
+
+### 2.6 Register chat cleanup queue in module.rs
+
+File: `src/module.rs` (around line 205)
+
+Add a new queue registration in the outbox builder:
+
+```rust
+.queue(&chat_cleanup_queue_name, partitions)
+.decoupled(ChatCleanupHandler::new(/* deps */))
+```
+
+For now (before Phase 4), register with a stub handler that returns `Retry`, similar to current `AttachmentCleanupHandler`.
+
+### 2.7 Update test helpers
+
+File: `src/domain/service/test_helpers.rs`
+
+- Add `chat_cleanup_events: Mutex<Vec<ChatCleanupEvent>>` to `RecordingOutboxEnqueuer`
+- Implement `enqueue_chat_cleanup` to record events
+
+## Acceptance Criteria
+
+- [ ] `ChatCleanupEvent` serializes/deserializes correctly
+- [ ] `delete_chat` atomically: soft-deletes chat, marks attachments pending, enqueues event
+- [ ] Chat cleanup queue is registered in module startup
+- [ ] Existing `delete_chat` tests updated to verify event enqueue
+- [ ] New test: `delete_chat` on chat with attachments → attachments get `cleanup_status = 'pending'`
+- [ ] New test: `delete_chat` on chat with no attachments → event still enqueued (handler handles empty attachment list gracefully)

--- a/modules/mini-chat/docs/plans/cleanup-worker/phase-3-attachment-handler.md
+++ b/modules/mini-chat/docs/plans/cleanup-worker/phase-3-attachment-handler.md
@@ -1,0 +1,119 @@
+# Phase 3: Per-Attachment Cleanup Handler
+
+## Goal
+
+Implement `AttachmentCleanupHandler` to actually delete a single provider file when an attachment is deleted via the attachment-deletion API path.
+
+## Current State
+
+- Stub returns `HandlerResult::Retry` for every message.
+- `AttachmentCleanupEvent` already exists with `provider_file_id`, `storage_backend`, `attachment_kind`.
+- `RagHttpClient.delete()` is best-effort (404 = success, no status check).
+- Handler is registered in `module.rs` as `.decoupled(AttachmentCleanupHandler)`.
+
+## Design Constraints (from DESIGN.md)
+
+- 404 from provider = success (idempotency).
+- On success: `cleanup_status = 'done'`, `cleanup_updated_at = now()`.
+- On retryable failure: increment `cleanup_attempts`, record error, keep `pending`, return `Retry`.
+- On `cleanup_attempts >= max_attempts`: `cleanup_status = 'failed'`, return `Reject`.
+- Attachment-level cleanup MUST NOT process attachments whose parent chat is soft-deleted (ownership transfers to chat-deletion path).
+
+## Tasks
+
+### 3.1 Add dependencies to handler struct
+
+File: `src/infra/workers/cleanup_worker.rs`
+
+```rust
+pub struct AttachmentCleanupHandler {
+    rag_client: Arc<RagHttpClient>,
+    attachment_repo: Arc<dyn AttachmentRepository>,
+    db: Arc<dyn DatabaseProvider>,       // for DB connection
+    max_attempts: u32,                    // from CleanupWorkerConfig
+    oagw_route_prefix: String,           // e.g., "/outbound/llm" — to build DELETE URI
+}
+```
+
+### 3.2 Implement handle()
+
+```rust
+async fn handle(&self, msg: &OutboxMessage, cancel: CancellationToken) -> HandlerResult {
+    // 1. Deserialize payload
+    let event: AttachmentCleanupEvent = match serde_json::from_slice(&msg.payload) {
+        Ok(e) => e,
+        Err(e) => return HandlerResult::Reject {
+            reason: format!("invalid payload: {e}"),
+        },
+    };
+
+    // 2. Guard: skip if parent chat is soft-deleted (ownership transferred to chat-deletion path)
+    //    Check chats.deleted_at via a lightweight query.
+    //    If chat is deleted → Ok (ack as no-op; chat-deletion handler owns cleanup).
+
+    // 3. Build DELETE URI from event fields
+    //    URI pattern depends on storage_backend + attachment_kind:
+    //    - provider_file_id → DELETE {oagw_route_prefix}/files/{provider_file_id}
+
+    // 4. Call RagHttpClient.delete() with system SecurityContext
+    //    RagHttpClient.delete() is already idempotent (404 = success).
+
+    // 5. On success → mark_cleanup_done(attachment_id)
+    //    Return HandlerResult::Success
+
+    // 6. On error → record_cleanup_attempt(attachment_id, error, max_attempts)
+    //    If returned status = "failed" → HandlerResult::Reject
+    //    If returned status = "pending" → HandlerResult::Retry
+}
+```
+
+### 3.3 System SecurityContext
+
+The handler runs in a background worker — no user session. Need a way to construct a system-level `SecurityContext` for OAGW calls.
+
+Options:
+- Check if `SecurityContext` has a `system()` or `service()` constructor.
+- Or construct from `tenant_id` in the event payload with a service-account identity.
+
+Investigate how `UsageEventHandler` or other background code obtains credentials for outbound calls. The OAGW `proxy_request` may need specific auth headers.
+
+### 3.4 Wire dependencies in module.rs
+
+File: `src/module.rs`
+
+Change from:
+```rust
+.decoupled(crate::infra::workers::cleanup_worker::AttachmentCleanupHandler)
+```
+
+To:
+```rust
+.decoupled(AttachmentCleanupHandler::new(
+    rag_client.clone(),
+    attachment_repo.clone(),
+    db.clone(),
+    config.cleanup_worker.max_attempts,
+    oagw_route_prefix.clone(),
+))
+```
+
+### 3.5 Handle cancellation
+
+Check `cancel.is_cancelled()` before the provider call. If cancelled, return `Retry` to allow graceful shutdown without losing work.
+
+## Open Questions
+
+1. **System SecurityContext construction** — how does a background worker authenticate to OAGW? This may require investigation of existing patterns (e.g., service tokens, tenant-scoped system contexts).
+2. **OAGW route prefix** — what's the exact DELETE URI pattern? Check existing file upload/delete code paths for the route structure.
+3. **Chat soft-delete guard** — **Settled**: handler checks `chats.deleted_at` via `is_deleted_system()`. If parent chat is soft-deleted, returns `MessageResult::Ok` (no-op ack) — ownership transferred to chat-deletion handler. Implemented in `cleanup_worker.rs:124-131`.
+
+## Acceptance Criteria
+
+- [ ] Handler deserializes `AttachmentCleanupEvent` and calls provider DELETE
+- [ ] Success → `cleanup_status = 'done'`, returns `Success`
+- [ ] Retryable error → increments attempts, returns `Retry`
+- [ ] Max attempts exceeded → `cleanup_status = 'failed'`, returns `Reject`
+- [ ] Invalid payload → `Reject` (dead-letter)
+- [ ] Parent chat soft-deleted → ack as no-op success (ownership transferred to chat-deletion handler)
+- [ ] Cancellation token respected
+- [ ] Structured tracing for each outcome

--- a/modules/mini-chat/docs/plans/cleanup-worker/phase-4-chat-handler.md
+++ b/modules/mini-chat/docs/plans/cleanup-worker/phase-4-chat-handler.md
@@ -1,0 +1,200 @@
+# Phase 4: Chat-Level Cleanup Handler
+
+## Goal
+
+Implement `ChatCleanupHandler` that processes a chat-scoped cleanup event: iterates all pending attachments, deletes provider files, then deletes the vector store.
+
+## Design Requirements (from DESIGN.md)
+
+### Attachment cleanup loop
+- Load all attachments with `cleanup_status = 'pending'` for the chat.
+- For each: call provider DELETE via OAGW → update `cleanup_status`.
+- 404 from provider = success.
+- On retryable failure: increment attempts, record error, keep `pending`.
+- On `attempts >= max_attempts`: set `failed` (terminal).
+
+### Vector store cleanup ordering
+- Vector store is delete-eligible only when ALL attachment rows are terminal (`done` or `failed`).
+- MUST NOT delete vector store while any attachment is `pending`.
+- If delete-eligible with any `failed` attachments: emit `mini_chat_cleanup_vector_store_with_failed_attachments_total` metric, proceed with deletion.
+- On successful delete or 404: hard-delete `chat_vector_stores` row (durable completion marker).
+- On retryable failure: leave row, return `Retry`.
+
+### Idempotency
+- Handler may be invoked multiple times for the same event (outbox redelivery).
+- Must be idempotent: skip already-terminal attachments, skip already-deleted vector stores.
+
+### Guard
+- Active chats (`chats.deleted_at IS NULL`) MUST NOT be processed.
+
+## Tasks
+
+### 4.1 Create `ChatCleanupHandler` struct
+
+File: `src/infra/workers/cleanup_worker.rs` (or a new `chat_cleanup_worker.rs`)
+
+```rust
+pub struct ChatCleanupHandler {
+    rag_client: Arc<RagHttpClient>,
+    attachment_repo: Arc<dyn AttachmentRepository>,
+    vector_store_repo: Arc<dyn VectorStoreRepository>,
+    chat_repo: Arc<dyn ChatRepository>,         // to verify chat is deleted
+    db: Arc<dyn DatabaseProvider>,
+    max_attempts: u32,
+    oagw_route_prefix: String,
+}
+```
+
+### 4.2 Implement handle()
+
+```rust
+async fn handle(&self, msg: &OutboxMessage, cancel: CancellationToken) -> HandlerResult {
+    // 1. Deserialize ChatCleanupEvent (no tenant_id — chat_id is globally unique)
+    let event: ChatCleanupEvent = match serde_json::from_slice(&msg.payload) {
+        Ok(e) => e,
+        Err(e) => return HandlerResult::Reject { reason: ... },
+    };
+
+    // 2. Guard: verify chat is actually soft-deleted (query by chat_id, no scope)
+    //    If chats.deleted_at IS NULL → Reject (programming error or race)
+
+    // 3. Load pending attachments
+    let pending = attachment_repo.find_pending_cleanup_by_chat(
+        &conn, event.chat_id
+    ).await?;
+
+    // 4. Process each attachment
+    let mut any_retry = false;
+    for att in &pending {
+        if cancel.is_cancelled() {
+            return HandlerResult::Retry { reason: "shutdown".into() };
+        }
+
+        match self.delete_provider_file(att).await {
+            Ok(()) => {
+                attachment_repo.mark_cleanup_done(&conn, att.id).await?;
+            }
+            Err(e) => {
+                let status = attachment_repo.record_cleanup_attempt(
+                    &conn, att.id, &e.to_string(), self.max_attempts
+                ).await?;
+                if status == "pending" {
+                    any_retry = true;
+                }
+                // if "failed" → terminal, continue to next attachment
+            }
+        }
+    }
+
+    // 5. If any attachment is still pending → Retry (come back later)
+    if any_retry {
+        return HandlerResult::Retry {
+            reason: "some attachments still pending".into(),
+        };
+    }
+
+    // 6. Vector store cleanup
+    //    Load chat_vector_stores row. If no row → all done.
+    let vs = vector_store_repo.find_by_chat_system(&conn, event.chat_id).await?;
+    if let Some(vs_row) = vs {
+        // Re-check: all attachments must be terminal (no pending left)
+        let still_pending = attachment_repo.find_pending_cleanup_by_chat(
+            &conn, event.chat_id
+        ).await?;
+        if !still_pending.is_empty() {
+            return HandlerResult::Retry { reason: "attachments still pending" };
+        }
+
+        // Check for failed attachments → emit metric if any
+        // (query count of cleanup_status = 'failed' for this chat)
+
+        // Delete vector store via OAGW
+        if let Some(vs_id) = &vs_row.vector_store_id {
+            match self.delete_vector_store(&event, vs_id).await {
+                Ok(()) => {}
+                Err(e) => {
+                    return HandlerResult::Retry {
+                        reason: format!("vector store delete failed: {e}"),
+                    };
+                }
+            }
+        }
+
+        // Hard-delete chat_vector_stores row (durable completion marker)
+        vector_store_repo.delete_system(&conn, vs_row.id).await?;
+    }
+
+    // 7. All done
+    HandlerResult::Success
+}
+```
+
+### 4.3 Provider delete helpers
+
+```rust
+impl ChatCleanupHandler {
+    async fn delete_provider_file(
+        &self,
+        att: &AttachmentModel,
+    ) -> Result<(), FileStorageError> {
+        if let Some(ref file_id) = att.provider_file_id {
+            let uri = format!("{}/files/{}", self.oagw_route_prefix, file_id);
+            // System-level SecurityContext from client credentials (no tenant/user session).
+            let ctx = self.system_security_context();
+            self.rag_client.delete(ctx, &uri).await
+        } else {
+            // No provider file to delete — treat as success
+            Ok(())
+        }
+    }
+
+    async fn delete_vector_store(
+        &self,
+        vector_store_id: &str,
+    ) -> Result<(), FileStorageError> {
+        let uri = format!("{}/vector_stores/{}", self.oagw_route_prefix, vector_store_id);
+        let ctx = self.system_security_context();
+        self.rag_client.delete(ctx, &uri).await
+    }
+}
+```
+
+### 4.4 Register in module.rs
+
+```rust
+.queue(&chat_cleanup_queue_name, partitions)
+.decoupled(ChatCleanupHandler::new(
+    rag_client.clone(),
+    attachment_repo.clone(),
+    vector_store_repo.clone(),
+    chat_repo.clone(),
+    db.clone(),
+    config.cleanup_worker.max_attempts,
+    oagw_route_prefix.clone(),
+))
+```
+
+### 4.5 Error handling strategy
+
+| Scenario | Action |
+|----------|--------|
+| Payload deserialization fails | `Reject` (dead-letter) |
+| Chat not soft-deleted | `Reject` (guard violation) |
+| Provider 5xx / timeout | `record_cleanup_attempt`, `Retry` |
+| Provider 4xx (not 404) | `record_cleanup_attempt`, may become `failed` |
+| DB error | `Retry` (transient infra) |
+| All attachments terminal, VS deleted | `Success` |
+| Some attachments still `pending` after batch | `Retry` |
+| Cancellation token fired | `Retry` (graceful shutdown) |
+
+## Acceptance Criteria
+
+- [ ] Chat guard: rejects event if chat is not soft-deleted
+- [ ] Processes all pending attachments, marks each done/failed
+- [ ] Respects max_attempts per attachment
+- [ ] Vector store deleted only after all attachments are terminal
+- [ ] Metric emitted when vector store deleted with failed attachments
+- [ ] chat_vector_stores row hard-deleted on VS cleanup success
+- [ ] Idempotent: safe to re-run on same event
+- [ ] Cancellation-aware within the attachment loop
+- [ ] Structured tracing for every state transition

--- a/modules/mini-chat/docs/plans/cleanup-worker/phase-5-observability.md
+++ b/modules/mini-chat/docs/plans/cleanup-worker/phase-5-observability.md
@@ -1,0 +1,94 @@
+# Phase 5: Observability
+
+## Goal
+
+Add Prometheus metrics specified in DESIGN.md for cleanup operations.
+
+## Required Metrics (from DESIGN.md line 1800-1806)
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `mini_chat_cleanup_completed_total` | counter | `resource_type=file\|vector_store` | Successful cleanup operations |
+| `mini_chat_cleanup_failed_total` | counter | `resource_type=file` | Attachments reaching terminal `failed` |
+| `mini_chat_cleanup_retry_total` | counter | `resource_type=file\|vector_store`, `reason` | Retries delegated to outbox |
+| `mini_chat_cleanup_backlog` | gauge | `state=pending\|failed`, `resource_type=file` | Current cleanup backlog from attachment row states |
+| `mini_chat_cleanup_vector_store_with_failed_attachments_total` | counter | — | VS deleted with at least one `failed` attachment |
+
+## Tasks
+
+### 5.1 Define metric constants
+
+File: `src/infra/workers/cleanup_metrics.rs` (new file)
+
+Use `prometheus` or whatever metrics crate the project uses. Check existing metrics patterns in the codebase.
+
+```rust
+use once_cell::sync::Lazy;
+use prometheus::{IntCounterVec, IntGaugeVec, register_int_counter_vec, register_int_gauge_vec};
+
+pub static CLEANUP_COMPLETED: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "mini_chat_cleanup_completed_total",
+        "Successful provider cleanup operations",
+        &["resource_type"]
+    ).unwrap()
+});
+
+pub static CLEANUP_FAILED: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "mini_chat_cleanup_failed_total",
+        "Attachments reaching terminal failed state",
+        &["resource_type"]
+    ).unwrap()
+});
+
+pub static CLEANUP_RETRY: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "mini_chat_cleanup_retry_total",
+        "Cleanup retries delegated to shared outbox",
+        &["resource_type", "reason"]
+    ).unwrap()
+});
+
+pub static CLEANUP_BACKLOG: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "mini_chat_cleanup_backlog",
+        "Current cleanup backlog by state",
+        &["state", "resource_type"]
+    ).unwrap()
+});
+
+pub static CLEANUP_VS_WITH_FAILED: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "mini_chat_cleanup_vector_store_with_failed_attachments_total",
+        "Vector store deletions with at least one failed attachment"
+    ).unwrap()
+});
+```
+
+### 5.2 Instrument handlers
+
+Wire metric increments into `AttachmentCleanupHandler` and `ChatCleanupHandler`:
+
+- On `mark_cleanup_done` → `CLEANUP_COMPLETED.with_label_values(&["file"]).inc()`
+- On `record_cleanup_attempt` returning `"failed"` → `CLEANUP_FAILED.with_label_values(&["file"]).inc()`
+- On `record_cleanup_attempt` returning `"pending"` → `CLEANUP_RETRY.with_label_values(&["file", &reason]).inc()`
+- On VS delete success → `CLEANUP_COMPLETED.with_label_values(&["vector_store"]).inc()`
+- On VS delete retry → `CLEANUP_RETRY.with_label_values(&["vector_store", &reason]).inc()`
+- On VS deleted with failed attachments → `CLEANUP_VS_WITH_FAILED.inc()`
+
+### 5.3 Backlog gauge
+
+The backlog gauge needs periodic updates. Options:
+
+1. **Update in handler** — decrement `pending` on each transition, increment `failed` on terminal failure. Risk: drift over restarts.
+2. **Periodic query** — a background task runs `SELECT cleanup_status, COUNT(*) FROM attachments WHERE cleanup_status IS NOT NULL GROUP BY cleanup_status` and sets the gauge. More accurate.
+
+Recommendation: Use option 2 — a lightweight periodic query (e.g., every 60s from the reconcile interval). This can be a simple addition to the existing worker loop or a separate metric-refresh tick.
+
+## Acceptance Criteria
+
+- [ ] All 5 metrics registered and exposed at `/metrics`
+- [ ] Counter increments verified in unit tests
+- [ ] Backlog gauge reflects actual DB state
+- [ ] Metric names match DESIGN.md exactly

--- a/modules/mini-chat/docs/plans/cleanup-worker/phase-6-tests.md
+++ b/modules/mini-chat/docs/plans/cleanup-worker/phase-6-tests.md
@@ -1,0 +1,101 @@
+# Phase 6: Tests
+
+## Goal
+
+Comprehensive test coverage for the cleanup worker across unit and integration layers.
+
+## Test Categories
+
+### 6.1 Unit Tests — Repository Methods (Phase 1)
+
+File: `src/infra/db/repo/attachment_repo.rs` (test module)
+
+| Test | Asserts |
+|------|---------|
+| `find_pending_cleanup_by_chat_returns_only_pending` | Filters out `done`, `failed`, NULL cleanup_status |
+| `find_pending_cleanup_by_chat_scoped_to_tenant` | Different tenant's attachments not returned |
+| `mark_cleanup_done_transitions_pending` | `cleanup_status` = `done`, `cleanup_updated_at` set |
+| `mark_cleanup_done_idempotent_on_terminal` | Returns 0 rows affected if already `done` or `failed` |
+| `record_cleanup_attempt_increments_counter` | `cleanup_attempts` incremented, error recorded |
+| `record_cleanup_attempt_transitions_to_failed` | At max_attempts threshold, status becomes `failed` |
+| `mark_attachments_pending_for_chat_bulk` | All matching attachments get `pending`, others untouched |
+| `mark_attachments_pending_skips_already_set` | Attachments with existing cleanup_status unchanged |
+
+File: `src/infra/db/repo/vector_store_repo.rs` (test module)
+
+| Test | Asserts |
+|------|---------|
+| `find_by_chat_system_no_scope` | Returns row without AccessScope |
+| `delete_system_hard_deletes` | Row removed from table |
+
+### 6.2 Unit Tests — AttachmentCleanupHandler (Phase 3)
+
+File: `src/infra/workers/cleanup_worker.rs` (test module)
+
+| Test | Asserts |
+|------|---------|
+| `invalid_payload_rejects` | Malformed JSON → `Reject` |
+| `success_marks_done` | Provider delete OK → `mark_cleanup_done` called → `Success` |
+| `provider_error_retries` | Provider 5xx → `record_cleanup_attempt` → `Retry` |
+| `max_attempts_rejects` | `record_cleanup_attempt` returns `failed` → `Reject` |
+| `no_provider_file_id_succeeds` | `provider_file_id = None` → `Success` (nothing to delete) |
+| `chat_soft_deleted_skips` | Parent chat deleted → appropriate handling |
+| `cancel_returns_retry` | CancellationToken fired → `Retry` |
+
+### 6.3 Unit Tests — ChatCleanupHandler (Phase 4)
+
+File: `src/infra/workers/chat_cleanup_worker.rs` (or same file, test module)
+
+| Test | Asserts |
+|------|---------|
+| `invalid_payload_rejects` | Malformed JSON → `Reject` |
+| `active_chat_rejects` | `chats.deleted_at IS NULL` → `Reject` |
+| `no_attachments_no_vs_succeeds` | Empty chat → `Success` |
+| `all_attachments_done_no_vs_succeeds` | All files deleted, no VS → `Success` |
+| `all_attachments_done_vs_deleted` | Files done, VS deleted, row removed → `Success` |
+| `partial_failure_retries` | Some files fail → `Retry` |
+| `all_failed_vs_deleted_with_metric` | All files failed, VS still deleted, metric emitted |
+| `vs_delete_failure_retries` | VS provider error → `Retry`, VS row preserved |
+| `idempotent_rerun` | Second invocation with all terminal → `Success` |
+| `cancel_mid_loop_retries` | Token fired during attachment loop → `Retry` |
+| `vs_not_deleted_while_pending` | Pending attachments → VS not touched |
+
+### 6.4 Unit Tests — Chat Deletion Service (Phase 2)
+
+File: `src/domain/service/chat_service_test.rs`
+
+| Test | Asserts |
+|------|---------|
+| `delete_chat_enqueues_cleanup_event` | `ChatCleanupEvent` recorded in `RecordingOutboxEnqueuer` |
+| `delete_chat_marks_attachments_pending` | Attachments get `cleanup_status = 'pending'` |
+| `delete_chat_event_has_stable_request_id` | `system_request_id` is a valid UUID |
+| `delete_chat_no_attachments_still_enqueues` | Event enqueued even for empty chat |
+
+### 6.5 Integration Tests
+
+File: `tests/cleanup_integration.rs` (or appropriate integration test location)
+
+| Test | Asserts |
+|------|---------|
+| `end_to_end_attachment_delete_cleanup` | Delete attachment → outbox delivers → handler processes → status `done` |
+| `end_to_end_chat_delete_cleanup` | Delete chat → attachments marked pending → handler processes all → VS deleted → row removed |
+| `crash_recovery_resumes` | Handler processes partial batch, restart, resumes remaining |
+
+Integration tests may need:
+- In-memory SQLite or test Postgres
+- Mock OAGW (or `RagHttpClient` with test double)
+- Outbox running in test mode
+
+### 6.6 Test Infrastructure
+
+- **Mock `RagHttpClient`**: return configurable success/failure per call. Can use the existing `FileStorageError` variants.
+- **Mock repos**: extend existing `RecordingOutboxEnqueuer` pattern. Or use the real repos with in-memory DB.
+- **Outbox test harness**: if `modkit_db::outbox` supports synchronous/test-mode delivery, use it. Otherwise, test handlers directly by calling `handle()` with constructed `OutboxMessage`.
+
+## Acceptance Criteria
+
+- [ ] All unit tests pass
+- [ ] Integration tests cover the happy path and crash recovery
+- [ ] No `#[ignore]` tests without documented reason
+- [ ] Test coverage for every `HandlerResult` variant in both handlers
+- [ ] Test coverage for every cleanup_status transition

--- a/modules/mini-chat/docs/plans/orphan-worker/README.md
+++ b/modules/mini-chat/docs/plans/orphan-worker/README.md
@@ -1,0 +1,88 @@
+# Orphan Watchdog Implementation Plan
+
+Implements `cpt-cf-mini-chat-component-orphan-watchdog` (P1) from DESIGN.md.
+
+## Context
+
+When a Mini-Chat pod crashes mid-stream, the turn row stays stuck in `running` state
+indefinitely — the user is locked out, the quota reserve remains uncommitted, and no
+billing event is emitted. The orphan watchdog is a leader-elected periodic job that
+detects these stalled turns via a durable `last_progress_at` timestamp and finalizes
+them as `failed/orphan_timeout` with `ABORTED` billing outcome.
+
+The watchdog stub already exists (`src/infra/workers/orphan_watchdog.rs`) — the
+leader election loop runs and logs ticks, but performs no scan or finalization. This
+plan fills in the real logic.
+
+Two key prerequisites do NOT exist yet:
+
+1. **`last_progress_at` column** — not in `chat_turns` entity, migration, or any repo
+   method. Must be added before any orphan detection logic.
+
+2. **Orphan-specific CAS** — the existing `cas_update_state` checks only
+   `WHERE state = 'running'`. The orphan CAS must additionally re-check
+   `deleted_at IS NULL AND last_progress_at <= now() - :timeout` to prevent
+   false orphan finalization after renewed progress (DESIGN.md P1 invariant).
+
+## Architecture Decisions
+
+- **Outbox-driven billing, leader-elected scan** — the watchdog scan itself is NOT
+  outbox-driven (unlike the cleanup worker). It is a periodic poll under leader
+  election. Billing events are enqueued into the outbox within the CAS transaction.
+
+- **Single finalization path** — per DESIGN.md: "MUST NOT implement a second, divergent
+  finalization path." `finalize_orphan_turn()` is added to `FinalizationService`,
+  reusing `derive_billing_outcome`, `QuotaSettler::settle_in_tx`, and
+  `OutboxEnqueuer::enqueue_usage_event`. Key differences from the normal path:
+  no message persistence, no provider usage, always `Estimated` settlement.
+
+- **Unscoped repo methods** — `find_orphan_candidates` and `cas_finalize_orphan` omit
+  `AccessScope`. Safe because: leader election guarantees single-instance execution,
+  and the CAS guard ensures at-most-once finalization.
+
+- **`AccessScope` from turn row** — constructed from the turn's `tenant_id` for quota
+  settlement (same pattern as test helpers and cleanup worker).
+
+- **Progress update throttling** — `update_progress_at` called only on `ClientSseEvent::Delta`
+  (content deltas), throttled to at most once per ~30s via local `Instant`. Non-text events
+  (tool status, lifecycle) do not advance liveness — delta-only heartbeat.
+
+## Rust Guidelines Applied (M-* from Microsoft Pragmatic Rust Guidelines)
+
+- **M-ERRORS-CANONICAL-STRUCTS**: orphan errors use existing `DomainError` variants.
+- **M-LOG-STRUCTURED**: structured tracing with named fields (`turn_id`, `tenant_id`,
+  `chat_id`, `timeout_secs`, `last_progress_at`).
+- **M-PANIC-ON-BUG**: unreachable states panic; expected race conditions (CAS loser) log
+  and skip.
+- **M-CONCISE-NAMES**: `OrphanWatchdogDeps`, not `OrphanDetectionAndFinalizationManager`.
+- **M-SERVICES-CLONE**: watchdog holds `Arc<T>` deps, is `Send + Sync`.
+- **M-STATIC-VERIFICATION**: clippy clean, no `#[allow]` without `reason`.
+
+## Phases
+
+| Phase | File | Summary |
+|-------|------|---------|
+| 1 | [phase-1-migration-entity.md](phase-1-migration-entity.md) | Add `last_progress_at` column: migration, entity, `create_turn` init |
+| 2 | [phase-2-progress-updates.md](phase-2-progress-updates.md) | Wire `last_progress_at` updates into the streaming path |
+| 3 | [phase-3-repo-layer.md](phase-3-repo-layer.md) | `find_orphan_candidates` + `cas_finalize_orphan` on TurnRepository |
+| 4 | [phase-4-orphan-finalization.md](phase-4-orphan-finalization.md) | `finalize_orphan_turn` on FinalizationService (CAS + quota + outbox) |
+| 5 | [phase-5-watchdog-wiring.md](phase-5-watchdog-wiring.md) | Replace stub with real scan-finalize loop, inject deps |
+| 6 | [phase-6-observability.md](phase-6-observability.md) | Metrics: detected, finalized, scan_duration |
+| 7 | [phase-7-tests.md](phase-7-tests.md) | Unit + integration tests |
+
+## Dependency Graph
+
+```
+Phase 1 ──┬──► Phase 2 (progress updates need the column)
+           │
+           └──► Phase 3 (orphan query uses last_progress_at)
+                   │
+                   └──► Phase 4 (finalization uses repo methods)
+                           │
+                           └──► Phase 5 (watchdog calls finalization service)
+                                   │
+Phase 6 ◄─────────────────────────┘ (metrics wired into watchdog + finalization)
+Phase 7 depends on all above
+```
+
+Phases 2 and 3 can be developed in parallel after Phase 1.

--- a/modules/mini-chat/docs/plans/orphan-worker/phase-1-migration-entity.md
+++ b/modules/mini-chat/docs/plans/orphan-worker/phase-1-migration-entity.md
@@ -1,0 +1,101 @@
+# Phase 1: Migration + Entity — Add `last_progress_at` Column
+
+## Goal
+
+Add the `last_progress_at` column to `chat_turns` so orphan detection can use durable stale-progress timestamps instead of raw age from `started_at`.
+
+## Current State
+
+- `chat_turns` table has no `last_progress_at` column (see initial migration at `src/infra/db/migrations/m20260302_000001_initial.rs`).
+- Entity at `src/infra/db/entity/chat_turn.rs` has no `last_progress_at` field. Current columns end with `started_at`, `completed_at`, `updated_at`.
+- `CreateTurnParams` at `src/domain/repos/turn_repo.rs` has no `last_progress_at` — the timestamp is always `now()` so it's not a caller-provided param.
+- `create_turn` implementation at `src/infra/db/repo/turn_repo.rs` lines 22–55 sets `started_at: Set(now)` but has no `last_progress_at`.
+- `OrphanWatchdogConfig` at `src/config/background.rs` line 14 already references the column in a doc comment.
+
+## Tasks
+
+### 1.1 New migration file
+
+File: `src/infra/db/migrations/m20260329_000001_add_last_progress_at.rs` (new)
+
+**Postgres UP:**
+```sql
+ALTER TABLE chat_turns ADD COLUMN last_progress_at TIMESTAMPTZ;
+
+-- Backfill any existing running turns so orphan watchdog can evaluate them.
+UPDATE chat_turns
+   SET last_progress_at = started_at
+ WHERE last_progress_at IS NULL
+   AND state = 'running';
+
+-- Partial index for efficient watchdog scans.
+-- Only running, non-deleted turns with a progress timestamp participate.
+CREATE INDEX IF NOT EXISTS idx_chat_turns_orphan_scan
+    ON chat_turns (last_progress_at)
+    WHERE state = 'running' AND deleted_at IS NULL;
+```
+
+**SQLite UP:**
+```sql
+ALTER TABLE chat_turns ADD COLUMN last_progress_at TEXT;
+
+UPDATE chat_turns
+   SET last_progress_at = started_at
+ WHERE last_progress_at IS NULL
+   AND state = 'running';
+
+-- SQLite does not support partial indexes with WHERE on expressions involving
+-- multiple columns reliably across all versions. Use a regular index instead;
+-- the application-level query still filters correctly.
+CREATE INDEX IF NOT EXISTS idx_chat_turns_orphan_scan
+    ON chat_turns (last_progress_at);
+```
+
+**DOWN:**
+```sql
+DROP INDEX IF EXISTS idx_chat_turns_orphan_scan;
+ALTER TABLE chat_turns DROP COLUMN last_progress_at;
+```
+
+Design notes:
+- Column is nullable — terminal turns (`completed`, `failed`, `cancelled`) do not require `last_progress_at`. Only `running` turns must have a non-NULL value.
+- No `CHECK` constraint at the DB level. SQLite does not support `ADD CONSTRAINT` via `ALTER TABLE`. The invariant (`running` → `last_progress_at IS NOT NULL`) is enforced by the application: `create_turn` always sets the value, and `cas_finalize_orphan` (Phase 3) does not clear it.
+- The partial index `idx_chat_turns_orphan_scan` on Postgres dramatically narrows the scan to only rows the watchdog cares about.
+
+### 1.2 Register migration
+
+File: `src/infra/db/migrations/mod.rs`
+
+Add the new module declaration and append the migration to `Migrator::migrations()` vec, after the last existing migration entry.
+
+### 1.3 Update entity
+
+File: `src/infra/db/entity/chat_turn.rs`
+
+Add to `Model` struct (after `started_at`):
+```rust
+pub last_progress_at: Option<OffsetDateTime>,
+```
+
+The field is `Option<OffsetDateTime>` because terminal turns may have NULL.
+
+### 1.4 Initialize in `create_turn`
+
+File: `src/infra/db/repo/turn_repo.rs`
+
+In the `create_turn` method (lines 29–53), add to the `ActiveModel`:
+```rust
+last_progress_at: Set(Some(now)),
+```
+
+This satisfies the DESIGN.md requirement: "MUST be initialized when the turn enters `running`."
+
+No change to `CreateTurnParams` is needed — `last_progress_at` is always `now()` at creation time, not a caller-provided parameter.
+
+## Acceptance Criteria
+
+- [ ] Migration runs successfully on both Postgres and SQLite
+- [ ] Entity compiles with the new `last_progress_at` field
+- [ ] `create_turn` sets `last_progress_at = now()`
+- [ ] Partial index `idx_chat_turns_orphan_scan` exists (Postgres) for efficient watchdog queries
+- [ ] Existing tests pass — new field is `Option`, backward compatible

--- a/modules/mini-chat/docs/plans/orphan-worker/phase-2-progress-updates.md
+++ b/modules/mini-chat/docs/plans/orphan-worker/phase-2-progress-updates.md
@@ -1,0 +1,125 @@
+# Phase 2: Progress Timestamp Updates
+
+## Goal
+
+Wire `last_progress_at` updates into the streaming path so the orphan watchdog can distinguish stalled turns from healthy long-running ones.
+
+## Current State
+
+- No mechanism exists to update `last_progress_at` after turn creation.
+- The streaming path processes provider chunks in `stream_service.rs` — this is where progress events arrive.
+- `TurnRepository` trait has no `update_progress_at` method.
+
+## Design Constraints
+
+From DESIGN.md:
+- `last_progress_at` MUST be updated on meaningful forward progress:
+  - Provider chunk receipt
+  - SSE relay progress
+  - Tool event progress (if durably persisted)
+  - Terminal provider event reception
+- Uses database server time (`now()` from Postgres) for monotonic clock consistency, NOT application-side timestamps.
+- Throttling at ~30s keeps DB overhead minimal while ensuring orphan detection works within the 300s default timeout (at least 10 progress updates before a turn could be misclassified).
+
+## Tasks
+
+### 2.1 Add `update_progress_at` to TurnRepository trait
+
+File: `src/domain/repos/turn_repo.rs`
+
+```rust
+/// Update `last_progress_at = now()` for a running turn.
+///
+/// No `AccessScope` — called from the streaming task which already validated
+/// authorization at turn creation time. The CAS guard (`WHERE state = 'running'`)
+/// prevents mutation on terminal turns.
+///
+/// Returns `rows_affected` (0 if turn is no longer running — benign, no error).
+async fn update_progress_at<C: DBRunner>(
+    &self,
+    runner: &C,
+    turn_id: Uuid,
+) -> Result<u64, DomainError>;
+```
+
+Design notes:
+- Intentionally omits `AccessScope`: the streaming task already authorized the request at turn creation. This update only touches `last_progress_at` on a turn owned by the caller.
+- Returns `u64` (rows_affected) rather than `Result<(), _>` so callers can distinguish "turn still running" (1) from "already finalized" (0) without an error.
+
+### 2.2 Implement in infra layer
+
+File: `src/infra/db/repo/turn_repo.rs`
+
+```rust
+async fn update_progress_at<C: DBRunner>(
+    &self,
+    runner: &C,
+    turn_id: Uuid,
+) -> Result<u64, DomainError> {
+    let now = OffsetDateTime::now_utc();
+    let result = TurnEntity::update_many()
+        .col_expr(Column::LastProgressAt, Expr::value(Some(now)))
+        .col_expr(Column::UpdatedAt, Expr::value(now))
+        .filter(
+            Condition::all()
+                .add(Column::Id.eq(turn_id))
+                .add(Column::State.eq(TurnState::Running)),
+        )
+        .exec(runner)
+        .await?;
+    Ok(result.rows_affected)
+}
+```
+
+No `.secure().scope_with()` — system-level update on an already-authorized turn.
+
+### 2.3 Call from streaming path (throttled)
+
+File: `src/domain/service/stream_service.rs`
+
+In the chunk-processing loop (the `select!` loop that receives `StreamChunk` events from the provider), add a throttled `update_progress_at` call:
+
+```rust
+// At the top of the streaming task, before the loop:
+let mut last_progress_update = std::time::Instant::now();
+const PROGRESS_UPDATE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+// Inside the chunk-processing branch:
+if last_progress_update.elapsed() >= PROGRESS_UPDATE_INTERVAL {
+    let conn = db.conn();
+    // Fire-and-forget: if update fails, orphan timeout is a safe fallback.
+    if let Err(e) = turn_repo.update_progress_at(&conn, turn_id).await {
+        tracing::warn!(turn_id = %turn_id, error = %e, "failed to update progress timestamp");
+    }
+    last_progress_update = std::time::Instant::now();
+}
+```
+
+Design notes:
+- **Throttling at ~30s** prevents excessive DB writes. With the default 300s orphan timeout, a healthy turn gets ~10 progress updates before it could be misclassified.
+- **Fire-and-forget**: if the update fails (e.g., transient DB error), the orphan timeout is a safe fallback — it just means the turn might be detected as orphan slightly earlier than necessary. The CAS re-check in Phase 3 prevents false finalization.
+- The call is placed in the main chunk-processing branch, which covers provider chunk receipt. Since chunks arrive frequently during active streaming, this single call site is sufficient to cover all progress types.
+
+### 2.4 (Optional) Clear `last_progress_at` on terminal transition
+
+File: `src/infra/db/repo/turn_repo.rs` (in `cas_update_state`)
+
+When a turn transitions to a terminal state, `last_progress_at` becomes irrelevant. Optionally set it to `NULL` in the CAS update to keep data clean:
+
+```rust
+.col_expr(Column::LastProgressAt, Expr::value(Option::<OffsetDateTime>::None))
+```
+
+This is not strictly required — the orphan scan filters `state = 'running'` so terminal turns are excluded regardless. Decide based on data hygiene preference.
+
+## Open Questions
+
+- **Exact location in `stream_service.rs`**: The chunk-processing loop structure needs to be verified during implementation. The throttled update should be placed where provider chunks are received, before finalization.
+
+## Acceptance Criteria
+
+- [ ] `update_progress_at` compiles and is callable from the streaming task
+- [ ] Running turns have a recent `last_progress_at` during active streaming
+- [ ] Progress updates are throttled (at most once per ~30s)
+- [ ] Failed progress updates are logged but don't abort the stream
+- [ ] Existing streaming tests pass

--- a/modules/mini-chat/docs/plans/orphan-worker/phase-3-repo-layer.md
+++ b/modules/mini-chat/docs/plans/orphan-worker/phase-3-repo-layer.md
@@ -1,0 +1,164 @@
+# Phase 3: Repository Layer — Orphan Query + CAS
+
+## Goal
+
+Add query and CAS methods to `TurnRepository` for orphan detection and finalization. Pure data access, no domain logic.
+
+## Current State
+
+- `TurnRepository` trait (`src/domain/repos/turn_repo.rs`) has `cas_update_state(CasTerminalParams)` which checks only `WHERE id = :id AND state = 'running'` — no `last_progress_at` or `deleted_at` guard.
+- No method to discover orphan candidates.
+- All existing query/mutation methods require `AccessScope`.
+
+## Design Constraints
+
+From DESIGN.md (mandatory P1 invariants):
+- Orphan detection MUST use `last_progress_at` (stale-progress), NOT raw age from `started_at`.
+- The terminal UPDATE itself MUST re-check ALL orphan predicates — not just `state = 'running'`.
+- If `rows_affected = 0`, the turn was already finalized, soft-deleted, or made progress → MUST skip.
+- Stale-progress predicate MUST participate in both candidate discovery AND final conditional update.
+
+## Tasks
+
+### 3.1 Add `find_orphan_candidates` to TurnRepository trait
+
+File: `src/domain/repos/turn_repo.rs`
+
+```rust
+/// Find running turns with stale progress (orphan candidates).
+///
+/// No `AccessScope` — system-level background worker query under leader election.
+/// Returns at most `limit` rows ordered by oldest progress first.
+async fn find_orphan_candidates<C: DBRunner>(
+    &self,
+    runner: &C,
+    timeout_secs: u64,
+    limit: u32,
+) -> Result<Vec<TurnModel>, DomainError>;
+```
+
+Design notes:
+- No `AccessScope` — the orphan watchdog runs under leader election, is single-instance, and queries all tenants. This follows the same pattern as the cleanup worker's unscoped repo methods (Phase 1 of cleanup-worker plan).
+- `limit` bounds the batch size to prevent unbounded result sets. Remaining orphans are picked up on the next tick.
+- Ordered by `last_progress_at ASC` so the oldest orphans are processed first.
+
+### 3.2 Add `cas_finalize_orphan` to TurnRepository trait
+
+File: `src/domain/repos/turn_repo.rs`
+
+```rust
+/// CAS update for orphan finalization with full predicate re-check.
+///
+/// The terminal UPDATE re-checks ALL orphan predicates:
+/// `state = 'running' AND deleted_at IS NULL AND last_progress_at <= now() - timeout`.
+/// This prevents "false orphan finalization after renewed progress" (DESIGN.md P1 invariant).
+///
+/// Returns `rows_affected`:
+/// - `0`: turn is no longer orphan-eligible (already finalized, soft-deleted, or progress renewed)
+/// - `1`: turn transitioned to `Failed` with `error_code = 'orphan_timeout'`
+async fn cas_finalize_orphan<C: DBRunner>(
+    &self,
+    runner: &C,
+    turn_id: Uuid,
+    timeout_secs: u64,
+) -> Result<u64, DomainError>;
+```
+
+### 3.3 Implement `find_orphan_candidates` in infra
+
+File: `src/infra/db/repo/turn_repo.rs`
+
+The query:
+```sql
+SELECT * FROM chat_turns
+WHERE state = 'running'
+  AND deleted_at IS NULL
+  AND last_progress_at <= now() - interval '1 second' * :timeout_secs
+ORDER BY last_progress_at ASC
+LIMIT :limit
+```
+
+Implementation approach:
+- Use SeaORM `find()` with `Condition::all()` for `state = Running`, `deleted_at IS NULL`.
+- For the `last_progress_at` interval arithmetic, use `Expr::cust_with_values` or raw SQL expression, since SeaORM doesn't have native interval subtraction.
+- **Backend-specific SQL**: Postgres uses `now() - interval '1 second' * $1`. SQLite uses `datetime('now', '-' || $1 || ' seconds')`. Use a conditional expression or raw query with backend detection.
+- No `.secure().scope_with()` — unscoped per AD-3.
+
+**Postgres expression:**
+```rust
+Column::LastProgressAt.lte(
+    Expr::cust_with_values("now() - interval '1 second' * $1", [timeout_secs as i64])
+)
+```
+
+**SQLite expression:**
+```rust
+Column::LastProgressAt.lte(
+    Expr::cust_with_values("datetime('now', '-' || $1 || ' seconds')", [timeout_secs as i64])
+)
+```
+
+### 3.4 Implement `cas_finalize_orphan` in infra
+
+File: `src/infra/db/repo/turn_repo.rs`
+
+The CAS update:
+```sql
+UPDATE chat_turns
+   SET state = 'failed',
+       error_code = 'orphan_timeout',
+       completed_at = now(),
+       updated_at = now()
+ WHERE id = :turn_id
+   AND state = 'running'
+   AND deleted_at IS NULL
+   AND last_progress_at <= now() - interval '1 second' * :timeout_secs
+```
+
+Implementation:
+```rust
+async fn cas_finalize_orphan<C: DBRunner>(
+    &self,
+    runner: &C,
+    turn_id: Uuid,
+    timeout_secs: u64,
+) -> Result<u64, DomainError> {
+    let now = OffsetDateTime::now_utc();
+    let result = TurnEntity::update_many()
+        .col_expr(Column::State, Expr::value(TurnState::Failed.into_value()))
+        .col_expr(Column::ErrorCode, Expr::value(Some("orphan_timeout".to_owned())))
+        .col_expr(Column::CompletedAt, Expr::value(now))
+        .col_expr(Column::UpdatedAt, Expr::value(now))
+        .filter(
+            Condition::all()
+                .add(Column::Id.eq(turn_id))
+                .add(Column::State.eq(TurnState::Running))
+                .add(Column::DeletedAt.is_null())
+                .add(/* last_progress_at <= now() - timeout — backend-specific expr */),
+        )
+        .exec(runner)
+        .await?;
+    Ok(result.rows_affected)
+}
+```
+
+**Critical**: The `last_progress_at` predicate is re-checked in the CAS. If a streaming task refreshed progress between `find_orphan_candidates` and this CAS, `rows_affected = 0` and the turn is safely skipped.
+
+No `.secure().scope_with()` — unscoped per AD-3.
+
+## Open Questions
+
+- **Backend detection pattern**: How does the existing codebase handle backend-specific SQL (Postgres vs SQLite)? Check if there's an existing utility or pattern for conditional expressions. The migration already handles this via separate up/down blocks.
+
+## Acceptance Criteria
+
+- [ ] `find_orphan_candidates` returns only running, non-deleted, stale turns
+- [ ] `find_orphan_candidates` excludes turns with recent progress
+- [ ] `find_orphan_candidates` excludes soft-deleted turns
+- [ ] `find_orphan_candidates` excludes terminal turns (completed/failed/cancelled)
+- [ ] `find_orphan_candidates` respects `limit`
+- [ ] `cas_finalize_orphan` returns 1 and transitions to `Failed/orphan_timeout`
+- [ ] `cas_finalize_orphan` returns 0 on already-terminal turn
+- [ ] `cas_finalize_orphan` returns 0 if progress was renewed (critical safety invariant)
+- [ ] `cas_finalize_orphan` returns 0 on soft-deleted turn
+- [ ] Works with both Postgres and SQLite backends

--- a/modules/mini-chat/docs/plans/orphan-worker/phase-4-orphan-finalization.md
+++ b/modules/mini-chat/docs/plans/orphan-worker/phase-4-orphan-finalization.md
@@ -1,0 +1,250 @@
+# Phase 4: Orphan Finalization — Domain Logic
+
+## Goal
+
+Add `finalize_orphan_turn` method to `FinalizationService` that uses the orphan CAS and reuses billing derivation, quota settlement, and outbox enqueue — all within a single DB transaction.
+
+## Current State
+
+- `FinalizationService::finalize_turn_cas(FinalizationInput)` is the universal finalization function. It requires many streaming-context fields (`accumulated_text`, `usage`, `ttft_ms`, `provider_response_id`, `message_id`, etc.) that are not available to the orphan watchdog.
+- `derive_billing_outcome` at `src/domain/model/billing_outcome.rs:88-93` already maps `Failed + orphan_timeout → Aborted/Estimated`.
+- `QuotaSettler::settle_in_tx` takes `SettlementInput` with fields: `tenant_id`, `user_id`, `effective_model`, `policy_version_applied`, `reserve_tokens`, `max_output_tokens_applied`, `reserved_credits_micro`, `minimal_generation_floor_applied`, `settlement_path`, `period_starts`, `web_search_calls`, `code_interpreter_calls`.
+- The turn row (`TurnModel`) contains all quota fields: `tenant_id`, `requester_user_id`, `effective_model`, `policy_version_applied`, `reserve_tokens`, `max_output_tokens_applied`, `reserved_credits_micro`, `minimal_generation_floor_applied`.
+
+## Design Constraints
+
+From DESIGN.md:
+- MUST NOT implement a second, divergent finalization path — reuse `derive_billing_outcome`, `QuotaSettler`, `OutboxEnqueuer`.
+- Billing outcome for orphan timeout: `ABORTED` (not `FAILED`), `settlement_method = estimated`.
+- Outbox usage payload: `outcome = "aborted"`, `settlement_method = "estimated"`.
+- Orphan path has NO provider usage, NO accumulated text, NO message to persist.
+
+## Tasks
+
+### 4.1 Define `OrphanFinalizationInput`
+
+File: `src/domain/model/finalization.rs`
+
+```rust
+/// Simplified input for orphan finalization.
+/// Built from the `TurnModel` row — no streaming context available.
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct OrphanFinalizationInput {
+    pub turn_id: Uuid,
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    pub request_id: Uuid,
+    /// From `requester_user_id`. Nullable because some turns may have system requesters.
+    pub user_id: Option<Uuid>,
+    pub effective_model: Option<String>,
+    pub reserve_tokens: Option<i64>,
+    pub max_output_tokens_applied: Option<i32>,
+    pub reserved_credits_micro: Option<i64>,
+    pub policy_version_applied: Option<i64>,
+    pub minimal_generation_floor_applied: Option<i32>,
+    /// `started_at` — used to derive `period_starts` for quota settlement.
+    pub started_at: OffsetDateTime,
+}
+```
+
+Add a constructor from `TurnModel`:
+
+```rust
+impl OrphanFinalizationInput {
+    pub fn from_turn(turn: &TurnModel) -> Self {
+        Self {
+            turn_id: turn.id,
+            tenant_id: turn.tenant_id,
+            chat_id: turn.chat_id,
+            request_id: turn.request_id,
+            user_id: turn.requester_user_id,
+            effective_model: turn.effective_model.clone(),
+            reserve_tokens: turn.reserve_tokens,
+            max_output_tokens_applied: turn.max_output_tokens_applied,
+            reserved_credits_micro: turn.reserved_credits_micro,
+            policy_version_applied: turn.policy_version_applied,
+            minimal_generation_floor_applied: turn.minimal_generation_floor_applied,
+            started_at: turn.started_at,
+        }
+    }
+}
+```
+
+### 4.2 Add `finalize_orphan_turn` to FinalizationService
+
+File: `src/domain/service/finalization_service.rs`
+
+```rust
+/// Finalize an orphan turn within a single database transaction.
+///
+/// Steps:
+/// 1. CAS finalize orphan (re-checks all predicates)
+/// 2. If CAS won: derive billing, settle quota, enqueue usage event
+/// 3. Return whether CAS was won
+///
+/// Called by the orphan watchdog for each candidate. Safe under retries
+/// and concurrent finalization — CAS ensures at-most-once.
+pub async fn finalize_orphan_turn(
+    &self,
+    input: OrphanFinalizationInput,
+    timeout_secs: u64,
+) -> Result<bool, DomainError>
+```
+
+Transaction body:
+
+```
+1. turn_repo.cas_finalize_orphan(tx, input.turn_id, timeout_secs)
+   → rows_affected = 0 → return Ok(false)  // CAS loser
+
+2. derive_billing_outcome(BillingDerivationInput {
+       terminal_state: Failed,
+       error_code: Some("orphan_timeout"),
+       has_usage: false,
+   })
+   → Aborted / Estimated  (confirmed by existing tests)
+
+3. Guard: if quota fields are available (effective_model, user_id, reserve_tokens
+   are all Some), build SettlementInput and call quota_settler.settle_in_tx().
+   If any required field is None → log warning, skip settlement (turn still
+   transitions to Failed, but quota is not debited — acceptable edge case
+   for turns that failed during preflight).
+
+4. Build UsageEvent:
+   - terminal_state: "failed"
+   - billing_outcome: "aborted"
+   - settlement_method: "estimated"
+   - usage: None (no provider usage)
+   - error_code: "orphan_timeout"
+   - All quota fields from turn row
+   Call outbox_enqueuer.enqueue_usage_event(tx, usage_event)
+
+5. After transaction commit: outbox_enqueuer.flush()
+
+6. Return Ok(true)
+```
+
+### 4.3 Construct `AccessScope` from turn row
+
+The `QuotaSettler::settle_in_tx` requires `&AccessScope`. Construct a tenant-scoped scope:
+
+```rust
+use modkit_security::{AccessScope, ScopeConstraint, ScopeFilter};
+
+let scope = AccessScope::from_constraints(vec![
+    ScopeConstraint::new(vec![
+        ScopeFilter::eq(pep_properties::OWNER_TENANT_ID, input.tenant_id),
+    ]),
+]);
+```
+
+Check the test helpers for the exact construction pattern — they build `AccessScope` for similar background-worker contexts.
+
+### 4.4 Handle missing quota fields
+
+Some turns may have `NULL` quota fields (e.g., turns that crashed before preflight completed). In this case:
+
+```rust
+let has_quota_fields = input.effective_model.is_some()
+    && input.user_id.is_some()
+    && input.reserve_tokens.is_some()
+    && input.policy_version_applied.is_some();
+
+if has_quota_fields {
+    // Build SettlementInput and settle
+} else {
+    warn!(turn_id = %input.turn_id, "orphan turn missing quota fields, skipping settlement");
+}
+```
+
+The CAS update to `Failed/orphan_timeout` still succeeds (it doesn't depend on quota fields). The user is unblocked, which is the primary goal. The uncommitted quota reserve will eventually be reconciled by the quota reconciliation job (if one exists) or will expire with the quota period.
+
+### 4.5 Build `SettlementInput` from turn row
+
+```rust
+let settlement_input = SettlementInput {
+    tenant_id: input.tenant_id,
+    user_id: input.user_id.unwrap(),  // guarded by has_quota_fields check
+    effective_model: input.effective_model.clone().unwrap(),
+    policy_version_applied: input.policy_version_applied.unwrap(),
+    reserve_tokens: input.reserve_tokens.unwrap(),
+    max_output_tokens_applied: input.max_output_tokens_applied.unwrap_or(0),
+    reserved_credits_micro: input.reserved_credits_micro.unwrap_or(0),
+    minimal_generation_floor_applied: input.minimal_generation_floor_applied.unwrap_or(0),
+    settlement_path: SettlementPath::Estimated,
+    period_starts: /* see Open Questions */,
+    web_search_calls: 0,
+    code_interpreter_calls: 0,
+};
+```
+
+### 4.6 Build audit event from turn row
+
+The orphan path enqueues an audit event (`AuditEnvelope::Turn`) alongside the usage event, same as the normal finalization path. Fields not available from `chat_turns` use sensible defaults:
+
+```rust
+AuditEnvelope::Turn(TurnAuditEvent {
+    event_type: TurnAuditEventType::TurnFailed,
+    timestamp: OffsetDateTime::now_utc(),        // time of watchdog finalization
+    tenant_id: input.tenant_id,
+    requester_type: /* parse turn.requester_type String → RequesterType */,
+    trace_id: None,                               // no active span in background worker
+    user_id: input.user_id.unwrap_or(Uuid::nil()),
+    chat_id: input.chat_id,
+    turn_id: input.turn_id,
+    request_id: input.request_id,
+    selected_model: input.effective_model.clone().unwrap_or_default(),  // *
+    effective_model: input.effective_model.clone().unwrap_or_default(),
+    policy_version_applied: input.policy_version_applied.map(|v| v as u64),
+    usage: AuditUsageTokens {                     // no provider usage available
+        input_tokens: 0,
+        output_tokens: 0,
+        model: input.effective_model.clone(),
+        cache_read_input_tokens: Some(0),
+        cache_write_input_tokens: Some(0),
+        reasoning_tokens: Some(0),
+    },
+    latency_ms: LatencyMs { ttft_ms: None, total_ms: None },
+    policy_decisions: PolicyDecisions {
+        license: None,
+        quota: QuotaDecision {
+            decision: "unknown".to_owned(),       // *
+            quota_scope: None,
+            downgrade_from: None,                  // *
+            downgrade_reason: None,                // *
+        },
+    },
+    error_code: Some("orphan_timeout".to_owned()),
+    prompt: None,
+    response: None,
+    attachments: vec![],
+    tool_calls: None,
+})
+```
+
+Fields marked `*` are not persisted in `chat_turns` — they use best-effort defaults:
+- `selected_model` = `effective_model` (pre-downgrade model not stored)
+- `quota_decision` = `"unknown"` (decision not stored)
+- `downgrade_from` / `downgrade_reason` = `None`
+
+`timestamp` is `now()` — reflects when the watchdog finalized the turn, not when the pod crashed. This is correct: the audit event records the finalization action, consistent with how `build_turn_audit_envelope` works in the normal path.
+
+**Future improvement**: persist `quota_decision`, `selected_model`, `downgrade_from`, `downgrade_reason` in `chat_turns` so any background finalizer can reconstruct a complete audit event. Out of scope for this plan.
+
+## Open Questions
+
+- **`period_starts` for `SettlementInput`**: The `Estimated` settlement path needs `period_starts` to update the correct quota usage rows. Options:
+  (a) Query `quota_usage` table within the transaction for existing reserve rows for this turn's tenant+user+model+period.
+  (b) Derive from `input.started_at` — the turn was started on a specific date, compute the daily and monthly period starts from that date.
+  (c) Use empty vec if `QuotaService::settle_in_tx` handles missing period_starts on the Estimated path (investigate).
+  **Recommendation**: Option (b) — derive from `started_at` using the same period computation as the preflight path. This avoids an extra query and is deterministic.
+
+## Acceptance Criteria
+
+- [ ] CAS winner: turn transitions to `Failed/orphan_timeout`, quota debited (estimated), usage event enqueued
+- [ ] CAS loser: returns `false`, no side effects (no quota, no outbox)
+- [ ] Missing quota fields: turn still finalized, settlement skipped with warning
+- [ ] No `accumulated_text` or message persistence in orphan path
+- [ ] `derive_billing_outcome` produces `Aborted/Estimated` for `orphan_timeout` (already verified by existing test at `billing_outcome.rs:183-188`)
+- [ ] Outbox `flush()` called post-commit on CAS win

--- a/modules/mini-chat/docs/plans/orphan-worker/phase-5-watchdog-wiring.md
+++ b/modules/mini-chat/docs/plans/orphan-worker/phase-5-watchdog-wiring.md
@@ -1,0 +1,191 @@
+# Phase 5: Watchdog Wiring — Replace Stub with Real Logic
+
+## Goal
+
+Replace the stub tick log in `orphan_watchdog.rs` with a real scan-finalize loop and inject the required dependencies through `background_workers.rs` and `module.rs`.
+
+## Current State
+
+- Stub at `src/infra/workers/orphan_watchdog.rs` (98 lines): leader-elected periodic loop, logs `"orphan_watchdog: tick (stub -- no scan yet)"` on each tick. Accepts `(elector, config, cancel)`.
+- `spawn_workers` at `src/background_workers.rs` passes only `(elector, config, cancel)` — no repo, DB, or service dependencies.
+- `WorkerConfigs` struct holds only `orphan_watchdog: OrphanWatchdogConfig`.
+- Two existing unit tests: `disabled_returns_immediately`, `shutdown_on_cancel`.
+
+## Tasks
+
+### 5.1 Define `OrphanWatchdogDeps` struct
+
+File: `src/infra/workers/orphan_watchdog.rs`
+
+Bundle all dependencies to keep the `run` signature clean:
+
+```rust
+/// Dependencies for the orphan watchdog scan-finalize loop.
+pub struct OrphanWatchdogDeps<TR: TurnRepository + 'static, MR: MessageRepository + 'static> {
+    pub finalization_svc: Arc<FinalizationService<TR, MR>>,
+    pub turn_repo: Arc<TR>,
+    pub db: Arc<DbProvider>,
+    pub metrics: Arc<dyn MiniChatMetricsPort>,
+}
+```
+
+### 5.2 Update `run` function signature
+
+```rust
+pub async fn run<TR: TurnRepository + 'static, MR: MessageRepository + 'static>(
+    elector: Arc<dyn LeaderElector>,
+    config: OrphanWatchdogConfig,
+    deps: OrphanWatchdogDeps<TR, MR>,
+    cancel: CancellationToken,
+) -> anyhow::Result<()>
+```
+
+### 5.3 Implement scan-finalize loop
+
+Replace the stub tick log with:
+
+```rust
+const BATCH_LIMIT: u32 = 100;
+
+loop {
+    tokio::select! {
+        _ = ticker.tick() => {
+            let scan_start = std::time::Instant::now();
+            let conn = deps.db.conn();
+
+            // 1. Find candidates
+            let candidates = match deps.turn_repo
+                .find_orphan_candidates(&conn, config.timeout_secs, BATCH_LIMIT)
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    error!(error = %e, "orphan_watchdog: scan query failed");
+                    continue; // retry on next tick
+                }
+            };
+
+            info!(
+                count = candidates.len(),
+                "orphan_watchdog: scan completed"
+            );
+
+            // 2. Process each candidate
+            for turn in &candidates {
+                if cancel.is_cancelled() {
+                    info!("orphan_watchdog: shutting down mid-scan");
+                    return Ok(());
+                }
+
+                deps.metrics.record_orphan_detected("stale_progress");
+
+                let input = OrphanFinalizationInput::from_turn(turn);
+                match deps.finalization_svc
+                    .finalize_orphan_turn(input, config.timeout_secs)
+                    .await
+                {
+                    Ok(true) => {
+                        deps.metrics.record_orphan_finalized("stale_progress");
+                        info!(
+                            turn_id = %turn.id,
+                            tenant_id = %turn.tenant_id,
+                            chat_id = %turn.chat_id,
+                            "orphan_watchdog: finalized orphan turn"
+                        );
+                    }
+                    Ok(false) => {
+                        debug!(
+                            turn_id = %turn.id,
+                            "orphan_watchdog: CAS lost (already finalized or progress renewed)"
+                        );
+                    }
+                    Err(e) => {
+                        error!(
+                            turn_id = %turn.id,
+                            error = %e,
+                            "orphan_watchdog: finalization error"
+                        );
+                        // Continue to next candidate — don't abort the scan.
+                    }
+                }
+            }
+
+            // 3. Record scan duration
+            let scan_secs = scan_start.elapsed().as_secs_f64();
+            deps.metrics.record_orphan_scan_duration_seconds(scan_secs);
+        }
+        () = cancel.cancelled() => {
+            info!("orphan_watchdog: shutting down");
+            return Ok(());
+        }
+    }
+}
+```
+
+Design notes:
+- **`BATCH_LIMIT = 100`**: bounds the scan result set. If more orphans exist, they're picked up on the next tick (60s default). In practice, orphan counts should be low.
+- **`cancel.is_cancelled()` between candidates**: ensures prompt shutdown during a large batch.
+- **Scan query failure**: logs error and retries on the next tick. Does not abort the watchdog.
+- **Individual finalization error**: logs and continues. One bad turn doesn't block others.
+- **Structured logging**: every outcome is logged with `turn_id`, `tenant_id`, `chat_id`.
+
+### 5.4 Update `background_workers.rs`
+
+File: `src/background_workers.rs`
+
+Expand `spawn_workers` to accept the orphan watchdog dependencies:
+
+```rust
+pub fn spawn_workers<TR, MR>(
+    configs: &WorkerConfigs,
+    parent_cancel: &CancellationToken,
+    leader_elector: Option<&Arc<dyn LeaderElector>>,
+    orphan_deps: Option<OrphanWatchdogDeps<TR, MR>>,  // None if watchdog disabled
+) -> anyhow::Result<(WorkerHandles, CancellationToken)>
+where
+    TR: TurnRepository + 'static,
+    MR: MessageRepository + 'static,
+```
+
+Alternative: add deps to `WorkerConfigs` as an `Option<OrphanWatchdogDeps>`, or create a separate `WorkerDeps` struct. Choose whichever approach is cleanest given the existing signature.
+
+### 5.5 Update `module.rs` wiring
+
+File: `src/module.rs`
+
+In the `start()` method, construct `OrphanWatchdogDeps` from the already-available services:
+
+```rust
+let orphan_deps = if self.worker_configs.orphan_watchdog.enabled {
+    Some(OrphanWatchdogDeps {
+        finalization_svc: Arc::clone(&self.finalization_svc),
+        turn_repo: Arc::clone(&self.turn_repo),
+        db: Arc::clone(&self.db),
+        metrics: Arc::clone(&self.metrics),
+    })
+} else {
+    None
+};
+```
+
+Pass `orphan_deps` to `spawn_workers`.
+
+### 5.6 Update existing tests
+
+File: `src/infra/workers/orphan_watchdog.rs` (test module)
+
+The existing `disabled_returns_immediately` and `shutdown_on_cancel` tests need to be updated to pass the new `OrphanWatchdogDeps` parameter. For these tests, use mock/noop implementations:
+- `MockTurnRepository` that returns empty candidates
+- `MockFinalizationService` (or construct a real one with mock repos)
+- Noop metrics
+
+## Acceptance Criteria
+
+- [ ] Stub tick log replaced with real scan-finalize loop
+- [ ] Dependencies injected through `background_workers.rs` → `module.rs`
+- [ ] Graceful shutdown between candidates (`cancel.is_cancelled()` check)
+- [ ] Leader election still works correctly
+- [ ] Scan query failures don't crash the watchdog (retry on next tick)
+- [ ] Individual finalization errors don't block other candidates
+- [ ] Structured logging for each outcome (finalized, CAS lost, error)
+- [ ] Existing tests updated and passing

--- a/modules/mini-chat/docs/plans/orphan-worker/phase-6-observability.md
+++ b/modules/mini-chat/docs/plans/orphan-worker/phase-6-observability.md
@@ -1,0 +1,138 @@
+# Phase 6: Observability — Metrics
+
+## Goal
+
+Wire the three DESIGN.md-specified orphan watchdog metrics into the `MiniChatMetricsPort` trait and the OpenTelemetry implementation.
+
+## Current State
+
+- `MiniChatMetricsPort` trait at `src/domain/ports/metrics.rs` has no orphan-specific methods.
+- `MiniChatMetricsMeter` at `src/infra/metrics.rs` has two deferred instruments:
+  - `cancel_orphan: Counter<u64>` (line 108) — tracks "orphaned cancel events" (a turn remaining running after cancellation). This is a different concept — keep as-is.
+  - `orphan_turn: Counter<u64>` (line 189) — placeholder for "orphan turns detected by watchdog". Rename to `orphan_detected`.
+- Metric label `trigger::ORPHAN_TIMEOUT = "orphan_timeout"` exists at `src/domain/ports/metric_labels.rs:108`.
+- No `reason` label constants exist yet (needed for `reason="stale_progress"`).
+
+## Required Metrics (from DESIGN.md)
+
+| Metric Name | Type | Labels | Description |
+|-------------|------|--------|-------------|
+| `mini_chat_orphan_detected_total` | counter | `reason="stale_progress"` | Orphan candidate identified by stale-progress scan |
+| `mini_chat_orphan_finalized_total` | counter | `reason="stale_progress"` | CAS finalization succeeded (turn transitioned to terminal) |
+| `mini_chat_orphan_scan_duration_seconds` | histogram | — | Watchdog scan execution duration |
+
+Note: OTel counter names omit `_total` — the Prometheus exporter appends it automatically.
+
+## Tasks
+
+### 6.1 Add `reason` label constant
+
+File: `src/domain/ports/metric_labels.rs`
+
+```rust
+pub mod reason {
+    pub const STALE_PROGRESS: &str = "stale_progress";
+}
+```
+
+### 6.2 Add methods to `MiniChatMetricsPort` trait
+
+File: `src/domain/ports/metrics.rs`
+
+```rust
+// ── P1: Orphan Watchdog (3 metrics) ─────────────────────────────────
+
+/// `{prefix}_orphan_detected` — counter
+/// Increments when watchdog identifies orphan candidate by stale-progress rule.
+/// `reason`: `stale_progress`
+fn record_orphan_detected(&self, reason: &str);
+
+/// `{prefix}_orphan_finalized` — counter
+/// Increments ONLY when watchdog wins CAS finalization.
+/// `reason`: `stale_progress`
+fn record_orphan_finalized(&self, reason: &str);
+
+/// `{prefix}_orphan_scan_duration_seconds` — histogram
+/// Watchdog scan execution duration (including candidate processing).
+fn record_orphan_scan_duration_seconds(&self, seconds: f64);
+```
+
+### 6.3 Add no-op implementations
+
+File: `src/domain/ports/metrics.rs` (in `NoopMetrics` impl)
+
+```rust
+fn record_orphan_detected(&self, _reason: &str) {}
+fn record_orphan_finalized(&self, _reason: &str) {}
+fn record_orphan_scan_duration_seconds(&self, _seconds: f64) {}
+```
+
+### 6.4 Update infra metrics struct
+
+File: `src/infra/metrics.rs`
+
+Replace the deferred `orphan_turn` field with properly named instruments:
+
+```rust
+// ── P1: Orphan Watchdog ──────────────────────────────────────────────
+orphan_detected: Counter<u64>,
+orphan_finalized: Counter<u64>,
+orphan_scan_duration: Histogram<f64>,
+```
+
+Remove the `#[allow(dead_code)]` and `// deferred:` comments since these are now active.
+
+### 6.5 Register instruments with OTel meter
+
+File: `src/infra/metrics.rs` (in constructor)
+
+```rust
+orphan_detected: meter
+    .u64_counter(format!("{prefix}_orphan_detected"))
+    .with_description("Orphan turns detected by watchdog")
+    .build(),
+orphan_finalized: meter
+    .u64_counter(format!("{prefix}_orphan_finalized"))
+    .with_description("Orphan turns finalized by watchdog (CAS won)")
+    .build(),
+orphan_scan_duration: meter
+    .f64_histogram(format!("{prefix}_orphan_scan_duration_seconds"))
+    .with_description("Watchdog scan execution duration")
+    .build(),
+```
+
+### 6.6 Implement `MiniChatMetricsPort` methods
+
+File: `src/infra/metrics.rs` (in `impl MiniChatMetricsPort for MiniChatMetricsMeter`)
+
+```rust
+fn record_orphan_detected(&self, reason: &str) {
+    self.orphan_detected.add(1, &[KeyValue::new(key::REASON, reason.to_owned())]);
+}
+
+fn record_orphan_finalized(&self, reason: &str) {
+    self.orphan_finalized.add(1, &[KeyValue::new(key::REASON, reason.to_owned())]);
+}
+
+fn record_orphan_scan_duration_seconds(&self, seconds: f64) {
+    self.orphan_scan_duration.record(seconds, &[]);
+}
+```
+
+Add `REASON` constant to `key` module in `metric_labels.rs` if not already present:
+```rust
+pub const REASON: &str = "reason";
+```
+
+### 6.7 Keep `cancel_orphan` as-is
+
+The existing `cancel_orphan` counter tracks a different concept — "a turn remained running longer than configured timeout after cancellation." This is NOT the same as the orphan watchdog detection. Keep it unchanged as a deferred metric.
+
+## Acceptance Criteria
+
+- [ ] All 3 metrics registered with OTel meter and exposed at `/metrics`
+- [ ] Metric names match DESIGN.md: `orphan_detected`, `orphan_finalized`, `orphan_scan_duration_seconds`
+- [ ] `reason` label populated with `"stale_progress"` on counter metrics
+- [ ] `NoopMetrics` updated with no-op implementations
+- [ ] Existing metrics (including `cancel_orphan`) unbroken
+- [ ] Deferred `orphan_turn` field removed/replaced — no dead code

--- a/modules/mini-chat/docs/plans/orphan-worker/phase-7-tests.md
+++ b/modules/mini-chat/docs/plans/orphan-worker/phase-7-tests.md
@@ -1,0 +1,92 @@
+# Phase 7: Tests
+
+## Goal
+
+Comprehensive test coverage for the orphan watchdog across unit and integration layers.
+
+## Test Infrastructure
+
+- **SQLite in-memory DB** with all migrations applied (same as existing test helpers in `src/domain/service/test_helpers.rs`).
+- **Mock `QuotaSettler`** and **`RecordingOutboxEnqueuer`** — follow existing patterns from `finalization_service.rs` tests.
+- **Mock turn repo** for watchdog loop unit tests (isolate loop logic from real DB).
+- **Noop metrics** for unit tests; real metrics for integration tests if needed.
+
+## Unit Tests — Migration + Entity (Phase 1)
+
+| Test | File | Asserts |
+|------|------|---------|
+| `create_turn_sets_last_progress_at` | `infra/db/repo/turn_repo.rs` | New running turn has `last_progress_at` approximately equal to `now()` |
+| `terminal_turn_allows_null_last_progress_at` | `infra/db/repo/turn_repo.rs` | Completed/failed/cancelled turns can have `last_progress_at = NULL` |
+
+## Unit Tests — Progress Updates (Phase 2)
+
+| Test | File | Asserts |
+|------|------|---------|
+| `update_progress_at_updates_running_turn` | `infra/db/repo/turn_repo.rs` | `rows_affected = 1`, `last_progress_at` is updated to a more recent value |
+| `update_progress_at_noop_on_terminal` | `infra/db/repo/turn_repo.rs` | `rows_affected = 0` for a completed turn |
+
+## Unit Tests — Repo Methods (Phase 3)
+
+| Test | File | Asserts |
+|------|------|---------|
+| `find_orphan_candidates_returns_stale_running` | `infra/db/repo/turn_repo.rs` | Turn with `last_progress_at` older than timeout is found |
+| `find_orphan_candidates_excludes_recent_progress` | `infra/db/repo/turn_repo.rs` | Turn with recent `last_progress_at` not returned |
+| `find_orphan_candidates_excludes_deleted` | `infra/db/repo/turn_repo.rs` | Soft-deleted running turn not returned |
+| `find_orphan_candidates_excludes_terminal` | `infra/db/repo/turn_repo.rs` | Completed/failed/cancelled turns not returned |
+| `find_orphan_candidates_respects_limit` | `infra/db/repo/turn_repo.rs` | Returns at most `limit` rows |
+| `find_orphan_candidates_orders_by_oldest_first` | `infra/db/repo/turn_repo.rs` | Oldest `last_progress_at` comes first |
+| `cas_finalize_orphan_transitions_to_failed` | `infra/db/repo/turn_repo.rs` | `rows_affected = 1`, state = `Failed`, `error_code = "orphan_timeout"`, `completed_at` set |
+| `cas_finalize_orphan_noop_if_already_terminal` | `infra/db/repo/turn_repo.rs` | `rows_affected = 0` on completed turn |
+| `cas_finalize_orphan_noop_if_progress_renewed` | `infra/db/repo/turn_repo.rs` | `rows_affected = 0` when `last_progress_at` was refreshed after candidate discovery — **critical safety test** |
+| `cas_finalize_orphan_noop_if_deleted` | `infra/db/repo/turn_repo.rs` | `rows_affected = 0` on soft-deleted running turn |
+
+## Unit Tests — Orphan Finalization (Phase 4)
+
+| Test | File | Asserts |
+|------|------|---------|
+| `finalize_orphan_cas_winner` | `domain/service/finalization_service.rs` | Returns `true`, quota debited (estimated), usage event enqueued in `RecordingOutboxEnqueuer` |
+| `finalize_orphan_cas_loser` | `domain/service/finalization_service.rs` | Returns `false`, `RecordingOutboxEnqueuer` has no new events, `MockQuotaSettler` not called |
+| `finalize_orphan_billing_is_aborted_estimated` | `domain/model/billing_outcome.rs` | Already exists: `orphan_timeout_derives_aborted_estimated` at line 183-188. Verify it still passes. |
+| `finalize_orphan_no_message_persisted` | `domain/service/finalization_service.rs` | No `insert_assistant_message` call on mock message repo |
+| `finalize_orphan_missing_quota_fields_skips_settlement` | `domain/service/finalization_service.rs` | Turn with `effective_model = NULL` still transitions to Failed, `MockQuotaSettler` not called, warning logged |
+
+## Unit Tests — Watchdog Loop (Phase 5)
+
+| Test | File | Asserts |
+|------|------|---------|
+| `disabled_returns_immediately` | `infra/workers/orphan_watchdog.rs` | Already exists — update to pass new deps |
+| `shutdown_on_cancel` | `infra/workers/orphan_watchdog.rs` | Already exists — update to pass new deps |
+| `scan_finds_and_finalizes_orphan` | `infra/workers/orphan_watchdog.rs` | Mock turn_repo returns 1 candidate, finalization_svc called once, finalized metric recorded |
+| `scan_empty_is_noop` | `infra/workers/orphan_watchdog.rs` | Mock turn_repo returns 0 candidates, no finalization calls |
+| `scan_continues_after_individual_error` | `infra/workers/orphan_watchdog.rs` | Finalization errors on turn 1 don't prevent processing turn 2 |
+| `shutdown_between_candidates` | `infra/workers/orphan_watchdog.rs` | Cancel fired mid-batch, exits cleanly after current candidate |
+
+## Integration Tests
+
+File: `tests/orphan_integration.rs` (new) or added to existing integration test file.
+
+| Test | Setup | Asserts |
+|------|-------|---------|
+| `e2e_orphan_detection_and_finalization` | Create running turn with `last_progress_at` = 10 minutes ago. Run one watchdog tick. | Turn state = `Failed`, `error_code = "orphan_timeout"`. Quota debited (estimated). Usage event in outbox with `outcome = "aborted"`. |
+| `no_false_orphan_after_renewed_progress` | Create running turn with recent `last_progress_at` (within timeout). Run watchdog tick. | Turn still `Running`. No outbox events. No metrics. |
+| `idempotent_double_scan` | Create orphan turn. Run watchdog tick twice. | First tick: finalized. Second tick: candidate not found (already terminal) or CAS returns 0. No duplicate outbox events. |
+| `concurrent_finalization_cas_safety` | Create orphan turn. Run orphan CAS and normal `cas_update_state` concurrently. | Exactly one wins. No duplicate quota settlement. No duplicate outbox events. |
+| `deleted_turn_not_finalized` | Create running turn with stale progress, then soft-delete it. Run watchdog tick. | Turn not finalized by watchdog (CAS fails on `deleted_at IS NULL`). |
+
+## Existing Tests to Verify
+
+These tests should continue passing without modification:
+
+- `orphan_timeout_derives_aborted_estimated` — billing_outcome.rs:183-188
+- `disabled_returns_immediately` — orphan_watchdog.rs:71 (updated for new deps)
+- `shutdown_on_cancel` — orphan_watchdog.rs:83 (updated for new deps)
+- All existing `finalize_turn_cas` tests in `finalization_service.rs`
+
+## Acceptance Criteria
+
+- [ ] All unit tests pass: `cargo test -p mini-chat`
+- [ ] Integration tests cover: happy path, CAS safety, renewed-progress safety, idempotency
+- [ ] No `#[ignore]` tests without documented reason
+- [ ] `cas_finalize_orphan_noop_if_progress_renewed` specifically validates the P1 invariant
+- [ ] `concurrent_finalization_cas_safety` validates at-most-once finalization
+- [ ] Existing billing derivation test for `orphan_timeout` still passes

--- a/modules/mini-chat/docs/plans/thread-summary-worker/README.md
+++ b/modules/mini-chat/docs/plans/thread-summary-worker/README.md
@@ -1,0 +1,108 @@
+# Thread Summary Worker Implementation Plan
+
+Implements `cpt-cf-mini-chat-seq-thread-summary` (P1) from DESIGN.md.
+
+## Context
+
+When a long conversation accumulates enough context to approach the model's token budget,
+the system must asynchronously summarize older messages into a compressed "thread summary."
+This is a Level 1 compression strategy: the LLM generates a summary of older messages,
+which replaces them in the context window for subsequent turns. This keeps token costs
+bounded while preserving key facts, decisions, and document references.
+
+The infrastructure stubs already exist:
+
+1. **`thread_summaries` table** — created in the initial migration
+   (`m20260302_000001_initial.rs:186-197`), but the current schema has `summarized_up_to UUID`
+   which stores only the message ID. DESIGN.md requires a composite frontier
+   `(summarized_up_to_created_at, summarized_up_to_message_id)` for the strict total order
+   `(created_at ASC, id ASC)`. A migration is needed to add the `created_at` component.
+
+2. **`ThreadSummaryHandler`** — P1 stub at `src/infra/workers/thread_summary_worker.rs`
+   that returns `Retry` for all messages. Registered in `module.rs` on the
+   `mini-chat.thread_summary` queue with decoupled strategy.
+
+3. **`ThreadSummaryRepository`** — trait at `src/domain/repos/thread_summary_repo.rs` with
+   `get_latest()` method; infra impl at `src/infra/db/repo/thread_summary_repo.rs` always
+   returns `Ok(None)`.
+
+4. **`enqueue_thread_summary_task`** — already implemented on `InfraOutboxEnqueuer`
+   (`src/infra/outbox.rs:88-120`), partitioned by `chat_id`, marked `#[allow(dead_code)]`.
+
+5. **`is_compressed` column** — exists on `messages` table (always `false`), entity has
+   the field at `src/infra/db/entity/message.rs:33`.
+
+6. **`LlmProvider::complete()`** — non-streaming Responses API method already available on
+   the `LlmProvider` trait (`src/infra/llm/mod.rs:420-427`).
+
+7. **Context assembly** — `gather_context()` in `stream_service/mod.rs` already fetches
+   `thread_summary_repo.get_latest()` and passes it to `assemble_context()`.
+
+## Architecture Decisions
+
+- **Outbox-driven, no module-local polling** — per DESIGN.md MUST. Uses the shared
+  transactional outbox. No leader election, no second worker state machine.
+
+- **System task isolation** — thread summary is a `requester_type=system` task. It MUST NOT
+  create `chat_turns` rows, MUST NOT debit per-user quota. Usage events carry
+  `requester_type=system` and `system_task_type="thread_summary_update"` for tenant-level
+  billing attribution.
+
+- **Trigger in finalization path** — the trigger evaluates the assembled request's
+  `reserve_tokens` (already computed during preflight) against the compression threshold
+  (`80% of token_budget`). If exceeded, a durable outbox message is enqueued in the same
+  transaction as the turn's CAS finalization. This ensures atomicity per DESIGN.md.
+
+- **Frozen range identity** — the outbox payload carries `base_frontier` and
+  `frozen_target_frontier` as `(created_at, message_id)` pairs. The handler loads exactly
+  the messages in that range and does not recompute the target at execution time.
+
+- **CAS-protected commit** — the handler's atomic commit advances the frontier only if
+  it still equals `base_frontier`. At most one handler wins per frozen range.
+
+- **Non-streaming LLM call** — uses `LlmProvider::complete()` (Responses API non-streaming)
+  per DESIGN.md section 3.5: "Thread summary generation, doc summary" uses
+  `POST /outbound/llm/responses`.
+
+- **`OutboxEnqueuer` trait extension** — add `enqueue_thread_summary` to the domain trait
+  (currently the method is only on `InfraOutboxEnqueuer` directly, not on the trait).
+
+## Rust Guidelines Applied (M-* from Microsoft Pragmatic Rust Guidelines)
+
+- **M-ERRORS-CANONICAL-STRUCTS**: summary errors use existing `DomainError` variants.
+- **M-LOG-STRUCTURED**: structured tracing with named fields (`chat_id`, `tenant_id`,
+  `base_frontier`, `frozen_target`, `system_request_id`).
+- **M-PANIC-ON-BUG**: payload deserialization failure -> `Reject` (dead-letter).
+  CAS losers log and return `Success` (idempotent skip).
+- **M-CONCISE-NAMES**: `ThreadSummaryHandler`, `ThreadSummaryTaskPayload`.
+- **M-SERVICES-CLONE**: handler holds `Arc<T>` deps, is `Send + Sync`.
+- **M-STATIC-VERIFICATION**: clippy clean, no `#[allow]` without `reason`.
+- **M-STRONG-TYPES**: `SummaryFrontier` struct instead of loose `(OffsetDateTime, Uuid)` tuples.
+
+## Phases
+
+| Phase | File | Summary |
+|-------|------|---------|
+| 1 | [phase-1-migration-schema.md](phase-1-migration-schema.md) | Migrate `thread_summaries` schema to composite frontier; add SeaORM entity |
+| 2 | [phase-2-domain-types.md](phase-2-domain-types.md) | Domain types: `ThreadSummaryTaskPayload`, `SummaryFrontier`, outbox enqueuer trait extension |
+| 3 | [phase-3-repo-layer.md](phase-3-repo-layer.md) | Repository methods: `get_latest` (real impl), `upsert_with_cas`, `mark_compressed` |
+| 4 | [phase-4-trigger.md](phase-4-trigger.md) | Trigger evaluation in finalization path + outbox enqueue in CAS transaction |
+| 5 | [phase-5-handler.md](phase-5-handler.md) | Replace stub handler: load range, call LLM, CAS commit, emit usage event |
+| 6 | [phase-6-observability.md](phase-6-observability.md) | Prometheus metrics per DESIGN.md |
+| 7 | [phase-7-tests.md](phase-7-tests.md) | Unit + integration tests |
+
+## Dependency Graph
+
+```
+Phase 1 ──┬──► Phase 3 (repo uses new entity columns)
+           │
+           └──► Phase 2 ──► Phase 4 (trigger uses domain types + enqueuer)
+                   │
+                   └──────► Phase 5 (handler uses domain types + repo + LLM)
+                               │
+Phase 6 ◄────────────────────┘ (metrics wired into trigger + handler)
+Phase 7 depends on all above
+```
+
+Phases 2 and 3 can be developed in parallel after Phase 1.
+Phases 4 and 5 can be developed in parallel after Phases 2 and 3.

--- a/modules/mini-chat/docs/plans/thread-summary-worker/phase-1-migration-schema.md
+++ b/modules/mini-chat/docs/plans/thread-summary-worker/phase-1-migration-schema.md
@@ -1,0 +1,137 @@
+# Phase 1: Migration + Entity — Composite Summary Frontier
+
+## Goal
+
+Migrate `thread_summaries` table to use a composite frontier `(summarized_up_to_created_at, summarized_up_to_message_id)` as required by DESIGN.md, and create the SeaORM entity.
+
+## Current State
+
+- `thread_summaries` table exists in `m20260302_000001_initial.rs:186-197` with schema:
+  `id, tenant_id, chat_id, summary_text, summarized_up_to (UUID), token_estimate, created_at, updated_at`
+- The `summarized_up_to` column is a single UUID — DESIGN.md requires a composite pair
+  `(summarized_up_to_created_at TIMESTAMPTZ, summarized_up_to_message_id UUID)` for the
+  strict total order `(created_at ASC, id ASC)`.
+- No SeaORM entity file exists for `thread_summaries` (no `src/infra/db/entity/thread_summary.rs`).
+- Domain model `ThreadSummaryModel` at `src/domain/repos/thread_summary_repo.rs:13-17`
+  already has `boundary_message_id: Uuid` and `boundary_created_at: OffsetDateTime` — aligned
+  with the composite frontier. Field names differ from DB columns (domain vs persistence naming).
+
+## Tasks
+
+### 1.1 New migration file
+
+File: `src/infra/db/migrations/m20260330_000001_thread_summary_composite_frontier.rs` (new)
+
+**Postgres UP:**
+```sql
+-- Rename the single-UUID column to the message_id component.
+ALTER TABLE thread_summaries
+    RENAME COLUMN summarized_up_to TO summarized_up_to_message_id;
+
+-- Add the created_at component of the composite frontier.
+ALTER TABLE thread_summaries
+    ADD COLUMN summarized_up_to_created_at TIMESTAMPTZ;
+
+-- The table has UNIQUE(chat_id), so at most one row per chat.
+-- No backfill needed: the table is empty in P1 (no summary rows exist yet).
+-- If any rows existed, we would backfill from messages:
+--   UPDATE thread_summaries ts
+--   SET summarized_up_to_created_at = (
+--       SELECT m.created_at FROM messages m WHERE m.id = ts.summarized_up_to_message_id
+--   )
+--   WHERE summarized_up_to_created_at IS NULL;
+
+-- Make NOT NULL (safe: table is empty in production).
+ALTER TABLE thread_summaries
+    ALTER COLUMN summarized_up_to_created_at SET NOT NULL;
+```
+
+**SQLite UP:**
+```sql
+-- SQLite does not support RENAME COLUMN on older versions; use the
+-- standard ALTER TABLE ... RENAME COLUMN syntax (supported since 3.25).
+ALTER TABLE thread_summaries
+    RENAME COLUMN summarized_up_to TO summarized_up_to_message_id;
+
+ALTER TABLE thread_summaries
+    ADD COLUMN summarized_up_to_created_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00Z';
+```
+
+**DOWN:**
+```sql
+ALTER TABLE thread_summaries DROP COLUMN summarized_up_to_created_at;
+ALTER TABLE thread_summaries RENAME COLUMN summarized_up_to_message_id TO summarized_up_to;
+```
+
+Design notes:
+- The table is empty in production (no summary has ever been committed). The migration
+  is safe to run without backfill.
+- `summarized_up_to_created_at` + `summarized_up_to_message_id` together form the
+  inclusive summary frontier per DESIGN.md section "Thread Summary - Stable Range and
+  Commit Invariant."
+- A missing `thread_summaries` row means no messages have been summarized (empty frontier).
+
+### 1.2 Register migration
+
+File: `src/infra/db/migrations/mod.rs`
+
+Add the new module declaration and append the migration to `Migrator::migrations()` vec,
+after the last existing migration entry.
+
+### 1.3 Create SeaORM entity
+
+File: `src/infra/db/entity/thread_summary.rs` (new)
+
+```rust
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "thread_summaries")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    pub summary_text: String,
+    pub summarized_up_to_created_at: OffsetDateTime,
+    pub summarized_up_to_message_id: Uuid,
+    pub token_estimate: i32,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::chat::Entity",
+        from = "Column::ChatId",
+        to = "super::chat::Column::Id"
+    )]
+    Chat,
+}
+
+impl Related<super::chat::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Chat.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}
+```
+
+### 1.4 Register entity module
+
+File: `src/infra/db/entity/mod.rs`
+
+Add `pub mod thread_summary;` to the entity module declarations.
+
+## Acceptance Criteria
+
+- [ ] Migration runs successfully on both Postgres and SQLite
+- [ ] `thread_summaries` table has `summarized_up_to_created_at TIMESTAMPTZ NOT NULL` and
+      `summarized_up_to_message_id UUID NOT NULL` columns
+- [ ] SeaORM entity `thread_summary::Model` compiles and reflects all DB columns
+- [ ] Entity registered in `entity/mod.rs`
+- [ ] Existing tests pass (no data in `thread_summaries` table, so migration is backward-compatible)

--- a/modules/mini-chat/docs/plans/thread-summary-worker/phase-2-domain-types.md
+++ b/modules/mini-chat/docs/plans/thread-summary-worker/phase-2-domain-types.md
@@ -1,0 +1,171 @@
+# Phase 2: Domain Types — Payload, Frontier, Enqueuer Trait Extension
+
+## Goal
+
+Define the domain-level types for thread summary orchestration: the durable outbox payload,
+the summary frontier value object, and extend the `OutboxEnqueuer` trait to include
+thread summary enqueue.
+
+## Current State
+
+- `ThreadSummaryModel` at `src/domain/repos/thread_summary_repo.rs:13-17` has
+  `content`, `boundary_message_id`, `boundary_created_at`. Used for context assembly reads.
+- `InfraOutboxEnqueuer::enqueue_thread_summary_task()` at `src/infra/outbox.rs:88-120`
+  accepts raw `Vec<u8>` payload, partitions by `chat_id`. Marked `#[allow(dead_code)]`.
+  **Not** on the `OutboxEnqueuer` trait — only on the concrete struct.
+- `OutboxEnqueuer` trait at `src/domain/repos/outbox_enqueuer.rs:90-154` has methods for
+  usage, attachment cleanup, chat cleanup, and audit — but NOT thread summary.
+- No `ThreadSummaryTaskPayload` type exists.
+
+## Tasks
+
+### 2.1 Define `SummaryFrontier` value object
+
+File: `src/domain/repos/thread_summary_repo.rs`
+
+A strongly-typed composite frontier to avoid loose `(OffsetDateTime, Uuid)` tuples
+throughout the codebase (M-STRONG-TYPES):
+
+```rust
+/// Inclusive summary frontier in the per-chat message order `(created_at ASC, id ASC)`.
+///
+/// Identifies the last message represented in the summary text.
+/// Per DESIGN.md: "created_at alone is insufficient because multiple messages may share
+/// the same timestamp. id is used only as a deterministic UUID tie-breaker."
+#[domain_model]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SummaryFrontier {
+    pub created_at: OffsetDateTime,
+    pub message_id: Uuid,
+}
+```
+
+Update `ThreadSummaryModel` to use `SummaryFrontier`:
+
+```rust
+#[domain_model]
+#[derive(Debug, Clone)]
+pub struct ThreadSummaryModel {
+    pub content: String,
+    pub frontier: SummaryFrontier,
+    pub token_estimate: i32,
+}
+```
+
+Update all call sites that use `boundary_message_id` / `boundary_created_at` to use
+`model.frontier.message_id` / `model.frontier.created_at` instead:
+- `stream_service/mod.rs` `gather_context()` (line ~802-809)
+- Context assembly `thread_summary` parameter (unchanged — still passes `ts.content`)
+- `recent_after_boundary()` call uses `ts.frontier.created_at`, `ts.frontier.message_id`
+
+### 2.2 Define `ThreadSummaryTaskPayload`
+
+File: `src/domain/repos/outbox_enqueuer.rs`
+
+Per DESIGN.md (line 1574), the serialized outbox message MUST contain at minimum:
+
+```rust
+/// Durable outbox payload for thread summary generation.
+///
+/// Persisted at enqueue time in the finalization transaction. The handler
+/// reads this payload to know exactly which message range to summarize.
+/// `system_request_id` is generated once and reused across retries.
+#[domain_model]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreadSummaryTaskPayload {
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    /// Stable system-task identity — generated at enqueue, reused across retries.
+    pub system_request_id: Uuid,
+    pub system_task_type: String,  // always "thread_summary_update"
+
+    // ── Base frontier (current summary boundary at enqueue time) ──
+    // None if no summary exists yet (first summary for this chat).
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub base_frontier_created_at: Option<OffsetDateTime>,
+    pub base_frontier_message_id: Option<Uuid>,
+
+    // ── Frozen target frontier (last message to include in this summary) ──
+    #[serde(with = "time::serde::rfc3339")]
+    pub frozen_target_created_at: OffsetDateTime,
+    pub frozen_target_message_id: Uuid,
+}
+```
+
+### 2.3 Add `enqueue_thread_summary` to `OutboxEnqueuer` trait
+
+File: `src/domain/repos/outbox_enqueuer.rs`
+
+```rust
+/// Enqueue a thread summary task within the caller's transaction.
+///
+/// Called in the finalization transaction when the trigger fires.
+/// Partitioned by `chat_id` so all summary events for one chat are
+/// processed sequentially within the same partition.
+async fn enqueue_thread_summary(
+    &self,
+    runner: &(dyn DBRunner + Sync),
+    payload: ThreadSummaryTaskPayload,
+) -> Result<(), DomainError>;
+```
+
+### 2.4 Implement `enqueue_thread_summary` in infra
+
+File: `src/infra/outbox.rs`
+
+Update the `OutboxEnqueuer for InfraOutboxEnqueuer` impl block. The existing
+`enqueue_thread_summary_task` method (lines 88-120) already has the correct partition
+and queue logic. Refactor it:
+
+```rust
+async fn enqueue_thread_summary(
+    &self,
+    runner: &(dyn DBRunner + Sync),
+    payload: ThreadSummaryTaskPayload,
+) -> Result<(), DomainError> {
+    let partition = Self::compute_partition(payload.chat_id, self.num_partitions);
+    let serialized = serde_json::to_vec(&payload)
+        .map_err(|e| DomainError::internal(format!("thread summary serialize: {e}")))?;
+
+    self.outbox()
+        .enqueue(
+            runner,
+            &self.thread_summary_queue_name,
+            partition,
+            serialized,
+            "application/json",
+        )
+        .await
+        .map_err(|e| DomainError::internal(format!("outbox enqueue: {e}")))?;
+
+    info!(
+        queue = %self.thread_summary_queue_name,
+        partition,
+        chat_id = %payload.chat_id,
+        system_request_id = %payload.system_request_id,
+        "thread summary task enqueued"
+    );
+
+    Ok(())
+}
+```
+
+Remove the old `enqueue_thread_summary_task` method and its `#[allow(dead_code)]`.
+
+### 2.5 Update `RecordingOutboxEnqueuer` in test helpers
+
+File: `src/domain/service/test_helpers.rs`
+
+Add `thread_summary_payloads: Mutex<Vec<ThreadSummaryTaskPayload>>` field and implement
+the new trait method to record payloads for test assertions.
+
+## Acceptance Criteria
+
+- [ ] `SummaryFrontier` value object defined and used in `ThreadSummaryModel`
+- [ ] `ThreadSummaryTaskPayload` serializes/deserializes correctly (round-trip test)
+- [ ] `OutboxEnqueuer` trait extended with `enqueue_thread_summary`
+- [ ] Infra implementation delegates to `outbox.enqueue()` with `chat_id`-based partition
+- [ ] Old `enqueue_thread_summary_task` removed, `#[allow(dead_code)]` cleaned up
+- [ ] `RecordingOutboxEnqueuer` updated in test helpers
+- [ ] All callers of `ThreadSummaryModel.boundary_*` migrated to `frontier.*`
+- [ ] Existing tests compile and pass

--- a/modules/mini-chat/docs/plans/thread-summary-worker/phase-3-repo-layer.md
+++ b/modules/mini-chat/docs/plans/thread-summary-worker/phase-3-repo-layer.md
@@ -1,0 +1,232 @@
+# Phase 3: Repository Layer — Thread Summary Persistence
+
+## Goal
+
+Implement real `ThreadSummaryRepository` methods: `get_latest` (replace stub), `upsert_with_cas`
+(CAS-protected frontier advance), and `mark_messages_compressed` (set `is_compressed = true`
+on the summarized range).
+
+## Current State
+
+- `ThreadSummaryRepository` trait at `src/domain/repos/thread_summary_repo.rs:20-31` has
+  only `get_latest()` returning `Option<ThreadSummaryModel>`.
+- Infra impl at `src/infra/db/repo/thread_summary_repo.rs` always returns `Ok(None)`.
+- `messages` entity has `is_compressed: bool` (always `false`, line 33).
+- SeaORM entity for `thread_summaries` created in Phase 1.
+- Message index: `(chat_id, created_at, id) WHERE deleted_at IS NULL` — supports the
+  range query needed by the handler.
+
+## Tasks
+
+### 3.1 Implement real `get_latest`
+
+File: `src/infra/db/repo/thread_summary_repo.rs`
+
+Replace the stub with a real DB query:
+
+```rust
+async fn get_latest<C: DBRunner>(
+    &self,
+    runner: &C,
+    _scope: &AccessScope,
+    chat_id: Uuid,
+) -> Result<Option<ThreadSummaryModel>, DomainError> {
+    let row = thread_summary::Entity::find()
+        .filter(thread_summary::Column::ChatId.eq(chat_id))
+        .one(runner.as_ref())
+        .await
+        .map_err(|e| DomainError::internal(format!("thread_summary query: {e}")))?;
+
+    Ok(row.map(|r| ThreadSummaryModel {
+        content: r.summary_text,
+        frontier: SummaryFrontier {
+            created_at: r.summarized_up_to_created_at,
+            message_id: r.summarized_up_to_message_id,
+        },
+        token_estimate: r.token_estimate,
+    }))
+}
+```
+
+Note: `_scope` is unused because `thread_summaries` has no independent authorization
+(accessed through parent chat, per DESIGN.md). The scope parameter is kept for API
+consistency with other repository traits.
+
+### 3.2 Add `upsert_with_cas` to trait and impl
+
+File: `src/domain/repos/thread_summary_repo.rs`
+
+```rust
+/// CAS-protected upsert: insert or update the summary only if the stored frontier
+/// matches `expected_base_frontier`.
+///
+/// Returns the number of rows affected:
+/// - 1 = success (frontier advanced)
+/// - 0 = CAS conflict (another handler already advanced the frontier)
+///
+/// If no `thread_summaries` row exists and `expected_base_frontier` is `None`,
+/// inserts a new row (first summary for this chat).
+async fn upsert_with_cas<C: DBRunner>(
+    &self,
+    runner: &C,
+    chat_id: Uuid,
+    tenant_id: Uuid,
+    expected_base_frontier: Option<&SummaryFrontier>,
+    new_frontier: &SummaryFrontier,
+    summary_text: &str,
+    token_estimate: i32,
+) -> Result<u64, DomainError>;
+```
+
+File: `src/infra/db/repo/thread_summary_repo.rs`
+
+Implementation uses raw SQL for the atomic CAS because SeaORM's update API does not
+natively support conditional UPDATE with composite WHERE on nullable pairs:
+
+**Case 1: First summary (`expected_base_frontier` is `None`)**
+
+```sql
+INSERT INTO thread_summaries (
+    id, tenant_id, chat_id, summary_text,
+    summarized_up_to_created_at, summarized_up_to_message_id,
+    token_estimate, created_at, updated_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, now(), now())
+ON CONFLICT (chat_id) DO NOTHING
+```
+
+`DO NOTHING` ensures that if another handler already inserted a row, we get 0 rows
+affected (CAS semantics). The first INSERT wins.
+
+**Case 2: Subsequent summary (`expected_base_frontier` is `Some`)**
+
+```sql
+UPDATE thread_summaries
+SET summary_text = $1,
+    summarized_up_to_created_at = $2,
+    summarized_up_to_message_id = $3,
+    token_estimate = $4,
+    updated_at = now()
+WHERE chat_id = $5
+  AND summarized_up_to_created_at = $6
+  AND summarized_up_to_message_id = $7
+```
+
+The WHERE clause on the composite frontier is the CAS guard. Returns 0 if the frontier
+was already advanced by another handler.
+
+### 3.3 Add `mark_messages_compressed` to `MessageRepository`
+
+File: `src/domain/repos/message_repo.rs` (trait extension)
+
+```rust
+/// Mark messages in the given range as compressed (included in a thread summary).
+///
+/// Sets `is_compressed = true` for all non-deleted messages in
+/// `(base_frontier, target_frontier]` ordered by `(created_at ASC, id ASC)`.
+/// Returns the number of rows updated.
+async fn mark_messages_compressed<C: DBRunner>(
+    &self,
+    runner: &C,
+    chat_id: Uuid,
+    base_frontier: Option<&SummaryFrontier>,
+    target_frontier: &SummaryFrontier,
+) -> Result<u64, DomainError>;
+```
+
+File: `src/infra/db/repo/message_repo.rs` (implementation)
+
+Uses raw SQL for the composite range predicate:
+
+**When `base_frontier` is `None` (first summary):**
+```sql
+UPDATE messages
+SET is_compressed = true
+WHERE chat_id = $1
+  AND deleted_at IS NULL
+  AND is_compressed = false
+  AND (created_at, id) <= ($2, $3)
+```
+
+**When `base_frontier` is `Some`:**
+```sql
+UPDATE messages
+SET is_compressed = true
+WHERE chat_id = $1
+  AND deleted_at IS NULL
+  AND is_compressed = false
+  AND (created_at, id) > ($2, $3)
+  AND (created_at, id) <= ($4, $5)
+```
+
+The row-value comparison `(created_at, id)` leverages Postgres tuple comparison for
+the strict total order.
+
+### 3.4 Add `fetch_messages_in_range` to `MessageRepository`
+
+File: `src/domain/repos/message_repo.rs` (trait extension)
+
+The handler needs to load the actual message content for the LLM summarization prompt:
+
+```rust
+/// Load non-deleted, non-compressed messages in the range (base_frontier, target_frontier].
+///
+/// Returns messages ordered by `(created_at ASC, id ASC)`.
+/// Per DESIGN.md: messages appended after `frozen_target_frontier` are excluded.
+async fn fetch_messages_in_range<C: DBRunner>(
+    &self,
+    runner: &C,
+    chat_id: Uuid,
+    base_frontier: Option<&SummaryFrontier>,
+    target_frontier: &SummaryFrontier,
+) -> Result<Vec<MessageModel>, DomainError>;
+```
+
+File: `src/infra/db/repo/message_repo.rs`
+
+Similar SQL to `mark_messages_compressed` but SELECT instead of UPDATE, with
+`ORDER BY created_at ASC, id ASC`.
+
+The `WHERE` clauses match the DESIGN.md range selection rules (section "Thread Summary -
+Stable Range and Commit Invariant"):
+1. `deleted_at IS NULL`
+2. `is_compressed = false`
+3. `(created_at, id) > base_frontier` (omitted if first summary)
+4. `(created_at, id) <= frozen_target_frontier`
+
+### 3.5 Add `find_latest_message_before` to `MessageRepository`
+
+The trigger needs to determine the `frozen_target_frontier` — the last message that should
+be included in the summary. This is the latest non-deleted message at the time the trigger
+fires (which is the just-persisted assistant message from the current turn, or the user
+message if no assistant message was persisted):
+
+```rust
+/// Find the most recent non-deleted message for a chat.
+///
+/// Returns `(created_at, message_id)` for use as `frozen_target_frontier`.
+/// Returns `None` if no messages exist.
+async fn find_latest_message<C: DBRunner>(
+    &self,
+    runner: &C,
+    chat_id: Uuid,
+) -> Result<Option<SummaryFrontier>, DomainError>;
+```
+
+```sql
+SELECT created_at, id
+FROM messages
+WHERE chat_id = $1 AND deleted_at IS NULL
+ORDER BY created_at DESC, id DESC
+LIMIT 1
+```
+
+## Acceptance Criteria
+
+- [ ] `get_latest` returns real data from `thread_summaries` table (not `Ok(None)` stub)
+- [ ] `upsert_with_cas` returns 1 on success, 0 on CAS conflict
+- [ ] `upsert_with_cas` handles first-summary INSERT with `ON CONFLICT DO NOTHING`
+- [ ] `mark_messages_compressed` updates exactly the messages in the specified range
+- [ ] `fetch_messages_in_range` returns correct messages in `(created_at ASC, id ASC)` order
+- [ ] `find_latest_message` returns the most recent non-deleted message
+- [ ] All range queries use the composite `(created_at, id)` tuple comparison
+- [ ] Existing tests pass (stub removal is backward-compatible since no data existed)

--- a/modules/mini-chat/docs/plans/thread-summary-worker/phase-4-trigger.md
+++ b/modules/mini-chat/docs/plans/thread-summary-worker/phase-4-trigger.md
@@ -1,0 +1,173 @@
+# Phase 4: Trigger — Evaluation in Finalization Path + Outbox Enqueue
+
+## Goal
+
+Evaluate the thread summary trigger during turn finalization and, if conditions are met,
+enqueue a durable thread-summary outbox message atomically within the CAS finalization
+transaction.
+
+## Current State
+
+- `FinalizationService::try_finalize()` at `src/domain/service/finalization_service.rs`
+  runs steps 1-6 (CAS, billing, quota, message persist, usage event, audit event) inside
+  a single `db.transaction()`.
+- `FinalizationInput` carries `assembled_context_tokens: u64` (from context assembly —
+  the real conversation size including system prompt, thread summary, history, and current message),
+  `messages_truncated: bool` (true when context assembly dropped older messages), and
+  `context_window: u32` / `max_output_tokens_applied: i32` for budget calculation.
+- `OutboxEnqueuer` has `enqueue_thread_summary` (Phase 2).
+- `ThreadSummaryRepository::get_latest` returns real data (Phase 3).
+- `MessageRepository::find_latest_message` exists (Phase 3).
+
+## Design Constraints
+
+From DESIGN.md:
+- Two-condition trigger (OR):
+  1. **Proactive**: `assembled_context_tokens >= compression_threshold_pct% of effective_budget`
+     AND no existing summary (`ThreadSummaryRepository::get_latest` returns `None`).
+  2. **Urgent**: `messages_truncated == true` — context assembly dropped older messages,
+     meaning the existing summary is stale and the conversation is losing context.
+- When a summary already exists and context is not truncated, trigger MUST NOT fire.
+- Default compression threshold: **60%** of effective input token budget.
+- Durable scheduling MUST occur only in the same transaction that makes the causing turn durable.
+- Thread summary generation MUST NOT block or modify the user-visible response path.
+- The trigger SHOULD fire only for `Completed` turns.
+- The request path SHOULD avoid enqueueing a duplicate when the frontier is unchanged.
+
+## Tasks
+
+### 4.1 Add compression threshold to config
+
+File: `src/config/background.rs`
+
+Add to `ThreadSummaryWorkerConfig`:
+
+```rust
+/// Compression threshold: summary triggered when assembled context tokens
+/// reach this percentage of the effective input token budget. Default: 60.
+pub compression_threshold_pct: u32,
+```
+
+Default: `60`. Range: `1-99`.
+
+### 4.2 Carry context assembly data in `FinalizationInput`
+
+File: `src/domain/model/finalization.rs`
+
+Fields on `FinalizationInput` needed for trigger evaluation:
+
+```rust
+/// Context window size of the effective model (tokens).
+pub context_window: u32,
+/// Estimated input tokens from context assembly (all messages + system prompt).
+pub assembled_context_tokens: u64,
+/// True when context assembly dropped older messages due to budget.
+pub messages_truncated: bool,
+```
+
+These flow from `AssembledContext` → `FinalizationCtx` → `FinalizationInput`.
+
+### 4.3 Add trigger evaluation function
+
+File: `src/domain/service/finalization_service.rs`
+
+Pure function — no I/O:
+
+```rust
+/// Two conditions (OR):
+/// 1. Context assembly truncated messages (urgent — conversation losing context).
+/// 2. Context fills >= threshold% of budget AND no summary exists yet (proactive).
+fn should_trigger_summary(
+    assembled_context_tokens: u64,
+    max_output_tokens_applied: i32,
+    context_window: u32,
+    compression_threshold_pct: u32,
+    messages_truncated: bool,
+    has_existing_summary: bool,
+) -> bool {
+    if messages_truncated {
+        return true; // Urgent: messages already being dropped
+    }
+    if has_existing_summary {
+        return false; // Existing summary still effective
+    }
+    // Proactive: context filling up, first summary
+    let estimated_input = i64::try_from(assembled_context_tokens).unwrap_or(i64::MAX);
+    let effective_budget = i64::from(context_window) - i64::from(max_output_tokens_applied);
+    if effective_budget <= 0 || estimated_input <= 0 {
+        return false;
+    }
+    let threshold = effective_budget * i64::from(compression_threshold_pct) / 100;
+    estimated_input >= threshold
+}
+```
+
+### 4.4 Wire trigger into finalization transaction
+
+File: `src/domain/service/finalization_service.rs`
+
+Inside `try_finalize()`, after step 6 (audit event), add step 7:
+
+```rust
+// 7. Evaluate thread summary trigger (completed turns only)
+// Fetch existing summary first — needed for both trigger decision and frontier.
+let current_summary = if input.terminal_state == TurnState::Completed
+    && summary_config.enabled
+{
+    ThreadSummaryRepository::get_latest(&ts_repo, tx, &scope, input.chat_id).await?
+} else {
+    None
+};
+
+let summary_triggered = input.terminal_state == TurnState::Completed
+    && summary_config.enabled
+    && should_trigger_summary(
+        input.assembled_context_tokens,
+        input.max_output_tokens_applied,
+        input.context_window,
+        summary_config.compression_threshold_pct,
+        input.messages_truncated,
+        current_summary.is_some(),
+    );
+
+if summary_triggered {
+    let base_frontier = current_summary.as_ref().map(|s| &s.frontier);
+    let frozen_target = message_repo
+        .find_latest_message(tx, &scope, input.chat_id)
+        .await?;
+
+    if let Some(target) = frozen_target {
+        let should_enqueue = match base_frontier {
+            Some(bf) => bf != &target,
+            None => true,
+        };
+        if should_enqueue {
+            let payload = ThreadSummaryTaskPayload { /* ... */ };
+            outbox_enqueuer.enqueue_thread_summary(tx, payload).await?;
+            metrics.record_thread_summary_trigger("scheduled");
+        } else {
+            metrics.record_thread_summary_trigger("not_needed");
+        }
+    }
+}
+```
+
+### 4.5–4.6 Unchanged
+
+Dependencies and wiring remain as originally planned.
+
+## Acceptance Criteria
+
+- [ ] `should_trigger_summary` returns `true` when `assembled_context_tokens >= 60% of budget` and no existing summary
+- [ ] `should_trigger_summary` returns `false` when below threshold
+- [ ] `should_trigger_summary` returns `false` when summary exists and context not truncated (proactive suppressed)
+- [ ] `should_trigger_summary` returns `true` when `messages_truncated` even with existing summary (urgent)
+- [ ] `should_trigger_summary` returns `false` when effective budget is non-positive
+- [ ] Trigger only fires for `Completed` turns
+- [ ] `OutboxEnqueuer::enqueue_thread_summary` called atomically within the finalization transaction
+- [ ] `system_request_id` is `Uuid::new_v4()` generated once at enqueue
+- [ ] Dedupe: no enqueue when base frontier equals target (frontier hasn't moved)
+- [ ] Trigger does NOT block the user-visible response path (all within existing tx)
+- [ ] Metrics: `record_thread_summary_trigger("scheduled"|"not_needed")` emitted
+- [ ] Existing finalization tests pass with summary trigger disabled or below threshold
+- [ ] New unit tests for `should_trigger_summary`: proactive, suppressed, urgent, non-positive budget, zero tokens

--- a/modules/mini-chat/docs/plans/thread-summary-worker/phase-5-handler.md
+++ b/modules/mini-chat/docs/plans/thread-summary-worker/phase-5-handler.md
@@ -1,0 +1,468 @@
+# Phase 5: Handler — Replace Stub with Real Summary Logic
+
+## Goal
+
+Replace the `ThreadSummaryHandler` stub with real logic: deserialize payload, load messages
+in the frozen range, call the LLM via Responses API (non-streaming), and CAS-commit the
+new summary with frontier advance and `is_compressed` marking.
+
+## Current State
+
+- Stub at `src/infra/workers/thread_summary_worker.rs` returns `HandlerResult::Retry`.
+- `ThreadSummaryTaskPayload` (Phase 2) defines the deserialized outbox payload.
+- Repository methods (Phase 3): `get_latest`, `upsert_with_cas`, `mark_messages_compressed`,
+  `fetch_messages_in_range`.
+- `LlmProvider::complete()` at `src/infra/llm/mod.rs:420-427` sends non-streaming requests.
+- `SecurityContext` can be constructed for system tasks (pattern from `ChatCleanupHandler`
+  which uses `DEFAULT_SUBJECT_ID`).
+- Config: `ThreadSummaryWorkerConfig` has `enabled`, `reconcile_interval_secs`, etc.
+
+## Design Constraints
+
+From DESIGN.md:
+- Handler MUST bind to the frozen target frontier from the outbox payload.
+- Handler MUST load non-deleted, non-compressed messages in `(base_frontier, frozen_target]`.
+- LLM call uses `POST /outbound/llm/responses` (non-streaming Responses API).
+- If LLM succeeds: atomic CAS commit (save summary, advance frontier, mark compressed).
+- CAS MUST succeed only if stored frontier still equals `base_frontier`.
+- If CAS fails (frontier already advanced): finish without another commit (`Success`).
+- If LLM fails: keep previous summary unchanged, don't advance frontier, return `Retry`.
+- System task: `requester_type=system`, no `chat_turns` row, no user quota debit.
+- Usage event MUST carry `requester_type=system`, `system_task_type="thread_summary_update"`.
+- `system_request_id` from payload reused across retries (not regenerated).
+
+## Tasks
+
+### 5.1 Define `ThreadSummaryDeps` struct
+
+File: `src/infra/workers/thread_summary_worker.rs`
+
+```rust
+/// Dependencies for the thread summary outbox handler.
+pub struct ThreadSummaryDeps {
+    pub db: Arc<DbProvider>,
+    pub thread_summary_repo: Arc<dyn ThreadSummaryRepository>,
+    pub message_repo: Arc<dyn MessageRepository>,
+    pub llm_provider: Arc<dyn LlmProvider>,
+    pub outbox_enqueuer: Arc<dyn OutboxEnqueuer>,
+    pub metrics: Arc<dyn MiniChatMetricsPort>,
+    pub upstream_alias: String,
+    pub summary_model: String,  // model to use for summarization (from config)
+    pub summary_system_prompt: String,  // system instructions for summary generation
+}
+```
+
+### 5.2 Replace `ThreadSummaryHandler` struct
+
+File: `src/infra/workers/thread_summary_worker.rs`
+
+```rust
+pub struct ThreadSummaryHandler {
+    deps: Arc<ThreadSummaryDeps>,
+}
+
+impl ThreadSummaryHandler {
+    pub fn new(deps: Arc<ThreadSummaryDeps>) -> Self {
+        Self { deps }
+    }
+}
+```
+
+### 5.3 Implement `MessageHandler` for `ThreadSummaryHandler`
+
+File: `src/infra/workers/thread_summary_worker.rs`
+
+```rust
+#[async_trait]
+impl MessageHandler for ThreadSummaryHandler {
+    async fn handle(&self, msg: &OutboxMessage, cancel: CancellationToken) -> HandlerResult {
+        // 1. Deserialize payload
+        let payload: ThreadSummaryTaskPayload = match serde_json::from_slice(&msg.payload) {
+            Ok(p) => p,
+            Err(e) => {
+                error!(
+                    partition_id = msg.partition_id,
+                    seq = msg.seq,
+                    error = %e,
+                    "thread summary: invalid payload, dead-lettering"
+                );
+                return HandlerResult::Reject {
+                    reason: format!("payload deserialization failed: {e}"),
+                };
+            }
+        };
+
+        let span_fields = /* structured: chat_id, tenant_id, system_request_id */;
+
+        // 2. Pre-check: verify stored frontier still matches base_frontier
+        //    (early CAS guard before expensive LLM call)
+        let conn = match self.deps.db.conn() {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(error = %e, "thread summary: DB connection failed");
+                return HandlerResult::Retry {
+                    reason: format!("db connection: {e}"),
+                };
+            }
+        };
+
+        let base_frontier = match (&payload.base_frontier_created_at, &payload.base_frontier_message_id) {
+            (Some(ca), Some(mid)) => Some(SummaryFrontier { created_at: *ca, message_id: *mid }),
+            _ => None,
+        };
+
+        let current = self.deps.thread_summary_repo
+            .get_latest(&conn, &AccessScope::for_tenant(payload.tenant_id), payload.chat_id)
+            .await;
+
+        match &current {
+            Ok(Some(existing)) => {
+                if base_frontier.as_ref() != Some(&existing.frontier) {
+                    // Frontier already advanced — another handler won. Idempotent skip.
+                    info!("thread summary: frontier already advanced, skipping");
+                    self.deps.metrics.record_thread_summary_cas_conflict();
+                    return HandlerResult::Success;
+                }
+            }
+            Ok(None) => {
+                if base_frontier.is_some() {
+                    // Expected existing frontier but none exists — should not happen.
+                    // Could be a race with chat deletion (CASCADE). Skip gracefully.
+                    warn!("thread summary: expected frontier but none found, skipping");
+                    return HandlerResult::Success;
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "thread summary: pre-check query failed");
+                return HandlerResult::Retry {
+                    reason: format!("pre-check query: {e}"),
+                };
+            }
+        }
+
+        let target_frontier = SummaryFrontier {
+            created_at: payload.frozen_target_created_at,
+            message_id: payload.frozen_target_message_id,
+        };
+
+        // 3. Load messages in range
+        let messages = match self.deps.message_repo
+            .fetch_messages_in_range(
+                &conn,
+                payload.chat_id,
+                base_frontier.as_ref(),
+                &target_frontier,
+            )
+            .await
+        {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(error = %e, "thread summary: message fetch failed");
+                return HandlerResult::Retry {
+                    reason: format!("message fetch: {e}"),
+                };
+            }
+        };
+
+        if messages.is_empty() {
+            // No messages to summarize (all deleted or already compressed).
+            info!("thread summary: no messages in range, skipping");
+            return HandlerResult::Success;
+        }
+
+        // 4. Build summarization prompt
+        let existing_summary = current
+            .as_ref()
+            .ok()
+            .and_then(|c| c.as_ref())
+            .map(|s| s.content.as_str());
+
+        let user_content = build_summary_prompt(existing_summary, &messages);
+
+        // 5. Call LLM (non-streaming Responses API)
+        let security_ctx = build_system_security_context(payload.tenant_id);
+
+        let request = llm_request(&self.deps.summary_model)
+            .system(&self.deps.summary_system_prompt)
+            .user(&user_content)
+            .build_non_streaming();
+
+        let llm_result = self.deps.llm_provider
+            .complete(security_ctx, request, &self.deps.upstream_alias)
+            .await;
+
+        let response = match llm_result {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(error = %e, "thread summary: LLM call failed");
+                self.deps.metrics.record_thread_summary_execution("provider_error");
+                self.deps.metrics.record_summary_fallback();
+                return HandlerResult::Retry {
+                    reason: format!("LLM provider error: {e}"),
+                };
+            }
+        };
+
+        if cancel.is_cancelled() {
+            return HandlerResult::Retry {
+                reason: "cancelled".to_owned(),
+            };
+        }
+
+        let summary_text = response.output_text();
+        let token_estimate = estimate_summary_tokens(&summary_text);
+        let usage = response.usage();
+
+        // 6. CAS-protected atomic commit
+        let cas_result = self.deps.db.transaction(|tx| {
+            let deps = Arc::clone(&self.deps);
+            let payload = payload.clone();
+            let base_frontier = base_frontier.clone();
+            let target_frontier = target_frontier.clone();
+            let summary_text = summary_text.clone();
+            Box::pin(async move {
+                // 6a. Upsert summary with CAS
+                let rows = deps.thread_summary_repo
+                    .upsert_with_cas(
+                        tx,
+                        payload.chat_id,
+                        payload.tenant_id,
+                        base_frontier.as_ref(),
+                        &target_frontier,
+                        &summary_text,
+                        token_estimate,
+                    )
+                    .await?;
+
+                if rows == 0 {
+                    // CAS conflict — another handler won.
+                    return Ok(false);
+                }
+
+                // 6b. Mark messages as compressed
+                deps.message_repo
+                    .mark_messages_compressed(
+                        tx,
+                        payload.chat_id,
+                        base_frontier.as_ref(),
+                        &target_frontier,
+                    )
+                    .await?;
+
+                // 6c. Enqueue system usage event
+                let usage_event = build_system_usage_event(
+                    &payload,
+                    usage,
+                );
+                deps.outbox_enqueuer
+                    .enqueue_usage_event(tx, usage_event)
+                    .await?;
+
+                Ok(true)
+            })
+        }).await;
+
+        match cas_result {
+            Ok(true) => {
+                self.deps.outbox_enqueuer.flush();
+                self.deps.metrics.record_thread_summary_execution("success");
+                info!(
+                    chat_id = %payload.chat_id,
+                    messages_compressed = messages.len(),
+                    "thread summary: committed successfully"
+                );
+                HandlerResult::Success
+            }
+            Ok(false) => {
+                self.deps.metrics.record_thread_summary_cas_conflict();
+                info!("thread summary: CAS conflict on commit, skipping");
+                HandlerResult::Success
+            }
+            Err(e) => {
+                warn!(error = %e, "thread summary: commit failed");
+                self.deps.metrics.record_thread_summary_execution("retry");
+                HandlerResult::Retry {
+                    reason: format!("commit failed: {e}"),
+                }
+            }
+        }
+    }
+}
+```
+
+### 5.4 Build summarization prompt
+
+File: `src/infra/workers/thread_summary_worker.rs`
+
+```rust
+/// Build the user message content for the summarization LLM call.
+///
+/// If an existing summary exists, it is included as context so the LLM can
+/// produce an incremental update rather than starting from scratch.
+fn build_summary_prompt(
+    existing_summary: Option<&str>,
+    messages: &[MessageModel],
+) -> String {
+    let mut prompt = String::new();
+
+    if let Some(summary) = existing_summary {
+        prompt.push_str("## Existing Summary\n\n");
+        prompt.push_str(summary);
+        prompt.push_str("\n\n## New Messages to Incorporate\n\n");
+    } else {
+        prompt.push_str("## Messages to Summarize\n\n");
+    }
+
+    for msg in messages {
+        let role = match msg.role {
+            MessageRole::User => "User",
+            MessageRole::Assistant => "Assistant",
+            MessageRole::System => "System",
+        };
+        prompt.push_str(&format!("**{role}**: {}\n\n", msg.content));
+    }
+
+    prompt.push_str(
+        "Produce a concise summary that preserves key facts, decisions, \
+         document references, and action items. If an existing summary was \
+         provided, update it to incorporate the new messages."
+    );
+
+    prompt
+}
+```
+
+### 5.5 Build system usage event
+
+File: `src/infra/workers/thread_summary_worker.rs`
+
+Per DESIGN.md section "System Task Attribution Rules":
+
+```rust
+fn build_system_usage_event(
+    payload: &ThreadSummaryTaskPayload,
+    usage: Option<Usage>,
+) -> UsageEvent {
+    let u = usage.unwrap_or_default();
+    let dedupe_key = format!(
+        "{}/{}/{}",
+        payload.tenant_id.simple(),
+        payload.system_task_type,
+        payload.system_request_id.simple(),
+    );
+
+    UsageEvent {
+        event_type: "usage_snapshot".to_owned(),
+        dedupe_key,
+        tenant_id: payload.tenant_id,
+        user_id: None,  // system task — no user attribution
+        requester_type: "system".to_owned(),
+        chat_id: Some(payload.chat_id),
+        request_id: payload.system_request_id,
+        usage: UsageTokens {
+            input_tokens: u.input_tokens,
+            output_tokens: u.output_tokens,
+            cache_read_input_tokens: u.cache_read_input_tokens,
+            cache_write_input_tokens: u.cache_write_input_tokens,
+            reasoning_tokens: u.reasoning_tokens,
+        },
+        outcome: "completed".to_owned(),
+        settlement_method: "actual".to_owned(),
+        // System tasks do not carry model/credit fields from preflight.
+        // CyberChatManager attributes cost via tenant operational bucket.
+        effective_model: None,
+        actual_credits_micro: None,
+    }
+}
+```
+
+### 5.6 Build system `SecurityContext`
+
+File: `src/infra/workers/thread_summary_worker.rs`
+
+Same pattern as `ChatCleanupHandler` (cleanup_worker.rs line ~46):
+
+```rust
+fn build_system_security_context(tenant_id: Uuid) -> SecurityContext {
+    SecurityContext::new(
+        DEFAULT_SUBJECT_ID,
+        tenant_id,
+        /* additional claims as needed */
+    )
+}
+```
+
+### 5.7 Update handler registration in `module.rs`
+
+File: `src/module.rs`
+
+Replace the stub handler registration (line ~515-516) with the real handler:
+
+```rust
+let summary_deps = Arc::new(ThreadSummaryDeps {
+    db: Arc::clone(&db),
+    thread_summary_repo: Arc::clone(&thread_summary_repo),
+    message_repo: Arc::clone(&message_repo),
+    llm_provider: Arc::clone(&llm_provider),
+    outbox_enqueuer: Arc::clone(&outbox_enqueuer),
+    metrics: Arc::clone(&metrics),
+    upstream_alias: config.upstream_alias.clone(),
+    summary_model: config.thread_summary_worker.model.clone(),
+    summary_system_prompt: config.thread_summary_worker.system_prompt.clone(),
+});
+
+// ...in outbox pipeline builder:
+.queue(&od.outbox_config.thread_summary_queue_name, partitions)
+.decoupled(ThreadSummaryHandler::new(summary_deps))
+```
+
+### 5.8 Add config fields for summary model and prompt
+
+File: `src/config/background.rs`
+
+Add to `ThreadSummaryWorkerConfig`:
+
+```rust
+/// Model to use for summary generation (e.g., "gpt-4o-mini").
+/// If empty, uses the chat's configured model.
+pub model: String,
+
+/// System prompt for the summarization LLM call.
+pub system_prompt: String,
+```
+
+Defaults: implementation-defined (e.g., `model: "gpt-4o-mini"`, `system_prompt: "You are a conversation summarizer..."`)
+
+## Open Questions
+
+- **Summary model**: Should the summary use the same model as the chat, or a cheaper model
+  (e.g., gpt-4o-mini)? DESIGN.md doesn't specify. Recommend: configurable, default to a
+  cost-effective model since summaries don't need the full capabilities of the chat model.
+
+- **Summary system prompt**: The exact wording needs product input. The handler should use
+  a configurable string. A reasonable default focuses on preserving facts, decisions,
+  references, and action items.
+
+- **`ResponseResult` shape**: Need to verify `LlmProvider::complete()` return type structure
+  to extract `output_text()` and `usage()`. Adapt based on the actual `ResponseResult` type.
+
+- **Token estimation for summary**: `estimate_summary_tokens(&summary_text)` could use
+  `estimate_item_tokens(text_bytes, budgets)` from context_assembly, or a simpler
+  `len() / 4` heuristic since this is stored for informational purposes.
+
+## Acceptance Criteria
+
+- [ ] Payload deserialization failure -> `Reject` (dead-letter)
+- [ ] DB connection failure -> `Retry`
+- [ ] Pre-check: frontier already advanced -> `Success` (idempotent skip)
+- [ ] Empty message range -> `Success` (nothing to summarize)
+- [ ] LLM call failure -> `Retry`, previous summary unchanged, metrics emitted
+- [ ] LLM success + CAS win: summary saved, frontier advanced, messages compressed, usage enqueued
+- [ ] LLM success + CAS loss: `Success` (idempotent skip), no summary written
+- [ ] Commit failure -> `Retry`
+- [ ] `outbox_enqueuer.flush()` called post-commit on CAS win
+- [ ] Usage event carries `requester_type=system`, `dedupe_key` format per DESIGN.md
+- [ ] `system_request_id` from payload — not regenerated
+- [ ] Cancellation token checked after LLM call
+- [ ] Structured logging with `chat_id`, `tenant_id`, `system_request_id` on all paths
+- [ ] Stub handler and stub test removed

--- a/modules/mini-chat/docs/plans/thread-summary-worker/phase-6-observability.md
+++ b/modules/mini-chat/docs/plans/thread-summary-worker/phase-6-observability.md
@@ -1,0 +1,115 @@
+# Phase 6: Observability — Prometheus Metrics
+
+## Goal
+
+Wire the thread summary metrics specified in DESIGN.md into the trigger and handler paths.
+
+## Current State
+
+- `MiniChatMetricsPort` trait at `src/domain/ports/metrics.rs` defines the metrics interface.
+- Existing metrics pattern: `record_*` methods on the trait, implemented via Prometheus
+  counters/histograms in the infra metrics layer.
+- DESIGN.md (lines 3522-3628) specifies:
+  - `mini_chat_thread_summary_trigger_total{result}` (`scheduled|not_needed`)
+  - `mini_chat_thread_summary_execution_total{result}` (`success|provider_error|timeout|retry`)
+  - `mini_chat_thread_summary_cas_conflicts_total`
+  - `mini_chat_summary_fallback_total`
+
+## Tasks
+
+### 6.1 Add metric methods to `MiniChatMetricsPort` trait
+
+File: `src/domain/ports/metrics.rs`
+
+```rust
+/// Thread summary trigger evaluation result.
+/// `result`: "scheduled" or "not_needed"
+fn record_thread_summary_trigger(&self, result: &str);
+
+/// Thread summary execution outcome.
+/// `result`: "success", "provider_error", "timeout", or "retry"
+fn record_thread_summary_execution(&self, result: &str);
+
+/// Thread summary CAS conflict (another handler already advanced frontier).
+fn record_thread_summary_cas_conflict(&self);
+
+/// Summary fallback: previous summary kept because generation failed.
+fn record_summary_fallback(&self);
+```
+
+### 6.2 Implement in infra metrics layer
+
+File: `src/infra/metrics.rs` (or wherever the Prometheus impl lives)
+
+Register counters:
+
+```rust
+// In the metrics struct:
+thread_summary_trigger_total: IntCounterVec,       // label: "result"
+thread_summary_execution_total: IntCounterVec,     // label: "result"
+thread_summary_cas_conflicts_total: IntCounter,
+summary_fallback_total: IntCounter,
+```
+
+Registration:
+
+```rust
+let thread_summary_trigger_total = register_int_counter_vec!(
+    opts!("mini_chat_thread_summary_trigger_total", "Thread summary trigger evaluations"),
+    &["result"]
+)?;
+
+let thread_summary_execution_total = register_int_counter_vec!(
+    opts!("mini_chat_thread_summary_execution_total", "Thread summary execution outcomes"),
+    &["result"]
+)?;
+
+let thread_summary_cas_conflicts_total = register_int_counter!(
+    opts!("mini_chat_thread_summary_cas_conflicts_total", "Thread summary CAS conflicts")
+)?;
+
+let summary_fallback_total = register_int_counter!(
+    opts!("mini_chat_summary_fallback_total", "Summary fallback (previous summary kept)")
+)?;
+```
+
+### 6.3 Update noop/test metrics implementations
+
+File: `src/domain/service/test_helpers.rs` (and any noop impl)
+
+Add no-op implementations of the new metric methods so existing tests compile.
+
+### 6.4 Verify metric emission points
+
+Per Phases 4 and 5, verify these are called at the right places:
+
+| Metric | Called from | When |
+|--------|-----------|------|
+| `record_thread_summary_trigger("scheduled")` | Phase 4 (trigger in finalization) | Outbox message enqueued |
+| `record_thread_summary_trigger("not_needed")` | Phase 4 (trigger in finalization) | Threshold not exceeded or dedupe |
+| `record_thread_summary_execution("success")` | Phase 5 (handler) | CAS commit succeeded |
+| `record_thread_summary_execution("provider_error")` | Phase 5 (handler) | LLM call failed |
+| `record_thread_summary_execution("retry")` | Phase 5 (handler) | Commit failed, returning Retry |
+| `record_thread_summary_cas_conflict()` | Phase 5 (handler) | Pre-check or commit CAS lost |
+| `record_summary_fallback()` | Phase 5 (handler) | LLM failed, keeping previous summary |
+
+### 6.5 Alert rules (documentation only)
+
+Per DESIGN.md (lines 3626-3628), the following alert rules should be configured in the
+monitoring system (not implemented in code, documented for ops):
+
+| Rule | Window | Severity |
+|------|--------|----------|
+| `rate(mini_chat_thread_summary_execution_total{result=~"provider_error\|timeout"}[15m])` sustained above threshold | 15m | warning |
+| `mini_chat_outbox_dead_letter_backlog{kind="thread_summary"}` > 0 | 15m | critical |
+| `mini_chat_thread_summary_cas_conflicts_total` above background threshold | 15m | warning |
+
+## Acceptance Criteria
+
+- [ ] All four metric families registered and exposed via `/metrics` endpoint
+- [ ] Trigger metrics emitted in finalization path (Phase 4)
+- [ ] Execution metrics emitted in handler (Phase 5)
+- [ ] CAS conflict metric emitted on pre-check and commit CAS loss
+- [ ] Fallback metric emitted when LLM fails
+- [ ] Noop/test implementations compile
+- [ ] Label cardinality bounded (only allowed `result` values, no unbounded labels)

--- a/modules/mini-chat/docs/plans/thread-summary-worker/phase-7-tests.md
+++ b/modules/mini-chat/docs/plans/thread-summary-worker/phase-7-tests.md
@@ -1,0 +1,178 @@
+# Phase 7: Tests — Unit + Integration
+
+## Goal
+
+Comprehensive test coverage for the thread summary trigger, handler, and repository layer.
+
+## Test Categories
+
+### 7.1 Unit tests — `should_trigger_summary`
+
+File: `src/domain/service/finalization_service.rs` (test module)
+
+| Test | Input | Expected |
+|------|-------|----------|
+| `proactive_fires_above_threshold_no_summary` | `assembled_context_tokens=2000, ctx=4096, max_out=1024, threshold=60, truncated=false, has_summary=false` → budget=3072, 60%=1843 | `true` |
+| `proactive_skipped_below_threshold` | `assembled_context_tokens=1000` (same budget) | `false` |
+| `proactive_suppressed_when_summary_exists` | `assembled_context_tokens=2000, has_summary=true, truncated=false` | `false` |
+| `urgent_fires_when_truncated_even_with_summary` | `assembled_context_tokens=500, truncated=true, has_summary=true` | `true` |
+| `non_positive_budget_returns_false` | `max_output >= context_window` | `false` |
+| `zero_tokens_returns_false` | `assembled_context_tokens=0` | `false` |
+
+### 7.2 Unit tests — `build_summary_prompt`
+
+File: `src/infra/workers/thread_summary_worker.rs` (test module)
+
+| Test | Input | Expected |
+|------|-------|----------|
+| `prompt_without_existing_summary` | `existing=None, messages=[user:"hi", assistant:"hello"]` | Contains "Messages to Summarize", both messages |
+| `prompt_with_existing_summary` | `existing=Some("prev summary"), messages=[...]` | Contains "Existing Summary", "New Messages to Incorporate" |
+| `prompt_empty_messages` | `existing=None, messages=[]` | No message section (edge case) |
+
+### 7.3 Unit tests — `build_system_usage_event`
+
+File: `src/infra/workers/thread_summary_worker.rs` (test module)
+
+| Test | Input | Expected |
+|------|-------|----------|
+| `usage_event_fields` | payload with known IDs | `requester_type="system"`, `user_id=None`, `dedupe_key` format correct |
+| `dedupe_key_format` | `tenant=abc, system_request_id=def` | `"abc/thread_summary_update/def"` (hex-normalized) |
+
+### 7.4 Unit tests — `ThreadSummaryTaskPayload` serialization
+
+File: `src/domain/repos/outbox_enqueuer.rs` (test module)
+
+| Test | Input | Expected |
+|------|-------|----------|
+| `round_trip_with_base_frontier` | Payload with Some base frontier | Deserializes back to equal |
+| `round_trip_without_base_frontier` | Payload with None base frontier | Deserializes back to equal |
+| `deserialization_from_invalid_json` | `b"{invalid}"` | `Err` |
+
+### 7.5 Integration tests — Repository layer
+
+File: `src/infra/db/repo/thread_summary_repo.rs` (test module) or `repo_test.rs`
+
+**`get_latest`:**
+| Test | Setup | Expected |
+|------|-------|----------|
+| `get_latest_returns_none_when_empty` | No rows | `Ok(None)` |
+| `get_latest_returns_summary` | Insert one summary row | `Ok(Some(...))` with correct fields |
+
+**`upsert_with_cas`:**
+| Test | Setup | Expected |
+|------|-------|----------|
+| `first_summary_inserts` | No existing row, `base=None` | Returns 1, row exists |
+| `first_summary_conflict` | Row already exists, `base=None` | Returns 0 (ON CONFLICT DO NOTHING) |
+| `advance_frontier_succeeds` | Existing row with frontier A, `base=A` | Returns 1, frontier=B |
+| `advance_frontier_cas_conflict` | Existing row with frontier B, `base=A` | Returns 0 |
+
+**`mark_messages_compressed`:**
+| Test | Setup | Expected |
+|------|-------|----------|
+| `marks_range_compressed` | 5 messages, mark range [2..4] | Messages 2-4 have `is_compressed=true` |
+| `skips_deleted_messages` | Message 3 is soft-deleted | Message 3 not marked |
+| `skips_already_compressed` | Message 2 already compressed | Not double-marked |
+| `first_summary_marks_all_up_to_target` | `base=None`, target=msg3 | Messages 1-3 compressed |
+
+**`fetch_messages_in_range`:**
+| Test | Setup | Expected |
+|------|-------|----------|
+| `returns_messages_in_order` | 5 messages | Correct `(created_at, id)` order |
+| `excludes_deleted` | Message 3 deleted | Not in result |
+| `excludes_compressed` | Message 2 compressed | Not in result |
+| `excludes_after_target` | Target = msg3 | Messages 4-5 excluded |
+| `first_summary_includes_from_beginning` | `base=None`, target=msg3 | Messages 1-3 returned |
+
+**`find_latest_message`:**
+| Test | Setup | Expected |
+|------|-------|----------|
+| `returns_latest` | 3 messages | Returns frontier of msg3 |
+| `excludes_deleted` | msg3 deleted | Returns frontier of msg2 |
+| `returns_none_when_empty` | No messages | `Ok(None)` |
+
+### 7.6 Integration tests — Handler (outbox handler path)
+
+File: `src/infra/workers/thread_summary_worker.rs` (test module)
+
+These tests use mock `LlmProvider` and real DB (SQLite or test Postgres):
+
+| Test | Scenario | Expected |
+|------|----------|----------|
+| `handler_rejects_invalid_payload` | Garbage bytes in payload | `HandlerResult::Reject` |
+| `handler_succeeds_first_summary` | No existing summary, 3 messages, LLM returns "summary" | `Success`, summary row created, messages compressed |
+| `handler_succeeds_incremental_summary` | Existing summary, 2 new messages | `Success`, summary updated, only new messages compressed |
+| `handler_cas_conflict_pre_check` | Frontier already advanced before LLM call | `Success` (skip), no LLM call |
+| `handler_cas_conflict_on_commit` | Frontier advanced between LLM call and commit | `Success` (skip), no summary written |
+| `handler_retries_on_llm_failure` | LLM returns error | `Retry`, previous summary unchanged |
+| `handler_skips_empty_range` | All messages in range are deleted | `Success` |
+| `handler_enqueues_system_usage_event` | Successful summary | Usage event in outbox with `requester_type=system` |
+
+### 7.7 Integration tests — Trigger in finalization
+
+File: `src/domain/service/finalization_service.rs` (test module)
+
+| Test | Scenario | Expected |
+|------|----------|----------|
+| `completed_turn_above_threshold_enqueues_summary` | `reserve_tokens` above 80% budget | `ThreadSummaryTaskPayload` in recorded outbox |
+| `completed_turn_below_threshold_no_enqueue` | `reserve_tokens` below threshold | No summary payload in outbox |
+| `failed_turn_does_not_trigger` | `terminal_state=Failed` | No summary payload |
+| `cancelled_turn_does_not_trigger` | `terminal_state=Cancelled` | No summary payload |
+| `dedupe_no_enqueue_when_frontier_unchanged` | Frontier matches target | No summary payload |
+| `summary_disabled_no_enqueue` | `summary_config.enabled=false` | No summary payload |
+
+### 7.8 End-to-end tests — Full pipeline
+
+File: `tests/thread_summary_e2e.rs` (new) or added to existing integration test file.
+
+These tests exercise the complete trigger → outbox → handler → commit pipeline with
+a real DB (SQLite in-memory with all migrations), mock `LlmProvider`, and the outbox
+running in test/synchronous mode. They validate the cross-cutting invariants that
+unit tests for individual phases cannot cover.
+
+| Test | Setup | Asserts |
+|------|-------|---------|
+| `e2e_first_summary_generation` | Create chat with 10+ messages. Complete a turn where `reserve_tokens` exceeds 80% of budget. Let outbox deliver to handler. Mock LLM returns "summary text". | 1. `thread_summaries` row created with correct `summarized_up_to_*` frontier. 2. All messages up to frozen target have `is_compressed = true`. 3. Usage event in outbox with `requester_type=system`, `system_task_type="thread_summary_update"`. 4. Subsequent `get_latest()` returns the new summary. |
+| `e2e_incremental_summary` | Create chat, generate first summary (frontier at msg 5). Add 5 more messages. Complete another turn above threshold. Let outbox deliver. Mock LLM returns updated summary. | 1. `thread_summaries` row updated (not duplicated — UNIQUE on `chat_id`). 2. Only messages 6-10 newly marked `is_compressed = true`. 3. Previously compressed messages (1-5) unchanged. 4. Frontier advanced to msg 10. |
+| `e2e_below_threshold_no_summary` | Create chat with few short messages. Complete a turn where `reserve_tokens` is below 80%. | 1. No outbox message enqueued for `thread_summary` queue. 2. No `thread_summaries` row created. 3. All messages remain `is_compressed = false`. |
+| `e2e_llm_failure_preserves_previous_summary` | Create chat, generate first summary. Add more messages, trigger fires. Mock LLM returns error. | 1. Previous summary text and frontier unchanged. 2. No messages newly marked as compressed. 3. Handler returns `Retry`. 4. `mini_chat_summary_fallback_total` incremented. |
+| `e2e_concurrent_handlers_cas_safety` | Enqueue two thread-summary outbox messages for the same chat with the same `(base_frontier, frozen_target)`. Process both handlers concurrently (e.g., via `tokio::join!`). Both mock LLM calls succeed. | 1. Exactly one handler wins the CAS commit. 2. Exactly one `thread_summaries` row with correct frontier. 3. Messages compressed exactly once. 4. `mini_chat_thread_summary_cas_conflicts_total` incremented by 1 (the loser). 5. No duplicate usage events (losers don't emit usage). |
+| `e2e_chat_deleted_during_summary` | Trigger fires, outbox message enqueued. Soft-delete chat before handler runs. Handler executes. | 1. Handler either returns `Success` (messages not found — empty range) or gracefully skips. 2. No `thread_summaries` row created (CASCADE may have removed it). 3. No crash or panic. |
+| `e2e_summary_used_in_next_turn_context` | Generate first summary for a chat. On the next turn, verify context assembly. | 1. `gather_context()` returns `thread_summary = Some(...)` with the committed summary text. 2. `recent_after_boundary()` is called (not `recent_for_context`) — messages after frontier are loaded as recent. 3. Compressed messages are NOT loaded as recent context (they are represented by the summary). |
+| `e2e_idempotent_redelivery` | Generate summary successfully (frontier advanced). Redeliver the same outbox message (simulating outbox replay). | 1. Pre-check detects frontier already advanced. 2. Handler returns `Success` without making an LLM call. 3. No duplicate summary writes. 4. `mini_chat_thread_summary_cas_conflicts_total` incremented. |
+| `e2e_system_task_isolation` | Complete the full summary pipeline. Inspect all DB tables. | 1. No `chat_turns` row created for the summary task. 2. No `quota_usage` row debited for any user. 3. Usage event has `user_id = null` and `requester_type = "system"`. |
+
+**Test infrastructure required:**
+
+- **Mock `LlmProvider`**: configurable per-call responses (success with text/usage, or error).
+  Can use `Arc<Mutex<VecDeque<Result<ResponseResult, LlmProviderError>>>>` for sequenced
+  responses across multiple handler invocations.
+- **Real DB**: SQLite in-memory with all migrations applied (same as test_helpers pattern).
+- **Outbox test mode**: either use `modkit_db::outbox` in synchronous/test delivery mode,
+  or call `handler.handle()` directly with constructed `OutboxMessage` from the outbox table
+  after the trigger transaction commits.
+- **Deterministic timestamps**: use controlled `created_at` values for messages to ensure
+  the strict `(created_at, id)` ordering is predictable and testable.
+- **Assertion helpers**: `assert_messages_compressed(chat_id, expected_ids)` to verify
+  `is_compressed` status across the messages table.
+
+### 7.9 Unit tests — `SummaryFrontier` equality
+
+File: `src/domain/repos/thread_summary_repo.rs` (test module)
+
+| Test | Input | Expected |
+|------|-------|----------|
+| `same_frontier_eq` | Same `(created_at, message_id)` | `==` true |
+| `different_message_id_ne` | Same `created_at`, different `message_id` | `!=` true |
+| `different_created_at_ne` | Different `created_at`, same `message_id` | `!=` true |
+
+## Acceptance Criteria
+
+- [ ] All unit tests pass
+- [ ] All integration tests pass on both SQLite and Postgres
+- [ ] All e2e tests pass: full trigger → outbox → handler → commit pipeline
+- [ ] No test uses `#[ignore]` without documented reason
+- [ ] Test coverage: trigger logic, handler happy/error paths, CAS conflicts, repo operations
+- [ ] E2e coverage: first summary, incremental, CAS concurrency, LLM failure, idempotent replay, context integration, system task isolation
+- [ ] No flaky timing-dependent tests (use deterministic inputs and controlled timestamps)
+- [ ] `e2e_concurrent_handlers_cas_safety` validates at-most-once summary commit
+- [ ] `e2e_summary_used_in_next_turn_context` validates the summary is actually used downstream

--- a/modules/mini-chat/mini-chat-sdk/src/models.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/models.rs
@@ -151,6 +151,10 @@ pub struct ModelApiParams {
     /// value under the `"extra_body"` key in the request payload.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extra_body: Option<serde_json::Value>,
+    /// Reasoning effort for o-series models (low/medium/high).
+    /// Omitted for non-reasoning models.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
 }
 
 /// Feature capability flags (API: `PolicyModelFeatures`).
@@ -307,9 +311,13 @@ pub struct UsageTokens {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UsageEvent {
     pub tenant_id: Uuid,
-    pub user_id: Uuid,
+    /// User who initiated the turn. `None` for system tasks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<Uuid>,
     pub chat_id: Uuid,
-    pub turn_id: Uuid,
+    /// Turn ID. `None` for system tasks (no `chat_turns` row).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<Uuid>,
     pub request_id: Uuid,
     pub effective_model: String,
     pub selected_model: String,
@@ -323,6 +331,19 @@ pub struct UsageEvent {
     pub code_interpreter_calls: u32,
     #[serde(with = "time::serde::rfc3339")]
     pub timestamp: OffsetDateTime,
+    /// `"user"` for normal turns, `"system"` for background system tasks.
+    #[serde(default = "default_requester_type")]
+    pub requester_type: String,
+    /// Deduplication key. For system tasks: `"{tenant_id}/{system_task_type}/{system_request_id}"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dedupe_key: Option<String>,
+    /// System task type identifier (e.g. `"thread_summary_update"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system_task_type: Option<String>,
+}
+
+fn default_requester_type() -> String {
+    "user".to_owned()
 }
 
 #[cfg(test)]
@@ -410,6 +431,7 @@ mod tests {
                 presence_penalty: 0.0,
                 stop: vec![],
                 extra_body: None,
+                reasoning_effort: None,
             },
             features: ModelFeatures {
                 streaming: true,

--- a/modules/mini-chat/mini-chat/src/api/rest/sse.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/sse.rs
@@ -615,6 +615,7 @@ mod tests {
             request_id: rid,
             message_id: mid,
             is_new_turn: true,
+            thread_summary_applied: None,
         };
         let json = serde_json::to_string(&data).unwrap();
         assert!(json.contains(&format!("\"request_id\":\"{rid}\"")));
@@ -632,6 +633,7 @@ mod tests {
             request_id: uuid::Uuid::new_v4(),
             message_id: uuid::Uuid::new_v4(),
             is_new_turn: false,
+            thread_summary_applied: None,
         };
         let json = serde_json::to_string(&data).unwrap();
         assert!(json.contains("\"is_new_turn\":false"));

--- a/modules/mini-chat/mini-chat/src/config/background.rs
+++ b/modules/mini-chat/mini-chat/src/config/background.rs
@@ -71,6 +71,22 @@ pub struct ThreadSummaryWorkerConfig {
     /// Max claim/execution attempts per task. Default: 3.
     #[serde(default = "default_ts_max_attempts")]
     pub max_attempts: u32,
+    /// Compression threshold: summary triggered when estimated input tokens
+    /// reach this percentage of the effective input token budget. Default: 80.
+    #[serde(default = "default_compression_threshold")]
+    pub compression_threshold_pct: u32,
+    /// Model ID from the model catalog for summary generation.
+    /// Empty string falls back to `gpt-4.1-mini`. Default: empty.
+    #[serde(default)]
+    pub summary_model_id: String,
+    /// Fallback system prompt when `ModelCatalogEntry.thread_summary_prompt` is empty.
+    #[serde(default = "default_summary_system_prompt")]
+    pub summary_system_prompt: String,
+    /// Maximum characters per message included in the summary prompt.
+    /// Messages longer than this are truncated with "..." appended.
+    /// 0 = no truncation. Default: 4000.
+    #[serde(default = "default_message_content_limit")]
+    pub message_content_limit: usize,
 }
 
 impl Default for ThreadSummaryWorkerConfig {
@@ -80,6 +96,10 @@ impl Default for ThreadSummaryWorkerConfig {
             reconcile_interval_secs: default_ts_reconcile_interval(),
             claim_timeout_secs: default_ts_claim_timeout(),
             max_attempts: default_ts_max_attempts(),
+            compression_threshold_pct: default_compression_threshold(),
+            summary_model_id: String::new(),
+            summary_system_prompt: default_summary_system_prompt(),
+            message_content_limit: default_message_content_limit(),
         }
     }
 }
@@ -95,6 +115,12 @@ impl ThreadSummaryWorkerConfig {
         if self.max_attempts == 0 {
             return Err("thread_summary_worker.max_attempts must be > 0".to_owned());
         }
+        if self.compression_threshold_pct == 0 || self.compression_threshold_pct > 99 {
+            return Err(format!(
+                "thread_summary_worker.compression_threshold_pct must be 1-99, got {}",
+                self.compression_threshold_pct
+            ));
+        }
         Ok(())
     }
 }
@@ -107,6 +133,20 @@ fn default_ts_claim_timeout() -> u64 {
 }
 fn default_ts_max_attempts() -> u32 {
     3
+}
+fn default_compression_threshold() -> u32 {
+    80
+}
+fn default_summary_system_prompt() -> String {
+    "You are a conversation summarizer. Given a conversation (and optionally an existing \
+     summary), produce a detailed structured summary. Respond with an <analysis> block \
+     (your reasoning) followed by a <summary> block (the final summary). Only the \
+     <summary> content will be stored. Do not invent information not present in the \
+     conversation."
+        .to_owned()
+}
+fn default_message_content_limit() -> usize {
+    4000
 }
 
 /// Cleanup worker — removes provider resources for soft-deleted chats.

--- a/modules/mini-chat/mini-chat/src/domain/model/finalization.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/finalization.rs
@@ -55,6 +55,14 @@ pub struct FinalizationInput {
     /// Number of completed code interpreter calls during this turn.
     pub code_interpreter_calls: u32,
 
+    /// Context window size of the effective model (tokens) — for summary trigger.
+    pub context_window: u32,
+    /// Estimated input tokens from context assembly (all messages + system prompt).
+    pub assembled_context_tokens: u64,
+    /// `true` when context assembly dropped older messages due to budget.
+    /// Primary signal for the thread summary trigger.
+    pub messages_truncated: bool,
+
     /// Time-to-first-token in milliseconds (captured in `stream_service`).
     pub ttft_ms: Option<u64>,
     /// Total stream duration in milliseconds (captured in `stream_service`).

--- a/modules/mini-chat/mini-chat/src/domain/model/quota.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/quota.rs
@@ -124,6 +124,10 @@ pub struct PreflightInput {
     pub web_search_enabled: bool,
     pub code_interpreter_enabled: bool,
     pub max_output_tokens_cap: u32,
+    /// Accumulated context tokens from prior turns: `last_input_tokens + last_output_tokens`.
+    /// This represents the conversation history that will be sent again to the LLM.
+    /// `0` for the first message in a chat.
+    pub prior_context_tokens: u64,
 }
 
 /// Input to `settle()`.

--- a/modules/mini-chat/mini-chat/src/domain/models.rs
+++ b/modules/mini-chat/mini-chat/src/domain/models.rs
@@ -171,6 +171,11 @@ pub struct ResolvedModel {
     pub system_prompt: String,
     /// Tool support flags captured at resolution time.
     pub tool_support: mini_chat_sdk::ModelToolSupport,
+    /// Model-specific prompt for thread summary generation.
+    /// Empty = fall back to global config.
+    pub thread_summary_prompt: String,
+    /// Maximum output tokens for this model.
+    pub max_output_tokens: u32,
 }
 
 impl From<&mini_chat_sdk::ModelCatalogEntry> for ResolvedModel {
@@ -195,6 +200,8 @@ impl From<&mini_chat_sdk::ModelCatalogEntry> for ResolvedModel {
             max_file_size_mb: e.general_config.max_file_size_mb,
             system_prompt: e.system_prompt.clone(),
             tool_support: e.general_config.tool_support.clone(),
+            thread_summary_prompt: e.thread_summary_prompt.clone(),
+            max_output_tokens: e.max_output_tokens,
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/ports/metrics.rs
+++ b/modules/mini-chat/mini-chat/src/domain/ports/metrics.rs
@@ -178,6 +178,22 @@ pub trait MiniChatMetricsPort: Send + Sync {
     /// `{prefix}_orphan_scan_duration_seconds` — histogram
     fn record_orphan_scan_duration_seconds(&self, seconds: f64);
 
+    // ── P1: Thread Summary Health (4 metrics) ──────────────────────────
+
+    /// `{prefix}_thread_summary_trigger` — counter
+    /// `result`: `scheduled`, `not_needed`
+    fn record_thread_summary_trigger(&self, result: &str);
+
+    /// `{prefix}_thread_summary_execution` — counter
+    /// `result`: `success`, `provider_error`, `timeout`, `retry`
+    fn record_thread_summary_execution(&self, result: &str);
+
+    /// `{prefix}_thread_summary_cas_conflicts` — counter
+    fn record_thread_summary_cas_conflict(&self);
+
+    /// `{prefix}_summary_fallback` — counter
+    fn record_summary_fallback(&self);
+
     // ── P2: Tool Call Counters (1 metric) ────────────────────────────
 
     /// `{prefix}_code_interpreter_calls` — counter
@@ -219,13 +235,17 @@ impl MiniChatMetricsPort for NoopMetrics {
     fn increment_attachments_pending(&self) {}
     fn decrement_attachments_pending(&self) {}
     fn record_image_inputs_per_turn(&self, _: u32) {}
-    fn record_orphan_detected(&self, _: &str) {}
-    fn record_orphan_finalized(&self, _: &str) {}
-    fn record_orphan_scan_duration_seconds(&self, _: f64) {}
     fn record_code_interpreter_calls(&self, _: &str, _: u32) {}
     fn record_cleanup_completed(&self, _: &str) {}
     fn record_cleanup_failed(&self, _: &str) {}
     fn record_cleanup_retry(&self, _: &str, _: &str) {}
     fn record_cleanup_backlog(&self, _: &str, _: &str, _: i64) {}
     fn record_cleanup_vs_with_failed_attachments(&self) {}
+    fn record_orphan_detected(&self, _: &str) {}
+    fn record_orphan_finalized(&self, _: &str) {}
+    fn record_orphan_scan_duration_seconds(&self, _: f64) {}
+    fn record_thread_summary_trigger(&self, _: &str) {}
+    fn record_thread_summary_execution(&self, _: &str) {}
+    fn record_thread_summary_cas_conflict(&self) {}
+    fn record_summary_fallback(&self) {}
 }

--- a/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/message_repo.rs
@@ -159,6 +159,52 @@ pub trait MessageRepository: Send + Sync {
         request_id: Uuid,
     ) -> Result<u64, DomainError>;
 
+    /// Return `(input_tokens, output_tokens)` from the last assistant message
+    /// in the chat. Used by preflight to estimate context size for quota reserve.
+    /// Returns `None` if the chat has no assistant messages with token data.
+    async fn last_assistant_token_counts<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<(i64, i64)>, DomainError>;
+
+    /// Fetch the latest non-deleted message frontier for a chat.
+    ///
+    /// Returns `(created_at, message_id)` of the most recent message,
+    /// used as `frozen_target_frontier` for thread summary trigger.
+    /// Returns `None` if the chat has no messages.
+    async fn find_latest_message<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<crate::domain::repos::SummaryFrontier>, DomainError>;
+
+    /// Fetch messages in a range defined by frontiers for thread summary.
+    ///
+    /// Returns messages where `(created_at, id) > base_frontier` (if provided)
+    /// and `(created_at, id) <= target_frontier`, `deleted_at IS NULL`,
+    /// ordered by `(created_at ASC, id ASC)`.
+    async fn fetch_messages_in_range<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        base_frontier: Option<&crate::domain::repos::SummaryFrontier>,
+        target_frontier: &crate::domain::repos::SummaryFrontier,
+    ) -> Result<Vec<MessageModel>, DomainError>;
+
+    /// Mark messages in a range as compressed by setting `is_compressed = true`.
+    async fn mark_messages_compressed<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        base_frontier: Option<&crate::domain::repos::SummaryFrontier>,
+        target_frontier: &crate::domain::repos::SummaryFrontier,
+    ) -> Result<u64, DomainError>;
+
     /// Fetch recent messages after a thread summary boundary for context assembly.
     ///
     /// Same as [`recent_for_context`] but only returns messages with

--- a/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/mod.rs
@@ -26,11 +26,14 @@ pub(crate) use message_repo::{
 pub(crate) use model_resolver::ModelResolver;
 pub(crate) use outbox_enqueuer::{
     AttachmentCleanupEvent, ChatCleanupEvent, CleanupOutcome, CleanupReason, OutboxEnqueuer,
+    ThreadSummaryTaskPayload,
 };
 pub(crate) use policy_snapshot_provider::PolicySnapshotProvider;
 pub(crate) use quota_usage_repo::{IncrementReserveParams, QuotaUsageRepository, SettleParams};
 pub(crate) use reaction_repo::{ReactionRepository, UpsertReactionParams};
-pub(crate) use thread_summary_repo::{ThreadSummaryModel, ThreadSummaryRepository};
+pub(crate) use thread_summary_repo::{
+    SummaryFrontier, ThreadSummaryModel, ThreadSummaryRepository,
+};
 pub(crate) use turn_repo::{
     CasCompleteParams, CasTerminalParams, CreateTurnParams, ToolCallType, TurnRepository,
     UpdatePreflightParams,

--- a/modules/mini-chat/mini-chat/src/domain/repos/outbox_enqueuer.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/outbox_enqueuer.rs
@@ -65,6 +65,27 @@ pub struct ChatCleanupEvent {
     pub chat_deleted_at: OffsetDateTime,
 }
 
+/// Durable outbox payload for thread summary generation.
+///
+/// Persisted at enqueue time in the finalization transaction. The handler
+/// reads this payload to know exactly which message range to summarize.
+/// `system_request_id` is generated once and reused across retries.
+#[domain_model]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ThreadSummaryTaskPayload {
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    /// Stable system-task identity -- generated at enqueue, reused across retries.
+    pub system_request_id: Uuid,
+    pub system_task_type: String,
+    #[serde(default, with = "time::serde::rfc3339::option")]
+    pub base_frontier_created_at: Option<OffsetDateTime>,
+    pub base_frontier_message_id: Option<Uuid>,
+    #[serde(with = "time::serde::rfc3339")]
+    pub frozen_target_created_at: OffsetDateTime,
+    pub frozen_target_message_id: Uuid,
+}
+
 /// Domain-layer abstraction for enqueuing outbox events within a transaction.
 ///
 /// The finalization service calls this trait to insert outbox rows atomically
@@ -140,6 +161,16 @@ pub trait OutboxEnqueuer: Send + Sync {
         &self,
         runner: &(dyn DBRunner + Sync),
         event: AuditEnvelope,
+    ) -> Result<(), DomainError>;
+
+    /// Enqueue a thread summary task within the caller's transaction.
+    ///
+    /// Partitioned by `chat_id` so all summary events for one chat are
+    /// processed sequentially within the same partition.
+    async fn enqueue_thread_summary(
+        &self,
+        runner: &(dyn DBRunner + Sync),
+        payload: ThreadSummaryTaskPayload,
     ) -> Result<(), DomainError>;
 
     /// Notify the outbox sequencer that new events are available.

--- a/modules/mini-chat/mini-chat/src/domain/repos/thread_summary_repo.rs
+++ b/modules/mini-chat/mini-chat/src/domain/repos/thread_summary_repo.rs
@@ -7,13 +7,25 @@ use uuid::Uuid;
 
 use crate::domain::error::DomainError;
 
+/// Inclusive summary frontier in the per-chat message order `(created_at ASC, id ASC)`.
+///
+/// Identifies the last message represented in the summary text.
+/// `created_at` alone is insufficient because multiple messages may share the
+/// same timestamp; `message_id` is the deterministic UUID tie-breaker.
+#[domain_model]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SummaryFrontier {
+    pub created_at: OffsetDateTime,
+    pub message_id: Uuid,
+}
+
 /// Domain model for a thread summary used in context assembly.
 #[domain_model]
 #[derive(Debug, Clone)]
 pub struct ThreadSummaryModel {
     pub content: String,
-    pub boundary_message_id: Uuid,
-    pub boundary_created_at: OffsetDateTime,
+    pub frontier: SummaryFrontier,
+    pub token_estimate: i32,
 }
 
 /// Repository trait for thread summary persistence operations.
@@ -21,11 +33,27 @@ pub struct ThreadSummaryModel {
 pub trait ThreadSummaryRepository: Send + Sync {
     /// Fetch the latest thread summary for a chat.
     ///
-    /// Returns `None` if no summary exists (graceful degradation for P1).
+    /// Returns `None` if no summary exists yet.
     async fn get_latest<C: DBRunner>(
         &self,
         runner: &C,
         scope: &AccessScope,
         chat_id: Uuid,
     ) -> Result<Option<ThreadSummaryModel>, DomainError>;
+
+    /// CAS-protected upsert: insert or update the summary only if the stored
+    /// frontier matches `expected_base_frontier`.
+    ///
+    /// Returns rows affected: 1 = success, 0 = CAS conflict.
+    #[allow(clippy::too_many_arguments)]
+    async fn upsert_with_cas<C: DBRunner>(
+        &self,
+        runner: &C,
+        chat_id: Uuid,
+        tenant_id: Uuid,
+        expected_base_frontier: Option<&SummaryFrontier>,
+        new_frontier: &SummaryFrontier,
+        summary_text: &str,
+        token_estimate: i32,
+    ) -> Result<u64, DomainError>;
 }

--- a/modules/mini-chat/mini-chat/src/domain/service/context_assembly.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/context_assembly.rs
@@ -6,6 +6,12 @@
 use modkit_macros::domain_model;
 
 use crate::config::EstimationBudgets;
+
+/// Preamble injected before the thread summary text in the LLM context.
+const SUMMARY_PREAMBLE: &str = "This conversation has earlier messages that have been summarized. \
+The summary below covers the earlier portion of the conversation. \
+Recent messages follow after.\n\n";
+
 use crate::domain::llm::{
     ContentPart, ContextMessage, FileSearchFilter, LlmMessage, LlmTool, Role,
 };
@@ -78,6 +84,16 @@ pub struct AssembledContext {
     pub messages: Vec<LlmMessage>,
     /// Tool definitions to include in the request.
     pub tools: Vec<LlmTool>,
+    /// Estimated input tokens consumed by assembled content items
+    /// (system instructions + thread summary + history messages + current message + images).
+    /// Tool surcharges are deducted from the budget separately.
+    /// Used by the thread summary trigger. `0` when no token budget was provided.
+    pub estimated_context_tokens: u64,
+    /// `true` when context assembly had to drop older messages because they
+    /// exceeded the available token budget. This is the primary signal for
+    /// the thread summary trigger — when messages are being truncated, the
+    /// conversation needs compression.
+    pub messages_truncated: bool,
 }
 
 /// Error during context assembly.
@@ -245,7 +261,7 @@ pub fn assemble_context(
         // P3: Thread summary (droppable)
         let keep_summary = if let Some(summary) = input.thread_summary {
             let cost =
-                estimate_item_tokens((summary.len() + "[Thread Summary]\n".len()) as u64, budgets);
+                estimate_item_tokens((summary.len() + SUMMARY_PREAMBLE.len()) as u64, budgets);
             if cost <= remaining {
                 remaining -= cost;
                 true
@@ -275,7 +291,7 @@ pub fn assemble_context(
         let mut messages = Vec::new();
 
         if keep_summary && let Some(summary) = input.thread_summary {
-            messages.push(LlmMessage::user(format!("[Thread Summary]\n{summary}")));
+            messages.push(LlmMessage::user(format!("{SUMMARY_PREAMBLE}{summary}")));
         }
 
         for msg in &input.recent_messages[keep_from_index..] {
@@ -288,17 +304,25 @@ pub fn assemble_context(
 
         messages.push(build_user_message(input.user_message, input.image_file_ids));
 
+        let estimated_context_tokens = available - remaining;
+        // Only flag truncation if non-system messages were actually dropped.
+        // System messages are always skipped in output and don't count.
+        let messages_truncated = input.recent_messages[..keep_from_index]
+            .iter()
+            .any(|m| !matches!(m.role, Role::System));
         Ok(AssembledContext {
             system_instructions,
             messages,
             tools,
+            estimated_context_tokens,
+            messages_truncated,
         })
     } else {
         // No budget — include everything without truncation.
         let mut messages = Vec::new();
 
         if let Some(summary) = input.thread_summary {
-            messages.push(LlmMessage::user(format!("[Thread Summary]\n{summary}")));
+            messages.push(LlmMessage::user(format!("{SUMMARY_PREAMBLE}{summary}")));
         }
 
         for msg in input.recent_messages {
@@ -315,6 +339,8 @@ pub fn assemble_context(
             system_instructions,
             messages,
             tools,
+            estimated_context_tokens: 0,
+            messages_truncated: false,
         })
     }
 }
@@ -490,7 +516,7 @@ mod tests {
         let first_content = &result.messages[0].content;
         match &first_content[0] {
             crate::domain::llm::ContentPart::Text { text } => {
-                assert!(text.contains("[Thread Summary]"));
+                assert!(text.contains("earlier messages that have been summarized"));
                 assert!(text.contains("Summary of prior conversation."));
             }
             crate::domain::llm::ContentPart::Image { .. } => {
@@ -838,7 +864,7 @@ mod tests {
         // Make summary expensive enough that it won't fit alongside 2 messages
         let big_summary = "X".repeat(2000);
         let summary_cost = estimate_item_tokens(
-            (big_summary.len() + "[Thread Summary]\n".len()) as u64,
+            (big_summary.len() + SUMMARY_PREAMBLE.len()) as u64,
             &budgets,
         );
         // Budget: mandatory + 2 messages, but NOT enough for summary

--- a/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/finalization_service.rs
@@ -52,6 +52,45 @@ pub struct FinalizationService<TR: TurnRepository + 'static, MR: MessageReposito
     quota_settler: Arc<dyn QuotaSettler>,
     outbox_enqueuer: Arc<dyn OutboxEnqueuer>,
     metrics: Arc<dyn MiniChatMetricsPort>,
+    summary_config: crate::config::background::ThreadSummaryWorkerConfig,
+}
+
+/// Evaluate whether thread summary should be triggered.
+///
+/// Two conditions (OR):
+/// 1. Context assembly already truncated messages (`messages_truncated`) — urgent,
+///    the conversation is losing context right now.
+/// 2. Context fills `>= threshold%` of budget AND no summary exists yet —
+///    proactive trigger before truncation starts.
+///
+/// When a summary already exists and context isn't truncated, we skip —
+/// the existing summary is still effective.
+fn should_trigger_summary(
+    assembled_context_tokens: u64,
+    max_output_tokens_applied: i32,
+    context_window: u32,
+    compression_threshold_pct: u32,
+    messages_truncated: bool,
+    has_existing_summary: bool,
+) -> bool {
+    // Urgent: messages already being dropped
+    if messages_truncated {
+        return true;
+    }
+    // Proactive: context filling up, but only if no summary exists yet.
+    // If a summary already covers older messages, wait until truncation
+    // actually starts before re-summarizing.
+    if has_existing_summary {
+        return false;
+    }
+    let estimated_input = i64::try_from(assembled_context_tokens).unwrap_or(i64::MAX);
+    let effective_budget = i64::from(context_window) - i64::from(max_output_tokens_applied);
+    if effective_budget <= 0 || estimated_input <= 0 {
+        return false;
+    }
+    #[allow(clippy::integer_division)]
+    let threshold = effective_budget * i64::from(compression_threshold_pct) / 100;
+    estimated_input >= threshold
 }
 
 impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> FinalizationService<TR, MR> {
@@ -62,6 +101,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
         quota_settler: Arc<dyn QuotaSettler>,
         outbox_enqueuer: Arc<dyn OutboxEnqueuer>,
         metrics: Arc<dyn MiniChatMetricsPort>,
+        summary_config: crate::config::background::ThreadSummaryWorkerConfig,
     ) -> Self {
         Self {
             db,
@@ -70,6 +110,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
             quota_settler,
             outbox_enqueuer,
             metrics,
+            summary_config,
         }
     }
 
@@ -187,6 +228,7 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
     }
 
     /// Core finalization logic inside a transaction.
+    #[allow(clippy::too_many_lines)]
     async fn try_finalize(
         &self,
         input: &FinalizationInput,
@@ -196,6 +238,8 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
         let message_repo = Arc::clone(&self.message_repo);
         let quota_settler = Arc::clone(&self.quota_settler);
         let outbox_enqueuer = Arc::clone(&self.outbox_enqueuer);
+        let metrics = Arc::clone(&self.metrics);
+        let summary_config = self.summary_config.clone();
         let input = input.clone();
 
         let tx_result = self
@@ -322,6 +366,98 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
                         .enqueue_audit_event(tx, audit_event)
                         .await
                         .map_err(to_db)?;
+
+                    // 7. Evaluate thread summary trigger (completed turns only).
+                    //
+                    // Short-circuit: skip the DB read for get_latest() when
+                    // the trigger clearly cannot fire (neither truncated nor
+                    // above threshold). This avoids an extra SELECT on every
+                    // completed turn.
+                    let ts_repo =
+                        crate::infra::db::repo::thread_summary_repo::ThreadSummaryRepository;
+                    let may_trigger = input.terminal_state == TurnState::Completed
+                        && summary_config.enabled
+                        && (input.messages_truncated
+                            || should_trigger_summary(
+                                input.assembled_context_tokens,
+                                input.max_output_tokens_applied,
+                                input.context_window,
+                                summary_config.compression_threshold_pct,
+                                false, // messages_truncated already checked above
+                                false, // optimistic: assume no summary for threshold check
+                            ));
+
+                    let (current_summary, summary_triggered) = if may_trigger {
+                        let summary = crate::domain::repos::ThreadSummaryRepository::get_latest(
+                            &ts_repo,
+                            tx,
+                            &scope,
+                            input.chat_id,
+                        )
+                        .await
+                        .map_err(to_db)?;
+                        let triggered = should_trigger_summary(
+                            input.assembled_context_tokens,
+                            input.max_output_tokens_applied,
+                            input.context_window,
+                            summary_config.compression_threshold_pct,
+                            input.messages_truncated,
+                            summary.is_some(),
+                        );
+                        (summary, triggered)
+                    } else {
+                        (None, false)
+                    };
+                    tracing::debug!(
+                        terminal_state = ?input.terminal_state,
+                        summary_enabled = summary_config.enabled,
+                        assembled_context_tokens = input.assembled_context_tokens,
+                        messages_truncated = input.messages_truncated,
+                        has_existing_summary = current_summary.is_some(),
+                        context_window = input.context_window,
+                        threshold_pct = summary_config.compression_threshold_pct,
+                        summary_triggered,
+                        "thread summary trigger decision"
+                    );
+                    if summary_triggered {
+                        let base_frontier = current_summary.as_ref().map(|s| &s.frontier);
+
+                        let frozen_target =
+                            crate::domain::repos::MessageRepository::find_latest_message(
+                                message_repo.as_ref(),
+                                tx,
+                                &scope,
+                                input.chat_id,
+                            )
+                            .await
+                            .map_err(to_db)?;
+
+                        if let Some(target) = frozen_target {
+                            let should_enqueue = match base_frontier {
+                                Some(bf) => bf != &target,
+                                None => true,
+                            };
+                            if should_enqueue {
+                                let payload = crate::domain::repos::ThreadSummaryTaskPayload {
+                                    tenant_id: input.tenant_id,
+                                    chat_id: input.chat_id,
+                                    system_request_id: Uuid::new_v4(),
+                                    system_task_type: "thread_summary_update".to_owned(),
+                                    base_frontier_created_at: base_frontier.map(|f| f.created_at),
+                                    base_frontier_message_id: base_frontier.map(|f| f.message_id),
+                                    frozen_target_created_at: target.created_at,
+                                    frozen_target_message_id: target.message_id,
+                                };
+                                outbox_enqueuer
+                                    .enqueue_thread_summary(tx, payload)
+                                    .await
+                                    .map_err(to_db)?;
+                                metrics.record_thread_summary_trigger("scheduled");
+                            } else {
+                                metrics.record_thread_summary_trigger("not_needed");
+                            }
+                        }
+                    }
 
                     Ok(FinalizationOutcome {
                         won_cas: true,
@@ -559,9 +695,9 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
 
                     let usage_event = UsageEvent {
                         tenant_id: input.tenant_id,
-                        user_id,
+                        user_id: input.user_id,
                         chat_id: input.chat_id,
-                        turn_id: input.turn_id,
+                        turn_id: Some(input.turn_id),
                         request_id: input.request_id,
                         effective_model: effective_model_str.clone(),
                         selected_model: effective_model_str.clone(),
@@ -574,6 +710,9 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
                         web_search_calls: input.web_search_completed_count,
                         code_interpreter_calls: input.code_interpreter_completed_count,
                         timestamp: now,
+                        requester_type: "user".to_owned(),
+                        dedupe_key: None,
+                        system_task_type: None,
                     };
                     outbox_enqueuer
                         .enqueue_usage_event(tx, usage_event)
@@ -721,9 +860,9 @@ fn build_usage_event(
     };
     UsageEvent {
         tenant_id: input.tenant_id,
-        user_id: input.user_id,
+        user_id: Some(input.user_id),
         chat_id: input.chat_id,
-        turn_id: input.turn_id,
+        turn_id: Some(input.turn_id),
         request_id: input.request_id,
         effective_model: input.effective_model.clone(),
         selected_model: input.selected_model.clone(),
@@ -742,6 +881,9 @@ fn build_usage_event(
         web_search_calls: input.web_search_calls,
         code_interpreter_calls: input.code_interpreter_calls,
         timestamp: time::OffsetDateTime::now_utc(),
+        requester_type: "user".to_owned(),
+        dedupe_key: None,
+        system_task_type: None,
     }
 }
 
@@ -754,7 +896,46 @@ enum FinalizationError {
 }
 
 #[cfg(test)]
-#[cfg_attr(coverage_nightly, coverage(off))]
+mod trigger_tests {
+    use super::should_trigger_summary;
+
+    #[test]
+    fn proactive_fires_above_threshold_no_summary() {
+        // 2000 tokens, budget=3072 (4096-1024), 60% threshold=1843
+        assert!(should_trigger_summary(2000, 1024, 4096, 60, false, false));
+    }
+
+    #[test]
+    fn proactive_skipped_below_threshold() {
+        // 1000 tokens < 1843 threshold
+        assert!(!should_trigger_summary(1000, 1024, 4096, 60, false, false));
+    }
+
+    #[test]
+    fn proactive_suppressed_when_summary_exists() {
+        // Above threshold but summary already exists — skip
+        assert!(!should_trigger_summary(2000, 1024, 4096, 60, false, true));
+    }
+
+    #[test]
+    fn urgent_fires_when_truncated_even_with_summary() {
+        // messages_truncated=true overrides everything
+        assert!(should_trigger_summary(500, 1024, 4096, 60, true, true));
+    }
+
+    #[test]
+    fn non_positive_budget_returns_false() {
+        // max_output >= context_window → effective_budget <= 0
+        assert!(!should_trigger_summary(1000, 5000, 4096, 60, false, false));
+    }
+
+    #[test]
+    fn zero_tokens_returns_false() {
+        assert!(!should_trigger_summary(0, 1024, 4096, 60, false, false));
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::domain::llm::Usage;
@@ -848,6 +1029,14 @@ mod tests {
             Ok(())
         }
 
+        async fn enqueue_thread_summary(
+            &self,
+            _: &(dyn modkit_db::secure::DBRunner + Sync),
+            _: crate::domain::repos::ThreadSummaryTaskPayload,
+        ) -> Result<(), DomainError> {
+            Ok(())
+        }
+
         fn flush(&self) {
             self.flush_count
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -871,6 +1060,7 @@ mod tests {
             Arc::new(MockQuotaSettler),
             outbox.clone(),
             Arc::new(crate::domain::ports::metrics::NoopMetrics),
+            crate::config::background::ThreadSummaryWorkerConfig::default(),
         );
         (svc, outbox)
     }
@@ -893,6 +1083,7 @@ mod tests {
             Arc::new(MockQuotaSettler),
             outbox.clone(),
             metrics,
+            crate::config::background::ThreadSummaryWorkerConfig::default(),
         );
         (svc, outbox)
     }
@@ -1004,6 +1195,9 @@ mod tests {
             ],
             web_search_calls: 3,
             code_interpreter_calls: 0,
+            context_window: 128_000,
+            assembled_context_tokens: 0,
+            messages_truncated: false,
             ttft_ms: None,
             total_ms: None,
         }
@@ -1164,6 +1358,7 @@ mod tests {
             Arc::new(FailingQuotaSettler),
             Arc::new(RecordingOutboxEnqueuer::new()),
             Arc::new(crate::domain::ports::metrics::NoopMetrics),
+            crate::config::background::ThreadSummaryWorkerConfig::default(),
         );
 
         let tenant_id = Uuid::new_v4();

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -203,6 +203,7 @@ impl<
         rag_config: RagConfig,
         thumbnail_config: ThumbnailConfig,
         metrics: Arc<dyn MiniChatMetricsPort>,
+        summary_config: crate::config::background::ThreadSummaryWorkerConfig,
     ) -> Self {
         let enforcer = PolicyEnforcer::new(authz);
 
@@ -224,6 +225,7 @@ impl<
             Arc::clone(&quota_svc) as Arc<dyn QuotaSettler>,
             Arc::clone(outbox_enqueuer),
             Arc::clone(&metrics),
+            summary_config,
         ));
 
         let turns = TurnService::new(

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
@@ -453,8 +453,11 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
             return Err(DomainError::WebSearchDisabled);
         }
 
-        // 2. Estimate tokens
-        let estimation = token_estimator::estimate_tokens(
+        // 2. Estimate tokens — includes prior context (conversation history)
+        //    plus the current message. `prior_context_tokens` is the actual
+        //    input_tokens + output_tokens from the last completed turn, i.e.
+        //    the context that will be re-sent to the LLM on this request.
+        let mut estimation = token_estimator::estimate_tokens(
             &EstimationInput {
                 utf8_bytes: input.utf8_bytes,
                 num_images: input.num_images,
@@ -464,6 +467,9 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
             },
             &self.estimation_budgets,
         );
+        estimation.estimated_input_tokens = estimation
+            .estimated_input_tokens
+            .saturating_add(input.prior_context_tokens);
 
         // 3. Find selected model's multipliers for conservative initial reserve
         let catalog_entry = snapshot
@@ -1831,6 +1837,7 @@ mod tests {
             web_search_enabled: false,
             code_interpreter_enabled: false,
             max_output_tokens_cap: 4096,
+            prior_context_tokens: 0,
         }
     }
 

--- a/modules/mini-chat/mini-chat/src/domain/service/replay.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/replay.rs
@@ -58,6 +58,7 @@ pub async fn replay_turn<MR: MessageRepository>(
         request_id: turn.request_id,
         message_id: assistant_msg_id,
         is_new_turn: false,
+        thread_summary_applied: None,
     });
 
     let delta = StreamEvent::Delta(DeltaData {
@@ -260,6 +261,46 @@ mod tests {
             _: Option<crate::domain::repos::SnapshotBoundary>,
         ) -> Result<Vec<MessageModel>, DomainError> {
             unimplemented!()
+        }
+
+        async fn last_assistant_token_counts<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+        ) -> Result<Option<(i64, i64)>, DomainError> {
+            Ok(None)
+        }
+
+        async fn find_latest_message<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+        ) -> Result<Option<crate::domain::repos::SummaryFrontier>, DomainError> {
+            Ok(None)
+        }
+
+        async fn fetch_messages_in_range<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+            _: Option<&crate::domain::repos::SummaryFrontier>,
+            _: &crate::domain::repos::SummaryFrontier,
+        ) -> Result<Vec<MessageModel>, DomainError> {
+            Ok(vec![])
+        }
+
+        async fn mark_messages_compressed<C: DBRunner>(
+            &self,
+            _: &C,
+            _: &AccessScope,
+            _: Uuid,
+            _: Option<&crate::domain::repos::SummaryFrontier>,
+            _: &crate::domain::repos::SummaryFrontier,
+        ) -> Result<u64, DomainError> {
+            Ok(0)
         }
     }
 

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/mod.rs
@@ -23,7 +23,7 @@ use crate::domain::repos::{
     InsertUserMessageParams, MessageAttachmentRepository, MessageRepository, QuotaUsageRepository,
     SnapshotBoundary, ThreadSummaryRepository, TurnRepository, VectorStoreRepository,
 };
-use crate::domain::stream_events::{StreamEvent, StreamStartedData};
+use crate::domain::stream_events::{StreamEvent, StreamStartedData, ThreadSummaryInfo};
 use crate::infra::db::entity::chat_turn::TurnState;
 use crate::infra::llm::provider_resolver::ProviderResolver;
 
@@ -263,6 +263,20 @@ impl<
             .await
             .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
 
+        // ── Prior context size (for accurate quota reserve) ──
+        // Fetch the last assistant message's actual token counts so preflight
+        // can estimate the full context size, not just the current message.
+        let prior_context_tokens = self
+            .message_repo
+            .last_assistant_token_counts(&conn, &scope, chat_id)
+            .await
+            .map_err(|e| StreamError::TurnCreationFailed { source: e })?
+            .map_or(0u64, |(inp, out)| {
+                u64::try_from(inp.max(0))
+                    .unwrap_or(0)
+                    .saturating_add(u64::try_from(out.max(0)).unwrap_or(0))
+            });
+
         // ── Pre-preflight attachment queries (for surcharge estimation) ──
         let pre_ready_doc_count = self
             .attachment_repo
@@ -322,6 +336,7 @@ impl<
                 web_search_enabled,
                 code_interpreter_enabled: !pre_ci_file_ids.is_empty(),
                 max_output_tokens_cap: self.streaming_config.max_output_tokens,
+                prior_context_tokens,
             })
             .await
             .map_err(|e| match e {
@@ -452,7 +467,7 @@ impl<
         // Pre-generate assistant message ID (sent in StreamStartedData and used in CAS)
         let message_id = Uuid::new_v4();
 
-        let finalization_ctx = FinalizationCtx {
+        let mut finalization_ctx = FinalizationCtx {
             finalization_svc: Arc::clone(&self.finalization),
             db: Arc::clone(&self.db),
             turn_repo: Arc::clone(&self.turn_repo),
@@ -475,6 +490,9 @@ impl<
             downgrade_from: pf.downgrade_from,
             downgrade_reason: pf.downgrade_reason,
             period_starts,
+            context_window: pf.context_window,
+            assembled_context_tokens: 0, // updated after context assembly
+            messages_truncated: false,   // updated after context assembly
             provider_id: provider_id.clone(),
             metrics: Arc::clone(&self.metrics),
             quota_warnings_provider: Arc::clone(&self.quota)
@@ -490,7 +508,7 @@ impl<
             web_search_enabled,
             code_interpreter_enabled,
         });
-        let assembled = self
+        let (assembled, summary_info) = self
             .gather_context(
                 tenant_id,
                 chat_id,
@@ -508,6 +526,9 @@ impl<
                 &image_file_ids,
             )
             .await?;
+
+        finalization_ctx.assembled_context_tokens = assembled.estimated_context_tokens;
+        finalization_ctx.messages_truncated = assembled.messages_truncated;
 
         // Record image metrics
         if num_images > 0 {
@@ -528,7 +549,7 @@ impl<
             .replace("{model}", &effective_provider_model_id);
         let proxy_path = format!("{}{api_path}", resolved_provider.upstream_alias);
 
-        emit_stream_started(&tx, request_id, message_id).await;
+        emit_stream_started(&tx, request_id, message_id, summary_info).await;
 
         Ok(provider_task::spawn_provider_task(
             ctx,
@@ -789,7 +810,13 @@ impl<
         code_interpreter_file_ids: Vec<String>,
         token_budget: Option<super::context_assembly::TokenBudget>,
         image_file_ids: &[String],
-    ) -> Result<super::context_assembly::AssembledContext, StreamError> {
+    ) -> Result<
+        (
+            super::context_assembly::AssembledContext,
+            Option<ThreadSummaryInfo>,
+        ),
+        StreamError,
+    > {
         let conn = self
             .db
             .conn()
@@ -804,6 +831,10 @@ impl<
             .await
             .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
 
+        let summary_info = thread_summary.as_ref().map(|ts| ThreadSummaryInfo {
+            token_estimate: u32::try_from(ts.token_estimate).unwrap_or(0),
+        });
+
         let recent_messages = match &thread_summary {
             Some(ts) => {
                 self.message_repo
@@ -811,8 +842,8 @@ impl<
                         &conn,
                         &scope,
                         chat_id,
-                        ts.boundary_created_at,
-                        ts.boundary_message_id,
+                        ts.frontier.created_at,
+                        ts.frontier.message_id,
                         self.context_config.recent_messages_limit,
                         snapshot_boundary,
                     )
@@ -851,37 +882,40 @@ impl<
             })
             .collect();
 
-        super::context_assembly::assemble_context(&super::context_assembly::ContextInput {
-            system_prompt,
-            web_search_guard: &self.context_config.web_search_guard,
-            file_search_guard: &self.context_config.file_search_guard,
-            thread_summary: thread_summary.as_ref().map(|ts| ts.content.as_str()),
-            recent_messages: &context_messages,
-            user_message,
-            web_search_enabled,
-            file_search_enabled,
-            vector_store_ids,
-            file_search_filters,
-            web_search_context_size,
-            file_search_max_num_results,
-            code_interpreter_file_ids,
-            token_budget,
-            image_file_ids,
-        })
-        .map_err(|e| StreamError::ContextBudgetExceeded {
-            required_tokens: match &e {
-                super::context_assembly::ContextAssemblyError::BudgetExceeded {
-                    required_tokens,
-                    ..
-                } => *required_tokens,
-            },
-            available_tokens: match &e {
-                super::context_assembly::ContextAssemblyError::BudgetExceeded {
-                    available_tokens,
-                    ..
-                } => *available_tokens,
-            },
-        })
+        let assembled =
+            super::context_assembly::assemble_context(&super::context_assembly::ContextInput {
+                system_prompt,
+                web_search_guard: &self.context_config.web_search_guard,
+                file_search_guard: &self.context_config.file_search_guard,
+                thread_summary: thread_summary.as_ref().map(|ts| ts.content.as_str()),
+                recent_messages: &context_messages,
+                user_message,
+                web_search_enabled,
+                file_search_enabled,
+                vector_store_ids,
+                file_search_filters,
+                web_search_context_size,
+                file_search_max_num_results,
+                code_interpreter_file_ids,
+                token_budget,
+                image_file_ids,
+            })
+            .map_err(|e| StreamError::ContextBudgetExceeded {
+                required_tokens: match &e {
+                    super::context_assembly::ContextAssemblyError::BudgetExceeded {
+                        required_tokens,
+                        ..
+                    } => *required_tokens,
+                },
+                available_tokens: match &e {
+                    super::context_assembly::ContextAssemblyError::BudgetExceeded {
+                        available_tokens,
+                        ..
+                    } => *available_tokens,
+                },
+            })?;
+
+        Ok((assembled, summary_info))
     }
 
     /// Run streaming for an already-created turn (used by retry/edit mutations).
@@ -933,6 +967,17 @@ impl<
             .await
             .map_err(|e| StreamError::TurnCreationFailed { source: e })?;
 
+        let prior_context_tokens = self
+            .message_repo
+            .last_assistant_token_counts(&conn, &scope, chat_id)
+            .await
+            .map_err(|e| StreamError::TurnCreationFailed { source: e })?
+            .map_or(0u64, |(inp, out)| {
+                u64::try_from(inp.max(0))
+                    .unwrap_or(0)
+                    .saturating_add(u64::try_from(out.max(0)).unwrap_or(0))
+            });
+
         // ── Preflight quota evaluate ────────────────────────────────────
         let selected_model = model;
         let computed = self
@@ -947,6 +992,7 @@ impl<
                 web_search_enabled,
                 code_interpreter_enabled: !pre_ci_file_ids.is_empty(),
                 max_output_tokens_cap: self.streaming_config.max_output_tokens,
+                prior_context_tokens,
             })
             .await
             .map_err(|e| match e {
@@ -1137,7 +1183,7 @@ impl<
         // ── Build finalization context + resolve provider + spawn ────────
         let message_id = Uuid::new_v4();
 
-        let finalization_ctx = FinalizationCtx {
+        let mut finalization_ctx = FinalizationCtx {
             finalization_svc: Arc::clone(&self.finalization),
             db: Arc::clone(&self.db),
             turn_repo: Arc::clone(&self.turn_repo),
@@ -1160,6 +1206,9 @@ impl<
             downgrade_from: pf.downgrade_from,
             downgrade_reason: pf.downgrade_reason,
             period_starts,
+            context_window: pf.context_window,
+            assembled_context_tokens: 0, // updated after context assembly
+            messages_truncated: false,   // updated after context assembly
             provider_id: provider_id.clone(),
             metrics: Arc::clone(&self.metrics),
             quota_warnings_provider: Arc::clone(&self.quota)
@@ -1175,7 +1224,7 @@ impl<
             web_search_enabled,
             code_interpreter_enabled,
         });
-        let assembled = self
+        let (assembled, summary_info) = self
             .gather_context(
                 tenant_id,
                 chat_id,
@@ -1194,6 +1243,9 @@ impl<
             )
             .await?;
 
+        finalization_ctx.assembled_context_tokens = assembled.estimated_context_tokens;
+        finalization_ctx.messages_truncated = assembled.messages_truncated;
+
         let tenant_id_str = tenant_id.to_string();
         let resolved_provider = self
             .provider_resolver
@@ -1207,7 +1259,7 @@ impl<
             .replace("{model}", &effective_provider_model_id);
         let proxy_path = format!("{}{api_path}", resolved_provider.upstream_alias);
 
-        emit_stream_started(&tx, request_id, message_id).await;
+        emit_stream_started(&tx, request_id, message_id, summary_info).await;
 
         Ok(provider_task::spawn_provider_task(
             ctx,
@@ -1234,12 +1286,18 @@ impl<
 }
 
 /// Emit `stream_started` before handing `tx` to the provider task (D3).
-async fn emit_stream_started(tx: &mpsc::Sender<StreamEvent>, request_id: Uuid, message_id: Uuid) {
+async fn emit_stream_started(
+    tx: &mpsc::Sender<StreamEvent>,
+    request_id: Uuid,
+    message_id: Uuid,
+    thread_summary_applied: Option<ThreadSummaryInfo>,
+) {
     if tx
         .send(StreamEvent::StreamStarted(StreamStartedData {
             request_id,
             message_id,
             is_new_turn: true,
+            thread_summary_applied,
         }))
         .await
         .is_err()
@@ -1321,6 +1379,14 @@ mod tests {
             &self,
             _runner: &(dyn modkit_db::secure::DBRunner + Sync),
             _event: crate::domain::model::audit_envelope::AuditEnvelope,
+        ) -> Result<(), crate::domain::error::DomainError> {
+            Ok(())
+        }
+
+        async fn enqueue_thread_summary(
+            &self,
+            _: &(dyn modkit_db::secure::DBRunner + Sync),
+            _: crate::domain::repos::ThreadSummaryTaskPayload,
         ) -> Result<(), crate::domain::error::DomainError> {
             Ok(())
         }
@@ -1634,6 +1700,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -1696,6 +1763,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -1751,6 +1819,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -1855,6 +1924,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -1961,6 +2031,7 @@ mod tests {
             Arc::new(MockQuotaSettler) as Arc<dyn QuotaSettler>,
             Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
             Arc::clone(&metrics),
+            crate::config::background::ThreadSummaryWorkerConfig::default(),
         ));
 
         // QuotaService with permissive defaults — model catalog includes
@@ -2080,6 +2151,8 @@ mod tests {
                 computer_use: false,
                 mcp: false,
             },
+            thread_summary_prompt: String::new(),
+            max_output_tokens: 16_384,
         }
     }
 
@@ -2544,6 +2617,7 @@ mod tests {
                 presence_penalty: 0.0,
                 stop: vec![],
                 extra_body: None,
+                reasoning_effort: None,
             },
         };
 
@@ -2589,6 +2663,7 @@ mod tests {
                 presence_penalty: 0.0,
                 stop: vec![],
                 extra_body: None,
+                reasoning_effort: None,
             },
         };
 
@@ -2657,6 +2732,7 @@ mod tests {
             Arc::new(MockQuotaSettler) as Arc<dyn QuotaSettler>,
             Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
             Arc::clone(&metrics),
+            crate::config::background::ThreadSummaryWorkerConfig::default(),
         ));
 
         // Keep max_output_tokens well below context_window so preflight maths
@@ -3098,6 +3174,7 @@ mod tests {
             Arc::new(NoopSettler) as Arc<dyn QuotaSettler>,
             Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
             Arc::new(crate::domain::ports::metrics::NoopMetrics),
+            crate::config::background::ThreadSummaryWorkerConfig::default(),
         ));
 
         let fctx = FinalizationCtx {
@@ -3123,6 +3200,9 @@ mod tests {
             downgrade_from: Some("gpt-4o".to_owned()),
             downgrade_reason: Some("premium_exhausted".to_owned()),
             period_starts: Vec::new(),
+            context_window: 128_000,
+            assembled_context_tokens: 0,
+            messages_truncated: false,
             provider_id: "openai".to_owned(),
             metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
             quota_warnings_provider: Arc::new(NoopQuotaWarningsProvider),
@@ -3153,6 +3233,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -3271,6 +3352,7 @@ mod tests {
             Arc::new(FailingSettler) as Arc<dyn QuotaSettler>,
             Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
             Arc::new(crate::domain::ports::metrics::NoopMetrics),
+            crate::config::background::ThreadSummaryWorkerConfig::default(),
         ));
 
         let fctx = FinalizationCtx {
@@ -3296,6 +3378,9 @@ mod tests {
             downgrade_from: Some("gpt-4o".to_owned()),
             downgrade_reason: Some("premium_exhausted".to_owned()),
             period_starts: Vec::new(),
+            context_window: 128_000,
+            assembled_context_tokens: 0,
+            messages_truncated: false,
             provider_id: "openai".to_owned(),
             metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
             quota_warnings_provider: Arc::new(NoopQuotaWarningsProvider),
@@ -3326,6 +3411,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -3442,6 +3528,7 @@ mod tests {
             Arc::new(FailingSettler) as Arc<dyn QuotaSettler>,
             Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
             Arc::new(crate::domain::ports::metrics::NoopMetrics),
+            crate::config::background::ThreadSummaryWorkerConfig::default(),
         ));
 
         let fctx = FinalizationCtx {
@@ -3467,6 +3554,9 @@ mod tests {
             downgrade_from: Some("gpt-4o".to_owned()),
             downgrade_reason: Some("premium_exhausted".to_owned()),
             period_starts: Vec::new(),
+            context_window: 128_000,
+            assembled_context_tokens: 0,
+            messages_truncated: false,
             provider_id: "openai".to_owned(),
             metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
             quota_warnings_provider: Arc::new(NoopQuotaWarningsProvider),
@@ -3498,6 +3588,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -3617,6 +3708,7 @@ mod tests {
             Arc::new(MockQuotaSettler) as Arc<dyn QuotaSettler>,
             Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
             Arc::new(crate::domain::ports::metrics::NoopMetrics),
+            crate::config::background::ThreadSummaryWorkerConfig::default(),
         ));
 
         let quota_svc = Arc::new(crate::domain::service::QuotaService::new(
@@ -3879,6 +3971,8 @@ mod tests {
                         computer_use: false,
                         mcp: false,
                     },
+                    thread_summary_prompt: String::new(),
+                    max_output_tokens: 16_384,
                 },
                 false,
                 Vec::new(),
@@ -4042,6 +4136,8 @@ mod tests {
                         computer_use: false,
                         mcp: false,
                     },
+                    thread_summary_prompt: String::new(),
+                    max_output_tokens: 16_384,
                 },
                 false,
                 Vec::new(),
@@ -4261,6 +4357,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -4317,6 +4414,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -4383,6 +4481,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -4436,6 +4535,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -4491,6 +4591,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -4557,6 +4658,7 @@ mod tests {
                     presence_penalty: 0.0,
                     stop: vec![],
                     extra_body: None,
+                    reasoning_effort: None,
                 },
                 provider_file_id_map: std::collections::HashMap::new(),
             },
@@ -5240,6 +5342,7 @@ mod tests {
             Arc::new(MockQuotaSettler) as Arc<dyn QuotaSettler>,
             Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
             Arc::new(crate::domain::ports::metrics::NoopMetrics),
+            crate::config::background::ThreadSummaryWorkerConfig::default(),
         ));
 
         let quota_svc = Arc::new(crate::domain::service::QuotaService::new(
@@ -5613,6 +5716,10 @@ mod tests {
         fn record_cleanup_retry(&self, _: &str, _: &str) {}
         fn record_cleanup_backlog(&self, _: &str, _: &str, _: i64) {}
         fn record_cleanup_vs_with_failed_attachments(&self) {}
+        fn record_thread_summary_trigger(&self, _: &str) {}
+        fn record_thread_summary_execution(&self, _: &str) {}
+        fn record_thread_summary_cas_conflict(&self) {}
+        fn record_summary_fallback(&self) {}
     }
 
     // ── Metric emission tests ────────────────────────────────────────────

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/provider_task.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/provider_task.rs
@@ -139,6 +139,9 @@ pub(super) fn spawn_provider_task<TR: TurnRepository + 'static, MR: MessageRepos
             if let Some(extra_body) = api_params.extra_body {
                 params["extra_body"] = extra_body;
             }
+            if let Some(ref effort) = api_params.reasoning_effort {
+                params["reasoning_effort"] = serde_json::json!(effort);
+            }
             builder = builder.additional_params(params);
         }
 

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/types.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/types.rs
@@ -216,6 +216,12 @@ pub(super) struct FinalizationCtx<TR: TurnRepository + 'static, MR: MessageRepos
         crate::infra::db::entity::quota_usage::PeriodType,
         time::Date,
     )>,
+    /// Context window size of the effective model (tokens) — for summary trigger.
+    pub(super) context_window: u32,
+    /// Estimated input tokens from context assembly (all messages + system prompt).
+    pub(super) assembled_context_tokens: u64,
+    /// `true` when context assembly dropped older messages due to budget.
+    pub(super) messages_truncated: bool,
     /// Provider ID for metrics labels.
     pub(super) provider_id: String,
     /// Metrics port for recording stream metrics in the spawned task.
@@ -269,6 +275,9 @@ impl<TR: TurnRepository + 'static, MR: MessageRepository + 'static> Finalization
             period_starts: self.period_starts.clone(),
             web_search_calls,
             code_interpreter_calls,
+            context_window: self.context_window,
+            assembled_context_tokens: self.assembled_context_tokens,
+            messages_truncated: self.messages_truncated,
             ttft_ms,
             total_ms,
         }

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -376,6 +376,19 @@ impl ThreadSummaryRepository for MockThreadSummaryRepo {
     {
         Ok(None)
     }
+
+    async fn upsert_with_cas<C: modkit_db::secure::DBRunner>(
+        &self,
+        _runner: &C,
+        _chat_id: uuid::Uuid,
+        _tenant_id: uuid::Uuid,
+        _expected_base_frontier: Option<&crate::domain::repos::SummaryFrontier>,
+        _new_frontier: &crate::domain::repos::SummaryFrontier,
+        _summary_text: &str,
+        _token_estimate: i32,
+    ) -> Result<u64, crate::domain::error::DomainError> {
+        Ok(1)
+    }
 }
 
 pub fn mock_thread_summary_repo() -> Arc<MockThreadSummaryRepo> {
@@ -461,6 +474,7 @@ pub fn test_catalog_entry(params: TestCatalogEntryParams) -> ModelCatalogEntry {
                 presence_penalty: 0.0,
                 stop: vec![],
                 extra_body: None,
+                reasoning_effort: None,
             },
             features: ModelFeatures {
                 streaming: true,
@@ -904,6 +918,13 @@ impl OutboxEnqueuer for NoopOutboxEnqueuer {
     ) -> Result<(), crate::domain::error::DomainError> {
         Ok(())
     }
+    async fn enqueue_thread_summary(
+        &self,
+        _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+        _payload: crate::domain::repos::ThreadSummaryTaskPayload,
+    ) -> Result<(), crate::domain::error::DomainError> {
+        Ok(())
+    }
     fn flush(&self) {}
 }
 
@@ -913,6 +934,7 @@ pub struct RecordingOutboxEnqueuer {
     pub usage_events: Mutex<Vec<mini_chat_sdk::UsageEvent>>,
     pub cleanup_events: Mutex<Vec<AttachmentCleanupEvent>>,
     pub chat_cleanup_events: Mutex<Vec<ChatCleanupEvent>>,
+    pub thread_summary_payloads: Mutex<Vec<crate::domain::repos::ThreadSummaryTaskPayload>>,
     recorded_audit_events: Mutex<Vec<AuditEnvelope>>,
     recorded_flush_count: AtomicU32,
 }
@@ -923,6 +945,7 @@ impl RecordingOutboxEnqueuer {
             usage_events: Mutex::new(Vec::new()),
             cleanup_events: Mutex::new(Vec::new()),
             chat_cleanup_events: Mutex::new(Vec::new()),
+            thread_summary_payloads: Mutex::new(Vec::new()),
             recorded_audit_events: Mutex::new(Vec::new()),
             recorded_flush_count: AtomicU32::new(0),
         }
@@ -975,6 +998,14 @@ impl OutboxEnqueuer for RecordingOutboxEnqueuer {
         self.recorded_audit_events.lock().unwrap().push(event);
         Ok(())
     }
+    async fn enqueue_thread_summary(
+        &self,
+        _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+        payload: crate::domain::repos::ThreadSummaryTaskPayload,
+    ) -> Result<(), crate::domain::error::DomainError> {
+        self.thread_summary_payloads.lock().unwrap().push(payload);
+        Ok(())
+    }
     fn flush(&self) {
         self.recorded_flush_count.fetch_add(1, Ordering::SeqCst);
     }
@@ -1015,6 +1046,13 @@ impl OutboxEnqueuer for FailingOutboxEnqueuer {
         &self,
         _runner: &(dyn modkit_db::secure::DBRunner + Sync),
         _event: AuditEnvelope,
+    ) -> Result<(), crate::domain::error::DomainError> {
+        Ok(())
+    }
+    async fn enqueue_thread_summary(
+        &self,
+        _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+        _payload: crate::domain::repos::ThreadSummaryTaskPayload,
     ) -> Result<(), crate::domain::error::DomainError> {
         Ok(())
     }
@@ -1285,9 +1323,6 @@ impl crate::domain::ports::MiniChatMetricsPort for TestMetrics {
         self.attachments_pending.fetch_add(-1, Ordering::Relaxed);
     }
     fn record_image_inputs_per_turn(&self, _count: u32) {}
-    fn record_orphan_detected(&self, _: &str) {}
-    fn record_orphan_finalized(&self, _: &str) {}
-    fn record_orphan_scan_duration_seconds(&self, _: f64) {}
     fn record_code_interpreter_calls(&self, _: &str, _: u32) {
         self.code_interpreter_calls.fetch_add(1, Ordering::Relaxed);
     }
@@ -1296,6 +1331,13 @@ impl crate::domain::ports::MiniChatMetricsPort for TestMetrics {
     fn record_cleanup_retry(&self, _: &str, _: &str) {}
     fn record_cleanup_backlog(&self, _: &str, _: &str, _: i64) {}
     fn record_cleanup_vs_with_failed_attachments(&self) {}
+    fn record_orphan_detected(&self, _: &str) {}
+    fn record_orphan_finalized(&self, _: &str) {}
+    fn record_orphan_scan_duration_seconds(&self, _: f64) {}
+    fn record_thread_summary_trigger(&self, _: &str) {}
+    fn record_thread_summary_execution(&self, _: &str) {}
+    fn record_thread_summary_cas_conflict(&self) {}
+    fn record_summary_fallback(&self) {}
 }
 
 // ── Mock User Limits Provider ──

--- a/modules/mini-chat/mini-chat/src/domain/stream_events.rs
+++ b/modules/mini-chat/mini-chat/src/domain/stream_events.rs
@@ -80,6 +80,17 @@ pub struct ErrorData {
     pub message: String,
 }
 
+/// Metadata about a thread summary applied to the current turn's context.
+///
+/// Sent in the `stream_started` event when the conversation has an active
+/// thread summary. The UI can use this to show an informational banner.
+#[domain_model]
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ThreadSummaryInfo {
+    /// Estimated token cost of the summary in the context window.
+    pub token_estimate: u32,
+}
+
 /// Stream header event carrying the stream request ID and server-generated
 /// assistant message ID.
 ///
@@ -94,6 +105,10 @@ pub struct StreamStartedData {
     /// `true` for a live generation (new turn); `false` when the stream
     /// replays an already-completed turn (idempotent replay).
     pub is_new_turn: bool,
+    /// Present when a thread summary is included in the context window.
+    /// UI can display an informational indicator.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_summary_applied: Option<ThreadSummaryInfo>,
 }
 
 /// Quota tier classification.

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/mod.rs
@@ -6,3 +6,4 @@ pub mod message;
 pub mod message_attachment;
 pub mod message_reaction;
 pub mod quota_usage;
+pub mod thread_summary;

--- a/modules/mini-chat/mini-chat/src/infra/db/entity/thread_summary.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/entity/thread_summary.rs
@@ -1,0 +1,42 @@
+use modkit_db::secure::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+/// Per DESIGN.md: "No independent #[secure] — accessed through parent chat."
+/// We derive `Scopable` with `no_owner`/`no_type` so the entity can pass through
+/// the secure query pipeline with `AccessScope::allow_all()` for background workers.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "thread_summaries")]
+#[secure(tenant_col = "tenant_id", resource_col = "id", no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub chat_id: Uuid,
+    #[sea_orm(column_type = "Text")]
+    pub summary_text: String,
+    pub summarized_up_to_created_at: OffsetDateTime,
+    pub summarized_up_to_message_id: Uuid,
+    pub token_estimate: i32,
+    pub created_at: OffsetDateTime,
+    pub updated_at: OffsetDateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::chat::Entity",
+        from = "Column::ChatId",
+        to = "super::chat::Column::Id"
+    )]
+    Chat,
+}
+
+impl Related<super::chat::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Chat.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/mini-chat/mini-chat/src/infra/db/migrations/m20260330_000001_thread_summary_composite_frontier.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/migrations/m20260330_000001_thread_summary_composite_frontier.rs
@@ -1,0 +1,108 @@
+use sea_orm_migration::prelude::*;
+use sea_orm_migration::sea_orm::ConnectionTrait;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+        let conn = manager.get_connection();
+
+        let sql = match backend {
+            sea_orm::DatabaseBackend::Postgres => POSTGRES_UP,
+            sea_orm::DatabaseBackend::Sqlite => SQLITE_UP,
+            sea_orm::DatabaseBackend::MySql => {
+                return Err(DbErr::Migration("MySQL not supported for mini-chat".into()));
+            }
+        };
+
+        conn.execute_unprepared(sql).await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let backend = manager.get_database_backend();
+        let conn = manager.get_connection();
+
+        let sql = match backend {
+            sea_orm::DatabaseBackend::Postgres => POSTGRES_DOWN,
+            sea_orm::DatabaseBackend::Sqlite => SQLITE_DOWN,
+            sea_orm::DatabaseBackend::MySql => {
+                return Err(DbErr::Migration("MySQL not supported for mini-chat".into()));
+            }
+        };
+
+        conn.execute_unprepared(sql).await?;
+        Ok(())
+    }
+}
+
+const POSTGRES_UP: &str = r"
+ALTER TABLE thread_summaries
+    RENAME COLUMN summarized_up_to TO summarized_up_to_message_id;
+
+ALTER TABLE thread_summaries
+    ADD COLUMN summarized_up_to_created_at TIMESTAMPTZ;
+
+-- Backfill from the actual message timestamp when the row exists.
+UPDATE thread_summaries ts
+    SET summarized_up_to_created_at = m.created_at
+    FROM messages m
+    WHERE m.id = ts.summarized_up_to_message_id
+      AND m.chat_id = ts.chat_id
+      AND ts.summarized_up_to_created_at IS NULL;
+
+-- Fallback for orphaned rows (message deleted): use the summary's own updated_at.
+UPDATE thread_summaries
+    SET summarized_up_to_created_at = updated_at
+    WHERE summarized_up_to_created_at IS NULL;
+
+ALTER TABLE thread_summaries
+    ALTER COLUMN summarized_up_to_created_at SET NOT NULL;
+";
+
+const POSTGRES_DOWN: &str = r"
+ALTER TABLE thread_summaries
+    DROP COLUMN summarized_up_to_created_at;
+
+ALTER TABLE thread_summaries
+    RENAME COLUMN summarized_up_to_message_id TO summarized_up_to;
+";
+
+// SQLite: ADD COLUMN with DEFAULT, then backfill from messages, then fix remaining.
+// SQLite does not support UPDATE ... FROM, so use correlated subquery.
+const SQLITE_UP: &str = r"
+ALTER TABLE thread_summaries
+    RENAME COLUMN summarized_up_to TO summarized_up_to_message_id;
+
+ALTER TABLE thread_summaries
+    ADD COLUMN summarized_up_to_created_at TEXT NOT NULL DEFAULT '1970-01-01T00:00:00Z';
+
+-- Backfill from the actual message timestamp.
+UPDATE thread_summaries
+    SET summarized_up_to_created_at = (
+        SELECT messages.created_at FROM messages
+        WHERE messages.id = thread_summaries.summarized_up_to_message_id
+          AND messages.chat_id = thread_summaries.chat_id
+    )
+    WHERE EXISTS (
+        SELECT 1 FROM messages
+        WHERE messages.id = thread_summaries.summarized_up_to_message_id
+          AND messages.chat_id = thread_summaries.chat_id
+    );
+
+-- Fallback for orphaned rows: use the summary's own updated_at.
+UPDATE thread_summaries
+    SET summarized_up_to_created_at = updated_at
+    WHERE summarized_up_to_created_at = '1970-01-01T00:00:00Z';
+";
+
+const SQLITE_DOWN: &str = r"
+ALTER TABLE thread_summaries
+    DROP COLUMN summarized_up_to_created_at;
+
+ALTER TABLE thread_summaries
+    RENAME COLUMN summarized_up_to_message_id TO summarized_up_to;
+";

--- a/modules/mini-chat/mini-chat/src/infra/db/migrations/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/migrations/mod.rs
@@ -2,6 +2,7 @@ use sea_orm_migration::prelude::*;
 
 mod m20260302_000001_initial;
 mod m20260329_000001_add_last_progress_at;
+mod m20260330_000001_thread_summary_composite_frontier;
 mod m20260330_000002_add_web_search_enabled_to_turns;
 mod m20260402_000003_add_tool_counts_to_turns;
 
@@ -14,6 +15,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260302_000001_initial::Migration),
             Box::new(m20260329_000001_add_last_progress_at::Migration),
             Box::new(m20260330_000002_add_web_search_enabled_to_turns::Migration),
+            Box::new(m20260330_000001_thread_summary_composite_frontier::Migration),
             Box::new(m20260402_000003_add_tool_counts_to_turns::Migration),
         ]
     }

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/message_repo.rs
@@ -339,7 +339,8 @@ impl crate::domain::repos::MessageRepository for MessageRepository {
         let mut cond = Condition::all()
             .add(Column::ChatId.eq(chat_id))
             .add(Column::RequestId.is_not_null())
-            .add(Column::DeletedAt.is_null());
+            .add(Column::DeletedAt.is_null())
+            .add(Column::IsCompressed.eq(false));
 
         if let Some(b) = boundary {
             cond = cond.add(upper_bound_filter(b));
@@ -381,6 +382,7 @@ impl crate::domain::repos::MessageRepository for MessageRepository {
             .add(Column::ChatId.eq(chat_id))
             .add(Column::RequestId.is_not_null())
             .add(Column::DeletedAt.is_null())
+            .add(Column::IsCompressed.eq(false))
             .add(lower_filter);
 
         if let Some(b) = boundary {
@@ -398,6 +400,151 @@ impl crate::domain::repos::MessageRepository for MessageRepository {
             .await?;
         rows.reverse();
         Ok(rows)
+    }
+
+    async fn last_assistant_token_counts<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<(i64, i64)>, DomainError> {
+        let row = MessageEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::Role.eq(MessageRole::Assistant))
+                    .add(Column::DeletedAt.is_null())
+                    // Skip fully-unknown rows (both tokens 0 = no usage data).
+                    // Keep rows where either field is known.
+                    .add(
+                        Condition::any()
+                            .add(Column::InputTokens.gt(0))
+                            .add(Column::OutputTokens.gt(0)),
+                    ),
+            )
+            .secure()
+            .scope_with(scope)
+            .order_by(Column::CreatedAt, Order::Desc)
+            .order_by(Column::Id, Order::Desc)
+            .one(runner)
+            .await?;
+        Ok(row.map(|m| (m.input_tokens, m.output_tokens)))
+    }
+
+    // Unlike `snapshot_boundary` and context-building queries (`recent_for_context`,
+    // `recent_after_boundary`) which filter `RequestId.is_not_null()` to only include
+    // committed messages, this method intentionally includes ALL non-deleted messages
+    // to reflect the full frontier for thread summary tracking.
+    async fn find_latest_message<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+    ) -> Result<Option<crate::domain::repos::SummaryFrontier>, DomainError> {
+        let row = MessageEntity::find()
+            .filter(
+                Condition::all()
+                    .add(Column::ChatId.eq(chat_id))
+                    .add(Column::DeletedAt.is_null()),
+            )
+            .secure()
+            .scope_with(scope)
+            .order_by(Column::CreatedAt, Order::Desc)
+            .order_by(Column::Id, Order::Desc)
+            .one(runner)
+            .await?;
+        Ok(row.map(|m| crate::domain::repos::SummaryFrontier {
+            created_at: m.created_at,
+            message_id: m.id,
+        }))
+    }
+
+    async fn fetch_messages_in_range<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        base_frontier: Option<&crate::domain::repos::SummaryFrontier>,
+        target_frontier: &crate::domain::repos::SummaryFrontier,
+    ) -> Result<Vec<MessageModel>, DomainError> {
+        let mut cond = Condition::all()
+            .add(Column::ChatId.eq(chat_id))
+            .add(Column::DeletedAt.is_null())
+            .add(Column::IsCompressed.eq(false));
+
+        // Lower bound: (created_at, id) > base_frontier (exclusive)
+        if let Some(bf) = base_frontier {
+            let lower = Condition::any()
+                .add(Column::CreatedAt.gt(bf.created_at))
+                .add(
+                    Condition::all()
+                        .add(Column::CreatedAt.eq(bf.created_at))
+                        .add(Column::Id.gt(bf.message_id)),
+                );
+            cond = cond.add(lower);
+        }
+
+        // Upper bound: (created_at, id) <= target_frontier (inclusive)
+        let upper = Condition::any()
+            .add(Column::CreatedAt.lt(target_frontier.created_at))
+            .add(
+                Condition::all()
+                    .add(Column::CreatedAt.eq(target_frontier.created_at))
+                    .add(Column::Id.lte(target_frontier.message_id)),
+            );
+        cond = cond.add(upper);
+
+        let rows = MessageEntity::find()
+            .filter(cond)
+            .secure()
+            .scope_with(scope)
+            .order_by(Column::CreatedAt, Order::Asc)
+            .order_by(Column::Id, Order::Asc)
+            .all(runner)
+            .await?;
+        Ok(rows)
+    }
+
+    async fn mark_messages_compressed<C: DBRunner>(
+        &self,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
+        base_frontier: Option<&crate::domain::repos::SummaryFrontier>,
+        target_frontier: &crate::domain::repos::SummaryFrontier,
+    ) -> Result<u64, DomainError> {
+        let mut cond = Condition::all()
+            .add(Column::ChatId.eq(chat_id))
+            .add(Column::DeletedAt.is_null());
+
+        if let Some(bf) = base_frontier {
+            let lower = Condition::any()
+                .add(Column::CreatedAt.gt(bf.created_at))
+                .add(
+                    Condition::all()
+                        .add(Column::CreatedAt.eq(bf.created_at))
+                        .add(Column::Id.gt(bf.message_id)),
+                );
+            cond = cond.add(lower);
+        }
+
+        let upper = Condition::any()
+            .add(Column::CreatedAt.lt(target_frontier.created_at))
+            .add(
+                Condition::all()
+                    .add(Column::CreatedAt.eq(target_frontier.created_at))
+                    .add(Column::Id.lte(target_frontier.message_id)),
+            );
+        cond = cond.add(upper);
+
+        let result = MessageEntity::update_many()
+            .col_expr(Column::IsCompressed, Expr::value(true))
+            .filter(cond)
+            .secure()
+            .scope_with(scope)
+            .exec(runner)
+            .await?;
+        Ok(result.rows_affected)
     }
 }
 

--- a/modules/mini-chat/mini-chat/src/infra/db/repo/thread_summary_repo.rs
+++ b/modules/mini-chat/mini-chat/src/infra/db/repo/thread_summary_repo.rs
@@ -1,26 +1,117 @@
 use async_trait::async_trait;
-use modkit_db::secure::DBRunner;
+use modkit_db::secure::{DBRunner, SecureEntityExt, SecureUpdateExt, secure_insert};
 use modkit_security::AccessScope;
+use sea_orm::sea_query::Expr;
+use sea_orm::{ColumnTrait, Condition, EntityTrait, QueryFilter, Set};
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::domain::error::DomainError;
-use crate::domain::repos::ThreadSummaryModel;
+use crate::domain::repos::{SummaryFrontier, ThreadSummaryModel};
+use crate::infra::db::entity::thread_summary::{self, Column, Entity};
 
 /// Repository for thread summary persistence operations.
-///
-/// P1: No `thread_summaries` table exists yet — always returns `None`.
-/// When the summarization job is implemented (P2+), this will query the DB.
 pub struct ThreadSummaryRepository;
 
 #[async_trait]
 impl crate::domain::repos::ThreadSummaryRepository for ThreadSummaryRepository {
     async fn get_latest<C: DBRunner>(
         &self,
-        _runner: &C,
-        _scope: &AccessScope,
-        _chat_id: Uuid,
+        runner: &C,
+        scope: &AccessScope,
+        chat_id: Uuid,
     ) -> Result<Option<ThreadSummaryModel>, DomainError> {
-        // Graceful degradation: no summary table in P1.
-        Ok(None)
+        let row = Entity::find()
+            .filter(Column::ChatId.eq(chat_id))
+            .secure()
+            .scope_with(scope)
+            .one(runner)
+            .await?;
+
+        Ok(row.map(|r| ThreadSummaryModel {
+            content: r.summary_text,
+            frontier: SummaryFrontier {
+                created_at: r.summarized_up_to_created_at,
+                message_id: r.summarized_up_to_message_id,
+            },
+            token_estimate: r.token_estimate,
+        }))
+    }
+
+    async fn upsert_with_cas<C: DBRunner>(
+        &self,
+        runner: &C,
+        chat_id: Uuid,
+        tenant_id: Uuid,
+        expected_base_frontier: Option<&SummaryFrontier>,
+        new_frontier: &SummaryFrontier,
+        summary_text: &str,
+        token_estimate: i32,
+    ) -> Result<u64, DomainError> {
+        let now = OffsetDateTime::now_utc();
+        let scope = AccessScope::allow_all();
+
+        match expected_base_frontier {
+            None => {
+                // First summary: INSERT via secure_insert.
+                // UNIQUE(chat_id) acts as the CAS guard — if another handler
+                // already inserted, the unique violation returns 0.
+                let am = thread_summary::ActiveModel {
+                    id: Set(Uuid::new_v4()),
+                    tenant_id: Set(tenant_id),
+                    chat_id: Set(chat_id),
+                    summary_text: Set(summary_text.to_owned()),
+                    summarized_up_to_created_at: Set(new_frontier.created_at),
+                    summarized_up_to_message_id: Set(new_frontier.message_id),
+                    token_estimate: Set(token_estimate),
+                    created_at: Set(now),
+                    updated_at: Set(now),
+                };
+
+                match secure_insert::<Entity>(am, &scope, runner).await {
+                    Ok(_) => Ok(1),
+                    Err(e) => {
+                        let msg = e.to_string();
+                        if msg.contains("UNIQUE")
+                            || msg.contains("unique")
+                            || msg.contains("duplicate")
+                        {
+                            // Another handler already inserted — CAS lost.
+                            Ok(0)
+                        } else {
+                            Err(DomainError::internal(format!("thread_summary insert: {e}")))
+                        }
+                    }
+                }
+            }
+            Some(base) => {
+                // Subsequent summary: UPDATE WHERE frontier matches (CAS guard).
+                // Returns 0 if frontier was already advanced by another handler.
+                let result = Entity::update_many()
+                    .col_expr(Column::SummaryText, Expr::value(summary_text.to_owned()))
+                    .col_expr(
+                        Column::SummarizedUpToCreatedAt,
+                        Expr::value(new_frontier.created_at),
+                    )
+                    .col_expr(
+                        Column::SummarizedUpToMessageId,
+                        Expr::value(new_frontier.message_id),
+                    )
+                    .col_expr(Column::TokenEstimate, Expr::value(token_estimate))
+                    .col_expr(Column::UpdatedAt, Expr::value(now))
+                    .filter(
+                        Condition::all()
+                            .add(Column::ChatId.eq(chat_id))
+                            .add(Column::SummarizedUpToCreatedAt.eq(base.created_at))
+                            .add(Column::SummarizedUpToMessageId.eq(base.message_id)),
+                    )
+                    .secure()
+                    .scope_with(&scope)
+                    .exec(runner)
+                    .await?;
+
+                Ok(result.rows_affected)
+            }
+        }
     }
 }

--- a/modules/mini-chat/mini-chat/src/infra/llm/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/mod.rs
@@ -324,6 +324,18 @@ impl ProviderStream {
             }
         }
 
+        // After the terminal event, drain remaining inner-stream frames so
+        // the upstream HTTP body is fully consumed before the connection is
+        // dropped. This prevents Pingora "Downstream ConnectionClosed"
+        // errors when the provider sends trailing SSE frames after the
+        // terminal event (e.g. response.incomplete → stream close).
+        if self.terminal.is_some() && !self.cancel.is_cancelled() {
+            let _drain = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                while self.inner.next().await.is_some() {}
+            })
+            .await;
+        }
+
         match self.terminal {
             Some(terminal) => terminal,
             None if self.cancel.is_cancelled() => TerminalOutcome::Incomplete {

--- a/modules/mini-chat/mini-chat/src/infra/llm/provider_resolver.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/provider_resolver.rs
@@ -38,6 +38,17 @@ pub struct ProviderResolver {
 }
 
 impl ProviderResolver {
+    /// Empty resolver for testing. All `resolve()` calls will fail with
+    /// `ProviderError` since no providers are registered.
+    #[cfg(test)]
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            adapters: HashMap::new(),
+            registry: HashMap::new(),
+        }
+    }
+
     /// Build from config + OAGW gateway. Creates one adapter per distinct
     /// `ProviderKind` (not per `provider_id`).
     ///

--- a/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
+++ b/modules/mini-chat/mini-chat/src/infra/llm/providers/openai_responses.rs
@@ -58,7 +58,7 @@ pub(super) enum ProviderEvent {
         error: ProviderErrorPayload,
     },
     ResponseIncomplete {
-        reason: String,
+        response: ResponseObject,
     },
     Unknown {
         #[allow(dead_code)]
@@ -77,6 +77,15 @@ pub struct ResponseObject {
     #[serde(default)]
     pub output: Vec<OutputItem>,
     pub usage: RawUsage,
+    #[serde(default)]
+    pub incomplete_details: Option<IncompleteDetails>,
+}
+
+/// Details returned when a response finishes with status `"incomplete"`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct IncompleteDetails {
+    #[serde(default)]
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -255,8 +264,7 @@ struct ResponseFailedData {
 
 #[derive(Deserialize)]
 struct ResponseIncompleteData {
-    #[serde(default)]
-    reason: String,
+    response: ResponseObject,
 }
 
 /// A single output item from `response.code_interpreter_call.completed`.
@@ -388,7 +396,7 @@ impl FromServerEvent for ProviderEvent {
                         }
                     })?;
                 Ok(ProviderEvent::ResponseIncomplete {
-                    reason: data.reason,
+                    response: data.response,
                 })
             }
 
@@ -521,16 +529,15 @@ pub(super) fn translate_provider_event(
             })
         }
 
-        ProviderEvent::ResponseIncomplete { reason } => {
+        ProviderEvent::ResponseIncomplete { response } => {
+            let reason = response
+                .incomplete_details
+                .as_ref()
+                .map_or_else(String::new, |d| d.reason.clone());
+            let usage = response.usage.to_usage();
             TranslatedEvent::Terminal(TerminalOutcome::Incomplete {
-                reason: reason.clone(),
-                usage: Usage {
-                    input_tokens: 0,
-                    output_tokens: 0,
-                    cache_read_input_tokens: 0,
-                    cache_write_input_tokens: 0,
-                    reasoning_tokens: 0,
-                },
+                reason,
+                usage,
                 partial_content: accumulated_text.to_owned(),
             })
         }
@@ -730,6 +737,17 @@ fn build_request_body<M>(request: &LlmRequest<M>, stream: bool) -> serde_json::V
         for (k, v) in extra_obj {
             body_obj.insert(k.clone(), v.clone());
         }
+    }
+
+    // Responses API uses `reasoning: { effort: "..." }` instead of the
+    // top-level `reasoning_effort` key used by Chat Completions.
+    if let Some(body_obj) = body.as_object_mut()
+        && let Some(effort) = body_obj.remove("reasoning_effort")
+    {
+        body_obj.insert(
+            "reasoning".to_owned(),
+            serde_json::json!({ "effort": effort }),
+        );
     }
 
     body
@@ -1445,6 +1463,44 @@ mod tests {
         assert!(body.get("tools").is_none());
     }
 
+    #[test]
+    fn builder_reasoning_effort_nested_under_reasoning() {
+        let request = llm_request("o3")
+            .message(LlmMessage::user("Think hard"))
+            .additional_params(serde_json::json!({
+                "temperature": 1.0,
+                "reasoning_effort": "high"
+            }))
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        // Top-level key must be removed
+        assert!(
+            body.get("reasoning_effort").is_none(),
+            "reasoning_effort should not appear at top level"
+        );
+        // Must be nested as `reasoning.effort`
+        assert_eq!(body["reasoning"]["effort"], "high");
+        // Other additional_params are still top-level
+        assert_eq!(body["temperature"], 1.0);
+    }
+
+    #[test]
+    fn builder_no_reasoning_key_when_effort_absent() {
+        let request = llm_request("gpt-4o")
+            .message(LlmMessage::user("Hello"))
+            .additional_params(serde_json::json!({
+                "temperature": 0.7
+            }))
+            .build_streaming();
+
+        let body = build_request_body(&request, true);
+
+        assert!(body.get("reasoning_effort").is_none());
+        assert!(body.get("reasoning").is_none());
+    }
+
     // ── Unit tests: FromServerEvent ────────────────────────────────────────
 
     #[test]
@@ -1681,14 +1737,23 @@ mod tests {
     fn parse_response_incomplete_event() {
         let event = ServerEvent {
             event: Some("response.incomplete".to_string()),
-            data: r#"{"reason":"max_output_tokens"}"#.to_string(),
+            data: r#"{"response":{"id":"resp-inc","output":[],"usage":{"input_tokens":200,"output_tokens":4096},"incomplete_details":{"reason":"max_output_tokens"}}}"#.to_string(),
             id: None,
             retry: None,
         };
         let result = ProviderEvent::from_server_event(event).unwrap();
-        assert!(
-            matches!(result, ProviderEvent::ResponseIncomplete { reason } if reason == "max_output_tokens")
-        );
+        match result {
+            ProviderEvent::ResponseIncomplete { response } => {
+                assert_eq!(response.id, "resp-inc");
+                assert_eq!(response.usage.input_tokens, 200);
+                assert_eq!(response.usage.output_tokens, 4096);
+                assert_eq!(
+                    response.incomplete_details.as_ref().unwrap().reason,
+                    "max_output_tokens"
+                );
+            }
+            _ => panic!("expected ResponseIncomplete"),
+        }
     }
 
     #[test]
@@ -1862,6 +1927,7 @@ mod tests {
                     input_tokens_details: None,
                     output_tokens_details: None,
                 },
+                incomplete_details: None,
             },
         };
         let translated = translate_provider_event(&event, "Hello");
@@ -1895,6 +1961,7 @@ mod tests {
                         reasoning_tokens: 60,
                     }),
                 },
+                incomplete_details: None,
             },
         };
         let translated = translate_provider_event(&event, "");
@@ -1930,17 +1997,31 @@ mod tests {
     #[test]
     fn translate_incomplete_returns_terminal() {
         let event = ProviderEvent::ResponseIncomplete {
-            reason: "max_output_tokens".into(),
+            response: ResponseObject {
+                id: "resp-inc".into(),
+                output: vec![],
+                usage: RawUsage {
+                    input_tokens: 200,
+                    output_tokens: 4096,
+                    input_tokens_details: None,
+                    output_tokens_details: None,
+                },
+                incomplete_details: Some(IncompleteDetails {
+                    reason: "max_output_tokens".into(),
+                }),
+            },
         };
         let translated = translate_provider_event(&event, "partial");
         match translated {
             TranslatedEvent::Terminal(TerminalOutcome::Incomplete {
                 reason,
+                usage,
                 partial_content,
-                ..
             }) => {
                 assert_eq!(reason, "max_output_tokens");
                 assert_eq!(partial_content, "partial");
+                assert_eq!(usage.input_tokens, 200);
+                assert_eq!(usage.output_tokens, 4096);
             }
             _ => panic!("expected Terminal(Incomplete)"),
         }
@@ -1981,6 +2062,7 @@ mod tests {
                 input_tokens_details: None,
                 output_tokens_details: None,
             },
+            incomplete_details: None,
         };
         let citations = extract_citations(&response, "");
         assert_eq!(citations.len(), 1);
@@ -2017,6 +2099,7 @@ mod tests {
                 input_tokens_details: None,
                 output_tokens_details: None,
             },
+            incomplete_details: None,
         };
         let citations = extract_citations(&response, "");
         assert_eq!(citations.len(), 1);
@@ -2043,6 +2126,7 @@ mod tests {
                 input_tokens_details: None,
                 output_tokens_details: None,
             },
+            incomplete_details: None,
         };
         let citations = extract_citations(&response, "");
         assert!(citations.is_empty());
@@ -2075,6 +2159,7 @@ mod tests {
                 input_tokens_details: None,
                 output_tokens_details: None,
             },
+            incomplete_details: None,
         };
         let citations = extract_citations(&response, accumulated);
         assert_eq!(citations.len(), 1);
@@ -2107,6 +2192,7 @@ mod tests {
                 input_tokens_details: None,
                 output_tokens_details: None,
             },
+            incomplete_details: None,
         };
         let citations = extract_citations(&response, "Hello world");
         assert_eq!(citations.len(), 1);
@@ -2139,6 +2225,7 @@ mod tests {
                 input_tokens_details: None,
                 output_tokens_details: None,
             },
+            incomplete_details: None,
         };
         let citations = extract_citations(&response, "Hello");
         assert_eq!(citations.len(), 1);

--- a/modules/mini-chat/mini-chat/src/infra/metrics.rs
+++ b/modules/mini-chat/mini-chat/src/infra/metrics.rs
@@ -147,11 +147,9 @@ pub struct MiniChatMetricsMeter {
     cleanup_backlog: Gauge<i64>,
     cleanup_vs_with_failed_attachments: Counter<u64>,
 
-    // ── P3: Summary (deferred: summary feature not implemented) ──
+    // ── P3: Summary regen (deferred) ──
     #[allow(dead_code)]
     summary_regen: Counter<u64>,
-    #[allow(dead_code)]
-    summary_fallback: Counter<u64>,
 
     // ── P3: Image quota (deferred: image quota not implemented) ──
     #[allow(dead_code)]
@@ -188,6 +186,12 @@ pub struct MiniChatMetricsMeter {
     orphan_detected: Counter<u64>,
     orphan_finalized: Counter<u64>,
     orphan_scan_duration: Histogram<f64>,
+
+    // ── P1: Thread Summary Health ───────────────────────────────────────
+    thread_summary_trigger: Counter<u64>,
+    thread_summary_execution: Counter<u64>,
+    thread_summary_cas_conflicts: Counter<u64>,
+    summary_fallback: Counter<u64>,
 
     // ── Low-priority deferred ──────────────────────────────────────────
     #[allow(dead_code)]
@@ -503,11 +507,6 @@ impl MiniChatMetricsMeter {
                 .u64_counter(format!("{prefix}_summary_regen"))
                 .with_description("Summary regeneration events")
                 .build(),
-            summary_fallback: meter
-                .u64_counter(format!("{prefix}_summary_fallback"))
-                .with_description("Summary fallback events")
-                .build(),
-
             // deferred: image quota not implemented
             quota_image_commit: meter
                 .u64_counter(format!("{prefix}_quota_image_commit"))
@@ -570,6 +569,24 @@ impl MiniChatMetricsMeter {
             orphan_scan_duration: meter
                 .f64_histogram(format!("{prefix}_orphan_scan_duration_seconds"))
                 .with_description("Watchdog scan execution duration")
+                .build(),
+
+            // ── P1: Thread Summary Health ───────────────────────────────
+            thread_summary_trigger: meter
+                .u64_counter(format!("{prefix}_thread_summary_trigger"))
+                .with_description("Thread summary trigger evaluations")
+                .build(),
+            thread_summary_execution: meter
+                .u64_counter(format!("{prefix}_thread_summary_execution"))
+                .with_description("Thread summary execution outcomes")
+                .build(),
+            thread_summary_cas_conflicts: meter
+                .u64_counter(format!("{prefix}_thread_summary_cas_conflicts"))
+                .with_description("Thread summary CAS frontier conflicts")
+                .build(),
+            summary_fallback: meter
+                .u64_counter(format!("{prefix}_summary_fallback"))
+                .with_description("Summary fallback - previous summary kept")
                 .build(),
 
             // deferred: low-priority
@@ -827,6 +844,26 @@ impl MiniChatMetricsPort for MiniChatMetricsMeter {
 
     fn record_orphan_scan_duration_seconds(&self, seconds: f64) {
         self.orphan_scan_duration.record(seconds, &[]);
+    }
+
+    // ── P1: Thread Summary Health ────────────────────────────────────
+
+    fn record_thread_summary_trigger(&self, result: &str) {
+        self.thread_summary_trigger
+            .add(1, &[KeyValue::new(key::RESULT, result.to_owned())]);
+    }
+
+    fn record_thread_summary_execution(&self, result: &str) {
+        self.thread_summary_execution
+            .add(1, &[KeyValue::new(key::RESULT, result.to_owned())]);
+    }
+
+    fn record_thread_summary_cas_conflict(&self) {
+        self.thread_summary_cas_conflicts.add(1, &[]);
+    }
+
+    fn record_summary_fallback(&self) {
+        self.summary_fallback.add(1, &[]);
     }
 
     // ── P1: Cleanup ──────────────────────────────────────────────────

--- a/modules/mini-chat/mini-chat/src/infra/outbox.rs
+++ b/modules/mini-chat/mini-chat/src/infra/outbox.rs
@@ -146,7 +146,7 @@ impl OutboxEnqueuer for InfraOutboxEnqueuer {
             queue = %self.usage_queue_name,
             partition,
             tenant_id = %event.tenant_id,
-            turn_id = %event.turn_id,
+            turn_id = ?event.turn_id,
             "usage event enqueued"
         );
 
@@ -252,6 +252,38 @@ impl OutboxEnqueuer for InfraOutboxEnqueuer {
         Ok(())
     }
 
+    async fn enqueue_thread_summary(
+        &self,
+        runner: &(dyn modkit_db::secure::DBRunner + Sync),
+        payload: crate::domain::repos::ThreadSummaryTaskPayload,
+    ) -> Result<(), DomainError> {
+        let partition = Self::compute_partition(payload.chat_id, self.num_partitions);
+        let serialized = serde_json::to_vec(&payload).map_err(|e| {
+            DomainError::internal(format!("serialize ThreadSummaryTaskPayload: {e}"))
+        })?;
+
+        self.outbox()
+            .enqueue(
+                runner,
+                &self.thread_summary_queue_name,
+                partition,
+                serialized,
+                "application/json",
+            )
+            .await
+            .map_err(|e| DomainError::internal(format!("outbox enqueue: {e}")))?;
+
+        info!(
+            queue = %self.thread_summary_queue_name,
+            partition,
+            chat_id = %payload.chat_id,
+            system_request_id = %payload.system_request_id,
+            "thread summary task enqueued"
+        );
+
+        Ok(())
+    }
+
     fn flush(&self) {
         // flush is a no-op if outbox isn't set yet (before start).
         if let Some(outbox) = self.outbox.get() {
@@ -302,6 +334,7 @@ pub struct UsageEventHandler {
 
 #[async_trait]
 impl modkit_db::outbox::LeasedMessageHandler for UsageEventHandler {
+    #[tracing::instrument(name = "worker", skip_all, fields(worker = "usage_event"))]
     async fn handle(
         &self,
         msg: &modkit_db::outbox::OutboxMessage,
@@ -323,8 +356,8 @@ impl modkit_db::outbox::LeasedMessageHandler for UsageEventHandler {
 
         info!(
             tenant_id = %event.tenant_id,
-            user_id = %event.user_id,
-            turn_id = %event.turn_id,
+            user_id = ?event.user_id,
+            turn_id = ?event.turn_id,
             request_id = %event.request_id,
             effective_model = %event.effective_model,
             billing_outcome = ?event.billing_outcome,
@@ -390,6 +423,7 @@ pub struct AuditEventHandler {
 
 #[async_trait]
 impl modkit_db::outbox::LeasedMessageHandler for AuditEventHandler {
+    #[tracing::instrument(name = "worker", skip_all, fields(worker = "audit_event"))]
     async fn handle(
         &self,
         msg: &modkit_db::outbox::OutboxMessage,
@@ -495,9 +529,9 @@ mod tests {
     fn make_usage_event() -> UsageEvent {
         UsageEvent {
             tenant_id: Uuid::new_v4(),
-            user_id: Uuid::new_v4(),
+            user_id: Some(Uuid::new_v4()),
             chat_id: Uuid::new_v4(),
-            turn_id: Uuid::new_v4(),
+            turn_id: Some(Uuid::new_v4()),
             request_id: Uuid::new_v4(),
             effective_model: "gpt-4o".to_owned(),
             selected_model: "gpt-4o".to_owned(),
@@ -510,6 +544,9 @@ mod tests {
             web_search_calls: 0,
             code_interpreter_calls: 0,
             timestamp: OffsetDateTime::now_utc(),
+            requester_type: "user".to_owned(),
+            dedupe_key: None,
+            system_task_type: None,
         }
     }
 

--- a/modules/mini-chat/mini-chat/src/infra/plugins/static_model_policy/service.rs
+++ b/modules/mini-chat/mini-chat/src/infra/plugins/static_model_policy/service.rs
@@ -94,7 +94,7 @@ impl MiniChatModelPolicyPluginClientV1 for Service {
 
     async fn publish_usage(&self, payload: UsageEvent) -> Result<(), PublishError> {
         debug!(
-            turn_id = %payload.turn_id,
+            turn_id = ?payload.turn_id,
             tenant_id = %payload.tenant_id,
             billing_outcome = %payload.billing_outcome,
             "static plugin: publish_usage no-op"

--- a/modules/mini-chat/mini-chat/src/infra/plugins/static_model_policy/tests.rs
+++ b/modules/mini-chat/mini-chat/src/infra/plugins/static_model_policy/tests.rs
@@ -45,6 +45,7 @@ fn make_entry(model_id: &str, tier: ModelTier) -> ModelCatalogEntry {
                 presence_penalty: 0.0,
                 stop: vec![],
                 extra_body: None,
+                reasoning_effort: None,
             },
             features: ModelFeatures {
                 streaming: true,

--- a/modules/mini-chat/mini-chat/src/infra/workers/cleanup_worker.rs
+++ b/modules/mini-chat/mini-chat/src/infra/workers/cleanup_worker.rs
@@ -92,6 +92,7 @@ struct AttachmentCleanupPayload {
 
 #[async_trait]
 impl LeasedMessageHandler for AttachmentCleanupHandler {
+    #[tracing::instrument(name = "worker", skip_all, fields(worker = "attachment_cleanup"))]
     async fn handle(&self, msg: &OutboxMessage) -> MessageResult {
         // 1. Deserialize payload
         let event: AttachmentCleanupPayload = match serde_json::from_slice(&msg.payload) {
@@ -291,6 +292,7 @@ struct ChatCleanupPayload {
 
 #[async_trait]
 impl LeasedMessageHandler for ChatCleanupHandler {
+    #[tracing::instrument(name = "worker", skip_all, fields(worker = "chat_cleanup"))]
     async fn handle(&self, msg: &OutboxMessage) -> MessageResult {
         use crate::domain::repos::{
             AttachmentRepository as _, ChatRepository as _, VectorStoreRepository as _,

--- a/modules/mini-chat/mini-chat/src/infra/workers/orphan_watchdog.rs
+++ b/modules/mini-chat/mini-chat/src/infra/workers/orphan_watchdog.rs
@@ -109,6 +109,7 @@ pub async fn run<TR: TurnRepository + 'static, MR: MessageRepository + 'static>(
 /// - `Ok(false)` — scan completed normally
 /// - `Ok(true)` — shutdown requested mid-scan
 /// - `Err(())` — scan failed (already logged)
+#[tracing::instrument(name = "worker", skip_all, fields(worker = "orphan_watchdog"))]
 async fn scan_and_finalize<TR: TurnRepository + 'static, MR: MessageRepository + 'static>(
     deps: &OrphanWatchdogDeps<TR, MR>,
     config: &OrphanWatchdogConfig,
@@ -275,6 +276,7 @@ mod tests {
                 as Arc<dyn crate::domain::service::quota_settler::QuotaSettler>,
             Arc::new(NoopOutboxEnqueuer) as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
             Arc::new(NoopMetrics),
+            crate::config::background::ThreadSummaryWorkerConfig::default(),
         ));
 
         OrphanWatchdogDeps {
@@ -334,6 +336,13 @@ mod tests {
             &self,
             _runner: &(dyn modkit_db::secure::DBRunner + Sync),
             _event: crate::domain::model::audit_envelope::AuditEnvelope,
+        ) -> Result<(), crate::domain::error::DomainError> {
+            Ok(())
+        }
+        async fn enqueue_thread_summary(
+            &self,
+            _runner: &(dyn modkit_db::secure::DBRunner + Sync),
+            _payload: crate::domain::repos::ThreadSummaryTaskPayload,
         ) -> Result<(), crate::domain::error::DomainError> {
             Ok(())
         }

--- a/modules/mini-chat/mini-chat/src/infra/workers/thread_summary_worker.rs
+++ b/modules/mini-chat/mini-chat/src/infra/workers/thread_summary_worker.rs
@@ -2,32 +2,566 @@
 //!
 //! Runs as part of the outbox pipeline (leased strategy). All replicas
 //! process events in parallel, partitioned by `chat_id`. No leader election needed.
-//!
-//! **P1 stub**: logs each message but performs no actual LLM invocation or
-//! summary generation. Returns `Retry` so events accumulate safely in the
-//! outbox until the handler is fully implemented.
+
+use std::sync::{Arc, LazyLock};
 
 use async_trait::async_trait;
+use modkit_db::DBProvider;
 use modkit_db::outbox::{LeasedMessageHandler, MessageResult, OutboxMessage};
-use tracing::warn;
+use modkit_security::AccessScope;
+use tracing::{debug, error, info, warn};
 
-/// Stub handler for thread summary task events.
-///
-/// Returns `Retry` for every message - events accumulate safely in the outbox
-/// until the summary worker ships. This ensures the queue is registered and
-/// partitioned from day one.
-pub struct ThreadSummaryHandler;
+use crate::domain::ports::MiniChatMetricsPort;
+use crate::domain::repos::{SummaryFrontier, ThreadSummaryRepository, ThreadSummaryTaskPayload};
+use crate::infra::db::entity::message::MessageRole;
+
+type DbProvider = DBProvider<modkit_db::DbError>;
+type MessageRepo = crate::infra::db::repo::message_repo::MessageRepository;
+type ThreadSummaryRepo = crate::infra::db::repo::thread_summary_repo::ThreadSummaryRepository;
+
+pub struct ThreadSummaryDeps {
+    pub db: Arc<DbProvider>,
+    pub thread_summary_repo: Arc<ThreadSummaryRepo>,
+    pub message_repo: Arc<MessageRepo>,
+    pub outbox_enqueuer: Arc<dyn crate::domain::repos::OutboxEnqueuer>,
+    pub metrics: Arc<dyn MiniChatMetricsPort>,
+    pub provider_resolver: Arc<crate::infra::llm::provider_resolver::ProviderResolver>,
+    pub model_resolver: Arc<dyn crate::domain::repos::ModelResolver>,
+    pub config: crate::config::background::ThreadSummaryWorkerConfig,
+}
+
+pub struct ThreadSummaryHandler {
+    deps: Arc<ThreadSummaryDeps>,
+}
+
+impl ThreadSummaryHandler {
+    pub fn new(deps: Arc<ThreadSummaryDeps>) -> Self {
+        Self { deps }
+    }
+}
 
 #[async_trait]
 impl LeasedMessageHandler for ThreadSummaryHandler {
+    #[tracing::instrument(name = "worker", skip_all, fields(worker = "thread_summary"))]
     async fn handle(&self, msg: &OutboxMessage) -> MessageResult {
-        warn!(
-            partition_id = msg.partition_id,
-            seq = msg.seq,
-            "thread summary handler not yet implemented - retrying"
-        );
-        MessageResult::Retry
+        // 1. Deserialize payload
+        let payload: ThreadSummaryTaskPayload = match serde_json::from_slice(&msg.payload) {
+            Ok(p) => p,
+            Err(e) => {
+                error!(
+                    partition_id = msg.partition_id,
+                    seq = msg.seq,
+                    error = %e,
+                    "thread summary: invalid payload, dead-lettering"
+                );
+                return MessageResult::Reject(format!("payload deserialization failed: {e}"));
+            }
+        };
+
+        let base_frontier = match (
+            &payload.base_frontier_created_at,
+            &payload.base_frontier_message_id,
+        ) {
+            (Some(ca), Some(mid)) => Some(SummaryFrontier {
+                created_at: *ca,
+                message_id: *mid,
+            }),
+            (None, None) => None,
+            _ => {
+                error!(
+                    chat_id = %payload.chat_id,
+                    "thread summary: partial frontier (one field set, other missing), dead-lettering"
+                );
+                return MessageResult::Reject(
+                    "partial base_frontier: both fields must be set or both absent".to_owned(),
+                );
+            }
+        };
+
+        let target_frontier = SummaryFrontier {
+            created_at: payload.frozen_target_created_at,
+            message_id: payload.frozen_target_message_id,
+        };
+
+        // 2. Pre-check: verify stored frontier still matches base_frontier
+        let conn = match self.deps.db.conn() {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(
+                    chat_id = %payload.chat_id,
+                    error = %e,
+                    "thread summary: DB connection failed"
+                );
+                return MessageResult::Retry;
+            }
+        };
+
+        let scope = AccessScope::for_tenant(payload.tenant_id);
+
+        let current = self
+            .deps
+            .thread_summary_repo
+            .get_latest(&conn, &scope, payload.chat_id)
+            .await;
+
+        match &current {
+            Ok(Some(existing)) => {
+                if base_frontier.as_ref() != Some(&existing.frontier) {
+                    info!(
+                        chat_id = %payload.chat_id,
+                        "thread summary: frontier already advanced, skipping"
+                    );
+                    self.deps.metrics.record_thread_summary_cas_conflict();
+                    return MessageResult::Ok;
+                }
+            }
+            Ok(None) => {
+                if base_frontier.is_some() {
+                    warn!(
+                        chat_id = %payload.chat_id,
+                        "thread summary: expected frontier but none found, skipping"
+                    );
+                    return MessageResult::Ok;
+                }
+            }
+            Err(e) => {
+                warn!(
+                    chat_id = %payload.chat_id,
+                    error = %e,
+                    "thread summary: pre-check query failed"
+                );
+                return MessageResult::Retry;
+            }
+        }
+
+        // 3. Load messages in range
+        let messages = match crate::domain::repos::MessageRepository::fetch_messages_in_range(
+            self.deps.message_repo.as_ref(),
+            &conn,
+            &scope,
+            payload.chat_id,
+            base_frontier.as_ref(),
+            &target_frontier,
+        )
+        .await
+        {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(
+                    chat_id = %payload.chat_id,
+                    error = %e,
+                    "thread summary: message fetch failed"
+                );
+                return MessageResult::Retry;
+            }
+        };
+
+        // Note: `conn` is a pool handle released when it goes out of scope.
+        // The LLM call below may take seconds, but conn is a lightweight
+        // reference — actual pool slot is managed by the DB pool internals.
+
+        if messages.is_empty() {
+            debug!(
+                chat_id = %payload.chat_id,
+                "thread summary: no messages in range, skipping"
+            );
+            return MessageResult::Ok;
+        }
+
+        // 4. Generate summary via LLM
+        let existing_summary = current
+            .as_ref()
+            .ok()
+            .and_then(|c| c.as_ref())
+            .map(|s| s.content.as_str());
+
+        // 4a. Resolve model
+        let model_id = if self.deps.config.summary_model_id.is_empty() {
+            "gpt-4.1-mini".to_owned()
+        } else {
+            self.deps.config.summary_model_id.clone()
+        };
+
+        let resolved_model = match self
+            .deps
+            .model_resolver
+            .resolve_model(
+                modkit_security::constants::DEFAULT_SUBJECT_ID,
+                Some(model_id.clone()),
+            )
+            .await
+        {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(chat_id = %payload.chat_id, error = %e, "thread summary: model resolution failed");
+                self.deps.metrics.record_thread_summary_execution("retry");
+                return MessageResult::Retry;
+            }
+        };
+
+        // 4b. Resolve provider
+        let tenant_id_str = payload.tenant_id.to_string();
+        let resolved_provider = match self
+            .deps
+            .provider_resolver
+            .resolve(&resolved_model.provider_id, Some(&tenant_id_str))
+        {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(chat_id = %payload.chat_id, error = %e, "thread summary: provider resolution failed");
+                self.deps.metrics.record_thread_summary_execution("retry");
+                return MessageResult::Retry;
+            }
+        };
+
+        // 4c. Build prompt — 3-tier cascade: model-specific → global config → default
+        let system_prompt = if !resolved_model.thread_summary_prompt.is_empty() {
+            resolved_model.thread_summary_prompt.clone()
+        } else if !self.deps.config.summary_system_prompt.is_empty() {
+            self.deps.config.summary_system_prompt.clone()
+        } else {
+            crate::config::background::ThreadSummaryWorkerConfig::default().summary_system_prompt
+        };
+
+        // Build full OAGW proxy path: {alias}{api_path} — same as stream flow.
+        let api_path = resolved_provider
+            .api_path
+            .replace("{model}", &resolved_model.provider_model_id);
+        let upstream_path = format!("{}{api_path}", resolved_provider.upstream_alias);
+
+        // 4d. Call LLM with PTL retry — if context_length_exceeded, drop
+        //     oldest messages and retry (up to 2 times).
+        let max_ptl_retries = 2u32;
+        let mut messages_for_prompt = messages.clone();
+        let mut ptl_retries = 0u32;
+        let content_limit = self.deps.config.message_content_limit;
+
+        #[allow(clippy::expect_used)]
+        let security_ctx = modkit_security::SecurityContext::builder()
+            .subject_tenant_id(payload.tenant_id)
+            .subject_id(modkit_security::constants::DEFAULT_SUBJECT_ID)
+            .build()
+            .expect("tenant SecurityContext must build");
+
+        let response = loop {
+            let user_content =
+                build_summary_prompt(existing_summary, &messages_for_prompt, content_limit);
+
+            let request = crate::infra::llm::llm_request(&resolved_model.provider_model_id)
+                .system_instructions(&system_prompt)
+                .message(crate::infra::llm::LlmMessage::user(&user_content))
+                .max_output_tokens(u64::from(resolved_model.max_output_tokens))
+                .build_non_streaming();
+
+            let ctx = security_ctx.clone();
+            match resolved_provider
+                .adapter
+                .complete(ctx, request, &upstream_path)
+                .await
+            {
+                Ok(r) => break r,
+                Err(e) if is_context_length_error(&e) && ptl_retries < max_ptl_retries => {
+                    let drop_count = (messages_for_prompt.len().div_ceil(5)).max(2);
+                    let actual_drop = drop_count.min(messages_for_prompt.len().saturating_sub(2));
+                    if actual_drop == 0 {
+                        warn!(chat_id = %payload.chat_id, error = %e,
+                              "thread summary: prompt too long, cannot drop more messages");
+                        self.deps
+                            .metrics
+                            .record_thread_summary_execution("provider_error");
+                        self.deps.metrics.record_summary_fallback();
+                        return MessageResult::Retry;
+                    }
+                    messages_for_prompt.drain(..actual_drop);
+                    ptl_retries += 1;
+                    warn!(
+                        chat_id = %payload.chat_id,
+                        ptl_retries,
+                        dropped = actual_drop,
+                        remaining = messages_for_prompt.len(),
+                        "thread summary: prompt too long, dropping oldest messages and retrying"
+                    );
+                }
+                Err(e) => {
+                    warn!(chat_id = %payload.chat_id, error = %e, "thread summary: LLM call failed");
+                    self.deps
+                        .metrics
+                        .record_thread_summary_execution("provider_error");
+                    self.deps.metrics.record_summary_fallback();
+                    return MessageResult::Retry;
+                }
+            }
+        };
+
+        let summary_text = format_summary_output(&response.content);
+        if summary_text.trim().is_empty() {
+            warn!(chat_id = %payload.chat_id, "thread summary: LLM returned empty summary, retrying");
+            self.deps
+                .metrics
+                .record_thread_summary_execution("empty_summary");
+            return MessageResult::Retry;
+        }
+        let llm_usage = response.usage;
+        let token_estimate = estimate_summary_tokens(llm_usage.output_tokens, summary_text.len());
+
+        // 5. CAS-protected atomic commit
+        let deps = Arc::clone(&self.deps);
+        let base_clone = base_frontier.clone();
+        let target_clone = target_frontier.clone();
+        let summary_clone = summary_text;
+        let msg_count = messages.len();
+        let payload_clone = payload.clone();
+        let model_id_clone = model_id;
+
+        let cas_result = self
+            .deps
+            .db
+            .transaction(|tx| {
+                let deps = Arc::clone(&deps);
+                let base_clone = base_clone.clone();
+                let target_clone = target_clone.clone();
+                let summary_clone = summary_clone.clone();
+                let scope = scope.clone();
+                let payload_clone = payload_clone.clone();
+                let model_id_clone = model_id_clone.clone();
+                Box::pin(async move {
+                    // 5a. Upsert summary with CAS
+                    let rows = deps
+                        .thread_summary_repo
+                        .upsert_with_cas(
+                            tx,
+                            payload_clone.chat_id,
+                            payload_clone.tenant_id,
+                            base_clone.as_ref(),
+                            &target_clone,
+                            &summary_clone,
+                            token_estimate,
+                        )
+                        .await
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::anyhow!("{e}")))?;
+
+                    if rows == 0 {
+                        return Ok(false);
+                    }
+
+                    // 5b. Mark messages as compressed
+                    crate::domain::repos::MessageRepository::mark_messages_compressed(
+                        deps.message_repo.as_ref(),
+                        tx,
+                        &scope,
+                        payload_clone.chat_id,
+                        base_clone.as_ref(),
+                        &target_clone,
+                    )
+                    .await
+                    .map_err(|e| modkit_db::DbError::Other(anyhow::anyhow!("{e}")))?;
+
+                    // 5c. Enqueue system usage event
+                    let usage_event = mini_chat_sdk::UsageEvent {
+                        tenant_id: payload_clone.tenant_id,
+                        user_id: None,
+                        chat_id: payload_clone.chat_id,
+                        turn_id: None,
+                        request_id: payload_clone.system_request_id,
+                        effective_model: model_id_clone.clone(),
+                        selected_model: model_id_clone,
+                        terminal_state: "completed".to_owned(),
+                        billing_outcome: "system_task".to_owned(),
+                        usage: Some(mini_chat_sdk::UsageTokens {
+                            input_tokens: u64::try_from(llm_usage.input_tokens.max(0)).unwrap_or(0),
+                            output_tokens: u64::try_from(llm_usage.output_tokens.max(0))
+                                .unwrap_or(0),
+                            cache_read_input_tokens: u64::try_from(
+                                llm_usage.cache_read_input_tokens.max(0),
+                            )
+                            .unwrap_or(0),
+                            cache_write_input_tokens: u64::try_from(
+                                llm_usage.cache_write_input_tokens.max(0),
+                            )
+                            .unwrap_or(0),
+                            reasoning_tokens: u64::try_from(llm_usage.reasoning_tokens.max(0))
+                                .unwrap_or(0),
+                        }),
+                        actual_credits_micro: 0,
+                        settlement_method: "none".to_owned(),
+                        policy_version_applied: 0,
+                        web_search_calls: 0,
+                        code_interpreter_calls: 0,
+                        timestamp: time::OffsetDateTime::now_utc(),
+                        requester_type: "system".to_owned(),
+                        dedupe_key: Some(format!(
+                            "{}/{}/{}",
+                            payload_clone.tenant_id.as_simple(),
+                            "thread_summary_update",
+                            payload_clone.system_request_id.as_simple(),
+                        )),
+                        system_task_type: Some("thread_summary_update".to_owned()),
+                    };
+                    deps.outbox_enqueuer
+                        .enqueue_usage_event(tx, usage_event)
+                        .await
+                        .map_err(|e| modkit_db::DbError::Other(anyhow::anyhow!("{e}")))?;
+
+                    Ok(true)
+                })
+            })
+            .await;
+
+        match cas_result {
+            Ok(true) => {
+                self.deps.outbox_enqueuer.flush();
+                self.deps.metrics.record_thread_summary_execution("success");
+                info!(
+                    chat_id = %payload.chat_id,
+                    messages_compressed = msg_count,
+                    "thread summary: committed successfully"
+                );
+                MessageResult::Ok
+            }
+            Ok(false) => {
+                self.deps.metrics.record_thread_summary_cas_conflict();
+                info!(
+                    chat_id = %payload.chat_id,
+                    "thread summary: CAS conflict on commit, skipping"
+                );
+                MessageResult::Ok
+            }
+            Err(e) => {
+                warn!(
+                    chat_id = %payload.chat_id,
+                    error = %e,
+                    "thread summary: commit failed"
+                );
+                self.deps.metrics.record_thread_summary_execution("retry");
+                MessageResult::Retry
+            }
+        }
     }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Prompt construction & output formatting
+// ════════════════════════════════════════════════════════════════════════════
+
+const ANALYSIS_INSTRUCTION: &str = "\
+Before providing your final summary, wrap your analysis in <analysis> tags. In your analysis:
+1. Chronologically review each exchange, identifying:
+   - The user's requests and questions
+   - Key decisions, answers, and information shared
+   - Any follow-up actions or commitments
+   - Specific names, dates, numbers, URLs, or references mentioned
+2. Verify accuracy and completeness.
+
+Your summary MUST include these sections:
+
+1. Conversation Purpose: The user's primary goals and recurring themes
+2. Key Information Exchanged: Important facts, decisions, recommendations, and answers
+3. User Requests and Preferences: All explicit user requests, stated preferences, and corrections
+4. Open Items: Any unresolved questions, pending actions, or things the user asked to revisit
+5. Current Topic: What was being discussed most recently, with enough detail to continue naturally
+
+Respond with an <analysis> block followed by a <summary> block.";
+
+/// Build the user-message prompt for summary generation.
+///
+/// Two variants:
+/// - **Full** (`existing_summary` is `None`): summarize the entire conversation.
+/// - **Partial** (`existing_summary` is `Some`): incorporate existing summary with new messages.
+fn build_summary_prompt(
+    existing_summary: Option<&str>,
+    messages: &[crate::infra::db::entity::message::Model],
+    message_content_limit: usize,
+) -> String {
+    let mut prompt = String::new();
+
+    if let Some(prev) = existing_summary {
+        prompt.push_str("The existing summary below covers the earlier conversation. Incorporate it with the new messages into a single updated summary.\n\n");
+        prompt.push_str("IMPORTANT: Keep the summary concise. If the combined information is too large, prioritize: current topic and recent decisions > user preferences and corrections > older facts. Compress or drop the least relevant older details rather than letting the summary grow unboundedly.\n\n");
+        prompt.push_str("<existing_summary>\n");
+        prompt.push_str(prev);
+        prompt.push_str("\n</existing_summary>\n\n");
+        prompt.push_str("New messages to incorporate:\n\n");
+    } else {
+        prompt.push_str("Summarize the following conversation:\n\n");
+    }
+
+    for msg in messages {
+        // Skip system messages — they contain internal prompts that should
+        // not leak into the stored summary (matches context_assembly behavior).
+        if matches!(msg.role, MessageRole::System) {
+            continue;
+        }
+        let role = match msg.role {
+            MessageRole::User => "User",
+            MessageRole::Assistant => "Assistant",
+            MessageRole::System => unreachable!(),
+        };
+        let content =
+            if message_content_limit > 0 && msg.content.chars().count() > message_content_limit {
+                let truncated: String = msg.content.chars().take(message_content_limit).collect();
+                format!("{truncated}...")
+            } else {
+                msg.content.clone()
+            };
+        prompt.push_str(role);
+        prompt.push_str(": ");
+        prompt.push_str(&content);
+        prompt.push_str("\n\n");
+    }
+
+    prompt.push_str(ANALYSIS_INSTRUCTION);
+    prompt
+}
+
+#[allow(clippy::expect_used)]
+static ANALYSIS_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(?s)<analysis>.*?</analysis>").expect("valid regex"));
+#[allow(clippy::expect_used)]
+static SUMMARY_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"(?s)<summary>(.*?)</summary>").expect("valid regex"));
+#[allow(clippy::expect_used)]
+static MULTI_NEWLINE_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"\n{3,}").expect("valid regex"));
+
+/// Strip the `<analysis>` drafting scratchpad and extract `<summary>` content.
+///
+/// The `<analysis>` block improves summary quality by forcing step-by-step
+/// reasoning, but wastes tokens when stored. Only `<summary>` is persisted.
+fn format_summary_output(raw: &str) -> String {
+    let without_analysis = ANALYSIS_RE.replace(raw, "");
+
+    if let Some(caps) = SUMMARY_RE.captures(&without_analysis) {
+        let content = caps.get(1).map_or("", |m| m.as_str()).trim();
+        MULTI_NEWLINE_RE.replace_all(content, "\n\n").into_owned()
+    } else {
+        // Graceful fallback: no <summary> tags
+        let cleaned = ANALYSIS_RE.replace(raw, "");
+        let trimmed = cleaned.trim();
+        // Reject if residual markup tags remain (malformed LLM output)
+        if trimmed.contains("<analysis") || trimmed.contains("<summary") {
+            return String::new(); // empty → triggers retry upstream
+        }
+        MULTI_NEWLINE_RE.replace_all(trimmed, "\n\n").into_owned()
+    }
+}
+
+/// Derive a token estimate for the stored summary.
+/// Prefers actual `output_tokens` from the provider; falls back to `bytes/4`.
+fn estimate_summary_tokens(output_tokens: i64, summary_byte_len: usize) -> i32 {
+    if output_tokens > 0 {
+        i32::try_from(output_tokens).unwrap_or(i32::MAX)
+    } else {
+        i32::try_from(summary_byte_len.div_ceil(4)).unwrap_or(i32::MAX)
+    }
+}
+
+/// Check if an LLM error indicates the input exceeded the model's context length.
+fn is_context_length_error(e: &crate::infra::llm::LlmProviderError) -> bool {
+    let msg = e.to_string().to_lowercase();
+    msg.contains("context_length_exceeded")
+        || msg.contains("maximum context length")
+        || msg.contains("token limit")
+        || msg.contains("too many tokens")
 }
 
 #[cfg(test)]
@@ -35,22 +569,706 @@ mod tests {
     use super::*;
     use modkit_db::outbox::LeasedMessageHandler;
 
-    fn make_msg() -> OutboxMessage {
+    // `rejects_invalid_payload` removed — superseded by `e2e_handler_rejects_invalid_payload`
+    // which exercises the actual handler's Reject branch.
+
+    #[test]
+    fn placeholder_summary_builds_correctly() {
+        use crate::infra::db::entity::message::Model;
+        use time::OffsetDateTime;
+        use uuid::Uuid;
+
+        let msg = Model {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            chat_id: Uuid::new_v4(),
+            request_id: Some(Uuid::new_v4()),
+            role: MessageRole::User,
+            content: "Hello world".to_owned(),
+            content_type: "text/plain".to_owned(),
+            token_estimate: 5,
+            provider_response_id: None,
+            request_kind: None,
+            features_used: serde_json::json!([]),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_write_input_tokens: 0,
+            reasoning_tokens: 0,
+            model: None,
+            is_compressed: false,
+            created_at: OffsetDateTime::now_utc(),
+            deleted_at: None,
+        };
+
+        let summary = build_summary_prompt(None, &[msg], 4000);
+        assert!(summary.contains("User: Hello world"));
+    }
+
+    #[test]
+    fn token_estimate_prefers_output_tokens() {
+        assert_eq!(estimate_summary_tokens(250, 1000), 250);
+    }
+
+    #[test]
+    fn token_estimate_falls_back_to_len_div_4() {
+        // 200 bytes / 4 = 50 tokens
+        assert_eq!(estimate_summary_tokens(0, 200), 50);
+    }
+
+    // ── E2E tests: full handler pipeline with real DB ──────────────────
+
+    /// Insert a message with controllable content and `created_at` for e2e tests.
+    async fn insert_message(
+        db: &modkit_db::Db,
+        tenant_id: uuid::Uuid,
+        chat_id: uuid::Uuid,
+        role: MessageRole,
+        content: &str,
+        created_at: time::OffsetDateTime,
+    ) -> uuid::Uuid {
+        use crate::infra::db::entity::message::{
+            ActiveModel as MessageAM, Entity as MessageEntity,
+        };
+        use sea_orm::Set;
+
+        let msg_id = uuid::Uuid::new_v4();
+        let am = MessageAM {
+            id: Set(msg_id),
+            tenant_id: Set(tenant_id),
+            chat_id: Set(chat_id),
+            request_id: Set(None),
+            role: Set(role),
+            content: Set(content.to_owned()),
+            content_type: Set("text".to_owned()),
+            token_estimate: Set(1),
+            provider_response_id: Set(None),
+            request_kind: Set(None),
+            features_used: Set(serde_json::json!([])),
+            input_tokens: Set(0),
+            output_tokens: Set(0),
+            cache_read_input_tokens: Set(0),
+            cache_write_input_tokens: Set(0),
+            reasoning_tokens: Set(0),
+            model: Set(None),
+            is_compressed: Set(false),
+            created_at: Set(created_at),
+            deleted_at: Set(None),
+        };
+        let conn = db.conn().unwrap();
+        modkit_db::secure::secure_insert::<MessageEntity>(
+            am,
+            &modkit_security::AccessScope::allow_all(),
+            &conn,
+        )
+        .await
+        .expect("insert test message");
+        msg_id
+    }
+
+    /// Insert a chat row for e2e tests.
+    async fn insert_chat(db: &modkit_db::Db, tenant_id: uuid::Uuid, chat_id: uuid::Uuid) {
+        use crate::infra::db::entity::chat::{ActiveModel as ChatAM, Entity as ChatEntity};
+        use sea_orm::Set;
+        let now = time::OffsetDateTime::now_utc();
+        let am = ChatAM {
+            id: Set(chat_id),
+            tenant_id: Set(tenant_id),
+            user_id: Set(uuid::Uuid::new_v4()),
+            model: Set("gpt-5.2".to_owned()),
+            title: Set(Some("test".to_owned())),
+            is_temporary: Set(false),
+            created_at: Set(now),
+            updated_at: Set(now),
+            deleted_at: Set(None),
+        };
+        let conn = db.conn().unwrap();
+        modkit_db::secure::secure_insert::<ChatEntity>(
+            am,
+            &modkit_security::AccessScope::allow_all(),
+            &conn,
+        )
+        .await
+        .expect("insert chat");
+    }
+
+    /// Build a valid outbox message from a `ThreadSummaryTaskPayload`.
+    fn make_outbox_msg(payload: &ThreadSummaryTaskPayload) -> OutboxMessage {
         OutboxMessage {
-            partition_id: 1,
+            partition_id: 0,
             seq: 1,
-            payload: b"{}".to_vec(),
+            payload: serde_json::to_vec(payload).unwrap(),
             payload_type: "application/json".to_owned(),
             created_at: chrono::Utc::now(),
             attempts: 0i16,
         }
     }
 
+    /// Build `ThreadSummaryDeps` with real DB for e2e tests.
+    /// Model/provider resolution will fail (no real providers), so these tests
+    /// validate the handler's DB + CAS logic, not the LLM call path.
+    async fn make_e2e_deps() -> (Arc<ThreadSummaryDeps>, modkit_db::Db) {
+        use crate::domain::service::test_helpers;
+        let db = test_helpers::inmem_db().await;
+        let db_provider = test_helpers::mock_db_provider(db.clone());
+        let deps = Arc::new(ThreadSummaryDeps {
+            db: db_provider,
+            thread_summary_repo: Arc::new(
+                crate::infra::db::repo::thread_summary_repo::ThreadSummaryRepository,
+            ),
+            message_repo: Arc::new(
+                crate::infra::db::repo::message_repo::MessageRepository::new(
+                    modkit_db::odata::LimitCfg {
+                        default: 20,
+                        max: 100,
+                    },
+                ),
+            ),
+            outbox_enqueuer: Arc::new(test_helpers::RecordingOutboxEnqueuer::new()),
+            metrics: Arc::new(crate::domain::ports::metrics::NoopMetrics),
+            provider_resolver: Arc::new(
+                crate::infra::llm::provider_resolver::ProviderResolver::empty(),
+            ),
+            model_resolver: Arc::new(test_helpers::MockModelResolver::default()),
+            config: crate::config::background::ThreadSummaryWorkerConfig::default(),
+        });
+        (deps, db)
+    }
+
     #[tokio::test]
-    async fn stub_returns_retry() {
-        let handler = ThreadSummaryHandler;
-        let msg = make_msg();
-        let result = LeasedMessageHandler::handle(&handler, &msg).await;
-        assert!(matches!(result, MessageResult::Retry));
+    async fn e2e_handler_rejects_invalid_payload() {
+        let (deps, _db) = make_e2e_deps().await;
+        let handler = ThreadSummaryHandler::new(deps);
+        let msg = OutboxMessage {
+            partition_id: 0,
+            seq: 1,
+            payload: b"not json".to_vec(),
+            payload_type: "application/json".to_owned(),
+            created_at: chrono::Utc::now(),
+            attempts: 0i16,
+        };
+        let result = handler.handle(&msg).await;
+        assert!(matches!(result, MessageResult::Reject(_)));
+    }
+
+    #[tokio::test]
+    async fn e2e_handler_skips_empty_message_range() {
+        let (deps, db) = make_e2e_deps().await;
+        let tenant_id = uuid::Uuid::new_v4();
+        let chat_id = uuid::Uuid::new_v4();
+
+        insert_chat(&db, tenant_id, chat_id).await;
+
+        let now = time::OffsetDateTime::now_utc();
+        // Create payload with a target frontier but no messages in range
+        let payload = ThreadSummaryTaskPayload {
+            tenant_id,
+            chat_id,
+            system_request_id: uuid::Uuid::new_v4(),
+            system_task_type: "thread_summary_update".to_owned(),
+            base_frontier_created_at: None,
+            base_frontier_message_id: None,
+            frozen_target_created_at: now,
+            frozen_target_message_id: uuid::Uuid::new_v4(),
+        };
+
+        let handler = ThreadSummaryHandler::new(deps);
+        let result = handler.handle(&make_outbox_msg(&payload)).await;
+        // No messages → should succeed (skip)
+        assert!(matches!(result, MessageResult::Ok));
+    }
+
+    #[tokio::test]
+    async fn e2e_payload_serialization_roundtrip() {
+        let now = time::OffsetDateTime::now_utc();
+        let payload = ThreadSummaryTaskPayload {
+            tenant_id: uuid::Uuid::new_v4(),
+            chat_id: uuid::Uuid::new_v4(),
+            system_request_id: uuid::Uuid::new_v4(),
+            system_task_type: "thread_summary_update".to_owned(),
+            base_frontier_created_at: Some(now),
+            base_frontier_message_id: Some(uuid::Uuid::new_v4()),
+            frozen_target_created_at: now,
+            frozen_target_message_id: uuid::Uuid::new_v4(),
+        };
+
+        let json = serde_json::to_vec(&payload).unwrap();
+        let deserialized: ThreadSummaryTaskPayload = serde_json::from_slice(&json).unwrap();
+        assert_eq!(payload.tenant_id, deserialized.tenant_id);
+        assert_eq!(payload.chat_id, deserialized.chat_id);
+        assert_eq!(payload.system_request_id, deserialized.system_request_id);
+        assert_eq!(payload.system_task_type, deserialized.system_task_type);
+        assert_eq!(
+            payload.base_frontier_created_at,
+            deserialized.base_frontier_created_at
+        );
+        assert_eq!(
+            payload.base_frontier_message_id,
+            deserialized.base_frontier_message_id
+        );
+        assert_eq!(
+            payload.frozen_target_created_at,
+            deserialized.frozen_target_created_at
+        );
+        assert_eq!(
+            payload.frozen_target_message_id,
+            deserialized.frozen_target_message_id
+        );
+    }
+
+    #[tokio::test]
+    async fn e2e_repo_get_latest_returns_none_when_empty() {
+        let db = crate::domain::service::test_helpers::inmem_db().await;
+        let tenant_id = uuid::Uuid::new_v4();
+        let chat_id = uuid::Uuid::new_v4();
+
+        insert_chat(&db, tenant_id, chat_id).await;
+
+        let repo = crate::infra::db::repo::thread_summary_repo::ThreadSummaryRepository;
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::for_tenant(tenant_id);
+        let result = crate::domain::repos::ThreadSummaryRepository::get_latest(
+            &repo, &conn, &scope, chat_id,
+        )
+        .await
+        .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn e2e_repo_upsert_first_summary_and_get_latest() {
+        let db = crate::domain::service::test_helpers::inmem_db().await;
+        let tenant_id = uuid::Uuid::new_v4();
+        let chat_id = uuid::Uuid::new_v4();
+
+        insert_chat(&db, tenant_id, chat_id).await;
+
+        let now = time::OffsetDateTime::now_utc();
+        let frontier = SummaryFrontier {
+            created_at: now,
+            message_id: uuid::Uuid::new_v4(),
+        };
+
+        let repo = crate::infra::db::repo::thread_summary_repo::ThreadSummaryRepository;
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::for_tenant(tenant_id);
+
+        // Insert first summary
+        let rows = crate::domain::repos::ThreadSummaryRepository::upsert_with_cas(
+            &repo,
+            &conn,
+            chat_id,
+            tenant_id,
+            None,
+            &frontier,
+            "test summary",
+            42,
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows, 1);
+
+        // Read it back
+        let summary = crate::domain::repos::ThreadSummaryRepository::get_latest(
+            &repo, &conn, &scope, chat_id,
+        )
+        .await
+        .unwrap()
+        .expect("summary should exist");
+        assert_eq!(summary.content, "test summary");
+        assert_eq!(summary.frontier, frontier);
+        assert_eq!(summary.token_estimate, 42);
+    }
+
+    #[tokio::test]
+    async fn e2e_repo_upsert_cas_conflict_on_first_summary() {
+        let db = crate::domain::service::test_helpers::inmem_db().await;
+        let tenant_id = uuid::Uuid::new_v4();
+        let chat_id = uuid::Uuid::new_v4();
+
+        insert_chat(&db, tenant_id, chat_id).await;
+
+        let now = time::OffsetDateTime::now_utc();
+        let frontier = SummaryFrontier {
+            created_at: now,
+            message_id: uuid::Uuid::new_v4(),
+        };
+
+        let repo = crate::infra::db::repo::thread_summary_repo::ThreadSummaryRepository;
+        let conn = db.conn().unwrap();
+
+        // First insert succeeds
+        let rows = crate::domain::repos::ThreadSummaryRepository::upsert_with_cas(
+            &repo, &conn, chat_id, tenant_id, None, &frontier, "first", 10,
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows, 1);
+
+        // Second insert with base=None conflicts (UNIQUE on chat_id)
+        let rows = crate::domain::repos::ThreadSummaryRepository::upsert_with_cas(
+            &repo, &conn, chat_id, tenant_id, None, &frontier, "second", 20,
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows, 0, "CAS should fail - row already exists");
+    }
+
+    #[tokio::test]
+    async fn e2e_repo_advance_frontier_succeeds() {
+        let db = crate::domain::service::test_helpers::inmem_db().await;
+        let tenant_id = uuid::Uuid::new_v4();
+        let chat_id = uuid::Uuid::new_v4();
+
+        insert_chat(&db, tenant_id, chat_id).await;
+
+        let now = time::OffsetDateTime::now_utc();
+        let frontier_a = SummaryFrontier {
+            created_at: now,
+            message_id: uuid::Uuid::new_v4(),
+        };
+        let frontier_b = SummaryFrontier {
+            created_at: now + time::Duration::seconds(10),
+            message_id: uuid::Uuid::new_v4(),
+        };
+
+        let repo = crate::infra::db::repo::thread_summary_repo::ThreadSummaryRepository;
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::for_tenant(tenant_id);
+
+        // Insert first
+        crate::domain::repos::ThreadSummaryRepository::upsert_with_cas(
+            &repo,
+            &conn,
+            chat_id,
+            tenant_id,
+            None,
+            &frontier_a,
+            "first",
+            10,
+        )
+        .await
+        .unwrap();
+
+        // Advance frontier
+        let rows = crate::domain::repos::ThreadSummaryRepository::upsert_with_cas(
+            &repo,
+            &conn,
+            chat_id,
+            tenant_id,
+            Some(&frontier_a),
+            &frontier_b,
+            "second",
+            20,
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows, 1, "CAS should succeed - frontier matches");
+
+        // Verify
+        let summary = crate::domain::repos::ThreadSummaryRepository::get_latest(
+            &repo, &conn, &scope, chat_id,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        assert_eq!(summary.content, "second");
+        assert_eq!(summary.frontier, frontier_b);
+    }
+
+    #[tokio::test]
+    async fn e2e_repo_advance_frontier_cas_conflict() {
+        let db = crate::domain::service::test_helpers::inmem_db().await;
+        let tenant_id = uuid::Uuid::new_v4();
+        let chat_id = uuid::Uuid::new_v4();
+
+        insert_chat(&db, tenant_id, chat_id).await;
+
+        let now = time::OffsetDateTime::now_utc();
+        let frontier_a = SummaryFrontier {
+            created_at: now,
+            message_id: uuid::Uuid::new_v4(),
+        };
+        let frontier_b = SummaryFrontier {
+            created_at: now + time::Duration::seconds(10),
+            message_id: uuid::Uuid::new_v4(),
+        };
+        let stale_frontier = SummaryFrontier {
+            created_at: now - time::Duration::seconds(10),
+            message_id: uuid::Uuid::new_v4(),
+        };
+
+        let repo = crate::infra::db::repo::thread_summary_repo::ThreadSummaryRepository;
+        let conn = db.conn().unwrap();
+
+        // Insert first
+        crate::domain::repos::ThreadSummaryRepository::upsert_with_cas(
+            &repo,
+            &conn,
+            chat_id,
+            tenant_id,
+            None,
+            &frontier_a,
+            "first",
+            10,
+        )
+        .await
+        .unwrap();
+
+        // Try to advance with stale base frontier
+        let rows = crate::domain::repos::ThreadSummaryRepository::upsert_with_cas(
+            &repo,
+            &conn,
+            chat_id,
+            tenant_id,
+            Some(&stale_frontier),
+            &frontier_b,
+            "stale",
+            30,
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows, 0, "CAS should fail - frontier doesn't match");
+    }
+
+    #[tokio::test]
+    async fn e2e_mark_messages_compressed() {
+        let db = crate::domain::service::test_helpers::inmem_db().await;
+        let tenant_id = uuid::Uuid::new_v4();
+        let chat_id = uuid::Uuid::new_v4();
+
+        insert_chat(&db, tenant_id, chat_id).await;
+
+        let base_time = time::OffsetDateTime::now_utc();
+        let _msg1 = insert_message(
+            &db,
+            tenant_id,
+            chat_id,
+            MessageRole::User,
+            "msg1",
+            base_time,
+        )
+        .await;
+        let msg2 = insert_message(
+            &db,
+            tenant_id,
+            chat_id,
+            MessageRole::Assistant,
+            "msg2",
+            base_time + time::Duration::seconds(1),
+        )
+        .await;
+        let msg3 = insert_message(
+            &db,
+            tenant_id,
+            chat_id,
+            MessageRole::User,
+            "msg3",
+            base_time + time::Duration::seconds(2),
+        )
+        .await;
+
+        let target = SummaryFrontier {
+            created_at: base_time + time::Duration::seconds(1),
+            message_id: msg2,
+        };
+
+        let repo = crate::infra::db::repo::message_repo::MessageRepository::new(
+            modkit_db::odata::LimitCfg {
+                default: 20,
+                max: 100,
+            },
+        );
+        let conn = db.conn().unwrap();
+        let scope = AccessScope::for_tenant(tenant_id);
+
+        // Mark messages up to msg2 as compressed
+        let rows = crate::domain::repos::MessageRepository::mark_messages_compressed(
+            &repo, &conn, &scope, chat_id, None, &target,
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows, 2, "msg1 and msg2 should be compressed");
+
+        // Verify msg3 is NOT compressed
+        let remaining = crate::domain::repos::MessageRepository::fetch_messages_in_range(
+            &repo,
+            &conn,
+            &scope,
+            chat_id,
+            Some(&target),
+            &SummaryFrontier {
+                created_at: base_time + time::Duration::seconds(10),
+                message_id: uuid::Uuid::max(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].id, msg3);
+    }
+
+    #[test]
+    fn placeholder_summary_appends_to_existing() {
+        use crate::infra::db::entity::message::Model;
+        use time::OffsetDateTime;
+        use uuid::Uuid;
+
+        let msg = Model {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            chat_id: Uuid::new_v4(),
+            request_id: Some(Uuid::new_v4()),
+            role: MessageRole::Assistant,
+            content: "I can help with that.".to_owned(),
+            content_type: "text/plain".to_owned(),
+            token_estimate: 10,
+            provider_response_id: None,
+            request_kind: None,
+            features_used: serde_json::json!([]),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_write_input_tokens: 0,
+            reasoning_tokens: 0,
+            model: None,
+            is_compressed: false,
+            created_at: OffsetDateTime::now_utc(),
+            deleted_at: None,
+        };
+
+        let summary = build_summary_prompt(Some("Previous summary"), &[msg], 4000);
+        assert!(summary.contains("Previous summary"));
+        assert!(summary.contains("existing_summary"));
+        assert!(summary.contains("Assistant: I can help with that."));
+    }
+
+    // ── format_summary_output tests ─────────────────────────────────
+
+    #[test]
+    fn format_summary_output_strips_analysis_extracts_summary() {
+        let raw = "<analysis>\nThinking about the conversation...\n</analysis>\n\n<summary>\n1. Purpose: Testing\n2. Key Info: Works\n</summary>";
+        let result = format_summary_output(raw);
+        assert!(!result.contains("<analysis>"));
+        assert!(!result.contains("Thinking about"));
+        assert!(result.contains("1. Purpose: Testing"));
+        assert!(result.contains("2. Key Info: Works"));
+        assert!(!result.contains("<summary>"));
+    }
+
+    #[test]
+    fn format_summary_output_fallback_when_no_tags() {
+        let raw = "Just a plain text summary without XML tags.";
+        let result = format_summary_output(raw);
+        assert_eq!(result, "Just a plain text summary without XML tags.");
+    }
+
+    #[test]
+    fn format_summary_output_handles_empty_analysis() {
+        let raw = "<analysis></analysis>\n<summary>Clean result</summary>";
+        let result = format_summary_output(raw);
+        assert_eq!(result, "Clean result");
+    }
+
+    #[test]
+    fn format_summary_output_collapses_excessive_newlines() {
+        let raw = "<summary>Line 1\n\n\n\n\nLine 2</summary>";
+        let result = format_summary_output(raw);
+        assert_eq!(result, "Line 1\n\nLine 2");
+    }
+
+    // ── build_summary_prompt tests ──────────────────────────────────
+
+    #[test]
+    fn build_summary_prompt_full_compact_no_existing() {
+        let msg = test_message(MessageRole::User, "What is Rust?");
+        let prompt = build_summary_prompt(None, &[msg], 4000);
+        assert!(prompt.starts_with("Summarize the following conversation:"));
+        assert!(prompt.contains("User: What is Rust?"));
+        assert!(prompt.contains("<analysis>"));
+        assert!(prompt.contains("<summary>"));
+        assert!(!prompt.contains("existing_summary"));
+    }
+
+    #[test]
+    fn build_summary_prompt_partial_compact_with_existing() {
+        let msg = test_message(MessageRole::Assistant, "Rust is a systems language.");
+        let prompt = build_summary_prompt(Some("Prior context here"), &[msg], 4000);
+        assert!(prompt.contains("existing_summary"));
+        assert!(prompt.contains("Prior context here"));
+        assert!(prompt.contains("New messages to incorporate:"));
+        assert!(prompt.contains("Assistant: Rust is a systems language."));
+    }
+
+    #[test]
+    fn build_summary_prompt_respects_content_limit() {
+        let long_content = "x".repeat(200);
+        let msg = test_message(MessageRole::User, &long_content);
+        let prompt = build_summary_prompt(None, &[msg], 50);
+        // Should be truncated to 50 chars + "..."
+        assert!(prompt.contains(&"x".repeat(50)));
+        assert!(prompt.contains("..."));
+        assert!(!prompt.contains(&"x".repeat(200)));
+    }
+
+    #[test]
+    fn build_summary_prompt_no_truncation_when_limit_zero() {
+        let long_content = "y".repeat(10000);
+        let msg = test_message(MessageRole::User, &long_content);
+        let prompt = build_summary_prompt(None, &[msg], 0);
+        assert!(prompt.contains(&long_content));
+    }
+
+    // ── is_context_length_error tests ───────────────────────────────
+
+    #[test]
+    fn is_context_length_error_matches_known_patterns() {
+        use crate::infra::llm::LlmProviderError;
+
+        let e1 = LlmProviderError::ProviderError {
+            code: "context_length_exceeded".into(),
+            message: "too many tokens".into(),
+            raw_detail: None,
+        };
+        assert!(is_context_length_error(&e1));
+
+        let e2 = LlmProviderError::ProviderError {
+            code: "invalid_request".into(),
+            message: "maximum context length exceeded".into(),
+            raw_detail: None,
+        };
+        assert!(is_context_length_error(&e2));
+
+        let e3 = LlmProviderError::ProviderError {
+            code: "rate_limit".into(),
+            message: "rate limited".into(),
+            raw_detail: None,
+        };
+        assert!(!is_context_length_error(&e3));
+    }
+
+    fn test_message(role: MessageRole, content: &str) -> crate::infra::db::entity::message::Model {
+        crate::infra::db::entity::message::Model {
+            id: uuid::Uuid::new_v4(),
+            tenant_id: uuid::Uuid::new_v4(),
+            chat_id: uuid::Uuid::new_v4(),
+            request_id: Some(uuid::Uuid::new_v4()),
+            role,
+            content: content.to_owned(),
+            content_type: "text/plain".to_owned(),
+            token_estimate: 0,
+            provider_response_id: None,
+            request_kind: None,
+            features_used: serde_json::json!([]),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_write_input_tokens: 0,
+            reasoning_tokens: 0,
+            model: None,
+            is_compressed: false,
+            created_at: time::OffsetDateTime::now_utc(),
+            deleted_at: None,
+        }
     }
 }

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -93,6 +93,9 @@ struct OutboxDeferred {
     vector_store_prov: Arc<dyn crate::domain::ports::VectorStoreProvider>,
     metrics: Arc<dyn MiniChatMetricsPort>,
     enqueuer: Arc<InfraOutboxEnqueuer>,
+    provider_resolver: Arc<crate::infra::llm::provider_resolver::ProviderResolver>,
+    model_resolver: Arc<dyn crate::domain::repos::ModelResolver>,
+    thread_summary_config: crate::config::background::ThreadSummaryWorkerConfig,
 }
 
 impl Default for MiniChatModule {
@@ -364,6 +367,9 @@ impl Module for MiniChatModule {
             vector_store_prov: Arc::clone(&vector_store_prov),
             metrics: Arc::clone(&metrics),
             enqueuer: Arc::clone(&outbox_enqueuer),
+            provider_resolver: Arc::clone(&provider_resolver),
+            model_resolver: model_policy_gw.clone() as Arc<dyn crate::domain::repos::ModelResolver>,
+            thread_summary_config: cfg.thread_summary_worker.clone(),
         }));
 
         // ── Services ────────────────────────────────────────────────────────
@@ -386,6 +392,7 @@ impl Module for MiniChatModule {
             cfg.rag,
             cfg.thumbnail,
             metrics,
+            cfg.thread_summary_worker,
         ));
 
         self.service
@@ -509,7 +516,28 @@ impl RunnableCapability for MiniChatModule {
                     ),
                 )
                 .queue(&od.outbox_config.thread_summary_queue_name, partitions)
-                .leased(crate::infra::workers::thread_summary_worker::ThreadSummaryHandler)
+                .leased(
+                    crate::infra::workers::thread_summary_worker::ThreadSummaryHandler::new(
+                        Arc::new(
+                            crate::infra::workers::thread_summary_worker::ThreadSummaryDeps {
+                                db: Arc::clone(&od.db),
+                                thread_summary_repo: Arc::new(ThreadSummaryRepository),
+                                message_repo: Arc::new(MessageRepository::new(
+                                    modkit_db::odata::LimitCfg {
+                                        default: 20,
+                                        max: 100,
+                                    },
+                                )),
+                                outbox_enqueuer: Arc::clone(&od.enqueuer)
+                                    as Arc<dyn crate::domain::repos::OutboxEnqueuer>,
+                                metrics: Arc::clone(&od.metrics),
+                                provider_resolver: Arc::clone(&od.provider_resolver),
+                                model_resolver: Arc::clone(&od.model_resolver),
+                                config: od.thread_summary_config.clone(),
+                            },
+                        ),
+                    ),
+                )
                 .queue(&od.outbox_config.audit_queue_name, partitions)
                 .leased(AuditEventHandler {
                     audit_gateway: Arc::clone(&od.audit_gateway),

--- a/modules/system/oagw/oagw/src/infra/proxy/pingora_proxy.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/pingora_proxy.rs
@@ -193,6 +193,37 @@ pub fn new_http_proxy(
 /// domain-level `Endpoint` (which carries scheme, original hostname, port).
 type AddrMap = Arc<ArcSwap<HashMap<String, Endpoint>>>;
 
+/// Resolve a hostname with retry and exponential backoff.
+///
+/// Retries up to 3 times with 100ms / 500ms / 2500ms delays. This handles
+/// transient DNS failures (common in container environments where CoreDNS
+/// may briefly drop queries under load).
+async fn dns_lookup_with_retry(addr: &str) -> Result<Vec<std::net::SocketAddr>, std::io::Error> {
+    const MAX_RETRIES: u32 = 3;
+    const BASE_DELAY_MS: u64 = 100;
+
+    let mut last_err = None;
+    for attempt in 0..=MAX_RETRIES {
+        match tokio::net::lookup_host(addr).await {
+            Ok(addrs) => return Ok(addrs.collect()),
+            Err(e) => {
+                last_err = Some(e);
+                if attempt < MAX_RETRIES {
+                    let delay = BASE_DELAY_MS * 5u64.pow(attempt); // 100ms, 500ms, 2500ms
+                    tracing::debug!(
+                        addr,
+                        attempt = attempt + 1,
+                        delay_ms = delay,
+                        "DNS lookup failed, retrying"
+                    );
+                    tokio::time::sleep(Duration::from_millis(delay)).await;
+                }
+            }
+        }
+    }
+    Err(last_err.expect("retry loop always sets last_err on failure"))
+}
+
 /// [`ServiceDiscovery`] implementation that re-resolves hostnames on every
 /// `discover()` call. IP-only endpoints are passed through without DNS.
 ///
@@ -216,7 +247,8 @@ impl DnsDiscovery {
     /// Resolve endpoints to `Backend`s and rebuild the reverse-lookup map.
     ///
     /// Uses async `tokio::net::lookup_host` to avoid blocking the Tokio
-    /// worker thread during DNS resolution.
+    /// worker thread during DNS resolution. Retries up to 3 times with
+    /// exponential backoff on transient DNS failures.
     async fn resolve(&self) -> (BTreeSet<Backend>, HashMap<String, Endpoint>) {
         let mut backends = BTreeSet::new();
         let mut map = HashMap::with_capacity(self.endpoints.len());
@@ -224,7 +256,7 @@ impl DnsDiscovery {
         for ep in &self.endpoints {
             let addr_str = format!("{}:{}", ep.host, ep.port);
 
-            let resolved = tokio::net::lookup_host(addr_str.clone()).await;
+            let resolved = dns_lookup_with_retry(&addr_str).await;
             match resolved {
                 Ok(addrs) => {
                     for sock in addrs {
@@ -237,7 +269,7 @@ impl DnsDiscovery {
                     }
                 }
                 Err(e) => {
-                    warn!(addr = %addr_str, error = %e, "DNS resolution failed, using original address");
+                    warn!(addr = %addr_str, error = %e, "DNS resolution failed after retries, using original address");
                     if let Ok(b) = Backend::new(&addr_str) {
                         backends.insert(b);
                         map.entry(addr_str).or_insert_with(|| ep.clone());
@@ -498,17 +530,18 @@ impl ProxyHttp for PingoraProxy {
             Some(a) => a,
             None => {
                 // Fallback: resolve DNS explicitly (single-endpoint bypass, target-host header).
-                tokio::net::lookup_host((ep.host.as_str(), ep.port))
+                let addr_str = format!("{}:{}", ep.host, ep.port);
+                let addrs = dns_lookup_with_retry(&addr_str)
                     .await
                     .map_err(|e| {
-                        warn!(upstream_id = ?ctx.upstream_id, host = %ep.host, port = ep.port, error = %e, "DNS resolution failed");
+                        warn!(upstream_id = ?ctx.upstream_id, host = %ep.host, port = ep.port, error = %e, "DNS resolution failed after retries");
                         pingora_core::Error::because(
                             pingora_core::ErrorType::ConnectError,
                             "DNS resolution failed",
                             e,
                         )
-                    })?
-                    .next()
+                    })?;
+                addrs.into_iter().next()
                     .ok_or_else(|| {
                         warn!(upstream_id = ?ctx.upstream_id, host = %ep.host, port = ep.port, "DNS returned no addresses");
                         pingora_core::Error::explain(

--- a/testing/e2e/modules/mini_chat/config/base.yaml
+++ b/testing/e2e/modules/mini_chat/config/base.yaml
@@ -34,6 +34,10 @@ logging:
     console_level: debug
     file: "logs/api.log"
     file_level: debug
+  mini_chat:
+    console_level: debug
+    file: "logs/mini-chat.log"
+    file_level: debug
 
 modules:
   api-gateway:
@@ -121,6 +125,11 @@ modules:
         enabled: true
         scan_interval_secs: 2
         timeout_secs: 90
+      thread_summary_worker:
+        enabled: true
+        summary_model_id: ""
+        compression_threshold_pct: 60
+        summary_system_prompt: "You are a conversation summarizer. Given a conversation (and optionally an existing summary), produce a detailed structured summary. Respond with an <analysis> block (your reasoning) followed by a <summary> block (the final summary). Only the <summary> content will be stored. Do not invent information not present in the conversation."
       # S2S credentials for obtaining SecurityContext
       # that will be used for communication with other modules.
       client_credentials:
@@ -167,6 +176,7 @@ modules:
           tier: Standard
           enabled: true
           system_prompt: "You are a helpful assistant. IMPORTANT RULE: When the user says exactly 'PING', you MUST respond with exactly 'PONG' and nothing else."
+          thread_summary_prompt: ""
           input_tokens_credit_multiplier_micro: 1000000
           output_tokens_credit_multiplier_micro: 3000000
           multimodal_capabilities: ["VISION_INPUT"]
@@ -253,6 +263,7 @@ modules:
           tier: Standard
           enabled: true
           system_prompt: "You are a helpful assistant. IMPORTANT RULE: When the user says exactly 'PING', you MUST respond with exactly 'PONG' and nothing else."
+          thread_summary_prompt: ""
           input_tokens_credit_multiplier_micro: 1000000
           output_tokens_credit_multiplier_micro: 3000000
           multimodal_capabilities: ["VISION_INPUT"]
@@ -339,6 +350,7 @@ modules:
           tier: Standard
           enabled: true
           system_prompt: "You are a helpful assistant. IMPORTANT RULE: When the user says exactly 'PING', you MUST respond with exactly 'PONG' and nothing else."
+          thread_summary_prompt: ""
           input_tokens_credit_multiplier_micro: 500000
           output_tokens_credit_multiplier_micro: 1500000
           multimodal_capabilities: ["VISION_INPUT"]
@@ -425,6 +437,7 @@ modules:
           tier: Premium
           enabled: true
           system_prompt: "You are a helpful assistant. IMPORTANT RULE: When the user says exactly 'PING', you MUST respond with exactly 'PONG' and nothing else."
+          thread_summary_prompt: ""
           input_tokens_credit_multiplier_micro: 3000000
           output_tokens_credit_multiplier_micro: 15000000
           multimodal_capabilities: ["VISION_INPUT"]
@@ -504,6 +517,10 @@ modules:
             performance:
               response_latency_ms: 1000
               speed_tokens_per_second: 120
+
+  static-mini-chat-audit-plugin:
+    config:
+      enabled: true
 
   static-credstore-plugin:
     config:

--- a/testing/e2e/modules/mini_chat/conftest.py
+++ b/testing/e2e/modules/mini_chat/conftest.py
@@ -158,11 +158,9 @@ def _patch_mini_chat_config(config_text: str, env) -> str:
     # home_dir
     config_text = re.sub(r"(home_dir\s*:\s*).*", rf'\1"{_TEMP_HOME}"', config_text, count=1)
 
-    # Log level
+    # Log level — mini_chat logging is already in base.yaml; only inject oagw
     mini_chat_log = os.environ.get("MINI_CHAT_LOG", "debug")
     log_inject = (
-        f"  mini_chat:\n"
-        f"    console_level: {mini_chat_log}\n"
         f"  oagw:\n"
         f"    console_level: {mini_chat_log}\n"
     )

--- a/testing/e2e/modules/mini_chat/test_live_smoke.py
+++ b/testing/e2e/modules/mini_chat/test_live_smoke.py
@@ -1,0 +1,860 @@
+"""
+Live smoke tests against an already-running mini-chat backend.
+
+Usage:
+    E2E_BINARY=skip python3 -m pytest testing/e2e/modules/mini_chat/test_live_smoke.py -v
+
+No orchestrator, no mock provider required.
+Exercises real LLM calls (azure-gpt-4.1 / gpt-5-mini).
+Tests skip gracefully when the provider is unavailable (Azure upstream errors).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import time
+
+import httpx
+import pytest
+
+BASE_URL = os.environ.get("BASE_URL", "http://127.0.0.1:8087")
+API = f"{BASE_URL}/cf/mini-chat/v1"
+TIMEOUT = 90
+
+# Model IDs must match the e2e model catalog (testing/e2e/modules/mini_chat/config/base.yaml)
+DEFAULT_MODEL = "azure-gpt-4.1"   # Premium tier, Azure
+MINI_MODEL = "gpt-5-mini"         # Standard tier, OpenAI
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def parse_sse(text: str) -> list[dict]:
+    """Minimal SSE parser: returns [{event, data}, ...]."""
+    import json as _json
+    events = []
+    current_event = None
+    current_data = []
+
+    def _flush():
+        nonlocal current_event, current_data
+        if current_event:
+            raw = "\n".join(current_data)
+            try:
+                data = _json.loads(raw)
+            except _json.JSONDecodeError:
+                data = raw
+            events.append({"event": current_event, "data": data})
+        current_event = None
+        current_data = []
+
+    for line in text.splitlines():
+        if line.startswith("event: "):
+            current_event = line[7:]
+        elif line.startswith("data: "):
+            current_data.append(line[6:])
+        elif line == "":
+            _flush()
+    _flush()  # emit trailing frame at EOF
+    return events
+
+
+def create_chat(model: str = DEFAULT_MODEL) -> dict:
+    resp = httpx.post(f"{API}/chats", json={"model": model}, timeout=TIMEOUT)
+    assert resp.status_code == 201, f"create chat: {resp.status_code} {resp.text}"
+    return resp.json()
+
+
+def send_message(chat_id: str, content: str, **extra) -> tuple[int, list[dict], str]:
+    body = {"content": content, **extra}
+    resp = httpx.post(
+        f"{API}/chats/{chat_id}/messages:stream",
+        json=body,
+        headers={"Accept": "text/event-stream"},
+        timeout=TIMEOUT,
+    )
+    events = parse_sse(resp.text) if resp.status_code == 200 else []
+    return resp.status_code, events, resp.text
+
+
+def find_event(events: list[dict], name: str) -> dict | None:
+    return next((e for e in events if e["event"] == name), None)
+
+
+_TRANSIENT_ERROR_PHRASES = ("provider", "upstream", "rate limit", "timeout", "unavailable", "gateway")
+
+
+def require_done(events: list[dict]) -> dict:
+    """Assert stream completed successfully (has 'done' event, no 'error').
+
+    Only skips for known transient/provider errors; fails on all others
+    so real bugs are not masked.
+    """
+    err = find_event(events, "error")
+    if err:
+        err_data = str(err.get("data", "")).lower()
+        if any(phrase in err_data for phrase in _TRANSIENT_ERROR_PHRASES):
+            pytest.skip(f"Provider error (transient): {err['data']}")
+        else:
+            pytest.fail(f"Stream error (non-transient): {err['data']}")
+    done = find_event(events, "done")
+    if done is None:
+        pytest.fail(f"No 'done' event in stream. Events: {[e['event'] for e in events]}")
+    return done
+
+
+def get_response_text(events: list[dict]) -> str:
+    return "".join(
+        d["data"]["content"] for d in events if d["event"] == "delta"
+    )
+
+
+def upload_file(chat_id: str, filename: str, content: bytes, content_type: str = "text/plain") -> str:
+    """Upload a file and return attachment_id. Skips on provider errors."""
+    resp = httpx.post(
+        f"{API}/chats/{chat_id}/attachments",
+        files={"file": (filename, io.BytesIO(content), content_type)},
+        timeout=60,
+    )
+    assert resp.status_code == 201, f"Upload failed: {resp.status_code} {resp.text}"
+    return resp.json()["id"]
+
+
+def poll_attachment_ready(chat_id: str, att_id: str, timeout_secs: int = 30) -> dict:
+    """Poll until attachment is ready or failed."""
+    deadline = time.time() + timeout_secs
+    while time.time() < deadline:
+        resp = httpx.get(f"{API}/chats/{chat_id}/attachments/{att_id}", timeout=10)
+        data = resp.json()
+        if data["status"] in ("ready", "failed"):
+            return data
+        time.sleep(1)
+    raise TimeoutError(f"Attachment {att_id} not ready after {timeout_secs}s")
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def _check_live():
+    """Skip if backend is not reachable."""
+    try:
+        resp = httpx.get(f"{BASE_URL}/cf/openapi.json", timeout=5)
+        if resp.status_code != 200:
+            pytest.skip(f"Backend not healthy: {resp.status_code}")
+    except httpx.ConnectError:
+        pytest.skip(f"Backend not reachable at {BASE_URL}")
+
+
+@pytest.fixture
+def chat(_check_live):
+    return create_chat(DEFAULT_MODEL)
+
+
+@pytest.fixture
+def mini_chat(_check_live):
+    return create_chat(MINI_MODEL)
+
+
+# ── Tests: Core Streaming ────────────────────────────────────────────────
+
+
+class TestLiveSmoke:
+    """Basic live smoke tests against real LLM."""
+
+    def test_health(self, _check_live):
+        resp = httpx.get(f"{BASE_URL}/cf/openapi.json", timeout=10)
+        assert resp.status_code == 200
+
+    def test_list_models(self, _check_live):
+        resp = httpx.get(f"{API}/models", timeout=10)
+        assert resp.status_code == 200
+        models = resp.json()["items"]
+        ids = [m["model_id"] for m in models]
+        assert DEFAULT_MODEL in ids
+
+    def test_create_chat(self, _check_live):
+        chat = create_chat()
+        assert "id" in chat
+        assert chat["model"] == DEFAULT_MODEL
+
+    def test_stream_single_turn(self, chat):
+        status, events, raw = send_message(chat["id"], "Say 'hello' and nothing else.")
+        assert status == 200, f"stream failed: {raw}"
+
+        started = find_event(events, "stream_started")
+        assert started is not None
+        assert started["data"]["is_new_turn"] is True
+
+        done = require_done(events)
+        assert done["data"]["usage"]["input_tokens"] > 0
+        assert done["data"]["usage"]["output_tokens"] > 0
+
+    def test_stream_has_deltas(self, chat):
+        status, events, _ = send_message(chat["id"], "Count from 1 to 5.")
+        assert status == 200
+        require_done(events)
+        deltas = [e for e in events if e["event"] == "delta"]
+        assert len(deltas) > 0, "expected at least one delta event"
+
+    @pytest.mark.online_only
+    def test_multi_turn_context(self, chat):
+        """Two turns: assistant should remember the first."""
+        cid = chat["id"]
+        s1, ev1, _ = send_message(cid, "Remember: the secret word is 'banana'.")
+        assert s1 == 200
+        require_done(ev1)
+
+        status, events, _ = send_message(cid, "What is the secret word?")
+        assert status == 200
+        require_done(events)
+        text = get_response_text(events)
+        assert "banana" in text.lower(), f"expected 'banana' in response: {text}"
+
+
+# ── Tests: SSE Summary Field ────────────────────────────────────────────
+
+
+class TestLiveStreamStartedSummary:
+    """Verify thread_summary_applied field in stream_started events."""
+
+    def test_stream_started_has_no_summary_initially(self, chat):
+        status, events, _ = send_message(chat["id"], "Hello")
+        assert status == 200
+        started = find_event(events, "stream_started")
+        assert started is not None
+        assert started["data"].get("thread_summary_applied") is None
+
+
+# ── Tests: Mini Model ───────────────────────────────────────────────────
+
+
+class TestLiveMiniModel:
+    """Tests using gpt-5-mini (cheaper, faster)."""
+
+    def test_mini_model_works(self, mini_chat):
+        status, events, raw = send_message(
+            mini_chat["id"], "What is 2+2? Answer with just the number."
+        )
+        assert status == 200, f"mini model failed: {raw}"
+        done = require_done(events)
+        assert done["data"]["effective_model"] == MINI_MODEL
+
+
+# ── Tests: Chat CRUD ────────────────────────────────────────────────────
+
+
+class TestLiveChatCRUD:
+    """Basic CRUD operations."""
+
+    def test_list_chats(self, _check_live):
+        resp = httpx.get(f"{API}/chats", timeout=10)
+        assert resp.status_code == 200
+        assert "items" in resp.json()
+
+    def test_get_chat(self, chat):
+        resp = httpx.get(f"{API}/chats/{chat['id']}", timeout=10)
+        assert resp.status_code == 200
+        assert resp.json()["id"] == chat["id"]
+
+    def test_list_messages_empty(self, chat):
+        resp = httpx.get(f"{API}/chats/{chat['id']}/messages", timeout=10)
+        assert resp.status_code == 200
+        assert resp.json()["items"] == []
+
+    def test_list_messages_after_turn(self, chat):
+        status, events, _ = send_message(chat["id"], "Hi")
+        assert status == 200
+        require_done(events)  # skip if provider error
+
+        resp = httpx.get(f"{API}/chats/{chat['id']}/messages", timeout=10)
+        assert resp.status_code == 200
+        msgs = resp.json()["items"]
+        assert len(msgs) >= 2  # user + assistant
+
+    def test_delete_chat(self, _check_live):
+        c = create_chat()
+        resp = httpx.delete(f"{API}/chats/{c['id']}", timeout=10)
+        assert resp.status_code == 204
+
+    def test_get_deleted_chat_404(self, _check_live):
+        c = create_chat()
+        httpx.delete(f"{API}/chats/{c['id']}", timeout=10)
+        resp = httpx.get(f"{API}/chats/{c['id']}", timeout=10)
+        assert resp.status_code == 404
+
+
+# ── Tests: Quota ─────────────────────────────────────────────────────────
+
+
+class TestLiveQuota:
+    """Quota status endpoint."""
+
+    def test_quota_status(self, _check_live):
+        resp = httpx.get(f"{API}/quota/status", timeout=10)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "tiers" in data
+
+
+# ── Tests: Attachment Deletion ───────────────────────────────────────────
+
+
+class TestLiveTurnMutations:
+    """Retry, edit, delete turns."""
+
+    def test_retry_turn(self, chat):
+        """Complete a turn, then retry it — should produce a new response."""
+        cid = chat["id"]
+        s1, ev1, _ = send_message(cid, "Say a random number between 1 and 100.")
+        assert s1 == 200
+        require_done(ev1)
+        started1 = find_event(ev1, "stream_started")
+        request_id = started1["data"]["request_id"]
+
+        # Retry
+        resp = httpx.post(
+            f"{API}/chats/{cid}/turns/{request_id}/retry",
+            json={},
+            headers={"Accept": "text/event-stream"},
+            timeout=TIMEOUT,
+        )
+        assert resp.status_code == 200, f"retry failed: {resp.status_code} {resp.text}"
+        ev2 = parse_sse(resp.text)
+        require_done(ev2)
+        started2 = find_event(ev2, "stream_started")
+        assert started2["data"]["request_id"] != request_id, "retry should have a new request_id"
+
+    def test_delete_last_turn(self, chat):
+        """Complete a turn, then delete it."""
+        cid = chat["id"]
+        s1, ev1, _ = send_message(cid, "Temporary message")
+        assert s1 == 200
+        require_done(ev1)
+        started = find_event(ev1, "stream_started")
+        request_id = started["data"]["request_id"]
+
+        resp = httpx.delete(f"{API}/chats/{cid}/turns/{request_id}", timeout=10)
+        assert resp.status_code == 204
+
+    def test_edit_turn(self, chat):
+        """Complete a turn, then edit it with new content."""
+        cid = chat["id"]
+        s1, ev1, _ = send_message(cid, "What is 1+1?")
+        assert s1 == 200
+        require_done(ev1)
+        started = find_event(ev1, "stream_started")
+        request_id = started["data"]["request_id"]
+
+        resp = httpx.patch(
+            f"{API}/chats/{cid}/turns/{request_id}",
+            json={"content": "What is 2+2?"},
+            headers={"Accept": "text/event-stream"},
+            timeout=TIMEOUT,
+        )
+        assert resp.status_code == 200, f"edit failed: {resp.status_code} {resp.text}"
+        ev2 = parse_sse(resp.text)
+        require_done(ev2)
+
+
+class TestLiveParallelTurn:
+    """Concurrent turn conflict."""
+
+    @pytest.mark.online_only
+    def test_second_stream_409(self, _check_live):
+        """Sending a second message while first is running should return 409."""
+        chat = create_chat(DEFAULT_MODEL)
+        cid = chat["id"]
+
+        # Start a long-running request (stream but don't wait for completion)
+        with httpx.Client(timeout=TIMEOUT) as client:
+            with client.stream(
+                "POST",
+                f"{API}/chats/{cid}/messages:stream",
+                json={"content": "Write a long essay about the history of mathematics."},
+                headers={"Accept": "text/event-stream"},
+            ) as first:
+                # Wait until server confirms the turn is running (stream_started event)
+                # instead of a fixed sleep — eliminates race condition.
+                for line in first.iter_lines():
+                    if "stream_started" in line:
+                        break
+
+                resp2 = httpx.post(
+                    f"{API}/chats/{cid}/messages:stream",
+                    json={"content": "Hello"},
+                    headers={"Accept": "text/event-stream"},
+                    timeout=10,
+                )
+                # 409 = generation in progress
+                assert resp2.status_code == 409, (
+                    f"Expected 409, got {resp2.status_code}: {resp2.text[:200]}"
+                )
+
+
+class TestLiveWebSearch:
+    """Web search tool integration."""
+
+    def test_web_search_enabled_completes(self, chat):
+        """Enable web_search — stream should complete even if LLM skips the tool."""
+        status, events, raw = send_message(
+            chat["id"],
+            "Search the web: what is the current population of Tokyo?",
+            web_search_enabled=True,
+        )
+        assert status == 200, f"web search failed: {raw}"
+        done = require_done(events)
+        # Verify web_search was at least offered (done event shows usage)
+        assert done["data"]["usage"]["input_tokens"] > 0
+        # Tool events are not guaranteed — LLM may answer from knowledge.
+        # Just verify the stream completes without error.
+
+
+class TestLiveReactions:
+    """Message reactions."""
+
+    def test_set_and_remove_reaction(self, chat):
+        cid = chat["id"]
+        s, ev, _ = send_message(cid, "Tell me a joke.")
+        assert s == 200
+        require_done(ev)
+        started = find_event(ev, "stream_started")
+        msg_id = started["data"]["message_id"]
+
+        # Set reaction
+        resp = httpx.put(
+            f"{API}/chats/{cid}/messages/{msg_id}/reaction",
+            json={"reaction": "like"},
+            timeout=10,
+        )
+        assert resp.status_code == 200
+
+        # Remove reaction
+        resp = httpx.delete(
+            f"{API}/chats/{cid}/messages/{msg_id}/reaction",
+            timeout=10,
+        )
+        assert resp.status_code == 204
+
+
+class TestLiveErrorHandling:
+    """Error scenarios."""
+
+    def test_empty_content_rejected(self, chat):
+        resp = httpx.post(
+            f"{API}/chats/{chat['id']}/messages:stream",
+            json={"content": ""},
+            headers={"Accept": "text/event-stream"},
+            timeout=10,
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_chat_not_found_stream(self, _check_live):
+        fake_id = "00000000-0000-0000-0000-000000000000"
+        resp = httpx.post(
+            f"{API}/chats/{fake_id}/messages:stream",
+            json={"content": "hello"},
+            headers={"Accept": "text/event-stream"},
+            timeout=10,
+        )
+        assert resp.status_code in (403, 404)
+
+    def test_invalid_attachment_id_rejected(self, chat):
+        fake_att = "00000000-0000-0000-0000-000000000000"
+        resp = httpx.post(
+            f"{API}/chats/{chat['id']}/messages:stream",
+            json={"content": "hello", "attachment_ids": [fake_att]},
+            headers={"Accept": "text/event-stream"},
+            timeout=10,
+        )
+        assert resp.status_code in (400, 404, 422)
+
+
+class TestLiveMessagesAPI:
+    """Messages list with OData-like features."""
+
+    def test_messages_have_role_and_content(self, chat):
+        status, events, _ = send_message(chat["id"], "Ping")
+        assert status == 200, f"Stream failed: {status}"
+        require_done(events)
+        resp = httpx.get(f"{API}/chats/{chat['id']}/messages", timeout=10)
+        assert resp.status_code == 200
+        msgs = resp.json()["items"]
+        assert len(msgs) > 0, "Expected at least one message after completed turn"
+        for msg in msgs:
+            assert "role" in msg
+            assert "content" in msg
+
+    def test_messages_have_created_at(self, chat):
+        status, events, _ = send_message(chat["id"], "Ping")
+        assert status == 200, f"Stream failed: {status}"
+        require_done(events)
+        resp = httpx.get(f"{API}/chats/{chat['id']}/messages", timeout=10)
+        assert resp.status_code == 200
+        msgs = resp.json()["items"]
+        assert len(msgs) > 0, "Expected at least one message after completed turn"
+        for msg in msgs:
+            assert "created_at" in msg
+
+
+class TestLiveChatUpdate:
+    """Chat title update."""
+
+    def test_update_title(self, chat):
+        resp = httpx.patch(
+            f"{API}/chats/{chat['id']}",
+            json={"title": "My Updated Chat"},
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "My Updated Chat"
+
+    def test_update_empty_title_rejected(self, chat):
+        resp = httpx.patch(
+            f"{API}/chats/{chat['id']}",
+            json={"title": "   "},
+            timeout=10,
+        )
+        assert resp.status_code in (400, 422)
+
+
+class TestLiveThreadSummary:
+    """Thread summary infrastructure verification.
+
+    Note: with azure-gpt-4.1's 1M token context window, the 80% compression threshold
+    (~800K tokens) cannot be reached in a reasonable e2e test. These tests verify
+    the plumbing is correct: no premature compression, SSE field absent when
+    no summary exists, and messages remain accessible across multiple turns.
+    """
+
+    def test_no_summary_on_fresh_chat(self, chat):
+        """First turn: stream_started should not have thread_summary_applied."""
+        status, events, _ = send_message(chat["id"], "Hello")
+        assert status == 200
+        require_done(events)
+        started = find_event(events, "stream_started")
+        assert started["data"].get("thread_summary_applied") is None
+
+    def test_no_premature_compression_after_multiple_turns(self, _check_live):
+        """After several turns, messages should NOT be compressed (threshold not reached)."""
+        chat = create_chat(MINI_MODEL)
+        cid = chat["id"]
+
+        # Send 6 turns (12 messages total — nowhere near 80% of 1M tokens)
+        for i in range(6):
+            s, ev, _ = send_message(cid, f"Turn {i}: The quick brown fox jumps over the lazy dog.")
+            assert s == 200
+            require_done(ev)
+
+        # All messages should be visible (none compressed away)
+        resp = httpx.get(f"{API}/chats/{cid}/messages", timeout=10)
+        assert resp.status_code == 200
+        msgs = resp.json()["items"]
+        # 6 user + 6 assistant = 12 messages
+        assert len(msgs) >= 12, f"Expected >= 12 messages, got {len(msgs)}"
+
+    @pytest.mark.online_only
+    def test_no_summary_after_multiple_turns(self, _check_live):
+        """After several turns, stream_started still should not have summary."""
+        chat = create_chat(MINI_MODEL)
+        cid = chat["id"]
+
+        for i in range(4):
+            s, ev, _ = send_message(cid, f"Message {i}: remember {i * 7}")
+            assert s == 200
+            require_done(ev)
+
+        # 5th turn: check stream_started for summary
+        s, events, _ = send_message(cid, "What numbers did I ask you to remember?")
+        assert s == 200
+        require_done(events)
+
+        started = find_event(events, "stream_started")
+        assert started["data"].get("thread_summary_applied") is None, (
+            "Summary should not exist — context is far below compression threshold"
+        )
+
+        # Verify the model can still recall earlier messages (context intact)
+        text = get_response_text(events)
+        assert "0" in text or "7" in text or "14" in text or "21" in text, (
+            f"Model should recall at least one remembered number, got: {text}"
+        )
+
+TINY_CTX_MODEL = "gpt-4.1-mini-tiny-ctx"
+
+
+class TestLiveThreadSummaryTrigger:
+    """Full thread summary trigger e2e test.
+
+    Uses `gpt-4.1-mini-tiny-ctx` — a test model with context_window=4096
+    so the 80% compression threshold (~2458 tokens) is reachable in ~3 turns.
+    After the trigger fires (async outbox handler), the next turn should see
+    `thread_summary_applied` in the `stream_started` event.
+    """
+
+    def test_model_available(self, _check_live):
+        """Verify the tiny-context model exists in the catalog."""
+        resp = httpx.get(f"{API}/models", timeout=10)
+        assert resp.status_code == 200
+        ids = [m["model_id"] for m in resp.json()["items"]]
+        if TINY_CTX_MODEL not in ids:
+            pytest.skip(f"Model {TINY_CTX_MODEL} not in catalog — add it to config")
+
+    def test_summary_trigger_fires_and_applied_on_next_turn(self, _check_live):
+        """
+        1. Create chat with tiny context model
+        2. Send several verbose turns to exceed 80% of 4096 tokens
+        3. Wait briefly for async outbox handler to process
+        4. Send one more turn and check stream_started.thread_summary_applied
+        """
+        # Check model availability
+        resp = httpx.get(f"{API}/models", timeout=10)
+        ids = [m["model_id"] for m in resp.json()["items"]]
+        if TINY_CTX_MODEL not in ids:
+            pytest.skip(f"Model {TINY_CTX_MODEL} not in catalog")
+
+        chat = create_chat(TINY_CTX_MODEL)
+        cid = chat["id"]
+
+        # Send verbose messages to fill context.
+        # System prompt asks model to be verbose, so responses will be long.
+        # Each turn: ~200 token user msg + ~300-500 token assistant response
+        # After 3-4 turns we should exceed 80% of 4096 = ~2458 tokens.
+        prompts = [
+            "Explain in great detail how photosynthesis works, step by step. "
+            "Include all chemical reactions, the role of chlorophyll, and "
+            "the difference between light-dependent and light-independent reactions.",
+
+            "Now explain in equal detail how cellular respiration works. "
+            "Compare and contrast it with photosynthesis. Include glycolysis, "
+            "the Krebs cycle, and the electron transport chain.",
+
+            "Describe the full nitrogen cycle in ecosystems. Explain nitrogen "
+            "fixation, nitrification, denitrification, and the role of bacteria. "
+            "Give real-world examples of each stage.",
+
+            "Explain the water cycle in comprehensive detail. Include "
+            "evaporation, transpiration, condensation, precipitation, "
+            "surface runoff, and groundwater flow. How does climate change affect it?",
+        ]
+
+        for i, prompt in enumerate(prompts):
+            s, ev, raw = send_message(cid, prompt)
+            assert s == 200, f"Turn {i} failed: {raw[:200]}"
+            done = require_done(ev)
+            usage = done["data"].get("usage", {})
+            input_tokens = usage.get("input_tokens", 0)
+            # Log for debugging
+            print(f"  Turn {i}: input_tokens={input_tokens}, output_tokens={usage.get('output_tokens', 0)}")
+
+        # Wait for the outbox handler to process the summary task.
+        # The trigger fires in the finalization transaction of the turn that
+        # exceeded the threshold. The handler runs asynchronously.
+        print("  Waiting 5s for thread summary handler...")
+        time.sleep(5)
+
+        # One more turn — check if summary is now applied
+        s, events, raw = send_message(cid, "Briefly, what topics have we discussed?")
+        assert s == 200, f"Final turn failed: {raw[:200]}"
+        require_done(events)
+
+        started = find_event(events, "stream_started")
+        assert started is not None
+
+        summary_info = started["data"].get("thread_summary_applied")
+        if summary_info is not None:
+            print(f"  thread_summary_applied: {summary_info}")
+            assert "token_estimate" in summary_info
+            assert summary_info["token_estimate"] > 0
+        else:
+            # Summary may not have been generated yet (handler latency)
+            # or threshold wasn't reached (model responses were too short).
+            # Check messages to see if any are compressed.
+            resp = httpx.get(f"{API}/chats/{cid}/messages", timeout=10)
+            msg_count = len(resp.json()["items"])
+            print(f"  No summary yet. Message count: {msg_count}")
+            # Don't fail — this is best-effort with real LLM.
+            # The trigger depends on actual token counts which vary.
+            pytest.skip(
+                f"Summary not triggered after {len(prompts)} turns "
+                f"(token threshold may not have been reached with this model). "
+                f"Messages: {msg_count}"
+            )
+
+
+class TestLiveAttachmentDeletion:
+    """Upload a document, verify LLM can find it, delete it, verify LLM cannot."""
+
+    @pytest.mark.online_only
+    def test_delete_makes_document_invisible_to_llm(self, _check_live):
+        """
+        1. Create chat, upload file with unique fact
+        2. Ask LLM about the fact WITH attachment → should know
+        3. Delete attachment
+        4. New chat, ask same question WITHOUT attachment → should NOT know
+        """
+        chat = create_chat(DEFAULT_MODEL)
+        chat_id = chat["id"]
+
+        # Upload file with a unique fact no LLM would know.
+        # Repeat content so Azure vector store indexes it reliably.
+        unique_fact = (
+            "The capital of the fictional country Zarvonia is Plimberwick.\n"
+            "Zarvonia's capital city Plimberwick was founded in 1823.\n"
+            "The city of Plimberwick is the largest city in Zarvonia.\n"
+        ) * 5
+        att_id = upload_file(chat_id, "zarvonia.txt", unique_fact.encode())
+        detail = poll_attachment_ready(chat_id, att_id)
+        assert detail["status"] == "ready", f"Attachment not ready: {detail}"
+
+        # Wait for Azure vector store to finish chunking/embedding.
+        # Our attachment status tracks our DB row, not the provider's
+        # async indexing pipeline (see Azure docs: "Adding files to
+        # vector stores is an async operation").
+        time.sleep(5)
+
+        # Ask WITH attachment
+        status, events, raw = send_message(chat_id, "What is the capital of Zarvonia? Use the attached document.")
+        assert status == 200, f"Stream failed: {raw}"
+        require_done(events)
+        response_text = get_response_text(events)
+        assert "plimberwick" in response_text.lower(), (
+            f"LLM should know about Plimberwick from attachment, got: {response_text}"
+        )
+
+        # Delete attachment
+        resp = httpx.delete(f"{API}/chats/{chat_id}/attachments/{att_id}", timeout=10)
+        assert resp.status_code in (204, 409)  # 409 = referenced by message, still soft-deleted
+
+        # NEW chat — no vector store, no history
+        clean_chat = create_chat(DEFAULT_MODEL)
+        status2, events2, raw2 = send_message(
+            clean_chat["id"], "What is the capital of Zarvonia?"
+        )
+        assert status2 == 200, f"Stream failed: {raw2}"
+        require_done(events2)
+        response_text2 = get_response_text(events2)
+
+        # LLM should NOT know — Plimberwick is a made-up fact from a deleted file
+        assert "plimberwick" not in response_text2.lower(), (
+            f"LLM should NOT know about Plimberwick without document, got: {response_text2}"
+        )
+
+    def test_attachment_api_returns_404_after_delete(self, _check_live):
+        """After deletion, GET attachment returns 404."""
+        chat = create_chat(MINI_MODEL)
+        chat_id = chat["id"]
+
+        att_id = upload_file(chat_id, "ephemeral.txt", b"temporary data")
+        poll_attachment_ready(chat_id, att_id)
+
+        resp = httpx.delete(f"{API}/chats/{chat_id}/attachments/{att_id}", timeout=10)
+        assert resp.status_code == 204
+
+        resp = httpx.get(f"{API}/chats/{chat_id}/attachments/{att_id}", timeout=10)
+        assert resp.status_code == 404
+
+
+class TestLiveChatDeletionCleanup:
+    """Delete a chat with attachments and verify cleanup removes all provider resources."""
+
+    def test_delete_chat_cleans_up_attachments(self, _check_live):
+        """
+        1. Create chat, upload attachment, verify it's ready
+        2. Send a message so the attachment is indexed in vector store
+        3. Delete the entire chat
+        4. Verify chat returns 404
+        5. Verify attachment returns 404
+        6. Create new chat, verify LLM cannot access the deleted fact
+        """
+        chat = create_chat(DEFAULT_MODEL)
+        chat_id = chat["id"]
+
+        # Upload file with unique fact — repeat content to ensure file_search indexes it
+        unique_fact = (
+            "The president of the fictional nation Glorpistan is Quuxley Fernwhistle.\n"
+            "Glorpistan's capital city is Fernwhistle City, named after President Quuxley Fernwhistle.\n"
+            "The nation of Glorpistan was founded in 1847 by Quuxley Fernwhistle Senior.\n"
+        ) * 5  # Repeat to increase file size for better indexing
+        att_id = upload_file(chat_id, "glorpistan.txt", unique_fact.encode())
+        detail = poll_attachment_ready(chat_id, att_id)
+        assert detail["status"] == "ready", f"Attachment not ready: {detail}"
+
+        # Send message to trigger file_search indexing
+        status, events, raw = send_message(
+            chat_id, "Who is the president of Glorpistan? Use the attached document."
+        )
+        assert status == 200, f"Stream failed: {raw}"
+        require_done(events)
+        response_text = get_response_text(events)
+        if "fernwhistle" not in response_text.lower():
+            pytest.skip(
+                "file_search did not retrieve the fact (flaky indexing); "
+                f"got: {response_text[:200]}"
+            )
+
+        # Delete the entire chat
+        resp = httpx.delete(f"{API}/chats/{chat_id}", timeout=10)
+        assert resp.status_code == 204
+
+        # Poll until chat returns 404 (cleanup worker processed)
+        deadline = time.time() + 15
+        while time.time() < deadline:
+            resp = httpx.get(f"{API}/chats/{chat_id}", timeout=10)
+            if resp.status_code == 404:
+                break
+            time.sleep(1)
+        else:
+            pytest.fail(f"Chat {chat_id} not cleaned up after 15s, status={resp.status_code}")
+
+        # Attachment endpoint should also 404
+        resp = httpx.get(f"{API}/chats/{chat_id}/attachments/{att_id}", timeout=10)
+        assert resp.status_code == 404, f"Attachment should be gone, got {resp.status_code}"
+
+        # New chat — verify LLM cannot see the deleted fact
+        clean_chat = create_chat(DEFAULT_MODEL)
+        status2, events2, raw2 = send_message(
+            clean_chat["id"], "Who is the president of Glorpistan?"
+        )
+        assert status2 == 200, f"Stream failed: {raw2}"
+        require_done(events2)
+        response_text2 = get_response_text(events2)
+        assert "fernwhistle" not in response_text2.lower(), (
+            f"LLM should NOT know about Fernwhistle after chat deletion, got: {response_text2}"
+        )
+
+    def test_delete_chat_without_attachments(self, _check_live):
+        """Deleting a chat with no attachments should succeed cleanly."""
+        chat = create_chat(MINI_MODEL)
+        chat_id = chat["id"]
+
+        # Send one message so the chat has content
+        status, events, _ = send_message(chat_id, "Hello")
+        assert status == 200
+        require_done(events)
+
+        # Delete chat
+        resp = httpx.delete(f"{API}/chats/{chat_id}", timeout=10)
+        assert resp.status_code == 204
+
+        # Should be gone
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            resp = httpx.get(f"{API}/chats/{chat_id}", timeout=10)
+            if resp.status_code == 404:
+                break
+            time.sleep(1)
+        else:
+            pytest.fail(f"Chat {chat_id} not deleted after 10s")
+
+    def test_delete_chat_idempotent(self, _check_live):
+        """Deleting the same chat twice should succeed both times."""
+        chat = create_chat(MINI_MODEL)
+        chat_id = chat["id"]
+
+        resp1 = httpx.delete(f"{API}/chats/{chat_id}", timeout=10)
+        assert resp1.status_code == 204
+
+        resp2 = httpx.delete(f"{API}/chats/{chat_id}", timeout=10)
+        assert resp2.status_code in (204, 404)


### PR DESCRIPTION
Thread summary system:
- Structured summary prompt with <analysis>/<summary> pattern (analysis stripped before storage)
- 3-tier system prompt cascade: model catalog → global config → hardcoded default
- max_output_tokens from ModelCatalogEntry (not hardcoded)
- PTL retry: drop oldest 20% messages on context_length_exceeded (up to 2 retries)
- Configurable message_content_limit (default 4000, was hardcoded 500)
- Summary growth control: prioritize recent topics over older facts on partial compact
- Summary preamble for LLM context injection (replaces raw "[Thread Summary]")

Stream fixes:
- Fix ResponseIncompleteData parsing: extract response object with usage + incomplete_details
- Fix zero usage on response.incomplete events (was hardcoded zeros)
- Drain inner stream after terminal event to prevent Pingora "Downstream ConnectionClosed"

Context & quota:
- Thread summary trigger uses assembled_context_tokens from context assembly (not reserve_tokens)
- Two-condition trigger: proactive (60% threshold, no existing summary) OR urgent (messages_truncated)
- Preflight reserve includes prior_context_tokens (last turn's actual input+output)
- Filter is_compressed=false in recent_for_context and recent_after_boundary queries
- Add last_assistant_token_counts() repo method for preflight estimation

Infrastructure:
- Hard shutdown timeout (15s OS thread) in modkit host_runtime to handle blocking getaddrinfo
- Thread summary worker upstream_path: {alias}{api_path} (was missing api_path)

Config sync:
- All 3 configs aligned (mini-chat.yaml, base.yaml, helm configmap)
- orphan_watchdog: scan_interval_secs=10, timeout_secs=90 for dev

DESIGN.md updates:
- Trigger logic, truncation priority (P3 droppable), quota preflight, config table, PTL retry, is_compressed filtering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic thread summaries with a background worker; stream events may include summary info
  * Orphan-turn watchdog to recover stuck streams
  * Durable background attachment & chat cleanup processing
  * New compact model option for tiny context workloads

* **Chores**
  * Build/packaging workflow updated; .docker-stage ignored
  * Helm replicaCount lowered to 1

* **Config**
  * CORS enabled for API gateway
  * Thread-summary worker configurable (thresholds, model, prompt)

* **Tests**
  * New end-to-end live smoke tests

* **Documentation**
  * Extensive design, migration, and plan docs for summary/orphan/cleanup workers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->