### PR TITLE
fix(tls): install CryptoProvider at startup, update api.json, fix stale server in make openapi

### DIFF
--- a/.github/workflows/api_contracts.yml
+++ b/.github/workflows/api_contracts.yml
@@ -110,6 +110,15 @@ jobs:
           cp docs/api/api.json /tmp/api.committed.json
           make openapi
 
+      - name: Dump server log on failure
+        if: failure()
+        run: |
+          echo "=== SERVER LOG ==="
+          for f in /tmp/server-*.log; do
+            echo "--- $f ---"
+            cat "$f" 2>/dev/null | tail -100
+          done
+
       # ── Phase 1: Spec freshness ───────────────────────────────────────
 
       - name: Check spec is up to date

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3909,6 +3909,7 @@ dependencies = [
  "cf-types-registry",
  "clap",
  "mimalloc",
+ "rustls",
  "serde-saphyr 0.0.16",
  "serde_json",
  "tempfile",

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,15 @@ endef
 define start_server_and_wait
 	TEMP_DIR=$$(if [ -n "$$TEMP" ]; then echo "$$TEMP"; elif [ -n "$$TMP" ]; then echo "$$TMP"; else echo "/tmp"; fi); \
 	LOG_FILE="$$TEMP_DIR/server-$$$$.log"; \
+	HEALTH_PORT=$$(echo "$(2)" | sed -E 's|.*://[^:]+:([0-9]+).*|\1|'); \
+	if [ -n "$$HEALTH_PORT" ] && command -v lsof >/dev/null 2>&1; then \
+		STALE_PIDS=$$(lsof -tiTCP:$$HEALTH_PORT -sTCP:LISTEN 2>/dev/null); \
+		if [ -n "$$STALE_PIDS" ]; then \
+			echo "Killing stale LISTEN processes on port $$HEALTH_PORT (PIDs: $$STALE_PIDS)"; \
+			echo "$$STALE_PIDS" | xargs kill 2>/dev/null || true; \
+			sleep 1; \
+		fi; \
+	fi; \
 	$(1) > "$$LOG_FILE" 2>&1 & \
 	SERVER_PID=$$!; \
 	echo "Server started with PID: $$SERVER_PID (log: $$LOG_FILE)"; \

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -62,6 +62,7 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 clap = { workspace = true }
+rustls = { workspace = true }
 
 # Optional mini-chat module
 mini-chat = { package = "cf-mini-chat", path = "../../modules/mini-chat/mini-chat", optional = true }

--- a/apps/hyperspot-server/src/main.rs
+++ b/apps/hyperspot-server/src/main.rs
@@ -64,6 +64,16 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Install aws-lc-rs as the default rustls CryptoProvider before any TLS
+    // config is constructed. Required because both `ring` and `aws-lc-rs`
+    // providers are compiled in (ring via aliri/pingora-rustls), and rustls
+    // 0.23 panics if it cannot auto-detect a single provider.
+    // Skip in FIPS mode — init_procedure() installs the FIPS provider instead.
+    #[cfg(not(feature = "fips"))]
+    if let Err(_e) = rustls::crypto::aws_lc_rs::default_provider().install_default() {
+        // Another provider was already installed — safe to continue.
+    }
+
     let cli = Cli::parse();
 
     // Layered config:

--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -293,12 +293,6 @@
           "allow_credentials": {
             "type": "boolean"
           },
-          "allowed_headers": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
           "allowed_methods": {
             "items": {
               "$ref": "#/components/schemas/CorsHttpMethod"
@@ -319,11 +313,6 @@
               "type": "string"
             },
             "type": "array"
-          },
-          "max_age": {
-            "format": "int32",
-            "minimum": 0,
-            "type": "integer"
           },
           "sharing": {
             "$ref": "#/components/schemas/SharingMode"
@@ -2732,6 +2721,17 @@
           "request_id": {
             "format": "uuid",
             "type": "string"
+          },
+          "thread_summary_applied": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ThreadSummaryInfo",
+                "description": "Present when a thread summary is included in the context window.\nUI can display an informational indicator."
+              }
+            ]
           }
         },
         "required": [
@@ -2886,6 +2886,21 @@
         "required": [
           "start",
           "end"
+        ],
+        "type": "object"
+      },
+      "ThreadSummaryInfo": {
+        "description": "Metadata about a thread summary applied to the current turn's context.\n\nSent in the `stream_started` event when the conversation has an active\nthread summary. The UI can use this to show an informational banner.",
+        "properties": {
+          "token_estimate": {
+            "description": "Estimated token cost of the summary in the context window.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "token_estimate"
         ],
         "type": "object"
       },


### PR DESCRIPTION
## Summary

Fixes three CI issues on main:

1. **CryptoProvider panic** — both `ring` and `aws-lc-rs` rustls providers are compiled in (ring via aliri/pingora-rustls transitive deps). rustls 0.23 panics if it cannot auto-detect a single provider. Fixed by calling `CryptoProvider::install_default()` at the top of `main()`, gated with `#[cfg(not(feature = "fips"))]` so FIPS builds are unaffected.

2. **Stale `api.json`** — committed spec was outdated: contained `allowed_headers`/`max_age` in CorsConfig (removed in 7fbf9b4e) and missed `ThreadSummaryInfo` (added in mini-chat). Root cause: `make openapi` on macOS connected to a **stale server process** still running on port 8087 from a previous session, returning the old spec.

3. **Stale server in `make openapi`** — `start_server_and_wait` in Makefile now kills any existing process on the target port before starting a new server, preventing stale spec generation.

## Changes

- `apps/hyperspot-server/src/main.rs` — install aws-lc-rs CryptoProvider before any TLS config
- `apps/hyperspot-server/Cargo.toml` — add `rustls` dependency
- `docs/api/api.json` — regenerated from clean server (CorsConfig fix + ThreadSummaryInfo)
- `Makefile` — kill stale process on port before `start_server_and_wait`
- `.github/workflows/api_contracts.yml` — dump server log on failure for debugging

Fixes #1498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for FIPS-compliant cryptography in server startup.
  * Extended API with thread summary information in stream events.

* **Chores**
  * Improved CI logging for better error diagnostics.
  * Enhanced server startup process for stale process handling.
  * Simplified CORS configuration schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->