### PR TITLE
chore(oagw-sdk): add usage examples when interacting with 3rd party API clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-openai"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec08254d61379df136135d3d1ac04301be7699fd7d9e57655c63ac7d650a6922"
+dependencies = [
+ "async-openai-macros",
+ "backoff",
+ "base64 0.22.1",
+ "bytes",
+ "derive_builder",
+ "eventsource-stream",
+ "futures",
+ "getrandom 0.3.4",
+ "rand 0.9.2",
+ "reqwest",
+ "reqwest-eventsource",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "async-openai-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81872a8e595e8ceceab71c6ba1f9078e313b452a1e31934e6763ef5d308705e4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -579,6 +619,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.17",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]
@@ -1047,6 +1101,39 @@ dependencies = [
  "cf-modkit-security",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1840,6 +1927,7 @@ dependencies = [
 name = "cf-oagw-sdk"
 version = "0.4.0"
 dependencies = [
+ "async-openai",
  "async-trait",
  "axum",
  "bytes",
@@ -1847,10 +1935,14 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
+ "http-body",
+ "http-body-util",
+ "octocrab",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tower",
  "tracing",
  "uuid",
 ]
@@ -2194,8 +2286,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -3033,6 +3127,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom 7.1.3",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "exr"
 version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3354,8 +3459,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4171,6 +4278,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4692,6 +4808,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5061,6 +5187,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "octocrab"
+version = "0.49.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63f6687a23731011d0117f9f4c3cdabaa7b5e42ca671f42b5cc0657c492540e3"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "cargo_metadata",
+ "cfg-if",
+ "chrono",
+ "either",
+ "futures",
+ "getrandom 0.2.17",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "jsonwebtoken",
+ "once_cell",
+ "percent-encoding",
+ "pin-project",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "snafu",
+ "tower",
+ "tower-http",
+ "url",
+ "web-time",
 ]
 
 [[package]]
@@ -6434,6 +6597,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "serde",
@@ -6441,13 +6605,31 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom 7.1.3",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7018,6 +7200,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -7357,6 +7543,27 @@ name = "smallvec"
 version = "2.0.0-alpha.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "socket2"
@@ -8989,6 +9196,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9017,6 +9237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/modules/system/oagw/oagw-sdk/Cargo.toml
+++ b/modules/system/oagw/oagw-sdk/Cargo.toml
@@ -37,3 +37,8 @@ axum = { workspace = true, features = ["ws"], optional = true }
 tokio = { workspace = true, features = ["macros", "rt", "sync"] }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["ws"] }
+async-openai = { version = "0.34", default-features = false, features = ["chat-completion"] }
+octocrab = { version = "0.49", default-features = false, features = ["jwt-aws-lc-rs"] }
+tower = { workspace = true, features = ["util"] }
+http-body = { workspace = true }
+http-body-util = { workspace = true }

