### PR TITLE
feat(mini-chat-sdk): simplify ModelGeneralConfig and add tool search configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ dependencies = [
  "time",
  "tokio-util",
  "tracing",
+ "utoipa",
  "uuid",
 ]
 

--- a/config/mini-chat.yaml
+++ b/config/mini-chat.yaml
@@ -195,11 +195,10 @@ modules:
       priority: 100
       model_catalog:
         # ── GPT-4.1 (Premium) ──
-        - model_id: "gpt-4.1"
+        - id: "gpt-4.1"
           provider_model_id: "gpt-4.1"
           display_name: "GPT-4.1"
           description: "Most capable model"
-          version: "4.1"
           provider_id: "azure_openai"
           provider_display_name: "Azure OpenAI"
           icon: ""
@@ -223,11 +222,11 @@ modules:
             web_search_surcharge_tokens: 500
             code_interpreter_surcharge_tokens: 1000
             minimal_generation_floor: 50
-          max_retrieved_chunks_per_turn: 5
+          max_num_results: 5
+          web_search_context_size: low
           max_tool_calls: 10
           general_config:
             type: ""
-            tier: "premium"
             available_from: "1970-01-01T00:00:00Z"
             max_file_size_mb: 25
             api_params:
@@ -238,56 +237,30 @@ modules:
               stop: []
             features:
               streaming: true
-              function_calling: true
               structured_output: true
-              fine_tuning: false
-              distillation: false
-              fim_completion: false
-              chat_prefix_completion: false
-            input_type:
-              text: true
-              image: true
-              audio: false
-              video: false
             tool_support:
               web_search: true
               file_search: true
               image_generation: false
               code_interpreter: true
-              computer_use: false
               mcp: false
             supported_endpoints:
               chat_completions: true
               responses: true
-              realtime: false
-              assistants: false
-              batch_api: false
-              fine_tuning: false
               embeddings: false
-              videos: false
               image_generation: false
-              image_edit: false
               audio_speech_generation: false
               audio_transcription: false
               audio_translation: false
-              moderations: false
-              completions: false
-            token_policy:
-              input_tokens_credit_multiplier: 3.0
-              output_tokens_credit_multiplier: 15.0
-            performance:
-              response_latency_ms: 800
-              speed_tokens_per_second: 75
           preference:
             is_default: true
             sort_order: 0
 
         # ── GPT-4.1 Mini (Standard) ──
-        - model_id: "gpt-4.1-mini"
+        - id: "gpt-4.1-mini"
           provider_model_id: "gpt-4.1-mini"
           display_name: "GPT-4.1 Mini"
           description: "Fast and efficient model"
-          version: "4.1"
           provider_id: "azure_openai"
           provider_display_name: "Azure OpenAI"
           icon: ""
@@ -311,11 +284,11 @@ modules:
             web_search_surcharge_tokens: 500
             code_interpreter_surcharge_tokens: 1000
             minimal_generation_floor: 50
-          max_retrieved_chunks_per_turn: 5
+          max_num_results: 5
+          web_search_context_size: low
           max_tool_calls: 10
           general_config:
             type: ""
-            tier: "standard"
             available_from: "1970-01-01T00:00:00Z"
             max_file_size_mb: 25
             api_params:
@@ -326,46 +299,21 @@ modules:
               stop: []
             features:
               streaming: true
-              function_calling: true
               structured_output: true
-              fine_tuning: false
-              distillation: false
-              fim_completion: false
-              chat_prefix_completion: false
-            input_type:
-              text: true
-              image: true
-              audio: false
-              video: false
             tool_support:
               web_search: false
               file_search: false
               image_generation: false
               code_interpreter: true
-              computer_use: false
               mcp: false
             supported_endpoints:
               chat_completions: true
               responses: true
-              realtime: false
-              assistants: false
-              batch_api: false
-              fine_tuning: false
               embeddings: false
-              videos: false
               image_generation: false
-              image_edit: false
               audio_speech_generation: false
               audio_transcription: false
               audio_translation: false
-              moderations: false
-              completions: false
-            token_policy:
-              input_tokens_credit_multiplier: 1.0
-              output_tokens_credit_multiplier: 3.0
-            performance:
-              response_latency_ms: 400
-              speed_tokens_per_second: 150
           preference:
             is_default: false
             sort_order: 1
@@ -373,11 +321,10 @@ modules:
         # ── GPT-4.1 Mini with tiny context (E2E thread summary testing) ──
         # Same provider model as gpt-4.1-mini but with context_window=4096
         # so the 80% compression threshold (~3200 tokens) is reachable in ~3 turns.
-        - model_id: "gpt-4.1-mini-tiny-ctx"
+        - id: "gpt-4.1-mini-tiny-ctx"
           provider_model_id: "gpt-4.1-mini"
           display_name: "GPT-4.1 Mini (Tiny Context - E2E)"
           description: "E2E testing model with small context for thread summary trigger"
-          version: "4.1"
           provider_id: "azure_openai"
           provider_display_name: "Azure OpenAI"
           icon: ""
@@ -401,11 +348,11 @@ modules:
             web_search_surcharge_tokens: 500
             code_interpreter_surcharge_tokens: 1000
             minimal_generation_floor: 50
-          max_retrieved_chunks_per_turn: 5
+          max_num_results: 5
+          web_search_context_size: low
           max_tool_calls: 10
           general_config:
             type: ""
-            tier: "standard"
             available_from: "1970-01-01T00:00:00Z"
             max_file_size_mb: 25
             api_params:
@@ -416,46 +363,21 @@ modules:
               stop: []
             features:
               streaming: true
-              function_calling: true
               structured_output: true
-              fine_tuning: false
-              distillation: false
-              fim_completion: false
-              chat_prefix_completion: false
-            input_type:
-              text: true
-              image: true
-              audio: false
-              video: false
             tool_support:
               web_search: false
               file_search: false
               image_generation: false
               code_interpreter: false
-              computer_use: false
               mcp: false
             supported_endpoints:
               chat_completions: true
               responses: true
-              realtime: false
-              assistants: false
-              batch_api: false
-              fine_tuning: false
               embeddings: false
-              videos: false
               image_generation: false
-              image_edit: false
               audio_speech_generation: false
               audio_transcription: false
               audio_translation: false
-              moderations: false
-              completions: false
-            token_policy:
-              input_tokens_credit_multiplier: 1.0
-              output_tokens_credit_multiplier: 3.0
-            performance:
-              response_latency_ms: 400
-              speed_tokens_per_second: 150
           preference:
             is_default: false
             sort_order: 99

--- a/modules/mini-chat/deploy/helm/mini-chat/templates/configmap.yaml
+++ b/modules/mini-chat/deploy/helm/mini-chat/templates/configmap.yaml
@@ -169,11 +169,10 @@ data:
           vendor: "hyperspot"
           priority: 100
           model_catalog:
-            - model_id: "gpt-4.1"
+            - id: "gpt-4.1"
               provider_model_id: "gpt-4.1"
               display_name: "GPT-4.1"
               description: "Most capable model"
-              version: "4.1"
               provider_id: "azure_openai"
               provider_display_name: "Azure OpenAI"
               icon: ""
@@ -197,11 +196,11 @@ data:
                 web_search_surcharge_tokens: 500
                 code_interpreter_surcharge_tokens: 1000
                 minimal_generation_floor: 50
-              max_retrieved_chunks_per_turn: 5
+              max_num_results: 5
+              web_search_context_size: low
               max_tool_calls: 10
               general_config:
                 type: ""
-                tier: "premium"
                 available_from: "1970-01-01T00:00:00Z"
                 max_file_size_mb: 25
                 api_params:
