### PR TITLE
feat(resource-group): SDK and module contracts

### DIFF
--- a/.cypilot/config/artifacts.toml
+++ b/.cypilot/config/artifacts.toml
@@ -6,6 +6,15 @@ reason = "Ignore rust-traits.md — reference document for planned Rust SDK cont
 patterns = ["modules/system/resource-group/docs/rust-traits.md"]
 
 [[ignore]]
+reason = "Ignore resource-group codebase and features — code traceability markers added incrementally across PR train. Remove after all PRs merged."
+patterns = [
+  "modules/system/resource-group/resource-group/src/*",
+  "modules/system/resource-group/resource-group/tests/*",
+  "modules/system/resource-group/resource-group-sdk/src/*",
+  "modules/system/resource-group/docs/features/*",
+]
+
+[[ignore]]
 reason = "Ignore 'modules/system' parent directory — not a module, only a grouping for system submodules."
 patterns = ["modules/system"]
 
@@ -34,16 +43,18 @@ reason = "Ignore module 'nodes-registry' (not SDLC-documented yet: missing requi
 patterns = ["modules/system/nodes-registry/*"]
 
 [[ignore]]
-reason = "Ignore oagw codebase — code traceability markers reverted, pending re-add. Docs still validated (DOCS-ONLY effective: all feature tasks unchecked)."
+reason = "Ignore oagw codebase and features — code traceability markers reverted, pending re-add. PRD/DESIGN/ADR/DECOMPOSITION still validated via autodetect."
 patterns = [
   "modules/system/oagw/oagw/src/*",
   "modules/system/oagw/oagw/tests/*",
   "modules/system/oagw/oagw-sdk/src/*",
+  "modules/system/oagw/docs/features/*",
 ]
 
 [[ignore]]
 reason = "Ignore legacy (pre-Cypilot) ADR files in oagw/docs root — converted copies live under docs/ADR/."
 patterns = ["modules/system/oagw/docs/adr-*.md"]
+
 
 [[ignore]]
 reason = "Ignore module 'tenant-resolver' (not SDLC-documented yet: missing required PRD/DESIGN)."

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ logs
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 CLAUDE.local.md
 .setup-stamp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -179,6 +179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,9 +210,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.15"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