--- a/modules/system/oagw/oagw-sdk/tests/third_party_base_url.rs
+++ b/modules/system/oagw/oagw-sdk/tests/third_party_base_url.rs
@@ -1,0 +1,110 @@
+//! Pattern: Custom base URL (over HTTP)
+//!
+//! Uses `async-openai`'s native reqwest-based client with `api_base` pointed
+//! at an axum mock server that mimics OAGW's proxy endpoint. This is the
+//! zero-code integration — just a URL change.
+//!
+//! Note: the `api_key` here is only needed to satisfy the SDK's config
+//! requirements. In production, OAGW handles upstream authentication
+//! transparently — the caller's key is not forwarded to the third-party API.
+
+use async_openai::Client;
+use async_openai::config::OpenAIConfig;
+use async_openai::types::chat::{
+    ChatCompletionRequestMessage, ChatCompletionRequestUserMessage,
+    ChatCompletionRequestUserMessageContent, CreateChatCompletionRequestArgs,
+};
+use tokio::net::TcpListener;
+
+type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+// ---------------------------------------------------------------------------
+// Canned OpenAI response
+// ---------------------------------------------------------------------------
+
+const CANNED_CHAT_RESPONSE: &str = r#"{
+    "id": "chatcmpl-test-456",
+    "object": "chat.completion",
+    "created": 1700000000,
+    "model": "gpt-4o",
+    "choices": [{
+        "index": 0,
+        "message": {
+            "role": "assistant",
+            "content": "Hello from OAGW via HTTP!"
+        },
+        "finish_reason": "stop"
+    }],
+    "usage": {
+        "prompt_tokens": 10,
+        "completion_tokens": 6,
+        "total_tokens": 16
+    }
+}"#;
+
+// ---------------------------------------------------------------------------
+// Mock server mimicking OAGW's proxy endpoint
+// ---------------------------------------------------------------------------
+
+async fn mock_openai_server() -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base_url = format!("http://{addr}");
+
+    let app = axum::Router::new().route(
+        "/oagw/v1/proxy/openai/v1/chat/completions",
+        axum::routing::post(|| async {
+            axum::response::Json(
+                serde_json::from_str::<serde_json::Value>(CANNED_CHAT_RESPONSE).unwrap(),
+            )
+        }),
+    );
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    (base_url, handle)
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn custom_base_url_chat_completion() -> TestResult {
+    // -- setup: start mock server -----------------------------------------------
+    let (base_url, server_handle) = mock_openai_server().await;
+
+    // Point async-openai at OAGW's proxy endpoint instead of api.openai.com
+    let config = OpenAIConfig::new()
+        .with_api_base(format!("{base_url}/oagw/v1/proxy/openai/v1"))
+        .with_api_key("test-key");
+
+    let client = Client::with_config(config);
+
+    // -- action: use the native async-openai client ----------------------------
+    let request = CreateChatCompletionRequestArgs::default()
+        .model("gpt-4o")
+        .messages(vec![ChatCompletionRequestMessage::User(
+            ChatCompletionRequestUserMessage {
+                content: ChatCompletionRequestUserMessageContent::Text("Say hello".into()),
+                name: None,
+            },
+        )])
+        .build()?;
+
+    let response = client.chat().create(request).await?;
+
+    // -- verify: response deserialized by async-openai --------------------------
+    assert_eq!(response.id, "chatcmpl-test-456");
+    assert_eq!(response.model, "gpt-4o");
+    assert_eq!(response.choices.len(), 1);
+    assert_eq!(
+        response.choices[0].message.content.as_deref(),
+        Some("Hello from OAGW via HTTP!")
+    );
+
+    server_handle.abort();
+    Ok(())
+}

