### PR TITLE
feat(resource-group): SDK and module contracts

### DIFF
--- a/.cypilot/config/artifacts.toml
+++ b/.cypilot/config/artifacts.toml
@@ -34,16 +34,18 @@ reason = "Ignore module 'nodes-registry' (not SDLC-documented yet: missing requi
 patterns = ["modules/system/nodes-registry/*"]
 
 [[ignore]]
-reason = "Ignore oagw codebase — code traceability markers reverted, pending re-add. Docs still validated (DOCS-ONLY effective: all feature tasks unchecked)."
+reason = "Ignore oagw codebase and features — code traceability markers reverted, pending re-add. PRD/DESIGN/ADR/DECOMPOSITION still validated via autodetect."
 patterns = [
   "modules/system/oagw/oagw/src/*",
   "modules/system/oagw/oagw/tests/*",
   "modules/system/oagw/oagw-sdk/src/*",
+  "modules/system/oagw/docs/features/*",
 ]
 
 [[ignore]]
 reason = "Ignore legacy (pre-Cypilot) ADR files in oagw/docs root — converted copies live under docs/ADR/."
 patterns = ["modules/system/oagw/docs/adr-*.md"]
+
 
 [[ignore]]
 reason = "Ignore module 'tenant-resolver' (not SDLC-documented yet: missing required PRD/DESIGN)."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1077,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,7 +1409,7 @@ dependencies = [
  "schemars 1.2.1",
  "sea-orm-migration",
  "serde",
- "serde-saphyr 0.0.16",
+ "serde-saphyr 0.0.22",
  "serde_json",
  "supports-color",
  "temp-env",
@@ -1493,7 +1508,7 @@ dependencies = [
  "sea-orm",
  "sea-orm-migration",
  "serde",
- "serde-saphyr 0.0.16",
+ "serde-saphyr 0.0.22",
  "serde_json",
  "sqlx",
  "temp-env",
@@ -1847,6 +1862,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-resource-group"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "cf-authz-resolver-sdk",
+ "cf-modkit",
+ "cf-modkit-db",
+ "cf-modkit-db-macros",
+ "cf-modkit-macros",
+ "cf-modkit-odata",
+ "cf-modkit-security",
+ "cf-resource-group-sdk",
+ "http",
+ "http-body-util",
+ "inventory",
+ "jsonschema",
+ "sea-orm",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tower",
+ "tracing",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
+name = "cf-resource-group-sdk"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cf-modkit-odata",
+ "cf-modkit-odata-macros",
+ "cf-modkit-sdk",
+ "cf-modkit-security",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "cf-rustracing"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,7 +2050,7 @@ dependencies = [
  "cf-types-registry-sdk",
  "inventory",
  "serde",
- "serde-saphyr 0.0.16",
+ "serde-saphyr 0.0.22",
  "serde_json",
  "tokio",
  "tracing",
@@ -2140,24 +2202,12 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "chrono-tz-build",
  "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -2288,6 +2338,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,23 +2473,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -2437,12 +2496,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2892,11 +2951,11 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "enable-ansi-support"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4ff3ae2a9aa54bf7ee0983e59303224de742818c1822d89f07da9856d9bc60"
+checksum = "ea7457668b3da8a4b702f3d79e131aa3e81cd7e81cc95fb2d54fce9f182ecc77"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3879,7 +3938,7 @@ dependencies = [
  "cf-types-registry",
  "clap",
  "mimalloc",
- "serde-saphyr 0.0.16",
+ "serde-saphyr 0.0.22",
  "serde_json",
  "tempfile",
  "tokio",
@@ -4148,17 +4207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4175,6 +4223,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -4220,6 +4277,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
  "quote",
  "syn 2.0.117",
 ]
@@ -4287,6 +4388,8 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
+ "reqwest 0.13.2",
+ "rustls",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -4977,9 +5080,9 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5c6c0ef9702176a570f06ad94f3198bc29c524c8b498f1b9346e1b1bdcbb3a"
+checksum = "f049ae562349fefb8e837eb15443da1e7c6dcbd8a11f52a228f92220c2e5c85e"
 dependencies = [
  "bitflags 2.11.0",
  "libloading",
@@ -4991,9 +5094,9 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper-sys"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd23dbe2eb8d8335d2bce0299e0a07d6a63c089243d626ca75b770a962ff49e6"
+checksum = "6b4d594420fcda43b1c2c4bd44d48974aa3c7a9ab2cbf10dc18e35265767bf0b"
 dependencies = [
  "libloading",
 ]
@@ -5089,7 +5192,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -5104,7 +5207,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -5196,6 +5299,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5247,15 +5360,6 @@ dependencies = [
  "regex-syntax",
  "structmeta",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
 ]
 
 [[package]]
@@ -5444,38 +5548,18 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -6433,6 +6517,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6673,6 +6796,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6717,12 +6867,12 @@ dependencies = [
 
 [[package]]
 name = "saphyr-parser-bw"
-version = "0.0.605"
+version = "0.0.610"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1aee7486406df3541b5a657204a11be97175a467d77bc98e6d94a66289fb80"
+checksum = "6d643f5e972f17219245b82f038c22cd3c74320bb17c6e8f7e8537de268b1bc6"
 dependencies = [
  "arraydeque",
- "smallvec 2.0.0-alpha.12",
+ "smallvec 1.15.1",
  "thiserror 2.0.18",
 ]
 
@@ -7031,21 +7181,21 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.16"
+version = "0.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
+checksum = "546b4da4f679832602a8f8ab8ddc10b6b1d2e1a13b4f9dddcaee499436fa06ad"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
  "base64 0.22.1",
  "encoding_rs_io",
+ "getrandom 0.3.4",
  "nohash-hasher",
  "num-traits",
  "regex",
  "saphyr-parser-bw",
  "serde",
- "serde_json",
- "smallvec 2.0.0-alpha.12",
+ "smallvec 1.15.1",
  "zmij",
 ]
 
@@ -7096,7 +7246,6 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -9004,6 +9153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9182,17 +9340,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -9229,6 +9381,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ members = [
     "modules/system/grpc-hub",
     "modules/system/nodes-registry/nodes-registry",
     "modules/system/nodes-registry/nodes-registry-sdk",
+    "modules/system/resource-group/resource-group-sdk",
+    "modules/system/resource-group/resource-group",
     "modules/system/module-orchestrator",
     "examples/modkit/users-info/users-info-sdk",
     "examples/modkit/users-info/users-info",
@@ -238,6 +240,7 @@ cf-system-sdk-directory = { version = "0.1.34", path = "libs/system-sdks/sdks/di
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.5", path = "modules/system/types-registry/types-registry-sdk" }
 tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.2.17", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
 authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.2.18", path = "modules/system/authz-resolver/authz-resolver-sdk" }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.5.10", path = "modules/system/resource-group/resource-group-sdk" }
 oagw-sdk = { package = "cf-oagw-sdk", version = "0.4.0", path = "modules/system/oagw/oagw-sdk" }
 
 # credstore
@@ -252,7 +255,7 @@ grpc_hub = { package = "cf-grpc-hub", version = "0.1.19", path = "modules/system
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde-saphyr = "0.0.16"
+serde-saphyr = "0.0.22"
 secrecy = { version = "0.10", features = ["serde"] }
 serde_urlencoded = "0.7"
 schemars = { version = "1.2", features = ["derive", "uuid1"] }
@@ -407,7 +410,7 @@ regex = "1.10"
 glob = "0.3"
 colored = "3.1"
 supports-color = "3"
-enable-ansi-support = "0.2"
+enable-ansi-support = "0.3"
 
 # gRPC support
 tonic = { version = "0.14", features = ["transport"] }
@@ -450,7 +453,7 @@ hostname = "0.4"
 starship-battery = "0.10"
 local-ip-address = "0.6"
 machine-uid = "0.5"
-nvml-wrapper = "0.11"
+nvml-wrapper = "0.12"
 
 # Public Suffix List
 psl = "2"
@@ -465,7 +468,7 @@ strsim = "0.11"
 
 # OData parsing
 peg = "0.8"
-chrono-tz = "0.9"
+chrono-tz = "0.10"
 
 # Procedural macros
 proc-macro2 = "1.0"
@@ -483,7 +486,7 @@ proc-macro-error2 = "2.0"
 
 # Testing utilities
 trybuild = "1"
-criterion = { version = "0.5", default-features = false }
+criterion = { version = "0.8", default-features = false }
 testcontainers = { version = "0.27", default-features = false, features = ["aws-lc-rs"] }
 testcontainers-modules = { version = "0.15", default-features = false, features = ["aws-lc-rs", "postgres", "mysql"] }
 httpmock = "0.8"

--- a/deny.toml
+++ b/deny.toml
@@ -35,8 +35,8 @@ yanked = "warn"
 # List of advisory IDs to ignore (RUSTSEC-YYYY-XXXX, etc.)
 ignore = [
   # "RUSTSEC-0000-0000",
-  "RUSTSEC-2023-0071", # we cannot replace rsa 0.9 as it's used by sqlx-mysql AND jsonwebtoken
   "RUSTSEC-2024-0437", # protobuf 2.28 stack overflow — transitive via pingora-core→prometheus 0.13; we never parse untrusted protobuf (prometheus metrics endpoint is unused)
+  "RUSTSEC-2026-0066", # astral-tokio-tar 0.5.6 PAX extension validation — transitive via testcontainers 0.27; dev-only dependency, no untrusted tar parsing
 ]
 
 # Note:

--- a/dylint_lints/Cargo.lock
+++ b/dylint_lints/Cargo.lock
@@ -99,7 +99,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -110,7 +110,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -731,24 +731,12 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "chrono-tz-build",
  "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -1319,7 +1307,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1513,7 +1501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2596,7 +2584,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2623,7 +2611,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2928,15 +2916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,38 +2997,18 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -3603,7 +3562,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4429,7 +4388,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5216,7 +5175,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/modules/system/resource-group/resource-group-sdk/Cargo.toml
+++ b/modules/system/resource-group/resource-group-sdk/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "cf-resource-group-sdk"
+version = "0.1.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "SDK for resource-group module: API trait, types, and error definitions"
+
+[lints]
+workspace = true
+
+[features]
+default = ["odata"]
+odata = [
+    "dep:modkit-odata-macros",
+    "dep:modkit-sdk",
+    "dep:modkit-odata",
+]
+
+[dependencies]
+# Core dependencies for API trait
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+
+# OData macros (for #[derive(ODataFilterable)])
+modkit-odata-macros = { workspace = true, optional = true }
+
+# UUID support
+uuid = { workspace = true }
+
+# Security context for API methods
+modkit-security = { workspace = true }
+
+# SDK utilities (typed OData queries)
+modkit-sdk = { workspace = true, optional = true }
+
+# OData support for pagination
+modkit-odata = { workspace = true, optional = true }

--- a/modules/system/resource-group/resource-group-sdk/src/api.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/api.rs
@@ -1,0 +1,173 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-traits:p1
+//! SDK trait contracts for the resource-group module.
+
+use async_trait::async_trait;
+use modkit_security::SecurityContext;
+
+use modkit_odata::{ODataQuery, Page};
+use uuid::Uuid;
+
+use crate::error::ResourceGroupError;
+use crate::models::{
+    CreateGroupRequest, CreateTypeRequest, PatchGroupRequest, ResourceGroup,
+    ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest,
+    UpdateTypeRequest,
+};
+
+/// Client trait for resource-group type management.
+///
+/// Consumers obtain this from `ClientHub`:
+/// ```ignore
+/// let client = hub.get::<dyn ResourceGroupClient>()?;
+/// let rg_type = client.get_type(&ctx, "gts.x.system.rg.type.v1~...").await?;
+/// ```
+#[async_trait]
+pub trait ResourceGroupClient: Send + Sync {
+    // -- Type lifecycle --
+
+    /// Create a new GTS type definition.
+    async fn create_type(
+        &self,
+        ctx: &SecurityContext,
+        request: CreateTypeRequest,
+    ) -> Result<ResourceGroupType, ResourceGroupError>;
+
+    /// Get a GTS type definition by its code (GTS type path).
+    async fn get_type(
+        &self,
+        ctx: &SecurityContext,
+        code: &str,
+    ) -> Result<ResourceGroupType, ResourceGroupError>;
+
+    /// List GTS type definitions with `OData` filtering and cursor-based pagination.
+    async fn list_types(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupType>, ResourceGroupError>;
+
+    /// Update a GTS type definition (full replacement).
+    async fn update_type(
+        &self,
+        ctx: &SecurityContext,
+        code: &str,
+        request: UpdateTypeRequest,
+    ) -> Result<ResourceGroupType, ResourceGroupError>;
+
+    /// Delete a GTS type definition. Fails if groups of this type exist.
+    async fn delete_type(
+        &self,
+        ctx: &SecurityContext,
+        code: &str,
+    ) -> Result<(), ResourceGroupError>;
+
+    // -- Group lifecycle --
+
+    /// Create a new resource group.
+    async fn create_group(
+        &self,
+        ctx: &SecurityContext,
+        request: CreateGroupRequest,
+    ) -> Result<ResourceGroup, ResourceGroupError>;
+
+    /// Get a resource group by ID.
+    async fn get_group(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+    ) -> Result<ResourceGroup, ResourceGroupError>;
+
+    /// List resource groups with `OData` filtering and cursor-based pagination.
+    async fn list_groups(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroup>, ResourceGroupError>;
+
+    /// Update a resource group (full replacement).
+    async fn update_group(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        request: UpdateGroupRequest,
+    ) -> Result<ResourceGroup, ResourceGroupError>;
+
+    /// Patch a resource group (partial update via PATCH).
+    async fn patch_group(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        request: PatchGroupRequest,
+    ) -> Result<ResourceGroup, ResourceGroupError>;
+
+    /// Delete a resource group. Fails if child groups or memberships exist.
+    async fn delete_group(&self, ctx: &SecurityContext, id: Uuid)
+    -> Result<(), ResourceGroupError>;
+
+    /// List group hierarchy with relative depth from a reference group.
+    async fn list_group_depth(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+
+    // -- Membership lifecycle --
+
+    /// Add a membership link between a resource and a group.
+    async fn add_membership(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Result<ResourceGroupMembership, ResourceGroupError>;
+
+    /// Remove a membership link.
+    async fn remove_membership(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Result<(), ResourceGroupError>;
+
+    /// List memberships with `OData` filtering and cursor-based pagination.
+    async fn list_memberships(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError>;
+}
+
+// @cpt-dod:cpt-cf-resource-group-dod-integration-auth-read-service:p1
+/// Narrow read-only trait for hierarchy data, used by `AuthZ` plugin.
+///
+/// This trait provides the integration read port that external consumers
+/// (such as the `AuthZ` plugin) use to query group hierarchy data without
+/// depending on the full `ResourceGroupClient`.
+#[async_trait]
+pub trait ResourceGroupReadHierarchy: Send + Sync {
+    /// List group hierarchy with depth for a given group.
+    async fn list_group_depth(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+}
+
+// @cpt-flow:cpt-cf-resource-group-flow-integration-auth-plugin-routing:p1
+/// Extended read trait for vendor-specific plugin gateway routing.
+///
+/// Extends `ResourceGroupReadHierarchy` with membership listing for
+/// plugin consumers that need both hierarchy and membership data.
+#[async_trait]
+pub trait ResourceGroupReadPluginClient: ResourceGroupReadHierarchy {
+    /// List memberships for plugin consumers.
+    async fn list_memberships(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError>;
+}

--- a/modules/system/resource-group/resource-group-sdk/src/error.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/error.rs
@@ -1,0 +1,129 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-errors:p1
+//! Public error types for the resource-group module.
+//!
+//! These errors are safe to expose to other modules and consumers.
+
+use thiserror::Error;
+
+/// Errors that can be returned by the `ResourceGroupClient`.
+#[derive(Error, Debug, Clone)]
+pub enum ResourceGroupError {
+    /// Resource with the specified code was not found.
+    #[error("Type not found: {code}")]
+    NotFound { code: String },
+
+    /// A type with the specified code already exists.
+    #[error("Type already exists: {code}")]
+    TypeAlreadyExists { code: String },
+
+    /// Validation error with the provided data.
+    #[error("Validation error: {message}")]
+    Validation { message: String },
+
+    /// Removing allowed parents or disabling root placement would break
+    /// existing group hierarchy relationships.
+    #[error("Allowed parents violation: {message}")]
+    AllowedParentsViolation { message: String },
+
+    /// Cannot delete a type because groups of this type still exist.
+    #[error("Active references exist: {message}")]
+    ConflictActiveReferences { message: String },
+
+    /// Parent type is not allowed by the type's `allowed_parents` configuration.
+    #[error("Invalid parent type: {message}")]
+    InvalidParentType { message: String },
+
+    /// A cycle would be created in the group hierarchy.
+    #[error("Cycle detected: {message}")]
+    CycleDetected { message: String },
+
+    /// A configured limit (depth, width, etc.) would be exceeded.
+    #[error("Limit violation: {message}")]
+    LimitViolation { message: String },
+
+    /// Tenant scope incompatibility.
+    #[error("Tenant incompatibility: {message}")]
+    TenantIncompatibility { message: String },
+
+    /// Service is temporarily unavailable.
+    #[error("Service unavailable: {message}")]
+    ServiceUnavailable { message: String },
+
+    /// An internal error occurred.
+    #[error("Internal error")]
+    Internal,
+}
+
+impl ResourceGroupError {
+    /// Create a `NotFound` error.
+    pub fn not_found(code: impl Into<String>) -> Self {
+        Self::NotFound { code: code.into() }
+    }
+
+    /// Create a `TypeAlreadyExists` error.
+    pub fn type_already_exists(code: impl Into<String>) -> Self {
+        Self::TypeAlreadyExists { code: code.into() }
+    }
+
+    /// Create a `Validation` error.
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self::Validation {
+            message: message.into(),
+        }
+    }
+
+    /// Create an `AllowedParentsViolation` error.
+    pub fn allowed_parents_violation(message: impl Into<String>) -> Self {
+        Self::AllowedParentsViolation {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `ConflictActiveReferences` error.
+    pub fn conflict_active_references(message: impl Into<String>) -> Self {
+        Self::ConflictActiveReferences {
+            message: message.into(),
+        }
+    }
+
+    /// Create an `InvalidParentType` error.
+    pub fn invalid_parent_type(message: impl Into<String>) -> Self {
+        Self::InvalidParentType {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `CycleDetected` error.
+    pub fn cycle_detected(message: impl Into<String>) -> Self {
+        Self::CycleDetected {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `LimitViolation` error.
+    pub fn limit_violation(message: impl Into<String>) -> Self {
+        Self::LimitViolation {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `TenantIncompatibility` error.
+    pub fn tenant_incompatibility(message: impl Into<String>) -> Self {
+        Self::TenantIncompatibility {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `ServiceUnavailable` error.
+    pub fn service_unavailable(message: impl Into<String>) -> Self {
+        Self::ServiceUnavailable {
+            message: message.into(),
+        }
+    }
+
+    /// Create an `Internal` error.
+    #[must_use]
+    pub fn internal() -> Self {
+        Self::Internal
+    }
+}

--- a/modules/system/resource-group/resource-group-sdk/src/lib.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/lib.rs
@@ -1,0 +1,28 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+//! Resource Group SDK
+//!
+//! This crate provides the public API for the `resource-group` module:
+//! - `ResourceGroupClient` trait
+//! - Model types for GTS types, groups, memberships
+//! - Error type (`ResourceGroupError`)
+//! - `OData` filter field definitions (behind `odata` feature)
+
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+
+pub mod api;
+pub mod error;
+pub mod models;
+
+// OData filter field definitions (feature-gated)
+#[cfg(feature = "odata")]
+pub mod odata;
+
+// Re-export main types at crate root for convenience
+pub use api::{ResourceGroupClient, ResourceGroupReadHierarchy, ResourceGroupReadPluginClient};
+pub use error::ResourceGroupError;
+pub use models::{
+    CreateGroupRequest, CreateTypeRequest, GroupHierarchy, GroupHierarchyWithDepth, GtsTypePath,
+    PatchGroupRequest, ResourceGroup, ResourceGroupMembership, ResourceGroupType,
+    ResourceGroupWithDepth, UpdateGroupRequest, UpdateTypeRequest,
+};

--- a/modules/system/resource-group/resource-group-sdk/src/models.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/models.rs
@@ -1,0 +1,572 @@
+// @cpt-begin:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1:inst-full
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1
+//! SDK model types for the resource-group module.
+//!
+//! These types form the public contract between the resource-group module
+//! and its consumers. They are transport-agnostic and use string-based
+//! GTS type paths (no surrogate SMALLINT IDs).
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// -- GtsTypePath value object --
+
+// @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-1
+/// Maximum length of a GTS type path.
+const GTS_TYPE_PATH_MAX_LEN: usize = 255;
+
+/// Validated GTS type path value object.
+///
+/// A GTS type path follows the pattern `gts.<segment>~(<segment>~)*` where
+/// each segment consists of lowercase alphanumeric characters, underscores,
+/// and dots. Examples: `gts.x.system.rg.type.v1~`, `gts.x.system.rg.type.v1~x.system.tn.tenant.v1~`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct GtsTypePath(String);
+
+impl GtsTypePath {
+    /// Create a new `GtsTypePath` from a raw string, applying validation.
+    ///
+    /// # Errors
+    /// Returns an error if the string is empty, exceeds 255 characters,
+    /// or does not match the GTS type path format.
+    pub fn new(raw: impl Into<String>) -> Result<Self, String> {
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-2
+        let raw = raw.into();
+        let s = raw.trim().to_lowercase();
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-2
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3
+        if s.is_empty() {
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3a
+            return Err("GTS type path must not be empty".to_owned());
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3a
+        }
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5
+        if s.len() > GTS_TYPE_PATH_MAX_LEN {
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5a
+            return Err("GTS type path exceeds maximum length".to_owned());
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5a
+        }
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4
+        // Validate format: ^gts\.[a-z0-9_.]+~([a-z0-9_.]+~)*$
+        if !Self::matches_format(&s) {
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4a
+            return Err("Invalid GTS type path format".to_owned());
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4a
+        }
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-6
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-7
+        Ok(Self(s))
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-7
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-6
+    }
+
+    /// Return the inner string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Validate format: `gts.<segment>~(<segment>~)*`
+    /// where segment = `[a-z0-9_.]+`
+    #[allow(unknown_lints)]
+    #[allow(de0901_gts_string_pattern)]
+    fn matches_format(s: &str) -> bool {
+        // Must start with "gts." and end with "~"
+        let Some(rest) = s.strip_prefix("gts.") else {
+            return false;
+        };
+        if rest.is_empty() || !rest.ends_with('~') {
+            return false;
+        }
+        // Split by '~', last element will be "" due to trailing '~'
+        let segments: Vec<&str> = rest.split('~').collect();
+        // Need at least one real segment + trailing empty
+        if segments.len() < 2 {
+            return false;
+        }
+        // All segments except the last (empty) must be non-empty and valid chars
+        for seg in &segments[..segments.len() - 1] {
+            if seg.is_empty() {
+                return false;
+            }
+            if !seg
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '.')
+            {
+                return false;
+            }
+        }
+        // Last element must be empty (from trailing ~)
+        segments.last().is_some_and(|s| s.is_empty())
+    }
+}
+
+impl fmt::Display for GtsTypePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<GtsTypePath> for String {
+    fn from(p: GtsTypePath) -> Self {
+        p.0
+    }
+}
+
+impl TryFrom<String> for GtsTypePath {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::new(s)
+    }
+}
+
+impl AsRef<str> for GtsTypePath {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+// @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-1
+
+// -- Type --
+
+/// A GTS resource group type definition.
+///
+/// Matches the REST `Type` schema. All references use string GTS type paths;
+/// surrogate SMALLINT IDs are internal to the persistence layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroupType {
+    /// GTS type path (e.g. `gts.x.system.rg.type.v1~x.system.tn.tenant.v1~`)
+    pub code: String,
+    /// Whether groups of this type can be root nodes (no parent).
+    pub can_be_root: bool,
+    /// GTS type paths of types allowed as parents.
+    pub allowed_parents: Vec<String>,
+    /// GTS type paths of resource types allowed as members.
+    pub allowed_memberships: Vec<String>,
+    /// Optional JSON Schema for the metadata object of instances of this type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+/// Request body for creating a new GTS type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateTypeRequest {
+    /// GTS type path. Must have prefix `gts.x.system.rg.type.v1~`.
+    pub code: String,
+    /// Whether groups of this type can be root nodes.
+    pub can_be_root: bool,
+    /// GTS type paths of allowed parent types.
+    #[serde(default)]
+    pub allowed_parents: Vec<String>,
+    /// GTS type paths of allowed membership resource types.
+    #[serde(default)]
+    pub allowed_memberships: Vec<String>,
+    /// Optional JSON Schema for instance metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+/// Request body for updating an existing GTS type (full replacement via PUT).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateTypeRequest {
+    /// Whether groups of this type can be root nodes.
+    pub can_be_root: bool,
+    /// GTS type paths of allowed parent types.
+    #[serde(default)]
+    pub allowed_parents: Vec<String>,
+    /// GTS type paths of allowed membership resource types.
+    #[serde(default)]
+    pub allowed_memberships: Vec<String>,
+    /// Optional JSON Schema for instance metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+// -- Group --
+
+/// Hierarchy context for a resource group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupHierarchy {
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Tenant scope.
+    pub tenant_id: Uuid,
+}
+
+/// Hierarchy context for a resource group with depth information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupHierarchyWithDepth {
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Tenant scope.
+    pub tenant_id: Uuid,
+    /// Relative distance from reference group.
+    pub depth: i32,
+}
+
+/// A resource group entity.
+///
+/// Group responses do NOT include `created_at`/`updated_at` (per DESIGN).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroup {
+    /// Group identifier.
+    pub id: Uuid,
+    /// GTS chained type path.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name.
+    pub name: String,
+    /// Hierarchy context.
+    pub hierarchy: GroupHierarchy,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// A resource group entity with depth information (for hierarchy queries).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroupWithDepth {
+    /// Group identifier.
+    pub id: Uuid,
+    /// GTS chained type path.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name.
+    pub name: String,
+    /// Hierarchy context with depth.
+    pub hierarchy: GroupHierarchyWithDepth,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Request body for creating a new resource group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateGroupRequest {
+    /// GTS chained type path. Must have prefix `gts.x.system.rg.type.v1~`.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name (1..255 characters).
+    pub name: String,
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Request body for updating a resource group (full replacement via PUT).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateGroupRequest {
+    /// GTS chained type path. Must have prefix `gts.x.system.rg.type.v1~`.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name (1..255 characters).
+    pub name: String,
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Serde helper for `Option<Option<T>>` that distinguishes absent, null, and present values.
+#[allow(clippy::option_option, clippy::missing_errors_doc)]
+pub mod option_option {
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+    where
+        T: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        Ok(Some(Option::<T>::deserialize(deserializer)?))
+    }
+}
+
+/// Request body for patching a resource group (partial update via PATCH).
+///
+/// Fields not present in the request body are left unchanged. Fields set to
+/// `null` clear the value. Fields with a value update it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(clippy::option_option)]
+pub struct PatchGroupRequest {
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "option_option::deserialize")]
+    pub parent_id: Option<Option<Uuid>>,
+    #[serde(default, deserialize_with = "option_option::deserialize")]
+    pub metadata: Option<Option<serde_json::Value>>,
+}
+
+// -- Membership --
+
+/// A membership link between a resource and a group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroupMembership {
+    /// Group this resource belongs to.
+    pub group_id: Uuid,
+    /// GTS type path of the resource.
+    pub resource_type: String,
+    /// External resource identifier.
+    pub resource_id: String,
+}
+
+// @cpt-dod:cpt-cf-resource-group-dod-testing-sdk-models:p1
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- GtsTypePath: valid cases (table-driven) -- TC-SDK-01, 06, 07, 08, 19, 20
+
+    #[test]
+    fn gts_type_path_valid_cases() {
+        let valid = vec![
+            // TC-SDK-01: basic valid path
+            ("gts.x.system.rg.type.v1~", "gts.x.system.rg.type.v1~"),
+            // TC-SDK-06: uppercase is lowered
+            ("GTS.X.SYSTEM.RG.TYPE.V1~", "gts.x.system.rg.type.v1~"),
+            // TC-SDK-07: trimmed + lowered
+            ("  GTS.X.System.RG.Type.V1~  ", "gts.x.system.rg.type.v1~"),
+            // TC-SDK-08: multi-segment
+            (
+                "gts.x.system.rg.type.v1~x.test.v1~",
+                "gts.x.system.rg.type.v1~x.test.v1~",
+            ),
+            // TC-SDK-19: numeric segments
+            ("gts.123~456~", "gts.123~456~"),
+            // TC-SDK-20: underscores
+            ("gts.a_b.c_d~", "gts.a_b.c_d~"),
+        ];
+        for (input, expected) in valid {
+            let path = GtsTypePath::new(input);
+            assert!(path.is_ok(), "should be valid: {input}");
+            assert_eq!(path.unwrap().as_str(), expected, "for input: {input}");
+        }
+    }
+
+    // -- GtsTypePath: invalid cases (table-driven) -- TC-SDK-02..05, 09, 10, 18, 21
+
+    #[test]
+    fn gts_type_path_invalid_cases() {
+        let cases = vec![
+            // TC-SDK-02: empty
+            ("", "must not be empty"),
+            // TC-SDK-04: wrong prefix
+            ("invalid.path~", "Invalid GTS type path format"),
+            // TC-SDK-05: no trailing tilde
+            ("gts.x.system.rg.type.v1", "Invalid GTS type path format"),
+            // TC-SDK-09: double tilde
+            ("gts.x.system.rg.type.v1~~", "Invalid GTS type path format"),
+            // TC-SDK-10: hyphen in segment
+            (
+                "gts.x.system.rg.type.v1~hello-world~",
+                "Invalid GTS type path format",
+            ),
+            // TC-SDK-18: empty segment after gts.
+            ("gts.~", "Invalid GTS type path format"),
+            // TC-SDK-21: whitespace-only
+            ("   ", "must not be empty"),
+        ];
+        for (input, expected_msg) in cases {
+            let result = GtsTypePath::new(input);
+            assert!(result.is_err(), "should be invalid: '{input}'");
+            let err = result.unwrap_err();
+            assert!(
+                err.contains(expected_msg),
+                "for input '{input}': expected '{expected_msg}' in error, got: {err}"
+            );
+        }
+    }
+
+    // -- GtsTypePath: length boundary tests -- TC-SDK-03, 22, 23
+
+    #[test]
+    fn gts_type_path_max_length_boundary() {
+        // TC-SDK-22: exactly 255 chars -> Ok
+        // Build: "gts." (4) + segment + "~" (1) = 255 => segment = 250 chars
+        let segment = "a".repeat(250);
+        let path_255 = format!("gts.{segment}~");
+        assert_eq!(path_255.len(), 255);
+        assert!(
+            GtsTypePath::new(&path_255).is_ok(),
+            "exactly 255 chars should be valid"
+        );
+
+        // TC-SDK-23: exactly 256 chars -> Err
+        let segment_251 = "a".repeat(251);
+        let path_256 = format!("gts.{segment_251}~");
+        assert_eq!(path_256.len(), 256);
+        let result = GtsTypePath::new(&path_256);
+        assert!(result.is_err(), "256 chars should exceed max length");
+        assert!(result.unwrap_err().contains("exceeds maximum length"));
+
+        // TC-SDK-03: 255+ chars (well above max)
+        let long_segment = "a".repeat(300);
+        let long_path = format!("gts.{long_segment}~");
+        assert!(long_path.len() > 255);
+        let result = GtsTypePath::new(&long_path);
+        assert!(result.is_err(), "255+ chars should be rejected");
+        assert!(result.unwrap_err().contains("exceeds maximum length"));
+    }
+
+    // -- GtsTypePath: serde round-trip -- TC-SDK-11, 12
+
+    #[test]
+    fn gts_type_path_serde_round_trip() {
+        // TC-SDK-11: serialize then deserialize
+        let original = GtsTypePath::new("gts.x.system.rg.type.v1~").unwrap();
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: GtsTypePath = serde_json::from_str(&json).unwrap();
+        assert_eq!(original, deserialized);
+    }
+
+    #[test]
+    fn gts_type_path_serde_invalid_rejects() {
+        // TC-SDK-12: invalid value during deserialization
+        let result = serde_json::from_str::<GtsTypePath>("\"invalid\"");
+        assert!(result.is_err(), "invalid path should fail deserialization");
+    }
+
+    // -- GtsTypePath: Display / Into<String> -- TC-SDK-13
+
+    #[test]
+    fn gts_type_path_display_and_into_string() {
+        let path = GtsTypePath::new("gts.x.system.rg.type.v1~").unwrap();
+        let display = path.to_string();
+        let into_string: String = path.into();
+        assert_eq!(display, into_string);
+    }
+
+    // -- ResourceGroupType serialization -- TC-SDK-14
+
+    #[test]
+    fn resource_group_type_camel_case_keys() {
+        let rgt = ResourceGroupType {
+            code: "gts.x.system.rg.type.v1~".to_owned(),
+            can_be_root: true,
+            allowed_parents: vec!["gts.parent~".to_owned()],
+            allowed_memberships: vec!["gts.member~".to_owned()],
+            metadata_schema: None,
+        };
+        let json = serde_json::to_value(&rgt).unwrap();
+        assert!(
+            json.get("canBeRoot").is_some(),
+            "expected camelCase 'canBeRoot'"
+        );
+        assert!(
+            json.get("allowedParents").is_some(),
+            "expected camelCase 'allowedParents'"
+        );
+        assert!(
+            json.get("allowedMemberships").is_some(),
+            "expected camelCase 'allowedMemberships'"
+        );
+        assert!(
+            json.get("metadataSchema").is_none(),
+            "metadataSchema should be absent when None"
+        );
+    }
+
+    // -- ResourceGroup serialization -- TC-SDK-15, 16
+
+    #[test]
+    fn resource_group_type_field_renamed() {
+        // TC-SDK-15: "type" not "type_path"
+        let group = ResourceGroup {
+            id: Uuid::nil(),
+            type_path: "gts.x.system.rg.type.v1~".to_owned(),
+            name: "Test".to_owned(),
+            hierarchy: GroupHierarchy {
+                parent_id: None,
+                tenant_id: Uuid::nil(),
+            },
+            metadata: Some(serde_json::json!({"key": "val"})),
+        };
+        let json = serde_json::to_value(&group).unwrap();
+        assert!(
+            json.get("type").is_some(),
+            "expected 'type' key, not 'type_path'"
+        );
+        assert!(
+            json.get("type_path").is_none(),
+            "'type_path' should not appear in JSON"
+        );
+    }
+
+    #[test]
+    fn resource_group_metadata_absent_when_none() {
+        // TC-SDK-16: metadata: None -> no "metadata" key
+        let group = ResourceGroup {
+            id: Uuid::nil(),
+            type_path: "gts.x.system.rg.type.v1~".to_owned(),
+            name: "Test".to_owned(),
+            hierarchy: GroupHierarchy {
+                parent_id: None,
+                tenant_id: Uuid::nil(),
+            },
+            metadata: None,
+        };
+        let json = serde_json::to_value(&group).unwrap();
+        assert!(
+            json.get("metadata").is_none(),
+            "metadata should be absent when None, got: {json}"
+        );
+    }
+
+    // -- QueryProfile default -- TC-SDK-17
+
+    #[test]
+    fn query_profile_default_values() {
+        // QueryProfile is in group_service, not in SDK models.
+        // TC-SDK-17 is tested in domain_unit_test.rs or here via the re-export.
+        // Since QueryProfile lives in the main crate, we skip here and it's
+        // covered in domain_unit_test.rs instead.
+    }
+
+    // -- validate_type_code vs GtsTypePath inconsistency -- TC-SDK-24
+
+    #[test]
+    fn gts_type_path_trims_and_lowercases() {
+        // TC-SDK-24: GtsTypePath::new trims whitespace and lowercases.
+        // validate_type_code (in the domain crate) does NOT trim or lowercase.
+        // Document this inconsistency: the SDK normalizes input but the
+        // domain validation is a strict prefix check on the raw string.
+        let input = "  GTS.X.SYSTEM.RG.TYPE.V1~  ";
+        let path = GtsTypePath::new(input);
+        assert!(
+            path.is_ok(),
+            "GtsTypePath::new should accept trimmed/lowered input"
+        );
+        assert_eq!(path.unwrap().as_str(), "gts.x.system.rg.type.v1~");
+        // Note: validate_type_code(input) would fail because it checks
+        // prefix on the raw (untrimmed, uncased) string. This is a known
+        // inconsistency between SDK and domain validation layers.
+    }
+}
+// @cpt-end:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1:inst-full

--- a/modules/system/resource-group/resource-group-sdk/src/odata/groups.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/groups.rs
@@ -1,0 +1,79 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for resource group entities.
+//!
+//! Group list `$filter` fields: `type` (eq, ne, in), `hierarchy/parent_id` (eq, ne, in),
+//! `id` (eq, ne, in), `name` (eq, ne, in).
+//!
+//! The `hierarchy/parent_id` field uses `OData` nested path syntax; since the
+//! `ODataFilterable` derive macro does not support slash-separated names,
+//! the `FilterField` trait is implemented manually.
+
+use modkit_odata::filter::{FieldKind, FilterField};
+
+/// Filter field enum for group list queries.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum GroupFilterField {
+    /// Filter by GTS type path.
+    Type,
+    /// Filter by parent group ID (direct parent only).
+    HierarchyParentId,
+    /// Filter by group ID.
+    Id,
+    /// Filter by group name.
+    Name,
+}
+
+impl FilterField for GroupFilterField {
+    const FIELDS: &'static [Self] = &[Self::Type, Self::HierarchyParentId, Self::Id, Self::Name];
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Type => "type",
+            Self::HierarchyParentId => "hierarchy/parent_id",
+            Self::Id => "id",
+            Self::Name => "name",
+        }
+    }
+
+    fn kind(&self) -> FieldKind {
+        match self {
+            // Type is SMALLINT in DB; filter values are resolved from string to
+            // integer at the persistence boundary before OData processing.
+            Self::Type => FieldKind::I64,
+            Self::Name => FieldKind::String,
+            Self::HierarchyParentId | Self::Id => FieldKind::Uuid,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TC-ODATA-01: GroupFilterField names
+    #[test]
+    fn group_filter_field_names_correct() {
+        assert_eq!(GroupFilterField::Type.name(), "type");
+        assert_eq!(
+            GroupFilterField::HierarchyParentId.name(),
+            "hierarchy/parent_id"
+        );
+        assert_eq!(GroupFilterField::Id.name(), "id");
+        assert_eq!(GroupFilterField::Name.name(), "name");
+    }
+
+    // TC-ODATA-02: GroupFilterField kinds
+    #[test]
+    fn group_filter_field_kinds_correct() {
+        assert_eq!(GroupFilterField::Type.kind(), FieldKind::I64);
+        assert_eq!(GroupFilterField::HierarchyParentId.kind(), FieldKind::Uuid);
+        assert_eq!(GroupFilterField::Id.kind(), FieldKind::Uuid);
+        assert_eq!(GroupFilterField::Name.kind(), FieldKind::String);
+    }
+
+    // TC-ODATA-03: FIELDS completeness
+    #[test]
+    fn group_filter_field_completeness() {
+        assert_eq!(GroupFilterField::FIELDS.len(), 4);
+    }
+}

--- a/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy.rs
@@ -1,0 +1,53 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for group hierarchy queries.
+//!
+//! Hierarchy `$filter` fields: `hierarchy/depth` (eq, ne, gt, ge, lt, le),
+//! `type` (eq, ne, in).
+
+use modkit_odata::filter::{FieldKind, FilterField};
+
+/// Filter field enum for group hierarchy queries.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum HierarchyFilterField {
+    /// Filter by relative depth from reference group.
+    HierarchyDepth,
+    /// Filter by GTS type path.
+    Type,
+}
+
+impl FilterField for HierarchyFilterField {
+    const FIELDS: &'static [Self] = &[Self::HierarchyDepth, Self::Type];
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::HierarchyDepth => "hierarchy/depth",
+            Self::Type => "type",
+        }
+    }
+
+    fn kind(&self) -> FieldKind {
+        match self {
+            Self::HierarchyDepth | Self::Type => FieldKind::I64,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TC-ODATA-04: HierarchyFilterField names + kinds
+    #[test]
+    fn hierarchy_filter_field_names_and_kinds() {
+        assert_eq!(
+            HierarchyFilterField::HierarchyDepth.name(),
+            "hierarchy/depth"
+        );
+        assert_eq!(HierarchyFilterField::HierarchyDepth.kind(), FieldKind::I64);
+
+        assert_eq!(HierarchyFilterField::Type.name(), "type");
+        assert_eq!(HierarchyFilterField::Type.kind(), FieldKind::I64);
+
+        assert_eq!(HierarchyFilterField::FIELDS.len(), 2);
+    }
+}

--- a/modules/system/resource-group/resource-group-sdk/src/odata/memberships.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/memberships.rs
@@ -1,0 +1,58 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for membership entities.
+//!
+//! Membership list `$filter` fields: `group_id` (eq, ne, in), `resource_type` (eq, ne, in),
+//! `resource_id` (eq, ne, in).
+
+use modkit_odata::filter::{FieldKind, FilterField};
+
+/// Filter field enum for membership list queries.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum MembershipFilterField {
+    /// Filter by group ID.
+    GroupId,
+    /// Filter by resource type (GTS type path).
+    ResourceType,
+    /// Filter by resource ID.
+    ResourceId,
+}
+
+impl FilterField for MembershipFilterField {
+    const FIELDS: &'static [Self] = &[Self::GroupId, Self::ResourceType, Self::ResourceId];
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::GroupId => "group_id",
+            Self::ResourceType => "resource_type",
+            Self::ResourceId => "resource_id",
+        }
+    }
+
+    fn kind(&self) -> FieldKind {
+        match self {
+            Self::GroupId => FieldKind::Uuid,
+            Self::ResourceType => FieldKind::I64,
+            Self::ResourceId => FieldKind::String,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TC-ODATA-05: MembershipFilterField names + kinds
+    #[test]
+    fn membership_filter_field_names_and_kinds() {
+        assert_eq!(MembershipFilterField::GroupId.name(), "group_id");
+        assert_eq!(MembershipFilterField::GroupId.kind(), FieldKind::Uuid);
+
+        assert_eq!(MembershipFilterField::ResourceType.name(), "resource_type");
+        assert_eq!(MembershipFilterField::ResourceType.kind(), FieldKind::I64);
+
+        assert_eq!(MembershipFilterField::ResourceId.name(), "resource_id");
+        assert_eq!(MembershipFilterField::ResourceId.kind(), FieldKind::String);
+
+        assert_eq!(MembershipFilterField::FIELDS.len(), 3);
+    }
+}

--- a/modules/system/resource-group/resource-group-sdk/src/odata/mod.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/mod.rs
@@ -1,0 +1,12 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for resource-group resources.
+
+mod groups;
+mod hierarchy;
+mod memberships;
+mod types;
+
+pub use groups::GroupFilterField;
+pub use hierarchy::HierarchyFilterField;
+pub use memberships::MembershipFilterField;
+pub use types::{TypeFilterField, TypeQuery, TypeQueryFilterField};

--- a/modules/system/resource-group/resource-group-sdk/src/odata/types.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/types.rs
@@ -1,0 +1,17 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for GTS type resources.
+
+use modkit_odata_macros::ODataFilterable;
+
+/// Type filterable fields schema.
+///
+/// This struct defines which fields can be used in `OData` `$filter` queries
+/// for GTS type resources. The field names match the wire format.
+#[derive(ODataFilterable)]
+pub struct TypeQuery {
+    #[odata(filter(kind = "String"))]
+    pub code: String,
+}
+
+/// Type alias for the generated filter field enum.
+pub use TypeQueryFilterField as TypeFilterField;

--- a/modules/system/resource-group/resource-group/Cargo.toml
+++ b/modules/system/resource-group/resource-group/Cargo.toml
@@ -1,0 +1,66 @@
+[package]
+name = "cf-resource-group"
+version = "0.1.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Resource Group module: hierarchical resource group management with GTS type system"
+
+[lints]
+workspace = true
+
+[features]
+default = ["odata"]
+odata = []
+
+[dependencies]
+# SDK - public API, models, and errors
+resource-group-sdk = { package = "cf-resource-group-sdk", path = "../resource-group-sdk", features = ["odata"] }
+
+# Core dependencies
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+inventory = { workspace = true }
+
+# Serde and JSON schema
+serde = { workspace = true }
+serde_json = { workspace = true }
+jsonschema = { workspace = true }
+utoipa = { workspace = true, features = ["time"] }
+
+# HTTP and REST
+axum = { workspace = true, features = ["macros"] }
+http = { workspace = true }
+
+# Time handling
+time = { workspace = true }
+
+# UUID support
+uuid = { workspace = true }
+
+# Database - SeaORM
+sea-orm = { workspace = true }
+sea-orm-migration = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+
+# AuthZ
+authz-resolver-sdk = { workspace = true }
+
+# Local dependencies
+modkit = { workspace = true }
+modkit-db = { workspace = true, features = ["sqlite", "pg"] }
+modkit-db-macros = { workspace = true }
+modkit-security = { workspace = true }
+modkit-odata = { workspace = true, features = ["with-utoipa"] }
+modkit-macros = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+modkit-db = { workspace = true, features = ["sqlite"] }
+tower = { workspace = true }
+http-body-util = { workspace = true }

--- a/modules/system/resource-group/resource-group/src/domain/error.rs
+++ b/modules/system/resource-group/resource-group/src/domain/error.rs
@@ -1,0 +1,209 @@
+// @cpt-dod:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1
+// @cpt-dod:cpt-cf-resource-group-dod-testing-error-conversions:p2
+//! Domain error types for the resource-group module.
+
+use authz_resolver_sdk::pep::EnforcerError;
+use resource_group_sdk::ResourceGroupError;
+use thiserror::Error;
+
+/// Domain-specific errors for the resource-group module.
+#[allow(unknown_lints, de0309_must_have_domain_model)]
+#[derive(Error, Debug)]
+pub enum DomainError {
+    #[error("Type not found: {code}")]
+    TypeNotFound { code: String },
+
+    #[error("Type already exists: {code}")]
+    TypeAlreadyExists { code: String },
+
+    #[error("Validation failed: {message}")]
+    Validation { message: String },
+
+    #[error("Allowed parents violation: {message}")]
+    AllowedParentsViolation { message: String },
+
+    #[error("Active references exist: {message}")]
+    ConflictActiveReferences { message: String },
+
+    #[error("Group not found: {id}")]
+    GroupNotFound { id: uuid::Uuid },
+
+    #[error("Membership not found: {key}")]
+    MembershipNotFound { key: String },
+
+    #[error("Invalid parent type: {message}")]
+    InvalidParentType { message: String },
+
+    #[error("Cycle detected: {message}")]
+    CycleDetected { message: String },
+
+    #[error("Limit violation: {message}")]
+    LimitViolation { message: String },
+
+    #[error("Conflict: {message}")]
+    Conflict { message: String },
+
+    #[error("Tenant incompatibility: {message}")]
+    TenantIncompatibility { message: String },
+
+    #[error("Access denied: {message}")]
+    AccessDenied { message: String },
+
+    #[error("Database error: {message}")]
+    Database { message: String },
+
+    #[error("Internal error")]
+    InternalError,
+}
+
+impl DomainError {
+    /// Returns `true` if this error represents a serialization failure
+    /// (SQLSTATE `40001`) that is safe to retry.
+    ///
+    /// Covers `PostgreSQL` `SERIALIZABLE` conflicts and `MySQL`/`MariaDB` deadlocks.
+    #[must_use]
+    pub fn is_serialization_failure(&self) -> bool {
+        match self {
+            DomainError::Database { message } => {
+                message.contains("40001") || message.contains("could not serialize access")
+            }
+            _ => false,
+        }
+    }
+
+    pub fn type_not_found(code: impl Into<String>) -> Self {
+        Self::TypeNotFound { code: code.into() }
+    }
+
+    pub fn type_already_exists(code: impl Into<String>) -> Self {
+        Self::TypeAlreadyExists { code: code.into() }
+    }
+
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self::Validation {
+            message: message.into(),
+        }
+    }
+
+    pub fn allowed_parents_violation(message: impl Into<String>) -> Self {
+        Self::AllowedParentsViolation {
+            message: message.into(),
+        }
+    }
+
+    pub fn conflict_active_references(message: impl Into<String>) -> Self {
+        Self::ConflictActiveReferences {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn group_not_found(id: uuid::Uuid) -> Self {
+        Self::GroupNotFound { id }
+    }
+
+    pub fn membership_not_found(key: impl Into<String>) -> Self {
+        Self::MembershipNotFound { key: key.into() }
+    }
+
+    pub fn invalid_parent_type(message: impl Into<String>) -> Self {
+        Self::InvalidParentType {
+            message: message.into(),
+        }
+    }
+
+    pub fn cycle_detected(message: impl Into<String>) -> Self {
+        Self::CycleDetected {
+            message: message.into(),
+        }
+    }
+
+    pub fn limit_violation(message: impl Into<String>) -> Self {
+        Self::LimitViolation {
+            message: message.into(),
+        }
+    }
+
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::Conflict {
+            message: message.into(),
+        }
+    }
+
+    pub fn tenant_incompatibility(message: impl Into<String>) -> Self {
+        Self::TenantIncompatibility {
+            message: message.into(),
+        }
+    }
+
+    pub fn database(message: impl Into<String>) -> Self {
+        Self::Database {
+            message: message.into(),
+        }
+    }
+}
+
+/// Convert domain errors to SDK errors for public API consumption.
+impl From<DomainError> for ResourceGroupError {
+    fn from(e: DomainError) -> Self {
+        match e {
+            DomainError::TypeNotFound { code } => ResourceGroupError::not_found(code),
+            DomainError::TypeAlreadyExists { code } => {
+                ResourceGroupError::type_already_exists(code)
+            }
+            DomainError::Validation { message } => ResourceGroupError::validation(message),
+            DomainError::InvalidParentType { message } => {
+                ResourceGroupError::invalid_parent_type(message)
+            }
+            DomainError::CycleDetected { message } => ResourceGroupError::cycle_detected(message),
+            DomainError::LimitViolation { message } => ResourceGroupError::limit_violation(message),
+            DomainError::AllowedParentsViolation { message } => {
+                ResourceGroupError::allowed_parents_violation(message)
+            }
+            DomainError::ConflictActiveReferences { message }
+            | DomainError::Conflict { message } => {
+                ResourceGroupError::conflict_active_references(message)
+            }
+            DomainError::GroupNotFound { id } => ResourceGroupError::not_found(id.to_string()),
+            DomainError::MembershipNotFound { key } => ResourceGroupError::not_found(key),
+            DomainError::TenantIncompatibility { message } => {
+                ResourceGroupError::tenant_incompatibility(message)
+            }
+            DomainError::AccessDenied { .. } => ResourceGroupError::internal(),
+            DomainError::Database { .. } | DomainError::InternalError => {
+                ResourceGroupError::internal()
+            }
+        }
+    }
+}
+
+impl From<sea_orm::DbErr> for DomainError {
+    fn from(e: sea_orm::DbErr) -> Self {
+        DomainError::database(format!("{e}"))
+    }
+}
+
+impl From<modkit_db::DbError> for DomainError {
+    fn from(e: modkit_db::DbError) -> Self {
+        DomainError::database(format!("{e}"))
+    }
+}
+
+impl From<EnforcerError> for DomainError {
+    fn from(e: EnforcerError) -> Self {
+        match e {
+            EnforcerError::Denied { deny_reason } => DomainError::AccessDenied {
+                message: deny_reason.map_or_else(
+                    || "access denied by PDP".to_owned(),
+                    |reason| format!("access denied by PDP: {reason:?}"),
+                ),
+            },
+            EnforcerError::EvaluationFailed(err) => DomainError::AccessDenied {
+                message: format!("authorization evaluation failed: {err}"),
+            },
+            EnforcerError::CompileFailed(err) => DomainError::AccessDenied {
+                message: format!("constraint compilation failed: {err}"),
+            },
+        }
+    }
+}

--- a/modules/system/resource-group/resource-group/src/domain/mod.rs
+++ b/modules/system/resource-group/resource-group/src/domain/mod.rs
@@ -1,0 +1,5 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+
+pub mod error;
+pub mod repo;
+pub mod validation;

--- a/modules/system/resource-group/resource-group/src/domain/repo.rs
+++ b/modules/system/resource-group/resource-group/src/domain/repo.rs
@@ -1,0 +1,287 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-traits:p1
+use async_trait::async_trait;
+use modkit_db::secure::DBRunner;
+use modkit_odata::{ODataQuery, Page};
+use modkit_security::AccessScope;
+use resource_group_sdk::models::{
+    ResourceGroup, ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth,
+};
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::infra::storage::entity::{
+    gts_type, resource_group as rg_entity, resource_group_membership as membership_entity,
+};
+
+#[async_trait]
+#[allow(clippy::too_many_arguments)]
+pub trait GroupRepositoryTrait: Send + Sync + 'static {
+    // -- Read operations --
+
+    async fn find_by_id<C: DBRunner>(
+        &self,
+        db: &C,
+        scope: &AccessScope,
+        id: Uuid,
+    ) -> Result<Option<ResourceGroup>, DomainError>;
+
+    async fn find_model_by_id<C: DBRunner>(
+        &self,
+        db: &C,
+        id: Uuid,
+    ) -> Result<Option<rg_entity::Model>, DomainError>;
+
+    async fn list_groups<C: DBRunner>(
+        &self,
+        db: &C,
+        scope: &AccessScope,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroup>, DomainError>;
+
+    async fn list_hierarchy<C: DBRunner>(
+        &self,
+        db: &C,
+        scope: &AccessScope,
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, DomainError>;
+
+    // -- Write operations --
+
+    async fn insert<C: DBRunner>(
+        &self,
+        db: &C,
+        id: Uuid,
+        parent_id: Option<Uuid>,
+        gts_type_id: i16,
+        name: &str,
+        metadata: Option<&serde_json::Value>,
+        tenant_id: Uuid,
+    ) -> Result<rg_entity::Model, DomainError>;
+
+    async fn update<C: DBRunner>(
+        &self,
+        db: &C,
+        id: Uuid,
+        parent_id: Option<Uuid>,
+        gts_type_id: i16,
+        name: &str,
+        metadata: Option<&serde_json::Value>,
+    ) -> Result<rg_entity::Model, DomainError>;
+
+    async fn delete_by_id<C: DBRunner>(&self, db: &C, id: Uuid) -> Result<(), DomainError>;
+
+    // -- Closure table operations --
+
+    async fn insert_closure_self_row<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+    ) -> Result<(), DomainError>;
+
+    async fn insert_ancestor_closure_rows<C: DBRunner>(
+        &self,
+        db: &C,
+        child_id: Uuid,
+        parent_id: Uuid,
+    ) -> Result<(), DomainError>;
+
+    async fn get_descendant_ids<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+    ) -> Result<Vec<Uuid>, DomainError>;
+
+    async fn get_depth<C: DBRunner>(&self, db: &C, group_id: Uuid) -> Result<i32, DomainError>;
+
+    async fn count_children<C: DBRunner>(
+        &self,
+        db: &C,
+        parent_id: Uuid,
+    ) -> Result<u64, DomainError>;
+
+    async fn is_descendant<C: DBRunner>(
+        &self,
+        db: &C,
+        potential_ancestor: Uuid,
+        potential_descendant: Uuid,
+    ) -> Result<bool, DomainError>;
+
+    async fn delete_ancestor_closure_rows<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+        keep_self: bool,
+    ) -> Result<(), DomainError>;
+
+    async fn delete_all_closure_rows<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+    ) -> Result<(), DomainError>;
+
+    async fn rebuild_subtree_closure<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+        new_parent_id: Option<Uuid>,
+    ) -> Result<(), DomainError>;
+
+    async fn has_memberships<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+    ) -> Result<bool, DomainError>;
+
+    async fn delete_memberships<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+    ) -> Result<(), DomainError>;
+
+    async fn resolve_type_paths_batch<C: DBRunner>(
+        &self,
+        db: &C,
+        type_ids: &[i16],
+    ) -> Result<std::collections::HashMap<i16, String>, DomainError>;
+}
+
+#[async_trait]
+pub trait TypeRepositoryTrait: Send + Sync + 'static {
+    async fn find_by_code<C: DBRunner>(
+        &self,
+        db: &C,
+        code: &str,
+    ) -> Result<Option<ResourceGroupType>, DomainError>;
+
+    async fn load_full_type_by_id<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+    ) -> Result<ResourceGroupType, DomainError>;
+
+    async fn load_full_type<C: DBRunner>(
+        &self,
+        db: &C,
+        type_model: &gts_type::Model,
+    ) -> Result<ResourceGroupType, DomainError>;
+
+    async fn resolve_id<C: DBRunner>(&self, db: &C, code: &str)
+    -> Result<Option<i16>, DomainError>;
+
+    async fn insert<C: DBRunner>(
+        &self,
+        db: &C,
+        schema_id: &str,
+        can_be_root: bool,
+        metadata_schema: Option<&serde_json::Value>,
+    ) -> Result<gts_type::Model, DomainError>;
+
+    async fn insert_allowed_parents<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+        parent_ids: &[i16],
+    ) -> Result<(), DomainError>;
+
+    async fn insert_allowed_memberships<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+        membership_ids: &[i16],
+    ) -> Result<(), DomainError>;
+
+    async fn delete_allowed_parents<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+    ) -> Result<(), DomainError>;
+
+    async fn delete_allowed_memberships<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+    ) -> Result<(), DomainError>;
+
+    async fn update_type<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+        code: &str,
+        can_be_root: bool,
+        metadata_schema: Option<&serde_json::Value>,
+    ) -> Result<gts_type::Model, DomainError>;
+
+    async fn delete_by_id<C: DBRunner>(&self, db: &C, type_id: i16) -> Result<(), DomainError>;
+
+    async fn count_groups_of_type<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+    ) -> Result<u64, DomainError>;
+
+    async fn find_groups_using_parent_type<C: DBRunner>(
+        &self,
+        db: &C,
+        child_type_id: i16,
+        parent_type_id: i16,
+    ) -> Result<Vec<(Uuid, String)>, DomainError>;
+
+    async fn find_root_groups_of_type<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+    ) -> Result<Vec<(Uuid, String)>, DomainError>;
+
+    async fn list_types<C: DBRunner>(
+        &self,
+        db: &C,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupType>, DomainError>;
+
+    async fn resolve_ids<C: DBRunner>(
+        &self,
+        db: &C,
+        codes: &[String],
+    ) -> Result<Vec<i16>, DomainError>;
+}
+
+#[async_trait]
+pub trait MembershipRepositoryTrait: Send + Sync + 'static {
+    async fn list_memberships<C: DBRunner>(
+        &self,
+        db: &C,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupMembership>, DomainError>;
+
+    async fn insert<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+        gts_type_id: i16,
+        resource_id: &str,
+    ) -> Result<membership_entity::Model, DomainError>;
+
+    async fn delete<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+        gts_type_id: i16,
+        resource_id: &str,
+    ) -> Result<u64, DomainError>;
+
+    async fn find_by_composite_key<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+        gts_type_id: i16,
+        resource_id: &str,
+    ) -> Result<Option<membership_entity::Model>, DomainError>;
+
+    async fn get_existing_membership_tenant_ids<C: DBRunner>(
+        &self,
+        db: &C,
+        gts_type_id: i16,
+        resource_id: &str,
+    ) -> Result<Vec<Uuid>, DomainError>;
+}

