### PR TITLE
feat(minichat): Add concurrent upload semaphore for memory backpressure

### DIFF
--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -293,6 +293,12 @@
           "allow_credentials": {
             "type": "boolean"
           },
+          "allowed_headers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "allowed_methods": {
             "items": {
               "$ref": "#/components/schemas/CorsHttpMethod"
@@ -313,6 +319,11 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "max_age": {
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
           },
           "sharing": {
             "$ref": "#/components/schemas/SharingMode"

--- a/modules/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/handlers/attachments.rs
@@ -14,6 +14,7 @@ use crate::domain::mime_validation::{
     MIME_OCTET_STREAM, infer_mime_from_extension, normalize_mime, remap_csv_to_plain,
     truncate_filename, validate_mime,
 };
+use crate::domain::ports::metric_labels::{kind as kind_label, upload_result};
 use crate::module::AppServices;
 
 // ── multer::Field → FileStream adapter ──────────────────────────────────
@@ -228,7 +229,32 @@ pub(crate) async fn upload_attachment(
         }
     }
 
-    // 9. Call domain service with pre-resolved context.
+    // 9. Acquire upload concurrency permit — returns 503 + Retry-After if all permits are taken.
+    const UPLOAD_RETRY_AFTER_SECS: &str = "5";
+    let Ok(_permit) = svc.upload_semaphore.try_acquire() else {
+        let kind_metric = if is_document {
+            kind_label::DOCUMENT
+        } else {
+            kind_label::IMAGE
+        };
+        tracing::warn!("upload concurrency limit reached, rejecting upload");
+        svc.metrics
+            .record_attachment_upload(kind_metric, upload_result::CONCURRENCY_LIMIT);
+        let mut resp = Problem::new(
+            http::StatusCode::SERVICE_UNAVAILABLE,
+            "Too Many Uploads",
+            "Upload concurrency limit reached, retry shortly",
+        )
+        .with_code("upload_concurrency_limit".to_owned())
+        .into_response();
+        resp.headers_mut().insert(
+            http::header::RETRY_AFTER,
+            http::HeaderValue::from_static(UPLOAD_RETRY_AFTER_SECS),
+        );
+        return Ok(resp);
+    };
+
+    // 10. Call domain service with pre-resolved context.
     let row = svc
         .attachments
         .upload_file(

--- a/modules/mini-chat/mini-chat/src/config.rs
+++ b/modules/mini-chat/mini-chat/src/config.rs
@@ -772,10 +772,24 @@ pub struct RagConfig {
     /// Maximum number of image attachments per message (DESIGN.md B.8).
     #[serde(default = "default_max_images_per_message")]
     pub max_images_per_message: u32,
+
+    /// Maximum concurrent in-flight uploads **per process** (across all tenants
+    /// within this pod). Each upload can buffer up to `uploaded_file_max_size_kb`
+    /// in memory; this semaphore prevents OOM under burst load.
+    ///
+    /// Note: cluster-wide concurrency scales with the number of replicas
+    /// (`max_concurrent_uploads × num_pods`).
+    /// Valid range: 1–256 (default 10).
+    #[serde(default = "default_max_concurrent_uploads")]
+    pub max_concurrent_uploads: u16,
 }
 
 fn default_max_images_per_message() -> u32 {
     4
+}
+
+fn default_max_concurrent_uploads() -> u16 {
+    10
 }
 
 impl Default for RagConfig {
@@ -787,6 +801,7 @@ impl Default for RagConfig {
             uploaded_image_max_size_kb: default_uploaded_image_max_size_kb(),
             allow_csv_upload: true,
             max_images_per_message: default_max_images_per_message(),
+            max_concurrent_uploads: default_max_concurrent_uploads(),
         }
     }
 }
@@ -807,6 +822,12 @@ impl RagConfig {
         }
         if self.max_images_per_message == 0 {
             return Err("rag max_images_per_message must be > 0".into());
+        }
+        if self.max_concurrent_uploads == 0 || self.max_concurrent_uploads > 256 {
+            return Err(format!(
+                "rag max_concurrent_uploads must be 1-256, got {}",
+                self.max_concurrent_uploads
+            ));
         }
         Ok(())
     }
@@ -1498,5 +1519,70 @@ mod tests {
             prefix: "  custom.prefix  ".to_owned(),
         };
         assert_eq!(cfg.effective_prefix("mini-chat"), "custom.prefix");