@@ -212,55 +211,29 @@ data:
                   stop: []
                 features:
                   streaming: true
-                  function_calling: true
                   structured_output: true
-                  fine_tuning: false
-                  distillation: false
-                  fim_completion: false
-                  chat_prefix_completion: false
-                input_type:
-                  text: true
-                  image: true
-                  audio: false
-                  video: false
                 tool_support:
                   web_search: true
                   file_search: true
                   image_generation: false
                   code_interpreter: true
-                  computer_use: false
                   mcp: false
                 supported_endpoints:
                   chat_completions: true
                   responses: true
-                  realtime: false
-                  assistants: false
-                  batch_api: false
-                  fine_tuning: false
                   embeddings: false
-                  videos: false
                   image_generation: false
-                  image_edit: false
                   audio_speech_generation: false
                   audio_transcription: false
                   audio_translation: false
-                  moderations: false
-                  completions: false
-                token_policy:
-                  input_tokens_credit_multiplier: 3.0
-                  output_tokens_credit_multiplier: 15.0
-                performance:
-                  response_latency_ms: 800
-                  speed_tokens_per_second: 75
               preference:
                 is_default: true
                 sort_order: 0
 
-            - model_id: "gpt-4.1-mini"
+            - id: "gpt-4.1-mini"
               provider_model_id: "gpt-4.1-mini"
               display_name: "GPT-4.1 Mini"
               description: "Fast and efficient model"
-              version: "4.1"
               provider_id: "azure_openai"
               provider_display_name: "Azure OpenAI"
               icon: ""
@@ -284,11 +257,11 @@ data:
                 web_search_surcharge_tokens: 500
                 code_interpreter_surcharge_tokens: 1000
                 minimal_generation_floor: 50
-              max_retrieved_chunks_per_turn: 5
+              max_num_results: 5
+              web_search_context_size: low
               max_tool_calls: 10
               general_config:
                 type: ""
-                tier: "standard"
                 available_from: "1970-01-01T00:00:00Z"
                 max_file_size_mb: 25
                 api_params:
@@ -299,55 +272,29 @@ data:
                   stop: []
                 features:
                   streaming: true
-                  function_calling: true
                   structured_output: true
-                  fine_tuning: false
-                  distillation: false
-                  fim_completion: false
-                  chat_prefix_completion: false
-                input_type:
-                  text: true
-                  image: true
-                  audio: false
-                  video: false
                 tool_support:
                   web_search: false
                   file_search: false
                   image_generation: false
                   code_interpreter: true
-                  computer_use: false
                   mcp: false
                 supported_endpoints:
                   chat_completions: true
                   responses: true
-                  realtime: false
-                  assistants: false
-                  batch_api: false
-                  fine_tuning: false
                   embeddings: false
-                  videos: false
                   image_generation: false
-                  image_edit: false
                   audio_speech_generation: false
                   audio_transcription: false
                   audio_translation: false
-                  moderations: false
-                  completions: false
-                token_policy:
-                  input_tokens_credit_multiplier: 1.0
-                  output_tokens_credit_multiplier: 3.0
-                performance:
-                  response_latency_ms: 400
-                  speed_tokens_per_second: 150
               preference:
                 is_default: false
                 sort_order: 1
 
-            - model_id: "qwen3-0.6b"
+            - id: "qwen3-0.6b"
               provider_model_id: "Qwen/Qwen3-0.6B"
               display_name: "Qwen3 0.6B (vLLM local)"
               description: "Local vLLM model for development"
-              version: "3.0"
               provider_id: "vllm_local"
               provider_display_name: "vLLM Local"
               icon: ""
@@ -371,11 +318,11 @@ data:
                 web_search_surcharge_tokens: 0
                 code_interpreter_surcharge_tokens: 0
                 minimal_generation_floor: 50
-              max_retrieved_chunks_per_turn: 0
+              max_num_results: 0
+              web_search_context_size: low
               max_tool_calls: 0
               general_config:
                 type: ""
-                tier: "standard"
                 available_from: "1970-01-01T00:00:00Z"
                 max_file_size_mb: 0
                 api_params:
@@ -386,56 +333,30 @@ data:
                   stop: []
                 features:
                   streaming: true
-                  function_calling: false
                   structured_output: false
-                  fine_tuning: false
-                  distillation: false
-                  fim_completion: false
-                  chat_prefix_completion: false
-                input_type:
-                  text: true
-                  image: false
-                  audio: false
-                  video: false
                 tool_support:
                   web_search: false
                   file_search: false
                   image_generation: false
                   code_interpreter: false
-                  computer_use: false
                   mcp: false
                 supported_endpoints:
                   chat_completions: true
                   responses: true
-                  realtime: false
-                  assistants: false
-                  batch_api: false
-                  fine_tuning: false
                   embeddings: false
-                  videos: false
                   image_generation: false
-                  image_edit: false
                   audio_speech_generation: false
                   audio_transcription: false
                   audio_translation: false
-                  moderations: false
-                  completions: false
-                token_policy:
-                  input_tokens_credit_multiplier: 0.0
-                  output_tokens_credit_multiplier: 0.0
-                performance:
-                  response_latency_ms: 200
-                  speed_tokens_per_second: 200
               preference:
                 is_default: false
                 sort_order: 2
 
             # ── GPT-4.1 Mini with tiny context (E2E thread summary testing) ──
-            - model_id: "gpt-4.1-mini-tiny-ctx"
+            - id: "gpt-4.1-mini-tiny-ctx"
               provider_model_id: "gpt-4.1-mini"
               display_name: "GPT-4.1 Mini (Tiny Context - E2E)"
               description: "E2E testing model with small context for thread summary trigger"
-              version: "4.1"
               provider_id: "azure_openai"
               provider_display_name: "Azure OpenAI"
               icon: ""
@@ -459,11 +380,11 @@ data:
                 web_search_surcharge_tokens: 500
                 code_interpreter_surcharge_tokens: 1000
                 minimal_generation_floor: 50
-              max_retrieved_chunks_per_turn: 5
+              max_num_results: 5
+              web_search_context_size: low
               max_tool_calls: 10
               general_config:
                 type: ""
-                tier: "standard"
                 available_from: "1970-01-01T00:00:00Z"
                 max_file_size_mb: 25
                 api_params:
@@ -474,46 +395,21 @@ data:
                   stop: []
                 features:
                   streaming: true
-                  function_calling: true
                   structured_output: true
-                  fine_tuning: false
-                  distillation: false
-                  fim_completion: false
-                  chat_prefix_completion: false
-                input_type:
-                  text: true
-                  image: true
-                  audio: false
-                  video: false
                 tool_support:
                   web_search: false
                   file_search: false
                   image_generation: false
                   code_interpreter: false
-                  computer_use: false
                   mcp: false
                 supported_endpoints:
                   chat_completions: true
                   responses: true
-                  realtime: false
-                  assistants: false
-                  batch_api: false
-                  fine_tuning: false
                   embeddings: false
-                  videos: false
                   image_generation: false
-                  image_edit: false
                   audio_speech_generation: false
                   audio_transcription: false
                   audio_translation: false
-                  moderations: false
-                  completions: false
-                token_policy:
-                  input_tokens_credit_multiplier: 1.0
-                  output_tokens_credit_multiplier: 3.0
-                performance:
-                  response_latency_ms: 400
-                  speed_tokens_per_second: 150
               preference:
                 is_default: false
                 sort_order: 99