--- a/modules/system/oagw/oagw-sdk/tests/third_party_custom_transport.rs
+++ b/modules/system/oagw/oagw-sdk/tests/third_party_custom_transport.rs
@@ -1,0 +1,283 @@
+//! Pattern: Custom transport trait via octocrab
+//!
+//! Implements `tower::Service` on a `GatewayService` adapter that routes
+//! octocrab's HTTP requests through `ServiceGatewayClientV1::proxy_request`.
+//! This demonstrates the idiomatic Rust pattern for pluggable HTTP transports.
+//!
+//! Note: authentication with the upstream API (e.g. GitHub PAT) is configured
+//! on the OAGW upstream and injected transparently by the gateway — the
+//! octocrab client itself needs no auth configuration.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use http::{Request, Response};
+use http_body_util::{BodyExt, Full};
+use modkit_security::SecurityContext;
+use oagw_sdk::api::ServiceGatewayClientV1;
+use oagw_sdk::body::Body;
+use oagw_sdk::error::ServiceGatewayError;
+
+type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+// ---------------------------------------------------------------------------
+// Canned GitHub API response (repository object)
+// ---------------------------------------------------------------------------
+
+const CANNED_REPO_RESPONSE: &str = r#"{
+    "id": 42,
+    "node_id": "MDEwOlJlcG9zaXRvcnk0Mg==",
+    "name": "example-repo",
+    "full_name": "test-owner/example-repo",
+    "private": false,
+    "owner": {
+        "login": "test-owner",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://avatars.githubusercontent.com/u/1",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/test-owner",
+        "html_url": "https://github.com/test-owner",
+        "followers_url": "https://api.github.com/users/test-owner/followers",
+        "following_url": "https://api.github.com/users/test-owner/following{/other_user}",
+        "gists_url": "https://api.github.com/users/test-owner/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/test-owner/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/test-owner/subscriptions",
+        "organizations_url": "https://api.github.com/users/test-owner/orgs",
+        "repos_url": "https://api.github.com/users/test-owner/repos",
+        "events_url": "https://api.github.com/users/test-owner/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/test-owner/received_events",
+        "type": "User",
+        "site_admin": false
+    },
+    "html_url": "https://github.com/test-owner/example-repo",
+    "description": "A test repository routed through OAGW",
+    "fork": false,
+    "url": "https://api.github.com/repos/test-owner/example-repo",
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-06-01T00:00:00Z",
+    "pushed_at": "2024-06-01T00:00:00Z",
+    "default_branch": "main"
+}"#;
+
+fn canned_response() -> http::Response<Body> {
+    http::Response::builder()
+        .status(200)
+        .header("content-type", "application/json")
+        .body(Body::from(CANNED_REPO_RESPONSE))
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// MockGateway — same pattern as usage.rs
+// ---------------------------------------------------------------------------
+
+struct MockGateway {
+    response: Mutex<Option<http::Response<Body>>>,
+}
+
+impl MockGateway {
+    fn responding_with(resp: http::Response<Body>) -> Self {
+        Self {
+            response: Mutex::new(Some(resp)),
+        }
+    }
+}
+
+#[async_trait]
+impl ServiceGatewayClientV1 for MockGateway {
+    async fn create_upstream(
+        &self,
+        _: SecurityContext,
+        _: oagw_sdk::CreateUpstreamRequest,
+    ) -> Result<oagw_sdk::Upstream, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn get_upstream(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+    ) -> Result<oagw_sdk::Upstream, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn list_upstreams(
+        &self,
+        _: SecurityContext,
+        _: &oagw_sdk::ListQuery,
+    ) -> Result<Vec<oagw_sdk::Upstream>, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn update_upstream(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+        _: oagw_sdk::UpdateUpstreamRequest,
+    ) -> Result<oagw_sdk::Upstream, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn delete_upstream(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+    ) -> Result<(), ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn create_route(
+        &self,
+        _: SecurityContext,
+        _: oagw_sdk::CreateRouteRequest,
+    ) -> Result<oagw_sdk::Route, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn get_route(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+    ) -> Result<oagw_sdk::Route, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn list_routes(
+        &self,
+        _: SecurityContext,
+        _: Option<uuid::Uuid>,
+        _: &oagw_sdk::ListQuery,
+    ) -> Result<Vec<oagw_sdk::Route>, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn update_route(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+        _: oagw_sdk::UpdateRouteRequest,
+    ) -> Result<oagw_sdk::Route, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn delete_route(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+    ) -> Result<(), ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn resolve_proxy_target(
+        &self,
+        _: SecurityContext,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> Result<(oagw_sdk::Upstream, oagw_sdk::Route), ServiceGatewayError> {
+        unimplemented!()
+    }
+
+    async fn proxy_request(
+        &self,
+        _ctx: SecurityContext,
+        _req: http::Request<Body>,
+    ) -> Result<http::Response<Body>, ServiceGatewayError> {
+        Ok(self
+            .response
+            .lock()
+            .unwrap()
+            .take()
+            .expect("response already consumed"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GatewayService — tower::Service adapter for proxy_request
+// ---------------------------------------------------------------------------
+
+struct GatewayService<G> {
+    gateway: Arc<G>,
+    ctx: SecurityContext,
+}
+
+impl<G> Clone for GatewayService<G> {
+    fn clone(&self) -> Self {
+        Self {
+            gateway: Arc::clone(&self.gateway),
+            ctx: self.ctx.clone(),
+        }
+    }
+}
+
+impl<G, B> tower::Service<Request<B>> for GatewayService<G>
+where
+    G: ServiceGatewayClientV1 + 'static,
+    B: http_body::Body<Data = Bytes> + Send + 'static,
+    B::Error: Into<BoxError>,
+{
+    type Response = Response<Full<Bytes>>;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let gateway = Arc::clone(&self.gateway);
+        let ctx = self.ctx.clone();
+
+        Box::pin(async move {
+            // Convert any http_body::Body → oagw_sdk::Body
+            let (parts, body) = req.into_parts();
+            let collected = BodyExt::collect(body).await.map_err(Into::into)?;
+            let body_bytes = collected.to_bytes();
+            let oagw_body = if body_bytes.is_empty() {
+                Body::Empty
+            } else {
+                Body::from(body_bytes)
+            };
+            let oagw_req = Request::from_parts(parts, oagw_body);
+
+            // Route through the gateway
+            let oagw_resp = gateway.proxy_request(ctx, oagw_req).await?;
+
+            // Convert oagw_sdk::Body → Full<Bytes>
+            let (parts, body) = oagw_resp.into_parts();
+            let resp_bytes = body.into_bytes().await?;
+            Ok(Response::from_parts(parts, Full::new(resp_bytes)))
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn octocrab_custom_transport() -> TestResult {
+    // -- setup: gateway returning a canned GitHub repo response -----------------
+    let gateway = MockGateway::responding_with(canned_response());
+    let service = GatewayService {
+        gateway: Arc::new(gateway),
+        ctx: SecurityContext::anonymous(),
+    };
+
+    // Build octocrab with our custom transport (no HTTP client needed)
+    let octocrab = octocrab::OctocrabBuilder::new_empty()
+        .with_service(service)
+        .with_auth(octocrab::AuthState::None)
+        .build()
+        .expect("infallible");
+
+    // -- action: use octocrab's typed API to fetch a repo -----------------------
+    let repo: octocrab::models::Repository =
+        octocrab.repos("test-owner", "example-repo").get().await?;
+
+    // -- verify: response deserialized into octocrab types ----------------------
+    assert_eq!(repo.name, "example-repo");
+    assert_eq!(repo.full_name.as_deref(), Some("test-owner/example-repo"));
+    assert_eq!(
+        repo.description.as_deref(),
+        Some("A test repository routed through OAGW")
+    );
+
+    Ok(())
+}

--- a/modules/system/oagw/oagw-sdk/tests/third_party_in_process.rs
+++ b/modules/system/oagw/oagw-sdk/tests/third_party_in_process.rs
@@ -1,0 +1,341 @@
+//! Pattern: In-process transport via `ServiceGatewayClientV1`
+//!
+//! Uses real third-party SDK types (`async-openai`) for request/response
+//! serialization, but calls `proxy_request` directly as the HTTP transport.
+//! No reqwest, no HTTP server — just a thin `GatewayTransport` adapter.
+//!
+//! Note: authentication (API keys, OAuth2, etc.) is configured on the OAGW
+//! upstream and injected transparently by the gateway during the proxy
+//! pipeline — callers never handle third-party credentials.
+
+use std::sync::{Arc, Mutex};
+
+use async_openai::types::chat::{
+    ChatCompletionRequestMessage, ChatCompletionRequestUserMessage,
+    ChatCompletionRequestUserMessageContent, CreateChatCompletionRequestArgs,
+    CreateChatCompletionResponse,
+};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures_util::StreamExt;
+use modkit_security::SecurityContext;
+use oagw_sdk::api::ServiceGatewayClientV1;
+use oagw_sdk::body::{Body, BodyStream, BoxError};
+use oagw_sdk::error::ServiceGatewayError;
+use oagw_sdk::sse::{ServerEvent, ServerEventsResponse, ServerEventsStream};
+use serde::{Serialize, de::DeserializeOwned};
+
+type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+// ---------------------------------------------------------------------------
+// Canned OpenAI response
+// ---------------------------------------------------------------------------
+
+const CANNED_CHAT_RESPONSE: &str = r#"{
+    "id": "chatcmpl-test-123",
+    "object": "chat.completion",
+    "created": 1700000000,
+    "model": "gpt-4o",
+    "choices": [{
+        "index": 0,
+        "message": {
+            "role": "assistant",
+            "content": "Hello from OAGW!"
+        },
+        "finish_reason": "stop"
+    }],
+    "usage": {
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15
+    }
+}"#;
+
+fn canned_response() -> http::Response<Body> {
+    http::Response::builder()
+        .status(200)
+        .header("content-type", "application/json")
+        .body(Body::from(CANNED_CHAT_RESPONSE))
+        .unwrap()
+}
+
+/// Build an SSE response with a streaming body from the provided chunks.
+fn server_events_response(chunks: Vec<&str>) -> http::Response<Body> {
+    let owned: Vec<Result<Bytes, BoxError>> = chunks
+        .into_iter()
+        .map(|s| Ok(Bytes::from(s.to_owned())))
+        .collect();
+    let stream: BodyStream = Box::pin(futures_util::stream::iter(owned));
+    http::Response::builder()
+        .status(200)
+        .header("content-type", "text/event-stream")
+        .body(Body::Stream(stream))
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// MockGateway — same pattern as usage.rs
+// ---------------------------------------------------------------------------
+
+struct MockGateway {
+    response: Mutex<Option<http::Response<Body>>>,
+}
+
+impl MockGateway {
+    fn responding_with(resp: http::Response<Body>) -> Self {
+        Self {
+            response: Mutex::new(Some(resp)),
+        }
+    }
+}
+
+#[async_trait]
+impl ServiceGatewayClientV1 for MockGateway {
+    async fn create_upstream(
+        &self,
+        _: SecurityContext,
+        _: oagw_sdk::CreateUpstreamRequest,
+    ) -> Result<oagw_sdk::Upstream, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn get_upstream(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+    ) -> Result<oagw_sdk::Upstream, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn list_upstreams(
+        &self,
+        _: SecurityContext,
+        _: &oagw_sdk::ListQuery,
+    ) -> Result<Vec<oagw_sdk::Upstream>, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn update_upstream(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+        _: oagw_sdk::UpdateUpstreamRequest,
+    ) -> Result<oagw_sdk::Upstream, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn delete_upstream(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+    ) -> Result<(), ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn create_route(
+        &self,
+        _: SecurityContext,
+        _: oagw_sdk::CreateRouteRequest,
+    ) -> Result<oagw_sdk::Route, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn get_route(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+    ) -> Result<oagw_sdk::Route, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn list_routes(
+        &self,
+        _: SecurityContext,
+        _: Option<uuid::Uuid>,
+        _: &oagw_sdk::ListQuery,
+    ) -> Result<Vec<oagw_sdk::Route>, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn update_route(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+        _: oagw_sdk::UpdateRouteRequest,
+    ) -> Result<oagw_sdk::Route, ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn delete_route(
+        &self,
+        _: SecurityContext,
+        _: uuid::Uuid,
+    ) -> Result<(), ServiceGatewayError> {
+        unimplemented!()
+    }
+    async fn resolve_proxy_target(
+        &self,
+        _: SecurityContext,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> Result<(oagw_sdk::Upstream, oagw_sdk::Route), ServiceGatewayError> {
+        unimplemented!()
+    }
+
+    async fn proxy_request(
+        &self,
+        _ctx: SecurityContext,
+        _req: http::Request<Body>,
+    ) -> Result<http::Response<Body>, ServiceGatewayError> {
+        Ok(self
+            .response
+            .lock()
+            .unwrap()
+            .take()
+            .expect("response already consumed"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GatewayTransport — thin adapter over proxy_request
+// ---------------------------------------------------------------------------
+
+struct GatewayTransport<G> {
+    gateway: Arc<G>,
+    ctx: SecurityContext,
+    alias: String,
+}
+
+impl<G: ServiceGatewayClientV1> GatewayTransport<G> {
+    /// POST a JSON request body to `/{alias}/{path}` and deserialize the response.
+    async fn post_json<Req: Serialize, Resp: DeserializeOwned>(
+        &self,
+        path: &str,
+        request: &Req,
+    ) -> Result<Resp, Box<dyn std::error::Error + Send + Sync>> {
+        let body = serde_json::to_vec(request)?;
+        let req = http::Request::builder()
+            .method("POST")
+            .uri(format!("/{}/{}", self.alias, path))
+            .header("content-type", "application/json")
+            .body(Body::from(Bytes::from(body)))?;
+
+        let resp = self.gateway.proxy_request(self.ctx.clone(), req).await?;
+        let bytes = resp.into_body().into_bytes().await?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    /// POST a JSON request and return the response as an SSE event stream.
+    async fn post_stream<Req: Serialize>(
+        &self,
+        path: &str,
+        request: &Req,
+    ) -> Result<ServerEventsStream<ServerEvent>, Box<dyn std::error::Error + Send + Sync>> {
+        let body = serde_json::to_vec(request)?;
+        let req = http::Request::builder()
+            .method("POST")
+            .uri(format!("/{}/{}", self.alias, path))
+            .header("content-type", "application/json")
+            .body(Body::from(Bytes::from(body)))?;
+
+        let resp = self.gateway.proxy_request(self.ctx.clone(), req).await?;
+
+        match ServerEventsStream::from_response::<ServerEvent>(resp) {
+            ServerEventsResponse::Events(stream) => Ok(stream),
+            ServerEventsResponse::Response(_) => {
+                Err("expected SSE stream but got a non-streaming response".into())
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn in_process_transport_chat_completion() -> TestResult {
+    // -- setup: build request using async-openai types --------------------------
+    let request = CreateChatCompletionRequestArgs::default()
+        .model("gpt-4o")
+        .messages(vec![ChatCompletionRequestMessage::User(
+            ChatCompletionRequestUserMessage {
+                content: ChatCompletionRequestUserMessageContent::Text("Say hello".into()),
+                name: None,
+            },
+        )])
+        .build()?;
+
+    // Verify the request serializes correctly
+    let json = serde_json::to_value(&request)?;
+    assert_eq!(json["model"], "gpt-4o");
+    assert_eq!(json["messages"][0]["role"], "user");
+
+    // -- action: send through gateway transport ---------------------------------
+    let gateway = MockGateway::responding_with(canned_response());
+    let transport = GatewayTransport {
+        gateway: Arc::new(gateway),
+        ctx: SecurityContext::anonymous(),
+        alias: "openai".to_string(),
+    };
+
+    let response: CreateChatCompletionResponse =
+        transport.post_json("v1/chat/completions", &request).await?;
+
+    // -- verify: response deserializes into async-openai types ------------------
+    assert_eq!(response.id, "chatcmpl-test-123");
+    assert_eq!(response.model, "gpt-4o");
+    assert_eq!(response.choices.len(), 1);
+    assert_eq!(
+        response.choices[0].message.content.as_deref(),
+        Some("Hello from OAGW!")
+    );
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// SSE streaming test — OpenAI streaming chat completion
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn in_process_transport_streaming_chat_completion() -> TestResult {
+    // -- setup: gateway returns an SSE stream of OpenAI chat completion chunks --
+    let gateway = MockGateway::responding_with(server_events_response(vec![
+        "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",\"content\":\"Hello\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\" from\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\" OAGW!\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+        "data: [DONE]\n\n",
+    ]));
+
+    let request = CreateChatCompletionRequestArgs::default()
+        .model("gpt-4o")
+        .messages(vec![ChatCompletionRequestMessage::User(
+            ChatCompletionRequestUserMessage {
+                content: ChatCompletionRequestUserMessageContent::Text("Say hello".into()),
+                name: None,
+            },
+        )])
+        .build()?;
+
+    let transport = GatewayTransport {
+        gateway: Arc::new(gateway),
+        ctx: SecurityContext::anonymous(),
+        alias: "openai".to_string(),
+    };
+
+    // -- action: stream through gateway transport ---------------------------------
+    let mut events = transport
+        .post_stream("v1/chat/completions", &request)
+        .await?;
+
+    // -- verify: accumulate content deltas from streamed chunks --------------------
+    let mut text = String::new();
+    while let Some(result) = events.next().await {
+        let ev = result?;
+        if ev.data == "[DONE]" {
+            break;
+        }
+        let chunk: serde_json::Value = serde_json::from_str(&ev.data)?;
+        if let Some(content) = chunk["choices"][0]["delta"]["content"].as_str() {
+            text.push_str(content);
+        }
+    }
+
+    assert_eq!(text, "Hello from OAGW!");
+
+    Ok(())
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added three integration tests validating SDK behavior with custom HTTP base URLs, a custom transport adapter, and in-process proxy routing (chat completions, SSE stream handling, and third-party client integration).

* **Chores**
  * Added development-only dependencies to support the new integration tests and test tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->