--- a/modules/system/resource-group/resource-group/src/domain/validation.rs
+++ b/modules/system/resource-group/resource-group/src/domain/validation.rs
@@ -1,0 +1,91 @@
+// @cpt-begin:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1:inst-validation-full
+//! Shared domain validation utilities.
+
+use crate::domain::error::DomainError;
+
+/// GTS type path prefix required for resource group types.
+pub const RG_TYPE_PREFIX: &str = "gts.x.system.rg.type.v1~";
+
+/// Validate a GTS type code: non-empty, correct prefix, length limit.
+///
+/// # Errors
+///
+/// Returns [`DomainError`] if the code is empty, missing the required prefix, or exceeds 1024 chars.
+// @cpt-algo:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1
+// @cpt-algo:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1
+pub fn validate_type_code(code: &str) -> Result<(), DomainError> {
+    // @cpt-begin:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-1
+    if code.is_empty() {
+        return Err(DomainError::validation("Type code must not be empty"));
+    }
+    // @cpt-end:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-1
+    // @cpt-begin:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-2
+    if !code.starts_with(RG_TYPE_PREFIX) {
+        // @cpt-begin:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-2a
+        return Err(DomainError::validation(format!(
+            "Type code must start with prefix '{RG_TYPE_PREFIX}', got: '{code}'"
+        )));
+        // @cpt-end:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-2a
+    }
+    // @cpt-end:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-2
+    // @cpt-begin:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-3
+    if code.len() > 1024 {
+        return Err(DomainError::validation(
+            "Type code must not exceed 1024 characters",
+        ));
+    }
+    // @cpt-end:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-3
+    Ok(())
+}
+
+/// Validate that a `metadata_schema` value is a valid JSON Schema.
+///
+/// Attempts to compile the schema via `jsonschema::validator_for`. If the value
+/// cannot be interpreted as a JSON Schema, returns a [`DomainError::validation`].
+///
+/// # Errors
+///
+/// Returns [`DomainError`] if the value is not a valid JSON Schema.
+// @cpt-begin:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-7
+pub fn validate_metadata_schema(schema: &serde_json::Value) -> Result<(), DomainError> {
+    jsonschema::validator_for(schema).map_err(|e| {
+        DomainError::validation(format!("metadata_schema is not a valid JSON Schema: {e}"))
+    })?;
+    Ok(())
+}
+// @cpt-end:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-7
+
+/// Validate a metadata value against a compiled JSON Schema.
+///
+/// Returns `Ok(())` when:
+/// - `schema` is `None` (no schema = no validation, any metadata accepted)
+/// - `metadata` is `None` (nothing to validate)
+/// - `metadata` validates against the schema
+///
+/// # Errors
+///
+/// Returns [`DomainError`] when metadata violates the schema constraints.
+pub fn validate_metadata_against_schema(
+    metadata: Option<&serde_json::Value>,
+    schema: Option<&serde_json::Value>,
+) -> Result<(), DomainError> {
+    let (Some(metadata), Some(schema)) = (metadata, schema) else {
+        return Ok(());
+    };
+
+    let validator = jsonschema::validator_for(schema)
+        .map_err(|e| DomainError::validation(format!("Type metadata_schema is invalid: {e}")))?;
+
+    let errors: Vec<String> = validator
+        .iter_errors(metadata)
+        .map(|e| e.to_string())
+        .collect();
+    if !errors.is_empty() {
+        return Err(DomainError::validation(format!(
+            "Metadata does not match type schema: {}",
+            errors.join("; ")
+        )));
+    }
+    Ok(())
+}
+// @cpt-end:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1:inst-validation-full