--- a/modules/mini-chat/docs/DESIGN.md
+++ b/modules/mini-chat/docs/DESIGN.md
@@ -4057,8 +4057,8 @@ Contents (logically):
   - `description` (user-facing help text; used by Models API)
   - `multimodal_capabilities` (array of capability flags, e.g. `["VISION_INPUT", "RAG"]`; used by Models API)
   - `context_window` (integer; max context tokens; used by Models API and token budget computation)
-  - `input_tokens_credit_multiplier` (micro-credits per 1K tokens; > 0 always)
-  - `output_tokens_credit_multiplier` (micro-credits per 1K tokens; > 0 always)
+  - `input_tokens_credit_multiplier_micro` (micro-credits per 1K tokens; > 0 always)
+  - `output_tokens_credit_multiplier_micro` (micro-credits per 1K tokens; > 0 always)
   - `multiplier_display` (human-readable, e.g. `"1x"`, `"2x"`; used by Models API)
 
 - `estimation_budgets` (fixed surcharge token budgets for preflight reserve estimation):
@@ -4305,10 +4305,10 @@ Where:
 
 **Rounding rule (normative)**: `ceil_div` is applied **per-component** (input and output separately), NOT to the sum. This ensures deterministic results regardless of the ratio between input and output tokens. `ceil_div(a, 1000) + ceil_div(b, 1000)` may differ from `ceil_div(a + b, 1000)` by up to 1 micro-credit — this is intentional and consistent.
 
-**Note on zero multipliers**: if a model had `input_tokens_credit_multiplier = 0` and `output_tokens_credit_multiplier = 0`, then the system would not debit credits and a credit-based quota would not be consumed, which effectively creates unlimited usage. Therefore, in a credit-based enforcement model:
+**Note on zero multipliers**: if a model had `input_tokens_credit_multiplier_micro = 0` and `output_tokens_credit_multiplier_micro = 0`, then the system would not debit credits and a credit-based quota would not be consumed, which effectively creates unlimited usage. Therefore, in a credit-based enforcement model:
 
-- `input_tokens_credit_multiplier > 0` always
-- `output_tokens_credit_multiplier > 0` always
+- `input_tokens_credit_multiplier_micro > 0` always
+- `output_tokens_credit_multiplier_micro > 0` always
 
 #### Overflow Protection (Normative)
 
@@ -5043,8 +5043,8 @@ reserved_credits_micro =
 
 Where:
 
-- `in_mult` = `input_tokens_credit_multiplier` > 0 (always)
-- `out_mult` = `output_tokens_credit_multiplier` > 0 (always)
+- `in_mult` = `input_tokens_credit_multiplier_micro` > 0 (always)
+- `out_mult` = `output_tokens_credit_multiplier_micro` > 0 (always)
 - `max_output_tokens_applied` = the `max_output_tokens` value persisted on `chat_turns` for this turn
 
 #### 5.5.8 Limit Checks and max_output_tokens
@@ -6272,7 +6272,7 @@ A monotonic, strictly increasing integer that identifies a specific immutable po
 
 **Bump Triggers**:
 - Changes to model catalog
-- Changes to credit multipliers (`input_tokens_credit_multiplier`, `output_tokens_credit_multiplier`)
+- Changes to credit multipliers (`input_tokens_credit_multiplier_micro`, `output_tokens_credit_multiplier_micro`)
 - Changes to kill switches (`disable_premium_tier`, `force_standard_tier`, `disable_web_search`, `disable_code_interpreter`, `disable_file_search`, `disable_images`)
 - User allocation logic changes affecting `GetUserLimits` output
 - User entitlements/plan changes
@@ -6570,13 +6570,11 @@ All fields below are per-model entries inside the catalog.
 | `context_window` | `integer` | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].context_window` |
 | `max_output` | `integer` | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].max_output_tokens` |
 | `is_default` | `bool` | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].is_default` |
-| `input_tokens_credit_multiplier` | `number` | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].general_config.token_policy.input_tokens_credit_multiplier` and `input_tokens_credit_multiplier_micro` |
-| `output_tokens_credit_multiplier` | `number` | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].general_config.token_policy.output_tokens_credit_multiplier` and `output_tokens_credit_multiplier_micro` |
+| `input_tokens_credit_multiplier` | `number` | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].input_tokens_credit_multiplier_micro` |
+| `output_tokens_credit_multiplier` | `number` | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].output_tokens_credit_multiplier_micro` |
 | `api_params.*` | object | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].general_config.api_params` |
 | `features.*` | object | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].general_config.features` |
-| `input_type.*` | object | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].general_config.input_type` |
 | `tool_support.*` | object | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].general_config.tool_support` |
-| `supported_endpoints.*` | object | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].general_config.supported_endpoints` |
 | `sort_order` | `integer` | **CCM API**: `GET /policies/{v}` | `snapshot.model_catalog[].preference.sort_order` |
 
 ### B.2.3 Kill switches / emergency flags

--- a/modules/mini-chat/mini-chat-sdk/Cargo.toml
+++ b/modules/mini-chat/mini-chat-sdk/Cargo.toml
@@ -25,6 +25,7 @@ uuid = { workspace = true }
 time = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+utoipa = { workspace = true }
 schemars = { workspace = true }
 gts = { workspace = true }
 gts-macros = { workspace = true }

--- a/modules/mini-chat/mini-chat-sdk/src/models.rs
+++ b/modules/mini-chat/mini-chat-sdk/src/models.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
+use utoipa::ToSchema;
 use uuid::Uuid;
 
 /// Current policy version metadata for a user.
@@ -35,8 +36,8 @@ pub struct KillSwitches {
 /// A single model in the catalog (API: `PolicyModelCatalogItem`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelCatalogEntry {
-    /// Provider-level model identifier (e.g. "gpt-4").
-    pub model_id: String,
+    /// model identifier (e.g. "`gts.x.cyber_chat.llm.provider.v1.0~x.core.cyber_chat.azure_openai.v1.0`").
+    pub id: String,
     /// The model ID on the provider side (e.g., `"gpt-5.2"` for `OpenAI`,
     /// `"claude-opus-4-6"` for Anthropic). Sent in LLM API requests.
     pub provider_model_id: String,
@@ -45,9 +46,6 @@ pub struct ModelCatalogEntry {
     /// Short description of the model.
     #[serde(default)]
     pub description: String,
-    /// Model version string.
-    #[serde(default)]
-    pub version: String,
     /// LLM provider CTI identifier.
     pub provider_id: String,
     /// Routing identifier for provider resolution. Maps to a key in
@@ -80,7 +78,10 @@ pub struct ModelCatalogEntry {
     #[serde(default)]
     pub estimation_budgets: EstimationBudgets,
     /// Top-k chunks returned by similarity search per `file_search` call.
-    pub max_retrieved_chunks_per_turn: u32,
+    pub max_num_results: u32,
+    /// Search context size hint for the web search provider.
+    #[serde(default)]
+    pub web_search_context_size: WebSearchContextSize,
     /// Maximum tool calls the provider may make per request.
     #[serde(default = "default_max_tool_calls")]
     pub max_tool_calls: u32,
@@ -158,26 +159,20 @@ pub struct ModelApiParams {
 }
 
 /// Feature capability flags (API: `PolicyModelFeatures`).
-#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelFeatures {
     pub streaming: bool,
-    pub function_calling: bool,
     pub structured_output: bool,
-    pub fine_tuning: bool,
-    pub distillation: bool,
-    pub fim_completion: bool,
-    pub chat_prefix_completion: bool,
 }
 
-/// Supported input modalities (API: `PolicyModelInputType`).
-#[allow(clippy::struct_excessive_bools)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModelInputType {
-    pub text: bool,
-    pub image: bool,
-    pub audio: bool,
-    pub video: bool,
+/// Search context size hint passed to the web search provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum WebSearchContextSize {
+    #[default]
+    Low,
+    Medium,
+    High,
 }
 
 /// Tool support flags (API: `PolicyModelToolSupport`).
@@ -188,7 +183,6 @@ pub struct ModelToolSupport {
     pub file_search: bool,
     pub image_generation: bool,
     pub code_interpreter: bool,
-    pub computer_use: bool,
     pub mcp: bool,
 }
 
@@ -198,33 +192,11 @@ pub struct ModelToolSupport {
 pub struct ModelSupportedEndpoints {
     pub chat_completions: bool,
     pub responses: bool,
-    pub realtime: bool,
-    pub assistants: bool,
-    pub batch_api: bool,
-    pub fine_tuning: bool,
     pub embeddings: bool,
-    pub videos: bool,
     pub image_generation: bool,
-    pub image_edit: bool,
     pub audio_speech_generation: bool,
     pub audio_transcription: bool,
     pub audio_translation: bool,
-    pub moderations: bool,
-    pub completions: bool,
-}
-
-/// Token credit multipliers (API: `PolicyModelTokenPolicy`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModelTokenPolicy {
-    pub input_tokens_credit_multiplier: f64,
-    pub output_tokens_credit_multiplier: f64,
-}
-
-/// Estimated performance characteristics (API: `PolicyModelPerformance`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModelPerformance {
-    pub response_latency_ms: u32,
-    pub speed_tokens_per_second: u32,
 }
 
 /// General configuration from Settings Service (API: `PolicyModelGeneralConfig`).
