### PR TITLE
feat(oagw): wire DP rate limiter to effective config and add response header support

### DIFF
--- a/modules/system/oagw/docs/features/0006-cpt-cf-oagw-feature-rate-limiting.md
+++ b/modules/system/oagw/docs/features/0006-cpt-cf-oagw-feature-rate-limiting.md
@@ -162,10 +162,10 @@ Prevents abuse, cost overruns, and protects external service agreements. Maintai
 3. [ ] - `p2` - Refill tokens: `elapsed = now - last_update`, `new_tokens = elapsed_seconds × refill_rate`, `tokens = min(tokens + new_tokens, capacity)`, `last_update = now` - `inst-tb-3`
 4. [ ] - `p2` - **IF** `tokens >= cost` - `inst-tb-4`
    1. [ ] - `p2` - Deduct: `tokens -= cost` - `inst-tb-4a`
-   2. [ ] - `p2` - **RETURN** Allow with `remaining = floor(tokens)`, `limit = capacity`, `reset = window_end_timestamp` - `inst-tb-4b`
+   2. [ ] - `p2` - **RETURN** Allow with `remaining = floor(tokens)`, `limit = capacity`, `reset = now + ceil((capacity - tokens) / refill_rate)` (Unix epoch timestamp when bucket fully replenished; token buckets refill continuously so there is no discrete window boundary) - `inst-tb-4b`
 5. [ ] - `p2` - **ELSE** (insufficient tokens) - `inst-tb-5`
    1. [ ] - `p2` - Calculate `retry_after = ceil((cost - tokens) / refill_rate)` - `inst-tb-5a`
-   2. [ ] - `p2` - **RETURN** Deny with `retry_after`, `limit = capacity`, `remaining = 0`, `reset = window_end_timestamp` - `inst-tb-5b`
+   2. [ ] - `p2` - **RETURN** Deny with `retry_after`, `limit = capacity`, `remaining = 0`, `reset = now + retry_after` (Unix epoch timestamp) - `inst-tb-5b`
 
 ### Hierarchical Rate Limit Merge
 

--- a/modules/system/oagw/oagw-sdk/src/models.rs
+++ b/modules/system/oagw/oagw-sdk/src/models.rs
@@ -138,6 +138,7 @@ pub struct RateLimitConfig {
     pub scope: RateLimitScope,
     pub strategy: RateLimitStrategy,
     pub cost: u32,
+    pub response_headers: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/modules/system/oagw/oagw/src/api/rest/dto.rs
+++ b/modules/system/oagw/oagw/src/api/rest/dto.rs
@@ -134,6 +134,8 @@ pub struct RateLimitConfig {
     pub strategy: RateLimitStrategy,
     #[serde(default = "default_cost")]
     pub cost: u32,
+    #[serde(default = "default_true")]
+    pub response_headers: bool,
 }
 
 fn default_cost() -> u32 {
@@ -582,6 +584,7 @@ impl From<RateLimitConfig> for domain::RateLimitConfig {
             scope: v.scope.into(),
             strategy: v.strategy.into(),
             cost: v.cost,
+            response_headers: v.response_headers,
         }
     }
 }
@@ -845,6 +848,7 @@ impl From<domain::RateLimitConfig> for RateLimitConfig {
             scope: v.scope.into(),
             strategy: v.strategy.into(),
             cost: v.cost,
+            response_headers: v.response_headers,
         }
     }
 }