+checksum = "74fc7650eedcb2fee505aad48491529e408f0e854c2d9f63eb86c1361b9b3f93"
 dependencies = [
  "anstyle",
  "memchr",
@@ -277,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -468,9 +477,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.14"
+version = "0.13.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
+checksum = "f8bce4948d2520386c6d92a6ea2d472300257702242e5a1d01d6add52bd2e7c1"
 dependencies = [
  "bindgen",
  "cc",
@@ -494,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -506,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.9"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -563,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -625,7 +634,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -668,9 +677,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -722,7 +731,7 @@ checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -740,7 +749,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.9.3",
  "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
@@ -1057,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1098,7 +1107,7 @@ dependencies = [
  "http",
  "http-body",
  "inventory",
- "matchit 0.9.2",
+ "matchit 0.9.1",
  "nanoid",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1394,7 +1403,7 @@ dependencies = [
  "schemars 1.2.1",
  "sea-orm-migration",
  "serde",
- "serde-saphyr 0.0.16",
+ "serde-saphyr 0.0.22",
  "serde_json",
  "supports-color",
  "temp-env",
@@ -1493,7 +1502,7 @@ dependencies = [
  "sea-orm",
  "sea-orm-migration",
  "serde",
- "serde-saphyr 0.0.16",
+ "serde-saphyr 0.0.22",
  "serde_json",
  "sqlx",
  "temp-env",
@@ -1565,7 +1574,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.9.3",
  "rustls",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
@@ -1697,7 +1706,7 @@ version = "0.6.3"
 dependencies = [
  "anyhow",
  "cf-modkit-security",
- "rand 0.9.4",
+ "rand 0.9.3",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1847,28 +1856,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-resource-group"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "cf-authz-resolver-sdk",
+ "cf-modkit",
+ "cf-modkit-db",
+ "cf-modkit-db-macros",
+ "cf-modkit-macros",
+ "cf-modkit-odata",
+ "cf-modkit-security",
+ "cf-resource-group-sdk",
+ "cf-types-registry-sdk",
+ "http",
+ "http-body-util",
+ "inventory",
+ "jsonschema",
+ "sea-orm",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tower",
+ "tracing",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
+name = "cf-resource-group-sdk"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cf-modkit-odata",
+ "cf-modkit-odata-macros",
+ "cf-modkit-sdk",
+ "cf-modkit-security",
+ "gts",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "cf-rustracing"
-version = "1.3.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6565523d8145e63e0cf1b397a5f1bd4e90d5652a7dffb2de8cec460ff23ef6b1"
+checksum = "93f85c3824e4191621dec0551e3cef3d511f329da9a8990bf3e450a85651d97e"
 dependencies = [
  "backtrace",
- "rand 0.10.1",
+ "rand 0.8.5",
  "tokio",
  "trackable",
 ]
 
 [[package]]
 name = "cf-rustracing-jaeger"
-version = "1.3.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c0e4d8cce27f6a6eaff58d2b66f063a18b8ed0d6ef0947ae7a263afa3b7c08"
+checksum = "a6a5f80d44c257c3300a7f45ada676c211e64bbbac591bbec19344a8f61fbcab"
 dependencies = [
  "cf-rustracing",
  "hostname",
  "local-ip-address",
  "percent-encoding",
- "rand 0.10.1",
+ "rand 0.9.3",
  "thrift_codec",
  "tokio",
  "trackable",
@@ -1988,7 +2046,7 @@ dependencies = [
  "cf-types-registry-sdk",
  "inventory",
  "serde",
- "serde-saphyr 0.0.16",
+ "serde-saphyr 0.0.22",
  "serde_json",
  "tokio",
  "tracing",
@@ -2127,17 +2185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,24 +2198,12 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "chrono-tz-build",
  "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -2261,9 +2296,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.58"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -2399,15 +2434,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2433,23 +2459,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -2457,12 +2482,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -2912,11 +2937,11 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "enable-ansi-support"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4ff3ae2a9aa54bf7ee0983e59303224de742818c1822d89f07da9856d9bc60"
+checksum = "ea7457668b3da8a4b702f3d79e131aa3e81cd7e81cc95fb2d54fce9f182ecc77"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3038,9 +3063,9 @@ checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -3058,7 +3083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
 dependencies = [
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.3",
  "web-time",
 ]
 
@@ -3353,7 +3378,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3382,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
 dependencies = [
  "color_quant",
  "weezl",
@@ -3419,7 +3443,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.4",
+ "rand 0.9.3",
  "smallvec 1.15.1",
  "spinning_top",
  "web-time",
@@ -3503,7 +3527,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3540,7 +3564,7 @@ version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c43e7c3212bd992c11b6b9796563388170950521ae8487f5cdf6f6e792f1c8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3577,17 +3601,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3776,9 +3789,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3791,6 +3804,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec 1.15.1",
  "tokio",
  "want",
@@ -3813,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.9"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http",
  "hyper",
@@ -3823,6 +3837,7 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3909,7 +3924,7 @@ dependencies = [
  "cf-types-registry",
  "clap",
  "mimalloc",
- "serde-saphyr 0.0.16",
+ "serde-saphyr 0.0.22",
  "serde_json",
  "tempfile",
  "tokio",
@@ -3944,13 +3959,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -3958,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3971,9 +3985,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -3985,15 +3999,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -4005,15 +4019,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4084,7 +4098,7 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
- "gif 0.14.2",
+ "gif 0.14.1",
  "image-webp",
  "moxcms",
  "num-traits",
@@ -4116,12 +4130,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -4155,9 +4169,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.24"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
 dependencies = [
  "rustversion",
 ]
@@ -4170,23 +4184,12 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.12"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4200,15 +4203,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -4285,12 +4279,10 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -4456,9 +4448,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libloading"
@@ -4488,14 +4480,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -4511,9 +4503,9 @@ dependencies = [
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.28"
+version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be734b33b7bc6a42d92d23e25e69758f866cf564a88d0bf80866fcf5a52c2255"
+checksum = "89b6bd0c289b22f4973012fa91dfed9d5f4b633567bb26f9454fbf437817b499"
 dependencies = [
  "cmake",
  "libc",
@@ -4527,15 +4519,15 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.11"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a59a0cb1c7f84471ad5cd38d768c2a29390d17f1ff2827cdf49bc53e8ac70b"
+checksum = "79ef8c257c92ade496781a32a581d43e3d512cf8ce714ecf04ea80f93ed0ff4a"
 dependencies = [
  "libc",
  "neli",
@@ -4564,19 +4556,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7184fdea2bc3cd272a1acec4030c321a8f9875e877b3f92a53f2f6033fdc289"
 dependencies = [
  "aes",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cbc",
  "ecb",
  "encoding_rs",
  "flate2",
  "getrandom 0.3.4",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "itoa",
  "log",
  "md-5",
  "nom 8.0.0",
  "nom_locate",
- "rand 0.9.4",
+ "rand 0.9.3",
  "rangemap",
  "sha2",
  "stringprep",
@@ -4587,9 +4579,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -4613,17 +4605,6 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "mac_address"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
-dependencies = [
- "nix 0.29.0",
- "serde",
- "winapi",
 ]
 
 [[package]]
@@ -4663,9 +4644,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matchit"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
+checksum = "b3eede3bdf92f3b4f9dc04072a9ce5ab557d5ec9038773bf9ffcd5588b3cc05b"
 
 [[package]]
 name = "md-5"
@@ -4688,15 +4669,6 @@ name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -4734,9 +4706,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -4791,7 +4763,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "byteorder",
  "derive_builder",
  "getset",
@@ -4823,7 +4795,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.6.5",
+ "memoffset",
 ]
 
 [[package]]
@@ -4832,11 +4804,10 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -4845,7 +4816,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4974,9 +4945,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -5040,11 +5011,11 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5c6c0ef9702176a570f06ad94f3198bc29c524c8b498f1b9346e1b1bdcbb3a"
+checksum = "f049ae562349fefb8e837eb15443da1e7c6dcbd8a11f52a228f92220c2e5c85e"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "libloading",
  "nvml-wrapper-sys",
  "static_assertions",
@@ -5067,7 +5038,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -5198,7 +5169,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.4",
+ "rand 0.9.3",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -5259,6 +5230,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5310,15 +5291,6 @@ dependencies = [
  "regex-syntax",
  "structmeta",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
 ]
 
 [[package]]
@@ -5482,7 +5454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -5493,7 +5465,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -5507,38 +5479,18 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -5568,6 +5520,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pingora-cache"
@@ -5731,7 +5689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91bb5030596a3d442c0866ac68afe29c14ba558e77c726dcdf7016b0dbb359d9"
 dependencies = [
  "arrayvec",
- "hashbrown 0.17.0",
+ "hashbrown 0.12.3",
  "parking_lot",
  "rand 0.8.5",
 ]
@@ -5855,9 +5813,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain"
@@ -5872,7 +5830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "quick-xml",
  "serde",
  "time",
@@ -5897,7 +5855,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -5945,9 +5903,9 @@ checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -6075,7 +6033,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -6120,9 +6078,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psl"
-version = "2.1.203"
+version = "2.1.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c0777260d32b76a8c3c197646707085d37e79d63b5872a29192c8d4f60f50b"
+checksum = "70b63978a2742d3f662188698ab45854156e7e34658f53fa951e9253a3dfd583"
 dependencies = [
  "psl-types",
 ]
@@ -6159,7 +6117,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "memchr",
  "unicase",
 ]
@@ -6259,23 +6217,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
-dependencies = [
- "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6317,12 +6264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
 name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6334,14 +6275,14 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.12.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -6376,16 +6317,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -6630,9 +6571,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -6642,7 +6583,6 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -6653,9 +6593,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -6681,7 +6621,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -6690,9 +6630,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6792,12 +6732,12 @@ dependencies = [
 
 [[package]]
 name = "saphyr-parser-bw"
-version = "0.0.605"
+version = "0.0.610"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1aee7486406df3541b5a657204a11be97175a467d77bc98e6d94a66289fb80"
+checksum = "6d643f5e972f17219245b82f038c22cd3c74320bb17c6e8f7e8537de268b1bc6"
 dependencies = [
  "arraydeque",
- "smallvec 2.0.0-alpha.12",
+ "smallvec 1.15.1",
  "thiserror 2.0.18",
 ]
 
@@ -6869,9 +6809,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "1.1.20"
+version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc312fedd460a47ea563911761d254a84e7b51d8cc73ec92c929e78f33fa957"
+checksum = "6d945f62558fac19e5988680d2fdf747b734c2dbc6ce2cb81ba33ed8dde5b103"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6880,7 +6820,6 @@ dependencies = [
  "derive_more 2.1.1",
  "futures-util",
  "log",
- "mac_address",
  "ouroboros",
  "pgvector",
  "rust_decimal",
@@ -6900,9 +6839,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-cli"
-version = "1.1.20"
+version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450"
+checksum = "c94492e2ab6c045b4cc38013809ce255d14c3d352c9f0d11e6b920e2adc948ad"
 dependencies = [
  "chrono",
  "glob",
@@ -6917,9 +6856,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "1.1.20"
+version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9a3f90e336ec74803e8eb98c61bc98754c1adfba3b4f84d946237b752b1c88"
+checksum = "84c2e64a50a9cc8339f10a27577e10062c7f995488e469f2c95762c5ee847832"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6931,9 +6870,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-migration"
-version = "1.1.20"
+version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e"
+checksum = "7315c0cadb7e60fb17ee2bb282aa27d01911fc2a7e5836ec1d4ac37d19250bb4"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -7035,7 +6974,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -7048,7 +6987,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7073,9 +7012,9 @@ checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
 name = "semver"
-version = "1.0.28"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -7107,21 +7046,21 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.16"
+version = "0.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
+checksum = "546b4da4f679832602a8f8ab8ddc10b6b1d2e1a13b4f9dddcaee499436fa06ad"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
  "base64 0.22.1",
  "encoding_rs_io",
+ "getrandom 0.3.4",
  "nohash-hasher",
  "num-traits",
  "regex",
  "saphyr-parser-bw",
  "serde",
- "serde_json",
- "smallvec 2.0.0-alpha.12",
+ "smallvec 1.15.1",
  "zmij",
 ]
 
@@ -7172,7 +7111,6 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -7214,9 +7152,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -7243,7 +7181,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -7270,7 +7208,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -7284,7 +7222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fa1f336066b758b7c9df34ed049c0e693a426afe2b27ff7d5b14f410ab1a132"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "rust_decimal",
 ]
 
@@ -7295,7 +7233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -7312,7 +7250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -7362,9 +7300,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simdutf8"
@@ -7487,7 +7425,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "log",
  "memchr",
  "once_cell",
@@ -7554,7 +7492,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -7600,7 +7538,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "crc",
@@ -8036,9 +7974,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -8077,9 +8015,9 @@ checksum = "b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -8094,9 +8032,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8150,9 +8088,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.29.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -8176,11 +8114,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -8191,20 +8129,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d15b06e6c39068c203e7c1d0bc3944796d867449e7668ef7fa5ea43727cb846e"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -8212,18 +8150,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tonic"
@@ -8301,7 +8239,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -8320,7 +8258,7 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8524,18 +8462,19 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "tungstenite"
-version = "0.29.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
+ "utf-8",
 ]
 
 [[package]]
@@ -8822,6 +8761,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8-zero"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8845,7 +8790,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -8865,9 +8810,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -8961,33 +8906,36 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
- "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8995,9 +8943,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9008,9 +8956,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -9032,7 +8980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -9043,17 +8991,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9248,21 +9196,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -9339,12 +9272,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -9357,12 +9284,6 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -9372,12 +9293,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9399,12 +9314,6 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -9414,12 +9323,6 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9435,12 +9338,6 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -9450,12 +9347,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -9471,9 +9362,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
@@ -9506,7 +9397,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -9536,8 +9427,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -9556,7 +9447,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -9580,9 +9471,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wyz"
@@ -9665,9 +9556,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -9676,9 +9567,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9688,18 +9579,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9708,18 +9599,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9749,9 +9640,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -9760,9 +9651,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -9771,9 +9662,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9797,7 +9688,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.4",
  "hmac",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",
@@ -9819,7 +9710,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.14.0",
+ "indexmap 2.13.0",
  "memchr",
  "zopfli",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,11 +1893,14 @@ name = "cf-resource-group-sdk"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cf-modkit",
  "cf-modkit-odata",
  "cf-modkit-odata-macros",
  "cf-modkit-sdk",
  "cf-modkit-security",
  "gts",
+ "gts-macros",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+# Updated: 2026-04-16 by Constructor Tech
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
@@ -53,6 +54,8 @@ members = [
     "modules/system/grpc-hub",
     "modules/system/nodes-registry/nodes-registry",
     "modules/system/nodes-registry/nodes-registry-sdk",
+    "modules/system/resource-group/resource-group-sdk",
+    "modules/system/resource-group/resource-group",
     "modules/system/module-orchestrator",
     "examples/modkit/users-info/users-info-sdk",
     "examples/modkit/users-info/users-info",
@@ -239,6 +242,7 @@ cf-system-sdk-directory = { version = "0.1.34", path = "libs/system-sdks/sdks/di
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.5", path = "modules/system/types-registry/types-registry-sdk" }
 tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.2.17", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
 authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.2.18", path = "modules/system/authz-resolver/authz-resolver-sdk" }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.0", path = "modules/system/resource-group/resource-group-sdk" }
 oagw-sdk = { package = "cf-oagw-sdk", version = "0.4.0", path = "modules/system/oagw/oagw-sdk" }
 
 # credstore
@@ -253,7 +257,7 @@ grpc_hub = { package = "cf-grpc-hub", version = "0.1.19", path = "modules/system
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde-saphyr = "0.0.16"
+serde-saphyr = "0.0.22"
 secrecy = { version = "0.10", features = ["serde"] }
 serde_urlencoded = "0.7"
 schemars = { version = "1.2", features = ["derive", "uuid1"] }
@@ -408,7 +412,7 @@ regex = "1.10"
 glob = "0.3"
 colored = "3.1"
 supports-color = "3"
-enable-ansi-support = "0.2"
+enable-ansi-support = "0.3"
 
 # gRPC support
 tonic = { version = "0.14", features = ["transport"] }
@@ -451,7 +455,7 @@ hostname = "0.4"
 starship-battery = "0.10"
 local-ip-address = "0.6"
 machine-uid = "0.5"
-nvml-wrapper = "0.11"
+nvml-wrapper = "0.12"
 
 # Public Suffix List
 psl = "2"
@@ -466,7 +470,7 @@ strsim = "0.11"
 
 # OData parsing
 peg = "0.8"
-chrono-tz = "0.9"
+chrono-tz = "0.10"
 
 # Procedural macros
 proc-macro2 = "1.0"
@@ -484,7 +488,7 @@ proc-macro-error2 = "2.0"
 
 # Testing utilities
 trybuild = "1"
-criterion = { version = "0.5", default-features = false }
+criterion = { version = "0.8", default-features = false }
 testcontainers = { version = "0.27", default-features = false, features = ["aws-lc-rs"] }
 testcontainers-modules = { version = "0.15", default-features = false, features = ["aws-lc-rs", "postgres", "mysql"] }
 httpmock = "0.8"
@@ -523,7 +527,7 @@ nanoid = "0.4"
 tokio-metrics = { version = "0.4", features = ["rt"] }
 
 # GTS dependencies
-jsonschema = "0.40"
+jsonschema = { version = "0.40", default-features = false }
 walkdir = "2.5"
 shellexpand = "3.1"
 

--- a/dylint_lints/Cargo.lock
+++ b/dylint_lints/Cargo.lock
@@ -732,24 +732,12 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "chrono-tz-build",
  "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -2969,15 +2957,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3059,38 +3038,18 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]

--- a/modules/system/resource-group/docs/ADR/ADR-001-gts-type-system.md
+++ b/modules/system/resource-group/docs/ADR/ADR-001-gts-type-system.md
@@ -1,3 +1,4 @@
+<!-- Updated: 2026-04-16 by Constructor Tech -->
 ---
 status: accepted
 date: 2026-03-16
@@ -23,16 +24,16 @@ decision-makers: Constructor Tech
   - [Key Rules](#key-rules)
 - [Type Map](#type-map)
 - [Schemas](#schemas)
-  - [RG Type Contract — `gts.x.core.rg.type.v1~`](#rg-type-contract--gtsxcorergtypev1)
+  - [RG Type Contract — `gts.cf.core.rg.type.v1~`](#rg-type-contract--gtscfcorergtypev1)
   - [Tenant — `gts.y.core.tn.tenant.v1~`](#tenant--gtsycoretntenantv1)
   - [Department — `gts.w.core.org.department.v1~`](#department--gtswcoreorgdepartmentv1)
-  - [Branch — `gts.x.core.rg.branch.v1~`](#branch--gtsxcorergbranchv1)
+  - [Branch — `gts.cf.core.rg.branch.v1~`](#branch--gtscfcorergbranchv1)
   - [User — `gts.z.core.idp.user.v1~`](#user--gtszcoreidpuserv1)
   - [Course — `gts.z.core.lms.course.v1~`](#course--gtszcorelmscoursev1)
 - [Chained RG Type Schemas](#chained-rg-type-schemas)
-  - [Tenant as RG Type — `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~`](#tenant-as-rg-type--gtsxcorergtypev1ycoretntenantv1)
-  - [Department as RG Type — `gts.x.core.rg.type.v1~w.core.org.department.v1~`](#department-as-rg-type--gtsxcorergtypev1wcoreorgdepartmentv1)
-  - [Branch as RG Type — `gts.x.core.rg.type.v1~x.core.rg.branch.v1~`](#branch-as-rg-type--gtsxcorergtypev1xcorergbranchv1)
+  - [Tenant as RG Type — `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~`](#tenant-as-rg-type--gtscfcorergtypev1ycoretntenantv1)
+  - [Department as RG Type — `gts.cf.core.rg.type.v1~w.core.org.department.v1~`](#department-as-rg-type--gtscfcorergtypev1wcoreorgdepartmentv1)
+  - [Branch as RG Type — `gts.cf.core.rg.type.v1~x.core.rg.branch.v1~`](#branch-as-rg-type--gtscfcorergtypev1xcorergbranchv1)
 - [Instance Examples](#instance-examples)
   - [Tenant T1 (root)](#tenant-t1-root)
   - [Department D2 (under T1)](#department-d2-under-t1)
@@ -76,7 +77,7 @@ Chosen option: "GTS with traits pattern", because it is the only option that pro
 
 ### Consequences
 
-* RG types use chained GTS identifiers: `gts.x.core.rg.type.v1~<derived>~`
+* RG types use chained GTS identifiers: `gts.cf.core.rg.type.v1~<derived>~`
 * SMALLINT surrogate keys and junction tables (`gts_type_allowed_parent`, `gts_type_allowed_membership`) enforce type relationships at DB level
 * `x-gts-traits-schema` on the base contract defines type-level metadata shape; `x-gts-traits` on each chained type provides concrete values
 * **Base contract MUST include `x-gts-traits` with defaults** alongside `x-gts-traits-schema` — the `gts` crate enforces this (see [Finding 1](#finding-1-x-gts-traits-mandatory-on-base-contract))
@@ -136,25 +137,25 @@ Chosen option: "GTS with traits pattern", because it is the only option that pro
 
 | GTS Type Path | Kind | Vendor |
 |---|---|---|
-| `gts.x.core.rg.type.v1~` | RG base contract | x (platform) |
+| `gts.cf.core.rg.type.v1~` | RG base contract | x (platform) |
 | `gts.y.core.tn.tenant.v1~` | entity type | y (tenant service) |
 | `gts.w.core.org.department.v1~` | entity type | w (org service) |
-| `gts.x.core.rg.branch.v1~` | entity type | x (platform) |
+| `gts.cf.core.rg.branch.v1~` | entity type | x (platform) |
 | `gts.z.core.idp.user.v1~` | resource type | z (IDP) |
 | `gts.z.core.lms.course.v1~` | resource type | z (LMS) |
-| `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~` | chained RG type | x + y |
-| `gts.x.core.rg.type.v1~w.core.org.department.v1~` | chained RG type | x + w |
-| `gts.x.core.rg.type.v1~x.core.rg.branch.v1~` | chained RG type | x + x |
+| `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~` | chained RG type | x + y |
+| `gts.cf.core.rg.type.v1~w.core.org.department.v1~` | chained RG type | x + w |
+| `gts.cf.core.rg.type.v1~x.core.rg.branch.v1~` | chained RG type | x + x |
 
 ## Schemas
 
-### RG Type Contract — `gts.x.core.rg.type.v1~`
+### RG Type Contract — `gts.cf.core.rg.type.v1~`
 
 Base contract for all RG type definitions. Traits define topology rules; properties define instance fields.
 
 ```json
 {
-  "$id": "gts://gts.x.core.rg.type.v1~",
+  "$id": "gts://gts.cf.core.rg.type.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Resource Group Type",
   "type": "object",
@@ -169,7 +170,7 @@ Base contract for all RG type definitions. Traits define topology rules; propert
       },
       "allowed_parents": {
         "type": "array",
-        "items": { "type": "string", "x-gts-ref": "gts.x.core.rg.type.v1~" },
+        "items": { "type": "string", "x-gts-ref": "gts.cf.core.rg.type.v1~" },
         "description": "Well-known instances of allowed parent RG types.",
         "default": []
       },
@@ -261,11 +262,11 @@ Base contract for all RG type definitions. Traits define topology rules; propert
 }
 ```
 
-### Branch — `gts.x.core.rg.branch.v1~`
+### Branch — `gts.cf.core.rg.branch.v1~`
 
 ```json
 {
-  "$id": "gts://gts.x.core.rg.branch.v1~",
+  "$id": "gts://gts.cf.core.rg.branch.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Branch",
   "type": "object",
@@ -316,14 +317,14 @@ Base contract for all RG type definitions. Traits define topology rules; propert
 
 When a type is registered as an RG type, it chains with the base contract via a **single `$ref`** and provides: (1) trait values via `x-gts-traits`, and (2) type-specific fields via inline `properties.metadata` override. Entity schemas (e.g. `gts.y.core.tn.tenant.v1~`) are registered in GTS for reference but are **NOT `$ref`'d** from chained types — the `metadata` properties are defined inline. The `metadata` sub-object uses `additionalProperties: false` to reject unknown fields (see [Finding 3](#finding-3-entity-specific-field-validation-at-gts-level-via-metadata-object)).
 
-### Tenant as RG Type — `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~`
+### Tenant as RG Type — `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~`
 
 ```json
 {
-  "$id": "gts://gts.x.core.rg.type.v1~y.core.tn.tenant.v1~",
+  "$id": "gts://gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "allOf": [
-    { "$ref": "gts://gts.x.core.rg.type.v1~" },
+    { "$ref": "gts://gts.cf.core.rg.type.v1~" },
     {
       "properties": {
         "metadata": {
@@ -337,7 +338,7 @@ When a type is registered as an RG type, it chains with the base contract via a 
       },
       "x-gts-traits": {
         "can_be_root": true,
-        "allowed_parents": ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"],
+        "allowed_parents": ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"],
         "allowed_memberships": ["gts.z.core.idp.user.v1~"]
       }
     }
@@ -350,14 +351,14 @@ When a type is registered as an RG type, it chains with the base contract via a 
 - Members: users
 - Instance `metadata` fields: `custom_domain` (hostname), `barrier` (boolean)
 
-### Department as RG Type — `gts.x.core.rg.type.v1~w.core.org.department.v1~`
+### Department as RG Type — `gts.cf.core.rg.type.v1~w.core.org.department.v1~`
 
 ```json
 {
-  "$id": "gts://gts.x.core.rg.type.v1~w.core.org.department.v1~",
+  "$id": "gts://gts.cf.core.rg.type.v1~w.core.org.department.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "allOf": [
-    { "$ref": "gts://gts.x.core.rg.type.v1~" },
+    { "$ref": "gts://gts.cf.core.rg.type.v1~" },
     {
       "properties": {
         "metadata": {
@@ -371,7 +372,7 @@ When a type is registered as an RG type, it chains with the base contract via a 
       },
       "x-gts-traits": {
         "can_be_root": false,
-        "allowed_parents": ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"],
+        "allowed_parents": ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"],
         "allowed_memberships": ["gts.z.core.idp.user.v1~"]
       }
     }
@@ -384,14 +385,14 @@ When a type is registered as an RG type, it chains with the base contract via a 
 - Members: users
 - Instance `metadata` fields: `category` (maxLength: 100), `short_description` (maxLength: 500)
 
-### Branch as RG Type — `gts.x.core.rg.type.v1~x.core.rg.branch.v1~`
+### Branch as RG Type — `gts.cf.core.rg.type.v1~x.core.rg.branch.v1~`
 
 ```json
 {
-  "$id": "gts://gts.x.core.rg.type.v1~x.core.rg.branch.v1~",
+  "$id": "gts://gts.cf.core.rg.type.v1~x.core.rg.branch.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "allOf": [
-    { "$ref": "gts://gts.x.core.rg.type.v1~" },
+    { "$ref": "gts://gts.cf.core.rg.type.v1~" },
     {
       "properties": {
         "metadata": {
@@ -404,7 +405,7 @@ When a type is registered as an RG type, it chains with the base contract via a 
       },
       "x-gts-traits": {
         "can_be_root": false,
-        "allowed_parents": ["gts.x.core.rg.type.v1~w.core.org.department.v1~"],
+        "allowed_parents": ["gts.cf.core.rg.type.v1~w.core.org.department.v1~"],
         "allowed_memberships": ["gts.z.core.idp.user.v1~", "gts.z.core.lms.course.v1~"]
       }
     }
@@ -426,7 +427,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "11111111-1111-1111-1111-111111111111",
-  "type": "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~",
+  "type": "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~",
   "name": "T1",
   "parent_id": null,
   "tenant_id": "11111111-1111-1111-1111-111111111111",
@@ -439,7 +440,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "22222222-2222-2222-2222-222222222222",
-  "type": "gts.x.core.rg.type.v1~w.core.org.department.v1~",
+  "type": "gts.cf.core.rg.type.v1~w.core.org.department.v1~",
   "name": "D2",
   "parent_id": "11111111-1111-1111-1111-111111111111",
   "tenant_id": "11111111-1111-1111-1111-111111111111",
@@ -456,7 +457,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "33333333-3333-3333-3333-333333333333",
-  "type": "gts.x.core.rg.type.v1~x.core.rg.branch.v1~",
+  "type": "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~",
   "name": "B3",
   "parent_id": "22222222-2222-2222-2222-222222222222",
   "tenant_id": "11111111-1111-1111-1111-111111111111",
@@ -472,7 +473,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "77777777-7777-7777-7777-777777777777",
-  "type": "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~",
+  "type": "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~",
   "name": "T7",
   "parent_id": "11111111-1111-1111-1111-111111111111",
   "tenant_id": "77777777-7777-7777-7777-777777777777",
@@ -488,7 +489,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "99999999-9999-9999-9999-999999999999",
-  "type": "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~",
+  "type": "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~",
   "name": "T9",
   "parent_id": null,
   "tenant_id": "99999999-9999-9999-9999-999999999999",
@@ -504,7 +505,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "88888888-8888-8888-8888-888888888888",
-  "type": "gts.x.core.rg.type.v1~w.core.org.department.v1~",
+  "type": "gts.cf.core.rg.type.v1~w.core.org.department.v1~",
   "name": "D8",
   "parent_id": "77777777-7777-7777-7777-777777777777",
   "tenant_id": "77777777-7777-7777-7777-777777777777",
@@ -562,7 +563,7 @@ Key design choices:
 
 ### Finding 1: `x-gts-traits` mandatory on base contract
 
-**Problem**: The original base contract schema (`gts.x.core.rg.type.v1~`) defined `x-gts-traits-schema` (the shape of traits) but did not include `x-gts-traits` (concrete trait values). The `gts` crate (v0.8.4) rejects this at `switch_to_ready()` validation:
+**Problem**: The original base contract schema (`gts.cf.core.rg.type.v1~`) defined `x-gts-traits-schema` (the shape of traits) but did not include `x-gts-traits` (concrete trait values). The `gts` crate (v0.8.4) rejects this at `switch_to_ready()` validation:
 
 ```
 Entity defines x-gts-traits-schema but no x-gts-traits values are provided
@@ -612,10 +613,10 @@ Expected format: vendor.package.namespace.type.vMAJOR[.MINOR]
 
 | Where in RG | Format | Example | Valid? |
 |-------------|--------|---------|--------|
-| `gts_type.schema_id` (DB) | Type path, ends with `~` | `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~` | Yes — each segment is 4 tokens + version |
+| `gts_type.schema_id` (DB) | Type path, ends with `~` | `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~` | Yes — each segment is 4 tokens + version |
 | `resource_group.id` (DB) | UUID | `11111111-1111-1111-1111-111111111111` | N/A — not a GTS ID |
 | `resource_group.gts_type_id` (DB) | SMALLINT FK | `3` | N/A — internal surrogate |
-| API response `type` field | Same as `gts_type.schema_id` | `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~` | Yes |
+| API response `type` field | Same as `gts_type.schema_id` | `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~` | Yes |
 | `resource_group_membership.resource_id` (DB) | Opaque TEXT | `user-uuid-here` | N/A — not a GTS ID |
 
 **No contradictions with migration.sql**: The `gts_type_path` domain regex in `migration.sql` already enforces the 4-token rule per segment via:
@@ -628,7 +629,7 @@ Expected format: vendor.package.namespace.type.vMAJOR[.MINOR]
 
 This matches exactly 4 name tokens per segment — the DB constraint and the `gts` crate are consistent.
 
-**Test artifact note**: The unit tests in `rg_gts_type_system_tests.rs` use well-known GTS instance IDs (e.g. `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~x.core._.t1.v1`) to register test instances in the types-registry. The `x.core._.t1.v1` segment format (with `_` as namespace placeholder) is needed only for these test-level well-known instances. **RG itself never constructs such IDs** — resource groups are anonymous instances with UUID `id` and a `type` field pointing to a type path. The `_` placeholder format is documented here for completeness in case future code needs to construct well-known instances.
+**Test artifact note**: The unit tests in `rg_gts_type_system_tests.rs` use well-known GTS instance IDs (e.g. `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~x.core._.t1.v1`) to register test instances in the types-registry. The `x.core._.t1.v1` segment format (with `_` as namespace placeholder) is needed only for these test-level well-known instances. **RG itself never constructs such IDs** — resource groups are anonymous instances with UUID `id` and a `type` field pointing to a type path. The `_` placeholder format is documented here for completeness in case future code needs to construct well-known instances.
 
 ---
 
@@ -645,7 +646,7 @@ This matches exactly 4 name tokens per segment — the DB constraint and the `gt
 
 ```json
 "allOf": [
-  { "$ref": "gts://gts.x.core.rg.type.v1~" },
+  { "$ref": "gts://gts.cf.core.rg.type.v1~" },
   {
     "properties": {
       "metadata": {

--- a/modules/system/resource-group/docs/ADR/ADR-001-gts-type-system.md
+++ b/modules/system/resource-group/docs/ADR/ADR-001-gts-type-system.md
@@ -1,4 +1,3 @@
-<!-- Updated: 2026-04-16 by Constructor Tech -->
 ---
 status: accepted
 date: 2026-03-16
@@ -24,16 +23,16 @@ decision-makers: Constructor Tech
   - [Key Rules](#key-rules)
 - [Type Map](#type-map)
 - [Schemas](#schemas)
-  - [RG Type Contract — `gts.cf.core.rg.type.v1~`](#rg-type-contract--gtscfcorergtypev1)
+  - [RG Type Contract — `gts.x.core.rg.type.v1~`](#rg-type-contract--gtsxcorergtypev1)
   - [Tenant — `gts.y.core.tn.tenant.v1~`](#tenant--gtsycoretntenantv1)
   - [Department — `gts.w.core.org.department.v1~`](#department--gtswcoreorgdepartmentv1)
-  - [Branch — `gts.cf.core.rg.branch.v1~`](#branch--gtscfcorergbranchv1)
+  - [Branch — `gts.x.core.rg.branch.v1~`](#branch--gtsxcorergbranchv1)
   - [User — `gts.z.core.idp.user.v1~`](#user--gtszcoreidpuserv1)
   - [Course — `gts.z.core.lms.course.v1~`](#course--gtszcorelmscoursev1)
 - [Chained RG Type Schemas](#chained-rg-type-schemas)
-  - [Tenant as RG Type — `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~`](#tenant-as-rg-type--gtscfcorergtypev1ycoretntenantv1)
-  - [Department as RG Type — `gts.cf.core.rg.type.v1~w.core.org.department.v1~`](#department-as-rg-type--gtscfcorergtypev1wcoreorgdepartmentv1)
-  - [Branch as RG Type — `gts.cf.core.rg.type.v1~x.core.rg.branch.v1~`](#branch-as-rg-type--gtscfcorergtypev1xcorergbranchv1)
+  - [Tenant as RG Type — `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~`](#tenant-as-rg-type--gtsxcorergtypev1ycoretntenantv1)
+  - [Department as RG Type — `gts.x.core.rg.type.v1~w.core.org.department.v1~`](#department-as-rg-type--gtsxcorergtypev1wcoreorgdepartmentv1)
+  - [Branch as RG Type — `gts.x.core.rg.type.v1~x.core.rg.branch.v1~`](#branch-as-rg-type--gtsxcorergtypev1xcorergbranchv1)
 - [Instance Examples](#instance-examples)
   - [Tenant T1 (root)](#tenant-t1-root)
   - [Department D2 (under T1)](#department-d2-under-t1)
@@ -77,7 +76,7 @@ Chosen option: "GTS with traits pattern", because it is the only option that pro
 
 ### Consequences
 
-* RG types use chained GTS identifiers: `gts.cf.core.rg.type.v1~<derived>~`
+* RG types use chained GTS identifiers: `gts.x.core.rg.type.v1~<derived>~`
 * SMALLINT surrogate keys and junction tables (`gts_type_allowed_parent`, `gts_type_allowed_membership`) enforce type relationships at DB level
 * `x-gts-traits-schema` on the base contract defines type-level metadata shape; `x-gts-traits` on each chained type provides concrete values
 * **Base contract MUST include `x-gts-traits` with defaults** alongside `x-gts-traits-schema` — the `gts` crate enforces this (see [Finding 1](#finding-1-x-gts-traits-mandatory-on-base-contract))
@@ -137,25 +136,25 @@ Chosen option: "GTS with traits pattern", because it is the only option that pro
 
 | GTS Type Path | Kind | Vendor |
 |---|---|---|
-| `gts.cf.core.rg.type.v1~` | RG base contract | x (platform) |
+| `gts.x.core.rg.type.v1~` | RG base contract | x (platform) |
 | `gts.y.core.tn.tenant.v1~` | entity type | y (tenant service) |
 | `gts.w.core.org.department.v1~` | entity type | w (org service) |
-| `gts.cf.core.rg.branch.v1~` | entity type | x (platform) |
+| `gts.x.core.rg.branch.v1~` | entity type | x (platform) |
 | `gts.z.core.idp.user.v1~` | resource type | z (IDP) |
 | `gts.z.core.lms.course.v1~` | resource type | z (LMS) |
-| `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~` | chained RG type | x + y |
-| `gts.cf.core.rg.type.v1~w.core.org.department.v1~` | chained RG type | x + w |
-| `gts.cf.core.rg.type.v1~x.core.rg.branch.v1~` | chained RG type | x + x |
+| `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~` | chained RG type | x + y |
+| `gts.x.core.rg.type.v1~w.core.org.department.v1~` | chained RG type | x + w |
+| `gts.x.core.rg.type.v1~x.core.rg.branch.v1~` | chained RG type | x + x |
 
 ## Schemas
 
-### RG Type Contract — `gts.cf.core.rg.type.v1~`
+### RG Type Contract — `gts.x.core.rg.type.v1~`
 
 Base contract for all RG type definitions. Traits define topology rules; properties define instance fields.
 
 ```json
 {
-  "$id": "gts://gts.cf.core.rg.type.v1~",
+  "$id": "gts://gts.x.core.rg.type.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Resource Group Type",
   "type": "object",
@@ -170,7 +169,7 @@ Base contract for all RG type definitions. Traits define topology rules; propert
       },
       "allowed_parents": {
         "type": "array",
-        "items": { "type": "string", "x-gts-ref": "gts.cf.core.rg.type.v1~" },
+        "items": { "type": "string", "x-gts-ref": "gts.x.core.rg.type.v1~" },
         "description": "Well-known instances of allowed parent RG types.",
         "default": []
       },
@@ -240,7 +239,7 @@ Base contract for all RG type definitions. Traits define topology rules; propert
     "id": { "type": "string", "format": "uuid" },
     "name": { "type": "string", "minLength": 1, "maxLength": 255 },
     "custom_domain": { "type": "string", "format": "hostname" },
-    "barrier": { "type": "boolean", "default": false }
+    "self_managed": { "type": "boolean", "default": false }
   }
 }
 ```
@@ -262,11 +261,11 @@ Base contract for all RG type definitions. Traits define topology rules; propert
 }
 ```
 
-### Branch — `gts.cf.core.rg.branch.v1~`
+### Branch — `gts.x.core.rg.branch.v1~`
 
 ```json
 {
-  "$id": "gts://gts.cf.core.rg.branch.v1~",
+  "$id": "gts://gts.x.core.rg.branch.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Branch",
   "type": "object",
@@ -317,14 +316,14 @@ Base contract for all RG type definitions. Traits define topology rules; propert
 
 When a type is registered as an RG type, it chains with the base contract via a **single `$ref`** and provides: (1) trait values via `x-gts-traits`, and (2) type-specific fields via inline `properties.metadata` override. Entity schemas (e.g. `gts.y.core.tn.tenant.v1~`) are registered in GTS for reference but are **NOT `$ref`'d** from chained types — the `metadata` properties are defined inline. The `metadata` sub-object uses `additionalProperties: false` to reject unknown fields (see [Finding 3](#finding-3-entity-specific-field-validation-at-gts-level-via-metadata-object)).
 
-### Tenant as RG Type — `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~`
+### Tenant as RG Type — `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~`
 
 ```json
 {
-  "$id": "gts://gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~",
+  "$id": "gts://gts.x.core.rg.type.v1~y.core.tn.tenant.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "allOf": [
-    { "$ref": "gts://gts.cf.core.rg.type.v1~" },
+    { "$ref": "gts://gts.x.core.rg.type.v1~" },
     {
       "properties": {
         "metadata": {
@@ -332,13 +331,13 @@ When a type is registered as an RG type, it chains with the base contract via a 
           "additionalProperties": false,
           "properties": {
             "custom_domain": { "type": "string", "format": "hostname" },
-            "barrier": { "type": "boolean", "default": false }
+            "self_managed": { "type": "boolean", "default": false }
           }
         }
       },
       "x-gts-traits": {
         "can_be_root": true,
-        "allowed_parents": ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"],
+        "allowed_parents": ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"],
         "allowed_memberships": ["gts.z.core.idp.user.v1~"]
       }
     }
@@ -351,14 +350,14 @@ When a type is registered as an RG type, it chains with the base contract via a 
 - Members: users
 - Instance `metadata` fields: `custom_domain` (hostname), `barrier` (boolean)
 
-### Department as RG Type — `gts.cf.core.rg.type.v1~w.core.org.department.v1~`
+### Department as RG Type — `gts.x.core.rg.type.v1~w.core.org.department.v1~`
 
 ```json
 {
-  "$id": "gts://gts.cf.core.rg.type.v1~w.core.org.department.v1~",
+  "$id": "gts://gts.x.core.rg.type.v1~w.core.org.department.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "allOf": [
-    { "$ref": "gts://gts.cf.core.rg.type.v1~" },
+    { "$ref": "gts://gts.x.core.rg.type.v1~" },
     {
       "properties": {
         "metadata": {
@@ -372,7 +371,7 @@ When a type is registered as an RG type, it chains with the base contract via a 
       },
       "x-gts-traits": {
         "can_be_root": false,
-        "allowed_parents": ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"],
+        "allowed_parents": ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"],
         "allowed_memberships": ["gts.z.core.idp.user.v1~"]
       }
     }
@@ -385,14 +384,14 @@ When a type is registered as an RG type, it chains with the base contract via a 
 - Members: users
 - Instance `metadata` fields: `category` (maxLength: 100), `short_description` (maxLength: 500)
 
-### Branch as RG Type — `gts.cf.core.rg.type.v1~x.core.rg.branch.v1~`
+### Branch as RG Type — `gts.x.core.rg.type.v1~x.core.rg.branch.v1~`
 
 ```json
 {
-  "$id": "gts://gts.cf.core.rg.type.v1~x.core.rg.branch.v1~",
+  "$id": "gts://gts.x.core.rg.type.v1~x.core.rg.branch.v1~",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "allOf": [
-    { "$ref": "gts://gts.cf.core.rg.type.v1~" },
+    { "$ref": "gts://gts.x.core.rg.type.v1~" },
     {
       "properties": {
         "metadata": {
@@ -405,7 +404,7 @@ When a type is registered as an RG type, it chains with the base contract via a 
       },
       "x-gts-traits": {
         "can_be_root": false,
-        "allowed_parents": ["gts.cf.core.rg.type.v1~w.core.org.department.v1~"],
+        "allowed_parents": ["gts.x.core.rg.type.v1~w.core.org.department.v1~"],
         "allowed_memberships": ["gts.z.core.idp.user.v1~", "gts.z.core.lms.course.v1~"]
       }
     }
@@ -427,7 +426,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "11111111-1111-1111-1111-111111111111",
-  "type": "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~",
+  "type": "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~",
   "name": "T1",
   "parent_id": null,
   "tenant_id": "11111111-1111-1111-1111-111111111111",
@@ -440,7 +439,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "22222222-2222-2222-2222-222222222222",
-  "type": "gts.cf.core.rg.type.v1~w.core.org.department.v1~",
+  "type": "gts.x.core.rg.type.v1~w.core.org.department.v1~",
   "name": "D2",
   "parent_id": "11111111-1111-1111-1111-111111111111",
   "tenant_id": "11111111-1111-1111-1111-111111111111",
@@ -457,7 +456,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "33333333-3333-3333-3333-333333333333",
-  "type": "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~",
+  "type": "gts.x.core.rg.type.v1~x.core.rg.branch.v1~",
   "name": "B3",
   "parent_id": "22222222-2222-2222-2222-222222222222",
   "tenant_id": "11111111-1111-1111-1111-111111111111",
@@ -473,13 +472,13 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "77777777-7777-7777-7777-777777777777",
-  "type": "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~",
+  "type": "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~",
   "name": "T7",
   "parent_id": "11111111-1111-1111-1111-111111111111",
   "tenant_id": "77777777-7777-7777-7777-777777777777",
   "depth": 1,
   "metadata": {
-    "barrier": true
+    "self_managed": true
   }
 }
 ```
@@ -489,7 +488,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "99999999-9999-9999-9999-999999999999",
-  "type": "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~",
+  "type": "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~",
   "name": "T9",
   "parent_id": null,
   "tenant_id": "99999999-9999-9999-9999-999999999999",
@@ -505,7 +504,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
 ```json
 {
   "id": "88888888-8888-8888-8888-888888888888",
-  "type": "gts.cf.core.rg.type.v1~w.core.org.department.v1~",
+  "type": "gts.x.core.rg.type.v1~w.core.org.department.v1~",
   "name": "D8",
   "parent_id": "77777777-7777-7777-7777-777777777777",
   "tenant_id": "77777777-7777-7777-7777-777777777777",
@@ -535,7 +534,7 @@ tenant T9 (depth 0) {metadata: {custom_domain: "t9.example.com"}}
 ```
 
 Notes:
-- T7 has `metadata.barrier: true` — RG stores it in metadata JSONB. Tenant Resolver (`BarrierMode`) + AuthZ enforce it
+- T7 has `metadata.self_managed: true` — RG stores it in metadata JSONB. Tenant Resolver (`BarrierMode`) + AuthZ enforce it
 - R4 appears twice: as **course** in B3 and as **user** in T1 (different `gts_type_id`)
 - R8 appears twice: as **user** in D8 and T7 (same type, two group memberships)
 
@@ -563,7 +562,7 @@ Key design choices:
 
 ### Finding 1: `x-gts-traits` mandatory on base contract
 
-**Problem**: The original base contract schema (`gts.cf.core.rg.type.v1~`) defined `x-gts-traits-schema` (the shape of traits) but did not include `x-gts-traits` (concrete trait values). The `gts` crate (v0.8.4) rejects this at `switch_to_ready()` validation:
+**Problem**: The original base contract schema (`gts.x.core.rg.type.v1~`) defined `x-gts-traits-schema` (the shape of traits) but did not include `x-gts-traits` (concrete trait values). The `gts` crate (v0.8.4) rejects this at `switch_to_ready()` validation:
 
 ```
 Entity defines x-gts-traits-schema but no x-gts-traits values are provided
@@ -613,10 +612,10 @@ Expected format: vendor.package.namespace.type.vMAJOR[.MINOR]
 
 | Where in RG | Format | Example | Valid? |
 |-------------|--------|---------|--------|
-| `gts_type.schema_id` (DB) | Type path, ends with `~` | `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~` | Yes — each segment is 4 tokens + version |
+| `gts_type.schema_id` (DB) | Type path, ends with `~` | `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~` | Yes — each segment is 4 tokens + version |
 | `resource_group.id` (DB) | UUID | `11111111-1111-1111-1111-111111111111` | N/A — not a GTS ID |
 | `resource_group.gts_type_id` (DB) | SMALLINT FK | `3` | N/A — internal surrogate |
-| API response `type` field | Same as `gts_type.schema_id` | `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~` | Yes |
+| API response `type` field | Same as `gts_type.schema_id` | `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~` | Yes |
 | `resource_group_membership.resource_id` (DB) | Opaque TEXT | `user-uuid-here` | N/A — not a GTS ID |
 
 **No contradictions with migration.sql**: The `gts_type_path` domain regex in `migration.sql` already enforces the 4-token rule per segment via:
@@ -629,7 +628,7 @@ Expected format: vendor.package.namespace.type.vMAJOR[.MINOR]
 
 This matches exactly 4 name tokens per segment — the DB constraint and the `gts` crate are consistent.
 
-**Test artifact note**: The unit tests in `rg_gts_type_system_tests.rs` use well-known GTS instance IDs (e.g. `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~x.core._.t1.v1`) to register test instances in the types-registry. The `x.core._.t1.v1` segment format (with `_` as namespace placeholder) is needed only for these test-level well-known instances. **RG itself never constructs such IDs** — resource groups are anonymous instances with UUID `id` and a `type` field pointing to a type path. The `_` placeholder format is documented here for completeness in case future code needs to construct well-known instances.
+**Test artifact note**: The unit tests in `rg_gts_type_system_tests.rs` use well-known GTS instance IDs (e.g. `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~x.core._.t1.v1`) to register test instances in the types-registry. The `x.core._.t1.v1` segment format (with `_` as namespace placeholder) is needed only for these test-level well-known instances. **RG itself never constructs such IDs** — resource groups are anonymous instances with UUID `id` and a `type` field pointing to a type path. The `_` placeholder format is documented here for completeness in case future code needs to construct well-known instances.
 
 ---
 
@@ -646,7 +645,7 @@ This matches exactly 4 name tokens per segment — the DB constraint and the `gt
 
 ```json
 "allOf": [
-  { "$ref": "gts://gts.cf.core.rg.type.v1~" },
+  { "$ref": "gts://gts.x.core.rg.type.v1~" },
   {
     "properties": {
       "metadata": {
@@ -668,7 +667,7 @@ This matches exactly 4 name tokens per segment — the DB constraint and the `gt
 - Chained type narrows `metadata` via `allOf` merge — `additionalProperties: false` applies only within the `metadata` sub-object
 - Unknown metadata fields rejected (e.g. `metadata: {foo: "bar"}` → error)
 - Entity-specific constraints enforced (e.g. `metadata.category` maxLength: 100 → validated)
-- Top-level field isolation: `metadata.barrier` can never clash with a future base field `barrier`
+- Top-level field isolation: `metadata.self_managed` can never clash with a future base field `barrier`
 
 **Test results** (33 tests, all passing):
 
@@ -676,9 +675,9 @@ This matches exactly 4 name tokens per segment — the DB constraint and the `gt
 |-----------|----------|--------|
 | Department `metadata.category` 101 chars | rejected | rejected |
 | Department `metadata.short_description` 501 chars | rejected | rejected |
-| Tenant `metadata.barrier: "yes"` (string) | rejected | rejected |
+| Tenant `metadata.self_managed: "yes"` (string) | rejected | rejected |
 | Tenant `metadata: {foo: "bar"}` (unknown field) | rejected | rejected |
-| Tenant `metadata.barrier: true` | accepted | accepted |
+| Tenant `metadata.self_managed: true` | accepted | accepted |
 | Tenant `metadata.custom_domain: "t9.example.com"` | accepted | accepted |
 | Branch `metadata.location: "..."` | accepted | accepted |
 | Top-level `barrier: true` (no metadata wrapper) | accepted by GTS* | accepted* |

--- a/modules/system/resource-group/docs/DECOMPOSITION.md
+++ b/modules/system/resource-group/docs/DECOMPOSITION.md
@@ -41,7 +41,7 @@ The Resource Group DESIGN is decomposed into seven features organized around the
 - **Depends On**: None
 
 - **Scope**:
-  - SDK crate (`resource-group-sdk`): `models.rs` (ResourceGroupType, ResourceGroup, ResourceGroupWithDepth, ResourceGroupMembership, Page, PageInfo, GtsTypePath), `api.rs` (ResourceGroupClient, ResourceGroupReadHierarchy, ResourceGroupReadPluginClient traits), `error.rs` (ResourceGroupError taxonomy)
+  - SDK crate (`resource-group-sdk`): `models.rs` (ResourceGroupType, ResourceGroup, ResourceGroupWithDepth, ResourceGroupMembership, Page, PageInfo, GtsTypePath), `api.rs` (ResourceGroupClient, ResourceGroupReadHierarchy traits), `error.rs` (ResourceGroupError taxonomy)
   - Module scaffold: `#[modkit::module]` annotated module, ClientHub registration for `dyn ResourceGroupClient` and `dyn ResourceGroupReadHierarchy`
   - Persistence adapter: SeaORM entity definitions for all 6 tables (gts_type, gts_type_allowed_parent, gts_type_allowed_membership, resource_group, resource_group_membership, resource_group_closure), DB migration scripts
   - Error mapping: DomainError to Problem (RFC-9457) mapping for all deterministic error categories (Validation, NotFound, TypeAlreadyExists, InvalidParentType, CycleDetected, ConflictActiveReferences, LimitViolation, TenantIncompatibility, ServiceUnavailable, Internal)
@@ -303,7 +303,7 @@ The Resource Group DESIGN is decomposed into seven features organized around the
 
 - **Scope**:
   - Integration read service: expose `ResourceGroupReadHierarchy` via ClientHub for AuthZ plugin consumption, returning hierarchy data without policy or SQL semantics
-  - Plugin gateway routing: built-in provider (local persistence path) vs vendor-specific provider (resolve plugin instance by configured vendor, delegate to `ResourceGroupReadPluginClient`) with SecurityContext passthrough
+  - Plugin gateway routing: built-in provider (local persistence path) vs vendor-specific provider (resolve plugin instance by configured vendor, delegate to `ResourceGroupReadHierarchy`) with SecurityContext passthrough
   - JWT authentication: standard AuthZ evaluation via `PolicyEnforcer.access_scope()` on all REST endpoints, `AccessScope` applied via SecureORM for tenant-scoped queries
   - MTLS authentication: client certificate verification against trusted CA bundle, endpoint allowlist (only `GET /groups/{group_id}/hierarchy`), AuthZ bypass for trusted system principals, system SecurityContext creation
   - MTLS configuration: `ca_cert`, `allowed_clients` (by certificate CN), `allowed_endpoints` (method + path pairs)

--- a/modules/system/resource-group/docs/DECOMPOSITION.md
+++ b/modules/system/resource-group/docs/DECOMPOSITION.md
@@ -1,4 +1,5 @@
 <!-- Created: 2026-04-07 by Constructor Tech -->
+<!-- Updated: 2026-04-20 by Constructor Tech -->
 
 # Decomposition: Resource Group (RG)
 
@@ -41,7 +42,7 @@ The Resource Group DESIGN is decomposed into seven features organized around the
 - **Depends On**: None
 
 - **Scope**:
-  - SDK crate (`resource-group-sdk`): `models.rs` (ResourceGroupType, ResourceGroup, ResourceGroupWithDepth, ResourceGroupMembership, Page, PageInfo, GtsTypePath), `api.rs` (ResourceGroupClient, ResourceGroupReadHierarchy traits), `error.rs` (ResourceGroupError taxonomy)
+  - SDK crate (`resource-group-sdk`): `models.rs` (ResourceGroupType, ResourceGroup, ResourceGroupWithDepth, ResourceGroupMembership, Page, PageInfo, GtsTypePath), `api.rs` (ResourceGroupClient, ResourceGroupReadHierarchy, ResourceGroupReadPluginClient traits), `error.rs` (ResourceGroupError taxonomy)
   - Module scaffold: `#[modkit::module]` annotated module, ClientHub registration for `dyn ResourceGroupClient` and `dyn ResourceGroupReadHierarchy`
   - Persistence adapter: SeaORM entity definitions for all 6 tables (gts_type, gts_type_allowed_parent, gts_type_allowed_membership, resource_group, resource_group_membership, resource_group_closure), DB migration scripts
   - Error mapping: DomainError to Problem (RFC-9457) mapping for all deterministic error categories (Validation, NotFound, TypeAlreadyExists, InvalidParentType, CycleDetected, ConflictActiveReferences, LimitViolation, TenantIncompatibility, ServiceUnavailable, Internal)
@@ -303,12 +304,12 @@ The Resource Group DESIGN is decomposed into seven features organized around the
 
 - **Scope**:
   - Integration read service: expose `ResourceGroupReadHierarchy` via ClientHub for AuthZ plugin consumption, returning hierarchy data without policy or SQL semantics
-  - Plugin gateway routing: built-in provider (local persistence path) vs vendor-specific provider (resolve plugin instance by configured vendor, delegate to `ResourceGroupReadHierarchy`) with SecurityContext passthrough
+  - Plugin gateway routing: built-in provider (local persistence path) vs vendor-specific provider (resolve plugin instance by configured vendor, delegate to `ResourceGroupReadPluginClient`) with SecurityContext passthrough
   - JWT authentication: standard AuthZ evaluation via `PolicyEnforcer.access_scope()` on all REST endpoints, `AccessScope` applied via SecureORM for tenant-scoped queries
   - MTLS authentication: client certificate verification against trusted CA bundle, endpoint allowlist (only `GET /groups/{group_id}/hierarchy`), AuthZ bypass for trusted system principals, system SecurityContext creation
   - MTLS configuration: `ca_cert`, `allowed_clients` (by certificate CN), `allowed_endpoints` (method + path pairs)
   - Tenant scope enforcement for ownership-graph profile: parent-child edges and membership writes validated for tenant-hierarchy compatibility, platform-admin provisioning exception for cross-tenant management, tenant-scoped reads via `SecurityContext.subject_tenant_id`
-  - Barrier as data: `metadata.barrier` stored in group metadata JSONB without enforcement by RG, returned in API responses within `metadata` object for consumption by Tenant Resolver and AuthZ
+  - Barrier as data: `metadata.self_managed` stored in group metadata JSONB without enforcement by RG, returned in API responses within `metadata` object for consumption by Tenant Resolver and AuthZ
   - In-process vs out-of-process: ClientHub direct call (monolith, no MTLS needed) vs MTLS-authenticated remote call (microservices)
   - SecurityContext propagation: `ctx` passed through gateway to selected provider without policy interpretation
 

--- a/modules/system/resource-group/docs/DESIGN.md
+++ b/modules/system/resource-group/docs/DESIGN.md
@@ -180,7 +180,7 @@ Type rules are runtime-configurable through API/seed data with deterministic val
 
 **ADRs**: `cpt-cf-resource-group-adr-p1-gts-type-system`
 
-**Derived type fields — metadata object, JSONB storage (v1)**: Derived type fields (e.g. `barrier`, `custom_domain`, `category`) are nested inside a `metadata` object in API requests and responses. In the database, they are stored in a `metadata` JSONB column on `resource_group`. For chained types (e.g., `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~`), the chained GTS schema defines `properties.metadata` with `additionalProperties: false` for field isolation. `metadata_schema` on the RG type definition is null for chained types — instance metadata is validated against the GTS schema. The `metadata_schema` field is reserved for optional RG-level schema overrides. Advanced validation (e.g., Starlark-based cross-field rules) is out of scope for v1.
+**Derived type fields — metadata object, JSONB storage (v1)**: Derived type fields (e.g. `barrier`, `custom_domain`, `category`) are nested inside a `metadata` object in API requests and responses. In the database, they are stored in a `metadata` JSONB column on `resource_group`. For chained types (e.g., `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~`), the chained GTS schema defines `properties.metadata` with `additionalProperties: false` for field isolation. `metadata_schema` on the RG type definition is null for chained types — instance metadata is validated against the GTS schema. The `metadata_schema` field is reserved for optional RG-level schema overrides. Advanced validation (e.g., Starlark-based cross-field rules) is out of scope for v1.
 
 #### Query Profile as Guardrail
 
@@ -250,11 +250,11 @@ SMALLINT surrogate IDs (`gts_type.id`, `gts_type_id` FK columns) are a **DB-inte
 - `allowed_memberships` in type create/update requests
 - `resource_type` in membership operations (`POST /memberships/...`)
 
-If a referenced type does not exist, the operation **MUST** return a validation error. Each chained type (e.g., `gts.x.system.rg.type.v1~y.system.tn.tenant.v1~`) is a distinct type that must be registered separately — chaining does not auto-create constituent types. Registration order matters: base/resource types first, then chained RG types that reference them. Base types (including `gts.x.system.rg.type.v1~`) must be created before use — via seeding, API calls, or manual DB administration.
+If a referenced type does not exist, the operation **MUST** return a validation error. Each chained type (e.g., `gts.cf.core.rg.type.v1~y.system.tn.tenant.v1~`) is a distinct type that must be registered separately — chaining does not auto-create constituent types. Registration order matters: base/resource types first, then chained RG types that reference them. Base types (including `gts.cf.core.rg.type.v1~`) must be created before use — via seeding, API calls, or manual DB administration.
 
-**RG type prefix requirement (`gts.x.system.rg.type.v1~`)**:
-- **`type` in group operations**: `POST /groups`, `PUT /groups/{id}` — **MUST** have `gts.x.system.rg.type.v1~` prefix. Rejected without it.
-- **`allowed_parents`**: **MUST** have `gts.x.system.rg.type.v1~` prefix — parent groups are always RG types.
+**RG type prefix requirement (`gts.cf.core.rg.type.v1~`)**:
+- **`type` in group operations**: `POST /groups`, `PUT /groups/{id}` — **MUST** have `gts.cf.core.rg.type.v1~` prefix. Rejected without it.
+- **`allowed_parents`**: **MUST** have `gts.cf.core.rg.type.v1~` prefix — parent groups are always RG types.
 - **`allowed_memberships`**: **NO prefix requirement** — membership resource types are external domain types (e.g., `gts.z.system.idp.user.v1~`, `gts.z.system.lms.course.v1~`) that do not need to be RG types.
 
 This ensures the hierarchy is always governed by the RG type contract (`can_be_root`, `allowed_parents`, `allowed_memberships`), while membership resources can be any registered GTS type.
@@ -807,7 +807,7 @@ sequenceDiagram
 
     CS->>PE: access_scope(ctx, COURSE, "list", None)
     PE->>AZ: evaluate(EvaluationRequest)
-    Note right of AZ: subject.properties.tenant_id = T1<br/>action.name = "list"<br/>resource.type = "gts.x.lms.course.v1~"<br/>context.require_constraints = true<br/>context.supported_properties = ["owner_tenant_id"]
+    Note right of AZ: subject.properties.tenant_id = T1<br/>action.name = "list"<br/>resource.type = "gts.cf.lms.course.v1~"<br/>context.require_constraints = true<br/>context.supported_properties = ["owner_tenant_id"]
 
     AZ->>RG: list_group_depth(system_ctx, T1, filter: "hierarchy/depth ge 0 and type eq 'tenant'")
     RG-->>AZ: [{T1, depth:0, metadata:{}}, {T7, depth:1, metadata:{barrier:true}}]
@@ -828,7 +828,7 @@ Step-by-step:
 
 2. **Domain service** — Courses handler receives the request with `SecurityContext`. Before querying the database, it calls `PolicyEnforcer.access_scope(&ctx, &COURSE_RESOURCE, "list", None)` to obtain row-level access constraints.
 
-3. **AuthZ evaluation** — `PolicyEnforcer` builds an `EvaluationRequest` (subject with `tenant_id = T1`, action `"list"`, resource type `"gts.x.lms.course.v1~"`, `require_constraints = true`, `supported_properties = ["owner_tenant_id"]`) and calls `AuthZResolverClient.evaluate()`.
+3. **AuthZ evaluation** — `PolicyEnforcer` builds an `EvaluationRequest` (subject with `tenant_id = T1`, action `"list"`, resource type `"gts.cf.lms.course.v1~"`, `require_constraints = true`, `supported_properties = ["owner_tenant_id"]`) and calls `AuthZResolverClient.evaluate()`.
 
 4. **Hierarchy resolution** — The AuthZ plugin calls `ResourceGroupReadHierarchy.list_group_depth()` with `tenant_id = T1` and a depth filter to resolve the tenant hierarchy. RG returns `[T1 (depth 0), T7 (depth 1)]` — the accessible tenant subtree. The plugin does NOT see `T9` because it is outside `T1`'s hierarchy.
 
@@ -1228,21 +1228,21 @@ RG relies on database-level performance rather than application-level caching:
 
 | Resource (`resource.type`) | Action (`action.name`) | REST Operation | Method | Path | Auth Mode |
 | -------------------------- | ---------------------- | -------------- | ------ | ---- | --------- |
-| `gts.x.core.rg.type.v1~` | `list` | `listTypes` | GET | `/api/types-registry/v1/types` | JWT |
-| `gts.x.core.rg.type.v1~` | `create` | `createType` | POST | `/api/types-registry/v1/types` | JWT |
-| `gts.x.core.rg.type.v1~` | `read` | `getType` | GET | `/api/types-registry/v1/types/{code}` | JWT |
-| `gts.x.core.rg.type.v1~` | `update` | `updateType` | PUT | `/api/types-registry/v1/types/{code}` | JWT |
-| `gts.x.core.rg.type.v1~` | `delete` | `deleteType` | DELETE | `/api/types-registry/v1/types/{code}` | JWT |
-| `gts.x.core.rg.group.v1~` | `list` | `listGroups` | GET | `/groups` | JWT |
-| `gts.x.core.rg.group.v1~` | `create` | `createGroup` | POST | `/groups` | JWT |
-| `gts.x.core.rg.group.v1~` | `read` | `getGroup` | GET | `/groups/{group_id}` | JWT |
-| `gts.x.core.rg.group.v1~` | `update` | `updateGroup` | PUT | `/groups/{group_id}` | JWT |
-| `gts.x.core.rg.group.v1~` | `delete` | `deleteGroup` | DELETE | `/groups/{group_id}` | JWT |
-| `gts.x.core.rg.group.v1~` | `read` | `listGroupHierarchy` | GET | `/groups/{group_id}/hierarchy` | JWT |
+| `gts.cf.core.rg.type.v1~` | `list` | `listTypes` | GET | `/api/types-registry/v1/types` | JWT |
+| `gts.cf.core.rg.type.v1~` | `create` | `createType` | POST | `/api/types-registry/v1/types` | JWT |
+| `gts.cf.core.rg.type.v1~` | `read` | `getType` | GET | `/api/types-registry/v1/types/{code}` | JWT |
+| `gts.cf.core.rg.type.v1~` | `update` | `updateType` | PUT | `/api/types-registry/v1/types/{code}` | JWT |
+| `gts.cf.core.rg.type.v1~` | `delete` | `deleteType` | DELETE | `/api/types-registry/v1/types/{code}` | JWT |
+| `gts.cf.core.rg.group.v1~` | `list` | `listGroups` | GET | `/groups` | JWT |
+| `gts.cf.core.rg.group.v1~` | `create` | `createGroup` | POST | `/groups` | JWT |
+| `gts.cf.core.rg.group.v1~` | `read` | `getGroup` | GET | `/groups/{group_id}` | JWT |
+| `gts.cf.core.rg.group.v1~` | `update` | `updateGroup` | PUT | `/groups/{group_id}` | JWT |
+| `gts.cf.core.rg.group.v1~` | `delete` | `deleteGroup` | DELETE | `/groups/{group_id}` | JWT |
+| `gts.cf.core.rg.group.v1~` | `read` | `listGroupHierarchy` | GET | `/groups/{group_id}/hierarchy` | JWT |
 | _(AuthZ bypassed)_ | — | `listGroupHierarchy` | GET | `/groups/{group_id}/hierarchy` | MTLS |
-| `gts.x.core.rg.group_membership.v1~` | `list` | `listMemberships` | GET | `/memberships` | JWT |
-| `gts.x.core.rg.group_membership.v1~` | `create` | `addMembership` | POST | `/memberships/{group_id}/{resource_type}/{resource_id}` | JWT |
-| `gts.x.core.rg.group_membership.v1~` | `delete` | `deleteMembership` | DELETE | `/memberships/{group_id}/{resource_type}/{resource_id}` | JWT |
+| `gts.cf.core.rg.group_membership.v1~` | `list` | `listMemberships` | GET | `/memberships` | JWT |
+| `gts.cf.core.rg.group_membership.v1~` | `create` | `addMembership` | POST | `/memberships/{group_id}/{resource_type}/{resource_id}` | JWT |
+| `gts.cf.core.rg.group_membership.v1~` | `delete` | `deleteMembership` | DELETE | `/memberships/{group_id}/{resource_type}/{resource_id}` | JWT |
 
 Notes:
   - `resource.type` and `action.name` are illustrative names following CyberFabric AuthZ conventions. Actual GTS type paths and action names are configured in the AuthZ policy.

--- a/modules/system/resource-group/docs/DESIGN.md
+++ b/modules/system/resource-group/docs/DESIGN.md
@@ -1,5 +1,5 @@
 <!-- Created: 2026-03-06 by Constructor Tech -->
-<!-- Updated: 2026-04-07 by Constructor Tech -->
+<!-- Updated: 2026-04-20 by Constructor Tech -->
 
 # Technical Design - Resource Group (RG)
 
@@ -180,7 +180,7 @@ Type rules are runtime-configurable through API/seed data with deterministic val
 
 **ADRs**: `cpt-cf-resource-group-adr-p1-gts-type-system`
 
-**Derived type fields — metadata object, JSONB storage (v1)**: Derived type fields (e.g. `barrier`, `custom_domain`, `category`) are nested inside a `metadata` object in API requests and responses. In the database, they are stored in a `metadata` JSONB column on `resource_group`. For chained types (e.g., `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~`), the chained GTS schema defines `properties.metadata` with `additionalProperties: false` for field isolation. `metadata_schema` on the RG type definition is null for chained types — instance metadata is validated against the GTS schema. The `metadata_schema` field is reserved for optional RG-level schema overrides. Advanced validation (e.g., Starlark-based cross-field rules) is out of scope for v1.
+**Derived type fields — metadata object, JSONB storage (v1)**: Derived type fields (e.g. `barrier`, `custom_domain`, `category`) are nested inside a `metadata` object in API requests and responses. In the database, they are stored in a `metadata` JSONB column on `resource_group`. For chained types (e.g., `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~`), the chained GTS schema defines `properties.metadata` with `additionalProperties: false` for field isolation. `metadata_schema` on the RG type definition is null for chained types — instance metadata is validated against the GTS schema. The `metadata_schema` field is reserved for optional RG-level schema overrides. Advanced validation (e.g., Starlark-based cross-field rules) is out of scope for v1.
 
 #### Query Profile as Guardrail
 
@@ -198,12 +198,12 @@ In ownership-graph usage, groups are tenant-scoped and links must be tenant-hier
 
 - [x] `p1` - **ID**: `cpt-cf-resource-group-principle-barrier-as-data`
 
-`barrier` is not a dedicated database column. For GTS types that support barrier semantics (e.g. tenant types), `barrier` is stored inside the `metadata` JSONB field as `metadata.barrier` (boolean). **ADRs**: `cpt-cf-resource-group-adr-p1-gts-type-system`. **RG stores and returns it without enforcement** — RG does not filter, restrict, or alter query results based on the barrier value. RG stores it in `metadata` and returns it in API responses within the `metadata` object, nothing more.
+`barrier` is not a dedicated database column. For GTS types that support barrier semantics (e.g. tenant types), `barrier` is stored inside the `metadata` JSONB field as `metadata.self_managed` (boolean). **ADRs**: `cpt-cf-resource-group-adr-p1-gts-type-system`. **RG stores and returns it without enforcement** — RG does not filter, restrict, or alter query results based on the barrier value. RG stores it in `metadata` and returns it in API responses within the `metadata` object, nothing more.
 
 Barrier enforcement is a **joint responsibility of Tenant Resolver and AuthZ**:
 
-- **RG does not enforce barriers**: all RG queries (hierarchy, groups, memberships) return data regardless of barrier values. If a caller has an `AccessScope` that includes `tenant_id = T7`, RG will return T7's data even if T7 has `metadata.barrier = true`.
-- **Tenant Resolver enforces barriers in hierarchy traversal**: TR SDK defines `BarrierMode` (`Respect` / `Ignore`). The static-tr-plugin's `collect_descendants` skips barrier tenants (`self_managed = true`) and their entire subtrees. `collect_ancestors` from a barrier tenant returns empty. RG's `metadata.barrier` maps to TR's `TenantInfo.self_managed`.
+- **RG does not enforce barriers**: all RG queries (hierarchy, groups, memberships) return data regardless of barrier values. If a caller has an `AccessScope` that includes `tenant_id = T7`, RG will return T7's data even if T7 has `metadata.self_managed = true`.
+- **Tenant Resolver enforces barriers in hierarchy traversal**: TR SDK defines `BarrierMode` (`Respect` / `Ignore`). The static-tr-plugin's `collect_descendants` skips barrier tenants (`self_managed = true`) and their entire subtrees. `collect_ancestors` from a barrier tenant returns empty. RG's `metadata.self_managed` maps to TR's `TenantInfo.self_managed`.
 - **AuthZ integrates barriers into SQL constraints**: the `in_tenant_subtree` predicate supports `barrier_mode: "all"` (default, reads `metadata->>'barrier'` from the closure query) or `"none"` (ignores barriers for billing, provisioning).
 - **Each layer is vendor-replaceable**: vendors can implement custom TR plugins and AuthZ plugins with different barrier semantics. RG remains policy-agnostic.
 
@@ -250,11 +250,11 @@ SMALLINT surrogate IDs (`gts_type.id`, `gts_type_id` FK columns) are a **DB-inte
 - `allowed_memberships` in type create/update requests
 - `resource_type` in membership operations (`POST /memberships/...`)
 
-If a referenced type does not exist, the operation **MUST** return a validation error. Each chained type (e.g., `gts.cf.core.rg.type.v1~y.system.tn.tenant.v1~`) is a distinct type that must be registered separately — chaining does not auto-create constituent types. Registration order matters: base/resource types first, then chained RG types that reference them. Base types (including `gts.cf.core.rg.type.v1~`) must be created before use — via seeding, API calls, or manual DB administration.
+If a referenced type does not exist, the operation **MUST** return a validation error. Each chained type (e.g., `gts.x.system.rg.type.v1~y.system.tn.tenant.v1~`) is a distinct type that must be registered separately — chaining does not auto-create constituent types. Registration order matters: base/resource types first, then chained RG types that reference them. Base types (including `gts.x.system.rg.type.v1~`) must be created before use — via seeding, API calls, or manual DB administration.
 
-**RG type prefix requirement (`gts.cf.core.rg.type.v1~`)**:
-- **`type` in group operations**: `POST /groups`, `PUT /groups/{id}` — **MUST** have `gts.cf.core.rg.type.v1~` prefix. Rejected without it.
-- **`allowed_parents`**: **MUST** have `gts.cf.core.rg.type.v1~` prefix — parent groups are always RG types.
+**RG type prefix requirement (`gts.x.system.rg.type.v1~`)**:
+- **`type` in group operations**: `POST /groups`, `PUT /groups/{id}` — **MUST** have `gts.x.system.rg.type.v1~` prefix. Rejected without it.
+- **`allowed_parents`**: **MUST** have `gts.x.system.rg.type.v1~` prefix — parent groups are always RG types.
 - **`allowed_memberships`**: **NO prefix requirement** — membership resource types are external domain types (e.g., `gts.z.system.idp.user.v1~`, `gts.z.system.lms.course.v1~`) that do not need to be RG types.
 
 This ensures the hierarchy is always governed by the RG type contract (`can_be_root`, `allowed_parents`, `allowed_memberships`), while membership resources can be any registered GTS type.
@@ -432,7 +432,7 @@ Boundaries:
 | `create_group` / `update_group` | `ResourceGroup` | group lifecycle |
 | `get_group` | `ResourceGroup` | get group by ID |
 | `list_groups` | `Page<ResourceGroup>` | list groups with OData query |
-| `delete_group` | `()` | delete group (optional `force`) |
+| `delete_group` | `()` | delete group (non-cascade; cascade only via REST) |
 | `list_group_depth` | `Page<ResourceGroupWithDepth>` | traverse hierarchy from reference group with relative depth |
 | `add_membership` | `ResourceGroupMembership` | add membership |
 | `remove_membership` | `()` | remove membership |
@@ -523,10 +523,11 @@ Integration read models reuse the same SDK structs defined above:
 
 Integration read trait hierarchy (defined in `resource-group-sdk/src/api.rs`):
 
-| Trait | Methods | Used by |
-| ----- | ------- | ------- |
-| `ResourceGroupReadHierarchy` | `list_group_depth` | AuthZ plugin (hierarchy-only read) |
-| `ResourceGroupClient` | full CRUD (types, groups, memberships, hierarchy) | General consumers |
+| Trait | Extends | Methods | Used by |
+| ----- | ------- | ------- | ------- |
+| `ResourceGroupReadHierarchy` | — | `list_group_depth` | AuthZ plugin (hierarchy-only read) |
+| `ResourceGroupReadPluginClient` | `ResourceGroupReadHierarchy` | `list_memberships` | Vendor-specific plugin gateway |
+| `ResourceGroupClient` | — | full CRUD (types, groups, memberships, hierarchy) | General consumers |
 
 ClientHub registration: single implementation (`RgService`), registered as both `dyn ResourceGroupClient` and `dyn ResourceGroupReadHierarchy`. AuthZ plugin resolves `dyn ResourceGroupReadHierarchy`, general consumers resolve `dyn ResourceGroupClient`.
 
@@ -537,7 +538,7 @@ Plugin gateway routing notes:
 - both are registered in ClientHub backed by the same implementation
 - module service resolves configured provider:
   - built-in provider: serve reads from local RG persistence path
-  - vendor-specific provider: resolve plugin instance by configured vendor and delegate to `ResourceGroupReadHierarchy`
+  - vendor-specific provider: resolve plugin instance by configured vendor and delegate to `ResourceGroupReadPluginClient`
 - plugin registration is scoped (GTS instance ID), same pattern as tenant-resolver/authz-resolver gateways
 - `SecurityContext` is forwarded without policy interpretation in gateway layer (including plugin path)
 
@@ -570,7 +571,7 @@ The integration read contract returns **data rows only** (no policy/decision fie
 | `id`          | UUID        | Yes      | Group identifier                                                             |
 | `type`        | string      | Yes      | GTS chained type path                                                        |
 | `name`        | string      | Yes      | Display name                                                                 |
-| `metadata`     | object | No   | Type-specific fields nested in `metadata` object (e.g. `metadata.barrier`, `metadata.category`). Stored in DB `metadata` JSONB. Schema defined by chained GTS type. |
+| `metadata`     | object | No   | Type-specific fields nested in `metadata` object (e.g. `metadata.self_managed`, `metadata.category`). Stored in DB `metadata` JSONB. Schema defined by chained GTS type. |
 | `hierarchy`   | object      | Yes      | RG hierarchy context                                                         |
 | `hierarchy.parent_id` | UUID / null | No | Parent group (null for root groups)                                    |
 | `hierarchy.tenant_id` | UUID  | Yes    | Tenant scope (can differ per row under tenant hierarchy scope)               |
@@ -644,6 +645,7 @@ Client initialization: AuthZ plugin resolves `dyn ResourceGroupReadHierarchy` fr
 | ------------------------------------- | ------------------------------- | ------------------------------------------------------------- |
 | SQL database                          | SeaORM repositories             | durable canonical + closure storage                           |
 | AuthZ Resolver SDK                    | `PolicyEnforcer` / `AuthZResolverClient` | AuthZ evaluation for JWT-authenticated RG API requests (write + read) |
+| Vendor-specific RG backend (optional) | `ResourceGroupReadPluginClient` | alternative hierarchy/membership source for integration reads |
 | AuthZ plugin consumer (optional)      | `ResourceGroupReadHierarchy`    | read hierarchy context in PDP logic (narrow, hierarchy-only, MTLS/in-process) |
 | General consumers (optional)          | `ResourceGroupClient`           | full read+write access to types/entities/memberships/hierarchy |
 
@@ -805,11 +807,11 @@ sequenceDiagram
 
     CS->>PE: access_scope(ctx, COURSE, "list", None)
     PE->>AZ: evaluate(EvaluationRequest)
-    Note right of AZ: subject.properties.tenant_id = T1<br/>action.name = "list"<br/>resource.type = "gts.cf.lms.course.v1~"<br/>context.require_constraints = true<br/>context.supported_properties = ["owner_tenant_id"]
+    Note right of AZ: subject.properties.tenant_id = T1<br/>action.name = "list"<br/>resource.type = "gts.x.lms.course.v1~"<br/>context.require_constraints = true<br/>context.supported_properties = ["owner_tenant_id"]
 
     AZ->>RG: list_group_depth(system_ctx, T1, filter: "hierarchy/depth ge 0 and type eq 'tenant'")
-    RG-->>AZ: [{T1, depth:0, metadata:{}}, {T7, depth:1, metadata:{barrier:true}}]
-    Note right of AZ: AuthZ policy logic (not RG):<br/>T7.metadata.barrier=true, caller≠T7<br/>→ exclude T7 scope from AccessScope
+    RG-->>AZ: [{T1, depth:0, metadata:{}}, {T7, depth:1, metadata:{self_managed:true}}]
+    Note right of AZ: AuthZ policy logic (not RG):<br/>T7.metadata.self_managed=true, caller≠T7<br/>→ exclude T7 scope from AccessScope
 
     AZ-->>PE: decision=true, constraints=[{owner_tenant_id IN (T1)}]
     PE->>PE: compile_to_access_scope()
@@ -826,7 +828,7 @@ Step-by-step:
 
 2. **Domain service** — Courses handler receives the request with `SecurityContext`. Before querying the database, it calls `PolicyEnforcer.access_scope(&ctx, &COURSE_RESOURCE, "list", None)` to obtain row-level access constraints.
 
-3. **AuthZ evaluation** — `PolicyEnforcer` builds an `EvaluationRequest` (subject with `tenant_id = T1`, action `"list"`, resource type `"gts.cf.lms.course.v1~"`, `require_constraints = true`, `supported_properties = ["owner_tenant_id"]`) and calls `AuthZResolverClient.evaluate()`.
+3. **AuthZ evaluation** — `PolicyEnforcer` builds an `EvaluationRequest` (subject with `tenant_id = T1`, action `"list"`, resource type `"gts.x.lms.course.v1~"`, `require_constraints = true`, `supported_properties = ["owner_tenant_id"]`) and calls `AuthZResolverClient.evaluate()`.
 
 4. **Hierarchy resolution** — The AuthZ plugin calls `ResourceGroupReadHierarchy.list_group_depth()` with `tenant_id = T1` and a depth filter to resolve the tenant hierarchy. RG returns `[T1 (depth 0), T7 (depth 1)]` — the accessible tenant subtree. The plugin does NOT see `T9` because it is outside `T1`'s hierarchy.
 
@@ -1075,7 +1077,7 @@ Constraints:
 | `parent_id`   | UUID NULL   | parent entity (FK to `resource_group.id`)         |
 | `gts_type_id` | SMALLINT    | type reference (FK to `gts_type.id`)              |
 | `name`        | TEXT        | display name                                      |
-| `metadata`    | JSONB NULL  | type-specific fields for group instance, validated against the chained GTS type schema. For types supporting barrier semantics, includes `metadata.barrier` (boolean). |
+| `metadata`    | JSONB NULL  | type-specific fields for group instance, validated against the chained GTS type schema. For types supporting barrier semantics, includes `metadata.self_managed` (boolean). |
 | `tenant_id`   | UUID        | tenant scope                                      |
 | `created_at`     | TIMESTAMPTZ | creation time                                     |
 | `updated_at`    | TIMESTAMPTZ | update time (nullable)                            |
@@ -1226,21 +1228,21 @@ RG relies on database-level performance rather than application-level caching:
 
 | Resource (`resource.type`) | Action (`action.name`) | REST Operation | Method | Path | Auth Mode |
 | -------------------------- | ---------------------- | -------------- | ------ | ---- | --------- |
-| `gts.cf.core.rg.type.v1~` | `list` | `listTypes` | GET | `/api/types-registry/v1/types` | JWT |
-| `gts.cf.core.rg.type.v1~` | `create` | `createType` | POST | `/api/types-registry/v1/types` | JWT |
-| `gts.cf.core.rg.type.v1~` | `read` | `getType` | GET | `/api/types-registry/v1/types/{code}` | JWT |
-| `gts.cf.core.rg.type.v1~` | `update` | `updateType` | PUT | `/api/types-registry/v1/types/{code}` | JWT |
-| `gts.cf.core.rg.type.v1~` | `delete` | `deleteType` | DELETE | `/api/types-registry/v1/types/{code}` | JWT |
-| `gts.cf.core.rg.group.v1~` | `list` | `listGroups` | GET | `/groups` | JWT |
-| `gts.cf.core.rg.group.v1~` | `create` | `createGroup` | POST | `/groups` | JWT |
-| `gts.cf.core.rg.group.v1~` | `read` | `getGroup` | GET | `/groups/{group_id}` | JWT |
-| `gts.cf.core.rg.group.v1~` | `update` | `updateGroup` | PUT | `/groups/{group_id}` | JWT |
-| `gts.cf.core.rg.group.v1~` | `delete` | `deleteGroup` | DELETE | `/groups/{group_id}` | JWT |
-| `gts.cf.core.rg.group.v1~` | `read` | `listGroupHierarchy` | GET | `/groups/{group_id}/hierarchy` | JWT |
+| `gts.x.core.rg.type.v1~` | `list` | `listTypes` | GET | `/api/types-registry/v1/types` | JWT |
+| `gts.x.core.rg.type.v1~` | `create` | `createType` | POST | `/api/types-registry/v1/types` | JWT |
+| `gts.x.core.rg.type.v1~` | `read` | `getType` | GET | `/api/types-registry/v1/types/{code}` | JWT |
+| `gts.x.core.rg.type.v1~` | `update` | `updateType` | PUT | `/api/types-registry/v1/types/{code}` | JWT |
+| `gts.x.core.rg.type.v1~` | `delete` | `deleteType` | DELETE | `/api/types-registry/v1/types/{code}` | JWT |
+| `gts.x.core.rg.group.v1~` | `list` | `listGroups` | GET | `/groups` | JWT |
+| `gts.x.core.rg.group.v1~` | `create` | `createGroup` | POST | `/groups` | JWT |
+| `gts.x.core.rg.group.v1~` | `read` | `getGroup` | GET | `/groups/{group_id}` | JWT |
+| `gts.x.core.rg.group.v1~` | `update` | `updateGroup` | PUT | `/groups/{group_id}` | JWT |
+| `gts.x.core.rg.group.v1~` | `delete` | `deleteGroup` | DELETE | `/groups/{group_id}` | JWT |
+| `gts.x.core.rg.group.v1~` | `read` | `listGroupHierarchy` | GET | `/groups/{group_id}/hierarchy` | JWT |
 | _(AuthZ bypassed)_ | — | `listGroupHierarchy` | GET | `/groups/{group_id}/hierarchy` | MTLS |
-| `gts.cf.core.rg.group_membership.v1~` | `list` | `listMemberships` | GET | `/memberships` | JWT |
-| `gts.cf.core.rg.group_membership.v1~` | `create` | `addMembership` | POST | `/memberships/{group_id}/{resource_type}/{resource_id}` | JWT |
-| `gts.cf.core.rg.group_membership.v1~` | `delete` | `deleteMembership` | DELETE | `/memberships/{group_id}/{resource_type}/{resource_id}` | JWT |
+| `gts.x.core.rg.group_membership.v1~` | `list` | `listMemberships` | GET | `/memberships` | JWT |
+| `gts.x.core.rg.group_membership.v1~` | `create` | `addMembership` | POST | `/memberships/{group_id}/{resource_type}/{resource_id}` | JWT |
+| `gts.x.core.rg.group_membership.v1~` | `delete` | `deleteMembership` | DELETE | `/memberships/{group_id}/{resource_type}/{resource_id}` | JWT |
 
 Notes:
   - `resource.type` and `action.name` are illustrative names following CyberFabric AuthZ conventions. Actual GTS type paths and action names are configured in the AuthZ policy.
@@ -1333,7 +1335,7 @@ Test dataset: 100K groups, 200K memberships, 359K closure rows:
 
 #### Column Widths (avg bytes, measured via pg_stats in test environment)
 
-**resource_group** (~100 B/row): `id` 16 B (UUID), `parent_id` 16 B (UUID nullable), `gts_type_id` 2 B (SMALLINT), `name` 14 B (TEXT avg), `metadata` variable (JSONB nullable, typically 20–60 B when present; includes `barrier` for applicable types), `tenant_id` 16 B (UUID), `created_at`/`updated_at` 8 B each, row overhead ~20 B. Note: `barrier` is not a separate column — it is stored inside `metadata` JSONB as `metadata.barrier` (see `cpt-cf-resource-group-principle-barrier-as-data`).
+**resource_group** (~100 B/row): `id` 16 B (UUID), `parent_id` 16 B (UUID nullable), `gts_type_id` 2 B (SMALLINT), `name` 14 B (TEXT avg), `metadata` variable (JSONB nullable, typically 20–60 B when present; includes `barrier` for applicable types), `tenant_id` 16 B (UUID), `created_at`/`updated_at` 8 B each, row overhead ~20 B. Note: `barrier` is not a separate column — it is stored inside `metadata` JSONB as `metadata.self_managed` (see `cpt-cf-resource-group-principle-barrier-as-data`).
 
 **resource_group_closure** (68 B/row): `ancestor_id` 16 B, `descendant_id` 16 B, `depth` 4 B, row overhead ~32 B.
 

--- a/modules/system/resource-group/docs/DESIGN.md
+++ b/modules/system/resource-group/docs/DESIGN.md
@@ -523,11 +523,10 @@ Integration read models reuse the same SDK structs defined above:
 
 Integration read trait hierarchy (defined in `resource-group-sdk/src/api.rs`):
 
-| Trait | Extends | Methods | Used by |
-| ----- | ------- | ------- | ------- |
-| `ResourceGroupReadHierarchy` | — | `list_group_depth` | AuthZ plugin (hierarchy-only read) |
-| `ResourceGroupReadPluginClient` | `ResourceGroupReadHierarchy` | `list_memberships` | Vendor-specific plugin gateway |
-| `ResourceGroupClient` | — | full CRUD (types, groups, memberships, hierarchy) | General consumers |
+| Trait | Methods | Used by |
+| ----- | ------- | ------- |
+| `ResourceGroupReadHierarchy` | `list_group_depth` | AuthZ plugin (hierarchy-only read) |
+| `ResourceGroupClient` | full CRUD (types, groups, memberships, hierarchy) | General consumers |
 
 ClientHub registration: single implementation (`RgService`), registered as both `dyn ResourceGroupClient` and `dyn ResourceGroupReadHierarchy`. AuthZ plugin resolves `dyn ResourceGroupReadHierarchy`, general consumers resolve `dyn ResourceGroupClient`.
 
@@ -538,7 +537,7 @@ Plugin gateway routing notes:
 - both are registered in ClientHub backed by the same implementation
 - module service resolves configured provider:
   - built-in provider: serve reads from local RG persistence path
-  - vendor-specific provider: resolve plugin instance by configured vendor and delegate to `ResourceGroupReadPluginClient`
+  - vendor-specific provider: resolve plugin instance by configured vendor and delegate to `ResourceGroupReadHierarchy`
 - plugin registration is scoped (GTS instance ID), same pattern as tenant-resolver/authz-resolver gateways
 - `SecurityContext` is forwarded without policy interpretation in gateway layer (including plugin path)
 
@@ -645,7 +644,6 @@ Client initialization: AuthZ plugin resolves `dyn ResourceGroupReadHierarchy` fr
 | ------------------------------------- | ------------------------------- | ------------------------------------------------------------- |
 | SQL database                          | SeaORM repositories             | durable canonical + closure storage                           |
 | AuthZ Resolver SDK                    | `PolicyEnforcer` / `AuthZResolverClient` | AuthZ evaluation for JWT-authenticated RG API requests (write + read) |
-| Vendor-specific RG backend (optional) | `ResourceGroupReadPluginClient` | alternative hierarchy/membership source for integration reads |
 | AuthZ plugin consumer (optional)      | `ResourceGroupReadHierarchy`    | read hierarchy context in PDP logic (narrow, hierarchy-only, MTLS/in-process) |
 | General consumers (optional)          | `ResourceGroupClient`           | full read+write access to types/entities/memberships/hierarchy |
 

--- a/modules/system/resource-group/docs/PRD.md
+++ b/modules/system/resource-group/docs/PRD.md
@@ -313,7 +313,7 @@ A type includes:
 - `schema_id` (unique GTS type path, case-insensitive)
 - `can_be_root` (boolean; `true` means the type permits root placement — no `parent_id`). Resolved from `x-gts-traits` in the registered GTS schema.
 - `allowed_parents` (allowed parent type codes; may be empty if the type is root-only). Invariant: `can_be_root OR len(allowed_parents) >= 1` — a type must have at least one valid placement
-- `allowed_memberships` (GTS type paths of resource types allowed as members of groups of this type, e.g. `["gts.x.system.idp.user.v1~"]`)
+- `allowed_memberships` (GTS type paths of resource types allowed as members of groups of this type, e.g. `["gts.cf.core.idp.user.v1~"]`)
 - `metadata_schema` (optional JSON Schema — defines the structure and validation rules for the `metadata` field on group instances of this type)
 
 #### Validate Type Code Format
@@ -390,7 +390,7 @@ The module **MUST** provide API operations for:
 Entity fields (GTS-aligned naming):
 
 - `id` (UUID) — group identifier
-- `type` (GTS chained type path, e.g. `gts.x.system.rg.type.v1~w.system.org.department.v1~`)
+- `type` (GTS chained type path, e.g. `gts.cf.core.rg.type.v1~w.system.org.department.v1~`)
 - `name` (1..255) — display name
 - `metadata` (object) — type-specific fields defined by the chained RG type schema. Examples: `metadata.barrier`, `metadata.custom_domain`, `metadata.category`. For types supporting barrier semantics, `metadata.barrier` (boolean) is included here.
 - `hierarchy` (object) — RG hierarchy context:

--- a/modules/system/resource-group/docs/PRD.md
+++ b/modules/system/resource-group/docs/PRD.md
@@ -1,5 +1,5 @@
 <!-- Created: 2026-03-06 by Constructor Tech -->
-<!-- Updated: 2026-04-07 by Constructor Tech -->
+<!-- Updated: 2026-04-20 by Constructor Tech -->
 
 # PRD - Resource Group (RG)
 
@@ -220,9 +220,9 @@ This aligns RG behavior with `docs/arch/authorization/RESOURCE_GROUP_MODEL.md`.
 
 #### Responsibility Split: RG stores, Tenant Resolver + AuthZ enforce
 
-**RG treats `barrier` purely as data — RG does not filter, restrict, or alter query results based on the barrier value.** For GTS types that support barrier semantics (e.g. tenant types), `barrier` is stored inside the `metadata` field as `metadata.barrier` (boolean). RG returns it in API responses within `metadata`, nothing more. All RG queries return data regardless of barrier values — barrier enforcement is entirely outside RG's scope.
+**RG treats `barrier` purely as data — RG does not filter, restrict, or alter query results based on the barrier value.** For GTS types that support barrier semantics (e.g. tenant types), `barrier` is stored inside the `metadata` field as `metadata.self_managed` (boolean). RG returns it in API responses within `metadata`, nothing more. All RG queries return data regardless of barrier values — barrier enforcement is entirely outside RG's scope.
 
-**Tenant Resolver enforces barrier during hierarchy traversal.** TR applies barrier logic when collecting ancestors and descendants. RG's `metadata.barrier` maps to TR's `self_managed` flag.
+**Tenant Resolver enforces barrier during hierarchy traversal.** TR applies barrier logic when collecting ancestors and descendants. RG's `metadata.self_managed` maps to TR's `self_managed` flag.
 
 **AuthZ integrates barrier into access constraints.** AuthZ supports `barrier_mode` parameter (`respect` / `ignore`). When respecting barriers, barrier tenants and their subtrees are excluded from access scope.
 
@@ -244,7 +244,7 @@ The following rules describe the behavior of Tenant Resolver (`BarrierMode::Resp
 
 **Scenario 1: Parent reads hierarchy (`BarrierMode::Respect`)**
 ```
-T1 (root) → T7 (barrier:true) → D8 → R8
+T1 (root) → T7 (metadata.self_managed:true) → D8 → R8
 Caller: subject_tenant_id = T1
 ```
 - AccessScope: `{tenant_id IN (T1)}` — T7 excluded by TR/AuthZ.
@@ -262,7 +262,7 @@ Caller: subject_tenant_id = T7
 
 **Scenario 3: Nested barriers**
 ```
-T1 → Partner P (barrier:true) → Customer C (barrier:true) → D1
+T1 → Partner P (metadata.self_managed:true) → Customer C (metadata.self_managed:true) → D1
 ```
 - Caller T1: AccessScope `{T1}` — does NOT see P, C, or D1.
 - Caller P: AccessScope `{P}` — does NOT see C or D1.
@@ -313,7 +313,7 @@ A type includes:
 - `schema_id` (unique GTS type path, case-insensitive)
 - `can_be_root` (boolean; `true` means the type permits root placement — no `parent_id`). Resolved from `x-gts-traits` in the registered GTS schema.
 - `allowed_parents` (allowed parent type codes; may be empty if the type is root-only). Invariant: `can_be_root OR len(allowed_parents) >= 1` — a type must have at least one valid placement
-- `allowed_memberships` (GTS type paths of resource types allowed as members of groups of this type, e.g. `["gts.cf.core.idp.user.v1~"]`)
+- `allowed_memberships` (GTS type paths of resource types allowed as members of groups of this type, e.g. `["gts.x.system.idp.user.v1~"]`)
 - `metadata_schema` (optional JSON Schema — defines the structure and validation rules for the `metadata` field on group instances of this type)
 
 #### Validate Type Code Format
@@ -390,9 +390,9 @@ The module **MUST** provide API operations for:
 Entity fields (GTS-aligned naming):
 
 - `id` (UUID) — group identifier
-- `type` (GTS chained type path, e.g. `gts.cf.core.rg.type.v1~w.system.org.department.v1~`)
+- `type` (GTS chained type path, e.g. `gts.x.system.rg.type.v1~w.system.org.department.v1~`)
 - `name` (1..255) — display name
-- `metadata` (object) — type-specific fields defined by the chained RG type schema. Examples: `metadata.barrier`, `metadata.custom_domain`, `metadata.category`. For types supporting barrier semantics, `metadata.barrier` (boolean) is included here.
+- `metadata` (object) — type-specific fields defined by the chained RG type schema. Examples: `metadata.self_managed`, `metadata.custom_domain`, `metadata.category`. For types supporting barrier semantics, `metadata.self_managed` (boolean) is included here.
 - `hierarchy` (object) — RG hierarchy context:
   - `parent_id` (optional) — direct parent group
   - `tenant_id` (required) — tenant scope

--- a/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
+++ b/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
@@ -280,7 +280,7 @@ In-source `#[cfg(test)]` tests for filter field definitions and DTO conversions:
 ## 6. Acceptance Criteria
 
 - [x] SDK crate (`resource-group-sdk`) compiles with all model types, trait contracts, and error types defined
-- [x] `GtsTypePath::new("gts.x.system.rg.type.v1~")` succeeds; `GtsTypePath::new("invalid")` returns validation error
+- [x] `GtsTypePath::new("gts.cf.core.rg.type.v1~")` succeeds; `GtsTypePath::new("invalid")` returns validation error
 - [x] All 6 DB tables are created by migration scripts with correct constraints and indexes
 - [x] SeaORM entities compile and map to the DB schema without runtime errors
 - [x] Module registers `dyn ResourceGroupClient` and `dyn ResourceGroupReadHierarchy` in ClientHub during Phase 1 init
@@ -304,7 +304,7 @@ Other modules (`nodes-registry`, `types-registry`) place pure-logic tests direct
 
 #### TC-SDK-01: GtsTypePath::new() valid path [P1]
 - **Covers**: G36, 0001-AC-2
-- **Input**: `"gts.x.system.rg.type.v1~"`
+- **Input**: `"gts.cf.core.rg.type.v1~"`
 - **Assert**: `Ok(GtsTypePath)`, `as_str()` returns lowercase
 
 #### TC-SDK-02: GtsTypePath::new() empty string [P1]
@@ -327,32 +327,32 @@ Other modules (`nodes-registry`, `types-registry`) place pure-logic tests direct
 
 #### TC-SDK-06: GtsTypePath::new() invalid format - uppercase chars [P1]
 - **Covers**: G38
-- **Input**: `"gts.x.system.rg.type.v1~"` with uppercase -> trimmed/lowercased
+- **Input**: `"GTS.X.CORE.RG.TYPE.V1~"` with uppercase -> trimmed/lowercased
 
 #### TC-SDK-07: GtsTypePath::new() trims whitespace and lowercases [P2]
 - **Covers**: G36
-- **Input**: `"  GTS.X.System.RG.Type.V1~  "`
-- **Assert**: `Ok`, `as_str() == "gts.x.system.rg.type.v1~"`
+- **Input**: `"  GTS.X.CORE.RG.TYPE.V1~  "`
+- **Assert**: `Ok`, `as_str() == "gts.cf.core.rg.type.v1~"`
 
 #### TC-SDK-08: GtsTypePath::new() chained path (multi-segment) [P1]
 - **Covers**: G38
-- **Input**: `"gts.x.system.rg.type.v1~x.test.v1~"`
+- **Input**: `"gts.cf.core.rg.type.v1~x.test.v1~"`
 - **Assert**: `Ok`
 
 #### TC-SDK-09: GtsTypePath::new() double tilde (empty segment) [P2]
 - **Covers**: G38
-- **Input**: `"gts.x.system.rg.type.v1~~"`
+- **Input**: `"gts.cf.core.rg.type.v1~~"`
 - **Assert**: `Err` (empty segment between tildes)
 
 #### TC-SDK-10: GtsTypePath::new() special chars in segment [P2]
 - **Covers**: G38
-- **Input**: `"gts.x.system.rg.type.v1~hello-world~"` (hyphen not allowed)
+- **Input**: `"gts.cf.core.rg.type.v1~hello-world~"` (hyphen not allowed)
 - **Assert**: `Err`
 
 #### TC-SDK-11: GtsTypePath serde round-trip (JSON) [P1]
 - **Covers**: G37
 - **Setup**: Serialize `GtsTypePath` to JSON string, deserialize back
-- **Assert**: `serde_json::to_string(&path)` produces `"gts.x.system.rg.type.v1~"`, deserialize back equals original
+- **Assert**: `serde_json::to_string(&path)` produces `"gts.cf.core.rg.type.v1~"`, deserialize back equals original
 
 #### TC-SDK-12: GtsTypePath serde invalid JSON string [P1]
 - **Covers**: G37
@@ -466,7 +466,7 @@ OData filter fields use manual `FilterField` trait implementations with string f
 
 #### TC-ODATA-05: MembershipFilterField names and kinds [P1]
 - **Covers**: G44
-- **Assert**: `GroupId -> ("group_id", Uuid)`, `ResourceType -> ("resource_type", I64)`, `ResourceId -> ("resource_id", String)`
+- **Assert**: `GroupId -> ("group_id", Uuid)`, `ResourceType -> ("resource_type", String)`, `ResourceId -> ("resource_id", String)`
 
 #### TC-ODATA-06: TypeODataMapper field-to-column mapping [P2]
 - **Covers**: G45

--- a/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
+++ b/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
@@ -1,4 +1,5 @@
 <!-- Created: 2026-04-07 by Constructor Tech -->
+<!-- Updated: 2026-04-20 by Constructor Tech -->
 
 # Feature: SDK Contracts, Error Types & Module Foundation
 
@@ -165,11 +166,12 @@ The system **MUST** define SDK trait contracts in `resource-group-sdk/src/api.rs
 **Required traits**:
 - `ResourceGroupClient` — full CRUD trait: type management (`create_type`, `get_type`, `list_types`, `update_type`, `delete_type`), group management (`create_group`, `get_group`, `list_groups`, `update_group`, `delete_group`, `list_group_depth`), membership management (`add_membership`, `remove_membership`, `list_memberships`). All methods accept `SecurityContext` as first argument.
 - `ResourceGroupReadHierarchy` — narrow hierarchy-only read trait: `list_group_depth(ctx, group_id, query)` returning `Page<ResourceGroupWithDepth>`. Used exclusively by AuthZ plugin.
+- `ResourceGroupReadPluginClient` — extends `ResourceGroupReadHierarchy` with `list_memberships`. Used for vendor-specific plugin gateway routing.
 
 **Constraints**: `cpt-cf-resource-group-constraint-no-authz-decision`, `cpt-cf-resource-group-constraint-no-sql-filter-generation`
 
 **Touches**:
-- Entities: `ResourceGroupClient`, `ResourceGroupReadHierarchy`
+- Entities: `ResourceGroupClient`, `ResourceGroupReadHierarchy`, `ResourceGroupReadPluginClient`
 
 ### SDK Error Taxonomy
 
@@ -279,7 +281,7 @@ In-source `#[cfg(test)]` tests for filter field definitions and DTO conversions:
 ## 6. Acceptance Criteria
 
 - [x] SDK crate (`resource-group-sdk`) compiles with all model types, trait contracts, and error types defined
-- [x] `GtsTypePath::new("gts.cf.core.rg.type.v1~")` succeeds; `GtsTypePath::new("invalid")` returns validation error
+- [x] `GtsTypePath::new("gts.x.system.rg.type.v1~")` succeeds; `GtsTypePath::new("invalid")` returns validation error
 - [x] All 6 DB tables are created by migration scripts with correct constraints and indexes
 - [x] SeaORM entities compile and map to the DB schema without runtime errors
 - [x] Module registers `dyn ResourceGroupClient` and `dyn ResourceGroupReadHierarchy` in ClientHub during Phase 1 init
@@ -303,7 +305,7 @@ Other modules (`nodes-registry`, `types-registry`) place pure-logic tests direct
 
 #### TC-SDK-01: GtsTypePath::new() valid path [P1]
 - **Covers**: G36, 0001-AC-2
-- **Input**: `"gts.cf.core.rg.type.v1~"`
+- **Input**: `"gts.x.system.rg.type.v1~"`
 - **Assert**: `Ok(GtsTypePath)`, `as_str()` returns lowercase
 
 #### TC-SDK-02: GtsTypePath::new() empty string [P1]
@@ -326,32 +328,32 @@ Other modules (`nodes-registry`, `types-registry`) place pure-logic tests direct
 
 #### TC-SDK-06: GtsTypePath::new() invalid format - uppercase chars [P1]
 - **Covers**: G38
-- **Input**: `"GTS.X.CORE.RG.TYPE.V1~"` with uppercase -> trimmed/lowercased
+- **Input**: `"gts.x.system.rg.type.v1~"` with uppercase -> trimmed/lowercased
 
 #### TC-SDK-07: GtsTypePath::new() trims whitespace and lowercases [P2]
 - **Covers**: G36
-- **Input**: `"  GTS.X.CORE.RG.TYPE.V1~  "`
-- **Assert**: `Ok`, `as_str() == "gts.cf.core.rg.type.v1~"`
+- **Input**: `"  GTS.X.System.RG.Type.V1~  "`
+- **Assert**: `Ok`, `as_str() == "gts.x.system.rg.type.v1~"`
 
 #### TC-SDK-08: GtsTypePath::new() chained path (multi-segment) [P1]
 - **Covers**: G38
-- **Input**: `"gts.cf.core.rg.type.v1~x.test.v1~"`
+- **Input**: `"gts.x.system.rg.type.v1~x.test.v1~"`
 - **Assert**: `Ok`
 
 #### TC-SDK-09: GtsTypePath::new() double tilde (empty segment) [P2]
 - **Covers**: G38
-- **Input**: `"gts.cf.core.rg.type.v1~~"`
+- **Input**: `"gts.x.system.rg.type.v1~~"`
 - **Assert**: `Err` (empty segment between tildes)
 
 #### TC-SDK-10: GtsTypePath::new() special chars in segment [P2]
 - **Covers**: G38
-- **Input**: `"gts.cf.core.rg.type.v1~hello-world~"` (hyphen not allowed)
+- **Input**: `"gts.x.system.rg.type.v1~hello-world~"` (hyphen not allowed)
 - **Assert**: `Err`
 
 #### TC-SDK-11: GtsTypePath serde round-trip (JSON) [P1]
 - **Covers**: G37
 - **Setup**: Serialize `GtsTypePath` to JSON string, deserialize back
-- **Assert**: `serde_json::to_string(&path)` produces `"gts.cf.core.rg.type.v1~"`, deserialize back equals original
+- **Assert**: `serde_json::to_string(&path)` produces `"gts.x.system.rg.type.v1~"`, deserialize back equals original
 
 #### TC-SDK-12: GtsTypePath serde invalid JSON string [P1]
 - **Covers**: G37
@@ -465,7 +467,7 @@ OData filter fields use manual `FilterField` trait implementations with string f
 
 #### TC-ODATA-05: MembershipFilterField names and kinds [P1]
 - **Covers**: G44
-- **Assert**: `GroupId -> ("group_id", Uuid)`, `ResourceType -> ("resource_type", String)`, `ResourceId -> ("resource_id", String)`
+- **Assert**: `GroupId -> ("group_id", Uuid)`, `ResourceType -> ("resource_type", I64)`, `ResourceId -> ("resource_id", String)`
 
 #### TC-ODATA-06: TypeODataMapper field-to-column mapping [P2]
 - **Covers**: G45
@@ -528,7 +530,7 @@ No data setup needed. Fastest possible test.
 
 ```
 POST /types → create type
-POST /groups → create group with metadata: {"barrier": true}
+POST /groups → create group with metadata: {"self_managed": true}
 GET  /groups/{id} → 200
 
 Assert JSON keys:
@@ -538,7 +540,7 @@ Assert JSON keys:
   "tenant_id"  — string, UUID format
   "parent_id"  — null (root group)
   "depth"      — integer, == 0
-  "metadata"   — {"barrier": true} (JSONB roundtrip)
+  "metadata"   — {"self_managed": true} (JSONB roundtrip)
   "created_at" — string, ISO 8601
   "updated_at" — null or absent (fresh create)
 

--- a/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
+++ b/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
@@ -165,12 +165,11 @@ The system **MUST** define SDK trait contracts in `resource-group-sdk/src/api.rs
 **Required traits**:
 - `ResourceGroupClient` — full CRUD trait: type management (`create_type`, `get_type`, `list_types`, `update_type`, `delete_type`), group management (`create_group`, `get_group`, `list_groups`, `update_group`, `delete_group`, `list_group_depth`), membership management (`add_membership`, `remove_membership`, `list_memberships`). All methods accept `SecurityContext` as first argument.
 - `ResourceGroupReadHierarchy` — narrow hierarchy-only read trait: `list_group_depth(ctx, group_id, query)` returning `Page<ResourceGroupWithDepth>`. Used exclusively by AuthZ plugin.
-- `ResourceGroupReadPluginClient` — extends `ResourceGroupReadHierarchy` with `list_memberships`. Used for vendor-specific plugin gateway routing.
 
 **Constraints**: `cpt-cf-resource-group-constraint-no-authz-decision`, `cpt-cf-resource-group-constraint-no-sql-filter-generation`
 
 **Touches**:
-- Entities: `ResourceGroupClient`, `ResourceGroupReadHierarchy`, `ResourceGroupReadPluginClient`
+- Entities: `ResourceGroupClient`, `ResourceGroupReadHierarchy`
 
 ### SDK Error Taxonomy
 

--- a/modules/system/resource-group/docs/features/0002-type-management.md
+++ b/modules/system/resource-group/docs/features/0002-type-management.md
@@ -172,18 +172,18 @@ Types define the structural rules for the resource group hierarchy — which par
 
 **Steps**:
 1. [x] - `p1` - Validate `schema_id` via GtsTypePath value object (format, length, non-empty) - `inst-val-input-1`
-2. [x] - `p1` - **IF** `schema_id` does not have RG type prefix `gts.x.system.rg.type.v1~` - `inst-val-input-2`
+2. [x] - `p1` - **IF** `schema_id` does not have RG type prefix `gts.cf.core.rg.type.v1~` - `inst-val-input-2`
    1. [x] - `p1` - **RETURN** Validation error: "Type schema_id must have RG type prefix" - `inst-val-input-2a`
 3. [x] - `p1` - Validate placement invariant: `can_be_root == true OR len(allowed_parents) >= 1` - `inst-val-input-3`
 4. [x] - `p1` - **IF** invariant violated - `inst-val-input-4`
    1. [x] - `p1` - **RETURN** Validation error: "Type must allow root placement or have at least one allowed parent" - `inst-val-input-4a`
 5. [x] - `p1` - **FOR EACH** parent_path in allowed_parents - `inst-val-input-5`
-   1. [x] - `p1` - Validate parent_path has RG type prefix `gts.x.system.rg.type.v1~` - `inst-val-input-5a`
+   1. [x] - `p1` - Validate parent_path has RG type prefix `gts.cf.core.rg.type.v1~` - `inst-val-input-5a`
    2. [x] - `p1` - Verify parent_path exists in gts_type table - `inst-val-input-5b`
 6. [x] - `p1` - **FOR EACH** membership_path in allowed_memberships - `inst-val-input-6`
    1. [x] - `p1` - Validate membership_path is a valid GtsTypePath (no RG prefix requirement) - `inst-val-input-6a`
    2. [x] - `p1` - Verify membership_path exists in gts_type table - `inst-val-input-6b`
-7. [x] - `p1` - **IF** metadata_schema provided, validate it is a valid JSON Schema via `jsonschema::validator_for()`. Returns validation error if the schema cannot be compiled. - `inst-val-input-7`
+7. [x] - `p1` - **IF** metadata_schema provided, validate it is a valid JSON Schema via `jsonschema::validator_for()` (compile-check). Runtime metadata validation against group instances uses `validate_metadata_via_gts()` through `TypesRegistryClient`. - `inst-val-input-7`
 8. [x] - `p1` - **RETURN** validated type definition - `inst-val-input-8`
 
 ### Hierarchy Safety Check for Type Update
@@ -359,12 +359,12 @@ Test setup: SQLite in-memory + TypeService + GroupService (for hierarchy safety 
 
 #### TC-TYP-02: Create type with non-existent allowed_parents [P1]
 - **Covers**: G4
-- **Setup**: Create type with `allowed_parents: ["gts.x.system.rg.type.v1~nonexistent.v1~"]`
+- **Setup**: Create type with `allowed_parents: ["gts.cf.core.rg.type.v1~nonexistent.v1~"]`
 - **Assert**: `DomainError::TypeNotFound` or `DomainError::Validation`
 
 #### TC-TYP-03: Create type with non-existent allowed_memberships [P1]
 - **Covers**: G5
-- **Setup**: Create type with `allowed_memberships: ["gts.x.system.rg.type.v1~nonexistent.v1~"]`
+- **Setup**: Create type with `allowed_memberships: ["gts.cf.core.rg.type.v1~nonexistent.v1~"]`
 - **Assert**: Error (type not found)
 
 #### TC-TYP-04: Placement invariant violation (can_be_root=false, no parents) [P1]
@@ -570,7 +570,7 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 - Create type, verify `resolve_id(code)` returns `Some(id)` where id is `i16`
 
 #### TC-GTS-02: resolve_id returns None for nonexistent path [P1]
-- `resolve_id("gts.x.system.rg.type.v1~nonexistent.v1~")` → `None`
+- `resolve_id("gts.cf.core.rg.type.v1~nonexistent.v1~")` → `None`
 
 #### TC-GTS-03: resolve_ids batch — all found [P1]
 - Create 3 types, `resolve_ids([code1, code2, code3])` → `Ok(vec![id1, id2, id3])`
@@ -592,12 +592,12 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 
 #### TC-GTS-08: load_allowed_parents resolves junction → IDs → paths [P1]
 - Create parent type P, child type C(allowed_parents=[P])
-- load_allowed_parents(C.id) → `vec!["gts.x...P..."]`
+- load_allowed_parents(C.id) → `vec!["gts.cf...P..."]`
 - **Assert**: returned path == P's code
 
 #### TC-GTS-09: load_allowed_memberships resolves junction → IDs → paths [P1]
 - Create member type M, group type G(allowed_memberships=[M])
-- load_allowed_memberships(G.id) → `vec!["gts.x...M..."]`
+- load_allowed_memberships(G.id) → `vec!["gts.cf...M..."]`
 
 #### can_be_root Derivation & Internal Key Handling
 

--- a/modules/system/resource-group/docs/features/0002-type-management.md
+++ b/modules/system/resource-group/docs/features/0002-type-management.md
@@ -1,4 +1,5 @@
 <!-- Created: 2026-04-07 by Constructor Tech -->
+<!-- Updated: 2026-04-20 by Constructor Tech -->
 
 # Feature: GTS Type Management
 
@@ -79,32 +80,32 @@ Types define the structural rules for the resource group hierarchy — which par
 **Actor**: `cpt-cf-resource-group-actor-instance-administrator`
 
 **Success Scenarios**:
-- Type is created with schema_id, allowed_parents, allowed_memberships, and metadata_schema
+- Type is created with schema_id, allowed_parent_types, allowed_membership_types, and metadata_schema
 - Type is immediately available for group creation
 
 **Error Scenarios**:
 - Invalid GTS type path format → Validation error
 - Duplicate schema_id → TypeAlreadyExists
-- Referenced allowed_parents type does not exist → Validation error
-- Referenced allowed_memberships type does not exist → Validation error
-- Placement invariant violated (not can_be_root AND no allowed_parents) → Validation error
+- Referenced allowed_parent_types type does not exist → Validation error
+- Referenced allowed_membership_types type does not exist → Validation error
+- Placement invariant violated (not can_be_root AND no allowed_parent_types) → Validation error
 
 **Steps**:
 1. [x] - `p1` - Actor sends POST /api/types-registry/v1/types with type definition payload - `inst-create-type-1`
 2. [x] - `p1` - Validate GTS type path format via `GtsTypePath` value object - `inst-create-type-2`
-3. [x] - `p1` - Validate placement invariant: `can_be_root OR len(allowed_parents) >= 1` - `inst-create-type-3`
-4. [x] - `p1` - **IF** allowed_parents is non-empty - `inst-create-type-4`
-   1. [x] - `p1` - DB: SELECT id FROM gts_type WHERE schema_id IN (allowed_parents) — verify all referenced parent types exist - `inst-create-type-4a`
+3. [x] - `p1` - Validate placement invariant: `can_be_root OR len(allowed_parent_types) >= 1` - `inst-create-type-3`
+4. [x] - `p1` - **IF** allowed_parent_types is non-empty - `inst-create-type-4`
+   1. [x] - `p1` - DB: SELECT id FROM gts_type WHERE schema_id IN (allowed_parent_types) — verify all referenced parent types exist - `inst-create-type-4a`
    2. [x] - `p1` - **IF** any parent type not found → **RETURN** Validation error with missing type paths - `inst-create-type-4b`
-5. [x] - `p1` - **IF** allowed_memberships is non-empty - `inst-create-type-5`
-   1. [x] - `p1` - DB: SELECT id FROM gts_type WHERE schema_id IN (allowed_memberships) — verify all referenced membership types exist - `inst-create-type-5a`
+5. [x] - `p1` - **IF** allowed_membership_types is non-empty - `inst-create-type-5`
+   1. [x] - `p1` - DB: SELECT id FROM gts_type WHERE schema_id IN (allowed_membership_types) — verify all referenced membership types exist - `inst-create-type-5a`
    2. [x] - `p1` - **IF** any membership type not found → **RETURN** Validation error with missing type paths - `inst-create-type-5b`
 6. [x] - `p1` - Resolve GTS type path to SMALLINT surrogate ID at persistence boundary - `inst-create-type-6`
 7. [x] - `p1` - DB: INSERT INTO gts_type (schema_id, metadata_schema) — with uniqueness constraint on schema_id - `inst-create-type-7`
 8. [x] - `p1` - **IF** unique constraint violation → **RETURN** TypeAlreadyExists with conflicting schema_id - `inst-create-type-8`
 9. [x] - `p1` - DB: INSERT INTO gts_type_allowed_parent (type_id, parent_type_id) for each allowed parent - `inst-create-type-9`
 10. [x] - `p1` - DB: INSERT INTO gts_type_allowed_membership (type_id, membership_type_id) for each allowed membership - `inst-create-type-10`
-11. [x] - `p1` - **RETURN** created ResourceGroupType with schema_id, allowed_parents, allowed_memberships, can_be_root, metadata_schema - `inst-create-type-11`
+11. [x] - `p1` - **RETURN** created ResourceGroupType with schema_id, allowed_parent_types, allowed_membership_types, can_be_root, is_tenant, metadata_schema - `inst-create-type-11`
 
 ### Update Type
 
@@ -113,13 +114,13 @@ Types define the structural rules for the resource group hierarchy — which par
 **Actor**: `cpt-cf-resource-group-actor-instance-administrator`
 
 **Success Scenarios**:
-- Type definition updated (allowed_parents, allowed_memberships, metadata_schema)
+- Type definition updated (allowed_parent_types, allowed_membership_types, metadata_schema)
 - Existing groups remain valid under new rules
 
 **Error Scenarios**:
 - Type not found → NotFound
-- Removing allowed_parent that is in use by existing groups → AllowedParentsViolation
-- Setting can_be_root=false when root groups of this type exist → AllowedParentsViolation
+- Removing allowed_parent that is in use by existing groups → AllowedParentTypesViolation
+- Setting can_be_root=false when root groups of this type exist → AllowedParentTypesViolation
 - Referenced type does not exist → Validation error
 - Placement invariant violated → Validation error
 
@@ -128,9 +129,9 @@ Types define the structural rules for the resource group hierarchy — which par
 2. [x] - `p1` - DB: SELECT FROM gts_type WHERE schema_id = {code} — load existing type - `inst-update-type-2`
 3. [x] - `p1` - **IF** type not found → **RETURN** NotFound - `inst-update-type-3`
 4. [x] - `p1` - Validate placement invariant on new values - `inst-update-type-4`
-5. [x] - `p1` - Validate all referenced allowed_parents and allowed_memberships types exist - `inst-update-type-5`
-6. [x] - `p1` - Invoke hierarchy safety check algorithm for allowed_parents and can_be_root changes - `inst-update-type-6`
-7. [x] - `p1` - **IF** hierarchy safety check fails → **RETURN** AllowedParentsViolation with violating group details - `inst-update-type-7`
+5. [x] - `p1` - Validate all referenced allowed_parent_types and allowed_membership_types types exist - `inst-update-type-5`
+6. [x] - `p1` - Invoke hierarchy safety check algorithm for allowed_parent_types and can_be_root changes - `inst-update-type-6`
+7. [x] - `p1` - **IF** hierarchy safety check fails → **RETURN** AllowedParentTypesViolation with violating group details - `inst-update-type-7`
 8. [x] - `p1` - DB: DELETE FROM gts_type_allowed_parent WHERE type_id = {id} — clear old parents - `inst-update-type-8`
 9. [x] - `p1` - DB: INSERT INTO gts_type_allowed_parent — insert new parents - `inst-update-type-9`
 10. [x] - `p1` - DB: DELETE FROM gts_type_allowed_membership WHERE type_id = {id} — clear old memberships - `inst-update-type-10`
@@ -166,7 +167,7 @@ Types define the structural rules for the resource group hierarchy — which par
 
 - [x] `p1` - **ID**: `cpt-cf-resource-group-algo-type-mgmt-validate-type-input`
 
-**Input**: Type create/update payload (`schema_id`, `allowed_parents`, `allowed_memberships`, `can_be_root`, `metadata_schema`)
+**Input**: Type create/update payload (`schema_id`, `allowed_parent_types`, `allowed_membership_types`, `can_be_root`, `is_tenant` (default `false`), `metadata_schema`)
 
 **Output**: Validated type definition or validation error with field-level details
 
@@ -174,13 +175,13 @@ Types define the structural rules for the resource group hierarchy — which par
 1. [x] - `p1` - Validate `schema_id` via GtsTypePath value object (format, length, non-empty) - `inst-val-input-1`
 2. [x] - `p1` - **IF** `schema_id` does not have RG type prefix `gts.cf.core.rg.type.v1~` - `inst-val-input-2`
    1. [x] - `p1` - **RETURN** Validation error: "Type schema_id must have RG type prefix" - `inst-val-input-2a`
-3. [x] - `p1` - Validate placement invariant: `can_be_root == true OR len(allowed_parents) >= 1` - `inst-val-input-3`
+3. [x] - `p1` - Validate placement invariant: `can_be_root == true OR len(allowed_parent_types) >= 1` - `inst-val-input-3`
 4. [x] - `p1` - **IF** invariant violated - `inst-val-input-4`
    1. [x] - `p1` - **RETURN** Validation error: "Type must allow root placement or have at least one allowed parent" - `inst-val-input-4a`
-5. [x] - `p1` - **FOR EACH** parent_path in allowed_parents - `inst-val-input-5`
+5. [x] - `p1` - **FOR EACH** parent_path in allowed_parent_types - `inst-val-input-5`
    1. [x] - `p1` - Validate parent_path has RG type prefix `gts.cf.core.rg.type.v1~` - `inst-val-input-5a`
    2. [x] - `p1` - Verify parent_path exists in gts_type table - `inst-val-input-5b`
-6. [x] - `p1` - **FOR EACH** membership_path in allowed_memberships - `inst-val-input-6`
+6. [x] - `p1` - **FOR EACH** membership_path in allowed_membership_types - `inst-val-input-6`
    1. [x] - `p1` - Validate membership_path is a valid GtsTypePath (no RG prefix requirement) - `inst-val-input-6a`
    2. [x] - `p1` - Verify membership_path exists in gts_type table - `inst-val-input-6b`
 7. [x] - `p1` - **IF** metadata_schema provided, validate it is a valid JSON Schema via `jsonschema::validator_for()` (compile-check). Runtime metadata validation against group instances uses `validate_metadata_via_gts()` through `TypesRegistryClient`. - `inst-val-input-7`
@@ -190,19 +191,19 @@ Types define the structural rules for the resource group hierarchy — which par
 
 - [x] `p1` - **ID**: `cpt-cf-resource-group-algo-type-mgmt-check-hierarchy-safety`
 
-**Input**: Existing type definition, proposed new `allowed_parents` and `can_be_root` values
+**Input**: Existing type definition, proposed new `allowed_parent_types` and `can_be_root` values
 
-**Output**: Pass or AllowedParentsViolation with conflicting group details
+**Output**: Pass or AllowedParentTypesViolation with conflicting group details
 
 **Steps**:
-1. [x] - `p1` - Compute removed parent types: `old_allowed_parents - new_allowed_parents` - `inst-hier-check-1`
+1. [x] - `p1` - Compute removed parent types: `old_allowed_parent_types - new_allowed_parent_types` - `inst-hier-check-1`
 2. [x] - `p1` - **FOR EACH** removed_parent_type in removed set - `inst-hier-check-2`
    1. [x] - `p1` - DB: SELECT rg.id, rg.name FROM resource_group rg JOIN resource_group parent ON rg.parent_id = parent.id WHERE rg.gts_type_id = {this_type_id} AND parent.gts_type_id = {removed_parent_type_id} - `inst-hier-check-2a`
    2. [x] - `p1` - **IF** any groups found → collect as violations - `inst-hier-check-2b`
 3. [x] - `p1` - **IF** can_be_root changed from true to false - `inst-hier-check-3`
    1. [x] - `p1` - DB: SELECT id, name FROM resource_group WHERE gts_type_id = {this_type_id} AND parent_id IS NULL - `inst-hier-check-3a`
    2. [x] - `p1` - **IF** any root groups found → collect as violations - `inst-hier-check-3b`
-4. [x] - `p1` - **IF** violations collected → **RETURN** AllowedParentsViolation with violating group IDs, names, and constraint details - `inst-hier-check-4`
+4. [x] - `p1` - **IF** violations collected → **RETURN** AllowedParentTypesViolation with violating group IDs, names, and constraint details - `inst-hier-check-4`
 5. [x] - `p1` - **RETURN** pass - `inst-hier-check-5`
 
 ### Type Seeding
@@ -301,7 +302,7 @@ The system **MUST** provide an idempotent type seeding mechanism for deployment 
 - [x] `p1` - **ID**: `cpt-cf-resource-group-dod-testing-type-mgmt`
 
 All acceptance criteria from feature 0002 are covered by automated tests:
-- Create with valid/invalid `allowed_parents` and `allowed_memberships`
+- Create with valid/invalid `allowed_parent_types` and `allowed_membership_types`
 - Placement invariant enforcement
 - Update with hierarchy safety checks (removed parent in use, can_be_root toggle)
 - Delete with active group references blocked
@@ -326,12 +327,12 @@ Extend `domain_unit_test.rs` with FROM-direction error conversions:
 
 ## 6. Acceptance Criteria
 
-- [x] Type with valid schema_id and allowed_parents is created and persisted with junction table entries
+- [x] Type with valid schema_id and allowed_parent_types is created and persisted with junction table entries
 - [x] Creating type with duplicate schema_id returns `TypeAlreadyExists` (409)
 - [x] Creating type with invalid GTS type path format returns validation error (400) with field details
-- [x] Creating type without `can_be_root` and without `allowed_parents` returns validation error (placement invariant)
-- [x] Updating type to remove allowed_parent that is in use by existing groups returns `AllowedParentsViolation` (409)
-- [x] Updating type to set `can_be_root=false` when root groups exist returns `AllowedParentsViolation` (409)
+- [x] Creating type without `can_be_root` and without `allowed_parent_types` returns validation error (placement invariant)
+- [x] Updating type to remove allowed_parent that is in use by existing groups returns `AllowedParentTypesViolation` (409)
+- [x] Updating type to set `can_be_root=false` when root groups exist returns `AllowedParentTypesViolation` (409)
 - [x] Updating type to add new allowed_parent succeeds when no existing groups violate new rules
 - [x] Deleting unused type succeeds (204) and removes junction table entries via CASCADE
 - [x] Deleting type with existing groups returns `ConflictActiveReferences` (409) with response body including entity count so the caller can display what prevents deletion
@@ -352,40 +353,40 @@ Extend `domain_unit_test.rs` with FROM-direction error conversions:
 
 Test setup: SQLite in-memory + TypeService + GroupService (for hierarchy safety tests).
 
-#### TC-TYP-01: Create type with valid allowed_parents [P1]
+#### TC-TYP-01: Create type with valid allowed_parent_types [P1]
 - **Covers**: G4 (positive path), 0002-AC-1
 - **Setup**: Create parent type first, then create child type referencing it
-- **Assert**: Child type created, `allowed_parents` contains parent code
+- **Assert**: Child type created, `allowed_parent_types` contains parent code
 
-#### TC-TYP-02: Create type with non-existent allowed_parents [P1]
+#### TC-TYP-02: Create type with non-existent allowed_parent_types [P1]
 - **Covers**: G4
-- **Setup**: Create type with `allowed_parents: ["gts.cf.core.rg.type.v1~nonexistent.v1~"]`
+- **Setup**: Create type with `allowed_parent_types: ["gts.cf.core.rg.type.v1~x.core.rg.missing.v1~"]`
 - **Assert**: `DomainError::TypeNotFound` or `DomainError::Validation`
 
-#### TC-TYP-03: Create type with non-existent allowed_memberships [P1]
+#### TC-TYP-03: Create type with non-existent allowed_membership_types [P1]
 - **Covers**: G5
-- **Setup**: Create type with `allowed_memberships: ["gts.cf.core.rg.type.v1~nonexistent.v1~"]`
+- **Setup**: Create type with `allowed_membership_types: ["gts.z.core.idp.missing.v1~"]`
 - **Assert**: Error (type not found)
 
 #### TC-TYP-04: Placement invariant violation (can_be_root=false, no parents) [P1]
 - **Covers**: G6, 0002-AC-4
-- **Setup**: `CreateTypeRequest { can_be_root: false, allowed_parents: [] }`
+- **Setup**: `CreateTypeRequest { can_be_root: false, allowed_parent_types: [] }`
 - **Assert**: `DomainError::Validation` with "root placement or" message
 
 #### TC-TYP-05: Update type happy path [P1]
 - **Covers**: G1, 0002-AC-7
-- **Setup**: Create type, then update with new `allowed_parents`
+- **Setup**: Create type, then update with new `allowed_parent_types`
 - **Assert**: Updated type returned with new parents
 
 #### TC-TYP-06: Update type - remove allowed_parent in use by groups [P1]
 - **Covers**: G2, 0002-AC-5
-- **Setup**: Create parent type P, child type C (allowed_parents=[P]), create group of type P, create child group of type C under P group. Then update type C removing P from allowed_parents.
-- **Assert**: `DomainError::AllowedParentsViolation` with violating group names
+- **Setup**: Create parent type P, child type C (allowed_parent_types=[P]), create group of type P, create child group of type C under P group. Then update type C removing P from allowed_parent_types.
+- **Assert**: `DomainError::AllowedParentTypesViolation` with violating group names
 
 #### TC-TYP-07: Update type - set can_be_root=false with existing root groups [P1]
 - **Covers**: G3, 0002-AC-6
 - **Setup**: Create type with can_be_root=true, create root group of that type. Then update type setting can_be_root=false.
-- **Assert**: `DomainError::AllowedParentsViolation` with root group names
+- **Assert**: `DomainError::AllowedParentTypesViolation` with root group names
 
 #### TC-TYP-08: Update type - not found [P2]
 - **Covers**: G1
@@ -398,15 +399,15 @@ Test setup: SQLite in-memory + TypeService + GroupService (for hierarchy safety 
 
 #### TC-TYP-10: Update type - placement invariant on new values [P2]
 - **Covers**: G1
-- **Setup**: Update type with can_be_root=false and allowed_parents=[]
+- **Setup**: Update type with can_be_root=false and allowed_parent_types=[]
 - **Assert**: `DomainError::Validation`
 
-#### TC-TYP-11: Create type with self-reference in allowed_parents [P2]
+#### TC-TYP-11: Create type with self-reference in allowed_parent_types [P2]
 - Type A lists itself as allowed_parent, but A doesn't exist yet during resolve_ids
 - **Assert**: Error (type not found for self-reference)
 
-#### TC-TYP-12: Create type with invalid format in allowed_parents[i] [P2]
-- allowed_parents: `["wrong.prefix"]` — each parent validated via validate_type_code
+#### TC-TYP-12: Create type with invalid format in allowed_parent_types[i] [P2]
+- allowed_parent_types: `["wrong.prefix"]` — each parent validated via validate_type_code
 - **Assert**: `DomainError::Validation` (prefix error)
 
 #### TC-TYP-13: Delete nonexistent type [P2]
@@ -416,12 +417,12 @@ Test setup: SQLite in-memory + TypeService + GroupService (for hierarchy safety 
 - Create type with `metadata_schema: Some(json_schema)`, get type, verify schema stored
 - **Assert**: Returned type has matching metadata_schema
 
-#### TC-TYP-15: Update type replaces allowed_memberships [P2]
+#### TC-TYP-15: Update type replaces allowed_membership_types [P2]
 - Create type with memberships [A, B], update to [B, C]
 - **Assert**: Updated type has only [B, C], A removed
 
 #### TC-TYP-16: Update type - hierarchy check skips deleted parent type [P3]
-- Remove parent type from allowed_parents, but the parent type itself was already deleted from system
+- Remove parent type from allowed_parent_types, but the parent type itself was already deleted from system
 - **Assert**: No error (resolve_id returns None → skip)
 
 ### Error Conversions
@@ -452,7 +453,7 @@ Existing tests cover `DomainError -> ResourceGroupError` and `DomainError -> Pro
 
 **File**: `type_service_test.rs` (service-level with DB)
 
-`type_repo.rs` transforms metadata_schema on write (inject `__can_be_root`) and on read (strip `__` keys, derive `can_be_root`). This logic has **0 tests**.
+`type_service.rs` transforms metadata_schema on write (inject `__can_be_root` via `build_stored_schema`) and `type_repo.rs` transforms on read (strip `__` keys, derive `can_be_root`). This logic has **0 tests**.
 
 #### TC-META-01: Type with metadata_schema Object — round-trip [P1]
 - **Setup**: Create type with `metadata_schema: Some(json!({"type": "object", "properties": {"x": {"type": "string"}}}))`
@@ -501,8 +502,8 @@ Existing tests cover `DomainError -> ResourceGroupError` and `DomainError -> Pro
 
 #### TC-META-10: can_be_root fallback when __can_be_root missing from stored JSON [P1]
 - Manually insert gts_type row with `metadata_schema = '{}'` (no __can_be_root key)
-- Type has allowed_parents → `can_be_root = false` (fallback: `allowed_parents.is_empty()`)
-- Type has no allowed_parents → `can_be_root = true`
+- Type has allowed_parent_types → `can_be_root = false` (fallback: `allowed_parent_types.is_empty()`)
+- Type has no allowed_parent_types → `can_be_root = true`
 
 #### TC-META-11: metadata_schema not validated as JSON Schema [P2]
 - Feature 0002 says "validate it is valid JSON Schema" (inst-val-input-7)
@@ -515,7 +516,7 @@ Existing tests cover `DomainError -> ResourceGroupError` and `DomainError -> Pro
 These tests verify the system is resilient to adversarial metadata_schema payloads. The key attack surface is `build_stored_schema()` which clones user input into the storage JSONB.
 
 #### TC-META-ATK-01: Overwrite `__can_be_root` via metadata_schema to escalate privileges [P1]
-- Create type with `can_be_root: false, allowed_parents: [P], metadata_schema: {"__can_be_root": true}`
+- Create type with `can_be_root: false, allowed_parent_types: [P], metadata_schema: {"__can_be_root": true}`
 - **Attack**: user tries to force `can_be_root=true` via injected internal key
 - **Assert**: `get_type().can_be_root == false` (system wins, user's `__can_be_root` overwritten by `build_stored_schema`)
 
@@ -523,7 +524,7 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 - `metadata_schema: {"__can_be_root": "maybe", "x": 1}`
 - `build_stored_schema` overwrites with `Bool(can_be_root)` → no issue
 - But what if stored JSONB was manually corrupted to `{"__can_be_root": "not-a-bool"}`?
-- `load_full_type` calls `.as_bool()` → `None` → fallback to `allowed_parents.is_empty()`
+- `load_full_type` calls `.as_bool()` → `None` → fallback to `allowed_parent_types.is_empty()`
 - **Assert**: Verify fallback works, no panic
 
 #### TC-META-ATK-03: Inject multiple `__` prefixed keys to pollute internal storage [P1]
@@ -570,18 +571,18 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 - Create type, verify `resolve_id(code)` returns `Some(id)` where id is `i16`
 
 #### TC-GTS-02: resolve_id returns None for nonexistent path [P1]
-- `resolve_id("gts.cf.core.rg.type.v1~nonexistent.v1~")` → `None`
+- `resolve_id("gts.cf.core.rg.type.v1~x.core.rg.missing.v1~")` → `None`
 
 #### TC-GTS-03: resolve_ids batch — all found [P1]
 - Create 3 types, `resolve_ids([code1, code2, code3])` → `Ok(vec![id1, id2, id3])`
 - **Assert**: returned IDs match, order may differ
 
 #### TC-GTS-04: resolve_ids batch — some missing [P1]
-- Create type A, resolve_ids([A, "nonexistent"]) → `Err(Validation("Referenced types not found: nonexistent"))`
+- Create type A, `resolve_ids([A, "gts.cf.core.rg.type.v1~x.core.rg.missing.v1~"])` → `Err(Validation("Referenced types not found: gts.cf.core.rg.type.v1~x.core.rg.missing.v1~"))`
 - **Assert**: error message lists ALL missing codes
 
 #### TC-GTS-05: resolve_ids batch — multiple missing [P2]
-- resolve_ids(["missing1", "missing2"]) → error message contains both
+- `resolve_ids(["gts.cf.core.rg.type.v1~x.core.rg.missing1.v1~", "gts.cf.core.rg.type.v1~x.core.rg.missing2.v1~"])` → error message contains both
 
 #### TC-GTS-06: resolve_ids empty list [P2]
 - `resolve_ids([])` → `Ok(vec![])` (early return)
@@ -590,14 +591,14 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 - Create type with code X, resolve to ID, resolve back to path
 - **Assert**: returned path == X (exact string equality)
 
-#### TC-GTS-08: load_allowed_parents resolves junction → IDs → paths [P1]
-- Create parent type P, child type C(allowed_parents=[P])
-- load_allowed_parents(C.id) → `vec!["gts.cf...P..."]`
+#### TC-GTS-08: load_allowed_parent_types resolves junction → IDs → paths [P1]
+- Create parent type P, child type C(allowed_parent_types=[P])
+- load_allowed_parent_types(C.id) → `vec!["gts.cf...P..."]`
 - **Assert**: returned path == P's code
 
-#### TC-GTS-09: load_allowed_memberships resolves junction → IDs → paths [P1]
-- Create member type M, group type G(allowed_memberships=[M])
-- load_allowed_memberships(G.id) → `vec!["gts.cf...M..."]`
+#### TC-GTS-09: load_allowed_membership_types resolves junction → IDs → paths [P1]
+- Create member type M, group type G(allowed_membership_types=[M])
+- load_allowed_membership_types(G.id) → `vec!["gts.cf...M..."]`
 
 #### can_be_root Derivation & Internal Key Handling
 
@@ -610,7 +611,7 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 
 #### TC-GTS-11: can_be_root fallback when __can_be_root key missing [P1]
 - Manually insert row in gts_type with metadata_schema without `__can_be_root` key
-- load_full_type → `can_be_root` should default to `allowed_parents.is_empty()`
+- load_full_type → `can_be_root` should default to `allowed_parent_types.is_empty()`
 - **Scenario**: type with parents → false; type without parents → true
 
 #### TC-GTS-12: Internal keys stripped from metadata_schema response [P1]
@@ -630,8 +631,8 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 - Create type with no metadata_schema
 - DB has `{"__can_be_root": true}` → after stripping __ keys → empty object → `None`
 
-#### TC-GTS-19: allowed_parents.contains() exact string match after roundtrip [P1]
-- Create parent type P, child type C(allowed_parents=[P])
+#### TC-GTS-19: allowed_parent_types.contains() exact string match after roundtrip [P1]
+- Create parent type P, child type C(allowed_parent_types=[P])
 - Create group of type P (root), create child group of type C under it
 - **Assert**: success — proves the path stored for P matches P's code exactly during comparison
 
@@ -660,7 +661,7 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 
 #### TC-SEED-03: seed_types updates changed type [P1]
 - **Covers**: G46, 0002-AC-10
-- **Setup**: Seed type with can_be_root=true, then seed again with can_be_root=false + allowed_parents.
+- **Setup**: Seed type with can_be_root=true, then seed again with can_be_root=false + allowed_parent_types.
 - **Assert**: `result.updated == 1`, type in DB reflects new values
 
 #### TC-SEED-04: seed_types idempotent (3 runs) [P2]
@@ -689,7 +690,7 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 
 | Operation | Required DB Assertions |
 |-----------|----------------------|
-| **Create type with parents** | Junction rows COUNT = `len(allowed_parents)`. Each `parent_type_id` correctly resolved from GTS path to SMALLINT. |
-| **Update type (replace parents)** | Old junction rows **deleted**. New rows match new list. COUNT = `len(new_allowed_parents)`. |
+| **Create type with parents** | Junction rows COUNT = `len(allowed_parent_types)`. Each `parent_type_id` correctly resolved from GTS path to SMALLINT. |
+| **Update type (replace parents)** | Old junction rows **deleted**. New rows match new list. COUNT = `len(new_allowed_parent_types)`. |
 | **Update type (replace memberships)** | `gts_type_allowed_membership` contains only new entries. |
 | **Delete type (CASCADE)** | `gts_type_allowed_parent WHERE type_id` → 0. `gts_type_allowed_membership WHERE type_id` → 0. |

--- a/modules/system/resource-group/docs/features/0003-entity-hierarchy.md
+++ b/modules/system/resource-group/docs/features/0003-entity-hierarchy.md
@@ -472,7 +472,7 @@ The plan was originally based on a gap analysis against acceptance criteria defi
 | `authz_integration_test.rs` | 9 | PolicyEnforcer tenant scoping, deny-all, allow-all, resource_id passing, all CRUD actions, full chain list_groups/deny |
 | `domain_unit_test.rs` | 79 | `validate_type_code` (5 cases), `DomainError` construction (13 variants), `DomainError` → `ResourceGroupError` mapping, `DomainError` → `Problem` mapping, serialization failure detection, `EnforcerError` → `DomainError` conversions, `DbErr` → `DomainError`, ADR-001 hierarchy reproduction, GTS-specific logic, invalid/non-GTS input validation |
 | `group_service_test.rs` | 55 | TC-GRP-01..38: child creation + closure rows, 3-level hierarchy, incompatible parent type, can_be_root enforcement, move with closure rebuild, cycle detection, self-parent, type change validation, leaf/force delete, hierarchy depth traversal, max_depth/max_width enforcement, name validation, cross-tenant parent, simultaneous type+parent change, detach to root, metadata barrier tests |
-| `type_service_test.rs` | 45 | TC-TYP-01..16 + TC-META-01..11 + TC-META-ATK-01..11 + TC-GTS-01..15: create/update/delete types, placement invariant, hierarchy safety checks, metadata_schema round-trip (Object/Array/String/Number), `__can_be_root` derivation/fallback, internal key stripping, security attack vectors (privilege escalation, DoS, SQL injection), resolve_id/resolve_ids, allowed_parents/memberships resolution |
+| `type_service_test.rs` | 45 | TC-TYP-01..16 + TC-META-01..11 + TC-META-ATK-01..11 + TC-GTS-01..15: create/update/delete types, placement invariant, hierarchy safety checks, metadata_schema round-trip (Object/Array/String/Number), `can_be_root` resolution via TypesRegistry, internal key stripping, security attack vectors (privilege escalation, DoS, SQL injection), resolve_id/resolve_ids, allowed_parents/memberships resolution |
 | `membership_service_test.rs` | 15 | TC-MBR-01..15: add/remove membership, nonexistent group, duplicate, unregistered type, not in allowed_memberships, tenant incompatibility, multiple resource types, first-always-allowed tenant, empty resource_id |
 | `seeding_test.rs` | 12 | TC-SEED-01..12: seed_types (create/skip/update/idempotent), seed_groups (create with closure/skip/wrong order), seed_memberships (create/duplicate skip/tenant-incompatible skip/nonexistent group), empty list |
 | `tenant_filtering_db_test.rs` | 7 | Tenant isolation (list/get/hierarchy/update/delete cross-tenant), InGroup predicate, membership data storage |
@@ -754,7 +754,7 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 #### Type code / type_path — wrong GTS format:
 
 #### TC-NOGTS-01: Create type with valid GTS path but NOT RG prefix [P1]
-- `code: "gts.x.core.user.v1~"` — valid GTS format, but missing `system.rg.type.v1~` prefix
+- `code: "gts.cf.core.user.v1~"` — valid GTS format, but missing `system.rg.type.v1~` prefix
 - **Assert**: 400 Validation ("must start with prefix")
 
 #### TC-NOGTS-02: Create type with empty code [P1]
@@ -766,7 +766,7 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 - **Assert**: 400 Validation (wrong prefix) — no SQL injection
 
 #### TC-NOGTS-04: Create group with non-RG type_path [P1]
-- `type: "gts.x.core.user.v1~"` — valid GTS but not RG type
+- `type: "gts.cf.core.user.v1~"` — valid GTS but not RG type
 - **Assert**: 400 Validation ("must start with prefix")
 
 #### TC-NOGTS-05: Create group with empty type_path [P1]
@@ -790,7 +790,7 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 - **Assert**: 400/422
 
 #### TC-DESER-03: Create type with `can_be_root` missing [P1]
-- Body: `{"code": "gts.x.system.rg.type.v1~test.v1~"}`
+- Body: `{"code": "gts.cf.core.rg.type.v1~test.v1~"}`
 - **Assert**: 400/422 (required field missing — no `#[serde(default)]` on `can_be_root`)
 
 #### TC-DESER-04: Create group with `type` field missing [P1]
@@ -882,9 +882,7 @@ Per ADR-001, each chained RG type defines a `metadata_schema` with `additionalPr
 
 GTS-level validation (33 tests in `rg_gts_type_system_tests.rs`) validates at schema registration time. These unit tests verify the **runtime** validation path: when a caller creates/updates a group, RG checks the `metadata` payload against the stored `metadata_schema` for the group's type.
 
-> **Note**: As of current implementation, this validation is **missing** in code — `group_service.rs` stores metadata as-is without validation. These tests will initially fail and serve as acceptance criteria for implementing the validation.
->
-> **Implementation**: Use `TypesRegistryClient` (types-registry-sdk, already used by `credstore` module) + `gts` crate (v0.8.4, already in workspace). The GTS type system validates instance data (including `metadata` sub-object) against the chained RG type schema registered in types-registry. RG module should resolve the group's GTS type via `TypesRegistryClient`, then validate the incoming metadata against the type's inline `metadata` schema (which includes `additionalProperties: false`, field types, `maxLength`). This follows the same pattern as `credstore` module which uses `TypesRegistryClient` from ClientHub for GTS-level validation. Do NOT use raw `jsonschema` crate directly — validation must go through the GTS layer to respect `x-gts-traits`, `allOf` composition, and the metadata sub-object schema.
+> **Implementation**: `validate_metadata_via_gts()` in `validation.rs` resolves the type's schema through `TypesRegistryClient` (types-registry-sdk, same pattern as `credstore` module) and validates metadata via `jsonschema` against the resolved schema. The GTS layer handles `$ref` resolution, `allOf` composition, and `x-gts-traits` — the resolved schema from `TypesRegistryClient::get()` already includes these. No fallback — `TypesRegistryClient` is always available at runtime (application does not start without types-registry).
 
 ##### Tenant metadata (`barrier: boolean`, `custom_domain: hostname`)
 
@@ -995,12 +993,12 @@ GTS-level validation (33 tests in `rg_gts_type_system_tests.rs`) validates at sc
 
 #### TC-ADR-15: metadata_schema round-trip with ADR tenant schema [P1]
 - Create tenant RG type with metadata_schema from ADR (barrier: boolean, custom_domain: hostname)
-- Get type → metadata_schema returned correctly (no `__can_be_root`, no `__user_schema`)
+- Get type → metadata_schema returned correctly (no internal `__` keys in response)
 - **Assert**: metadata_schema matches input
 
 #### TC-ADR-16: Chained type path format in RG [P1]
-- ADR uses: `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~` (multi-segment)
-- Code validates prefix: `gts.x.system.rg.type.v1~` (different namespace!)
+- ADR uses: `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~` (multi-segment)
+- Code validates prefix: `gts.cf.core.rg.type.v1~` (different namespace!)
 - **Assert**: Verify which prefix the code actually requires. If `system` not `core` → document discrepancy with ADR.
 
 #### TC-ADR-17: Type response contains no SMALLINT IDs [P1]
@@ -1061,7 +1059,7 @@ GTS-level validation (33 tests in `rg_gts_type_system_tests.rs`) validates at sc
   - GET /groups/{random-uuid} → 404 Not Found
   - POST /types {duplicate code} → 409 Conflict
   - POST /types {invalid body} → 400 Bad Request
-  - POST /groups {type "gts.x.system.rg.type.v1~nonexistent.v1~"} → 404 (TypeNotFound)
+  - POST /groups {type "gts.cf.core.rg.type.v1~nonexistent.v1~"} → 404 (TypeNotFound)
 - **Assert per response**:
   - HTTP status code matches expected
   - `Content-Type` header contains `application/problem+json`
@@ -1352,3 +1350,30 @@ GET /groups/{root.id}                            → 404
 - [x] S5 verifies `depth` values on real PostgreSQL — not just "hierarchy returns items"
 - [x] S6 verifies child appears under new parent with correct depth after PG SERIALIZABLE move
 - [x] S7 verifies 204 + target returns 404 — PG FK cascade succeeds in correct deletion order
+
+### GTS Metadata Validation Test Requirements
+
+#### Unit tests (MUST)
+
+Unit tests MUST fully validate GTS metadata schema integration:
+
+- **Schema resolution**: `validate_metadata_via_gts()` resolves the type's schema through `TypesRegistryClient` and validates metadata against the resolved schema (including `allOf` composition, `$ref` resolution, `x-gts-traits`).
+- **Positive cases**: Valid metadata accepted for each type that defines a `metadata_schema` (tenant with `barrier: true`, department with `display_name`, etc.).
+- **Negative cases**: Invalid metadata rejected with field-level errors — wrong type (`barrier: "yes"` → 400), unknown fields (`additionalProperties: false`), missing required fields, length violations (`maxLength`).
+- **Round-trip**: `metadata_schema` stored in DB → loaded → used for validation produces the same result as the original schema. Non-object schemas (stored under `__user_schema`) round-trip correctly.
+
+Test files: `group_service_test.rs` (TC-ADR-09..TC-ADR-22), `type_service_test.rs` (TC-META-01..TC-META-11).
+
+Unit tests use a real `TypesRegistryClient` backed by `InMemoryGtsRepository` (same as `rg_gts_type_system_tests.rs`). RG type schemas are registered in the in-memory store before running group creation tests. No mocks needed — the types registry runs in-process with SQLite.
+
+#### E2E tests (MUST)
+
+E2E tests MUST verify the positive path of GTS metadata validation against a running server with real `TypesRegistryClient`:
+
+- Create a type with a `metadata_schema` that defines at least one typed field (e.g. `{"type": "object", "properties": {"label": {"type": "string"}}, "additionalProperties": false}`).
+- Create a group of that type with valid metadata matching the schema (e.g. `{"label": "test"}`).
+- **Assert**: 201 success, response contains the metadata as provided.
+
+E2E tests do NOT need to exhaustively test negative validation cases (wrong types, unknown fields, etc.) — those are covered by unit tests. The E2E test verifies the end-to-end wiring: type creation → schema storage → group creation → metadata validation → success.
+
+Modify existing E2E group creation tests (`test_integration_seams.py`) to use a type with `metadata_schema` instead of `metadata_schema: null`, and pass valid metadata in the group creation request.

--- a/modules/system/resource-group/docs/features/0003-entity-hierarchy.md
+++ b/modules/system/resource-group/docs/features/0003-entity-hierarchy.md
@@ -1,4 +1,5 @@
 <!-- Created: 2026-04-07 by Constructor Tech -->
+<!-- Updated: 2026-04-20 by Constructor Tech -->
 
 # Feature: Group Entity & Hierarchy Engine
 
@@ -472,7 +473,7 @@ The plan was originally based on a gap analysis against acceptance criteria defi
 | `authz_integration_test.rs` | 9 | PolicyEnforcer tenant scoping, deny-all, allow-all, resource_id passing, all CRUD actions, full chain list_groups/deny |
 | `domain_unit_test.rs` | 79 | `validate_type_code` (5 cases), `DomainError` construction (13 variants), `DomainError` → `ResourceGroupError` mapping, `DomainError` → `Problem` mapping, serialization failure detection, `EnforcerError` → `DomainError` conversions, `DbErr` → `DomainError`, ADR-001 hierarchy reproduction, GTS-specific logic, invalid/non-GTS input validation |
 | `group_service_test.rs` | 55 | TC-GRP-01..38: child creation + closure rows, 3-level hierarchy, incompatible parent type, can_be_root enforcement, move with closure rebuild, cycle detection, self-parent, type change validation, leaf/force delete, hierarchy depth traversal, max_depth/max_width enforcement, name validation, cross-tenant parent, simultaneous type+parent change, detach to root, metadata barrier tests |
-| `type_service_test.rs` | 45 | TC-TYP-01..16 + TC-META-01..11 + TC-META-ATK-01..11 + TC-GTS-01..15: create/update/delete types, placement invariant, hierarchy safety checks, metadata_schema round-trip (Object/Array/String/Number), `can_be_root` resolution via TypesRegistry, internal key stripping, security attack vectors (privilege escalation, DoS, SQL injection), resolve_id/resolve_ids, allowed_parents/memberships resolution |
+| `type_service_test.rs` | 45 | TC-TYP-01..16 + TC-META-01..11 + TC-META-ATK-01..11 + TC-GTS-01..15: create/update/delete types, placement invariant, hierarchy safety checks, metadata_schema round-trip (Object/Array/String/Number), `__can_be_root` derivation/fallback, internal key stripping, security attack vectors (privilege escalation, DoS, SQL injection), resolve_id/resolve_ids, allowed_parents/memberships resolution |
 | `membership_service_test.rs` | 15 | TC-MBR-01..15: add/remove membership, nonexistent group, duplicate, unregistered type, not in allowed_memberships, tenant incompatibility, multiple resource types, first-always-allowed tenant, empty resource_id |
 | `seeding_test.rs` | 12 | TC-SEED-01..12: seed_types (create/skip/update/idempotent), seed_groups (create with closure/skip/wrong order), seed_memberships (create/duplicate skip/tenant-incompatible skip/nonexistent group), empty list |
 | `tenant_filtering_db_test.rs` | 7 | Tenant isolation (list/get/hierarchy/update/delete cross-tenant), InGroup predicate, membership data storage |
@@ -637,7 +638,7 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 - This is NOT InvalidParentType — it's a separate Validation branch (line 379-384)
 
 #### TC-GRP-24: Create group with metadata (JSONB) [P2]
-- Create with `metadata: Some(json!({"barrier": true}))`, verify stored and returned
+- Create with `metadata: Some(json!({"self_managed": true}))`, verify stored and returned
 
 #### TC-GRP-25: Multiple root groups of same type [P2]
 - Create 2 root groups of same can_be_root=true type, both succeed
@@ -693,13 +694,13 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 **File**: `group_service_test.rs` (service-level), `api_rest_test.rs` (REST-level)
 
 #### TC-META-12: Group with metadata barrier stored and returned [P1]
-- Create group with `metadata: Some(json!({"barrier": true}))`
-- Get group → `metadata.barrier == true`
+- Create group with `metadata: Some(json!({"self_managed": true}))`
+- Get group → `metadata.self_managed == true`
 - **Covers**: PRD 3.4, Feature 0005-AC "barrier as data"
-- **DB assert**: `resource_group.metadata` JSONB column contains `{"barrier": true}`
+- **DB assert**: `resource_group.metadata` JSONB column contains `{"self_managed": true}`
 
 #### TC-META-13: Group with rich metadata — multiple fields [P1]
-- `metadata: Some(json!({"barrier": true, "label": "Partner", "category": "premium"}))`
+- `metadata: Some(json!({"self_managed": true, "label": "Partner", "category": "premium"}))`
 - **Assert**: all fields preserved in round-trip
 
 #### TC-META-14: Group metadata update replaces entirely (not merge) [P1]
@@ -708,14 +709,14 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 - **DB assert**: confirm in `resource_group` table
 
 #### TC-META-15: Group metadata None → update with metadata → get returns metadata [P2]
-- Create with None, update with `{"barrier": false}`, get → `{"barrier": false}`
+- Create with None, update with `{"self_managed": false}`, get → `{"self_managed": false}`
 
 #### TC-META-16: Group metadata set → update with None → metadata gone [P2]
 - Create with `{"x": 1}`, update with `metadata: None`
 - **Assert**: get returns metadata = None, JSON response has no `metadata` key
 
 #### TC-META-17: Barrier group visible in hierarchy (RG does NOT filter) [P1]
-- Create parent → child with `metadata: {"barrier": true}` → grandchild
+- Create parent → child with `metadata: {"self_managed": true}` → grandchild
 - `list_group_hierarchy(parent)` → returns ALL 3 including barrier child
 - **Covers**: PRD "RG does not filter based on barrier", Feature 0005-AC
 - **Assert**: barrier group present in results, depth correct
@@ -734,8 +735,8 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 - **Assert**: 201, response body has `"metadataSchema"` key (camelCase)
 
 #### TC-META-20: REST create group with metadata in body [P1]
-- POST body: `{"type": "...", "name": "X", "metadata": {"barrier": true}}`
-- **Assert**: 201, response body has `"metadata": {"barrier": true}`
+- POST body: `{"type": "...", "name": "X", "metadata": {"self_managed": true}}`
+- **Assert**: 201, response body has `"metadata": {"self_managed": true}`
 
 #### TC-META-21: REST response omits metadata when null [P2]
 - Create group without metadata
@@ -754,7 +755,7 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 #### Type code / type_path — wrong GTS format:
 
 #### TC-NOGTS-01: Create type with valid GTS path but NOT RG prefix [P1]
-- `code: "gts.cf.core.user.v1~"` — valid GTS format, but missing `system.rg.type.v1~` prefix
+- `code: "gts.x.core.user.v1~"` — valid GTS format, but missing `system.rg.type.v1~` prefix
 - **Assert**: 400 Validation ("must start with prefix")
 
 #### TC-NOGTS-02: Create type with empty code [P1]
@@ -766,7 +767,7 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 - **Assert**: 400 Validation (wrong prefix) — no SQL injection
 
 #### TC-NOGTS-04: Create group with non-RG type_path [P1]
-- `type: "gts.cf.core.user.v1~"` — valid GTS but not RG type
+- `type: "gts.x.core.user.v1~"` — valid GTS but not RG type
 - **Assert**: 400 Validation ("must start with prefix")
 
 #### TC-NOGTS-05: Create group with empty type_path [P1]
@@ -790,7 +791,7 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 - **Assert**: 400/422
 
 #### TC-DESER-03: Create type with `can_be_root` missing [P1]
-- Body: `{"code": "gts.cf.core.rg.type.v1~test.v1~"}`
+- Body: `{"code": "gts.x.system.rg.type.v1~test.v1~"}`
 - **Assert**: 400/422 (required field missing — no `#[serde(default)]` on `can_be_root`)
 
 #### TC-DESER-04: Create group with `type` field missing [P1]
@@ -834,7 +835,7 @@ Reproduce the full ADR example hierarchy (T1→D2→B3, T7→D8, T9) with correc
   - T1: root tenant, `parent_id=None`, `metadata: None`
   - D2: dept under T1, `metadata: {category: "finance", short_description: "Mega Department"}`
   - B3: branch under D2, `metadata: {location: "Building A, Floor 3"}`
-  - T7: barrier tenant under T1, `metadata: {barrier: true}`
+  - T7: self-managed tenant under T1, `metadata: {self_managed: true}`
   - D8: dept under T7, `metadata: {category: "hr"}`
   - T9: root tenant, `metadata: {custom_domain: "t9.example.com"}`
 - **Closure assert**: full hierarchy depths correct
@@ -882,24 +883,26 @@ Per ADR-001, each chained RG type defines a `metadata_schema` with `additionalPr
 
 GTS-level validation (33 tests in `rg_gts_type_system_tests.rs`) validates at schema registration time. These unit tests verify the **runtime** validation path: when a caller creates/updates a group, RG checks the `metadata` payload against the stored `metadata_schema` for the group's type.
 
-> **Implementation**: `validate_metadata_via_gts()` in `validation.rs` resolves the type's schema through `TypesRegistryClient` (types-registry-sdk, same pattern as `credstore` module) and validates metadata via `jsonschema` against the resolved schema. The GTS layer handles `$ref` resolution, `allOf` composition, and `x-gts-traits` — the resolved schema from `TypesRegistryClient::get()` already includes these. No fallback — `TypesRegistryClient` is always available at runtime (application does not start without types-registry).
+> **Note**: As of current implementation, this validation is **missing** in code — `group_service.rs` stores metadata as-is without validation. These tests will initially fail and serve as acceptance criteria for implementing the validation.
+>
+> **Implementation**: Use `TypesRegistryClient` (types-registry-sdk, already used by `credstore` module) + `gts` crate (v0.8.4, already in workspace). The GTS type system validates instance data (including `metadata` sub-object) against the chained RG type schema registered in types-registry. RG module should resolve the group's GTS type via `TypesRegistryClient`, then validate the incoming metadata against the type's inline `metadata` schema (which includes `additionalProperties: false`, field types, `maxLength`). This follows the same pattern as `credstore` module which uses `TypesRegistryClient` from ClientHub for GTS-level validation. Do NOT use raw `jsonschema` crate directly — validation must go through the GTS layer to respect `x-gts-traits`, `allOf` composition, and the metadata sub-object schema.
 
-##### Tenant metadata (`barrier: boolean`, `custom_domain: hostname`)
+##### Tenant metadata (`self_managed: boolean`, `custom_domain: hostname`)
 
-#### TC-ADR-09: Tenant — valid metadata.barrier=true accepted [P1]
-- Create tenant group with `metadata: {"barrier": true}`
+#### TC-ADR-09: Tenant — valid metadata.self_managed=true accepted [P1]
+- Create tenant group with `metadata: {"self_managed": true}`
 - **Assert**: 201 success
 
-#### TC-ADR-10: Tenant — barrier wrong type (string) rejected [P1]
-- Create tenant group with `metadata: {"barrier": "yes"}`
-- **Assert**: 400 Validation error — `barrier` must be boolean
+#### TC-ADR-10: Tenant — self_managed wrong type (string) rejected [P1]
+- Create tenant group with `metadata: {"self_managed": "yes"}`
+- **Assert**: 400 Validation error — `self_managed` must be boolean
 
-#### TC-ADR-11: Tenant — barrier wrong type (number) rejected [P1]
-- `metadata: {"barrier": 42}`
+#### TC-ADR-11: Tenant — self_managed wrong type (number) rejected [P1]
+- `metadata: {"self_managed": 42}`
 - **Assert**: 400
 
 #### TC-ADR-12: Tenant — unknown metadata field rejected [P1]
-- `metadata: {"barrier": true, "foo": "bar"}`
+- `metadata: {"self_managed": true, "foo": "bar"}`
 - **Assert**: 400 — `additionalProperties: false` rejects unknown fields
 
 #### TC-ADR-13: Tenant — valid custom_domain accepted [P1]
@@ -965,8 +968,8 @@ GTS-level validation (33 tests in `rg_gts_type_system_tests.rs`) validates at sc
 ##### Cross-type metadata isolation
 
 #### TC-ADR-27: Tenant metadata fields on department → rejected [P1]
-- Create department group with `metadata: {"barrier": true}`
-- Department schema does NOT have `barrier` → `additionalProperties: false` rejects
+- Create department group with `metadata: {"self_managed": true}`
+- Department schema does NOT have `self_managed` → `additionalProperties: false` rejects
 - **Assert**: 400
 
 #### TC-ADR-28: Department metadata fields on tenant → rejected [P1]
@@ -992,13 +995,13 @@ GTS-level validation (33 tests in `rg_gts_type_system_tests.rs`) validates at sc
 - **Assert**: existing group still readable. New groups validated against new schema.
 
 #### TC-ADR-15: metadata_schema round-trip with ADR tenant schema [P1]
-- Create tenant RG type with metadata_schema from ADR (barrier: boolean, custom_domain: hostname)
-- Get type → metadata_schema returned correctly (no internal `__` keys in response)
+- Create tenant RG type with metadata_schema from ADR (self_managed: boolean, custom_domain: hostname)
+- Get type → metadata_schema returned correctly (no `__can_be_root`, no `__user_schema`)
 - **Assert**: metadata_schema matches input
 
 #### TC-ADR-16: Chained type path format in RG [P1]
-- ADR uses: `gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~` (multi-segment)
-- Code validates prefix: `gts.cf.core.rg.type.v1~` (different namespace!)
+- ADR uses: `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~` (multi-segment)
+- Code validates prefix: `gts.x.system.rg.type.v1~` (different namespace!)
 - **Assert**: Verify which prefix the code actually requires. If `system` not `core` → document discrepancy with ADR.
 
 #### TC-ADR-17: Type response contains no SMALLINT IDs [P1]
@@ -1059,7 +1062,7 @@ GTS-level validation (33 tests in `rg_gts_type_system_tests.rs`) validates at sc
   - GET /groups/{random-uuid} → 404 Not Found
   - POST /types {duplicate code} → 409 Conflict
   - POST /types {invalid body} → 400 Bad Request
-  - POST /groups {type "gts.cf.core.rg.type.v1~nonexistent.v1~"} → 404 (TypeNotFound)
+  - POST /groups {type "gts.x.system.rg.type.v1~nonexistent.v1~"} → 404 (TypeNotFound)
 - **Assert per response**:
   - HTTP status code matches expected
   - `Content-Type` header contains `application/problem+json`
@@ -1350,30 +1353,3 @@ GET /groups/{root.id}                            → 404
 - [x] S5 verifies `depth` values on real PostgreSQL — not just "hierarchy returns items"
 - [x] S6 verifies child appears under new parent with correct depth after PG SERIALIZABLE move
 - [x] S7 verifies 204 + target returns 404 — PG FK cascade succeeds in correct deletion order
-
-### GTS Metadata Validation Test Requirements
-
-#### Unit tests (MUST)
-
-Unit tests MUST fully validate GTS metadata schema integration:
-
-- **Schema resolution**: `validate_metadata_via_gts()` resolves the type's schema through `TypesRegistryClient` and validates metadata against the resolved schema (including `allOf` composition, `$ref` resolution, `x-gts-traits`).
-- **Positive cases**: Valid metadata accepted for each type that defines a `metadata_schema` (tenant with `barrier: true`, department with `display_name`, etc.).
-- **Negative cases**: Invalid metadata rejected with field-level errors — wrong type (`barrier: "yes"` → 400), unknown fields (`additionalProperties: false`), missing required fields, length violations (`maxLength`).
-- **Round-trip**: `metadata_schema` stored in DB → loaded → used for validation produces the same result as the original schema. Non-object schemas (stored under `__user_schema`) round-trip correctly.
-
-Test files: `group_service_test.rs` (TC-ADR-09..TC-ADR-22), `type_service_test.rs` (TC-META-01..TC-META-11).
-
-Unit tests use a real `TypesRegistryClient` backed by `InMemoryGtsRepository` (same as `rg_gts_type_system_tests.rs`). RG type schemas are registered in the in-memory store before running group creation tests. No mocks needed — the types registry runs in-process with SQLite.
-
-#### E2E tests (MUST)
-
-E2E tests MUST verify the positive path of GTS metadata validation against a running server with real `TypesRegistryClient`:
-
-- Create a type with a `metadata_schema` that defines at least one typed field (e.g. `{"type": "object", "properties": {"label": {"type": "string"}}, "additionalProperties": false}`).
-- Create a group of that type with valid metadata matching the schema (e.g. `{"label": "test"}`).
-- **Assert**: 201 success, response contains the metadata as provided.
-
-E2E tests do NOT need to exhaustively test negative validation cases (wrong types, unknown fields, etc.) — those are covered by unit tests. The E2E test verifies the end-to-end wiring: type creation → schema storage → group creation → metadata validation → success.
-
-Modify existing E2E group creation tests (`test_integration_seams.py`) to use a type with `metadata_schema` instead of `metadata_schema: null`, and pass valid metadata in the group creation request.

--- a/modules/system/resource-group/docs/features/0005-integration-auth.md
+++ b/modules/system/resource-group/docs/features/0005-integration-auth.md
@@ -1,4 +1,5 @@
 <!-- Created: 2026-04-07 by Constructor Tech -->
+<!-- Updated: 2026-04-20 by Constructor Tech -->
 
 # Feature: Integration Read Port & Dual Authentication Modes
 
@@ -121,7 +122,7 @@ This feature bridges RG with the AuthZ ecosystem. The integration read port prov
 7. [x] - `p1` - **IF** endpoint not in allowlist → **RETURN** 403 Forbidden - `inst-mtls-7`
 8. [x] - `p1` - Create system SecurityContext (no AuthZ evaluation — trusted system principal) - `inst-mtls-8`
 9. [x] - `p1` - RG Hierarchy Service: execute list_group_depth(system_ctx, group_id, query) directly - `inst-mtls-9`
-10. [x] - `p1` - **RETURN** Page<ResourceGroupWithDepth> — hierarchy data with tenant_id per group, metadata including barrier - `inst-mtls-10`
+10. [x] - `p1` - **RETURN** Page<ResourceGroupWithDepth> — hierarchy data with tenant_id per group, metadata including `self_managed` - `inst-mtls-10`
 
 ### Plugin Gateway Routing
 
@@ -139,7 +140,7 @@ This feature bridges RG with the AuthZ ecosystem. The integration read port prov
    1. [x] - `p1` - Route to local persistence path: execute query against RG database - `inst-plugin-3a`
 4. [x] - `p1` - **IF** vendor-specific provider configured - `inst-plugin-4`
    1. [x] - `p1` - Resolve plugin instance by configured vendor via types-registry (scoped by GTS instance ID) - `inst-plugin-4a`
-   2. [x] - `p1` - Delegate to ResourceGroupReadHierarchy with SecurityContext passthrough - `inst-plugin-4b`
+   2. [x] - `p1` - Delegate to ResourceGroupReadPluginClient with SecurityContext passthrough - `inst-plugin-4b`
 5. [x] - `p1` - **RETURN** results from selected provider - `inst-plugin-5`
 
 ## 3. Processes / Business Logic (CDSL)
@@ -195,7 +196,7 @@ Not applicable. This feature configures authentication routing and integration r
 The system **MUST** implement an Integration Read Service that exposes `ResourceGroupReadHierarchy` via ClientHub for external consumers.
 
 **Required behavior**:
-- Expose `list_group_depth(ctx, group_id, query)` returning `Page<ResourceGroupWithDepth>` with hierarchy data including `tenant_id` per group and `metadata` (including `barrier` for applicable types)
+- Expose `list_group_depth(ctx, group_id, query)` returning `Page<ResourceGroupWithDepth>` with hierarchy data including `tenant_id` per group and `metadata` (including `self_managed` for applicable types)
 - Responses are policy-agnostic: no AuthZ decisions, no SQL fragments, no constraint objects
 - Plugin gateway routing: resolve configured provider (built-in vs vendor-specific), delegate with SecurityContext passthrough
 - In-process mode (monolith): direct ClientHub call, no network auth needed
@@ -252,13 +253,13 @@ The system **MUST** enforce tenant-hierarchy-compatible writes in ownership-grap
 - Membership writes validated against target group's tenant scope
 - Platform-admin provisioning exception: privileged calls may bypass caller tenant scoping for cross-tenant management, but data invariants (parent-child type compat, tenant hierarchy rules) remain strict
 - Tenant-scoped reads: in AuthZ query path, `SecurityContext.subject_tenant_id` determines effective tenant scope
-- Barrier as data: `metadata.barrier` stored in group metadata JSONB, returned in API responses within `metadata` object. RG does not filter, restrict, or alter query results based on barrier value.
+- Barrier as data: `metadata.self_managed` stored in group metadata JSONB, returned in API responses within `metadata` object. RG does not filter, restrict, or alter query results based on barrier value.
 
 **Implements**:
 - `cpt-cf-resource-group-algo-integration-auth-tenant-scope-enforcement`
 
 **Touches**:
-- DB: `resource_group` (tenant_id validation, metadata.barrier storage)
+- DB: `resource_group` (tenant_id validation, metadata.self_managed storage)
 
 ### Unit Test Coverage for Integration Auth
 
@@ -273,7 +274,7 @@ In-source `#[cfg(test)]` tests covering auth-mode decision and tenant-scope enfo
 ## 6. Acceptance Criteria
 
 - [x] AuthZ plugin resolves `dyn ResourceGroupReadHierarchy` from ClientHub and successfully calls `list_group_depth`
-- [x] Integration read responses include `tenant_id` per group and `metadata` (including `barrier`) but no AuthZ decision fields
+- [x] Integration read responses include `tenant_id` per group and `metadata` (including `self_managed`) but no AuthZ decision fields
 - [x] JWT request to any RG endpoint goes through AuthN → AuthZ (PolicyEnforcer) → AccessScope → SecureORM pipeline
 - [x] MTLS request to `/groups/{group_id}/hierarchy` bypasses AuthZ and returns hierarchy data
 - [x] MTLS request to any other endpoint (e.g., `POST /groups`) returns 403 Forbidden
@@ -283,7 +284,7 @@ In-source `#[cfg(test)]` tests covering auth-mode decision and tenant-scope enfo
 - [x] SecurityContext is passed through gateway to provider without policy interpretation
 - [x] Parent-child edge in ownership-graph profile with incompatible tenants is rejected with TenantIncompatibility
 - [x] Platform-admin provisioning call bypasses caller tenant scoping but still validates data invariants
-- [x] Group with `metadata.barrier = true` is stored and returned in API responses — RG does not filter based on barrier
+- [x] Group with `metadata.self_managed = true` is stored and returned in API responses — RG does not filter based on barrier
 - [x] In monolith deployment, AuthZ plugin uses ClientHub direct call (no MTLS needed)
 - [x] In microservice deployment, AuthZ plugin uses MTLS-authenticated remote call to hierarchy endpoint
 
@@ -318,7 +319,7 @@ In-source `#[cfg(test)]` tests covering auth-mode decision and tenant-scope enfo
 |----|----------|--------|
 | TC-READ-01 | `list_group_depth` response | Contains `tenant_id` and `metadata` per group; no AuthZ decision fields |
 | TC-READ-02 | Plugin gateway with built-in provider configured | Routes to local persistence path |
-| TC-READ-03 | Plugin gateway with vendor-specific provider configured | Delegates to `ResourceGroupReadHierarchy` |
+| TC-READ-03 | Plugin gateway with vendor-specific provider configured | Delegates to `ResourceGroupReadPluginClient` |
 
 ---
 

--- a/modules/system/resource-group/docs/features/0005-integration-auth.md
+++ b/modules/system/resource-group/docs/features/0005-integration-auth.md
@@ -139,7 +139,7 @@ This feature bridges RG with the AuthZ ecosystem. The integration read port prov
    1. [x] - `p1` - Route to local persistence path: execute query against RG database - `inst-plugin-3a`
 4. [x] - `p1` - **IF** vendor-specific provider configured - `inst-plugin-4`
    1. [x] - `p1` - Resolve plugin instance by configured vendor via types-registry (scoped by GTS instance ID) - `inst-plugin-4a`
-   2. [x] - `p1` - Delegate to ResourceGroupReadPluginClient with SecurityContext passthrough - `inst-plugin-4b`
+   2. [x] - `p1` - Delegate to ResourceGroupReadHierarchy with SecurityContext passthrough - `inst-plugin-4b`
 5. [x] - `p1` - **RETURN** results from selected provider - `inst-plugin-5`
 
 ## 3. Processes / Business Logic (CDSL)
@@ -318,7 +318,7 @@ In-source `#[cfg(test)]` tests covering auth-mode decision and tenant-scope enfo
 |----|----------|--------|
 | TC-READ-01 | `list_group_depth` response | Contains `tenant_id` and `metadata` per group; no AuthZ decision fields |
 | TC-READ-02 | Plugin gateway with built-in provider configured | Routes to local persistence path |
-| TC-READ-03 | Plugin gateway with vendor-specific provider configured | Delegates to `ResourceGroupReadPluginClient` |
+| TC-READ-03 | Plugin gateway with vendor-specific provider configured | Delegates to `ResourceGroupReadHierarchy` |
 
 ---
 

--- a/modules/system/resource-group/docs/openapi.yaml
+++ b/modules/system/resource-group/docs/openapi.yaml
@@ -86,10 +86,10 @@ paths:
                   summary: Chained RG types
                   value:
                     items:
-                      - $id: "gts://gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                      - $id: "gts://gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                         $schema: "http://json-schema.org/draft-07/schema#"
                         allOf:
-                          - { $ref: "gts://gts.x.core.rg.type.v1~" }
+                          - { $ref: "gts://gts.cf.core.rg.type.v1~" }
                           - properties:
                               metadata:
                                 type: object
@@ -99,12 +99,12 @@ paths:
                                   barrier: { type: boolean, default: false }
                             x-gts-traits:
                               can_be_root: true
-                              allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                              allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
                               allowed_memberships: ["gts.z.core.idp.user.v1~"]
-                      - $id: "gts://gts.x.core.rg.type.v1~w.core.org.department.v1~"
+                      - $id: "gts://gts.cf.core.rg.type.v1~w.core.org.department.v1~"
                         $schema: "http://json-schema.org/draft-07/schema#"
                         allOf:
-                          - { $ref: "gts://gts.x.core.rg.type.v1~" }
+                          - { $ref: "gts://gts.cf.core.rg.type.v1~" }
                           - properties:
                               metadata:
                                 type: object
@@ -114,12 +114,12 @@ paths:
                                   short_description: { type: string, maxLength: 500 }
                             x-gts-traits:
                               can_be_root: false
-                              allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                              allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
                               allowed_memberships: ["gts.z.core.idp.user.v1~"]
-                      - $id: "gts://gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
+                      - $id: "gts://gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
                         $schema: "http://json-schema.org/draft-07/schema#"
                         allOf:
-                          - { $ref: "gts://gts.x.core.rg.type.v1~" }
+                          - { $ref: "gts://gts.cf.core.rg.type.v1~" }
                           - properties:
                               metadata:
                                 type: object
@@ -128,7 +128,7 @@ paths:
                                   location: { type: string }
                             x-gts-traits:
                               can_be_root: false
-                              allowed_parents: ["gts.x.core.rg.type.v1~w.core.org.department.v1~"]
+                              allowed_parents: ["gts.cf.core.rg.type.v1~w.core.org.department.v1~"]
                               allowed_memberships: ["gts.z.core.idp.user.v1~", "gts.z.core.lms.course.v1~"]
                     page_info:
                       next_cursor: "eyJpZCI6Ijc3NzcuLi4ifQ"
@@ -155,7 +155,7 @@ paths:
               rg-base-contract:
                 summary: "Step 1a: RG base contract (x-gts-traits-schema)"
                 value:
-                  $id: "gts://gts.x.core.rg.type.v1~"
+                  $id: "gts://gts.cf.core.rg.type.v1~"
                   $schema: "http://json-schema.org/draft-07/schema#"
                   title: "Resource Group Type"
                   type: object
@@ -169,7 +169,7 @@ paths:
                         default: false
                       allowed_parents:
                         type: array
-                        items: { type: string, x-gts-ref: "gts.x.core.rg.type.v1~" }
+                        items: { type: string, x-gts-ref: "gts.cf.core.rg.type.v1~" }
                         description: "Well-known instances of allowed parent RG types."
                         default: []
                       allowed_memberships:
@@ -224,7 +224,7 @@ paths:
               branch-entity:
                 summary: "Step 2c: Branch entity type"
                 value:
-                  $id: "gts://gts.x.core.rg.branch.v1~"
+                  $id: "gts://gts.cf.core.rg.branch.v1~"
                   $schema: "http://json-schema.org/draft-07/schema#"
                   title: Branch
                   type: object
@@ -265,10 +265,10 @@ paths:
               tenant-rg-type:
                 summary: "Step 3a: Tenant as RG type (chained, x-gts-traits)"
                 value:
-                  $id: "gts://gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                  $id: "gts://gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                   $schema: "http://json-schema.org/draft-07/schema#"
                   allOf:
-                    - { $ref: "gts://gts.x.core.rg.type.v1~" }
+                    - { $ref: "gts://gts.cf.core.rg.type.v1~" }
                     - properties:
                         metadata:
                           type: object
@@ -278,16 +278,16 @@ paths:
                             barrier: { type: boolean, default: false }
                       x-gts-traits:
                         can_be_root: true
-                        allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                        allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
                         allowed_memberships: ["gts.z.core.idp.user.v1~"]
 
               department-rg-type:
                 summary: "Step 3b: Department as RG type (chained, x-gts-traits)"
                 value:
-                  $id: "gts://gts.x.core.rg.type.v1~w.core.org.department.v1~"
+                  $id: "gts://gts.cf.core.rg.type.v1~w.core.org.department.v1~"
                   $schema: "http://json-schema.org/draft-07/schema#"
                   allOf:
-                    - { $ref: "gts://gts.x.core.rg.type.v1~" }
+                    - { $ref: "gts://gts.cf.core.rg.type.v1~" }
                     - properties:
                         metadata:
                           type: object
@@ -297,16 +297,16 @@ paths:
                             short_description: { type: string, maxLength: 500 }
                       x-gts-traits:
                         can_be_root: false
-                        allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                        allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
                         allowed_memberships: ["gts.z.core.idp.user.v1~"]
 
               branch-rg-type:
                 summary: "Step 3c: Branch as RG type (chained, x-gts-traits)"
                 value:
-                  $id: "gts://gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
+                  $id: "gts://gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
                   $schema: "http://json-schema.org/draft-07/schema#"
                   allOf:
-                    - { $ref: "gts://gts.x.core.rg.type.v1~" }
+                    - { $ref: "gts://gts.cf.core.rg.type.v1~" }
                     - properties:
                         metadata:
                           type: object
@@ -315,7 +315,7 @@ paths:
                             location: { type: string }
                       x-gts-traits:
                         can_be_root: false
-                        allowed_parents: ["gts.x.core.rg.type.v1~w.core.org.department.v1~"]
+                        allowed_parents: ["gts.cf.core.rg.type.v1~w.core.org.department.v1~"]
                         allowed_memberships: ["gts.z.core.idp.user.v1~", "gts.z.core.lms.course.v1~"]
 
       responses:
@@ -329,7 +329,7 @@ paths:
                 rg-base-contract:
                   summary: "Base contract registered"
                   value:
-                    $id: "gts://gts.x.core.rg.type.v1~"
+                    $id: "gts://gts.cf.core.rg.type.v1~"
                     $schema: "http://json-schema.org/draft-07/schema#"
                     title: "Resource Group Type"
                     type: object
@@ -343,7 +343,7 @@ paths:
                           default: false
                         allowed_parents:
                           type: array
-                          items: { type: string, x-gts-ref: "gts.x.core.rg.type.v1~" }
+                          items: { type: string, x-gts-ref: "gts.cf.core.rg.type.v1~" }
                           description: "Well-known instances of allowed parent RG types."
                           default: []
                         allowed_memberships:
@@ -368,10 +368,10 @@ paths:
                 tenant-rg-type:
                   summary: "Chained tenant RG type registered"
                   value:
-                    $id: "gts://gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                    $id: "gts://gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                     $schema: "http://json-schema.org/draft-07/schema#"
                     allOf:
-                      - { $ref: "gts://gts.x.core.rg.type.v1~" }
+                      - { $ref: "gts://gts.cf.core.rg.type.v1~" }
                       - properties:
                           metadata:
                             type: object
@@ -381,7 +381,7 @@ paths:
                               barrier: { type: boolean, default: false }
                         x-gts-traits:
                           can_be_root: true
-                          allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                          allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
                           allowed_memberships: ["gts.z.core.idp.user.v1~"]
                 tenant-entity:
                   summary: "Entity type registered"
@@ -416,10 +416,10 @@ paths:
                 tenant-rg-type:
                   summary: "Chained: Tenant as RG type"
                   value:
-                    $id: "gts://gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                    $id: "gts://gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                     $schema: "http://json-schema.org/draft-07/schema#"
                     allOf:
-                      - { $ref: "gts://gts.x.core.rg.type.v1~" }
+                      - { $ref: "gts://gts.cf.core.rg.type.v1~" }
                       - properties:
                           metadata:
                             type: object
@@ -429,7 +429,7 @@ paths:
                               barrier: { type: boolean, default: false }
                         x-gts-traits:
                           can_be_root: true
-                          allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                          allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
                           allowed_memberships: ["gts.z.core.idp.user.v1~"]
                 tenant-entity:
                   summary: "Entity: Tenant"
@@ -447,7 +447,7 @@ paths:
                 rg-base-contract:
                   summary: "Base: RG contract"
                   value:
-                    $id: "gts://gts.x.core.rg.type.v1~"
+                    $id: "gts://gts.cf.core.rg.type.v1~"
                     $schema: "http://json-schema.org/draft-07/schema#"
                     title: "Resource Group Type"
                     type: object
@@ -536,12 +536,12 @@ paths:
                   value:
                     items:
                       - id: 11111111-1111-1111-1111-111111111111
-                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T1
                         parent_id: null
                         tenant_id: 11111111-1111-1111-1111-111111111111
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -549,14 +549,14 @@ paths:
                           category: "finance"
                           short_description: "Mega Department"
                       - id: 33333333-3333-3333-3333-333333333333
-                        type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
+                        type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
                         name: B3
                         parent_id: 22222222-2222-2222-2222-222222222222
                         tenant_id: 11111111-1111-1111-1111-111111111111
                         metadata:
                           location: "Building A, Floor 3"
                       - id: 77777777-7777-7777-7777-777777777777
-                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T7
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 77777777-7777-7777-7777-777777777777
@@ -571,12 +571,12 @@ paths:
                   value:
                     items:
                       - id: 11111111-1111-1111-1111-111111111111
-                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T1
                         parent_id: null
                         tenant_id: 11111111-1111-1111-1111-111111111111
                       - id: 77777777-7777-7777-7777-777777777777
-                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T7
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 77777777-7777-7777-7777-777777777777
@@ -592,7 +592,7 @@ paths:
                   value:
                     items:
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -600,7 +600,7 @@ paths:
                           category: "finance"
                           short_description: "Mega Department"
                       - id: 77777777-7777-7777-7777-777777777777
-                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T7
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 77777777-7777-7777-7777-777777777777
@@ -615,7 +615,7 @@ paths:
       tags: [groups]
       summary: Create a group
       description: |
-        `type` must be a chained GTS type with `gts.x.core.rg.type.v1~` prefix.
+        `type` must be a chained GTS type with `gts.cf.core.rg.type.v1~` prefix.
         Derived type fields (e.g. `category`) are sent inside `metadata` object.
       requestBody:
         required: true
@@ -628,12 +628,12 @@ paths:
                 summary: Create root tenant T1
                 value:
                   id: 11111111-1111-1111-1111-111111111111
-                  type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                  type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                   name: T1
               create-department:
                 summary: Create department D2 under T1
                 value:
-                  type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+                  type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
                   name: D2
                   parent_id: 11111111-1111-1111-1111-111111111111
                   metadata:
@@ -642,7 +642,7 @@ paths:
               create-branch:
                 summary: Create branch B3 under D2
                 value:
-                  type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
+                  type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
                   name: B3
                   parent_id: 22222222-2222-2222-2222-222222222222
                   metadata:
@@ -651,7 +651,7 @@ paths:
                 summary: Create nested tenant T7 (barrier) under T1
                 value:
                   id: 77777777-7777-7777-7777-777777777777
-                  type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                  type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                   name: T7
                   parent_id: 11111111-1111-1111-1111-111111111111
                   metadata:
@@ -659,7 +659,7 @@ paths:
               create-tenant-custom-domain:
                 summary: Create root tenant T9 (custom domain)
                 value:
-                  type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                  type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                   name: T9
                   metadata:
                     custom_domain: "t9.example.com"
@@ -675,7 +675,7 @@ paths:
                   summary: Tenant T1 response
                   value:
                     id: 11111111-1111-1111-1111-111111111111
-                    type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                    type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                     name: T1
                     parent_id: null
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -683,7 +683,7 @@ paths:
                   summary: Department D2 response
                   value:
                     id: 22222222-2222-2222-2222-222222222222
-                    type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+                    type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
                     name: D2
                     parent_id: 11111111-1111-1111-1111-111111111111
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -694,7 +694,7 @@ paths:
                   summary: Branch B3 response
                   value:
                     id: 33333333-3333-3333-3333-333333333333
-                    type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
+                    type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
                     name: B3
                     parent_id: 22222222-2222-2222-2222-222222222222
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -713,7 +713,7 @@ paths:
                     type: https://api.example.com/errors/invalid-parent-type
                     title: Invalid parent type
                     status: 400
-                    detail: "Type 'gts.x.core.rg.type.v1~x.core.rg.branch.v1~' does not allow parent of type 'gts.x.core.rg.type.v1~y.core.tn.tenant.v1~'"
+                    detail: "Type 'gts.cf.core.rg.type.v1~x.core.rg.branch.v1~' does not allow parent of type 'gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~'"
                     trace_id: 01HXYZRGVALIDATION
                 root-not-allowed:
                   summary: Type cannot be root
@@ -721,7 +721,7 @@ paths:
                     type: https://api.example.com/errors/validation
                     title: Validation error
                     status: 400
-                    detail: "Type 'gts.x.core.rg.type.v1~w.core.org.department.v1~' cannot be root (can_be_root=false and no parent_id provided)"
+                    detail: "Type 'gts.cf.core.rg.type.v1~w.core.org.department.v1~' cannot be root (can_be_root=false and no parent_id provided)"
                     trace_id: 01HXYZRGNOROOT
         '409':
           description: Conflict
@@ -758,7 +758,7 @@ paths:
                   summary: Tenant T1
                   value:
                     id: 11111111-1111-1111-1111-111111111111
-                    type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                    type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                     name: T1
                     parent_id: null
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -766,7 +766,7 @@ paths:
                   summary: Department D2
                   value:
                     id: 22222222-2222-2222-2222-222222222222
-                    type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+                    type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
                     name: D2
                     parent_id: 11111111-1111-1111-1111-111111111111
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -777,7 +777,7 @@ paths:
                   summary: Branch B3
                   value:
                     id: 33333333-3333-3333-3333-333333333333
-                    type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
+                    type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
                     name: B3
                     parent_id: 22222222-2222-2222-2222-222222222222
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -850,13 +850,13 @@ paths:
                   value:
                     items:
                       - id: 11111111-1111-1111-1111-111111111111
-                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T1
                         parent_id: null
                         tenant_id: 11111111-1111-1111-1111-111111111111
                         depth: 0
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -865,7 +865,7 @@ paths:
                           category: "finance"
                           short_description: "Mega Department"
                       - id: 33333333-3333-3333-3333-333333333333
-                        type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
+                        type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
                         name: B3
                         parent_id: 22222222-2222-2222-2222-222222222222
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -873,7 +873,7 @@ paths:
                         metadata:
                           location: "Building A, Floor 3"
                       - id: 77777777-7777-7777-7777-777777777777
-                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T7
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 77777777-7777-7777-7777-777777777777
@@ -889,7 +889,7 @@ paths:
                   value:
                     items:
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -898,7 +898,7 @@ paths:
                           category: "finance"
                           short_description: "Mega Department"
                       - id: 77777777-7777-7777-7777-777777777777
-                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T7
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 77777777-7777-7777-7777-777777777777
@@ -914,13 +914,13 @@ paths:
                   value:
                     items:
                       - id: 11111111-1111-1111-1111-111111111111
-                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T1
                         parent_id: null
                         tenant_id: 11111111-1111-1111-1111-111111111111
                         depth: -2
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -937,13 +937,13 @@ paths:
                   value:
                     items:
                       - id: 11111111-1111-1111-1111-111111111111
-                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T1
                         parent_id: null
                         tenant_id: 11111111-1111-1111-1111-111111111111
                         depth: -1
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -952,7 +952,7 @@ paths:
                           category: "finance"
                           short_description: "Mega Department"
                       - id: 33333333-3333-3333-3333-333333333333
-                        type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
+                        type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
                         name: B3
                         parent_id: 22222222-2222-2222-2222-222222222222
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -1055,7 +1055,7 @@ components:
       description: "GTS type path (`$id` value without `gts://` prefix)."
       schema:
         type: string
-      example: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
+      example: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
 
     MembershipGroupId:
       name: group_id
@@ -1177,7 +1177,7 @@ components:
         type:
           type: string
           description: "GTS type identifier (chained type path, ends with `~`)."
-          example: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+          example: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
         name:
           type: string
           example: D2
@@ -1243,7 +1243,7 @@ components:
         type:
           type: string
           description: "GTS type identifier (chained type path, ends with `~`)."
-          example: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+          example: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
         name:
           type: string
           example: D2
@@ -1262,7 +1262,7 @@ components:
       properties:
         type:
           type: string
-          example: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
+          example: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
         name:
           type: string
           example: D2

--- a/modules/system/resource-group/docs/openapi.yaml
+++ b/modules/system/resource-group/docs/openapi.yaml
@@ -86,10 +86,10 @@ paths:
                   summary: Chained RG types
                   value:
                     items:
-                      - $id: "gts://gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                      - $id: "gts://gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                         $schema: "http://json-schema.org/draft-07/schema#"
                         allOf:
-                          - { $ref: "gts://gts.cf.core.rg.type.v1~" }
+                          - { $ref: "gts://gts.x.core.rg.type.v1~" }
                           - properties:
                               metadata:
                                 type: object
@@ -99,12 +99,12 @@ paths:
                                   barrier: { type: boolean, default: false }
                             x-gts-traits:
                               can_be_root: true
-                              allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                              allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
                               allowed_memberships: ["gts.z.core.idp.user.v1~"]
-                      - $id: "gts://gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+                      - $id: "gts://gts.x.core.rg.type.v1~w.core.org.department.v1~"
                         $schema: "http://json-schema.org/draft-07/schema#"
                         allOf:
-                          - { $ref: "gts://gts.cf.core.rg.type.v1~" }
+                          - { $ref: "gts://gts.x.core.rg.type.v1~" }
                           - properties:
                               metadata:
                                 type: object
@@ -114,12 +114,12 @@ paths:
                                   short_description: { type: string, maxLength: 500 }
                             x-gts-traits:
                               can_be_root: false
-                              allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                              allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
                               allowed_memberships: ["gts.z.core.idp.user.v1~"]
-                      - $id: "gts://gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
+                      - $id: "gts://gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
                         $schema: "http://json-schema.org/draft-07/schema#"
                         allOf:
-                          - { $ref: "gts://gts.cf.core.rg.type.v1~" }
+                          - { $ref: "gts://gts.x.core.rg.type.v1~" }
                           - properties:
                               metadata:
                                 type: object
@@ -128,7 +128,7 @@ paths:
                                   location: { type: string }
                             x-gts-traits:
                               can_be_root: false
-                              allowed_parents: ["gts.cf.core.rg.type.v1~w.core.org.department.v1~"]
+                              allowed_parents: ["gts.x.core.rg.type.v1~w.core.org.department.v1~"]
                               allowed_memberships: ["gts.z.core.idp.user.v1~", "gts.z.core.lms.course.v1~"]
                     page_info:
                       next_cursor: "eyJpZCI6Ijc3NzcuLi4ifQ"
@@ -155,7 +155,7 @@ paths:
               rg-base-contract:
                 summary: "Step 1a: RG base contract (x-gts-traits-schema)"
                 value:
-                  $id: "gts://gts.cf.core.rg.type.v1~"
+                  $id: "gts://gts.x.core.rg.type.v1~"
                   $schema: "http://json-schema.org/draft-07/schema#"
                   title: "Resource Group Type"
                   type: object
@@ -169,7 +169,7 @@ paths:
                         default: false
                       allowed_parents:
                         type: array
-                        items: { type: string, x-gts-ref: "gts.cf.core.rg.type.v1~" }
+                        items: { type: string, x-gts-ref: "gts.x.core.rg.type.v1~" }
                         description: "Well-known instances of allowed parent RG types."
                         default: []
                       allowed_memberships:
@@ -224,7 +224,7 @@ paths:
               branch-entity:
                 summary: "Step 2c: Branch entity type"
                 value:
-                  $id: "gts://gts.cf.core.rg.branch.v1~"
+                  $id: "gts://gts.x.core.rg.branch.v1~"
                   $schema: "http://json-schema.org/draft-07/schema#"
                   title: Branch
                   type: object
@@ -265,10 +265,10 @@ paths:
               tenant-rg-type:
                 summary: "Step 3a: Tenant as RG type (chained, x-gts-traits)"
                 value:
-                  $id: "gts://gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                  $id: "gts://gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                   $schema: "http://json-schema.org/draft-07/schema#"
                   allOf:
-                    - { $ref: "gts://gts.cf.core.rg.type.v1~" }
+                    - { $ref: "gts://gts.x.core.rg.type.v1~" }
                     - properties:
                         metadata:
                           type: object
@@ -278,16 +278,16 @@ paths:
                             barrier: { type: boolean, default: false }
                       x-gts-traits:
                         can_be_root: true
-                        allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                        allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
                         allowed_memberships: ["gts.z.core.idp.user.v1~"]
 
               department-rg-type:
                 summary: "Step 3b: Department as RG type (chained, x-gts-traits)"
                 value:
-                  $id: "gts://gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+                  $id: "gts://gts.x.core.rg.type.v1~w.core.org.department.v1~"
                   $schema: "http://json-schema.org/draft-07/schema#"
                   allOf:
-                    - { $ref: "gts://gts.cf.core.rg.type.v1~" }
+                    - { $ref: "gts://gts.x.core.rg.type.v1~" }
                     - properties:
                         metadata:
                           type: object
@@ -297,16 +297,16 @@ paths:
                             short_description: { type: string, maxLength: 500 }
                       x-gts-traits:
                         can_be_root: false
-                        allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                        allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
                         allowed_memberships: ["gts.z.core.idp.user.v1~"]
 
               branch-rg-type:
                 summary: "Step 3c: Branch as RG type (chained, x-gts-traits)"
                 value:
-                  $id: "gts://gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
+                  $id: "gts://gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
                   $schema: "http://json-schema.org/draft-07/schema#"
                   allOf:
-                    - { $ref: "gts://gts.cf.core.rg.type.v1~" }
+                    - { $ref: "gts://gts.x.core.rg.type.v1~" }
                     - properties:
                         metadata:
                           type: object
@@ -315,7 +315,7 @@ paths:
                             location: { type: string }
                       x-gts-traits:
                         can_be_root: false
-                        allowed_parents: ["gts.cf.core.rg.type.v1~w.core.org.department.v1~"]
+                        allowed_parents: ["gts.x.core.rg.type.v1~w.core.org.department.v1~"]
                         allowed_memberships: ["gts.z.core.idp.user.v1~", "gts.z.core.lms.course.v1~"]
 
       responses:
@@ -329,7 +329,7 @@ paths:
                 rg-base-contract:
                   summary: "Base contract registered"
                   value:
-                    $id: "gts://gts.cf.core.rg.type.v1~"
+                    $id: "gts://gts.x.core.rg.type.v1~"
                     $schema: "http://json-schema.org/draft-07/schema#"
                     title: "Resource Group Type"
                     type: object
@@ -343,7 +343,7 @@ paths:
                           default: false
                         allowed_parents:
                           type: array
-                          items: { type: string, x-gts-ref: "gts.cf.core.rg.type.v1~" }
+                          items: { type: string, x-gts-ref: "gts.x.core.rg.type.v1~" }
                           description: "Well-known instances of allowed parent RG types."
                           default: []
                         allowed_memberships:
@@ -368,10 +368,10 @@ paths:
                 tenant-rg-type:
                   summary: "Chained tenant RG type registered"
                   value:
-                    $id: "gts://gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                    $id: "gts://gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                     $schema: "http://json-schema.org/draft-07/schema#"
                     allOf:
-                      - { $ref: "gts://gts.cf.core.rg.type.v1~" }
+                      - { $ref: "gts://gts.x.core.rg.type.v1~" }
                       - properties:
                           metadata:
                             type: object
@@ -381,7 +381,7 @@ paths:
                               barrier: { type: boolean, default: false }
                         x-gts-traits:
                           can_be_root: true
-                          allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                          allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
                           allowed_memberships: ["gts.z.core.idp.user.v1~"]
                 tenant-entity:
                   summary: "Entity type registered"
@@ -416,10 +416,10 @@ paths:
                 tenant-rg-type:
                   summary: "Chained: Tenant as RG type"
                   value:
-                    $id: "gts://gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                    $id: "gts://gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                     $schema: "http://json-schema.org/draft-07/schema#"
                     allOf:
-                      - { $ref: "gts://gts.cf.core.rg.type.v1~" }
+                      - { $ref: "gts://gts.x.core.rg.type.v1~" }
                       - properties:
                           metadata:
                             type: object
@@ -429,7 +429,7 @@ paths:
                               barrier: { type: boolean, default: false }
                         x-gts-traits:
                           can_be_root: true
-                          allowed_parents: ["gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"]
+                          allowed_parents: ["gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"]
                           allowed_memberships: ["gts.z.core.idp.user.v1~"]
                 tenant-entity:
                   summary: "Entity: Tenant"
@@ -447,7 +447,7 @@ paths:
                 rg-base-contract:
                   summary: "Base: RG contract"
                   value:
-                    $id: "gts://gts.cf.core.rg.type.v1~"
+                    $id: "gts://gts.x.core.rg.type.v1~"
                     $schema: "http://json-schema.org/draft-07/schema#"
                     title: "Resource Group Type"
                     type: object
@@ -536,12 +536,12 @@ paths:
                   value:
                     items:
                       - id: 11111111-1111-1111-1111-111111111111
-                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T1
                         parent_id: null
                         tenant_id: 11111111-1111-1111-1111-111111111111
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -549,14 +549,14 @@ paths:
                           category: "finance"
                           short_description: "Mega Department"
                       - id: 33333333-3333-3333-3333-333333333333
-                        type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
+                        type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
                         name: B3
                         parent_id: 22222222-2222-2222-2222-222222222222
                         tenant_id: 11111111-1111-1111-1111-111111111111
                         metadata:
                           location: "Building A, Floor 3"
                       - id: 77777777-7777-7777-7777-777777777777
-                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T7
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 77777777-7777-7777-7777-777777777777
@@ -571,12 +571,12 @@ paths:
                   value:
                     items:
                       - id: 11111111-1111-1111-1111-111111111111
-                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T1
                         parent_id: null
                         tenant_id: 11111111-1111-1111-1111-111111111111
                       - id: 77777777-7777-7777-7777-777777777777
-                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T7
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 77777777-7777-7777-7777-777777777777
@@ -592,7 +592,7 @@ paths:
                   value:
                     items:
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -600,7 +600,7 @@ paths:
                           category: "finance"
                           short_description: "Mega Department"
                       - id: 77777777-7777-7777-7777-777777777777
-                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T7
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 77777777-7777-7777-7777-777777777777
@@ -615,7 +615,7 @@ paths:
       tags: [groups]
       summary: Create a group
       description: |
-        `type` must be a chained GTS type with `gts.cf.core.rg.type.v1~` prefix.
+        `type` must be a chained GTS type with `gts.x.core.rg.type.v1~` prefix.
         Derived type fields (e.g. `category`) are sent inside `metadata` object.
       requestBody:
         required: true
@@ -628,12 +628,12 @@ paths:
                 summary: Create root tenant T1
                 value:
                   id: 11111111-1111-1111-1111-111111111111
-                  type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                  type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                   name: T1
               create-department:
                 summary: Create department D2 under T1
                 value:
-                  type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+                  type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
                   name: D2
                   parent_id: 11111111-1111-1111-1111-111111111111
                   metadata:
@@ -642,7 +642,7 @@ paths:
               create-branch:
                 summary: Create branch B3 under D2
                 value:
-                  type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
+                  type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
                   name: B3
                   parent_id: 22222222-2222-2222-2222-222222222222
                   metadata:
@@ -651,7 +651,7 @@ paths:
                 summary: Create nested tenant T7 (barrier) under T1
                 value:
                   id: 77777777-7777-7777-7777-777777777777
-                  type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                  type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                   name: T7
                   parent_id: 11111111-1111-1111-1111-111111111111
                   metadata:
@@ -659,7 +659,7 @@ paths:
               create-tenant-custom-domain:
                 summary: Create root tenant T9 (custom domain)
                 value:
-                  type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                  type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                   name: T9
                   metadata:
                     custom_domain: "t9.example.com"
@@ -675,7 +675,7 @@ paths:
                   summary: Tenant T1 response
                   value:
                     id: 11111111-1111-1111-1111-111111111111
-                    type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                    type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                     name: T1
                     parent_id: null
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -683,7 +683,7 @@ paths:
                   summary: Department D2 response
                   value:
                     id: 22222222-2222-2222-2222-222222222222
-                    type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+                    type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
                     name: D2
                     parent_id: 11111111-1111-1111-1111-111111111111
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -694,7 +694,7 @@ paths:
                   summary: Branch B3 response
                   value:
                     id: 33333333-3333-3333-3333-333333333333
-                    type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
+                    type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
                     name: B3
                     parent_id: 22222222-2222-2222-2222-222222222222
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -713,7 +713,7 @@ paths:
                     type: https://api.example.com/errors/invalid-parent-type
                     title: Invalid parent type
                     status: 400
-                    detail: "Type 'gts.cf.core.rg.type.v1~x.core.rg.branch.v1~' does not allow parent of type 'gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~'"
+                    detail: "Type 'gts.x.core.rg.type.v1~x.core.rg.branch.v1~' does not allow parent of type 'gts.x.core.rg.type.v1~y.core.tn.tenant.v1~'"
                     trace_id: 01HXYZRGVALIDATION
                 root-not-allowed:
                   summary: Type cannot be root
@@ -721,7 +721,7 @@ paths:
                     type: https://api.example.com/errors/validation
                     title: Validation error
                     status: 400
-                    detail: "Type 'gts.cf.core.rg.type.v1~w.core.org.department.v1~' cannot be root (can_be_root=false and no parent_id provided)"
+                    detail: "Type 'gts.x.core.rg.type.v1~w.core.org.department.v1~' cannot be root (can_be_root=false and no parent_id provided)"
                     trace_id: 01HXYZRGNOROOT
         '409':
           description: Conflict
@@ -758,7 +758,7 @@ paths:
                   summary: Tenant T1
                   value:
                     id: 11111111-1111-1111-1111-111111111111
-                    type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                    type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                     name: T1
                     parent_id: null
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -766,7 +766,7 @@ paths:
                   summary: Department D2
                   value:
                     id: 22222222-2222-2222-2222-222222222222
-                    type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+                    type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
                     name: D2
                     parent_id: 11111111-1111-1111-1111-111111111111
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -777,7 +777,7 @@ paths:
                   summary: Branch B3
                   value:
                     id: 33333333-3333-3333-3333-333333333333
-                    type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
+                    type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
                     name: B3
                     parent_id: 22222222-2222-2222-2222-222222222222
                     tenant_id: 11111111-1111-1111-1111-111111111111
@@ -850,13 +850,13 @@ paths:
                   value:
                     items:
                       - id: 11111111-1111-1111-1111-111111111111
-                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T1
                         parent_id: null
                         tenant_id: 11111111-1111-1111-1111-111111111111
                         depth: 0
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -865,7 +865,7 @@ paths:
                           category: "finance"
                           short_description: "Mega Department"
                       - id: 33333333-3333-3333-3333-333333333333
-                        type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
+                        type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
                         name: B3
                         parent_id: 22222222-2222-2222-2222-222222222222
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -873,7 +873,7 @@ paths:
                         metadata:
                           location: "Building A, Floor 3"
                       - id: 77777777-7777-7777-7777-777777777777
-                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T7
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 77777777-7777-7777-7777-777777777777
@@ -889,7 +889,7 @@ paths:
                   value:
                     items:
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -898,7 +898,7 @@ paths:
                           category: "finance"
                           short_description: "Mega Department"
                       - id: 77777777-7777-7777-7777-777777777777
-                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T7
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 77777777-7777-7777-7777-777777777777
@@ -914,13 +914,13 @@ paths:
                   value:
                     items:
                       - id: 11111111-1111-1111-1111-111111111111
-                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T1
                         parent_id: null
                         tenant_id: 11111111-1111-1111-1111-111111111111
                         depth: -2
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -937,13 +937,13 @@ paths:
                   value:
                     items:
                       - id: 11111111-1111-1111-1111-111111111111
-                        type: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+                        type: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
                         name: T1
                         parent_id: null
                         tenant_id: 11111111-1111-1111-1111-111111111111
                         depth: -1
                       - id: 22222222-2222-2222-2222-222222222222
-                        type: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+                        type: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
                         name: D2
                         parent_id: 11111111-1111-1111-1111-111111111111
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -952,7 +952,7 @@ paths:
                           category: "finance"
                           short_description: "Mega Department"
                       - id: 33333333-3333-3333-3333-333333333333
-                        type: "gts.cf.core.rg.type.v1~x.core.rg.branch.v1~"
+                        type: "gts.x.core.rg.type.v1~x.core.rg.branch.v1~"
                         name: B3
                         parent_id: 22222222-2222-2222-2222-222222222222
                         tenant_id: 11111111-1111-1111-1111-111111111111
@@ -1055,7 +1055,7 @@ components:
       description: "GTS type path (`$id` value without `gts://` prefix)."
       schema:
         type: string
-      example: "gts.cf.core.rg.type.v1~y.core.tn.tenant.v1~"
+      example: "gts.x.core.rg.type.v1~y.core.tn.tenant.v1~"
 
     MembershipGroupId:
       name: group_id
@@ -1177,7 +1177,7 @@ components:
         type:
           type: string
           description: "GTS type identifier (chained type path, ends with `~`)."
-          example: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+          example: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
         name:
           type: string
           example: D2
@@ -1243,7 +1243,7 @@ components:
         type:
           type: string
           description: "GTS type identifier (chained type path, ends with `~`)."
-          example: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+          example: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
         name:
           type: string
           example: D2
@@ -1262,7 +1262,7 @@ components:
       properties:
         type:
           type: string
-          example: "gts.cf.core.rg.type.v1~w.core.org.department.v1~"
+          example: "gts.x.core.rg.type.v1~w.core.org.department.v1~"
         name:
           type: string
           example: D2

--- a/modules/system/resource-group/docs/rust-traits.md
+++ b/modules/system/resource-group/docs/rust-traits.md
@@ -265,7 +265,7 @@ let descendants = rg_hierarchy
 let group = rg
     .create_group(&ctx, CreateGroupRequest {
         id: None,
-        r#type: "gts.x.system.rg.type.v1~y.system.tn.tenant.v1~".into(),
+        r#type: "gts.cf.core.rg.type.v1~y.system.tn.tenant.v1~".into(),
         name: "Acme Corp".into(),
         parent_id: None,
         metadata: Default::default(),

--- a/modules/system/resource-group/docs/rust-traits.md
+++ b/modules/system/resource-group/docs/rust-traits.md
@@ -1,4 +1,4 @@
-<!-- Updated: 2026-04-07 by Constructor Tech -->
+<!-- Updated: 2026-04-20 by Constructor Tech -->
 
 # Rust SDK Contracts — Resource Group
 
@@ -178,7 +178,7 @@ pub trait ResourceGroupClient: Send + Sync {
     async fn get_group(&self, ctx: &SecurityContext, group_id: Uuid) -> Result<ResourceGroup, ResourceGroupError>;
     async fn list_groups(&self, ctx: &SecurityContext, query: ListQuery) -> Result<Page<ResourceGroup>, ResourceGroupError>;
     async fn update_group(&self, ctx: &SecurityContext, group_id: Uuid, request: UpdateGroupRequest) -> Result<ResourceGroup, ResourceGroupError>;
-    async fn delete_group(&self, ctx: &SecurityContext, group_id: Uuid, force: bool) -> Result<(), ResourceGroupError>;
+    async fn delete_group(&self, ctx: &SecurityContext, group_id: Uuid) -> Result<(), ResourceGroupError>;
 
     // ── Hierarchy ───────────────────────────────────────────────────
     async fn list_group_depth(&self, ctx: &SecurityContext, group_id: Uuid, query: ListQuery) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
@@ -205,6 +205,22 @@ pub trait ResourceGroupReadHierarchy: Send + Sync {
         group_id: Uuid,
         query: ListQuery,
     ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+}
+```
+
+## Plugin Trait — `ResourceGroupReadPluginClient`
+
+Gateway delegates to selected scoped plugin (vendor-specific provider path).
+
+```rust
+/// Plugin hierarchy read contract. Extends `ResourceGroupReadHierarchy`.
+#[async_trait]
+pub trait ResourceGroupReadPluginClient: ResourceGroupReadHierarchy {
+    async fn list_memberships(
+        &self,
+        ctx: &SecurityContext,
+        query: ListQuery,
+    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError>;
 }
 ```
 
@@ -249,7 +265,7 @@ let descendants = rg_hierarchy
 let group = rg
     .create_group(&ctx, CreateGroupRequest {
         id: None,
-        r#type: "gts.cf.core.rg.type.v1~y.system.tn.tenant.v1~".into(),
+        r#type: "gts.x.system.rg.type.v1~y.system.tn.tenant.v1~".into(),
         name: "Acme Corp".into(),
         parent_id: None,
         metadata: Default::default(),
@@ -263,3 +279,4 @@ let group = rg
 |-------|---------|-----------|---------------|
 | `ResourceGroupClient` | 14 (full CRUD: types, groups, memberships, hierarchy) | Domain services, Apps, Admins | `dyn ResourceGroupClient` |
 | `ResourceGroupReadHierarchy` | 1 (`list_group_depth`) | AuthZ plugin | `dyn ResourceGroupReadHierarchy` |
+| `ResourceGroupReadPluginClient` | 1 + inherited (`list_memberships` + `list_group_depth`) | Vendor-specific plugin gateway | Scoped plugin resolution |

--- a/modules/system/resource-group/docs/rust-traits.md
+++ b/modules/system/resource-group/docs/rust-traits.md
@@ -208,22 +208,6 @@ pub trait ResourceGroupReadHierarchy: Send + Sync {
 }
 ```
 
-## Plugin Trait — `ResourceGroupReadPluginClient`
-
-Gateway delegates to selected scoped plugin (vendor-specific provider path).
-
-```rust
-/// Plugin hierarchy read contract. Extends `ResourceGroupReadHierarchy`.
-#[async_trait]
-pub trait ResourceGroupReadPluginClient: ResourceGroupReadHierarchy {
-    async fn list_memberships(
-        &self,
-        ctx: &SecurityContext,
-        query: ListQuery,
-    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError>;
-}
-```
-
 ## ClientHub Registration
 
 Single implementation, two registrations:
@@ -279,4 +263,3 @@ let group = rg
 |-------|---------|-----------|---------------|
 | `ResourceGroupClient` | 14 (full CRUD: types, groups, memberships, hierarchy) | Domain services, Apps, Admins | `dyn ResourceGroupClient` |
 | `ResourceGroupReadHierarchy` | 1 (`list_group_depth`) | AuthZ plugin | `dyn ResourceGroupReadHierarchy` |
-| `ResourceGroupReadPluginClient` | 1 + inherited (`list_memberships` + `list_group_depth`) | Vendor-specific plugin gateway | Scoped plugin resolution |

--- a/modules/system/resource-group/resource-group-sdk/Cargo.toml
+++ b/modules/system/resource-group/resource-group-sdk/Cargo.toml
@@ -1,0 +1,44 @@
+# Created: 2026-04-16 by Constructor Tech
+[package]
+name = "cf-resource-group-sdk"
+version = "0.1.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "SDK for resource-group module: API trait, types, and error definitions"
+
+[lints]
+workspace = true
+
+[features]
+default = ["odata"]
+odata = [
+    "dep:modkit-odata-macros",
+    "dep:modkit-sdk",
+]
+
+[dependencies]
+# Core dependencies for API trait
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+
+# OData macros (for #[derive(ODataFilterable)])
+modkit-odata-macros = { workspace = true, optional = true }
+
+# UUID support
+uuid = { workspace = true }
+
+# Security context for API methods
+modkit-security = { workspace = true }
+
+# SDK utilities (typed OData queries)
+modkit-sdk = { workspace = true, optional = true }
+
+# OData support for pagination and query types (required for API trait)
+modkit-odata = { workspace = true }
+
+# GTS type system — ID parsing and validation
+gts = { workspace = true }

--- a/modules/system/resource-group/resource-group-sdk/Cargo.toml
+++ b/modules/system/resource-group/resource-group-sdk/Cargo.toml
@@ -42,3 +42,12 @@ modkit-odata = { workspace = true }
 
 # GTS type system — ID parsing and validation
 gts = { workspace = true }
+
+# GTS macros — struct_to_gts_schema for GTS schema definitions
+gts-macros = { workspace = true }
+
+# JSON Schema (required by struct_to_gts_schema)
+schemars = { workspace = true }
+
+# ModKit — BaseModkitPluginV1 for plugin spec base type
+modkit = { workspace = true }

--- a/modules/system/resource-group/resource-group-sdk/src/api.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/api.rs
@@ -1,0 +1,181 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-traits:p1
+//! SDK trait contracts for the resource-group module.
+
+use async_trait::async_trait;
+use modkit_security::SecurityContext;
+
+use modkit_odata::{ODataQuery, Page};
+use uuid::Uuid;
+
+use crate::error::ResourceGroupError;
+use crate::models::{
+    CreateGroupRequest, CreateTypeRequest, PatchGroupRequest, ResourceGroup,
+    ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest,
+    UpdateTypeRequest,
+};
+
+/// Client trait for resource-group type management.
+///
+/// Consumers obtain this from `ClientHub`:
+/// ```ignore
+/// let client = hub.get::<dyn ResourceGroupClient>()?;
+/// let rg_type = client.get_type(&ctx, "gts.cf.core.rg.type.v1~...").await?;
+/// ```
+#[async_trait]
+pub trait ResourceGroupClient: Send + Sync {
+    // -- Type lifecycle --
+
+    /// Create a new GTS type definition.
+    async fn create_type(
+        &self,
+        ctx: &SecurityContext,
+        request: CreateTypeRequest,
+    ) -> Result<ResourceGroupType, ResourceGroupError>;
+
+    /// Get a GTS type definition by its code (GTS type path).
+    async fn get_type(
+        &self,
+        ctx: &SecurityContext,
+        code: &str,
+    ) -> Result<ResourceGroupType, ResourceGroupError>;
+
+    /// List GTS type definitions with `OData` filtering and cursor-based pagination.
+    async fn list_types(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupType>, ResourceGroupError>;
+
+    /// Update a GTS type definition (full replacement).
+    async fn update_type(
+        &self,
+        ctx: &SecurityContext,
+        code: &str,
+        request: UpdateTypeRequest,
+    ) -> Result<ResourceGroupType, ResourceGroupError>;
+
+    /// Delete a GTS type definition. Fails if groups of this type exist.
+    async fn delete_type(
+        &self,
+        ctx: &SecurityContext,
+        code: &str,
+    ) -> Result<(), ResourceGroupError>;
+
+    // -- Group lifecycle --
+
+    /// Create a new resource group.
+    async fn create_group(
+        &self,
+        ctx: &SecurityContext,
+        request: CreateGroupRequest,
+    ) -> Result<ResourceGroup, ResourceGroupError>;
+
+    /// Get a resource group by ID.
+    async fn get_group(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+    ) -> Result<ResourceGroup, ResourceGroupError>;
+
+    /// List resource groups with `OData` filtering and cursor-based pagination.
+    async fn list_groups(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroup>, ResourceGroupError>;
+
+    /// Update a resource group (full replacement).
+    async fn update_group(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        request: UpdateGroupRequest,
+    ) -> Result<ResourceGroup, ResourceGroupError>;
+
+    /// Patch a resource group (partial update via PATCH).
+    async fn patch_group(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        request: PatchGroupRequest,
+    ) -> Result<ResourceGroup, ResourceGroupError>;
+
+    /// Delete a resource group.
+    /// When `force` is false, fails with `ConflictActiveReferences` if child groups
+    /// or memberships exist. When `force` is true, recursively deletes the entire
+    /// subtree (all descendants and their memberships).
+    async fn delete_group(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        force: bool,
+    ) -> Result<(), ResourceGroupError>;
+
+    /// List group hierarchy with relative depth from a reference group.
+    async fn list_group_depth(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+
+    // -- Membership lifecycle --
+
+    /// Add a membership link between a resource and a group.
+    async fn add_membership(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Result<ResourceGroupMembership, ResourceGroupError>;
+
+    /// Remove a membership link.
+    async fn remove_membership(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Result<(), ResourceGroupError>;
+
+    /// List memberships with `OData` filtering and cursor-based pagination.
+    async fn list_memberships(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError>;
+}
+
+// @cpt-dod:cpt-cf-resource-group-dod-integration-auth-read-service:p1
+/// Narrow read-only trait for hierarchy data, used by `AuthZ` plugin.
+///
+/// This trait provides the integration read port that external consumers
+/// (such as the `AuthZ` plugin) use to query group hierarchy data without
+/// depending on the full `ResourceGroupClient`.
+#[async_trait]
+pub trait ResourceGroupReadHierarchy: Send + Sync {
+    /// List group hierarchy with depth for a given group.
+    async fn list_group_depth(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+}
+
+// @cpt-flow:cpt-cf-resource-group-flow-integration-auth-plugin-routing:p1
+/// Extended read trait for vendor-specific plugin gateway routing.
+///
+/// Extends `ResourceGroupReadHierarchy` with membership listing for
+/// plugin consumers that need both hierarchy and membership data.
+#[async_trait]
+pub trait ResourceGroupReadPluginClient: ResourceGroupReadHierarchy {
+    /// List memberships for plugin consumers.
+    async fn list_memberships(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError>;
+}

--- a/modules/system/resource-group/resource-group-sdk/src/api.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/api.rs
@@ -10,9 +10,8 @@ use uuid::Uuid;
 
 use crate::error::ResourceGroupError;
 use crate::models::{
-    CreateGroupRequest, CreateTypeRequest, PatchGroupRequest, ResourceGroup,
-    ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest,
-    UpdateTypeRequest,
+    CreateGroupRequest, CreateTypeRequest, ResourceGroup, ResourceGroupMembership,
+    ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest, UpdateTypeRequest,
 };
 
 /// Client trait for resource-group type management.
@@ -93,27 +92,24 @@ pub trait ResourceGroupClient: Send + Sync {
         request: UpdateGroupRequest,
     ) -> Result<ResourceGroup, ResourceGroupError>;
 
-    /// Patch a resource group (partial update via PATCH).
-    async fn patch_group(
-        &self,
-        ctx: &SecurityContext,
-        id: Uuid,
-        request: PatchGroupRequest,
-    ) -> Result<ResourceGroup, ResourceGroupError>;
-
     /// Delete a resource group.
-    /// When `force` is false, fails with `ConflictActiveReferences` if child groups
-    /// or memberships exist. When `force` is true, recursively deletes the entire
-    /// subtree (all descendants and their memberships).
-    async fn delete_group(
+    ///
+    /// SDK deletes are non-cascade: the call fails with
+    /// `ConflictActiveReferences` if the group has child groups or memberships.
+    /// Cascade deletion is only available through the REST surface.
+    async fn delete_group(&self, ctx: &SecurityContext, id: Uuid)
+    -> Result<(), ResourceGroupError>;
+
+    /// Get descendants of a reference group (depth >= 0).
+    async fn get_group_descendants(
         &self,
         ctx: &SecurityContext,
-        id: Uuid,
-        force: bool,
-    ) -> Result<(), ResourceGroupError>;
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
 
-    /// List group hierarchy with relative depth from a reference group.
-    async fn list_group_depth(
+    /// Get ancestors of a reference group (depth <= 0).
+    async fn get_group_ancestors(
         &self,
         ctx: &SecurityContext,
         group_id: Uuid,
@@ -156,8 +152,16 @@ pub trait ResourceGroupClient: Send + Sync {
 /// depending on the full `ResourceGroupClient`.
 #[async_trait]
 pub trait ResourceGroupReadHierarchy: Send + Sync {
-    /// List group hierarchy with depth for a given group.
-    async fn list_group_depth(
+    /// Get descendants of a reference group (depth >= 0).
+    async fn get_group_descendants(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+
+    /// Get ancestors of a reference group (depth <= 0).
+    async fn get_group_ancestors(
         &self,
         ctx: &SecurityContext,
         group_id: Uuid,

--- a/modules/system/resource-group/resource-group-sdk/src/api.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/api.rs
@@ -164,18 +164,3 @@ pub trait ResourceGroupReadHierarchy: Send + Sync {
         query: &ODataQuery,
     ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
 }
-
-// @cpt-flow:cpt-cf-resource-group-flow-integration-auth-plugin-routing:p1
-/// Extended read trait for vendor-specific plugin gateway routing.
-///
-/// Extends `ResourceGroupReadHierarchy` with membership listing for
-/// plugin consumers that need both hierarchy and membership data.
-#[async_trait]
-pub trait ResourceGroupReadPluginClient: ResourceGroupReadHierarchy {
-    /// List memberships for plugin consumers.
-    async fn list_memberships(
-        &self,
-        ctx: &SecurityContext,
-        query: &ODataQuery,
-    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError>;
-}

--- a/modules/system/resource-group/resource-group-sdk/src/error.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/error.rs
@@ -1,0 +1,151 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-errors:p1
+//! Public error types for the resource-group module.
+//!
+//! These errors are safe to expose to other modules and consumers.
+
+use thiserror::Error;
+
+/// Errors that can be returned by the `ResourceGroupClient`.
+#[derive(Error, Debug, Clone)]
+pub enum ResourceGroupError {
+    /// Resource with the specified identifier was not found.
+    #[error("Resource not found: {code}")]
+    NotFound { code: String },
+
+    /// A resource with the specified code already exists.
+    #[error("Resource already exists: {code}")]
+    TypeAlreadyExists { code: String },
+
+    /// Validation error with the provided data.
+    #[error("Validation error: {message}")]
+    Validation { message: String },
+
+    /// Removing allowed parents or disabling root placement would break
+    /// existing group hierarchy relationships.
+    #[error("Allowed parents violation: {message}")]
+    AllowedParentsViolation { message: String },
+
+    /// Cannot delete a type because groups of this type still exist.
+    #[error("Active references exist: {message}")]
+    ConflictActiveReferences { message: String },
+
+    /// A generic conflict (e.g. a concurrency or state conflict not related to references).
+    #[error("Conflict: {message}")]
+    Conflict { message: String },
+
+    /// Parent type is not allowed by the type's `allowed_parents` configuration.
+    #[error("Invalid parent type: {message}")]
+    InvalidParentType { message: String },
+
+    /// A cycle would be created in the group hierarchy.
+    #[error("Cycle detected: {message}")]
+    CycleDetected { message: String },
+
+    /// A configured limit (depth, width, etc.) would be exceeded.
+    #[error("Limit violation: {message}")]
+    LimitViolation { message: String },
+
+    /// Tenant scope incompatibility.
+    #[error("Tenant incompatibility: {message}")]
+    TenantIncompatibility { message: String },
+
+    /// Service is temporarily unavailable.
+    #[error("Service unavailable: {message}")]
+    ServiceUnavailable { message: String },
+
+    /// Access was denied by the authorization policy (PDP denial).
+    #[error("Access denied")]
+    AccessDenied,
+
+    /// An internal error occurred.
+    #[error("Internal error")]
+    Internal,
+}
+
+impl ResourceGroupError {
+    /// Create a `NotFound` error.
+    pub fn not_found(code: impl Into<String>) -> Self {
+        Self::NotFound { code: code.into() }
+    }
+
+    /// Create a `TypeAlreadyExists` error.
+    pub fn type_already_exists(code: impl Into<String>) -> Self {
+        Self::TypeAlreadyExists { code: code.into() }
+    }
+
+    /// Create a `Validation` error.
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self::Validation {
+            message: message.into(),
+        }
+    }
+
+    /// Create an `AllowedParentsViolation` error.
+    pub fn allowed_parents_violation(message: impl Into<String>) -> Self {
+        Self::AllowedParentsViolation {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `ConflictActiveReferences` error.
+    pub fn conflict_active_references(message: impl Into<String>) -> Self {
+        Self::ConflictActiveReferences {
+            message: message.into(),
+        }
+    }
+
+    /// Create a generic `Conflict` error.
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::Conflict {
+            message: message.into(),
+        }
+    }
+
+    /// Create an `InvalidParentType` error.
+    pub fn invalid_parent_type(message: impl Into<String>) -> Self {
+        Self::InvalidParentType {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `CycleDetected` error.
+    pub fn cycle_detected(message: impl Into<String>) -> Self {
+        Self::CycleDetected {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `LimitViolation` error.
+    pub fn limit_violation(message: impl Into<String>) -> Self {
+        Self::LimitViolation {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `TenantIncompatibility` error.
+    pub fn tenant_incompatibility(message: impl Into<String>) -> Self {
+        Self::TenantIncompatibility {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `ServiceUnavailable` error.
+    pub fn service_unavailable(message: impl Into<String>) -> Self {
+        Self::ServiceUnavailable {
+            message: message.into(),
+        }
+    }
+
+    /// Create an `AccessDenied` error.
+    #[must_use]
+    pub fn access_denied() -> Self {
+        Self::AccessDenied
+    }
+
+    /// Create an `Internal` error.
+    #[must_use]
+    pub fn internal() -> Self {
+        Self::Internal
+    }
+}

--- a/modules/system/resource-group/resource-group-sdk/src/error.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/error.rs
@@ -24,7 +24,7 @@ pub enum ResourceGroupError {
     /// Removing allowed parents or disabling root placement would break
     /// existing group hierarchy relationships.
     #[error("Allowed parents violation: {message}")]
-    AllowedParentsViolation { message: String },
+    AllowedParentTypesViolation { message: String },
 
     /// Cannot delete a type because groups of this type still exist.
     #[error("Active references exist: {message}")]
@@ -34,7 +34,7 @@ pub enum ResourceGroupError {
     #[error("Conflict: {message}")]
     Conflict { message: String },
 
-    /// Parent type is not allowed by the type's `allowed_parents` configuration.
+    /// Parent type is not allowed by the type's `allowed_parent_types` configuration.
     #[error("Invalid parent type: {message}")]
     InvalidParentType { message: String },
 
@@ -46,7 +46,14 @@ pub enum ResourceGroupError {
     #[error("Limit violation: {message}")]
     LimitViolation { message: String },
 
-    /// Tenant scope incompatibility.
+    /// Cross-tenant link would be created.
+    ///
+    /// Each resource (identified by the pair `(resource_type, resource_id)`)
+    /// belongs to groups in exactly one tenant. Returned by
+    /// `ResourceGroupClient::add_membership` when the target group's tenant
+    /// differs from the tenant of any existing membership for the same
+    /// resource. The resource continues to exist — only the cross-tenant link
+    /// is rejected.
     #[error("Tenant incompatibility: {message}")]
     TenantIncompatibility { message: String },
 
@@ -81,9 +88,9 @@ impl ResourceGroupError {
         }
     }
 
-    /// Create an `AllowedParentsViolation` error.
-    pub fn allowed_parents_violation(message: impl Into<String>) -> Self {
-        Self::AllowedParentsViolation {
+    /// Create an `AllowedParentTypesViolation` error.
+    pub fn allowed_parent_types_violation(message: impl Into<String>) -> Self {
+        Self::AllowedParentTypesViolation {
             message: message.into(),
         }
     }

--- a/modules/system/resource-group/resource-group-sdk/src/gts.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/gts.rs
@@ -1,0 +1,50 @@
+// Created: 2026-04-16 by Constructor Tech
+//! GTS schema definitions for the Resource Group type system.
+
+use gts_macros::struct_to_gts_schema;
+
+/// GTS base type schema for Resource Group types.
+///
+/// Defines the `x-gts-traits-schema` contract: `can_be_root`, `is_tenant`,
+/// `allowed_parent_types`, `allowed_membership_types`.
+///
+/// All chained RG types (tenant, department, branch, etc.) inherit from this
+/// base contract via `allOf` + `$ref`.
+///
+/// # TODO: replace manual DTOs when `gts-macros` supports `x-gts-traits-schema`
+///
+/// Currently `gts-macros` (`struct_to_gts_schema`) does not generate
+/// `x-gts-traits-schema` in the output JSON Schema. Once it does, this struct
+/// should replace:
+/// - `models::ResourceGroupType` (response DTO)
+/// - `models::CreateTypeRequest` (create request DTO)
+/// - `models::UpdateTypeRequest` (update request DTO)
+///
+/// Blockers: `gts-macros` needs camelCase serde support, `x-gts-traits-schema`
+/// generation, `metadata_schema` field support, and `Clone`/`Debug`/`Default`
+/// derives.
+///
+/// # Schema ID
+///
+/// ```text
+/// gts.cf.core.rg.type.v1~
+/// ```
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.cf.core.rg.type.v1~",
+    description = "Resource Group base type — defines placement and tenant scope traits",
+    properties = "id,can_be_root,is_tenant,allowed_parent_types,allowed_membership_types"
+)]
+pub struct ResourceGroupTypeV1 {
+    /// GTS type path (schema identifier).
+    pub id: gts::GtsInstanceId,
+    /// Whether groups of this type can be root nodes (no parent). Default `false`.
+    pub can_be_root: bool,
+    /// Whether instances create their own tenant scope (`tenant_id = group.id`). Default `false`.
+    pub is_tenant: bool,
+    /// GTS type paths of allowed parent types.
+    pub allowed_parent_types: Vec<String>,
+    /// GTS type paths of allowed membership resource types.
+    pub allowed_membership_types: Vec<String>,
+}

--- a/modules/system/resource-group/resource-group-sdk/src/lib.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/lib.rs
@@ -1,0 +1,29 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+//! Resource Group SDK
+//!
+//! This crate provides the public API for the `resource-group` module:
+//! - `ResourceGroupClient` trait
+//! - Model types for GTS types, groups, memberships
+//! - Error type (`ResourceGroupError`)
+//! - `OData` filter field definitions (behind `odata` feature)
+
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+
+pub mod api;
+pub mod error;
+pub mod models;
+
+// OData filter field definitions (feature-gated)
+#[cfg(feature = "odata")]
+pub mod odata;
+
+// Re-export main types at crate root for convenience
+pub use api::{ResourceGroupClient, ResourceGroupReadHierarchy, ResourceGroupReadPluginClient};
+pub use error::ResourceGroupError;
+pub use models::{
+    CreateGroupRequest, CreateTypeRequest, GroupHierarchy, GroupHierarchyWithDepth, GtsTypePath,
+    PatchGroupRequest, ResourceGroup, ResourceGroupMembership, ResourceGroupType,
+    ResourceGroupWithDepth, UpdateGroupRequest, UpdateTypeRequest,
+};

--- a/modules/system/resource-group/resource-group-sdk/src/lib.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/lib.rs
@@ -20,7 +20,7 @@ pub mod models;
 pub mod odata;
 
 // Re-export main types at crate root for convenience
-pub use api::{ResourceGroupClient, ResourceGroupReadHierarchy, ResourceGroupReadPluginClient};
+pub use api::{ResourceGroupClient, ResourceGroupReadHierarchy};
 pub use error::ResourceGroupError;
 pub use models::{
     CreateGroupRequest, CreateTypeRequest, GroupHierarchy, GroupHierarchyWithDepth, GtsTypePath,

--- a/modules/system/resource-group/resource-group-sdk/src/lib.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod api;
 pub mod error;
+pub mod gts;
 pub mod models;
 
 // OData filter field definitions (feature-gated)
@@ -24,6 +25,6 @@ pub use api::{ResourceGroupClient, ResourceGroupReadHierarchy};
 pub use error::ResourceGroupError;
 pub use models::{
     CreateGroupRequest, CreateTypeRequest, GroupHierarchy, GroupHierarchyWithDepth, GtsTypePath,
-    PatchGroupRequest, ResourceGroup, ResourceGroupMembership, ResourceGroupType,
-    ResourceGroupWithDepth, UpdateGroupRequest, UpdateTypeRequest,
+    ResourceGroup, ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth,
+    UpdateGroupRequest, UpdateTypeRequest,
 };

--- a/modules/system/resource-group/resource-group-sdk/src/models.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/models.rs
@@ -1,0 +1,352 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-begin:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1:inst-full
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1
+//! SDK model types for the resource-group module.
+//!
+//! These types form the public contract between the resource-group module
+//! and its consumers. They are transport-agnostic and use string-based
+//! GTS type paths (no surrogate SMALLINT IDs).
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// -- GtsTypePath value object --
+
+// @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-1
+/// Maximum length of a GTS type path.
+const GTS_TYPE_PATH_MAX_LEN: usize = 1024;
+
+/// Validated GTS type path value object.
+///
+/// A GTS type path follows the pattern `gts.<segment>~(<segment>~)*` where
+/// each segment consists of lowercase alphanumeric characters, underscores,
+/// and dots. Examples: `gts.cf.core.rg.type.v1~`, `gts.cf.core.rg.type.v1~x.system.tn.tenant.v1~`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct GtsTypePath(String);
+
+impl GtsTypePath {
+    /// Create a new `GtsTypePath` from a raw string, applying validation.
+    ///
+    /// # Errors
+    /// Returns an error if the string is empty, exceeds 1024 characters,
+    /// or does not match the GTS type path format.
+    pub fn new(raw: impl Into<String>) -> Result<Self, String> {
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-2
+        let raw = raw.into();
+        let s = raw.trim().to_lowercase();
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-2
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3
+        if s.is_empty() {
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3a
+            return Err("GTS type path must not be empty".to_owned());
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3a
+        }
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5
+        if s.len() > GTS_TYPE_PATH_MAX_LEN {
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5a
+            return Err("GTS type path exceeds maximum length".to_owned());
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5a
+        }
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4
+        // Validate format using the canonical gts crate parser.
+        // Each tilde-separated segment must be a valid GTS ID with 5+ tokens
+        // (vendor.package.namespace.type.vMAJOR).
+        if gts::GtsID::new(&s).is_err() {
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4a
+            return Err("Invalid GTS type path format".to_owned());
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4a
+        }
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-6
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-7
+        Ok(Self(s))
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-7
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-6
+    }
+
+    /// Return the inner string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for GtsTypePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<GtsTypePath> for String {
+    fn from(p: GtsTypePath) -> Self {
+        p.0
+    }
+}
+
+impl TryFrom<String> for GtsTypePath {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::new(s)
+    }
+}
+
+impl AsRef<str> for GtsTypePath {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+// @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-1
+
+// -- Type --
+
+/// A GTS resource group type definition.
+///
+/// Matches the REST `Type` schema. All references use string GTS type paths;
+/// surrogate SMALLINT IDs are internal to the persistence layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroupType {
+    /// GTS type path (e.g. `gts.cf.core.rg.type.v1~x.system.tn.tenant.v1~`)
+    pub code: String,
+    /// Whether groups of this type can be root nodes (no parent).
+    pub can_be_root: bool,
+    /// GTS type paths of types allowed as parents.
+    pub allowed_parents: Vec<String>,
+    /// GTS type paths of resource types allowed as members.
+    pub allowed_memberships: Vec<String>,
+    /// Optional JSON Schema for the metadata object of instances of this type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+/// Request body for creating a new GTS type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateTypeRequest {
+    /// GTS type path. Must have prefix `gts.cf.core.rg.type.v1~`.
+    pub code: String,
+    /// Whether groups of this type can be root nodes.
+    pub can_be_root: bool,
+    /// GTS type paths of allowed parent types.
+    #[serde(default)]
+    pub allowed_parents: Vec<String>,
+    /// GTS type paths of allowed membership resource types.
+    #[serde(default)]
+    pub allowed_memberships: Vec<String>,
+    /// Optional JSON Schema for instance metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+/// Request body for updating an existing GTS type (full replacement via PUT).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateTypeRequest {
+    /// Whether groups of this type can be root nodes.
+    pub can_be_root: bool,
+    /// GTS type paths of allowed parent types.
+    #[serde(default)]
+    pub allowed_parents: Vec<String>,
+    /// GTS type paths of allowed membership resource types.
+    #[serde(default)]
+    pub allowed_memberships: Vec<String>,
+    /// Optional JSON Schema for instance metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+// -- Group --
+
+/// Hierarchy context for a resource group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupHierarchy {
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Tenant scope.
+    pub tenant_id: Uuid,
+}
+
+/// Hierarchy context for a resource group with depth information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupHierarchyWithDepth {
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Tenant scope.
+    pub tenant_id: Uuid,
+    /// Relative distance from reference group.
+    pub depth: i32,
+}
+
+/// A resource group entity.
+///
+/// Group responses do NOT include `created_at`/`updated_at` (per DESIGN).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroup {
+    /// Group identifier.
+    pub id: Uuid,
+    /// GTS chained type path.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name.
+    pub name: String,
+    /// Hierarchy context.
+    pub hierarchy: GroupHierarchy,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// A resource group entity with depth information (for hierarchy queries).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroupWithDepth {
+    /// Group identifier.
+    pub id: Uuid,
+    /// GTS chained type path.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name.
+    pub name: String,
+    /// Hierarchy context with depth.
+    pub hierarchy: GroupHierarchyWithDepth,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Request body for creating a new resource group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateGroupRequest {
+    /// Optional caller-supplied ID (used by seeding for stable identity).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Uuid>,
+    /// GTS chained type path. Must have prefix `gts.cf.core.rg.type.v1~`.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name (1..255 characters).
+    pub name: String,
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Request body for updating a resource group (full replacement via PUT).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateGroupRequest {
+    /// GTS chained type path. Must have prefix `gts.cf.core.rg.type.v1~`.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name (1..255 characters).
+    pub name: String,
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Serde helper for `Option<Option<T>>` that distinguishes absent, null, and present values.
+///
+/// - `None` (absent): field is skipped (use `skip_serializing_if = "Option::is_none"`)
+/// - `Some(None)` (null): serializes as `null`
+/// - `Some(Some(v))` (present): serializes as the inner value
+#[allow(clippy::option_option, clippy::missing_errors_doc, clippy::ref_option)]
+pub mod option_option {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+    where
+        T: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        Ok(Some(Option::<T>::deserialize(deserializer)?))
+    }
+
+    pub fn serialize<T, S>(value: &Option<Option<T>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Serialize,
+        S: Serializer,
+    {
+        match value {
+            Some(Some(inner)) => inner.serialize(serializer),
+            Some(None) => serializer.serialize_none(),
+            None => unreachable!("field should be skipped by skip_serializing_if"),
+        }
+    }
+}
+
+/// Request body for patching a resource group (partial update via PATCH).
+///
+/// Fields not present in the request body are left unchanged. Fields set to
+/// `null` clear the value. Fields with a value update it.
+///
+/// Serialization semantics:
+/// - `name: None` → field omitted (leave unchanged)
+/// - `name: Some("x")` → `"name":"x"` (update to new value)
+/// - `parent_id: None` → field omitted (leave unchanged)
+/// - `parent_id: Some(None)` → `"parentId":null` (clear parent)
+/// - `parent_id: Some(Some(id))` → `"parentId":"<uuid>"` (set new parent)
+/// - Same tri-state semantics apply to `metadata`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(clippy::option_option)]
+pub struct PatchGroupRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "option_option::serialize",
+        deserialize_with = "option_option::deserialize"
+    )]
+    pub parent_id: Option<Option<Uuid>>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "option_option::serialize",
+        deserialize_with = "option_option::deserialize"
+    )]
+    pub metadata: Option<Option<serde_json::Value>>,
+}
+
+// -- Membership --
+
+/// A membership link between a resource and a group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroupMembership {
+    /// Group this resource belongs to.
+    pub group_id: Uuid,
+    /// GTS type path of the resource.
+    pub resource_type: String,
+    /// External resource identifier.
+    pub resource_id: String,
+}
+
+// @cpt-dod:cpt-cf-resource-group-dod-testing-sdk-models:p1
+#[cfg(test)]
+#[path = "models_tests.rs"]
+mod models_tests;
+
+// @cpt-end:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1:inst-full

--- a/modules/system/resource-group/resource-group-sdk/src/models.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/models.rs
@@ -199,9 +199,9 @@ pub struct GroupHierarchyWithDepth {
 pub struct ResourceGroup {
     /// Group identifier.
     pub id: Uuid,
-    /// GTS chained type path.
+    /// GTS chained type code (e.g. `gts.cf.core.rg.type.v1~x.system.tn.tenant.v1~`).
     #[serde(rename = "type")]
-    pub type_path: String,
+    pub code: String,
     /// Display name.
     pub name: String,
     /// Hierarchy context.
@@ -217,9 +217,9 @@ pub struct ResourceGroup {
 pub struct ResourceGroupWithDepth {
     /// Group identifier.
     pub id: Uuid,
-    /// GTS chained type path.
+    /// GTS chained type code (e.g. `gts.cf.core.rg.type.v1~x.system.tn.tenant.v1~`).
     #[serde(rename = "type")]
-    pub type_path: String,
+    pub code: String,
     /// Display name.
     pub name: String,
     /// Hierarchy context with depth.
@@ -236,9 +236,9 @@ pub struct CreateGroupRequest {
     /// Optional caller-supplied ID (used by seeding for stable identity).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Uuid>,
-    /// GTS chained type path. Must have prefix `gts.cf.core.rg.type.v1~`.
+    /// GTS chained type code. Must have prefix `gts.cf.core.rg.type.v1~`.
     #[serde(rename = "type")]
-    pub type_path: String,
+    pub code: String,
     /// Display name (1..255 characters).
     pub name: String,
     /// Parent group ID (null for root groups).
@@ -253,9 +253,9 @@ pub struct CreateGroupRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateGroupRequest {
-    /// GTS chained type path. Must have prefix `gts.cf.core.rg.type.v1~`.
+    /// GTS chained type code. Must have prefix `gts.cf.core.rg.type.v1~`.
     #[serde(rename = "type")]
-    pub type_path: String,
+    pub code: String,
     /// Display name (1..255 characters).
     pub name: String,
     /// Parent group ID (null for root groups).

--- a/modules/system/resource-group/resource-group-sdk/src/models.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/models.rs
@@ -113,53 +113,62 @@ impl AsRef<str> for GtsTypePath {
 ///
 /// Matches the REST `Type` schema. All references use string GTS type paths;
 /// surrogate SMALLINT IDs are internal to the persistence layer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceGroupType {
     /// GTS type path (e.g. `gts.cf.core.rg.type.v1~x.system.tn.tenant.v1~`)
     pub code: String,
     /// Whether groups of this type can be root nodes (no parent).
     pub can_be_root: bool,
+    /// Whether instances create their own tenant scope (`tenant_id = group.id`).
+    #[serde(default)]
+    pub is_tenant: bool,
     /// GTS type paths of types allowed as parents.
-    pub allowed_parents: Vec<String>,
+    pub allowed_parent_types: Vec<String>,
     /// GTS type paths of resource types allowed as members.
-    pub allowed_memberships: Vec<String>,
+    pub allowed_membership_types: Vec<String>,
     /// Optional JSON Schema for the metadata object of instances of this type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata_schema: Option<serde_json::Value>,
 }
 
 /// Request body for creating a new GTS type.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateTypeRequest {
     /// GTS type path. Must have prefix `gts.cf.core.rg.type.v1~`.
     pub code: String,
     /// Whether groups of this type can be root nodes.
     pub can_be_root: bool,
+    /// Whether instances create their own tenant scope. Default `false`.
+    #[serde(default)]
+    pub is_tenant: bool,
     /// GTS type paths of allowed parent types.
     #[serde(default)]
-    pub allowed_parents: Vec<String>,
+    pub allowed_parent_types: Vec<String>,
     /// GTS type paths of allowed membership resource types.
     #[serde(default)]
-    pub allowed_memberships: Vec<String>,
+    pub allowed_membership_types: Vec<String>,
     /// Optional JSON Schema for instance metadata.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata_schema: Option<serde_json::Value>,
 }
 
 /// Request body for updating an existing GTS type (full replacement via PUT).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateTypeRequest {
     /// Whether groups of this type can be root nodes.
     pub can_be_root: bool,
+    /// Whether instances create their own tenant scope. Default `false`.
+    #[serde(default)]
+    pub is_tenant: bool,
     /// GTS type paths of allowed parent types.
     #[serde(default)]
-    pub allowed_parents: Vec<String>,
+    pub allowed_parent_types: Vec<String>,
     /// GTS type paths of allowed membership resource types.
     #[serde(default)]
-    pub allowed_memberships: Vec<String>,
+    pub allowed_membership_types: Vec<String>,
     /// Optional JSON Schema for instance metadata.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata_schema: Option<serde_json::Value>,
@@ -264,70 +273,6 @@ pub struct UpdateGroupRequest {
     /// Type-specific metadata.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
-}
-
-/// Serde helper for `Option<Option<T>>` that distinguishes absent, null, and present values.
-///
-/// - `None` (absent): field is skipped (use `skip_serializing_if = "Option::is_none"`)
-/// - `Some(None)` (null): serializes as `null`
-/// - `Some(Some(v))` (present): serializes as the inner value
-#[allow(clippy::option_option, clippy::missing_errors_doc, clippy::ref_option)]
-pub mod option_option {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
-    where
-        T: Deserialize<'de>,
-        D: Deserializer<'de>,
-    {
-        Ok(Some(Option::<T>::deserialize(deserializer)?))
-    }
-
-    pub fn serialize<T, S>(value: &Option<Option<T>>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        T: Serialize,
-        S: Serializer,
-    {
-        match value {
-            Some(Some(inner)) => inner.serialize(serializer),
-            Some(None) => serializer.serialize_none(),
-            None => unreachable!("field should be skipped by skip_serializing_if"),
-        }
-    }
-}
-
-/// Request body for patching a resource group (partial update via PATCH).
-///
-/// Fields not present in the request body are left unchanged. Fields set to
-/// `null` clear the value. Fields with a value update it.
-///
-/// Serialization semantics:
-/// - `name: None` → field omitted (leave unchanged)
-/// - `name: Some("x")` → `"name":"x"` (update to new value)
-/// - `parent_id: None` → field omitted (leave unchanged)
-/// - `parent_id: Some(None)` → `"parentId":null` (clear parent)
-/// - `parent_id: Some(Some(id))` → `"parentId":"<uuid>"` (set new parent)
-/// - Same tri-state semantics apply to `metadata`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[allow(clippy::option_option)]
-pub struct PatchGroupRequest {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "option_option::serialize",
-        deserialize_with = "option_option::deserialize"
-    )]
-    pub parent_id: Option<Option<Uuid>>,
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        serialize_with = "option_option::serialize",
-        deserialize_with = "option_option::deserialize"
-    )]
-    pub metadata: Option<Option<serde_json::Value>>,
 }
 
 // -- Membership --

--- a/modules/system/resource-group/resource-group-sdk/src/models_tests.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/models_tests.rs
@@ -1,0 +1,212 @@
+// Created: 2026-04-16 by Constructor Tech
+use super::*;
+
+// -- GtsTypePath: valid cases (table-driven) -- TC-SDK-01, 06, 07, 08, 19, 20
+
+#[test]
+fn gts_type_path_valid_cases() {
+    let valid = vec![
+        // TC-SDK-01: basic valid path
+        ("gts.cf.core.rg.type.v1~", "gts.cf.core.rg.type.v1~"),
+        // TC-SDK-06: uppercase is lowered
+        ("GTS.CF.CORE.RG.TYPE.V1~", "gts.cf.core.rg.type.v1~"),
+        // TC-SDK-07: trimmed + lowered
+        ("  GTS.CF.CORE.RG.TYPE.V1~  ", "gts.cf.core.rg.type.v1~"),
+        // TC-SDK-08: multi-segment
+        (
+            "gts.cf.core.rg.type.v1~x.test.unit.root.v1~",
+            "gts.cf.core.rg.type.v1~x.test.unit.root.v1~",
+        ),
+        // TC-SDK-19: numeric version in segment
+        ("gts.cf.core.rg.type.v2~", "gts.cf.core.rg.type.v2~"),
+        // TC-SDK-20: underscores in segments
+        ("gts.cf.core.rg.my_type.v1~", "gts.cf.core.rg.my_type.v1~"),
+    ];
+    for (input, expected) in valid {
+        let path = GtsTypePath::new(input);
+        assert!(path.is_ok(), "should be valid: {input}");
+        assert_eq!(path.unwrap().as_str(), expected, "for input: {input}");
+    }
+}
+
+// -- GtsTypePath: invalid cases (table-driven) -- TC-SDK-02..05, 09, 10, 18, 21
+
+#[test]
+fn gts_type_path_invalid_cases() {
+    let cases = vec![
+        // TC-SDK-02: empty
+        ("", "must not be empty"),
+        // TC-SDK-04: wrong prefix
+        ("invalid.path~", "Invalid GTS type path format"),
+        // TC-SDK-05: no trailing tilde
+        ("gts.cf.core.rg.type.v1", "Invalid GTS type path format"),
+        // TC-SDK-09: double tilde
+        ("gts.cf.core.rg.type.v1~~", "Invalid GTS type path format"),
+        // TC-SDK-10: hyphen in segment
+        (
+            "gts.cf.core.rg.type.v1~hello-world~",
+            "Invalid GTS type path format",
+        ),
+        // TC-SDK-18: empty segment after gts.
+        ("gts.~", "Invalid GTS type path format"),
+        // TC-SDK-21: whitespace-only
+        ("   ", "must not be empty"),
+    ];
+    for (input, expected_msg) in cases {
+        let result = GtsTypePath::new(input);
+        assert!(result.is_err(), "should be invalid: '{input}'");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains(expected_msg),
+            "for input '{input}': expected '{expected_msg}' in error, got: {err}"
+        );
+    }
+}
+
+// -- GtsTypePath: length boundary tests -- TC-SDK-03, 22, 23
+
+#[test]
+#[allow(unknown_lints, de0901_gts_string_pattern)]
+fn gts_type_path_max_length_boundary() {
+    // TC-SDK-22: exactly 1024 chars -> Ok
+    // Base: "gts.cf.core.rg.type.v1~" = 24 chars.
+    // Pad the type name to fill remaining: 1024 - 24 = 1000 chars in first segment.
+    // "gts.cf.core.rg." (15) + padded_name + ".v1~" (4) = 1024
+    // padded_name = 1024 - 15 - 4 = 1005 chars
+    let name = "a".repeat(1005);
+    let path_1024 = format!("gts.cf.core.rg.{name}.v1~");
+    assert_eq!(path_1024.len(), 1024);
+    assert!(
+        GtsTypePath::new(&path_1024).is_ok(),
+        "exactly 1024 chars should be valid: {:?}",
+        GtsTypePath::new(&path_1024)
+    );
+
+    // TC-SDK-23: > 1024 chars -> Err (exceeds max length)
+    let name_long = "a".repeat(1006);
+    let path_1025 = format!("gts.cf.core.rg.{name_long}.v1~");
+    assert_eq!(path_1025.len(), 1025);
+    let result = GtsTypePath::new(&path_1025);
+    assert!(result.is_err(), "1025 chars should exceed max length");
+    assert!(result.unwrap_err().contains("exceeds maximum length"));
+}
+
+// -- GtsTypePath: serde round-trip -- TC-SDK-11, 12
+
+#[test]
+fn gts_type_path_serde_round_trip() {
+    // TC-SDK-11: serialize then deserialize
+    let original = GtsTypePath::new("gts.cf.core.rg.type.v1~").unwrap();
+    let json = serde_json::to_string(&original).unwrap();
+    let deserialized: GtsTypePath = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, deserialized);
+}
+
+#[test]
+fn gts_type_path_serde_invalid_rejects() {
+    // TC-SDK-12: invalid value during deserialization
+    let result = serde_json::from_str::<GtsTypePath>("\"invalid\"");
+    assert!(result.is_err(), "invalid path should fail deserialization");
+}
+
+// -- GtsTypePath: Display / Into<String> -- TC-SDK-13
+
+#[test]
+fn gts_type_path_display_and_into_string() {
+    let path = GtsTypePath::new("gts.cf.core.rg.type.v1~").unwrap();
+    let display = path.to_string();
+    let into_string: String = path.into();
+    assert_eq!(display, into_string);
+}
+
+// -- ResourceGroupType serialization -- TC-SDK-14
+
+#[test]
+fn resource_group_type_camel_case_keys() {
+    let rgt = ResourceGroupType {
+        code: "gts.cf.core.rg.type.v1~".to_owned(),
+        can_be_root: true,
+        allowed_parents: vec!["gts.parent~".to_owned()],
+        allowed_memberships: vec!["gts.member~".to_owned()],
+        metadata_schema: None,
+    };
+    let json = serde_json::to_value(&rgt).unwrap();
+    assert!(
+        json.get("canBeRoot").is_some(),
+        "expected camelCase 'canBeRoot'"
+    );
+    assert!(
+        json.get("allowedParents").is_some(),
+        "expected camelCase 'allowedParents'"
+    );
+    assert!(
+        json.get("allowedMemberships").is_some(),
+        "expected camelCase 'allowedMemberships'"
+    );
+    assert!(
+        json.get("metadataSchema").is_none(),
+        "metadataSchema should be absent when None"
+    );
+}
+
+// -- ResourceGroup serialization -- TC-SDK-15, 16
+
+#[test]
+fn resource_group_type_field_renamed() {
+    // TC-SDK-15: "type" not "type_path"
+    let group = ResourceGroup {
+        id: Uuid::nil(),
+        type_path: "gts.cf.core.rg.type.v1~".to_owned(),
+        name: "Test".to_owned(),
+        hierarchy: GroupHierarchy {
+            parent_id: None,
+            tenant_id: Uuid::nil(),
+        },
+        metadata: Some(serde_json::json!({"key": "val"})),
+    };
+    let json = serde_json::to_value(&group).unwrap();
+    assert!(
+        json.get("type").is_some(),
+        "expected 'type' key, not 'type_path'"
+    );
+    assert!(
+        json.get("type_path").is_none(),
+        "'type_path' should not appear in JSON"
+    );
+}
+
+#[test]
+fn resource_group_metadata_absent_when_none() {
+    // TC-SDK-16: metadata: None -> no "metadata" key
+    let group = ResourceGroup {
+        id: Uuid::nil(),
+        type_path: "gts.cf.core.rg.type.v1~".to_owned(),
+        name: "Test".to_owned(),
+        hierarchy: GroupHierarchy {
+            parent_id: None,
+            tenant_id: Uuid::nil(),
+        },
+        metadata: None,
+    };
+    let json = serde_json::to_value(&group).unwrap();
+    assert!(
+        json.get("metadata").is_none(),
+        "metadata should be absent when None, got: {json}"
+    );
+}
+
+// -- GtsTypePath normalization -- TC-SDK-24
+
+#[test]
+fn gts_type_path_trims_and_lowercases() {
+    // TC-SDK-24: GtsTypePath::new trims whitespace and lowercases.
+    // validate_type_code (in the domain crate) also trims and lowercases,
+    // ensuring consistent normalization across SDK and domain layers.
+    let input = "  GTS.CF.CORE.RG.TYPE.V1~  ";
+    let path = GtsTypePath::new(input);
+    assert!(
+        path.is_ok(),
+        "GtsTypePath::new should accept trimmed/lowered input"
+    );
+    assert_eq!(path.unwrap().as_str(), "gts.cf.core.rg.type.v1~");
+}

--- a/modules/system/resource-group/resource-group-sdk/src/models_tests.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/models_tests.rs
@@ -126,9 +126,10 @@ fn resource_group_type_camel_case_keys() {
     let rgt = ResourceGroupType {
         code: "gts.cf.core.rg.type.v1~".to_owned(),
         can_be_root: true,
-        allowed_parents: vec!["gts.parent~".to_owned()],
-        allowed_memberships: vec!["gts.member~".to_owned()],
+        allowed_parent_types: vec!["gts.parent~".to_owned()],
+        allowed_membership_types: vec!["gts.member~".to_owned()],
         metadata_schema: None,
+        ..Default::default()
     };
     let json = serde_json::to_value(&rgt).unwrap();
     assert!(
@@ -136,12 +137,12 @@ fn resource_group_type_camel_case_keys() {
         "expected camelCase 'canBeRoot'"
     );
     assert!(
-        json.get("allowedParents").is_some(),
-        "expected camelCase 'allowedParents'"
+        json.get("allowedParentTypes").is_some(),
+        "expected camelCase 'allowedParentTypes'"
     );
     assert!(
-        json.get("allowedMemberships").is_some(),
-        "expected camelCase 'allowedMemberships'"
+        json.get("allowedMembershipTypes").is_some(),
+        "expected camelCase 'allowedMembershipTypes'"
     );
     assert!(
         json.get("metadataSchema").is_none(),
@@ -171,7 +172,7 @@ fn resource_group_type_field_renamed() {
     );
     assert!(
         json.get("code").is_none(),
-        "'code' (Rust field name) must not leak to JSON — serde renames it to 'type'"
+        "'code' (Rust field name) must not leak to JSON -- serde renames it to 'type'"
     );
 }
 

--- a/modules/system/resource-group/resource-group-sdk/src/models_tests.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/models_tests.rs
@@ -153,10 +153,10 @@ fn resource_group_type_camel_case_keys() {
 
 #[test]
 fn resource_group_type_field_renamed() {
-    // TC-SDK-15: "type" not "type_path"
+    // TC-SDK-15: Rust field is `code`, serialized as JSON key `"type"`.
     let group = ResourceGroup {
         id: Uuid::nil(),
-        type_path: "gts.cf.core.rg.type.v1~".to_owned(),
+        code: "gts.cf.core.rg.type.v1~".to_owned(),
         name: "Test".to_owned(),
         hierarchy: GroupHierarchy {
             parent_id: None,
@@ -167,11 +167,11 @@ fn resource_group_type_field_renamed() {
     let json = serde_json::to_value(&group).unwrap();
     assert!(
         json.get("type").is_some(),
-        "expected 'type' key, not 'type_path'"
+        "expected 'type' key on the wire"
     );
     assert!(
-        json.get("type_path").is_none(),
-        "'type_path' should not appear in JSON"
+        json.get("code").is_none(),
+        "'code' (Rust field name) must not leak to JSON — serde renames it to 'type'"
     );
 }
 
@@ -180,7 +180,7 @@ fn resource_group_metadata_absent_when_none() {
     // TC-SDK-16: metadata: None -> no "metadata" key
     let group = ResourceGroup {
         id: Uuid::nil(),
-        type_path: "gts.cf.core.rg.type.v1~".to_owned(),
+        code: "gts.cf.core.rg.type.v1~".to_owned(),
         name: "Test".to_owned(),
         hierarchy: GroupHierarchy {
             parent_id: None,

--- a/modules/system/resource-group/resource-group-sdk/src/odata/groups.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/groups.rs
@@ -1,0 +1,51 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for resource group entities.
+//!
+//! Group list `$filter` fields: `type` (eq, ne, in), `hierarchy/parent_id` (eq, ne, in),
+//! `id` (eq, ne, in), `name` (eq, ne, in).
+//!
+//! The `hierarchy/parent_id` field uses `OData` nested path syntax; since the
+//! `ODataFilterable` derive macro does not support slash-separated names,
+//! the `FilterField` trait is implemented manually.
+
+use modkit_odata::filter::{FieldKind, FilterField};
+
+/// Filter field enum for group list queries.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum GroupFilterField {
+    /// Filter by GTS type path.
+    Type,
+    /// Filter by parent group ID (direct parent only).
+    HierarchyParentId,
+    /// Filter by group ID.
+    Id,
+    /// Filter by group name.
+    Name,
+}
+
+impl FilterField for GroupFilterField {
+    const FIELDS: &'static [Self] = &[Self::Type, Self::HierarchyParentId, Self::Id, Self::Name];
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Type => "type",
+            Self::HierarchyParentId => "hierarchy/parent_id",
+            Self::Id => "id",
+            Self::Name => "name",
+        }
+    }
+
+    fn kind(&self) -> FieldKind {
+        match self {
+            // Type is a GTS type path string in the public API; the persistence
+            // layer resolves string paths to SMALLINT IDs after OData parsing.
+            Self::Type | Self::Name => FieldKind::String,
+            Self::HierarchyParentId | Self::Id => FieldKind::Uuid,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "groups_tests.rs"]
+mod groups_tests;

--- a/modules/system/resource-group/resource-group-sdk/src/odata/groups.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/groups.rs
@@ -39,7 +39,7 @@ impl FilterField for GroupFilterField {
     fn kind(&self) -> FieldKind {
         match self {
             // Type is a GTS type path string in the public API; the persistence
-            // layer resolves string paths to SMALLINT IDs after OData parsing.
+            // layer resolves string paths to SMALLINT IDs after OData validation.
             Self::Type | Self::Name => FieldKind::String,
             Self::HierarchyParentId | Self::Id => FieldKind::Uuid,
         }

--- a/modules/system/resource-group/resource-group-sdk/src/odata/groups_tests.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/groups_tests.rs
@@ -1,0 +1,29 @@
+// Created: 2026-04-16 by Constructor Tech
+use super::*;
+
+// TC-ODATA-01: GroupFilterField names
+#[test]
+fn group_filter_field_names_correct() {
+    assert_eq!(GroupFilterField::Type.name(), "type");
+    assert_eq!(
+        GroupFilterField::HierarchyParentId.name(),
+        "hierarchy/parent_id"
+    );
+    assert_eq!(GroupFilterField::Id.name(), "id");
+    assert_eq!(GroupFilterField::Name.name(), "name");
+}
+
+// TC-ODATA-02: GroupFilterField kinds
+#[test]
+fn group_filter_field_kinds_correct() {
+    assert_eq!(GroupFilterField::Type.kind(), FieldKind::String);
+    assert_eq!(GroupFilterField::HierarchyParentId.kind(), FieldKind::Uuid);
+    assert_eq!(GroupFilterField::Id.kind(), FieldKind::Uuid);
+    assert_eq!(GroupFilterField::Name.kind(), FieldKind::String);
+}
+
+// TC-ODATA-03: FIELDS completeness
+#[test]
+fn group_filter_field_completeness() {
+    assert_eq!(GroupFilterField::FIELDS.len(), 4);
+}

--- a/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy.rs
@@ -1,0 +1,41 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for group hierarchy queries.
+//!
+//! Hierarchy `$filter` fields: `hierarchy/depth` (eq, ne, gt, ge, lt, le),
+//! `type` (eq, ne, in).
+
+use modkit_odata::filter::{FieldKind, FilterField};
+
+/// Filter field enum for group hierarchy queries.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum HierarchyFilterField {
+    /// Filter by relative depth from reference group.
+    HierarchyDepth,
+    /// Filter by GTS type path.
+    Type,
+}
+
+impl FilterField for HierarchyFilterField {
+    const FIELDS: &'static [Self] = &[Self::HierarchyDepth, Self::Type];
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::HierarchyDepth => "hierarchy/depth",
+            Self::Type => "type",
+        }
+    }
+
+    fn kind(&self) -> FieldKind {
+        match self {
+            Self::HierarchyDepth => FieldKind::I64,
+            // Type is a GTS type path string in the public API; the persistence
+            // layer resolves string paths to SMALLINT IDs after OData parsing.
+            Self::Type => FieldKind::String,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "hierarchy_tests.rs"]
+mod hierarchy_tests;

--- a/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy.rs
@@ -30,7 +30,7 @@ impl FilterField for HierarchyFilterField {
         match self {
             Self::HierarchyDepth => FieldKind::I64,
             // Type is a GTS type path string in the public API; the persistence
-            // layer resolves string paths to SMALLINT IDs after OData parsing.
+            // layer resolves string paths to SMALLINT IDs after OData validation.
             Self::Type => FieldKind::String,
         }
     }

--- a/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy_tests.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy_tests.rs
@@ -1,0 +1,17 @@
+// Created: 2026-04-16 by Constructor Tech
+use super::*;
+
+// TC-ODATA-04: HierarchyFilterField names + kinds
+#[test]
+fn hierarchy_filter_field_names_and_kinds() {
+    assert_eq!(
+        HierarchyFilterField::HierarchyDepth.name(),
+        "hierarchy/depth"
+    );
+    assert_eq!(HierarchyFilterField::HierarchyDepth.kind(), FieldKind::I64);
+
+    assert_eq!(HierarchyFilterField::Type.name(), "type");
+    assert_eq!(HierarchyFilterField::Type.kind(), FieldKind::String);
+
+    assert_eq!(HierarchyFilterField::FIELDS.len(), 2);
+}

--- a/modules/system/resource-group/resource-group-sdk/src/odata/memberships.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/memberships.rs
@@ -1,0 +1,42 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for membership entities.
+//!
+//! Membership list `$filter` fields: `group_id` (eq, ne, in), `resource_type` (eq, ne, in),
+//! `resource_id` (eq, ne, in).
+
+use modkit_odata::filter::{FieldKind, FilterField};
+
+/// Filter field enum for membership list queries.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum MembershipFilterField {
+    /// Filter by group ID.
+    GroupId,
+    /// Filter by resource type (GTS type path).
+    ResourceType,
+    /// Filter by resource ID.
+    ResourceId,
+}
+
+impl FilterField for MembershipFilterField {
+    const FIELDS: &'static [Self] = &[Self::GroupId, Self::ResourceType, Self::ResourceId];
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::GroupId => "group_id",
+            Self::ResourceType => "resource_type",
+            Self::ResourceId => "resource_id",
+        }
+    }
+
+    fn kind(&self) -> FieldKind {
+        match self {
+            Self::GroupId => FieldKind::Uuid,
+            Self::ResourceType | Self::ResourceId => FieldKind::String,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "memberships_tests.rs"]
+mod memberships_tests;

--- a/modules/system/resource-group/resource-group-sdk/src/odata/memberships_tests.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/memberships_tests.rs
@@ -1,0 +1,20 @@
+// Created: 2026-04-16 by Constructor Tech
+use super::*;
+
+// TC-ODATA-05: MembershipFilterField names + kinds
+#[test]
+fn membership_filter_field_names_and_kinds() {
+    assert_eq!(MembershipFilterField::GroupId.name(), "group_id");
+    assert_eq!(MembershipFilterField::GroupId.kind(), FieldKind::Uuid);
+
+    assert_eq!(MembershipFilterField::ResourceType.name(), "resource_type");
+    assert_eq!(
+        MembershipFilterField::ResourceType.kind(),
+        FieldKind::String
+    );
+
+    assert_eq!(MembershipFilterField::ResourceId.name(), "resource_id");
+    assert_eq!(MembershipFilterField::ResourceId.kind(), FieldKind::String);
+
+    assert_eq!(MembershipFilterField::FIELDS.len(), 3);
+}

--- a/modules/system/resource-group/resource-group-sdk/src/odata/mod.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/mod.rs
@@ -1,0 +1,13 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for resource-group resources.
+
+mod groups;
+mod hierarchy;
+mod memberships;
+mod types;
+
+pub use groups::GroupFilterField;
+pub use hierarchy::HierarchyFilterField;
+pub use memberships::MembershipFilterField;
+pub use types::{TypeFilterField, TypeQuery, TypeQueryFilterField};

--- a/modules/system/resource-group/resource-group-sdk/src/odata/types.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/types.rs
@@ -1,0 +1,18 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for GTS type resources.
+
+use modkit_odata_macros::ODataFilterable;
+
+/// Type filterable fields schema.
+///
+/// This struct defines which fields can be used in `OData` `$filter` queries
+/// for GTS type resources. The field names match the wire format.
+#[derive(ODataFilterable)]
+pub struct TypeQuery {
+    #[odata(filter(kind = "String"))]
+    pub code: String,
+}
+
+/// Type alias for the generated filter field enum.
+pub use TypeQueryFilterField as TypeFilterField;

--- a/modules/system/resource-group/resource-group/Cargo.toml
+++ b/modules/system/resource-group/resource-group/Cargo.toml
@@ -1,0 +1,70 @@
+# Created: 2026-04-16 by Constructor Tech
+[package]
+name = "cf-resource-group"
+version = "0.1.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Resource Group module: hierarchical resource group management with GTS type system"
+
+[lints]
+workspace = true
+
+[features]
+default = ["odata"]
+odata = []
+
+[dependencies]
+# SDK - public API, models, and errors
+resource-group-sdk = { package = "cf-resource-group-sdk", path = "../resource-group-sdk", features = ["odata"] }
+
+# Core dependencies
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+inventory = { workspace = true }
+
+# Serde and JSON schema
+serde = { workspace = true }
+serde_json = { workspace = true }
+jsonschema = { workspace = true }
+utoipa = { workspace = true, features = ["time"] }
+
+# HTTP and REST
+axum = { workspace = true, features = ["macros"] }
+http = { workspace = true }
+
+# Time handling
+time = { workspace = true }
+
+# UUID support
+uuid = { workspace = true }
+
+# Database - SeaORM
+sea-orm = { workspace = true }
+sea-orm-migration = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+
+# AuthZ
+authz-resolver-sdk = { workspace = true }
+
+# GTS type system — types registry for schema resolution
+types-registry-sdk = { workspace = true }
+
+# Local dependencies
+modkit = { workspace = true }
+modkit-db = { workspace = true, features = ["sqlite", "pg"] }
+modkit-db-macros = { workspace = true }
+modkit-security = { workspace = true }
+modkit-odata = { workspace = true, features = ["with-utoipa"] }
+modkit-macros = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+modkit-db = { workspace = true, features = ["sqlite"] }
+tower = { workspace = true }
+http-body-util = { workspace = true }

--- a/modules/system/resource-group/resource-group/src/domain/error.rs
+++ b/modules/system/resource-group/resource-group/src/domain/error.rs
@@ -1,0 +1,213 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1
+// @cpt-dod:cpt-cf-resource-group-dod-testing-error-conversions:p2
+//! Domain error types for the resource-group module.
+
+use authz_resolver_sdk::pep::EnforcerError;
+use resource_group_sdk::ResourceGroupError;
+use thiserror::Error;
+
+/// Domain-specific errors for the resource-group module.
+#[allow(unknown_lints, de0309_must_have_domain_model)]
+#[derive(Error, Debug)]
+pub enum DomainError {
+    #[error("Type not found: {code}")]
+    TypeNotFound { code: String },
+
+    #[error("Type already exists: {code}")]
+    TypeAlreadyExists { code: String },
+
+    #[error("Validation failed: {message}")]
+    Validation { message: String },
+
+    #[error("Allowed parents violation: {message}")]
+    AllowedParentsViolation { message: String },
+
+    #[error("Active references exist: {message}")]
+    ConflictActiveReferences { message: String },
+
+    #[error("Group not found: {id}")]
+    GroupNotFound { id: uuid::Uuid },
+
+    #[error("Membership not found: {key}")]
+    MembershipNotFound { key: String },
+
+    #[error("Invalid parent type: {message}")]
+    InvalidParentType { message: String },
+
+    #[error("Cycle detected: {message}")]
+    CycleDetected { message: String },
+
+    #[error("Limit violation: {message}")]
+    LimitViolation { message: String },
+
+    #[error("Conflict: {message}")]
+    Conflict { message: String },
+
+    #[error("Tenant incompatibility: {message}")]
+    TenantIncompatibility { message: String },
+
+    #[error("Access denied: {message}")]
+    AccessDenied { message: String },
+
+    #[error("Database error: {message}")]
+    Database { message: String },
+
+    #[error("Internal error")]
+    InternalError,
+}
+
+impl DomainError {
+    /// Returns `true` if this error represents a serialization failure
+    /// (SQLSTATE `40001`) that is safe to retry.
+    ///
+    /// Covers `PostgreSQL` `SERIALIZABLE` conflicts and `MySQL`/`MariaDB` deadlocks.
+    #[must_use]
+    pub fn is_serialization_failure(&self) -> bool {
+        match self {
+            DomainError::Database { message } => {
+                let msg = message.to_ascii_lowercase();
+                msg.contains("40001")
+                    || msg.contains("could not serialize access")
+                    || msg.contains("deadlock detected")
+                    || msg.contains("deadlock found when trying to get lock")
+            }
+            _ => false,
+        }
+    }
+
+    pub fn type_not_found(code: impl Into<String>) -> Self {
+        Self::TypeNotFound { code: code.into() }
+    }
+
+    pub fn type_already_exists(code: impl Into<String>) -> Self {
+        Self::TypeAlreadyExists { code: code.into() }
+    }
+
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self::Validation {
+            message: message.into(),
+        }
+    }
+
+    pub fn allowed_parents_violation(message: impl Into<String>) -> Self {
+        Self::AllowedParentsViolation {
+            message: message.into(),
+        }
+    }
+
+    pub fn conflict_active_references(message: impl Into<String>) -> Self {
+        Self::ConflictActiveReferences {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn group_not_found(id: uuid::Uuid) -> Self {
+        Self::GroupNotFound { id }
+    }
+
+    pub fn membership_not_found(key: impl Into<String>) -> Self {
+        Self::MembershipNotFound { key: key.into() }
+    }
+
+    pub fn invalid_parent_type(message: impl Into<String>) -> Self {
+        Self::InvalidParentType {
+            message: message.into(),
+        }
+    }
+
+    pub fn cycle_detected(message: impl Into<String>) -> Self {
+        Self::CycleDetected {
+            message: message.into(),
+        }
+    }
+
+    pub fn limit_violation(message: impl Into<String>) -> Self {
+        Self::LimitViolation {
+            message: message.into(),
+        }
+    }
+
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::Conflict {
+            message: message.into(),
+        }
+    }
+
+    pub fn tenant_incompatibility(message: impl Into<String>) -> Self {
+        Self::TenantIncompatibility {
+            message: message.into(),
+        }
+    }
+
+    pub fn database(message: impl Into<String>) -> Self {
+        Self::Database {
+            message: message.into(),
+        }
+    }
+}
+
+/// Convert domain errors to SDK errors for public API consumption.
+impl From<DomainError> for ResourceGroupError {
+    fn from(e: DomainError) -> Self {
+        match e {
+            DomainError::TypeNotFound { code } => ResourceGroupError::not_found(code),
+            DomainError::TypeAlreadyExists { code } => {
+                ResourceGroupError::type_already_exists(code)
+            }
+            DomainError::Validation { message } => ResourceGroupError::validation(message),
+            DomainError::InvalidParentType { message } => {
+                ResourceGroupError::invalid_parent_type(message)
+            }
+            DomainError::CycleDetected { message } => ResourceGroupError::cycle_detected(message),
+            DomainError::LimitViolation { message } => ResourceGroupError::limit_violation(message),
+            DomainError::AllowedParentsViolation { message } => {
+                ResourceGroupError::allowed_parents_violation(message)
+            }
+            DomainError::ConflictActiveReferences { message } => {
+                ResourceGroupError::conflict_active_references(message)
+            }
+            DomainError::Conflict { message } => ResourceGroupError::conflict(message),
+            DomainError::GroupNotFound { id } => ResourceGroupError::not_found(id.to_string()),
+            DomainError::MembershipNotFound { key } => ResourceGroupError::not_found(key),
+            DomainError::TenantIncompatibility { message } => {
+                ResourceGroupError::tenant_incompatibility(message)
+            }
+            DomainError::AccessDenied { .. } => ResourceGroupError::access_denied(),
+            DomainError::Database { .. } | DomainError::InternalError => {
+                ResourceGroupError::internal()
+            }
+        }
+    }
+}
+
+impl From<sea_orm::DbErr> for DomainError {
+    fn from(e: sea_orm::DbErr) -> Self {
+        DomainError::database(format!("{e}"))
+    }
+}
+
+impl From<modkit_db::DbError> for DomainError {
+    fn from(e: modkit_db::DbError) -> Self {
+        DomainError::database(format!("{e}"))
+    }
+}
+
+impl From<EnforcerError> for DomainError {
+    fn from(e: EnforcerError) -> Self {
+        match e {
+            EnforcerError::Denied { deny_reason } => DomainError::AccessDenied {
+                message: deny_reason.map_or_else(
+                    || "access denied by PDP".to_owned(),
+                    |reason| format!("access denied by PDP: {reason:?}"),
+                ),
+            },
+            // PDP RPC or constraint compilation failures are infrastructure problems,
+            // not authorization denials — surface as internal errors.
+            EnforcerError::EvaluationFailed(_) | EnforcerError::CompileFailed(_) => {
+                DomainError::InternalError
+            }
+        }
+    }
+}

--- a/modules/system/resource-group/resource-group/src/domain/error.rs
+++ b/modules/system/resource-group/resource-group/src/domain/error.rs
@@ -21,7 +21,7 @@ pub enum DomainError {
     Validation { message: String },
 
     #[error("Allowed parents violation: {message}")]
-    AllowedParentsViolation { message: String },
+    AllowedParentTypesViolation { message: String },
 
     #[error("Active references exist: {message}")]
     ConflictActiveReferences { message: String },
@@ -44,6 +44,12 @@ pub enum DomainError {
     #[error("Conflict: {message}")]
     Conflict { message: String },
 
+    /// Cross-tenant link rejected when adding a membership.
+    ///
+    /// Raised by `MembershipService::add_membership` when the target group's
+    /// tenant differs from the tenant of any existing membership for the same
+    /// `(resource_type, resource_id)` pair. A resource must belong to groups
+    /// of a single tenant.
     #[error("Tenant incompatibility: {message}")]
     TenantIncompatibility { message: String },
 
@@ -90,8 +96,8 @@ impl DomainError {
         }
     }
 
-    pub fn allowed_parents_violation(message: impl Into<String>) -> Self {
-        Self::AllowedParentsViolation {
+    pub fn allowed_parent_types_violation(message: impl Into<String>) -> Self {
+        Self::AllowedParentTypesViolation {
             message: message.into(),
         }
     }
@@ -162,8 +168,8 @@ impl From<DomainError> for ResourceGroupError {
             }
             DomainError::CycleDetected { message } => ResourceGroupError::cycle_detected(message),
             DomainError::LimitViolation { message } => ResourceGroupError::limit_violation(message),
-            DomainError::AllowedParentsViolation { message } => {
-                ResourceGroupError::allowed_parents_violation(message)
+            DomainError::AllowedParentTypesViolation { message } => {
+                ResourceGroupError::allowed_parent_types_violation(message)
             }
             DomainError::ConflictActiveReferences { message } => {
                 ResourceGroupError::conflict_active_references(message)

--- a/modules/system/resource-group/resource-group/src/domain/mod.rs
+++ b/modules/system/resource-group/resource-group/src/domain/mod.rs
@@ -1,0 +1,8 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+#![allow(unknown_lints)]
+#![allow(de0301_no_infra_in_domain)]
+
+pub mod error;
+pub mod repo;
+pub mod validation;

--- a/modules/system/resource-group/resource-group/src/domain/repo.rs
+++ b/modules/system/resource-group/resource-group/src/domain/repo.rs
@@ -1,0 +1,286 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-traits:p1
+use async_trait::async_trait;
+use modkit_db::secure::DBRunner;
+use modkit_odata::{ODataQuery, Page};
+use modkit_security::AccessScope;
+use resource_group_sdk::models::{
+    ResourceGroup, ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth,
+};
+use uuid::Uuid;
+
+use crate::domain::error::DomainError;
+use crate::infra::storage::entity::{
+    gts_type, resource_group as rg_entity, resource_group_membership as membership_entity,
+};
+
+#[async_trait]
+#[allow(clippy::too_many_arguments)]
+pub trait GroupRepositoryTrait: Send + Sync + 'static {
+    // -- Read operations --
+
+    async fn find_by_id<C: DBRunner>(
+        &self,
+        db: &C,
+        scope: &AccessScope,
+        id: Uuid,
+    ) -> Result<Option<ResourceGroup>, DomainError>;
+
+    async fn find_model_by_id<C: DBRunner>(
+        &self,
+        db: &C,
+        id: Uuid,
+    ) -> Result<Option<rg_entity::Model>, DomainError>;
+
+    async fn list_groups<C: DBRunner>(
+        &self,
+        db: &C,
+        scope: &AccessScope,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroup>, DomainError>;
+
+    async fn list_hierarchy<C: DBRunner>(
+        &self,
+        db: &C,
+        scope: &AccessScope,
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, DomainError>;
+
+    // -- Write operations --
+
+    async fn insert<C: DBRunner>(
+        &self,
+        db: &C,
+        id: Uuid,
+        parent_id: Option<Uuid>,
+        gts_type_id: i16,
+        name: &str,
+        metadata: Option<&serde_json::Value>,
+        tenant_id: Uuid,
+    ) -> Result<rg_entity::Model, DomainError>;
+
+    async fn update<C: DBRunner>(
+        &self,
+        db: &C,
+        id: Uuid,
+        parent_id: Option<Uuid>,
+        gts_type_id: i16,
+        name: &str,
+        metadata: Option<&serde_json::Value>,
+    ) -> Result<rg_entity::Model, DomainError>;
+
+    async fn delete_by_id<C: DBRunner>(&self, db: &C, id: Uuid) -> Result<(), DomainError>;
+
+    // -- Closure table operations --
+
+    async fn insert_closure_self_row<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+    ) -> Result<(), DomainError>;
+
+    async fn insert_ancestor_closure_rows<C: DBRunner>(
+        &self,
+        db: &C,
+        child_id: Uuid,
+        parent_id: Uuid,
+    ) -> Result<(), DomainError>;
+
+    async fn get_descendant_ids<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+    ) -> Result<Vec<Uuid>, DomainError>;
+
+    async fn get_depth<C: DBRunner>(&self, db: &C, group_id: Uuid) -> Result<i32, DomainError>;
+
+    async fn count_children<C: DBRunner>(
+        &self,
+        db: &C,
+        parent_id: Uuid,
+    ) -> Result<u64, DomainError>;
+
+    async fn is_descendant<C: DBRunner>(
+        &self,
+        db: &C,
+        potential_ancestor: Uuid,
+        potential_descendant: Uuid,
+    ) -> Result<bool, DomainError>;
+
+    async fn delete_ancestor_closure_rows<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+        keep_self: bool,
+    ) -> Result<(), DomainError>;
+
+    async fn delete_all_closure_rows<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+    ) -> Result<(), DomainError>;
+
+    async fn rebuild_subtree_closure<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+        new_parent_id: Option<Uuid>,
+    ) -> Result<(), DomainError>;
+
+    async fn has_memberships<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+    ) -> Result<bool, DomainError>;
+
+    async fn delete_memberships<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+    ) -> Result<(), DomainError>;
+
+    async fn resolve_type_paths_batch<C: DBRunner>(
+        &self,
+        db: &C,
+        type_ids: &[i16],
+    ) -> Result<std::collections::HashMap<i16, String>, DomainError>;
+}
+
+#[async_trait]
+pub trait TypeRepositoryTrait: Send + Sync + 'static {
+    async fn find_by_code<C: DBRunner>(
+        &self,
+        db: &C,
+        code: &str,
+    ) -> Result<Option<ResourceGroupType>, DomainError>;
+
+    async fn load_full_type_by_id<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+    ) -> Result<ResourceGroupType, DomainError>;
+
+    async fn load_full_type<C: DBRunner>(
+        &self,
+        db: &C,
+        type_model: &gts_type::Model,
+    ) -> Result<ResourceGroupType, DomainError>;
+
+    async fn resolve_id<C: DBRunner>(&self, db: &C, code: &str)
+    -> Result<Option<i16>, DomainError>;
+
+    async fn insert<C: DBRunner>(
+        &self,
+        db: &C,
+        schema_id: &str,
+        metadata_schema: Option<&serde_json::Value>,
+    ) -> Result<gts_type::Model, DomainError>;
+
+    async fn insert_allowed_parents<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+        parent_ids: &[i16],
+    ) -> Result<(), DomainError>;
+
+    async fn insert_allowed_memberships<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+        membership_ids: &[i16],
+    ) -> Result<(), DomainError>;
+
+    async fn delete_allowed_parents<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+    ) -> Result<(), DomainError>;
+
+    async fn delete_allowed_memberships<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+    ) -> Result<(), DomainError>;
+
+    async fn update_type<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+        code: &str,
+        metadata_schema: Option<&serde_json::Value>,
+    ) -> Result<gts_type::Model, DomainError>;
+
+    async fn delete_by_id<C: DBRunner>(&self, db: &C, type_id: i16) -> Result<(), DomainError>;
+
+    async fn count_groups_of_type<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+    ) -> Result<u64, DomainError>;
+
+    async fn find_groups_using_parent_type<C: DBRunner>(
+        &self,
+        db: &C,
+        child_type_id: i16,
+        parent_type_id: i16,
+    ) -> Result<Vec<(Uuid, String)>, DomainError>;
+
+    async fn find_root_groups_of_type<C: DBRunner>(
+        &self,
+        db: &C,
+        type_id: i16,
+    ) -> Result<Vec<(Uuid, String)>, DomainError>;
+
+    async fn list_types<C: DBRunner>(
+        &self,
+        db: &C,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupType>, DomainError>;
+
+    async fn resolve_ids<C: DBRunner>(
+        &self,
+        db: &C,
+        codes: &[String],
+    ) -> Result<Vec<i16>, DomainError>;
+}
+
+#[async_trait]
+pub trait MembershipRepositoryTrait: Send + Sync + 'static {
+    async fn list_memberships<C: DBRunner>(
+        &self,
+        db: &C,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupMembership>, DomainError>;
+
+    async fn insert<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+        gts_type_id: i16,
+        resource_id: &str,
+    ) -> Result<membership_entity::Model, DomainError>;
+
+    async fn delete<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+        gts_type_id: i16,
+        resource_id: &str,
+    ) -> Result<u64, DomainError>;
+
+    async fn find_by_composite_key<C: DBRunner>(
+        &self,
+        db: &C,
+        group_id: Uuid,
+        gts_type_id: i16,
+        resource_id: &str,
+    ) -> Result<Option<membership_entity::Model>, DomainError>;
+
+    async fn get_existing_membership_tenant_ids<C: DBRunner>(
+        &self,
+        db: &C,
+        gts_type_id: i16,
+        resource_id: &str,
+    ) -> Result<Vec<Uuid>, DomainError>;
+}

--- a/modules/system/resource-group/resource-group/src/domain/validation.rs
+++ b/modules/system/resource-group/resource-group/src/domain/validation.rs
@@ -1,0 +1,124 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-begin:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1:inst-validation-full
+//! Shared domain validation utilities.
+
+use crate::domain::error::DomainError;
+
+/// GTS type path prefix required for resource group types.
+pub const RG_TYPE_PREFIX: &str = "gts.cf.core.rg.type.v1~";
+
+/// Validate a GTS type code: non-empty, correct prefix, length limit.
+///
+/// Input is normalized (trimmed and lowercased) before validation, consistent
+/// with [`resource_group_sdk::models::GtsTypePath::new`].
+///
+/// # Errors
+///
+/// Returns [`DomainError`] if the code is empty, missing the required prefix, or exceeds 1024 chars.
+// @cpt-algo:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1
+// @cpt-algo:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1
+pub fn validate_type_code(code: &str) -> Result<(), DomainError> {
+    let code = code.trim().to_lowercase();
+    let code = code.as_str();
+    // @cpt-begin:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-1
+    if code.is_empty() {
+        return Err(DomainError::validation("Type code must not be empty"));
+    }
+    // @cpt-end:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-1
+    // @cpt-begin:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-2
+    if !code.starts_with(RG_TYPE_PREFIX) {
+        // @cpt-begin:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-2a
+        return Err(DomainError::validation(format!(
+            "Type code must start with prefix '{RG_TYPE_PREFIX}', got: '{code}'"
+        )));
+        // @cpt-end:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-2a
+    }
+    // @cpt-end:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-2
+    // @cpt-begin:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-3
+    if code.chars().count() > 1024 {
+        return Err(DomainError::validation(
+            "Type code must not exceed 1024 characters",
+        ));
+    }
+    // @cpt-end:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-3
+    Ok(())
+}
+
+/// Validate that a `metadata_schema` value is a valid JSON Schema.
+///
+/// Attempts to compile the schema via `jsonschema::validator_for`. If the value
+/// cannot be interpreted as a JSON Schema, returns a [`DomainError::validation`].
+///
+/// # Errors
+///
+/// Returns [`DomainError`] if the value is not a valid JSON Schema.
+// @cpt-begin:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-7
+pub fn validate_metadata_schema(schema: &serde_json::Value) -> Result<(), DomainError> {
+    jsonschema::validator_for(schema).map_err(|e| {
+        DomainError::validation(format!("metadata_schema is not a valid JSON Schema: {e}"))
+    })?;
+    Ok(())
+}
+// @cpt-end:cpt-cf-resource-group-algo-type-mgmt-validate-type-input:p1:inst-val-input-7
+
+/// Validate a metadata value against a resolved GTS type schema.
+///
+/// Uses `TypesRegistryClient` to fetch the resolved schema (with `allOf`
+/// composition, `$ref` resolution, and `x-gts-traits` applied), then validates
+/// the metadata against the resolved schema using `jsonschema`.
+///
+/// Returns `Ok(())` when:
+/// - `metadata` is `None` (nothing to validate)
+/// - `type_code` has no registered schema in the types registry
+/// - `metadata` validates against the resolved schema
+///
+/// # Errors
+///
+/// Returns [`DomainError`] when metadata violates the schema constraints
+/// or the types registry is unavailable.
+pub async fn validate_metadata_via_gts(
+    metadata: Option<&serde_json::Value>,
+    type_code: &str,
+    types_registry: &dyn types_registry_sdk::TypesRegistryClient,
+) -> Result<(), DomainError> {
+    let Some(metadata) = metadata else {
+        return Ok(());
+    };
+
+    // Fetch the GTS entity — its content contains the resolved schema
+    // including allOf composition and $ref resolution from types-registry.
+    let entity = types_registry.get(type_code).await.map_err(|e| {
+        DomainError::validation(format!(
+            "Failed to resolve GTS type '{type_code}' for metadata validation: {e}"
+        ))
+    })?;
+
+    // Extract metadata sub-schema from the GTS entity content.
+    // The chained RG type schema defines a `metadata` property within
+    // its `properties` object.
+    let metadata_schema = entity
+        .content
+        .get("properties")
+        .and_then(|p| p.get("metadata"));
+
+    let Some(metadata_schema) = metadata_schema else {
+        // No metadata property in the schema — any metadata accepted.
+        return Ok(());
+    };
+
+    let validator = jsonschema::validator_for(metadata_schema)
+        .map_err(|e| DomainError::validation(format!("Type metadata_schema is invalid: {e}")))?;
+
+    let errors: Vec<String> = validator
+        .iter_errors(metadata)
+        .map(|e| e.to_string())
+        .collect();
+    if !errors.is_empty() {
+        return Err(DomainError::validation(format!(
+            "Metadata does not match type schema: {}",
+            errors.join("; ")
+        )));
+    }
+    Ok(())
+}
+// @cpt-end:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1:inst-validation-full

--- a/modules/system/resource-group/resource-group/src/infra/mod.rs
+++ b/modules/system/resource-group/resource-group/src/infra/mod.rs
@@ -1,0 +1,3 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+pub mod storage;

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type.rs
@@ -1,0 +1,25 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "gts_type")]
+#[secure(no_tenant, no_resource, no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i16,
+    #[sea_orm(unique)]
+    pub schema_id: String,
+    #[sea_orm(column_type = "JsonBinary", nullable)]
+    pub metadata_schema: Option<serde_json::Value>,
+    pub created_at: OffsetDateTime,
+    #[sea_orm(nullable)]
+    pub updated_at: Option<OffsetDateTime>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type_allowed_membership.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type_allowed_membership.rs
@@ -1,0 +1,19 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "gts_type_allowed_membership")]
+#[secure(no_tenant, no_resource, no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub type_id: i16,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub membership_type_id: i16,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type_allowed_parent.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/gts_type_allowed_parent.rs
@@ -1,0 +1,19 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "gts_type_allowed_parent")]
+#[secure(no_tenant, no_resource, no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub type_id: i16,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub parent_type_id: i16,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/mod.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/mod.rs
@@ -1,0 +1,8 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+pub mod gts_type;
+pub mod gts_type_allowed_membership;
+pub mod gts_type_allowed_parent;
+pub mod resource_group;
+pub mod resource_group_closure;
+pub mod resource_group_membership;

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group.rs
@@ -1,0 +1,29 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "resource_group")]
+#[secure(tenant_col = "tenant_id", resource_col = "id", no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    #[sea_orm(nullable)]
+    pub parent_id: Option<Uuid>,
+    pub gts_type_id: i16,
+    pub name: String,
+    #[sea_orm(column_type = "JsonBinary", nullable)]
+    pub metadata: Option<serde_json::Value>,
+    pub tenant_id: Uuid,
+    pub created_at: OffsetDateTime,
+    #[sea_orm(nullable)]
+    pub updated_at: Option<OffsetDateTime>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group_closure.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group_closure.rs
@@ -1,0 +1,21 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "resource_group_closure")]
+#[secure(no_tenant, no_resource, no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub ancestor_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub descendant_id: Uuid,
+    pub depth: i32,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group_membership.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/entity/resource_group_membership.rs
@@ -1,0 +1,24 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+use modkit_db_macros::Scopable;
+use sea_orm::entity::prelude::*;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Scopable)]
+#[sea_orm(table_name = "resource_group_membership")]
+#[secure(no_tenant, no_resource, no_owner, no_type)]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub group_id: Uuid,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub gts_type_id: i16,
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub resource_id: String,
+    pub created_at: OffsetDateTime,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/modules/system/resource-group/resource-group/src/infra/storage/mod.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/mod.rs
@@ -1,0 +1,5 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-persistence:p1
+//! Infrastructure storage layer - database persistence and `OData` mapping.
+
+pub mod entity;

--- a/modules/system/resource-group/resource-group/src/lib.rs
+++ b/modules/system/resource-group/resource-group/src/lib.rs
@@ -1,0 +1,8 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+//! Resource Group Module — contracts and domain types.
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+pub mod domain;
+#[doc(hidden)]
+pub mod infra;


### PR DESCRIPTION
## Summary
- Resource Group SDK crate with API traits, models, error types, and OData filter definitions
- Module skeleton with domain layer (repo traits, validation, error types) and infrastructure (Sea-ORM entities, storage)
- Workspace and Cargo.toml wiring for the new `resource-group-sdk` and `resource-group` crates

## PR Train 🚂
Merge in order:
1. you are here — #1492

Next PR train https://github.com/cyberfabric/cyberfabric-core/pull/1552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Resource Group system and SDK: manage types and groups (create/read/update/delete), group hierarchy depth queries, membership management, OData filtering, and JSON Schema metadata validation.

* **Documentation**
  * Updated design, PRD, and feature docs to use the revised GTS type-path prefix and aligned examples/tests.

* **Chores**
  * Registered new workspace packages and updated project ignore rules.

* **Security**
  * Adjusted advisory handling: one advisory removed from the ignore list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->