### PR TITLE
bugfix: compile error when no-default-features are specified

### DIFF
--- a/libs/modkit/src/telemetry/init.rs
+++ b/libs/modkit/src/telemetry/init.rs
@@ -190,17 +190,6 @@ pub fn init_tracing(
     Ok(otel_layer)
 }
 
-/// No-op when the `otel` feature is disabled.
-///
-/// # Errors
-/// Always returns an error indicating the feature is disabled.
-#[cfg(not(feature = "otel"))]
-pub fn init_tracing(
-    _otel_cfg: &super::config::OpenTelemetryConfig,
-) -> anyhow::Result<crate::bootstrap::host::logging::OtelLayer> {
-    Err(anyhow::anyhow!("otel feature is disabled"))
-}
-
 #[cfg(feature = "otel")]
 pub(crate) fn build_headers_from_cfg_and_env(
     exporter: Option<&crate::telemetry::config::Exporter>,

--- a/libs/modkit/src/telemetry/mod.rs
+++ b/libs/modkit/src/telemetry/mod.rs
@@ -11,5 +11,7 @@ pub use config::{
     Exporter, HttpOpts, LogsCorrelation, MetricsConfig, OpenTelemetryConfig, OpenTelemetryResource,
     Propagation, Sampler, TracingConfig,
 };
-pub use init::{init_metrics_provider, init_tracing, shutdown_tracing};
+#[cfg(feature = "otel")]
+pub use init::init_tracing;
+pub use init::{init_metrics_provider, shutdown_tracing};
 pub use throttled_log::ThrottledLog;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Telemetry initialization is now exclusively available when OpenTelemetry support is enabled, removing inaccessible code paths from the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->