--- a/modules/system/oagw/oagw/src/api/rest/error.rs
+++ b/modules/system/oagw/oagw/src/api/rest/error.rs
@@ -216,11 +216,14 @@ pub(crate) fn domain_error_to_problem(err: DomainError, instance: &str) -> Probl
 /// Convert a `DomainError` into an axum `Response` with the
 /// `x-oagw-error-source: gateway` header. Used by the proxy handler.
 pub fn error_response(err: DomainError) -> Response {
-    let retry_after = match &err {
+    let rate_limit_meta = match &err {
         DomainError::RateLimitExceeded {
-            retry_after_secs: Some(secs),
+            retry_after_secs,
+            limit,
+            remaining,
+            reset_epoch,
             ..
-        } => Some(*secs),
+        } => Some((*retry_after_secs, *limit, *remaining, *reset_epoch)),
         _ => None,
     };
 
@@ -232,10 +235,27 @@ pub fn error_response(err: DomainError) -> Response {
         HeaderValue::from_static(ErrorSource::Gateway.as_str()),
     );
 
-    if let Some(secs) = retry_after
-        && let Ok(v) = secs.to_string().parse()
-    {
-        response.headers_mut().insert("retry-after", v);
+    if let Some((retry_after_secs, limit, remaining, reset_epoch)) = rate_limit_meta {
+        if let Some(secs) = retry_after_secs
+            && let Ok(v) = secs.to_string().parse()
+        {
+            response.headers_mut().insert("retry-after", v);
+        }
+        if let Some(l) = limit
+            && let Ok(v) = l.to_string().parse()
+        {
+            response.headers_mut().insert("x-ratelimit-limit", v);
+        }
+        if let Some(r) = remaining
+            && let Ok(v) = r.to_string().parse()
+        {
+            response.headers_mut().insert("x-ratelimit-remaining", v);
+        }
+        if let Some(re) = reset_epoch
+            && let Ok(v) = re.to_string().parse()
+        {
+            response.headers_mut().insert("x-ratelimit-reset", v);
+        }
     }
 
     response
@@ -276,6 +296,9 @@ mod tests {
             detail: "rate limit exceeded for upstream".into(),
             instance: "/oagw/v1/proxy/api.openai.com/v1/chat/completions".into(),
             retry_after_secs: Some(30),
+            limit: Some(100),
+            remaining: Some(0),
+            reset_epoch: Some(1706626800),
         };
         let p: Problem = err.into();
         assert_eq!(p.status, StatusCode::TOO_MANY_REQUESTS);
@@ -329,6 +352,9 @@ mod tests {
                 detail: "test".into(),
                 instance: "/test".into(),
                 retry_after_secs: None,
+                limit: None,
+                remaining: None,
+                reset_epoch: None,
             },
             DomainError::SecretNotFound {
                 detail: "test".into(),

--- a/modules/system/oagw/oagw/src/domain/error.rs
+++ b/modules/system/oagw/oagw/src/domain/error.rs
@@ -42,6 +42,9 @@ pub enum DomainError {
         detail: String,
         instance: String,
         retry_after_secs: Option<u64>,
+        limit: Option<u64>,
+        remaining: Option<u64>,
+        reset_epoch: Option<u64>,
     },
 
     #[error("{detail}")]

--- a/modules/system/oagw/oagw/src/domain/model.rs
+++ b/modules/system/oagw/oagw/src/domain/model.rs
@@ -152,6 +152,7 @@ pub struct RateLimitConfig {
     pub scope: RateLimitScope,
     pub strategy: RateLimitStrategy,
     pub cost: u32,
+    pub response_headers: bool,
 }
 
 #[domain_model]

--- a/modules/system/oagw/oagw/src/domain/rate_limit.rs
+++ b/modules/system/oagw/oagw/src/domain/rate_limit.rs
@@ -1,10 +1,22 @@
 use std::collections::HashSet;
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 
 use crate::domain::error::DomainError;
 use crate::domain::model::{RateLimitConfig, Window};
 use dashmap::DashMap;
 use modkit_macros::domain_model;
+
+/// Quota metadata returned on successful token consumption.
+#[domain_model]
+#[derive(Debug, Clone, Copy)]
+pub struct RateLimitOutcome {
+    /// The bucket capacity (maps to `X-RateLimit-Limit`).
+    pub limit: u64,
+    /// Remaining tokens after consumption (maps to `X-RateLimit-Remaining`).
+    pub remaining: u64,
+    /// Unix epoch timestamp when the bucket will be full again (maps to `X-RateLimit-Reset`).
+    pub reset_epoch: u64,
+}
 
 #[domain_model]
 pub struct RateLimiter {
@@ -104,21 +116,59 @@ impl RateLimiter {
         key: &str,
         config: &RateLimitConfig,
         instance_uri: &str,
-    ) -> Result<(), DomainError> {
+    ) -> Result<RateLimitOutcome, DomainError> {
         let cost = config.cost as f64;
         let mut bucket = self
             .buckets
             .entry(key.to_string())
             .or_insert_with(|| TokenBucket::new(config));
 
+        let now_epoch = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
         if bucket.try_consume(cost) {
-            Ok(())
+            let limit = bucket.capacity as u64;
+            let remaining = bucket.tokens.floor().max(0.0) as u64;
+            let secs_to_full = if bucket.refill_rate > 0.0 {
+                ((bucket.capacity - bucket.tokens) / bucket.refill_rate).ceil() as u64
+            } else {
+                0
+            };
+            Ok(RateLimitOutcome {
+                limit,
+                remaining,
+                reset_epoch: now_epoch + secs_to_full,
+            })
         } else {
             let retry_after = bucket.retry_after_secs(cost);
+            let limit = bucket.capacity as u64;
+            let remaining = bucket.tokens.floor().max(0.0) as u64;
+            let secs_to_full = if bucket.refill_rate > 0.0 {
+                ((bucket.capacity - bucket.tokens) / bucket.refill_rate).ceil() as u64
+            } else {
+                0
+            };
             Err(DomainError::RateLimitExceeded {
                 detail: format!("rate limit exceeded for key: {key}"),
                 instance: instance_uri.to_string(),
                 retry_after_secs: Some(retry_after),
+                limit: if config.response_headers {
+                    Some(limit)
+                } else {
+                    None
+                },
+                remaining: if config.response_headers {
+                    Some(remaining)
+                } else {
+                    None
+                },
+                reset_epoch: if config.response_headers {
+                    Some(now_epoch + secs_to_full)
+                } else {
+                    None
+                },
             })
         }
     }
@@ -141,6 +191,7 @@ mod tests {
             scope: RateLimitScope::Tenant,
             strategy: RateLimitStrategy::Reject,
             cost: 1,
+            response_headers: true,
         }
     }
 
@@ -250,5 +301,179 @@ mod tests {
         limiter.purge_keys(&HashSet::new());
 
         assert!(limiter.buckets.is_empty());
+    }
+
+    #[test]
+    fn try_consume_returns_outcome_metadata() {
+        let limiter = RateLimiter::new();
+        let config = make_config(10, Window::Second, Some(10));
+
+        let outcome = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(outcome.limit, 10);
+        assert_eq!(outcome.remaining, 9);
+
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(outcome.reset_epoch >= now_epoch);
+        assert!(outcome.reset_epoch <= now_epoch + 2);
+
+        // Consume more and verify remaining decreases.
+        let outcome2 = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(outcome2.remaining, 8);
+    }
+
+    #[test]
+    fn error_includes_rate_limit_metadata() {
+        let limiter = RateLimiter::new();
+        let config = make_config(1, Window::Second, Some(1));
+        limiter.try_consume("test", &config, "/test").unwrap();
+
+        match limiter.try_consume("test", &config, "/test") {
+            Err(DomainError::RateLimitExceeded {
+                limit,
+                remaining,
+                reset_epoch,
+                ..
+            }) => {
+                assert_eq!(limit, Some(1));
+                assert_eq!(remaining, Some(0));
+                let now_epoch = std::time::SystemTime::now()
+                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                assert!(reset_epoch.unwrap() >= now_epoch);
+            }
+            other => panic!("expected RateLimitExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn outcome_limit_falls_back_to_sustained_rate_without_burst() {
+        let limiter = RateLimiter::new();
+        let config = make_config(5, Window::Second, None); // no burst
+        let outcome = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(
+            outcome.limit, 5,
+            "limit should equal sustained rate when burst is absent"
+        );
+    }
+
+    #[test]
+    fn outcome_reset_epoch_in_future() {
+        let limiter = RateLimiter::new();
+        let config = make_config(10, Window::Second, Some(10));
+        // Consume 5 tokens so the bucket is partially drained.
+        for _ in 0..5 {
+            limiter.try_consume("test", &config, "/test").unwrap();
+        }
+        let outcome = limiter.try_consume("test", &config, "/test").unwrap();
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(
+            outcome.reset_epoch >= now_epoch,
+            "reset_epoch should be >= now"
+        );
+    }
+
+    #[test]
+    fn error_reset_epoch_is_time_until_full() {
+        let limiter = RateLimiter::new();
+        // capacity=5, rate=5/min → refill_rate ≈ 0.083 tok/s.
+        // Consuming all 5 means secs_to_full ≈ 60s, but retry_after ≈ 12s (1 token).
+        let config = make_config(5, Window::Minute, Some(5));
+        for _ in 0..5 {
+            limiter.try_consume("test", &config, "/test").unwrap();
+        }
+
+        match limiter.try_consume("test", &config, "/test") {
+            Err(DomainError::RateLimitExceeded {
+                retry_after_secs,
+                reset_epoch,
+                ..
+            }) => {
+                let now_epoch = std::time::SystemTime::now()
+                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                let retry = retry_after_secs.unwrap();
+                let reset = reset_epoch.unwrap();
+
+                // reset_epoch should reflect time-until-full (≈60s), not retry_after (≈12s).
+                assert!(
+                    reset >= now_epoch + 50,
+                    "reset_epoch ({reset}) should be ≈60s from now ({now_epoch}), \
+                     not ≈retry_after ({retry}s)"
+                );
+                assert!(
+                    retry < 20,
+                    "retry_after ({retry}s) should be much less than secs_to_full"
+                );
+            }
+            other => panic!("expected RateLimitExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cost_greater_than_one_consumes_multiple_tokens() {
+        let limiter = RateLimiter::new();
+        let mut config = make_config(100, Window::Second, Some(10));
+        config.cost = 3;
+
+        // 10 tokens, cost=3: should allow 3 requests (9 tokens), fail on 4th (1 < 3).
+        let o1 = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(o1.remaining, 7);
+
+        let o2 = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(o2.remaining, 4);
+
+        let o3 = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(o3.remaining, 1);
+
+        let err = limiter.try_consume("test", &config, "/test").unwrap_err();
+        assert!(matches!(err, DomainError::RateLimitExceeded { .. }));
+    }
+
+    #[test]
+    fn error_omits_metadata_when_response_headers_false() {
+        let limiter = RateLimiter::new();
+        let mut config = make_config(1, Window::Minute, Some(1));
+        config.response_headers = false;
+
+        // Exhaust the bucket.
+        limiter.try_consume("test", &config, "/test").unwrap();
+
+        // Second request should be rejected.
+        let err = limiter.try_consume("test", &config, "/test").unwrap_err();
+        match err {
+            DomainError::RateLimitExceeded {
+                retry_after_secs,
+                limit,
+                remaining,
+                reset_epoch,
+                ..
+            } => {
+                assert!(
+                    retry_after_secs.is_some(),
+                    "retry_after_secs must always be present regardless of response_headers"
+                );
+                assert!(
+                    limit.is_none(),
+                    "limit must be None when response_headers is false"
+                );
+                assert!(
+                    remaining.is_none(),
+                    "remaining must be None when response_headers is false"
+                );
+                assert!(
+                    reset_epoch.is_none(),
+                    "reset_epoch must be None when response_headers is false"
+                );
+            }
+            other => panic!("expected RateLimitExceeded, got {other:?}"),
+        }
     }
 }

--- a/modules/system/oagw/oagw/src/domain/services/client.rs
+++ b/modules/system/oagw/oagw/src/domain/services/client.rs
@@ -228,6 +228,7 @@ fn domain_err_to_sdk(err: DomainError) -> ServiceGatewayError {
             detail,
             instance,
             retry_after_secs,
+            ..
         } => ServiceGatewayError::RateLimitExceeded {
             detail,
             instance,
@@ -463,6 +464,7 @@ fn rate_limit_config_to_domain(v: oagw_sdk::RateLimitConfig) -> model::RateLimit
             oagw_sdk::RateLimitStrategy::Degrade => model::RateLimitStrategy::Degrade,
         },
         cost: v.cost,
+        response_headers: v.response_headers,
     }
 }
 
@@ -732,6 +734,7 @@ fn rate_limit_config_to_sdk(v: model::RateLimitConfig) -> oagw_sdk::RateLimitCon
             model::RateLimitStrategy::Degrade => oagw_sdk::RateLimitStrategy::Degrade,
         },
         cost: v.cost,
+        response_headers: v.response_headers,
     }
 }
 
@@ -839,6 +842,9 @@ mod tests {
             detail: "too fast".into(),
             instance: "/api".into(),
             retry_after_secs: Some(30),
+            limit: None,
+            remaining: None,
+            reset_epoch: None,
         };
         let sdk_err = domain_err_to_sdk(err);
         match sdk_err {

--- a/modules/system/oagw/oagw/src/domain/services/management.rs
+++ b/modules/system/oagw/oagw/src/domain/services/management.rs
@@ -2603,6 +2603,7 @@ mod tests {
             scope: RateLimitScope::Tenant,
             strategy: RateLimitStrategy::Reject,
             cost: 1,
+            response_headers: true,
         }
     }
 

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -24,7 +24,7 @@ use crate::domain::plugin::{
     AuthContext, GuardContext, GuardDecision, TransformErrorContext, TransformRequestContext,
     TransformResponseContext,
 };
-use crate::domain::rate_limit::RateLimiter;
+use crate::domain::rate_limit::{RateLimitOutcome, RateLimiter};
 use crate::domain::services::{
     ControlPlaneService, DataPlaneService, EndpointSelector, SelectedEndpoint,
 };
@@ -212,6 +212,19 @@ impl DataPlaneServiceImpl {
         // Apply response header rules (set/add/remove) from upstream config.
         if let Some(rules) = pipeline.response_header_rules {
             headers::apply_response_header_rules(&mut resp_headers, rules);
+        }
+
+        // Inject rate-limit response headers if configured.
+        if let Some((ref outcome, true)) = pipeline.rate_limit_outcome {
+            if let Ok(v) = outcome.limit.to_string().parse() {
+                resp_headers.insert("x-ratelimit-limit", v);
+            }
+            if let Ok(v) = outcome.remaining.to_string().parse() {
+                resp_headers.insert("x-ratelimit-remaining", v);
+            }
+            if let Ok(v) = outcome.reset_epoch.to_string().parse() {
+                resp_headers.insert("x-ratelimit-reset", v);
+            }
         }
 
         // Apply streaming lifecycle management for SSE responses:
@@ -683,13 +696,21 @@ impl DataPlaneService for DataPlaneServiceImpl {
         headers::set_host_header(&mut outbound_headers, &endpoint.host, endpoint.port);
 
         // 6. Check rate limit (upstream then route).
+        let mut rate_limit_outcome: Option<(RateLimitOutcome, bool)> = None;
         if let Some(ref rl) = upstream.rate_limit {
             let key = format!("upstream:{}", upstream.id);
-            self.rate_limiter.try_consume(&key, rl, &instance_uri)?;
+            let outcome = self.rate_limiter.try_consume(&key, rl, &instance_uri)?;
+            rate_limit_outcome = Some((outcome, rl.response_headers));
         }
         if let Some(ref rl) = route.rate_limit {
             let key = format!("route:{}", route.id);
-            self.rate_limiter.try_consume(&key, rl, &instance_uri)?;
+            let outcome = self.rate_limiter.try_consume(&key, rl, &instance_uri)?;
+            match &rate_limit_outcome {
+                Some((existing, _)) if existing.remaining <= outcome.remaining => {}
+                _ => {
+                    rate_limit_outcome = Some((outcome, rl.response_headers));
+                }
+            }
         }
 
         // 7. Build URL.
@@ -749,6 +770,7 @@ impl DataPlaneService for DataPlaneServiceImpl {
             cors_config: effective_cors.as_ref(),
             origin: request_origin,
             response_header_rules,
+            rate_limit_outcome,
         };
 
         // 8. WebSocket upgrade path: bypass the normal request/response bridge
@@ -1185,6 +1207,7 @@ struct ResponsePipelineCtx<'a> {
     cors_config: Option<&'a crate::domain::model::CorsConfig>,
     origin: Option<String>,
     response_header_rules: Option<&'a ResponseHeaderRules>,
+    rate_limit_outcome: Option<(RateLimitOutcome, bool)>,
 }
 
 /// Execute `on_error` for all transform bindings, logging errors without aborting.

--- a/modules/system/oagw/oagw/src/infra/type_provisioning.rs
+++ b/modules/system/oagw/oagw/src/infra/type_provisioning.rs
@@ -203,6 +203,8 @@ struct RateLimitConfig {
     strategy: RateLimitStrategy,
     #[serde(default = "default_cost")]
     cost: u32,
+    #[serde(default = "default_true")]
+    response_headers: bool,
 }
 
 #[derive(Deserialize)]
@@ -484,6 +486,7 @@ impl From<RateLimitConfig> for domain::RateLimitConfig {
             scope: v.scope.into(),
             strategy: v.strategy.into(),
             cost: v.cost,
+            response_headers: v.response_headers,
         }
     }
 }