+    }
+
+    #[test]
+    fn rag_config_max_concurrent_uploads_validation() {
+        // zero is rejected
+        assert!(
+            RagConfig {
+                max_concurrent_uploads: 0,
+                ..RagConfig::default()
+            }
+            .validate()
+            .is_err()
+        );
+
+        // over 256 is rejected
+        assert!(
+            RagConfig {
+                max_concurrent_uploads: 257,
+                ..RagConfig::default()
+            }
+            .validate()
+            .is_err()
+        );
+
+        // boundary values are accepted
+        assert!(
+            RagConfig {
+                max_concurrent_uploads: 1,
+                ..RagConfig::default()
+            }
+            .validate()
+            .is_ok()
+        );
+        assert!(
+            RagConfig {
+                max_concurrent_uploads: 256,
+                ..RagConfig::default()
+            }
+            .validate()
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn upload_semaphore_exhaustion_blocks_further_acquires() {
+        use tokio::sync::Semaphore;
+
+        let sem = Semaphore::new(2);
+
+        // Acquire all permits.
+        let p1 = sem.try_acquire().expect("first permit");
+        let _p2 = sem.try_acquire().expect("second permit");
+
+        // Third acquire must fail — this is the 503 path.
+        assert!(
+            sem.try_acquire().is_err(),
+            "semaphore should be exhausted after all permits are taken"
+        );
+
+        // Releasing a permit makes the semaphore available again.
+        drop(p1);
+        assert!(
+            sem.try_acquire().is_ok(),
+            "permit should be available after release"
+        );
     }
 }

--- a/modules/mini-chat/mini-chat/src/domain/ports/metric_labels.rs
+++ b/modules/mini-chat/mini-chat/src/domain/ports/metric_labels.rs
@@ -80,6 +80,7 @@ pub mod upload_result {
     pub const UNSUPPORTED_TYPE: &str = "unsupported_type";
     pub const PROVIDER_ERROR: &str = "provider_error";
     pub const STORAGE_LIMIT_EXCEEDED: &str = "storage_limit_exceeded";
+    pub const CONCURRENCY_LIMIT: &str = "concurrency_limit";
 }
 
 /// Cleanup resource type labels (`resource_type` label).

--- a/modules/mini-chat/mini-chat/src/domain/service/mod.rs
+++ b/modules/mini-chat/mini-chat/src/domain/service/mod.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use tokio::sync::Semaphore;
+
 use opentelemetry::trace::TraceContextExt as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
@@ -170,6 +172,8 @@ pub(crate) struct AppServices<
     pub(crate) turn_repo: Arc<TR>,
     pub(crate) enforcer: PolicyEnforcer,
     pub(crate) metrics: Arc<dyn MiniChatMetricsPort>,
+    /// Semaphore bounding concurrent in-flight uploads for memory backpressure.
+    pub(crate) upload_semaphore: Arc<Semaphore>,
 }
 
 impl<
@@ -238,6 +242,8 @@ impl<
             Arc::clone(outbox_enqueuer),
             Arc::clone(&metrics),
         );
+
+        let upload_semaphore = Arc::new(Semaphore::new(rag_config.max_concurrent_uploads.into()));
 
         Self {
             chats: ChatService::new(
@@ -309,6 +315,7 @@ impl<
             turn_repo: Arc::clone(&repos.turn),
             enforcer,
             metrics,
+            upload_semaphore,
         }
     }
 }

--- a/modules/mini-chat/mini-chat/src/module.rs
+++ b/modules/mini-chat/mini-chat/src/module.rs
@@ -155,6 +155,9 @@ impl Module for MiniChatModule {
         cfg.thumbnail
             .validate()
             .map_err(|e| anyhow::anyhow!("thumbnail config: {e}"))?;
+        cfg.rag
+            .validate()
+            .map_err(|e| anyhow::anyhow!("rag config: {e}"))?;
 
         let vendor = cfg.vendor.trim().to_owned();
         if vendor.is_empty() {


### PR DESCRIPTION
## Summary

Without a concurrency limit, each in-flight upload can buffer up to 25 MB
in memory. Under burst load (10+ concurrent uploads) this causes unbounded
heap growth with no backpressure.

Adds a `tokio::sync::Semaphore` acquired in `upload_attachment` before
calling the domain service. If all permits are taken the handler returns
HTTP 503 `upload_concurrency_limit` immediately. The permit is held for
the full upload duration and released automatically on return.

- `config.rs` — `max_concurrent_uploads: u16` added to `RagConfig`
  (default 10, validated 1–256)
- `service/mod.rs` — `upload_semaphore: Arc<Semaphore>` on `AppServices`,
  initialised from config
- `handlers/attachments.rs` — `try_acquire()` before step 10
- Config validation tests for boundary values (0, 1, 256, 257)

Closes #1250.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload concurrency limiting: Configurable maximum concurrent uploads (1–256) to prevent server overload; default set to 10.
  * Enhanced CORS configuration with support for custom allowed headers and cache duration settings.

* **Improvements**
  * Upload requests exceeding concurrency limits now return HTTP 503 with retry guidance and a 5-second retry-after header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->