@@ -238,11 +210,8 @@ pub struct ModelGeneralConfig {
     pub max_file_size_mb: u32,
     pub api_params: ModelApiParams,
     pub features: ModelFeatures,
-    pub input_type: ModelInputType,
     pub tool_support: ModelToolSupport,
     pub supported_endpoints: ModelSupportedEndpoints,
-    pub token_policy: ModelTokenPolicy,
-    pub performance: ModelPerformance,
 }
 
 /// Per-tenant preference settings (API: `PolicyModelPreference`).
@@ -256,8 +225,7 @@ pub struct ModelPreference {
 /// Model pricing/capability tier.
 ///
 /// Serializes as `"Standard"` / `"Premium"` (`PascalCase`).
-/// Accepts lowercase aliases (`"standard"`, `"premium"`) on deserialization
-/// for compatibility with CCM and DESIGN maps.
+/// Accepts lowercase aliases (`"standard"`, `"premium"`) on deserialization.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ModelTier {
     #[serde(alias = "standard")]
@@ -389,11 +357,10 @@ mod tests {
 
     fn sample_catalog_entry() -> ModelCatalogEntry {
         ModelCatalogEntry {
-            model_id: "test-model".to_owned(),
+            id: "test-model".to_owned(),
             provider_model_id: "test-model-v1".to_owned(),
             display_name: "Test Model".to_owned(),
             description: String::new(),
-            version: String::new(),
             provider_id: "default".to_owned(),
             provider_display_name: "Default".to_owned(),
             icon: String::new(),
@@ -407,7 +374,8 @@ mod tests {
             output_tokens_credit_multiplier_micro: 3_000_000,
             multiplier_display: "1x".to_owned(),
             estimation_budgets: EstimationBudgets::default(),
-            max_retrieved_chunks_per_turn: 5,
+            max_num_results: 5,
+            web_search_context_size: WebSearchContextSize::Low,
             max_tool_calls: 2,
             general_config: sample_general_config(),
             preference: Some(ModelPreference {
@@ -435,51 +403,23 @@ mod tests {
             },
             features: ModelFeatures {
                 streaming: true,
-                function_calling: false,
                 structured_output: false,
-                fine_tuning: false,
-                distillation: false,
-                fim_completion: false,
-                chat_prefix_completion: false,
-            },
-            input_type: ModelInputType {
-                text: true,
-                image: false,
-                audio: false,
-                video: false,
             },
             tool_support: ModelToolSupport {
                 web_search: false,
                 file_search: false,
                 image_generation: false,
                 code_interpreter: false,
-                computer_use: false,
                 mcp: false,
             },
             supported_endpoints: ModelSupportedEndpoints {
                 chat_completions: true,
                 responses: false,
-                realtime: false,
-                assistants: false,
-                batch_api: false,
-                fine_tuning: false,
                 embeddings: false,
-                videos: false,
                 image_generation: false,
-                image_edit: false,
                 audio_speech_generation: false,
                 audio_transcription: false,
                 audio_translation: false,
-                moderations: false,
-                completions: false,
-            },
-            token_policy: ModelTokenPolicy {
-                input_tokens_credit_multiplier: 1.0,
-                output_tokens_credit_multiplier: 3.0,
-            },
-            performance: ModelPerformance {
-                response_latency_ms: 500,
-                speed_tokens_per_second: 100,
             },
         }
     }
@@ -527,7 +467,6 @@ mod tests {
 
         let entry: ModelCatalogEntry = serde_json::from_value(json).unwrap();
         assert!(entry.description.is_empty());
-        assert!(entry.version.is_empty());
         assert!(entry.icon.is_empty());
         assert!(!entry.enabled);
         assert!(entry.preference.is_none());
@@ -611,7 +550,7 @@ mod tests {
 
     // ── ModelTier serde representation ──
     // Serializes as PascalCase ("Standard"/"Premium") for the UI/API.
-    // Accepts lowercase aliases for CCM/DESIGN compatibility.
+    // Accepts lowercase aliases.
 
     #[test]
     fn model_tier_serializes_as_pascal_case() {

--- a/modules/mini-chat/mini-chat/src/domain/llm.rs
+++ b/modules/mini-chat/mini-chat/src/domain/llm.rs
@@ -194,16 +194,7 @@ pub struct Citation {
     pub span: Option<TextSpan>,
 }
 
-/// How much context the web search tool should use.
-#[domain_model]
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum WebSearchContextSize {
-    #[default]
-    Low,
-    Medium,
-    High,
-}
+pub use mini_chat_sdk::models::WebSearchContextSize;
 
 /// Whether a citation came from a file or web search.
 #[domain_model]

--- a/modules/mini-chat/mini-chat/src/domain/model/quota.rs
+++ b/modules/mini-chat/mini-chat/src/domain/model/quota.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 use crate::config::EstimationBudgets;
 use crate::infra::db::entity::quota_usage::PeriodType;
-use mini_chat_sdk::{ModelApiParams, ModelToolSupport};
+use mini_chat_sdk::{ModelApiParams, ModelToolSupport, models::WebSearchContextSize};
 
 /// Result of preflight reserve evaluation.
 #[domain_model]
@@ -26,14 +26,16 @@ pub enum PreflightDecision {
         max_input_tokens: u32,
         /// Per-model estimation budgets from the effective model's catalog entry.
         estimation_budgets: EstimationBudgets,
-        /// Top-k chunks for `file_search` (from `ModelCatalogEntry`).
-        max_retrieved_chunks_per_turn: u32,
+        /// Max results per `file_search` call (from `ModelCatalogEntry`).
+        file_search_max_num_results: u32,
         /// Max tool calls per request (from `ModelCatalogEntry`).
         max_tool_calls: u32,
         /// Tool support flags of the effective model.
         tool_support: ModelToolSupport,
         /// LLM API inference parameters (temperature, `top_p`, etc.).
         api_params: ModelApiParams,
+        /// Web search context size hint (from `ModelCatalogEntry`).
+        web_search_context_size: WebSearchContextSize,
     },
     Downgrade {
         effective_model: String,
@@ -54,14 +56,16 @@ pub enum PreflightDecision {
         max_input_tokens: u32,
         /// Per-model estimation budgets from the effective model's catalog entry.
         estimation_budgets: EstimationBudgets,
-        /// Top-k chunks for `file_search` (from `ModelCatalogEntry`).
-        max_retrieved_chunks_per_turn: u32,
+        /// Max results per `file_search` call (from `ModelCatalogEntry`).
+        file_search_max_num_results: u32,
         /// Max tool calls per request (from `ModelCatalogEntry`).
         max_tool_calls: u32,
         /// Tool support flags of the effective model.
         tool_support: ModelToolSupport,
         /// LLM API inference parameters (temperature, `top_p`, etc.).
         api_params: ModelApiParams,
+        /// Web search context size hint (from `ModelCatalogEntry`).
+        web_search_context_size: WebSearchContextSize,
     },
     Reject {
         error_code: String,

--- a/modules/mini-chat/mini-chat/src/domain/models.rs
+++ b/modules/mini-chat/mini-chat/src/domain/models.rs
@@ -181,7 +181,7 @@ pub struct ResolvedModel {
 impl From<&mini_chat_sdk::ModelCatalogEntry> for ResolvedModel {
     fn from(e: &mini_chat_sdk::ModelCatalogEntry) -> Self {
         Self {
-            model_id: e.model_id.clone(),
+            model_id: e.id.clone(),
             provider_model_id: e.provider_model_id.clone(),
             provider_id: e.provider_id.clone(),
             display_name: e.display_name.clone(),

--- a/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/quota_service.rs
@@ -256,7 +256,7 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
         let ks = &ctx.snapshot.kill_switches;
 
         // 1. Look up selected model
-        let selected_entry = catalog.iter().find(|m| m.model_id == selected_model);
+        let selected_entry = catalog.iter().find(|m| m.id == selected_model);
 
         let (selected_tier, mut downgrade_reason) = match selected_entry {
             Some(e) if e.enabled => (e.tier, None),
@@ -324,7 +324,7 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
             let tier_matches = |m: &&ModelCatalogEntry| m.tier == tier && m.enabled;
             let model = catalog
                 .iter()
-                .find(|m| tier_matches(m) && m.model_id == selected_model)
+                .find(|m| tier_matches(m) && m.id == selected_model)
                 .or_else(|| {
                     catalog
                         .iter()
@@ -338,14 +338,14 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
             };
 
             // 3e. Decision
-            if effective.model_id == selected_model && downgrade_reason.is_none() {
+            if effective.id == selected_model && downgrade_reason.is_none() {
                 return CascadeDecision::Allow {
-                    effective_model: effective.model_id.clone(),
+                    effective_model: effective.id.clone(),
                     tier,
                 };
             }
             return CascadeDecision::Downgrade {
-                effective_model: effective.model_id.clone(),
+                effective_model: effective.id.clone(),
                 tier,
                 downgrade_from: selected_model.to_owned(),
                 reason: downgrade_reason.unwrap_or(DowngradeReason::PremiumQuotaExhausted),
@@ -475,7 +475,7 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
         let catalog_entry = snapshot
             .model_catalog
             .iter()
-            .find(|m| m.model_id == input.selected_model && m.enabled);
+            .find(|m| m.id == input.selected_model && m.enabled);
 
         let (in_mult, out_mult) = catalog_entry.map_or(
             (1_000_000, 1_000_000), // fallback for disabled models
@@ -589,7 +589,7 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                             let eff_entry = snapshot
                                 .model_catalog
                                 .iter()
-                                .find(|m| m.model_id == effective_model)
+                                .find(|m| m.id == effective_model)
                                 .ok_or_else(|| {
                                     to_db(DomainError::internal("effective model not in catalog"))
                                 })?;
@@ -717,11 +717,11 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                                     context_window: eff_entry.context_window,
                                     max_input_tokens: eff_entry.max_input_tokens,
                                     estimation_budgets: model_estimation_budgets,
-                                    max_retrieved_chunks_per_turn: eff_entry
-                                        .max_retrieved_chunks_per_turn,
+                                    file_search_max_num_results: eff_entry.max_num_results,
                                     max_tool_calls: eff_entry.max_tool_calls,
                                     tool_support: eff_entry.general_config.tool_support.clone(),
                                     api_params: eff_entry.general_config.api_params.clone(),
+                                    web_search_context_size: eff_entry.web_search_context_size,
                                 },
                                 CascadeDecision::Downgrade {
                                     downgrade_from,
@@ -743,11 +743,11 @@ impl<QR: QuotaUsageRepository + 'static> QuotaService<QR> {
                                     context_window: eff_entry.context_window,
                                     max_input_tokens: eff_entry.max_input_tokens,
                                     estimation_budgets: model_estimation_budgets,
-                                    max_retrieved_chunks_per_turn: eff_entry
-                                        .max_retrieved_chunks_per_turn,
+                                    file_search_max_num_results: eff_entry.max_num_results,
                                     max_tool_calls: eff_entry.max_tool_calls,
                                     tool_support: eff_entry.general_config.tool_support.clone(),
                                     api_params: eff_entry.general_config.api_params.clone(),
+                                    web_search_context_size: eff_entry.web_search_context_size,
                                 },
                                 CascadeDecision::Reject => unreachable!(),
                             };
@@ -887,7 +887,7 @@ impl<QR: QuotaUsageRepository> QuotaService<QR> {
         let catalog_entry = snapshot
             .model_catalog
             .iter()
-            .find(|m| m.model_id == input.effective_model)
+            .find(|m| m.id == input.effective_model)
             .ok_or_else(|| {
                 DomainError::internal(format!(
                     "model {} not found in policy version {}",

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/mod.rs
@@ -519,8 +519,8 @@ impl<
                 file_search_enabled,
                 &vector_store_ids,
                 None, // file_search_filters: wired by P4-6
-                self.streaming_config.web_search_context_size,
-                pf.max_retrieved_chunks_per_turn,
+                pf.web_search_context_size,
+                pf.file_search_max_num_results,
                 ci_file_ids,
                 token_budget,
                 &image_file_ids,
@@ -1235,8 +1235,8 @@ impl<
                 file_search_enabled,
                 &vector_store_ids,
                 None, // file_search_filters: wired by P4-6
-                self.streaming_config.web_search_context_size,
-                pf.max_retrieved_chunks_per_turn,
+                pf.web_search_context_size,
+                pf.file_search_max_num_results,
                 ci_file_ids,
                 token_budget,
                 &[], // retry/edit: no new image attachments
@@ -2148,7 +2148,6 @@ mod tests {
                 file_search: false,
                 image_generation: false,
                 code_interpreter: false,
-                computer_use: false,
                 mcp: false,
             },
             thread_summary_prompt: String::new(),
@@ -2600,14 +2599,13 @@ mod tests {
             context_window: 128_000,
             max_input_tokens: 65_536,
             estimation_budgets: EstimationBudgets::default(),
-            max_retrieved_chunks_per_turn: 5,
+            file_search_max_num_results: 4,
             max_tool_calls: 2,
             tool_support: mini_chat_sdk::ModelToolSupport {
                 web_search: false,
                 file_search: false,
                 image_generation: false,
                 code_interpreter: false,
-                computer_use: false,
                 mcp: false,
             },
             api_params: mini_chat_sdk::ModelApiParams {
@@ -2619,11 +2617,32 @@ mod tests {
                 extra_body: None,
                 reasoning_effort: None,
             },
+            web_search_context_size: mini_chat_sdk::models::WebSearchContextSize::Low,
         };
 
         let result = flatten_preflight(decision).expect("Allow should produce Ok");
         assert_eq!(result.max_input_tokens, 65_536);
         assert_eq!(result.context_window, 128_000);
+        assert_eq!(result.quota_decision, "allow");
+        assert!(result.downgrade_from.is_none());
+        assert!(result.downgrade_reason.is_none());
+        assert_eq!(result.reserve_tokens, 100);
+        assert_eq!(result.max_output_tokens_applied, 1024);
+        assert_eq!(result.reserved_credits_micro, 0);
+        assert_eq!(result.policy_version_applied, 1);
+        assert_eq!(result.minimal_generation_floor_applied, 50);
+        assert_eq!(result.system_prompt, "");
+        assert_eq!(
+            result.estimation_budgets.bytes_per_token_conservative,
+            EstimationBudgets::default().bytes_per_token_conservative,
+        );
+        assert_eq!(result.file_search_max_num_results, 4);
+        assert_eq!(result.max_tool_calls, 2);
+        assert!((result.api_params.temperature - 0.7).abs() < f64::EPSILON);
+        assert_eq!(
+            result.web_search_context_size,
+            mini_chat_sdk::models::WebSearchContextSize::Low,
+        );
     }
 
     /// `max_input_tokens` from `PreflightDecision::Downgrade` reaches `PreflightResult`.
@@ -2646,14 +2665,13 @@ mod tests {
             context_window: 32_000,
             max_input_tokens: 16_000,
             estimation_budgets: EstimationBudgets::default(),
-            max_retrieved_chunks_per_turn: 5,
+            file_search_max_num_results: 4,
             max_tool_calls: 2,
             tool_support: mini_chat_sdk::ModelToolSupport {
                 web_search: false,
                 file_search: false,
                 image_generation: false,
                 code_interpreter: false,
-                computer_use: false,
                 mcp: false,
             },
             api_params: mini_chat_sdk::ModelApiParams {
@@ -2665,12 +2683,32 @@ mod tests {
                 extra_body: None,
                 reasoning_effort: None,
             },
+            web_search_context_size: mini_chat_sdk::models::WebSearchContextSize::Low,
         };
 
         let result = flatten_preflight(decision).expect("Downgrade should produce Ok");
         assert_eq!(result.max_input_tokens, 16_000);
         assert_eq!(result.context_window, 32_000);
         assert_eq!(result.quota_decision, "downgrade");
+        assert_eq!(result.downgrade_from.as_deref(), Some("m"));
+        assert!(result.downgrade_reason.is_some());
+        assert_eq!(result.reserve_tokens, 50);
+        assert_eq!(result.max_output_tokens_applied, 512);
+        assert_eq!(result.reserved_credits_micro, 0);
+        assert_eq!(result.policy_version_applied, 1);
+        assert_eq!(result.minimal_generation_floor_applied, 50);
+        assert_eq!(result.system_prompt, "");
+        assert_eq!(
+            result.estimation_budgets.bytes_per_token_conservative,
+            EstimationBudgets::default().bytes_per_token_conservative,
+        );
+        assert_eq!(result.file_search_max_num_results, 4);
+        assert_eq!(result.max_tool_calls, 2);
+        assert!((result.api_params.temperature - 0.7).abs() < f64::EPSILON);
+        assert_eq!(
+            result.web_search_context_size,
+            mini_chat_sdk::models::WebSearchContextSize::Low,
+        );
     }
 
     // ── InputTooLong integration tests ──
@@ -3968,7 +4006,6 @@ mod tests {
                         file_search: false,
                         image_generation: false,
                         code_interpreter: false,
-                        computer_use: false,
                         mcp: false,
                     },
                     thread_summary_prompt: String::new(),
@@ -4133,7 +4170,6 @@ mod tests {
                         file_search: false,
                         image_generation: false,
                         code_interpreter: false,
-                        computer_use: false,
                         mcp: false,
                     },
                     thread_summary_prompt: String::new(),

--- a/modules/mini-chat/mini-chat/src/domain/service/stream_service/types.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/stream_service/types.rs
@@ -380,10 +380,11 @@ pub(super) struct PreflightResult {
     pub(super) context_window: u32,
     pub(super) max_input_tokens: u32,
     pub(super) estimation_budgets: crate::config::EstimationBudgets,
-    pub(super) max_retrieved_chunks_per_turn: u32,
+    pub(super) file_search_max_num_results: u32,
     pub(super) max_tool_calls: u32,
     pub(super) tool_support: mini_chat_sdk::ModelToolSupport,
     pub(super) api_params: mini_chat_sdk::ModelApiParams,
+    pub(super) web_search_context_size: mini_chat_sdk::models::WebSearchContextSize,
 }
 
 /// Convert a `PreflightDecision` into a flat `PreflightResult` or a `StreamError`.
@@ -404,10 +405,11 @@ pub(super) fn flatten_preflight(
             context_window,
             max_input_tokens,
             estimation_budgets,
-            max_retrieved_chunks_per_turn,
+            file_search_max_num_results,
             max_tool_calls,
             tool_support,
             api_params,
+            web_search_context_size,
             ..
         } => Ok(PreflightResult {
             effective_model,
@@ -424,10 +426,11 @@ pub(super) fn flatten_preflight(
             context_window,
             max_input_tokens,
             estimation_budgets,
-            max_retrieved_chunks_per_turn,
+            file_search_max_num_results,
             max_tool_calls,
             tool_support,
             api_params,
+            web_search_context_size,
         }),
         PreflightDecision::Downgrade {
             effective_model,
@@ -443,10 +446,11 @@ pub(super) fn flatten_preflight(
             context_window,
             max_input_tokens,
             estimation_budgets,
-            max_retrieved_chunks_per_turn,
+            file_search_max_num_results,
             max_tool_calls,
             tool_support,
             api_params,
+            web_search_context_size,
             ..
         } => Ok(PreflightResult {
             effective_model,
@@ -463,10 +467,11 @@ pub(super) fn flatten_preflight(
             context_window,
             max_input_tokens,
             estimation_budgets,
-            max_retrieved_chunks_per_turn,
+            file_search_max_num_results,
             max_tool_calls,
             tool_support,
             api_params,
+            web_search_context_size,
         }),
         PreflightDecision::Reject {
             error_code,

--- a/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/test_helpers.rs
@@ -200,7 +200,7 @@ impl ModelResolver for MockModelResolver {
             }
             Some(m) if m.is_empty() => Err(DomainError::invalid_model("model must not be empty")),
             Some(m) => {
-                let entry = catalog.iter().find(|e| e.model_id == m && e.enabled);
+                let entry = catalog.iter().find(|e| e.id == m && e.enabled);
                 match entry {
                     Some(e) => Ok(ResolvedModel::from(e)),
                     None => Err(DomainError::invalid_model(&m)),
@@ -226,7 +226,7 @@ impl ModelResolver for MockModelResolver {
         let catalog = self.catalog.lock().unwrap();
         catalog
             .iter()
-            .find(|m| m.model_id == model_id && m.enabled)
+            .find(|m| m.id == model_id && m.enabled)
             .map(ResolvedModel::from)
             .ok_or_else(|| DomainError::model_not_found(model_id))
     }
@@ -430,24 +430,15 @@ pub struct TestCatalogEntryParams {
 }
 
 /// Build a [`ModelCatalogEntry`] for tests, filling in new required fields with defaults.
-#[allow(clippy::cast_precision_loss)]
 pub fn test_catalog_entry(params: TestCatalogEntryParams) -> ModelCatalogEntry {
     use mini_chat_sdk::models::*;
     use time::OffsetDateTime;
 
-    let input_mult = params.input_tokens_credit_multiplier_micro as f64 / 1_000_000.0;
-    let output_mult = params.output_tokens_credit_multiplier_micro as f64 / 1_000_000.0;
-    let has_vision = params
-        .multimodal_capabilities
-        .iter()
-        .any(|c| c == "VISION_INPUT");
-
     ModelCatalogEntry {
-        model_id: params.model_id,
+        id: params.model_id,
         provider_model_id: params.provider_model_id,
         display_name: params.display_name,
         description: params.description,
-        version: String::new(),
         provider_id: params.provider_id,
         provider_display_name: params.provider_display_name,
         icon: String::new(),
@@ -461,7 +452,8 @@ pub fn test_catalog_entry(params: TestCatalogEntryParams) -> ModelCatalogEntry {
         output_tokens_credit_multiplier_micro: params.output_tokens_credit_multiplier_micro,
         multiplier_display: params.multiplier_display.clone(),
         estimation_budgets: EstimationBudgets::default(),
-        max_retrieved_chunks_per_turn: 5,
+        max_num_results: 5,
+        web_search_context_size: WebSearchContextSize::Low,
         max_tool_calls: 2,
         general_config: ModelGeneralConfig {
             config_type: String::new(),
@@ -478,51 +470,23 @@ pub fn test_catalog_entry(params: TestCatalogEntryParams) -> ModelCatalogEntry {
             },
             features: ModelFeatures {
                 streaming: true,
-                function_calling: true,
                 structured_output: true,
-                fine_tuning: false,
-                distillation: false,
-                fim_completion: false,
-                chat_prefix_completion: false,
-            },
-            input_type: ModelInputType {
-                text: true,
-                image: has_vision,
-                audio: false,
-                video: false,
             },
             tool_support: ModelToolSupport {
                 web_search: false,
                 file_search: false,
                 image_generation: false,
                 code_interpreter: false,
-                computer_use: false,
                 mcp: false,
             },
             supported_endpoints: ModelSupportedEndpoints {
                 chat_completions: true,
                 responses: false,
-                realtime: false,
-                assistants: false,
-                batch_api: false,
-                fine_tuning: false,
                 embeddings: false,
-                videos: false,
                 image_generation: false,
-                image_edit: false,
                 audio_speech_generation: false,
                 audio_transcription: false,
                 audio_translation: false,
-                moderations: false,
-                completions: false,
-            },
-            token_policy: ModelTokenPolicy {
-                input_tokens_credit_multiplier: input_mult,
-                output_tokens_credit_multiplier: output_mult,
-            },
-            performance: ModelPerformance {
-                response_latency_ms: 500,
-                speed_tokens_per_second: 100,
             },
         },
         preference: Some(ModelPreference {

--- a/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
@@ -115,7 +115,7 @@ impl ModelResolver for ModelPolicyGateway {
                 let entry = snapshot
                     .model_catalog
                     .iter()
-                    .find(|m| m.model_id == model && m.enabled);
+                    .find(|m| m.id == model && m.enabled);
 
                 match entry {
                     Some(e) => Ok(ResolvedModel::from(e)),
@@ -146,7 +146,7 @@ impl ModelResolver for ModelPolicyGateway {
         snapshot
             .model_catalog
             .iter()
-            .find(|m| m.model_id == model_id && m.enabled)
+            .find(|m| m.id == model_id && m.enabled)
             .map(ResolvedModel::from)
             .ok_or_else(|| DomainError::model_not_found(model_id))
     }

--- a/modules/mini-chat/mini-chat/src/infra/plugins/static_model_policy/tests.rs
+++ b/modules/mini-chat/mini-chat/src/infra/plugins/static_model_policy/tests.rs
@@ -2,8 +2,8 @@ use mini_chat_sdk::{
     EstimationBudgets, MiniChatModelPolicyPluginClientV1, MiniChatModelPolicyPluginError,
     ModelCatalogEntry, ModelGeneralConfig, ModelPreference, ModelTier,
     models::{
-        ModelApiParams, ModelFeatures, ModelInputType, ModelPerformance, ModelSupportedEndpoints,
-        ModelTokenPolicy, ModelToolSupport,
+        ModelApiParams, ModelFeatures, ModelSupportedEndpoints, ModelToolSupport,
+        WebSearchContextSize,
     },
 };
 use time::OffsetDateTime;
@@ -14,11 +14,10 @@ use super::service::Service;
 
 fn make_entry(model_id: &str, tier: ModelTier) -> ModelCatalogEntry {
     ModelCatalogEntry {
-        model_id: model_id.to_owned(),
+        id: model_id.to_owned(),
         provider_model_id: format!("{model_id}-v1"),
         display_name: model_id.to_owned(),
         description: String::new(),
-        version: String::new(),
         provider_id: "default".to_owned(),
         provider_display_name: "Default".to_owned(),
         icon: String::new(),
@@ -32,7 +31,8 @@ fn make_entry(model_id: &str, tier: ModelTier) -> ModelCatalogEntry {
         output_tokens_credit_multiplier_micro: 3_000_000,
         multiplier_display: "1x".to_owned(),
         estimation_budgets: EstimationBudgets::default(),
-        max_retrieved_chunks_per_turn: 5,
+        max_num_results: 5,
+        web_search_context_size: WebSearchContextSize::Low,
         max_tool_calls: 2,
         general_config: ModelGeneralConfig {
             config_type: String::new(),
@@ -49,51 +49,23 @@ fn make_entry(model_id: &str, tier: ModelTier) -> ModelCatalogEntry {
             },
             features: ModelFeatures {
                 streaming: true,
-                function_calling: true,
                 structured_output: true,
-                fine_tuning: false,
-                distillation: false,
-                fim_completion: false,
-                chat_prefix_completion: false,
-            },
-            input_type: ModelInputType {
-                text: true,
-                image: false,
-                audio: false,
-                video: false,
             },
             tool_support: ModelToolSupport {
                 web_search: false,
                 file_search: false,
                 image_generation: false,
                 code_interpreter: false,
-                computer_use: false,
                 mcp: false,
             },
             supported_endpoints: ModelSupportedEndpoints {
                 chat_completions: true,
                 responses: false,
-                realtime: false,
-                assistants: false,
-                batch_api: false,
-                fine_tuning: false,
                 embeddings: false,
-                videos: false,
                 image_generation: false,
-                image_edit: false,
                 audio_speech_generation: false,
                 audio_transcription: false,
                 audio_translation: false,
-                moderations: false,
-                completions: false,
-            },
-            token_policy: ModelTokenPolicy {
-                input_tokens_credit_multiplier: 1.0,
-                output_tokens_credit_multiplier: 3.0,
-            },
-            performance: ModelPerformance {
-                response_latency_ms: 500,
-                speed_tokens_per_second: 100,
             },
         },
         preference: Some(ModelPreference {

--- a/testing/e2e/modules/mini_chat/config/base.yaml
+++ b/testing/e2e/modules/mini_chat/config/base.yaml
@@ -170,7 +170,7 @@ modules:
       # not by system design. The production model policy plugin could map the same
       # model_id to different providers. Tests rely on this uniqueness for simplicity.
       model_catalog:
-        - model_id: "gpt-5.2"
+        - id: "gpt-5.2"
           provider_model_id: "gpt-5.2"
           display_name: "GPT-5.2"
           tier: Standard
@@ -189,7 +189,7 @@ modules:
           provider_display_name: "OpenAI"
           multiplier_display: "1x"
           provider_id: "openai"
-          max_retrieved_chunks_per_turn: 10
+          max_num_results: 10
           max_tool_calls: 2
           estimation_budgets:
             bytes_per_token_conservative: 4
@@ -205,7 +205,6 @@ modules:
             sort_order: 2
           general_config:
             type: "chat"
-            tier: "standard"
             available_from: "2025-01-01T00:00:00Z"
             max_file_size_mb: 50
             api_params:
@@ -216,48 +215,23 @@ modules:
               stop: []
             features:
               streaming: true
-              function_calling: true
               structured_output: true
-              fine_tuning: false
-              distillation: false
-              fim_completion: false
-              chat_prefix_completion: false
-            input_type:
-              text: true
-              image: true
-              audio: false
-              video: false
             tool_support:
               web_search: true
               file_search: true
               image_generation: false
               code_interpreter: true
-              computer_use: false
               mcp: false
             supported_endpoints:
               chat_completions: true
               responses: true
-              realtime: false
-              assistants: false
-              batch_api: false
-              fine_tuning: false
               embeddings: false
-              videos: false
               image_generation: false
-              image_edit: false
               audio_speech_generation: false
               audio_transcription: false
               audio_translation: false
-              moderations: false
-              completions: false
-            token_policy:
-              input_tokens_credit_multiplier: 1.0
-              output_tokens_credit_multiplier: 3.0
-            performance:
-              response_latency_ms: 2000
-              speed_tokens_per_second: 80
 
-        - model_id: "gpt-5-mini"
+        - id: "gpt-5-mini"
           provider_model_id: "gpt-5-mini"
           display_name: "GPT-5 Mini"
           tier: Standard
@@ -276,7 +250,7 @@ modules:
           provider_display_name: "OpenAI"
           multiplier_display: "1x"
           provider_id: "openai"
-          max_retrieved_chunks_per_turn: 10
+          max_num_results: 10
           max_tool_calls: 2
           estimation_budgets:
             bytes_per_token_conservative: 4
@@ -292,7 +266,6 @@ modules:
             sort_order: 3
           general_config:
             type: "chat"
-            tier: "standard"
             available_from: "2025-01-01T00:00:00Z"
             max_file_size_mb: 50
             api_params:
@@ -303,48 +276,23 @@ modules:
               stop: []
             features:
               streaming: true
-              function_calling: true
               structured_output: true
-              fine_tuning: false
-              distillation: false
-              fim_completion: false
-              chat_prefix_completion: false
-            input_type:
-              text: true
-              image: true
-              audio: false
-              video: false
             tool_support:
               web_search: true
               file_search: true
               image_generation: false
               code_interpreter: true
-              computer_use: false
               mcp: false
             supported_endpoints:
               chat_completions: true
               responses: true
-              realtime: false
-              assistants: false
-              batch_api: false
-              fine_tuning: false
               embeddings: false
-              videos: false
               image_generation: false
-              image_edit: false
               audio_speech_generation: false
               audio_transcription: false
               audio_translation: false
-              moderations: false
-              completions: false
-            token_policy:
-              input_tokens_credit_multiplier: 1.0
-              output_tokens_credit_multiplier: 3.0
-            performance:
-              response_latency_ms: 1000
-              speed_tokens_per_second: 120
 
-        - model_id: "gpt-5-nano"
+        - id: "gpt-5-nano"
           provider_model_id: "gpt-5-nano"
           display_name: "GPT-5 Nano"
           tier: Standard
@@ -363,7 +311,7 @@ modules:
           provider_display_name: "OpenAI"
           multiplier_display: "0.5x"
           provider_id: "openai"
-          max_retrieved_chunks_per_turn: 5
+          max_num_results: 5
           max_tool_calls: 2
           estimation_budgets:
             bytes_per_token_conservative: 4
@@ -379,7 +327,6 @@ modules:
             sort_order: 4
           general_config:
             type: "chat"
-            tier: "standard"
             available_from: "2025-01-01T00:00:00Z"
             max_file_size_mb: 25
             api_params:
@@ -390,48 +337,23 @@ modules:
               stop: []
             features:
               streaming: true
-              function_calling: true
               structured_output: true
-              fine_tuning: false
-              distillation: false
-              fim_completion: false
-              chat_prefix_completion: false
-            input_type:
-              text: true
-              image: true
-              audio: false
-              video: false
             tool_support:
               web_search: false
               file_search: false
               image_generation: false
               code_interpreter: false
-              computer_use: false
               mcp: false
             supported_endpoints:
               chat_completions: true
               responses: true
-              realtime: false
-              assistants: false
-              batch_api: false
-              fine_tuning: false
               embeddings: false
-              videos: false
               image_generation: false
-              image_edit: false
               audio_speech_generation: false
               audio_transcription: false
               audio_translation: false
-              moderations: false
-              completions: false
-            token_policy:
-              input_tokens_credit_multiplier: 0.5
-              output_tokens_credit_multiplier: 1.5
-            performance:
-              response_latency_ms: 500
-              speed_tokens_per_second: 200
 
-        - model_id: "azure-gpt-4.1"
+        - id: "azure-gpt-4.1"
           provider_model_id: "gpt-4.1"
           display_name: "Azure GPT-4.1"
           tier: Premium
@@ -450,7 +372,7 @@ modules:
           provider_display_name: "Azure OpenAI"
           multiplier_display: "3x"
           provider_id: "azure_openai"
-          max_retrieved_chunks_per_turn: 10
+          max_num_results: 10
           max_tool_calls: 2
           estimation_budgets:
             bytes_per_token_conservative: 4
@@ -466,7 +388,6 @@ modules:
             sort_order: 1
           general_config:
             type: "chat"
-            tier: "premium"
             available_from: "2025-01-01T00:00:00Z"
             max_file_size_mb: 50
             api_params:
@@ -477,46 +398,21 @@ modules:
               stop: []
             features:
               streaming: true
-              function_calling: true
               structured_output: true
-              fine_tuning: false
-              distillation: false
-              fim_completion: false
-              chat_prefix_completion: false
-            input_type:
-              text: true
-              image: true
-              audio: false
-              video: false
             tool_support:
               web_search: true
               file_search: true
               image_generation: false
               code_interpreter: true
-              computer_use: false
               mcp: false
             supported_endpoints:
               chat_completions: true
               responses: true
-              realtime: false
-              assistants: false
-              batch_api: false
-              fine_tuning: false
               embeddings: false
-              videos: false
               image_generation: false
-              image_edit: false
               audio_speech_generation: false
               audio_transcription: false
               audio_translation: false
-              moderations: false
-              completions: false
-            token_policy:
-              input_tokens_credit_multiplier: 3.0
-              output_tokens_credit_multiplier: 15.0
-            performance:
-              response_latency_ms: 1000
-              speed_tokens_per_second: 120
 
   static-mini-chat-audit-plugin:
     config:


### PR DESCRIPTION
- Remove ModelInputType, ModelSupportedEndpoints, ModelPerformance from ModelGeneralConfig (and their struct definitions)
- Add WebSearchToolConfig with search_context_size enum (low/medium/high, default low)
- Add FileSearchToolConfig with max_num_results (default 4)
- Update all test helpers and static policy plugin tests accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models now expose configurable web-search context size (Low/Medium/High, default Low) and file-search max results (default 4). Missing config keys now deserialize to sensible defaults.

* **Refactor**
  * Preflight, quota evaluation, and streaming flows now propagate and honor the new web/file search settings consistently.
  * Model configuration surface simplified to rely on tool-specific settings.

* **Tests**
  * Test fixtures and unit tests updated to use and assert the new tool config defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->