--- a/modules/system/oagw/oagw/tests/e2e_smoke_test.rs
+++ b/modules/system/oagw/oagw/tests/e2e_smoke_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use oagw::test_support::{
     APIKEY_AUTH_PLUGIN_ID, AppHarness, CapturingAuthZResolverClient, DenyingAuthZResolverClient,
@@ -755,4 +756,496 @@ async fn e2e_authz_request_carries_tenant_context() {
     );
     assert_eq!(req.resource.resource_type, "gts.x.core.oagw.proxy.v1~");
     assert_eq!(req.action.name, "invoke");
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit response header tests (Scenario 18.1, 18.1.1, ADR-0004)
+// ---------------------------------------------------------------------------
+
+/// Helper: create upstream + route with the given rate_limit JSON, returning the alias for proxy calls.
+async fn setup_rate_limited_upstream(
+    h: &AppHarness,
+    alias: &str,
+    rate_limit: serde_json::Value,
+    route_path: &str,
+) -> String {
+    let resp = h
+        .api_v1()
+        .post_upstream()
+        .with_body(serde_json::json!({
+            "server": {
+                "endpoints": [{"host": "127.0.0.1", "port": h.mock_port(), "scheme": "http"}]
+            },
+            "protocol": "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            "alias": alias,
+            "enabled": true,
+            "tags": [],
+            "rate_limit": rate_limit
+        }))
+        .expect_status(201)
+        .await;
+    let uid = resp.json()["id"].as_str().unwrap().to_string();
+
+    h.api_v1()
+        .post_route()
+        .with_body(serde_json::json!({
+            "upstream_id": &uid,
+            "match": { "http": { "methods": ["GET"], "path": route_path } },
+            "enabled": true,
+            "tags": [],
+            "priority": 0
+        }))
+        .expect_status(201)
+        .await;
+
+    uid
+}
+
+// Scenario 18.1, inst-rl-12, dod-rate-limit-headers — success response includes X-RateLimit-* headers.
+#[tokio::test]
+async fn e2e_rate_limit_success_includes_response_headers() {
+    let h = AppHarness::builder().build().await;
+
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-headers",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 10, "window": "second"},
+            "burst": {"capacity": 10},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1,
+            "response_headers": true
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-headers", "v1/models")
+        .expect_status(200)
+        .await;
+
+    resp.assert_header("x-ratelimit-limit", "10");
+    resp.assert_header("x-ratelimit-remaining", "9");
+    assert!(
+        resp.headers().get("x-ratelimit-reset").is_some(),
+        "expected x-ratelimit-reset header on success"
+    );
+    assert!(
+        resp.headers().get("retry-after").is_none(),
+        "retry-after should not be present on success"
+    );
+}
+
+// Scenario 18.1, inst-rl-6a1, dod-rate-limit-headers, dod-token-bucket — 429 includes all required headers.
+#[tokio::test]
+async fn e2e_rate_limit_429_includes_all_headers() {
+    let h = AppHarness::builder().build().await;
+
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-429h",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 1, "window": "minute"},
+            "burst": {"capacity": 1},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1,
+            "response_headers": true
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    // Exhaust the bucket.
+    h.api_v1()
+        .proxy_get("e2e-rl-429h", "v1/models")
+        .expect_status(200)
+        .await;
+
+    // Second request triggers 429.
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-429h", "v1/models")
+        .expect_status(429)
+        .await;
+
+    resp.assert_header("x-oagw-error-source", "gateway");
+    assert!(
+        resp.headers().get("retry-after").is_some(),
+        "expected retry-after header on 429"
+    );
+    let retry_after: u64 = resp
+        .headers()
+        .get("retry-after")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .parse()
+        .expect("retry-after should be a positive integer");
+    assert!(retry_after > 0, "retry-after should be > 0");
+
+    resp.assert_header("x-ratelimit-limit", "1");
+    resp.assert_header("x-ratelimit-remaining", "0");
+    assert!(
+        resp.headers().get("x-ratelimit-reset").is_some(),
+        "expected x-ratelimit-reset on 429"
+    );
+
+    // RFC 9457 Problem Details body.
+    assert!(
+        resp.headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("application/problem+json"),
+        "expected application/problem+json content type"
+    );
+    let body = resp.json();
+    assert_eq!(body["status"], 429);
+    assert!(
+        body.get("type").is_some(),
+        "expected 'type' in problem JSON"
+    );
+    assert!(
+        body.get("detail").is_some(),
+        "expected 'detail' in problem JSON"
+    );
+    assert!(
+        body.get("instance").is_some(),
+        "expected 'instance' in problem JSON"
+    );
+}
+
+// Scenario 18.1.1, inst-rl-12 (negative) — response_headers=false suppresses headers on success.
+#[tokio::test]
+async fn e2e_rate_limit_response_headers_disabled_on_success() {
+    let h = AppHarness::builder().build().await;
+
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-nohdr",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 5, "window": "second"},
+            "burst": {"capacity": 5},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1,
+            "response_headers": false
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-nohdr", "v1/models")
+        .expect_status(200)
+        .await;
+
+    assert!(
+        resp.headers().get("x-ratelimit-limit").is_none(),
+        "x-ratelimit-limit should be absent when response_headers=false"
+    );
+    assert!(
+        resp.headers().get("x-ratelimit-remaining").is_none(),
+        "x-ratelimit-remaining should be absent when response_headers=false"
+    );
+    assert!(
+        resp.headers().get("x-ratelimit-reset").is_none(),
+        "x-ratelimit-reset should be absent when response_headers=false"
+    );
+}
+
+// Scenario 18.1.1, inst-rl-6a1 — 429 still includes retry-after even when response_headers=false.
+#[tokio::test]
+async fn e2e_rate_limit_headers_disabled_429_still_has_retry_after() {
+    let h = AppHarness::builder().build().await;
+
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-nohdr429",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 1, "window": "minute"},
+            "burst": {"capacity": 1},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1,
+            "response_headers": false
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    h.api_v1()
+        .proxy_get("e2e-rl-nohdr429", "v1/models")
+        .expect_status(200)
+        .await;
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-nohdr429", "v1/models")
+        .expect_status(429)
+        .await;
+
+    resp.assert_header("x-oagw-error-source", "gateway");
+    assert!(
+        resp.headers().get("retry-after").is_some(),
+        "retry-after must always be present on 429 regardless of response_headers flag"
+    );
+    assert!(
+        resp.headers().get("x-ratelimit-limit").is_none(),
+        "x-ratelimit-limit must be absent when response_headers is false"
+    );
+    assert!(
+        resp.headers().get("x-ratelimit-remaining").is_none(),
+        "x-ratelimit-remaining must be absent when response_headers is false"
+    );
+    assert!(
+        resp.headers().get("x-ratelimit-reset").is_none(),
+        "x-ratelimit-reset must be absent when response_headers is false"
+    );
+    assert!(
+        resp.headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("application/problem+json"),
+        "expected application/problem+json content type on 429"
+    );
+}
+
+// Scenario 18.1, inst-tb-1..5b, dod-token-bucket — full burst → exhaust → refill → recover flow.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_rate_limit_burst_then_recover() {
+    let h = AppHarness::builder().build().await;
+
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-burst",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 10, "window": "second"},
+            "burst": {"capacity": 3},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1,
+            "response_headers": true
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    // Exhaust burst capacity (3 tokens).
+    for expected_remaining in (0..=2).rev() {
+        let resp = h
+            .api_v1()
+            .proxy_get("e2e-rl-burst", "v1/models")
+            .expect_status(200)
+            .await;
+        resp.assert_header("x-ratelimit-remaining", &expected_remaining.to_string());
+    }
+
+    // 4th request should be rejected.
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-burst", "v1/models")
+        .expect_status(429)
+        .await;
+    assert!(resp.headers().get("retry-after").is_some());
+
+    // Wait for refill (10 tokens/sec, so 500ms yields ~5 tokens).
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Should succeed again after refill.
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-burst", "v1/models")
+        .expect_status(200)
+        .await;
+    let remaining: u64 = resp
+        .headers()
+        .get("x-ratelimit-remaining")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(remaining > 0, "expected remaining > 0 after refill");
+}
+
+// ADR 0004 §response_headers default — response_headers defaults to true when omitted.
+#[tokio::test]
+async fn e2e_rate_limit_response_headers_default_true() {
+    let h = AppHarness::builder().build().await;
+
+    // Deliberately omit `response_headers` from the rate_limit JSON.
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-default",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 5, "window": "second"},
+            "burst": {"capacity": 5},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-default", "v1/models")
+        .expect_status(200)
+        .await;
+
+    assert!(
+        resp.headers().get("x-ratelimit-limit").is_some(),
+        "x-ratelimit-limit should be present when response_headers defaults to true"
+    );
+}
+
+// inst-rl-2, inst-rl-5, inst-merge-5a — route-level rate limit enforcement (no upstream limit).
+#[tokio::test]
+async fn e2e_rate_limit_route_level_enforcement() {
+    let h = AppHarness::builder().build().await;
+
+    // Create upstream WITHOUT rate_limit.
+    let resp = h
+        .api_v1()
+        .post_upstream()
+        .with_body(serde_json::json!({
+            "server": {
+                "endpoints": [{"host": "127.0.0.1", "port": h.mock_port(), "scheme": "http"}]
+            },
+            "protocol": "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            "alias": "e2e-rl-route",
+            "enabled": true,
+            "tags": []
+        }))
+        .expect_status(201)
+        .await;
+    let uid = resp.json()["id"].as_str().unwrap().to_string();
+
+    // Create route WITH rate_limit.
+    h.api_v1()
+        .post_route()
+        .with_body(serde_json::json!({
+            "upstream_id": &uid,
+            "match": { "http": { "methods": ["GET"], "path": "/v1/models" } },
+            "enabled": true,
+            "tags": [],
+            "priority": 0,
+            "rate_limit": {
+                "algorithm": "token_bucket",
+                "sustained": {"rate": 1, "window": "minute"},
+                "burst": {"capacity": 1},
+                "scope": "tenant",
+                "strategy": "reject",
+                "cost": 1,
+                "response_headers": true
+            }
+        }))
+        .expect_status(201)
+        .await;
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-route", "v1/models")
+        .expect_status(200)
+        .await;
+    resp.assert_header("x-ratelimit-limit", "1");
+    resp.assert_header("x-ratelimit-remaining", "0");
+
+    h.api_v1()
+        .proxy_get("e2e-rl-route", "v1/models")
+        .expect_status(429)
+        .await;
+}
+
+// inst-rl-2, inst-rl-5, inst-merge-5a — both upstream and route rate limits applied, tighter route wins.
+#[tokio::test]
+async fn e2e_rate_limit_upstream_and_route_both_applied() {
+    let h = AppHarness::builder().build().await;
+
+    // Upstream: generous limit.
+    let resp = h
+        .api_v1()
+        .post_upstream()
+        .with_body(serde_json::json!({
+            "server": {
+                "endpoints": [{"host": "127.0.0.1", "port": h.mock_port(), "scheme": "http"}]
+            },
+            "protocol": "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            "alias": "e2e-rl-dual",
+            "enabled": true,
+            "tags": [],
+            "rate_limit": {
+                "algorithm": "token_bucket",
+                "sustained": {"rate": 100, "window": "minute"},
+                "burst": {"capacity": 100},
+                "scope": "tenant",
+                "strategy": "reject",
+                "cost": 1,
+                "response_headers": true
+            }
+        }))
+        .expect_status(201)
+        .await;
+    let uid = resp.json()["id"].as_str().unwrap().to_string();
+
+    // Route: tight limit.
+    h.api_v1()
+        .post_route()
+        .with_body(serde_json::json!({
+            "upstream_id": &uid,
+            "match": { "http": { "methods": ["GET"], "path": "/v1/models" } },
+            "enabled": true,
+            "tags": [],
+            "priority": 0,
+            "rate_limit": {
+                "algorithm": "token_bucket",
+                "sustained": {"rate": 2, "window": "minute"},
+                "burst": {"capacity": 2},
+                "scope": "tenant",
+                "strategy": "reject",
+                "cost": 1,
+                "response_headers": true
+            }
+        }))
+        .expect_status(201)
+        .await;
+
+    // First two requests succeed; headers reflect tighter route limit.
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-dual", "v1/models")
+        .expect_status(200)
+        .await;
+    // After 1st request: upstream remaining=99, route remaining=1 → route wins (lower remaining).
+    resp.assert_header("x-ratelimit-limit", "2");
+    resp.assert_header("x-ratelimit-remaining", "1");
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-dual", "v1/models")
+        .expect_status(200)
+        .await;
+    resp.assert_header("x-ratelimit-remaining", "0");
+
+    // Third request exceeds route limit.
+    h.api_v1()
+        .proxy_get("e2e-rl-dual", "v1/models")
+        .expect_status(429)
+        .await;
 }

--- a/modules/system/oagw/oagw/tests/proxy_integration.rs
+++ b/modules/system/oagw/oagw/tests/proxy_integration.rs
@@ -407,6 +407,7 @@ async fn proxy_rate_limit_exceeded_returns_429() {
                 scope: RateLimitScope::Tenant,
                 strategy: RateLimitStrategy::Reject,
                 cost: 1,
+                response_headers: true,
             })
             .build(),
         )
@@ -1775,6 +1776,7 @@ async fn proxy_websocket_rate_limit_on_handshake() {
                 scope: RateLimitScope::Tenant,
                 strategy: RateLimitStrategy::Reject,
                 cost: 1,
+                response_headers: true,
             })
             .build(),
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate-limit response headers (x-ratelimit-limit, x-ratelimit-remaining, x-ratelimit-reset) added; header injection is configurable (defaults to true) and suppressed when disabled.
  * Successful responses report epoch when the bucket will be full; denials set reset based on retry-after. 429s include retry-after and an RFC 9457 problem+json body.
  * When both upstream and route limits exist, the most restrictive remaining governs.

* **Tests**
  * New e2e and integration tests for headers, defaulting, refill recovery, and enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->