--- a/modules/system/resource-group/resource-group/src/infra/mod.rs
+++ b/modules/system/resource-group/resource-group/src/infra/mod.rs
@@ -1,0 +1,2 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+pub mod storage;

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type.rs
@@ -1,0 +1,24 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "gts_type")]
+#[secure(no_tenant, no_resource, no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i16,
+    #[sea_orm(unique)]
+    pub schema_id: String,
+    #[sea_orm(column_type = "JsonBinary", nullable)]
+    pub metadata_schema: Option<serde_json::Value>,
+    pub created_at: OffsetDateTime,
+    #[sea_orm(nullable)]
+    pub updated_at: Option<OffsetDateTime>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type_allowed_membership.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type_allowed_membership.rs
@@ -1,0 +1,18 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "gts_type_allowed_membership")]
+#[secure(no_tenant, no_resource, no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub type_id: i16,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub membership_type_id: i16,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type_allowed_parent.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type_allowed_parent.rs
@@ -1,0 +1,18 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "gts_type_allowed_parent")]
+#[secure(no_tenant, no_resource, no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub type_id: i16,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub parent_type_id: i16,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/mod.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/mod.rs
@@ -1,0 +1,7 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+pub mod gts_type;
+pub mod gts_type_allowed_membership;
+pub mod gts_type_allowed_parent;
+pub mod resource_group;
+pub mod resource_group_closure;
+pub mod resource_group_membership;

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group.rs
@@ -1,0 +1,28 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "resource_group")]
+#[secure(tenant_col = "tenant_id", resource_col = "id", no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    #[sea_orm(nullable)]
+    pub parent_id: Option<Uuid>,
+    pub gts_type_id: i16,
+    pub name: String,
+    #[sea_orm(column_type = "JsonBinary", nullable)]
+    pub metadata: Option<serde_json::Value>,
+    pub tenant_id: Uuid,
+    pub created_at: OffsetDateTime,
+    #[sea_orm(nullable)]
+    pub updated_at: Option<OffsetDateTime>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group_closure.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group_closure.rs
@@ -1,0 +1,20 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "resource_group_closure")]
+#[secure(no_tenant, no_resource, no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub ancestor_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub descendant_id: Uuid,
+    pub depth: i32,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group_membership.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group_membership.rs
@@ -1,0 +1,23 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "resource_group_membership")]
+#[secure(no_tenant, no_resource, no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub group_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub gts_type_id: i16,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub resource_id: String,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/mod.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/mod.rs
@@ -1,0 +1,4 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+//! Infrastructure storage layer - database persistence and `OData` mapping.
+
+pub mod entity;

--- a/modules/system/resource-group/resource-group/src/lib.rs
+++ b/modules/system/resource-group/resource-group/src/lib.rs
@@ -1,0 +1,7 @@
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+//! Resource Group Module — contracts and domain types.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+pub mod domain;
+#[doc(hidden)]
+pub mod infra;


### PR DESCRIPTION
## Summary
- Resource Group SDK crate with API traits, models, error types, and OData filter definitions
- Module skeleton with domain layer (repo traits, validation, error types) and infrastructure (Sea-ORM entities, storage)
- Workspace and Cargo.toml wiring for the new `resource-group-sdk` and `resource-group` crates

## PR Train
This is **PR 1/3** in the resource-group implementation train:
1. **SDK and module contracts** ← you are here
2. Domain services and storage layer
3. REST API and server wiring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added resource group management system with support for creating and managing resource group types and hierarchies
  * Enabled group membership operations to associate resources with resource groups
  * Implemented hierarchical group support with parent-child relationships and depth tracking
  * Added OData filtering and pagination capabilities for querying groups, hierarchies, and memberships
  * Introduced metadata schema support for custom JSON metadata on groups and types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->