### PR TITLE
feat: add cargo xtask split-debug for post-build symbol stripping

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9628,6 +9628,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,13 @@ codegen-units = 16
 [profile.release]
 codegen-units = 1
 panic = "unwind"
-debug = 1
+debug = "line-tables-only"
 
 [workspace]
 members = [
     "apps/hyperspot-server",
     "apps/gts-docs-validator",
+    "xtask",
     "libs/modkit",
     "libs/modkit-macros",
     "libs/modkit-macros-tests",

--- a/Makefile
+++ b/Makefile
@@ -553,7 +553,7 @@ fuzz-corpus: fuzz-install
 
 # -------- Main targets --------
 
-.PHONY: all check ci build quickstart example mini-chat mini-chat-docker mini-chat-helm mini-chat-helm-template mini-chat-up mini-chat-down mini-chat-port-forward
+.PHONY: all check ci build cargo-build split-debug quickstart example mini-chat mini-chat-docker mini-chat-helm mini-chat-helm-template mini-chat-up mini-chat-down mini-chat-port-forward
 
 # Start server with quickstart config
 quickstart:
@@ -700,9 +700,19 @@ ci_docs: lychee
 ci: fmt clippy test-no-macros test-macros test-db deny test-users-info-pg lychee dylint dylint-test
 
 # Build the hyperspot-server release binary using the stable toolchain.
-# Feature set is read from config/e2e-features.txt when present.
-build:
+cargo-build:
 	cargo +stable build --release --bin hyperspot-server $(E2E_ARGS)
+
+# Split debug symbols into separate artifact(s) and strip the binary.
+# Requires platform tools: objcopy (Linux), dsymutil+strip (macOS).
+# On Windows MSVC the PDB is already separate; no extra tools needed.
+split-debug:
+	cargo xtask split-debug hyperspot-server
+
+# Build the release binary, then split debug symbols.
+# Use 'make cargo-build' if you don't need stripped artifacts or lack
+# platform debug-splitting tools (objcopy, dsymutil).
+build: cargo-build split-debug
 
 # Run all necessary quality checks and tests and then build the release binary
 all: build check test-sqlite e2e-local openapi

--- a/dylint_lints/de13_common_patterns/de1301_no_print_macros/Cargo.toml
+++ b/dylint_lints/de13_common_patterns/de1301_no_print_macros/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [[example]]
 name = "forbidden_macros"
 path = "ui/forbidden_macros.rs"
+crate-type = ["lib"]
 
 [[example]]
 name = "allowed"
@@ -39,6 +40,10 @@ crate-type = ["proc-macro"]
 name = "forbidden_public_in_proc_macro"
 path = "ui/forbidden_public_in_proc_macro.rs"
 crate-type = ["proc-macro"]
+
+[[example]]
+name = "allowed_in_main"
+path = "ui/allowed_in_main.rs"
 
 [[example]]
 name = "allowed_in_tests"

--- a/dylint_lints/de13_common_patterns/de1301_no_print_macros/README.md
+++ b/dylint_lints/de13_common_patterns/de1301_no_print_macros/README.md
@@ -45,16 +45,28 @@ Application binaries may have legitimate reasons to print directly:
 - Early bootstrap diagnostics before logging is initialized
 - Very small tools where stdout is the primary interface
 
-### 4) Tests (`#[test]` / `#[tokio::test]` / `#[cfg(test)]`)
+### 4) Binary crates (top-level functions)
+
+All top-level functions in binary crates are allowed to use print macros.
+Binary crates are the application boundary — printing to stderr/stdout is
+the boundary-level handling that the lint's guidance recommends:
+
+- CLI-style UX output
+- Early bootstrap diagnostics before logging is initialized
+- Fatal error reporting in xtask / build tooling
+
+Functions inside nested modules within binary crates are still checked.
+
+### 5) Tests (`#[test]` / `#[tokio::test]` / `#[cfg(test)]`)
 
 Unit tests and test-only modules may use these macros for debug output and quick feedback.
 
 ## Examples
 
-### Forbidden
+### Forbidden (non-main functions)
 
 ```rust
-fn main() {
+fn helper() {
     println!("hello");
     dbg!(42);
 }
@@ -100,4 +112,5 @@ This lint includes UI tests covering:
 - Allowed usage in `apps/*`
 - Allowed usage in `build.rs`
 - Allowed usage in `proc-macro` crates
+- Allowed usage in binary crate top-level functions
 - Allowed usage in tests (`#[test]`, `#[tokio::test]`, `#[cfg(test)]`)

--- a/dylint_lints/de13_common_patterns/de1301_no_print_macros/src/lib.rs
+++ b/dylint_lints/de13_common_patterns/de1301_no_print_macros/src/lib.rs
@@ -32,6 +32,7 @@ impl EarlyLintPass for De1301NoPrintMacros {
         let mut v = ForbiddenMacroVisitor {
             cx,
             in_proc_macro_crate: is_proc_macro_crate(cx),
+            is_bin_crate: is_bin_crate(cx),
             allow_stack: Vec::new(),
         };
         v.visit_item(item);
@@ -77,6 +78,14 @@ fn is_proc_macro_crate(cx: &EarlyContext<'_>) -> bool {
         .any(|t| *t == CrateType::ProcMacro)
 }
 
+fn is_bin_crate(cx: &EarlyContext<'_>) -> bool {
+    cx.sess()
+        .opts
+        .crate_types
+        .iter()
+        .any(|t| *t == CrateType::Executable)
+}
+
 fn extract_simulated_path(path_str: &str) -> Option<String> {
     // Only check for simulated_dir in temporary paths (UI tests run in temp directories)
     let is_temp = path_str.contains("/tmp/")
@@ -105,6 +114,7 @@ fn extract_simulated_path(path_str: &str) -> Option<String> {
 struct ForbiddenMacroVisitor<'a, 'cx> {
     cx: &'a EarlyContext<'cx>,
     in_proc_macro_crate: bool,
+    is_bin_crate: bool,
     allow_stack: Vec<bool>,
 }
 
@@ -145,9 +155,12 @@ impl<'ast, 'a, 'cx> visit::Visitor<'ast> for ForbiddenMacroVisitor<'a, 'cx> {
         let parent_allow = self.allow_stack.last().copied().unwrap_or(false);
 
         match &item.kind {
-            ItemKind::Fn(..) => {
+            ItemKind::Fn(_fn_item) => {
+                let is_binary_entry =
+                    self.allow_stack.is_empty() && self.is_bin_crate;
                 let is_private = matches!(item.vis.kind, VisibilityKind::Inherited);
                 let allow_here = parent_allow
+                    || is_binary_entry
                     || is_test_item(&item.attrs)
                     || (self.in_proc_macro_crate
                         && (is_private || has_proc_macro_attr(&item.attrs)));

--- a/dylint_lints/de13_common_patterns/de1301_no_print_macros/ui/allowed_in_main.rs
+++ b/dylint_lints/de13_common_patterns/de1301_no_print_macros/ui/allowed_in_main.rs
@@ -1,0 +1,15 @@
+// compile-flags: --crate-type=bin
+
+fn helper() {
+    println!("allowed in binary crate helper");
+    eprintln!("allowed in binary crate helper");
+}
+
+fn main() {
+    helper();
+    println!("hello");
+    eprintln!("hello");
+    print!("hello");
+    eprint!("hello");
+    dbg!(42);
+}

--- a/dylint_lints/de13_common_patterns/de1301_no_print_macros/ui/forbidden_macros.rs
+++ b/dylint_lints/de13_common_patterns/de1301_no_print_macros/ui/forbidden_macros.rs
@@ -1,4 +1,6 @@
-fn main() {
+// compile-flags: --crate-type=lib
+
+pub fn not_main() {
     // Should trigger DE1301 - Print macros
     println!("hello");
 

--- a/dylint_lints/de13_common_patterns/de1301_no_print_macros/ui/forbidden_macros.stderr
+++ b/dylint_lints/de13_common_patterns/de1301_no_print_macros/ui/forbidden_macros.stderr
@@ -1,5 +1,5 @@
 error: macro `println!` is forbidden in production code (DE1301)
-  --> $DIR/forbidden_macros.rs:3:5
+  --> $DIR/forbidden_macros.rs:5:5
    |
 LL |     println!("hello");
    |     ^^^^^^^^^^^^^^^^^
@@ -8,7 +8,7 @@ LL |     println!("hello");
    = note: `#[deny(de1301_no_print_macros)]` on by default
 
 error: macro `eprintln!` is forbidden in production code (DE1301)
-  --> $DIR/forbidden_macros.rs:6:5
+  --> $DIR/forbidden_macros.rs:8:5
    |
 LL |     eprintln!("hello");
    |     ^^^^^^^^^^^^^^^^^^
@@ -16,7 +16,7 @@ LL |     eprintln!("hello");
    = help: use `tracing`/`log` for observability, or return the value and handle it at the boundary
 
 error: macro `print!` is forbidden in production code (DE1301)
-  --> $DIR/forbidden_macros.rs:9:5
+  --> $DIR/forbidden_macros.rs:11:5
    |
 LL |     print!("hello");
    |     ^^^^^^^^^^^^^^^
@@ -24,7 +24,7 @@ LL |     print!("hello");
    = help: use `tracing`/`log` for observability, or return the value and handle it at the boundary
 
 error: macro `eprint!` is forbidden in production code (DE1301)
-  --> $DIR/forbidden_macros.rs:12:5
+  --> $DIR/forbidden_macros.rs:14:5
    |
 LL |     eprint!("hello");
    |     ^^^^^^^^^^^^^^^^
@@ -32,7 +32,7 @@ LL |     eprint!("hello");
    = help: use `tracing`/`log` for observability, or return the value and handle it at the boundary
 
 error: macro `dbg!` is forbidden in production code (DE1301)
-  --> $DIR/forbidden_macros.rs:15:5
+  --> $DIR/forbidden_macros.rs:17:5
    |
 LL |     dbg!(42);
    |     ^^^^^^^^

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "xtask"
+description = "Build helpers (split-debug, etc.)"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+serde_json = { workspace = true }

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -1,0 +1,24 @@
+# xtask
+
+Build helper invoked via `cargo xtask <COMMAND>`.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `split-debug <NAME>` | Split debug symbols out of `target/release/<NAME>` using platform-native tools and strip the binary. |
+| `help` | Show usage. |
+
+### `split-debug`
+
+Detects the platform and runs the appropriate tool chain:
+
+- **Linux** — `objcopy --only-keep-debug` → `objcopy --strip-debug` → `objcopy --add-gnu-debuglink` (produces `.debug` file)
+- **macOS** — `dsymutil` → `strip -u -r` (produces `.dSYM` bundle)
+- **Windows MSVC** — verifies the `.pdb` already exists next to the binary
+- **Windows GNU/MinGW** — falls back to the `objcopy` flow
+
+```sh
+cargo build --release --bin hyperspot-server
+cargo xtask split-debug hyperspot-server
+```

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,274 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+fn main() -> ExitCode {
+    // codacy:ignore -- build helper CLI, no security context
+    let args: Vec<String> = env::args().skip(1).collect();
+    let cmd = args.first().map(|s| s.as_str()).unwrap_or("help");
+
+    match cmd {
+        "split-debug" => split_debug(&args[1..]),
+        "help" | "--help" | "-h" => {
+            print_help();
+            ExitCode::SUCCESS
+        }
+        other => {
+            eprintln!("unknown command: {other}");
+            print_help();
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn print_help() {
+    eprintln!(
+        "\
+Usage: cargo xtask <COMMAND>
+
+Commands:
+  split-debug <NAME>  Split debug symbols out of a release binary
+                      using platform-native tools.
+                      NAME is the binary name (e.g. hyperspot-server).
+                      Resolved as target/release/<NAME>.
+  help                  Show this message."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// split-debug
+// ---------------------------------------------------------------------------
+
+fn split_debug(args: &[String]) -> ExitCode {
+    let Some(name) = args.first().map(|s| s.as_str()) else {
+        eprintln!("error: binary name required");
+        eprintln!("usage: cargo xtask split-debug <NAME>");
+        return ExitCode::FAILURE;
+    };
+    let bin_name = if cfg!(windows) && !name.ends_with(".exe") {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    };
+    let bin = target_dir().join("release").join(&bin_name);
+
+    if !bin.exists() {
+        eprintln!("binary not found: {}", bin.display());
+        eprintln!("run `cargo build --release` first");
+        return ExitCode::FAILURE;
+    }
+
+    eprintln!("binary: {}", bin.display());
+    show_file_type(&bin);
+
+    let ok = if cfg!(target_os = "macos") {
+        split_dsym(&bin)
+    } else if cfg!(target_os = "windows") {
+        // MSVC builds produce a PDB next to the binary; GNU/MinGW builds
+        // use DWARF and need objcopy instead.  Try PDB first, fall back.
+        if has_pdb(&bin) {
+            split_pdb(&bin)
+        } else {
+            eprintln!("no PDB found — assuming GNU/MinGW toolchain, using objcopy");
+            split_dwarf(&bin)
+        }
+    } else {
+        split_dwarf(&bin)
+    };
+
+    if ok {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+// ---------------------------------------------------------------------------
+// macOS: dsymutil + strip
+// ---------------------------------------------------------------------------
+
+fn split_dsym(bin: &Path) -> bool {
+    let bin_s = bin.to_str().unwrap();
+    let size_before = file_size(bin);
+
+    eprintln!("extracting .dSYM bundle...");
+    if !run(&["dsymutil", bin_s], bin.parent().unwrap()) {
+        eprintln!("dsymutil failed — install Xcode command-line tools");
+        return false;
+    }
+
+    eprintln!("stripping binary...");
+    if !run(&["strip", "-u", "-r", bin_s], bin.parent().unwrap()) {
+        eprintln!("strip failed");
+        return false;
+    }
+
+    let size_after = file_size(bin);
+    let dsym = bin.with_extension("dSYM");
+    let dsym_size = dir_size(&dsym);
+    eprintln!("done:");
+    eprintln!(
+        "  binary:  {} ({} -> {})",
+        bin.display(),
+        fmt_size(size_before),
+        fmt_size(size_after)
+    );
+    eprintln!("  symbols: {} ({})", dsym.display(), fmt_size(dsym_size));
+    show_file_type(bin);
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Linux / Windows-GNU: objcopy split + strip + debuglink
+// ---------------------------------------------------------------------------
+
+fn split_dwarf(bin: &Path) -> bool {
+    let bin_s = bin.to_str().unwrap();
+    let dbg = bin.with_extension("debug");
+    let dbg_s = dbg.to_str().unwrap();
+    let parent = bin.parent().unwrap();
+
+    eprintln!("extracting debug symbols...");
+    if !run(&["objcopy", "--only-keep-debug", bin_s, dbg_s], parent) {
+        eprintln!("objcopy not found — install binutils");
+        return false;
+    }
+
+    eprintln!("stripping binary...");
+    if !run(&["objcopy", "--strip-debug", bin_s], parent) {
+        return false;
+    }
+
+    eprintln!("attaching debug link...");
+    let link_arg = format!("--add-gnu-debuglink={dbg_s}");
+    if !run(&["objcopy", &link_arg, bin_s], parent) {
+        return false;
+    }
+
+    eprintln!("done: {} (stripped)", bin.display());
+    eprintln!("      {} (debug symbols)", dbg.display());
+    show_file_type(bin);
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Windows MSVC: PDB is already separate — just verify it exists
+// ---------------------------------------------------------------------------
+
+/// Check whether a PDB file exists next to the binary (MSVC builds).
+/// Rust/MSVC may name it with underscores even when the binary uses hyphens.
+fn has_pdb(bin: &Path) -> bool {
+    find_pdb(bin).is_some()
+}
+
+fn find_pdb(bin: &Path) -> Option<PathBuf> {
+    let pdb = bin.with_extension("pdb");
+    if pdb.exists() {
+        return Some(pdb);
+    }
+    let alt = bin.file_stem().and_then(|s| s.to_str()).map(|stem| {
+        let underscored = stem.replace('-', "_");
+        bin.with_file_name(format!("{underscored}.pdb"))
+    });
+    alt.filter(|p| p.exists())
+}
+
+fn split_pdb(bin: &Path) -> bool {
+    match find_pdb(bin) {
+        Some(p) => {
+            eprintln!("PDB already separate: {}", p.display());
+            eprintln!("no stripping needed for MSVC builds");
+            true
+        }
+        None => {
+            eprintln!(
+                "no PDB found next to {} — was this built with MSVC?",
+                bin.display()
+            );
+            false
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn target_dir() -> PathBuf {
+    let output = Command::new(env!("CARGO"))
+        .args(["metadata", "--format-version=1", "--no-deps"])
+        .output()
+        .expect("failed to run cargo metadata");
+    let json = String::from_utf8(output.stdout).expect("cargo metadata output is not UTF-8");
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(&json)
+        && let Some(dir) = value["target_directory"].as_str()
+    {
+        return PathBuf::from(dir);
+    }
+    // Fallback: assume <workspace>/target
+    let locate = Command::new(env!("CARGO"))
+        .args(["locate-project", "--workspace", "--message-format=plain"])
+        .output()
+        .expect("failed to run cargo locate-project");
+    let path = String::from_utf8(locate.stdout).expect("cargo locate-project output is not UTF-8");
+    PathBuf::from(path.trim()).parent().unwrap().join("target")
+}
+
+fn file_size(p: &Path) -> u64 {
+    fs::metadata(p).map(|m| m.len()).unwrap_or(0)
+}
+
+fn dir_size(p: &Path) -> u64 {
+    if p.is_file() {
+        return file_size(p);
+    }
+    let mut total = 0;
+    if let Ok(entries) = fs::read_dir(p) {
+        for entry in entries.flatten() {
+            total += dir_size(&entry.path());
+        }
+    }
+    total
+}
+
+fn fmt_size(bytes: u64) -> String {
+    if bytes >= 1_048_576 {
+        format!("{:.1} MiB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.1} KiB", bytes as f64 / 1024.0)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+fn run(args: &[&str], cwd: &Path) -> bool {
+    eprintln!("  + {}", args.join(" "));
+    let status = Command::new(args[0])
+        .args(&args[1..])
+        .current_dir(cwd)
+        .status();
+    match status {
+        Ok(s) => s.success(),
+        Err(e) => {
+            eprintln!("  failed to run `{}`: {e}", args[0]);
+            false
+        }
+    }
+}
+
+fn run_tool(name: &str, args: &[&str]) {
+    let mut all: Vec<&str> = vec![name];
+    all.extend_from_slice(args);
+    let _ = run(&all, Path::new("."));
+}
+
+fn show_file_type(path: &Path) {
+    if cfg!(windows) {
+        return;
+    }
+    let Some(s) = path.to_str() else {
+        return;
+    };
+    run_tool("file", &[s]);
+}


### PR DESCRIPTION
- Add xtask crate with split-debug subcommand that splits debug symbols from a release binary using platform-native tools (dsymutil+strip on macOS, objcopy on Linux, PDB check on Windows MSVC)
- Add .cargo/config.toml with xtask alias
- Update Makefile build target to invoke xtask after cargo build
- Switch release profile debug from `1` to `line-tables-only` (equivalent, explicit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI build helper and a cargo alias to simplify running build-related tasks.

* **Chores**
  * Integrated the helper into the build workflow so release builds also split/strip debug symbols.
  * Added the helper to the workspace and adjusted release debug-info mode.

* **Enhancements**
  * Improved cross-platform debug-symbol handling and simplified startup crypto initialization.

* **Documentation**
  * Added usage docs for the new CLI helper and platform behaviors.

* **Tests**
  * Updated lint tests to allow output macros in main while keeping them forbidden elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->