### PR TITLE
feat(oagw): implement rate limiting with hierarchical budget allocation

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,15 @@
+---
+engines:
+  bandit:
+    exclude_paths:
+      - "testing/**"
+      - "**/test_*.py"
+      - "**/conftest.py"
+
+exclude_paths:
+  - "target/**"
+  - "**/__pycache__/**"
+  - "**/node_modules/**"
+  - ".venv/**"
+  - "**/*.min.js"
+  - "**/*.min.css"

--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -229,6 +229,22 @@ modules:
             subject_id: "11111111-6a88-4768-9dfc-6bcd5187d9ed"
             subject_tenant_id: "00000000-df51-5b42-9538-d2b56b7ee953"
             token_scopes: ["*"]
+        # Hierarchy tenant tokens — used by budget allocation e2e tests
+        - token: "e2e-token-hierarchy-root"
+          identity:
+            subject_id: "22222222-0000-0000-0000-000000000001"
+            subject_tenant_id: "00000000-0000-0000-0000-000000000001"
+            token_scopes: ["*"]
+        - token: "e2e-token-hierarchy-l1a"
+          identity:
+            subject_id: "22222222-0000-0000-0000-000000000002"
+            subject_tenant_id: "00000000-0000-0000-0000-000000000002"
+            token_scopes: ["*"]
+        - token: "e2e-token-hierarchy-l1b"
+          identity:
+            subject_id: "22222222-0000-0000-0000-000000000005"
+            subject_tenant_id: "00000000-0000-0000-0000-000000000005"
+            token_scopes: ["*"]
         # Nil-tenant token: static-authz denies requests with the nil UUID
         # tenant, producing a clean 403 Forbidden. Used by
         # testing/e2e/modules/oagw/test_authz.py::test_proxy_authz_forbidden_nil_tenant

--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -125,6 +125,37 @@
         ],
         "type": "object"
       },
+      "BudgetConfig": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/BudgetMode"
+          },
+          "overcommit_ratio": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "total": {
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "BudgetMode": {
+        "enum": [
+          "unlimited",
+          "allocated",
+          "shared"
+        ],
+        "type": "string"
+      },
       "BurstConfig": {
         "properties": {
           "capacity": {
@@ -2197,6 +2228,16 @@
           "algorithm": {
             "$ref": "#/components/schemas/RateLimitAlgorithm"
           },
+          "budget": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BudgetConfig"
+              }
+            ]
+          },
           "burst": {
             "oneOf": [
               {
@@ -2211,6 +2252,9 @@
             "format": "int32",
             "minimum": 0,
             "type": "integer"
+          },
+          "response_headers": {
+            "type": "boolean"
           },
           "scope": {
             "$ref": "#/components/schemas/RateLimitScope"

--- a/modules/system/oagw/docs/ADR/0004-rate-limiting.md
+++ b/modules/system/oagw/docs/ADR/0004-rate-limiting.md
@@ -363,9 +363,13 @@ Rate limiting executes in **Data Plane (DP)**. Configuration is resolved from Co
 **Redis key structure**:
 
 ```text
-oagw:ratelimit:{scope}:{identifier}:{window} = {count}
-oagw:ratelimit:tenant:uuid-123:minute:202601301530 = 4523
+oagw:ratelimit:{resource_type}:{resource_id}:{scope}:{scope_id}:{window} = {count}
+oagw:ratelimit:upstream:uuid-upstream:tenant:uuid-tenant:minute:202601301530 = 4523
 ```
+
+The `{resource_type}:{resource_id}` prefix ensures all keys for a given
+upstream or route share a common prefix, enabling efficient prefix-based
+cleanup (in-memory `retain` and Redis `SCAN`) when a resource is deleted.
 
 > **Note:** Minute-bucket keys must use **YYYYMMDDHHMM** (12 digits) to avoid
 > confusion with hour-level granularity and prevent incorrect aggregation.

--- a/modules/system/oagw/docs/adr-rate-limiting.md
+++ b/modules/system/oagw/docs/adr-rate-limiting.md
@@ -358,9 +358,13 @@ is typically distributed evenly by load balancer.
 **Redis key structure**:
 
 ```
-oagw:ratelimit:{scope}:{identifier}:{window} = {count}
-oagw:ratelimit:tenant:uuid-123:minute:2026013015 = 4523
+oagw:ratelimit:{resource_type}:{resource_id}:{scope}:{scope_id}:{window} = {count}
+oagw:ratelimit:upstream:uuid-upstream:tenant:uuid-tenant:minute:2026013015 = 4523
 ```
+
+The `{resource_type}:{resource_id}` prefix ensures all keys for a given
+upstream or route share a common prefix, enabling efficient prefix-based
+cleanup (in-memory `retain` and Redis `SCAN`) when a resource is deleted.
 
 **Response headers** (RFC 6585 / draft-ietf-httpapi-ratelimit-headers):
 

--- a/modules/system/oagw/docs/features/0006-cpt-cf-oagw-feature-rate-limiting.md
+++ b/modules/system/oagw/docs/features/0006-cpt-cf-oagw-feature-rate-limiting.md
@@ -87,15 +87,15 @@ Prevents abuse, cost overruns, and protects external service agreements. Maintai
 - Circuit breaker half-open probe fails — circuit re-opens
 
 **Steps**:
-1. [ ] - `p2` - Actor sends proxy request via `cpt-cf-oagw-flow-proxy-request` (alias resolution and route matching complete) - `inst-rl-1`
-2. [ ] - `p2` - Resolve effective rate limit config via `cpt-cf-oagw-algo-hierarchical-rate-limit-merge` for upstream and matched route - `inst-rl-2`
+1. [x] - `p2` - Actor sends proxy request via `cpt-cf-oagw-flow-proxy-request` (alias resolution and route matching complete) - `inst-rl-1`
+2. [x] - `p2` - Resolve effective rate limit config via `cpt-cf-oagw-algo-hierarchical-rate-limit-merge` for upstream and matched route - `inst-rl-2`
 3. [ ] - `p2` - Check circuit breaker state via `cpt-cf-oagw-algo-circuit-breaker-evaluation` - `inst-rl-3`
 4. [ ] - `p2` - **IF** circuit breaker is OPEN - `inst-rl-4`
    1. [ ] - `p2` - **RETURN** 503 CircuitBreakerOpen with `Retry-After` and `X-Circuit-State: OPEN` via `cpt-cf-oagw-algo-error-source-classification` - `inst-rl-4a`
-5. [ ] - `p2` - Check rate limit via `cpt-cf-oagw-algo-token-bucket-check` with effective rate config and request cost - `inst-rl-5`
-6. [ ] - `p2` - **IF** rate limit exceeded - `inst-rl-6`
-   1. [ ] - `p2` - **IF** strategy = `reject` - `inst-rl-6a`
-      1. [ ] - `p2` - **RETURN** 429 RateLimitExceeded with `X-RateLimit-*` headers and `Retry-After` - `inst-rl-6a1`
+5. [x] - `p2` - Check rate limit via `cpt-cf-oagw-algo-token-bucket-check` with effective rate config and request cost - `inst-rl-5`
+6. [x] - `p2` - **IF** rate limit exceeded - `inst-rl-6`
+   1. [x] - `p2` - **IF** strategy = `reject` - `inst-rl-6a`
+      1. [x] - `p2` - **RETURN** 429 RateLimitExceeded with `X-RateLimit-*` headers and `Retry-After` - `inst-rl-6a1`
    2. [ ] - `p2` - **IF** strategy = `queue` - `inst-rl-6b`
       1. [ ] - `p2` - Enqueue request via `cpt-cf-oagw-algo-backpressure-queue` - `inst-rl-6b1`
       2. [ ] - `p2` - **IF** queue full or timeout expires - `inst-rl-6b2`
@@ -106,11 +106,11 @@ Prevents abuse, cost overruns, and protects external service agreements. Maintai
       1. [ ] - `p2` - **RETURN** 503 ConcurrencyLimitExceeded with `Retry-After` - `inst-rl-8a1`
    2. [ ] - `p2` - **IF** strategy = `queue` - `inst-rl-8b`
       1. [ ] - `p2` - Enqueue request via `cpt-cf-oagw-algo-backpressure-queue` - `inst-rl-8b1`
-9. [ ] - `p2` - Continue proxy flow (auth → guards → transform → upstream call) per `cpt-cf-oagw-flow-proxy-request` - `inst-rl-9`
+9. [x] - `p2` - Continue proxy flow (auth → guards → transform → upstream call) per `cpt-cf-oagw-flow-proxy-request` - `inst-rl-9`
 10. [ ] - `p2` - On upstream response: evaluate circuit breaker via `cpt-cf-oagw-algo-circuit-breaker-evaluation` (record success/failure) - `inst-rl-10`
 11. [ ] - `p2` - Concurrency permits auto-released via RAII Drop - `inst-rl-11`
-12. [ ] - `p2` - Include `X-RateLimit-*` response headers if `response_headers: true` in rate limit config - `inst-rl-12`
-13. [ ] - `p2` - **RETURN** upstream response to caller - `inst-rl-13`
+12. [x] - `p2` - Include `X-RateLimit-*` response headers if `response_headers: true` in rate limit config - `inst-rl-12`
+13. [x] - `p2` - **RETURN** upstream response to caller - `inst-rl-13`
 
 ### Configure Rate Limits
 
@@ -131,62 +131,67 @@ Prevents abuse, cost overruns, and protects external service agreements. Maintai
 - Invalid configuration values (400 ValidationError)
 
 **Steps**:
-1. [ ] - `p2` - Actor sends PUT /api/oagw/v1/upstreams/{id} or PUT /api/oagw/v1/routes/{id} with `rate_limit`, `circuit_breaker`, or `concurrency_limit` in request body - `inst-cfg-1`
-2. [ ] - `p2` - Validate rate limit config: `sustained.rate` > 0, `burst.capacity` ≥ 1, `scope` is valid enum, `strategy` is valid enum - `inst-cfg-2`
-3. [ ] - `p2` - **IF** `budget.mode` = `allocated` - `inst-cfg-3`
-   1. [ ] - `p2` - Validate sum of child allocations ≤ parent budget × `overcommit_ratio` - `inst-cfg-3a`
-   2. [ ] - `p2` - **IF** validation fails - `inst-cfg-3b`
-      1. [ ] - `p2` - **RETURN** 400 ValidationError with budget allocation details - `inst-cfg-3b1`
-4. [ ] - `p2` - **IF** ancestor has `sharing: enforce` on rate limit - `inst-cfg-4`
-   1. [ ] - `p2` - Validate descendant's limit does not exceed ancestor's enforced limit - `inst-cfg-4a`
+1. [x] - `p2` - Actor sends PUT /api/oagw/v1/upstreams/{id} or PUT /api/oagw/v1/routes/{id} with `rate_limit`, `circuit_breaker`, or `concurrency_limit` in request body - `inst-cfg-1`
+2. [x] - `p2` - Validate rate limit config: `sustained.rate` > 0, `burst.capacity` ≥ 1, `scope` is valid enum, `strategy` is valid enum - `inst-cfg-2`
+3. [x] - `p2` - **IF** `budget.mode` = `allocated` - `inst-cfg-3`
+   1. [x] - `p2` - Validate sum of child allocations ≤ parent budget × `overcommit_ratio` - `inst-cfg-3a`
+   2. [x] - `p2` - **IF** validation fails - `inst-cfg-3b`
+      1. [x] - `p2` - **RETURN** 400 ValidationError with budget allocation details - `inst-cfg-3b1`
+4. [x] - `p2` - **IF** ancestor has `sharing: enforce` on rate limit - `inst-cfg-4`
+   1. [x] - `p2` - Validate descendant's limit does not exceed ancestor's enforced limit - `inst-cfg-4a`
 5. [ ] - `p2` - Validate circuit breaker config: `failure_threshold` ≥ 1, `timeout_seconds` ≥ 1, `success_threshold` ≥ 1 - `inst-cfg-5`
 6. [ ] - `p2` - Validate concurrency limit config: `max_concurrent` > 0, `per_tenant_max` ≤ `max_concurrent` - `inst-cfg-6`
 7. [ ] - `p2` - **IF** `strategy` = `queue` on rate_limit or concurrency_limit - `inst-cfg-7`
    1. [ ] - `p2` - Validate queue config: `max_depth` (1–10,000), `timeout` (1–60s), `memory_limit` (1B–1GB), `overflow_strategy` is valid enum (`drop_newest`, `drop_oldest`, `reject`) - `inst-cfg-7a`
-8. [ ] - `p2` - Persist config to database via ControlPlaneService - `inst-cfg-8`
-9. [ ] - `p2` - **RETURN** updated resource - `inst-cfg-9`
+8. [x] - `p2` - Persist config to database via ControlPlaneService - `inst-cfg-8`
+9. [x] - `p2` - **RETURN** updated resource - `inst-cfg-9`
 
 ## 3. Processes / Business Logic (CDSL)
 
 ### Token Bucket Rate Check
 
-- [ ] `p2` - **ID**: `cpt-cf-oagw-algo-token-bucket-check`
+- [x] `p2` - **ID**: `cpt-cf-oagw-algo-token-bucket-check`
 
 **Input**: Rate limit config (algorithm, sustained rate, burst capacity, scope, cost), request context (tenant_id, user_id, IP, route_id)
 
 **Output**: Allow (with remaining tokens) or deny (with retry-after estimate)
 
 **Steps**:
-1. [ ] - `p2` - Determine counter key from scope: `oagw:ratelimit:{scope}:{identifier}:{window}` - `inst-tb-1`
-2. [ ] - `p2` - Load or create in-memory `TokenBucket` for key - `inst-tb-2`
-3. [ ] - `p2` - Refill tokens: `elapsed = now - last_update`, `new_tokens = elapsed_seconds × refill_rate`, `tokens = min(tokens + new_tokens, capacity)`, `last_update = now` - `inst-tb-3`
-4. [ ] - `p2` - **IF** `tokens >= cost` - `inst-tb-4`
-   1. [ ] - `p2` - Deduct: `tokens -= cost` - `inst-tb-4a`
-   2. [ ] - `p2` - **RETURN** Allow with `remaining = floor(tokens)`, `limit = capacity`, `reset = window_end_timestamp` - `inst-tb-4b`
-5. [ ] - `p2` - **ELSE** (insufficient tokens) - `inst-tb-5`
-   1. [ ] - `p2` - Calculate `retry_after = ceil((cost - tokens) / refill_rate)` - `inst-tb-5a`
-   2. [ ] - `p2` - **RETURN** Deny with `retry_after`, `limit = capacity`, `remaining = 0`, `reset = window_end_timestamp` - `inst-tb-5b`
+1. [x] - `p2` - Determine counter key from scope (format varies by scope): - `inst-tb-1`
+     - `tenant`: `oagw:ratelimit:{resource_type}:{resource_id}:tenant:{tenant_id}:{window}`
+     - `user`: `oagw:ratelimit:{resource_type}:{resource_id}:user:{subject_id}:{window}`
+     - `ip`: `oagw:ratelimit:{resource_type}:{resource_id}:ip:{client_ip}:{window}` (falls back to `unknown` when no client IP)
+     - `global`: `oagw:ratelimit:{resource_type}:{resource_id}:global:{window}` (no scope_id segment)
+     - `route`: `oagw:ratelimit:{resource_type}:{resource_id}:route:{window}` (no scope_id segment)
+2. [x] - `p2` - Load or create in-memory `TokenBucket` for key - `inst-tb-2`
+3. [x] - `p2` - Refill tokens: `elapsed = now - last_update`, `new_tokens = elapsed_seconds × refill_rate`, `tokens = min(tokens + new_tokens, capacity)`, `last_update = now` - `inst-tb-3`
+4. [x] - `p2` - **IF** `tokens >= cost` - `inst-tb-4`
+   1. [x] - `p2` - Deduct: `tokens -= cost` - `inst-tb-4a`
+   2. [x] - `p2` - **RETURN** Allow with `remaining = floor(tokens)`, `limit = capacity`, `reset = now + ceil((capacity - tokens) / refill_rate)` (Unix epoch timestamp when bucket fully replenished; token buckets refill continuously so there is no discrete window boundary) - `inst-tb-4b`
+5. [x] - `p2` - **ELSE** (insufficient tokens) - `inst-tb-5`
+   1. [x] - `p2` - Calculate `retry_after = ceil((cost - tokens) / refill_rate)` - `inst-tb-5a`
+   2. [x] - `p2` - **RETURN** Deny with `retry_after`, `limit = capacity`, `remaining = 0`, `reset = now + ceil((capacity - tokens) / refill_rate)` (Unix epoch timestamp when bucket fully replenished) - `inst-tb-5b`
 
 ### Hierarchical Rate Limit Merge
 
-- [ ] `p2` - **ID**: `cpt-cf-oagw-algo-hierarchical-rate-limit-merge`
+- [x] `p2` - **ID**: `cpt-cf-oagw-algo-hierarchical-rate-limit-merge`
 
 **Input**: Upstream rate limit config, route rate limit config, tenant hierarchy (ancestor chain from root to current tenant)
 
 **Output**: Effective rate limit config (sustained rate, burst capacity, scope, strategy)
 
 **Steps**:
-1. [ ] - `p2` - Collect all rate limit configs from tenant hierarchy (root → current) for the upstream - `inst-merge-1`
-2. [ ] - `p2` - **FOR EACH** ancestor config from root to current - `inst-merge-2`
-   1. [ ] - `p2` - **IF** ancestor sharing = `enforce` - `inst-merge-2a`
-      1. [ ] - `p2` - Add to enforced limits list - `inst-merge-2a1`
-   2. [ ] - `p2` - **IF** ancestor sharing = `inherit` and descendant has no own config - `inst-merge-2b`
-      1. [ ] - `p2` - Use ancestor's config as base - `inst-merge-2b1`
-3. [ ] - `p2` - Compute effective sustained rate: `min(own_rate, all_enforced_ancestor_rates)` - `inst-merge-3`
-4. [ ] - `p2` - Compute effective burst capacity: `min(own_burst, all_enforced_ancestor_bursts)` - `inst-merge-4`
-5. [ ] - `p2` - **IF** route has own rate limit config - `inst-merge-5`
-   1. [ ] - `p2` - Apply route-level override: `effective = min(upstream_effective, route_config)` - `inst-merge-5a`
-6. [ ] - `p2` - **RETURN** effective rate limit config - `inst-merge-6`
+1. [x] - `p2` - Collect all rate limit configs from tenant hierarchy (root → current) for the upstream - `inst-merge-1`
+2. [x] - `p2` - **FOR EACH** ancestor config from root to current - `inst-merge-2`
+   1. [x] - `p2` - **IF** ancestor sharing = `enforce` - `inst-merge-2a`
+      1. [x] - `p2` - Add to enforced limits list - `inst-merge-2a1`
+   2. [x] - `p2` - **IF** ancestor sharing = `inherit` and descendant has no own config - `inst-merge-2b`
+      1. [x] - `p2` - Use ancestor's config as base - `inst-merge-2b1`
+3. [x] - `p2` - Compute effective sustained rate: `min(own_rate, all_enforced_ancestor_rates)` - `inst-merge-3`
+4. [x] - `p2` - Compute effective burst capacity: `min(own_burst, all_enforced_ancestor_bursts)` - `inst-merge-4`
+5. [x] - `p2` - **IF** route has own rate limit config - `inst-merge-5`
+   1. [x] - `p2` - Apply route-level override: `effective = min(upstream_effective, route_config)` - `inst-merge-5a`
+6. [x] - `p2` - **RETURN** effective rate limit config - `inst-merge-6`
 
 ### Circuit Breaker State Evaluation
 
@@ -323,7 +328,7 @@ Prevents abuse, cost overruns, and protects external service agreements. Maintai
 
 ### Implement Token Bucket Rate Limiter
 
-- [ ] `p2` - **ID**: `cpt-cf-oagw-dod-token-bucket`
+- [x] `p2` - **ID**: `cpt-cf-oagw-dod-token-bucket`
 
 The system **MUST** implement token bucket rate limiting with dual-rate configuration (sustained rate + burst capacity) per `cpt-cf-oagw-adr-rate-limiting`. Tokens **MUST** be refilled at `sustained.rate` per `sustained.window`. Burst **MUST** be capped at `burst.capacity`. Each request **MUST** consume `cost` tokens (default: 1). Counter scope **MUST** support: `global`, `tenant`, `user`, `ip`, `route`. When tokens insufficient and strategy = `reject`, the system **MUST** return 429 RateLimitExceeded with `Retry-After` header.
 
@@ -336,7 +341,7 @@ The system **MUST** implement token bucket rate limiting with dual-rate configur
 
 ### Implement Rate Limit Response Headers
 
-- [ ] `p2` - **ID**: `cpt-cf-oagw-dod-rate-limit-headers`
+- [x] `p2` - **ID**: `cpt-cf-oagw-dod-rate-limit-headers`
 
 The system **MUST** include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` response headers on all proxy responses when `response_headers: true` in rate limit config (default: true) per RFC 6585 / draft-ietf-httpapi-ratelimit-headers. On 429 responses, the system **MUST** include `Retry-After` header with the calculated wait time in seconds.
 
@@ -348,7 +353,7 @@ The system **MUST** include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X
 
 ### Implement Hierarchical Rate Limit Merge
 
-- [ ] `p2` - **ID**: `cpt-cf-oagw-dod-hierarchical-rate-merge`
+- [x] `p2` - **ID**: `cpt-cf-oagw-dod-hierarchical-rate-merge`
 
 The system **MUST** compute effective rate limits by walking the tenant hierarchy and applying `min(ancestor.enforced, descendant)` per `cpt-cf-oagw-adr-rate-limiting`. When ancestor sharing = `enforce`, descendant **MUST NOT** exceed ancestor's limit. When sharing = `inherit` and descendant has no config, ancestor's config **MUST** be used. Budget allocation **MUST** validate that sum of child allocations ≤ parent budget × `overcommit_ratio`. Route-level rate limits **MUST** apply as `min(upstream_effective, route_config)`.
 
@@ -402,17 +407,17 @@ The system **MUST** implement `reject` and `queue` strategies for handling overl
 
 ## 6. Acceptance Criteria
 
-- [ ] Token bucket rate limiter allows requests when tokens available and rejects with 429 when tokens exhausted
-- [ ] Rate limit config supports dual-rate: `sustained` (rate + window) and `burst` (capacity) independently
-- [ ] Counter scopes (`global`, `tenant`, `user`, `ip`, `route`) track and enforce limits independently
-- [ ] Cost-based rate limiting deducts `cost` tokens per request (configurable per route)
-- [ ] `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers included in all proxy responses when `response_headers: true`
-- [ ] 429 RateLimitExceeded responses include `Retry-After` header with calculated wait time
-- [ ] Hierarchical rate limit merge computes `effective = min(ancestor.enforced, descendant)` across tenant hierarchy
-- [ ] Ancestor with `sharing: enforce` prevents descendant from exceeding enforced limit
-- [ ] Ancestor with `sharing: inherit` provides default config when descendant has none
-- [ ] Budget allocation validates sum of child allocations ≤ parent budget × `overcommit_ratio`; rejects if exceeded
-- [ ] Route-level rate limit applies as `min(upstream_effective, route_config)`
+- [x] Token bucket rate limiter allows requests when tokens available and rejects with 429 when tokens exhausted
+- [x] Rate limit config supports dual-rate: `sustained` (rate + window) and `burst` (capacity) independently
+- [x] Counter scopes (`global`, `tenant`, `user`, `ip`, `route`) track and enforce limits independently
+- [x] Cost-based rate limiting deducts `cost` tokens per request (configurable per route)
+- [x] `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers included in all proxy responses when `response_headers: true`
+- [x] 429 RateLimitExceeded responses include `Retry-After` header with calculated wait time
+- [x] Hierarchical rate limit merge computes `effective = min(ancestor.enforced, descendant)` across tenant hierarchy
+- [x] Ancestor with `sharing: enforce` prevents descendant from exceeding enforced limit
+- [x] Ancestor with `sharing: inherit` provides default config when descendant has none
+- [x] Budget allocation validates sum of child allocations ≤ parent budget × `overcommit_ratio`; rejects if exceeded
+- [x] Route-level rate limit applies as `min(upstream_effective, route_config)`
 - [ ] Circuit breaker transitions CLOSED → OPEN when consecutive failures ≥ `failure_threshold`
 - [ ] Circuit breaker transitions OPEN → HALF_OPEN after `timeout_seconds` elapsed
 - [ ] Circuit breaker transitions HALF_OPEN → CLOSED after `success_threshold` consecutive probe successes
@@ -432,10 +437,10 @@ The system **MUST** implement `reject` and `queue` strategies for handling overl
 - [ ] Queue overflow handled per `overflow_strategy`: `drop_newest`, `drop_oldest`, or `reject`
 - [ ] Queue timeout returns 503 QueueTimeout with `queue_wait_seconds` and `Retry-After`
 - [ ] Queue does not accumulate requests when circuit breaker is OPEN
-- [ ] All gateway-originated errors include `X-OAGW-Error-Source: gateway` and use RFC 9457 Problem Details format
+- [x] All gateway-originated errors include `X-OAGW-Error-Source: gateway` and use RFC 9457 Problem Details format
 - [ ] Prometheus metrics emitted: `oagw_rate_limit_exceeded_total`, `oagw_rate_limit_usage_ratio`, `oagw_circuit_breaker_state`, `oagw_circuit_breaker_transitions_total`, `oagw_requests_in_flight`, `oagw_concurrency_limit_exceeded_total`, `oagw_queue_depth`, `oagw_queue_wait_duration_seconds`
-- [ ] Rate limit check latency < 1ms (in-memory token bucket) per `cpt-cf-oagw-nfr-low-latency`
-- [ ] No credentials or PII appear in rate limit / circuit breaker error responses or logs
+- [x] Rate limit check latency < 1ms (in-memory token bucket) per `cpt-cf-oagw-nfr-low-latency`
+- [x] No credentials or PII appear in rate limit / circuit breaker error responses or logs
 
 ## 7. Additional Context
 
@@ -445,7 +450,7 @@ Rate limiting and concurrency control are on the hot path for every proxy reques
 
 ### Distributed State
 
-MVP uses per-instance rate limiting and concurrency control (no distributed coordination). Distributed rate limiting via Redis (hybrid local + periodic sync per `cpt-cf-oagw-adr-rate-limiting`) and distributed circuit breaker state (Redis-backed per `cpt-cf-oagw-adr-circuit-breaker`) are production-grade capabilities. Redis key structure: `oagw:ratelimit:{scope}:{identifier}:{window}` for rate limits, `oagw:cb:{tenant_id}:{upstream_id}:*` for circuit breaker.
+MVP uses per-instance rate limiting and concurrency control (no distributed coordination). Distributed rate limiting via Redis (hybrid local + periodic sync per `cpt-cf-oagw-adr-rate-limiting`) and distributed circuit breaker state (Redis-backed per `cpt-cf-oagw-adr-circuit-breaker`) are production-grade capabilities. Redis key structure: `oagw:ratelimit:{resource_type}:{resource_id}:{scope}:{scope_id}:{window}` for rate limits, `oagw:cb:{tenant_id}:{upstream_id}:*` for circuit breaker.
 
 ### Deliberate Omissions
 

--- a/modules/system/oagw/oagw-sdk/src/lib.rs
+++ b/modules/system/oagw/oagw-sdk/src/lib.rs
@@ -9,13 +9,14 @@ pub mod ws;
 pub mod models;
 
 pub use models::{
-    AuthConfig, BurstConfig, CorsConfig, CorsHttpMethod, CreateRouteRequest,
-    CreateRouteRequestBuilder, CreateUpstreamRequest, CreateUpstreamRequestBuilder, Endpoint,
-    GrpcMatch, HeadersConfig, HttpMatch, HttpMethod, ListQuery, MatchRules, PassthroughMode,
-    PathSuffixMode, PluginBinding, PluginsConfig, RateLimitAlgorithm, RateLimitConfig,
-    RateLimitScope, RateLimitStrategy, RequestHeaderRules, ResponseHeaderRules, Route, Scheme,
-    Server, SharingMode, SustainedRate, UpdateRouteRequest, UpdateRouteRequestBuilder,
-    UpdateUpstreamRequest, UpdateUpstreamRequestBuilder, Upstream, Window,
+    AuthConfig, BudgetConfig, BudgetMode, BurstConfig, CorsConfig, CorsHttpMethod,
+    CreateRouteRequest, CreateRouteRequestBuilder, CreateUpstreamRequest,
+    CreateUpstreamRequestBuilder, Endpoint, GrpcMatch, HeadersConfig, HttpMatch, HttpMethod,
+    ListQuery, MatchRules, PassthroughMode, PathSuffixMode, PluginBinding, PluginsConfig,
+    RateLimitAlgorithm, RateLimitConfig, RateLimitScope, RateLimitStrategy, RequestHeaderRules,
+    ResponseHeaderRules, Route, Scheme, Server, SharingMode, SustainedRate, UpdateRouteRequest,
+    UpdateRouteRequestBuilder, UpdateUpstreamRequest, UpdateUpstreamRequestBuilder, Upstream,
+    Window,
 };
 
 pub use api::ServiceGatewayClientV1;

--- a/modules/system/oagw/oagw-sdk/src/models.rs
+++ b/modules/system/oagw/oagw-sdk/src/models.rs
@@ -135,9 +135,11 @@ pub struct RateLimitConfig {
     pub algorithm: RateLimitAlgorithm,
     pub sustained: SustainedRate,
     pub burst: Option<BurstConfig>,
+    pub budget: Option<BudgetConfig>,
     pub scope: RateLimitScope,
     pub strategy: RateLimitStrategy,
     pub cost: u32,
+    pub response_headers: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -169,6 +171,24 @@ pub enum Window {
 pub struct BurstConfig {
     /// Maximum burst size. Defaults to sustained.rate if not specified.
     pub capacity: u32,
+}
+
+/// Budget allocation configuration for hierarchical rate limit management.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BudgetConfig {
+    pub mode: BudgetMode,
+    /// Total budget capacity. Required for `Allocated` and `Shared` modes.
+    pub total: Option<u32>,
+    /// Over-provisioning ratio (1.0–2.0, default 1.0). Only for `Allocated` mode.
+    pub overcommit_ratio: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BudgetMode {
+    #[default]
+    Unlimited,
+    Allocated,
+    Shared,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/modules/system/oagw/oagw/src/api/rest/dto.rs
+++ b/modules/system/oagw/oagw/src/api/rest/dto.rs
@@ -128,12 +128,16 @@ pub struct RateLimitConfig {
     pub sustained: SustainedRate,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub burst: Option<BurstConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget: Option<BudgetConfig>,
     #[serde(default)]
     pub scope: RateLimitScope,
     #[serde(default)]
     pub strategy: RateLimitStrategy,
     #[serde(default = "default_cost")]
     pub cost: u32,
+    #[serde(default = "default_true")]
+    pub response_headers: bool,
 }
 
 fn default_cost() -> u32 {
@@ -168,6 +172,25 @@ pub enum Window {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct BurstConfig {
     pub capacity: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct BudgetConfig {
+    #[serde(default)]
+    pub mode: BudgetMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overcommit_ratio: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BudgetMode {
+    #[default]
+    Unlimited,
+    Allocated,
+    Shared,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, utoipa::ToSchema)]
@@ -579,9 +602,32 @@ impl From<RateLimitConfig> for domain::RateLimitConfig {
             algorithm: v.algorithm.into(),
             sustained: v.sustained.into(),
             burst: v.burst.map(Into::into),
+            budget: v.budget.map(Into::into),
             scope: v.scope.into(),
             strategy: v.strategy.into(),
             cost: v.cost,
+            response_headers: v.response_headers,
+            pool_owner_id: None,
+        }
+    }
+}
+
+impl From<BudgetConfig> for domain::BudgetConfig {
+    fn from(v: BudgetConfig) -> Self {
+        Self {
+            mode: v.mode.into(),
+            total: v.total,
+            overcommit_ratio: v.overcommit_ratio,
+        }
+    }
+}
+
+impl From<BudgetMode> for domain::BudgetMode {
+    fn from(v: BudgetMode) -> Self {
+        match v {
+            BudgetMode::Unlimited => Self::Unlimited,
+            BudgetMode::Allocated => Self::Allocated,
+            BudgetMode::Shared => Self::Shared,
         }
     }
 }
@@ -842,9 +888,31 @@ impl From<domain::RateLimitConfig> for RateLimitConfig {
             algorithm: v.algorithm.into(),
             sustained: v.sustained.into(),
             burst: v.burst.map(Into::into),
+            budget: v.budget.map(Into::into),
             scope: v.scope.into(),
             strategy: v.strategy.into(),
             cost: v.cost,
+            response_headers: v.response_headers,
+        }
+    }
+}
+
+impl From<domain::BudgetConfig> for BudgetConfig {
+    fn from(v: domain::BudgetConfig) -> Self {
+        Self {
+            mode: v.mode.into(),
+            total: v.total,
+            overcommit_ratio: v.overcommit_ratio,
+        }
+    }
+}
+
+impl From<domain::BudgetMode> for BudgetMode {
+    fn from(v: domain::BudgetMode) -> Self {
+        match v {
+            domain::BudgetMode::Unlimited => Self::Unlimited,
+            domain::BudgetMode::Allocated => Self::Allocated,
+            domain::BudgetMode::Shared => Self::Shared,
         }
     }
 }

--- a/modules/system/oagw/oagw/src/api/rest/error.rs
+++ b/modules/system/oagw/oagw/src/api/rest/error.rs
@@ -216,15 +216,27 @@ pub(crate) fn domain_error_to_problem(err: DomainError, instance: &str) -> Probl
 /// Convert a `DomainError` into an axum `Response` with the
 /// `x-oagw-error-source: gateway` header. Used by the proxy handler.
 pub fn error_response(err: DomainError) -> Response {
-    let retry_after = match &err {
+    let rate_limit_meta = match &err {
         DomainError::RateLimitExceeded {
-            retry_after_secs: Some(secs),
+            retry_after_secs,
+            limit,
+            remaining,
+            reset_epoch,
             ..
-        } => Some(*secs),
+        } => Some((*retry_after_secs, *limit, *remaining, *reset_epoch)),
         _ => None,
     };
 
-    let problem: Problem = err.into();
+    let mut problem: Problem = err.into();
+
+    // Sanitize rate-limit detail to avoid leaking internal key structure
+    // (resource IDs, tenant IDs, scope) in the 429 response body.
+    if rate_limit_meta.is_some() {
+        problem.detail =
+            "Rate limit exceeded. Retry after the duration indicated by the Retry-After header."
+                .to_string();
+    }
+
     let mut response = problem.into_response();
 
     response.headers_mut().insert(
@@ -232,10 +244,27 @@ pub fn error_response(err: DomainError) -> Response {
         HeaderValue::from_static(ErrorSource::Gateway.as_str()),
     );
 
-    if let Some(secs) = retry_after
-        && let Ok(v) = secs.to_string().parse()
-    {
-        response.headers_mut().insert("retry-after", v);
+    if let Some((retry_after_secs, limit, remaining, reset_epoch)) = rate_limit_meta {
+        if let Some(secs) = retry_after_secs
+            && let Ok(v) = secs.to_string().parse()
+        {
+            response.headers_mut().insert("retry-after", v);
+        }
+        if let Some(l) = limit
+            && let Ok(v) = l.to_string().parse()
+        {
+            response.headers_mut().insert("x-ratelimit-limit", v);
+        }
+        if let Some(r) = remaining
+            && let Ok(v) = r.to_string().parse()
+        {
+            response.headers_mut().insert("x-ratelimit-remaining", v);
+        }
+        if let Some(re) = reset_epoch
+            && let Ok(v) = re.to_string().parse()
+        {
+            response.headers_mut().insert("x-ratelimit-reset", v);
+        }
     }
 
     response
@@ -276,6 +305,9 @@ mod tests {
             detail: "rate limit exceeded for upstream".into(),
             instance: "/oagw/v1/proxy/api.openai.com/v1/chat/completions".into(),
             retry_after_secs: Some(30),
+            limit: Some(100),
+            remaining: Some(0),
+            reset_epoch: Some(1706626800),
         };
         let p: Problem = err.into();
         assert_eq!(p.status, StatusCode::TOO_MANY_REQUESTS);
@@ -329,6 +361,9 @@ mod tests {
                 detail: "test".into(),
                 instance: "/test".into(),
                 retry_after_secs: None,
+                limit: None,
+                remaining: None,
+                reset_epoch: None,
             },
             DomainError::SecretNotFound {
                 detail: "test".into(),

--- a/modules/system/oagw/oagw/src/api/rest/handlers/route.rs
+++ b/modules/system/oagw/oagw/src/api/rest/handlers/route.rs
@@ -105,11 +105,22 @@ pub async fn update_route(
 ) -> Result<impl IntoResponse, Problem> {
     let instance = format!("/oagw/v1/routes/{id}");
     let uuid = parse_gts_id(&id, gts::ROUTE_SCHEMA, &instance)?;
+    // Snapshot old rate_limit before update so we can detect changes and
+    // clean up stale rate-limit keys (avoids accumulating orphaned buckets).
+    let old_rate_limit = state
+        .cp
+        .get_route(&ctx, uuid)
+        .await
+        .map_err(|e| domain_error_to_problem(e, &instance))?
+        .rate_limit;
     let route = state
         .cp
         .update_route(&ctx, uuid, req.into())
         .await
         .map_err(|e| domain_error_to_problem(e, &instance))?;
+    if route.rate_limit != old_rate_limit {
+        state.dp.remove_rate_limit_keys_for_route(uuid);
+    }
     Ok(Json(to_response(route)))
 }
 
@@ -125,6 +136,6 @@ pub async fn delete_route(
         .delete_route(&ctx, uuid)
         .await
         .map_err(|e| domain_error_to_problem(e, &instance))?;
-    state.dp.remove_rate_limit_key(&format!("route:{uuid}"));
+    state.dp.remove_rate_limit_keys_for_route(uuid);
     Ok(StatusCode::NO_CONTENT)
 }

--- a/modules/system/oagw/oagw/src/api/rest/handlers/upstream.rs
+++ b/modules/system/oagw/oagw/src/api/rest/handlers/upstream.rs
@@ -82,12 +82,23 @@ pub async fn update_upstream(
 ) -> Result<impl IntoResponse, Problem> {
     let instance = format!("/oagw/v1/upstreams/{id}");
     let uuid = parse_gts_id(&id, gts::UPSTREAM_SCHEMA, &instance)?;
+    // Snapshot old rate_limit before update so we can detect changes and
+    // clean up stale rate-limit keys (avoids accumulating orphaned buckets).
+    let old_rate_limit = state
+        .cp
+        .get_upstream(&ctx, uuid)
+        .await
+        .map_err(|e| domain_error_to_problem(e, &instance))?
+        .rate_limit;
     let upstream = state
         .cp
         .update_upstream(&ctx, uuid, req.into())
         .await
         .map_err(|e| domain_error_to_problem(e, &instance))?;
     state.backend_selector.invalidate(upstream.id);
+    if upstream.rate_limit != old_rate_limit {
+        state.dp.remove_rate_limit_keys_for_upstream(uuid);
+    }
     Ok(Json(to_response(upstream)))
 }
 
@@ -98,12 +109,15 @@ pub async fn delete_upstream(
 ) -> Result<impl IntoResponse, Problem> {
     let instance = format!("/oagw/v1/upstreams/{id}");
     let uuid = parse_gts_id(&id, gts::UPSTREAM_SCHEMA, &instance)?;
-    state
+    let deleted_route_ids = state
         .cp
         .delete_upstream(&ctx, uuid)
         .await
         .map_err(|e| domain_error_to_problem(e, &instance))?;
     state.backend_selector.invalidate(uuid);
-    state.dp.remove_rate_limit_key(&format!("upstream:{uuid}"));
+    state.dp.remove_rate_limit_keys_for_upstream(uuid);
+    for route_id in deleted_route_ids {
+        state.dp.remove_rate_limit_keys_for_route(route_id);
+    }
     Ok(StatusCode::NO_CONTENT)
 }

--- a/modules/system/oagw/oagw/src/domain/error.rs
+++ b/modules/system/oagw/oagw/src/domain/error.rs
@@ -42,6 +42,9 @@ pub enum DomainError {
         detail: String,
         instance: String,
         retry_after_secs: Option<u64>,
+        limit: Option<u64>,
+        remaining: Option<u64>,
+        reset_epoch: Option<u64>,
     },
 
     #[error("{detail}")]

--- a/modules/system/oagw/oagw/src/domain/model.rs
+++ b/modules/system/oagw/oagw/src/domain/model.rs
@@ -149,9 +149,15 @@ pub struct RateLimitConfig {
     pub algorithm: RateLimitAlgorithm,
     pub sustained: SustainedRate,
     pub burst: Option<BurstConfig>,
+    pub budget: Option<BudgetConfig>,
     pub scope: RateLimitScope,
     pub strategy: RateLimitStrategy,
     pub cost: u32,
+    pub response_headers: bool,
+    /// Upstream ID of the shared-pool owner. Populated during hierarchical merge
+    /// when `budget.mode == Shared` — causes all children to share one token
+    /// bucket keyed to the pool owner. Not user-facing (never serialized).
+    pub pool_owner_id: Option<Uuid>,
 }
 
 #[domain_model]
@@ -183,6 +189,28 @@ pub enum Window {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BurstConfig {
     pub capacity: u32,
+}
+
+#[domain_model]
+#[derive(Debug, Clone, PartialEq)]
+pub struct BudgetConfig {
+    pub mode: BudgetMode,
+    /// Total budget capacity. Required for `Allocated` and `Shared` modes.
+    pub total: Option<u32>,
+    /// Over-provisioning ratio (1.0–2.0, default 1.0). Only for `Allocated` mode.
+    pub overcommit_ratio: Option<f64>,
+}
+
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BudgetMode {
+    /// No budget tracking (default for leaf tenants).
+    #[default]
+    Unlimited,
+    /// Parent allocates fixed budget to children.
+    Allocated,
+    /// Children share parent's budget (first-come-first-served).
+    Shared,
 }
 
 #[domain_model]

--- a/modules/system/oagw/oagw/src/domain/rate_limit.rs
+++ b/modules/system/oagw/oagw/src/domain/rate_limit.rs
@@ -1,14 +1,46 @@
 use std::collections::HashSet;
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 
 use crate::domain::error::DomainError;
-use crate::domain::model::{RateLimitConfig, Window};
+use crate::domain::model::{RateLimitAlgorithm, RateLimitConfig, RateLimitScope, Window};
 use dashmap::DashMap;
 use modkit_macros::domain_model;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Clock abstraction — allows deterministic time control in tests.
+// ---------------------------------------------------------------------------
+
+#[cfg(not(test))]
+fn now() -> Instant {
+    Instant::now()
+}
+
+#[cfg(test)]
+thread_local! {
+    static MOCK_NOW: std::cell::Cell<Option<Instant>> = const { std::cell::Cell::new(None) };
+}
+
+#[cfg(test)]
+fn now() -> Instant {
+    MOCK_NOW.with(|cell| cell.get().unwrap_or_else(Instant::now))
+}
+
+/// Quota metadata returned on successful token consumption.
+#[domain_model]
+#[derive(Debug, Clone, Copy)]
+pub struct RateLimitOutcome {
+    /// The bucket capacity (maps to `X-RateLimit-Limit`).
+    pub limit: u64,
+    /// Remaining tokens after consumption (maps to `X-RateLimit-Remaining`).
+    pub remaining: u64,
+    /// Unix epoch timestamp when the bucket will be full again (maps to `X-RateLimit-Reset`).
+    pub reset_epoch: u64,
+}
 
 #[domain_model]
 pub struct RateLimiter {
-    buckets: DashMap<String, TokenBucket>,
+    buckets: DashMap<String, Bucket>,
 }
 
 #[domain_model]
@@ -31,15 +63,15 @@ impl TokenBucket {
             capacity,
             tokens: capacity,
             refill_rate,
-            last_refill: Instant::now(),
+            last_refill: now(),
         }
     }
 
     fn refill(&mut self) {
-        let now = Instant::now();
-        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        let t = now();
+        let elapsed = t.duration_since(self.last_refill).as_secs_f64();
         self.tokens = (self.tokens + elapsed * self.refill_rate).min(self.capacity);
-        self.last_refill = now;
+        self.last_refill = t;
     }
 
     fn try_consume(&mut self, cost: f64) -> bool {
@@ -61,6 +93,252 @@ impl TokenBucket {
             return 0;
         }
         (needed / self.refill_rate).ceil() as u64
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sliding Window — sub-window counting algorithm
+// ---------------------------------------------------------------------------
+
+/// Number of sub-windows per window size. More sub-windows = higher precision
+/// at the cost of slightly more memory per bucket.
+///
+/// | Window | Sub-windows | Sub-window duration | Precision |
+/// |--------|-------------|---------------------|-----------|
+/// | Second | 10          | 100ms               | 100ms     |
+/// | Minute | 60          | 1s                  | 1s        |
+/// | Hour   | 60          | 1min                | 1min      |
+/// | Day    | 144         | 10min               | 10min     |
+fn sub_windows_for(window: &Window) -> usize {
+    match window {
+        Window::Second => 10,
+        Window::Minute => 60,
+        Window::Hour => 60,
+        Window::Day => 144,
+    }
+}
+
+fn window_to_nanos(window: &Window) -> u64 {
+    match window {
+        Window::Second => 1_000_000_000,
+        Window::Minute => 60_000_000_000,
+        Window::Hour => 3_600_000_000_000,
+        Window::Day => 86_400_000_000_000,
+    }
+}
+
+#[domain_model]
+struct SlidingWindowBucket {
+    /// Maximum requests allowed per full window (`sustained.rate`).
+    /// Burst config is intentionally ignored — sliding window enforces strict limits.
+    limit: u32,
+    /// Ring buffer of sub-window request counters.
+    counters: Vec<u32>,
+    /// Number of sub-windows in the ring buffer.
+    num_sub_windows: usize,
+    /// Duration of each sub-window in nanoseconds.
+    sub_window_nanos: u64,
+    /// Index of the current (newest) sub-window in the ring buffer.
+    current_index: usize,
+    /// When the current sub-window started.
+    current_start: Instant,
+    /// Cached sum of all counters (avoids O(n) sum on every check).
+    total_count: u32,
+}
+
+impl SlidingWindowBucket {
+    fn new(config: &RateLimitConfig) -> Self {
+        let n = sub_windows_for(&config.sustained.window);
+        let total_nanos = window_to_nanos(&config.sustained.window);
+        Self {
+            limit: config.sustained.rate,
+            counters: vec![0; n],
+            num_sub_windows: n,
+            sub_window_nanos: total_nanos / n as u64,
+            current_index: 0,
+            current_start: now(),
+            total_count: 0,
+        }
+    }
+
+    /// Advance the ring buffer to the current time, zeroing expired sub-windows.
+    fn advance(&mut self) {
+        let elapsed_nanos = now().duration_since(self.current_start).as_nanos() as u64;
+        let steps = (elapsed_nanos / self.sub_window_nanos) as usize;
+        if steps == 0 {
+            return;
+        }
+        if steps >= self.num_sub_windows {
+            for c in &mut self.counters {
+                *c = 0;
+            }
+            self.total_count = 0;
+            self.current_index = 0;
+            self.current_start = now();
+            return;
+        }
+        for _ in 0..steps {
+            self.current_index = (self.current_index + 1) % self.num_sub_windows;
+            self.total_count -= self.counters[self.current_index];
+            self.counters[self.current_index] = 0;
+        }
+        self.current_start += std::time::Duration::from_nanos(self.sub_window_nanos * steps as u64);
+    }
+
+    fn try_consume(&mut self, cost: u32) -> bool {
+        self.advance();
+        if self.total_count + cost <= self.limit {
+            self.counters[self.current_index] += cost;
+            self.total_count += cost;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn remaining(&self) -> u32 {
+        self.limit.saturating_sub(self.total_count)
+    }
+
+    /// Seconds until enough sub-windows expire to free `cost` capacity.
+    fn retry_after_secs(&self, cost: u32) -> u64 {
+        let needed = (self.total_count + cost).saturating_sub(self.limit);
+        if needed == 0 {
+            return 0;
+        }
+        let elapsed_nanos = now().duration_since(self.current_start).as_nanos() as u64;
+        let remaining_nanos = self.sub_window_nanos.saturating_sub(elapsed_nanos);
+        let mut freed = 0u32;
+        // Walk from oldest sub-window; each step expires one sub-window.
+        for i in 0..self.num_sub_windows {
+            let idx = (self.current_index + 1 + i) % self.num_sub_windows;
+            freed += self.counters[idx];
+            if freed >= needed {
+                let wait_nanos = remaining_nanos + (i as u64) * self.sub_window_nanos;
+                return (wait_nanos as f64 / 1_000_000_000.0).ceil().max(1.0) as u64;
+            }
+        }
+        // Fallback: full window.
+        (self.num_sub_windows as u64 * self.sub_window_nanos / 1_000_000_000).max(1)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bucket — enum wrapper for algorithm dispatch
+// ---------------------------------------------------------------------------
+
+#[allow(unknown_lints, de0309_must_have_domain_model)] // internal runtime bucket, not a domain entity
+enum Bucket {
+    Token(TokenBucket),
+    Sliding(SlidingWindowBucket),
+}
+
+impl Bucket {
+    /// Returns `true` if this bucket's algorithm and parameters match `config`.
+    fn matches_config(&self, config: &RateLimitConfig) -> bool {
+        match (self, &config.algorithm) {
+            (Bucket::Token(tb), RateLimitAlgorithm::TokenBucket) => {
+                let expected_capacity = config
+                    .burst
+                    .as_ref()
+                    .map_or(config.sustained.rate as f64, |b| b.capacity as f64);
+                let expected_refill =
+                    config.sustained.rate as f64 / window_to_secs(&config.sustained.window);
+                (tb.capacity - expected_capacity).abs() < f64::EPSILON
+                    && (tb.refill_rate - expected_refill).abs() < f64::EPSILON
+            }
+            (Bucket::Sliding(sw), RateLimitAlgorithm::SlidingWindow) => {
+                let expected_n = sub_windows_for(&config.sustained.window);
+                let expected_sub_nanos =
+                    window_to_nanos(&config.sustained.window) / expected_n as u64;
+                sw.limit == config.sustained.rate
+                    && sw.num_sub_windows == expected_n
+                    && sw.sub_window_nanos == expected_sub_nanos
+            }
+            _ => false, // Algorithm changed.
+        }
+    }
+}
+
+/// The resource type that owns the rate-limit configuration.
+#[domain_model]
+pub enum RateLimitResource {
+    Upstream,
+    Route,
+}
+
+/// Context needed to build a scope-aware rate-limit key.
+#[allow(unknown_lints, de0309_must_have_domain_model)] // short-lived param container with lifetime, not a domain entity
+pub struct RateLimitKeyContext<'a> {
+    pub resource: RateLimitResource,
+    pub resource_id: &'a Uuid,
+    pub scope: &'a RateLimitScope,
+    pub tenant_id: &'a Uuid,
+    pub subject_id: &'a Uuid,
+    pub client_ip: Option<&'a str>,
+    pub window: &'a Window,
+}
+
+/// Build a rate-limit bucket key based on the configured scope.
+///
+/// Key format: `oagw:ratelimit:{resource_type}:{resource_id}:{scope}:{scope_id}:{window}`
+///
+/// The resource type and id are placed first so that all keys for a given
+/// resource share a common prefix. This enables efficient prefix-based cleanup
+/// in both the in-memory `DashMap` and Redis (`SCAN`).
+///
+/// For in-memory token buckets the window segment contains only the time unit
+/// (e.g. `second`). Phase 8 (Redis) will append the time-bucket ID
+/// (e.g. `minute:202601301530`).
+///
+/// **IP scope fallback:** When `scope` is `Ip` and `client_ip` is `None`
+/// (i.e. neither `X-Forwarded-For` nor `X-Real-IP` headers are present), the
+/// key uses the literal `"unknown"` as the scope identifier. This causes all
+/// such requests to share a single bucket, effectively degrading to global
+/// scope for the resource.
+pub fn build_rate_limit_key(ctx: &RateLimitKeyContext<'_>) -> String {
+    let res = match ctx.resource {
+        RateLimitResource::Upstream => "upstream",
+        RateLimitResource::Route => "route",
+    };
+    let w = window_label(ctx.window);
+    match ctx.scope {
+        RateLimitScope::Global => {
+            format!("oagw:ratelimit:{res}:{}:global:{w}", ctx.resource_id)
+        }
+        RateLimitScope::Tenant => {
+            format!(
+                "oagw:ratelimit:{res}:{}:tenant:{}:{w}",
+                ctx.resource_id, ctx.tenant_id
+            )
+        }
+        RateLimitScope::User => {
+            format!(
+                "oagw:ratelimit:{res}:{}:user:{}:{w}",
+                ctx.resource_id, ctx.subject_id
+            )
+        }
+        // When client_ip is None (no X-Forwarded-For / X-Real-IP), falls back to
+        // "unknown" — all such requests share one bucket (effectively global scope).
+        RateLimitScope::Ip => {
+            format!(
+                "oagw:ratelimit:{res}:{}:ip:{}:{w}",
+                ctx.resource_id,
+                ctx.client_ip.unwrap_or("unknown")
+            )
+        }
+        RateLimitScope::Route => {
+            format!("oagw:ratelimit:{res}:{}:route:{w}", ctx.resource_id)
+        }
+    }
+}
+
+fn window_label(window: &Window) -> &'static str {
+    match window {
+        Window::Second => "second",
+        Window::Minute => "minute",
+        Window::Hour => "hour",
+        Window::Day => "day",
     }
 }
 
@@ -87,15 +365,22 @@ impl RateLimiter {
         self.buckets.retain(|k, _| active_keys.contains(k));
     }
 
-    /// Remove a single rate-limit bucket by key.
-    ///
-    /// Called when an upstream or route is deleted so the stale bucket
-    /// does not linger in memory.
-    pub fn remove_key(&self, key: &str) {
-        self.buckets.remove(key);
+    /// Remove all rate-limit buckets associated with an upstream (across all scopes).
+    pub fn remove_keys_for_upstream(&self, upstream_id: Uuid) {
+        let prefix = format!("oagw:ratelimit:upstream:{upstream_id}:");
+        self.buckets.retain(|k, _| !k.starts_with(&prefix));
+    }
+
+    /// Remove all rate-limit buckets associated with a route.
+    pub fn remove_keys_for_route(&self, route_id: Uuid) {
+        let prefix = format!("oagw:ratelimit:route:{route_id}:");
+        self.buckets.retain(|k, _| !k.starts_with(&prefix));
     }
 
     /// Try to consume tokens for the given key.
+    ///
+    /// Dispatches to the appropriate algorithm (`TokenBucket` or `SlidingWindow`)
+    /// based on `config.algorithm`.
     ///
     /// # Errors
     /// Returns `DomainError::RateLimitExceeded` with Retry-After seconds when exhausted.
@@ -104,22 +389,121 @@ impl RateLimiter {
         key: &str,
         config: &RateLimitConfig,
         instance_uri: &str,
-    ) -> Result<(), DomainError> {
-        let cost = config.cost as f64;
-        let mut bucket = self
+    ) -> Result<RateLimitOutcome, DomainError> {
+        let mut entry = self
             .buckets
             .entry(key.to_string())
-            .or_insert_with(|| TokenBucket::new(config));
-
-        if bucket.try_consume(cost) {
-            Ok(())
-        } else {
-            let retry_after = bucket.retry_after_secs(cost);
-            Err(DomainError::RateLimitExceeded {
-                detail: format!("rate limit exceeded for key: {key}"),
-                instance: instance_uri.to_string(),
-                retry_after_secs: Some(retry_after),
+            .and_modify(|bucket| {
+                if !bucket.matches_config(config) {
+                    *bucket = match config.algorithm {
+                        RateLimitAlgorithm::TokenBucket => Bucket::Token(TokenBucket::new(config)),
+                        RateLimitAlgorithm::SlidingWindow => {
+                            Bucket::Sliding(SlidingWindowBucket::new(config))
+                        }
+                    };
+                }
             })
+            .or_insert_with(|| match config.algorithm {
+                RateLimitAlgorithm::TokenBucket => Bucket::Token(TokenBucket::new(config)),
+                RateLimitAlgorithm::SlidingWindow => {
+                    Bucket::Sliding(SlidingWindowBucket::new(config))
+                }
+            });
+
+        let now_epoch = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        match &mut *entry {
+            Bucket::Token(bucket) => {
+                let cost = config.cost as f64;
+                if bucket.try_consume(cost) {
+                    let limit = bucket.capacity as u64;
+                    let remaining = bucket.tokens.floor().max(0.0) as u64;
+                    let secs_to_full = if bucket.refill_rate > 0.0 {
+                        ((bucket.capacity - bucket.tokens) / bucket.refill_rate).ceil() as u64
+                    } else {
+                        0
+                    };
+                    Ok(RateLimitOutcome {
+                        limit,
+                        remaining,
+                        reset_epoch: now_epoch + secs_to_full,
+                    })
+                } else {
+                    let retry_after = bucket.retry_after_secs(cost);
+                    let limit = bucket.capacity as u64;
+                    let remaining = bucket.tokens.floor().max(0.0) as u64;
+                    let secs_to_full = if bucket.refill_rate > 0.0 {
+                        ((bucket.capacity - bucket.tokens) / bucket.refill_rate).ceil() as u64
+                    } else {
+                        0
+                    };
+                    Err(DomainError::RateLimitExceeded {
+                        detail: "rate limit exceeded".to_string(),
+                        instance: instance_uri.to_string(),
+                        retry_after_secs: Some(retry_after),
+                        limit: if config.response_headers {
+                            Some(limit)
+                        } else {
+                            None
+                        },
+                        remaining: if config.response_headers {
+                            Some(remaining)
+                        } else {
+                            None
+                        },
+                        reset_epoch: if config.response_headers {
+                            Some(now_epoch + secs_to_full)
+                        } else {
+                            None
+                        },
+                    })
+                }
+            }
+            Bucket::Sliding(bucket) => {
+                let cost = config.cost;
+                if bucket.try_consume(cost) {
+                    let limit = bucket.limit as u64;
+                    let remaining = bucket.remaining() as u64;
+                    let secs_to_full = if bucket.total_count == 0 {
+                        0
+                    } else {
+                        window_to_secs(&config.sustained.window).ceil() as u64
+                    };
+                    Ok(RateLimitOutcome {
+                        limit,
+                        remaining,
+                        reset_epoch: now_epoch + secs_to_full,
+                    })
+                } else {
+                    let retry_after = bucket.retry_after_secs(cost);
+                    let limit = bucket.limit as u64;
+                    let remaining = bucket.remaining() as u64;
+                    let window_secs = window_to_secs(&config.sustained.window).ceil() as u64;
+                    Err(DomainError::RateLimitExceeded {
+                        detail: "rate limit exceeded".to_string(),
+                        instance: instance_uri.to_string(),
+                        retry_after_secs: Some(retry_after),
+                        limit: if config.response_headers {
+                            Some(limit)
+                        } else {
+                            None
+                        },
+                        remaining: if config.response_headers {
+                            Some(remaining)
+                        } else {
+                            None
+                        },
+                        reset_epoch: if config.response_headers {
+                            Some(now_epoch + window_secs)
+                        } else {
+                            None
+                        },
+                    })
+                }
+            }
         }
     }
 }
@@ -129,6 +513,7 @@ mod tests {
     use crate::domain::model::{
         BurstConfig, RateLimitAlgorithm, RateLimitScope, RateLimitStrategy, SustainedRate,
     };
+    use uuid::Uuid;
 
     use super::*;
 
@@ -138,9 +523,12 @@ mod tests {
             algorithm: RateLimitAlgorithm::TokenBucket,
             sustained: SustainedRate { rate, window },
             burst: burst_capacity.map(|c| BurstConfig { capacity: c }),
+            budget: None,
             scope: RateLimitScope::Tenant,
             strategy: RateLimitStrategy::Reject,
             cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
         }
     }
 
@@ -218,29 +606,6 @@ mod tests {
     }
 
     #[test]
-    fn remove_key_deletes_single_bucket() {
-        let limiter = RateLimiter::new();
-        let config = make_config(10, Window::Second, None);
-        limiter
-            .try_consume("upstream:aaa", &config, "/test")
-            .unwrap();
-        limiter.try_consume("route:bbb", &config, "/test").unwrap();
-
-        limiter.remove_key("upstream:aaa");
-
-        assert!(!limiter.buckets.contains_key("upstream:aaa"));
-        assert!(limiter.buckets.contains_key("route:bbb"));
-    }
-
-    #[test]
-    fn remove_key_noop_for_missing_key() {
-        let limiter = RateLimiter::new();
-        // Should not panic.
-        limiter.remove_key("nonexistent");
-        assert!(limiter.buckets.is_empty());
-    }
-
-    #[test]
     fn purge_with_empty_set_removes_all() {
         let limiter = RateLimiter::new();
         let config = make_config(10, Window::Second, None);
@@ -250,5 +615,704 @@ mod tests {
         limiter.purge_keys(&HashSet::new());
 
         assert!(limiter.buckets.is_empty());
+    }
+
+    #[test]
+    fn try_consume_returns_outcome_metadata() {
+        let limiter = RateLimiter::new();
+        let config = make_config(10, Window::Second, Some(10));
+
+        let outcome = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(outcome.limit, 10);
+        assert_eq!(outcome.remaining, 9);
+
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(outcome.reset_epoch >= now_epoch);
+        assert!(outcome.reset_epoch <= now_epoch + 2);
+
+        // Consume more and verify remaining decreases.
+        let outcome2 = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(outcome2.remaining, 8);
+    }
+
+    #[test]
+    fn error_includes_rate_limit_metadata() {
+        let limiter = RateLimiter::new();
+        let config = make_config(1, Window::Second, Some(1));
+        limiter.try_consume("test", &config, "/test").unwrap();
+
+        match limiter.try_consume("test", &config, "/test") {
+            Err(DomainError::RateLimitExceeded {
+                limit,
+                remaining,
+                reset_epoch,
+                ..
+            }) => {
+                assert_eq!(limit, Some(1));
+                assert_eq!(remaining, Some(0));
+                let now_epoch = std::time::SystemTime::now()
+                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                assert!(reset_epoch.unwrap() >= now_epoch);
+            }
+            other => panic!("expected RateLimitExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn outcome_limit_falls_back_to_sustained_rate_without_burst() {
+        let limiter = RateLimiter::new();
+        let config = make_config(5, Window::Second, None); // no burst
+        let outcome = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(
+            outcome.limit, 5,
+            "limit should equal sustained rate when burst is absent"
+        );
+    }
+
+    #[test]
+    fn outcome_reset_epoch_in_future() {
+        let limiter = RateLimiter::new();
+        let config = make_config(10, Window::Second, Some(10));
+        // Consume 5 tokens so the bucket is partially drained.
+        for _ in 0..5 {
+            limiter.try_consume("test", &config, "/test").unwrap();
+        }
+        let outcome = limiter.try_consume("test", &config, "/test").unwrap();
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(
+            outcome.reset_epoch >= now_epoch,
+            "reset_epoch should be >= now"
+        );
+    }
+
+    #[test]
+    fn error_reset_epoch_is_time_until_full() {
+        let limiter = RateLimiter::new();
+        // capacity=5, rate=5/min → refill_rate ≈ 0.083 tok/s.
+        // Consuming all 5 means secs_to_full ≈ 60s, but retry_after ≈ 12s (1 token).
+        let config = make_config(5, Window::Minute, Some(5));
+        for _ in 0..5 {
+            limiter.try_consume("test", &config, "/test").unwrap();
+        }
+
+        match limiter.try_consume("test", &config, "/test") {
+            Err(DomainError::RateLimitExceeded {
+                retry_after_secs,
+                reset_epoch,
+                ..
+            }) => {
+                let now_epoch = std::time::SystemTime::now()
+                    .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                let retry = retry_after_secs.unwrap();
+                let reset = reset_epoch.unwrap();
+
+                // reset_epoch should reflect time-until-full (≈60s), not retry_after (≈12s).
+                assert!(
+                    reset >= now_epoch + 50,
+                    "reset_epoch ({reset}) should be ≈60s from now ({now_epoch}), \
+                     not ≈retry_after ({retry}s)"
+                );
+                assert!(
+                    retry < 20,
+                    "retry_after ({retry}s) should be much less than secs_to_full"
+                );
+            }
+            other => panic!("expected RateLimitExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cost_greater_than_one_consumes_multiple_tokens() {
+        let limiter = RateLimiter::new();
+        let mut config = make_config(100, Window::Second, Some(10));
+        config.cost = 3;
+
+        // 10 tokens, cost=3: should allow 3 requests (9 tokens), fail on 4th (1 < 3).
+        let o1 = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(o1.remaining, 7);
+
+        let o2 = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(o2.remaining, 4);
+
+        let o3 = limiter.try_consume("test", &config, "/test").unwrap();
+        assert_eq!(o3.remaining, 1);
+
+        let err = limiter.try_consume("test", &config, "/test").unwrap_err();
+        assert!(matches!(err, DomainError::RateLimitExceeded { .. }));
+    }
+
+    #[test]
+    fn error_omits_metadata_when_response_headers_false() {
+        let limiter = RateLimiter::new();
+        let mut config = make_config(1, Window::Minute, Some(1));
+        config.response_headers = false;
+
+        // Exhaust the bucket.
+        limiter.try_consume("test", &config, "/test").unwrap();
+
+        // Second request should be rejected.
+        let err = limiter.try_consume("test", &config, "/test").unwrap_err();
+        match err {
+            DomainError::RateLimitExceeded {
+                retry_after_secs,
+                limit,
+                remaining,
+                reset_epoch,
+                ..
+            } => {
+                assert!(
+                    retry_after_secs.is_some(),
+                    "retry_after_secs must always be present regardless of response_headers"
+                );
+                assert!(
+                    limit.is_none(),
+                    "limit must be None when response_headers is false"
+                );
+                assert!(
+                    remaining.is_none(),
+                    "remaining must be None when response_headers is false"
+                );
+                assert!(
+                    reset_epoch.is_none(),
+                    "reset_epoch must be None when response_headers is false"
+                );
+            }
+            other => panic!("expected RateLimitExceeded, got {other:?}"),
+        }
+    }
+
+    // --- build_rate_limit_key tests ---
+
+    fn upstream_ctx<'a>(
+        id: &'a Uuid,
+        scope: &'a RateLimitScope,
+        tenant_id: &'a Uuid,
+        subject_id: &'a Uuid,
+        client_ip: Option<&'a str>,
+        window: &'a Window,
+    ) -> RateLimitKeyContext<'a> {
+        RateLimitKeyContext {
+            resource: RateLimitResource::Upstream,
+            resource_id: id,
+            scope,
+            tenant_id,
+            subject_id,
+            client_ip,
+            window,
+        }
+    }
+
+    fn route_ctx<'a>(
+        id: &'a Uuid,
+        scope: &'a RateLimitScope,
+        tenant_id: &'a Uuid,
+        subject_id: &'a Uuid,
+        client_ip: Option<&'a str>,
+        window: &'a Window,
+    ) -> RateLimitKeyContext<'a> {
+        RateLimitKeyContext {
+            resource: RateLimitResource::Route,
+            resource_id: id,
+            scope,
+            tenant_id,
+            subject_id,
+            client_ip,
+            window,
+        }
+    }
+
+    #[test]
+    fn build_key_global() {
+        let uid = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let zero = Uuid::nil();
+        let key = build_rate_limit_key(&upstream_ctx(
+            &uid,
+            &RateLimitScope::Global,
+            &zero,
+            &zero,
+            None,
+            &Window::Second,
+        ));
+        assert_eq!(key, format!("oagw:ratelimit:upstream:{uid}:global:second"));
+    }
+
+    #[test]
+    fn build_key_tenant() {
+        let uid = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let tid = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
+        let zero = Uuid::nil();
+        let key = build_rate_limit_key(&upstream_ctx(
+            &uid,
+            &RateLimitScope::Tenant,
+            &tid,
+            &zero,
+            None,
+            &Window::Minute,
+        ));
+        assert_eq!(
+            key,
+            format!("oagw:ratelimit:upstream:{uid}:tenant:{tid}:minute")
+        );
+    }
+
+    #[test]
+    fn build_key_user() {
+        let uid = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let sid = Uuid::parse_str("00000000-0000-0000-0000-000000000003").unwrap();
+        let zero = Uuid::nil();
+        let key = build_rate_limit_key(&upstream_ctx(
+            &uid,
+            &RateLimitScope::User,
+            &zero,
+            &sid,
+            None,
+            &Window::Hour,
+        ));
+        assert_eq!(
+            key,
+            format!("oagw:ratelimit:upstream:{uid}:user:{sid}:hour")
+        );
+    }
+
+    #[test]
+    fn build_key_ip_present() {
+        let uid = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let zero = Uuid::nil();
+        let key = build_rate_limit_key(&upstream_ctx(
+            &uid,
+            &RateLimitScope::Ip,
+            &zero,
+            &zero,
+            Some("192.168.1.1"),
+            &Window::Day,
+        ));
+        assert_eq!(
+            key,
+            format!("oagw:ratelimit:upstream:{uid}:ip:192.168.1.1:day")
+        );
+    }
+
+    #[test]
+    fn build_key_ip_absent() {
+        let uid = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
+        let zero = Uuid::nil();
+        let key = build_rate_limit_key(&upstream_ctx(
+            &uid,
+            &RateLimitScope::Ip,
+            &zero,
+            &zero,
+            None,
+            &Window::Second,
+        ));
+        assert_eq!(
+            key,
+            format!("oagw:ratelimit:upstream:{uid}:ip:unknown:second")
+        );
+    }
+
+    #[test]
+    fn build_key_route_resource() {
+        let rid = Uuid::parse_str("00000000-0000-0000-0000-000000000004").unwrap();
+        let tid = Uuid::parse_str("00000000-0000-0000-0000-000000000002").unwrap();
+        let zero = Uuid::nil();
+        let key = build_rate_limit_key(&route_ctx(
+            &rid,
+            &RateLimitScope::Tenant,
+            &tid,
+            &zero,
+            None,
+            &Window::Second,
+        ));
+        assert_eq!(
+            key,
+            format!("oagw:ratelimit:route:{rid}:tenant:{tid}:second")
+        );
+    }
+
+    #[test]
+    fn build_key_route_scope() {
+        let rid = Uuid::parse_str("00000000-0000-0000-0000-000000000004").unwrap(); // lgtm[rs/cleartext-logging]
+        let zero = Uuid::nil();
+        let key = build_rate_limit_key(&route_ctx(
+            &rid,
+            &RateLimitScope::Route,
+            &zero,
+            &zero,
+            None,
+            &Window::Second,
+        ));
+        assert_eq!(key, format!("oagw:ratelimit:route:{rid}:route:second"));
+    }
+
+    #[test]
+    fn remove_keys_for_upstream_cleans_all_scopes() {
+        const UID: &str = "00000000-0000-0000-0000-000000000001";
+
+        let limiter = RateLimiter::new();
+        let config = make_config(10, Window::Second, None);
+        let uid = Uuid::parse_str(UID).unwrap();
+
+        // All scopes share the prefix `oagw:ratelimit:upstream:{UID}:`.
+        let keys: [&str; 4] = [
+            "oagw:ratelimit:upstream:00000000-0000-0000-0000-000000000001:global:second",
+            "oagw:ratelimit:upstream:00000000-0000-0000-0000-000000000001:tenant:aaa:minute",
+            "oagw:ratelimit:upstream:00000000-0000-0000-0000-000000000001:user:bbb:hour",
+            "oagw:ratelimit:upstream:00000000-0000-0000-0000-000000000001:ip:1.2.3.4:day",
+        ];
+        for k in &keys {
+            limiter.try_consume(k, &config, "/test").unwrap();
+        }
+        // Unrelated upstream key that should survive.
+        let other = "oagw:ratelimit:upstream:00000000-0000-0000-0000-000000000099:global:second";
+        limiter.try_consume(other, &config, "/test").unwrap();
+
+        limiter.remove_keys_for_upstream(uid);
+
+        for k in &keys {
+            assert!(
+                !limiter.buckets.contains_key(*k),
+                "key {k} should be removed"
+            );
+        }
+        assert!(limiter.buckets.contains_key(other));
+    }
+
+    #[test]
+    fn remove_keys_for_route_cleans_only_route() {
+        let limiter = RateLimiter::new();
+        let config = make_config(10, Window::Second, None);
+        let rid = Uuid::parse_str("00000000-0000-0000-0000-000000000004").unwrap();
+
+        let route_key = format!("oagw:ratelimit:route:{rid}:tenant:aaa:second");
+        let upstream_key =
+            "oagw:ratelimit:upstream:00000000-0000-0000-0000-000000000001:global:second";
+        limiter.try_consume(&route_key, &config, "/test").unwrap();
+        limiter.try_consume(upstream_key, &config, "/test").unwrap();
+
+        limiter.remove_keys_for_route(rid);
+
+        assert!(!limiter.buckets.contains_key(route_key.as_str()));
+        assert!(limiter.buckets.contains_key(upstream_key));
+    }
+
+    // --- Sliding Window tests ---
+
+    fn make_sliding_config(rate: u32, window: Window) -> RateLimitConfig {
+        RateLimitConfig {
+            sharing: Default::default(),
+            algorithm: RateLimitAlgorithm::SlidingWindow,
+            sustained: SustainedRate { rate, window },
+            burst: None,
+            budget: None,
+            scope: RateLimitScope::Tenant,
+            strategy: RateLimitStrategy::Reject,
+            cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
+        }
+    }
+
+    fn set_mock_time(t: Instant) {
+        MOCK_NOW.with(|cell| cell.set(Some(t)));
+    }
+
+    fn clear_mock_time() {
+        MOCK_NOW.with(|cell| cell.set(None));
+    }
+
+    #[test]
+    fn sliding_window_allows_within_rate() {
+        let limiter = RateLimiter::new();
+        let config = make_sliding_config(10, Window::Second);
+        for _ in 0..10 {
+            assert!(limiter.try_consume("sw", &config, "/test").is_ok());
+        }
+    }
+
+    #[test]
+    fn sliding_window_denies_when_exhausted() {
+        let limiter = RateLimiter::new();
+        let config = make_sliding_config(2, Window::Second);
+        assert!(limiter.try_consume("sw", &config, "/test").is_ok());
+        assert!(limiter.try_consume("sw", &config, "/test").is_ok());
+        let err = limiter.try_consume("sw", &config, "/test").unwrap_err();
+        assert!(matches!(err, DomainError::RateLimitExceeded { .. }));
+    }
+
+    #[test]
+    fn sliding_window_boundary_burst_prevented() {
+        let t0 = Instant::now();
+        set_mock_time(t0);
+
+        let limiter = RateLimiter::new();
+        let config = make_sliding_config(10, Window::Second);
+
+        // Fill the window at t0 (all 10 land in sub-window 0).
+        for _ in 0..10 {
+            assert!(limiter.try_consume("sw", &config, "/test").is_ok());
+        }
+
+        // Advance just past one sub-window boundary (100ms for Second/10 sub-windows).
+        // Only sub-window 0 is active with 10 counts; the window hasn't expired.
+        let one_sub = std::time::Duration::from_millis(100);
+        set_mock_time(t0 + one_sub);
+
+        // New requests should be rejected — the 10 counts from sub-window 0 haven't
+        // expired yet (only 1 of 10 sub-windows has rotated, but sub-window 0's
+        // counts are still within the sliding window).
+        let err = limiter.try_consume("sw", &config, "/test").unwrap_err();
+        assert!(matches!(err, DomainError::RateLimitExceeded { .. }));
+
+        clear_mock_time();
+    }
+
+    #[test]
+    fn sliding_window_ignores_burst_config() {
+        let limiter = RateLimiter::new();
+        let mut config = make_sliding_config(10, Window::Second);
+        config.burst = Some(BurstConfig { capacity: 50 });
+
+        // Limit should be sustained.rate (10), not burst (50).
+        for _ in 0..10 {
+            assert!(limiter.try_consume("sw", &config, "/test").is_ok());
+        }
+        let err = limiter.try_consume("sw", &config, "/test").unwrap_err();
+        assert!(matches!(err, DomainError::RateLimitExceeded { .. }));
+    }
+
+    #[test]
+    fn sliding_window_retry_after_calculated() {
+        let limiter = RateLimiter::new();
+        let config = make_sliding_config(1, Window::Minute);
+        assert!(limiter.try_consume("sw", &config, "/test").is_ok());
+        match limiter.try_consume("sw", &config, "/test") {
+            Err(DomainError::RateLimitExceeded {
+                retry_after_secs, ..
+            }) => {
+                let retry = retry_after_secs.unwrap();
+                assert!(retry >= 1, "retry_after should be >= 1s, got {retry}");
+                assert!(retry <= 60, "retry_after should be <= 60s, got {retry}");
+            }
+            other => panic!("expected RateLimitExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sliding_window_remaining_decreases() {
+        let limiter = RateLimiter::new();
+        let config = make_sliding_config(10, Window::Second);
+
+        let o1 = limiter.try_consume("sw", &config, "/test").unwrap();
+        assert_eq!(o1.limit, 10);
+        assert_eq!(o1.remaining, 9);
+
+        let o2 = limiter.try_consume("sw", &config, "/test").unwrap();
+        assert_eq!(o2.remaining, 8);
+    }
+
+    #[test]
+    fn sliding_window_success_reset_epoch_reflects_full_window() {
+        let limiter = RateLimiter::new();
+        let config = make_sliding_config(10, Window::Minute);
+
+        // Consume 6 of 10 — should succeed.
+        for _ in 0..6 {
+            limiter.try_consume("sw", &config, "/test").unwrap();
+        }
+
+        let outcome = limiter.try_consume("sw", &config, "/test").unwrap();
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        // reset_epoch should be approximately now + 60s (full minute window),
+        // NOT now + retry_after_for_1 (which would be ~1s).
+        assert!(
+            outcome.reset_epoch >= now_epoch + 50,
+            "reset_epoch ({}) should be ~60s from now ({}), reflecting full window duration",
+            outcome.reset_epoch,
+            now_epoch
+        );
+        assert!(
+            outcome.reset_epoch <= now_epoch + 70,
+            "reset_epoch ({}) should not overshoot the window duration",
+            outcome.reset_epoch
+        );
+    }
+
+    #[test]
+    fn sliding_window_cost_greater_than_one() {
+        let limiter = RateLimiter::new();
+        let mut config = make_sliding_config(10, Window::Second);
+        config.cost = 3;
+
+        // 10 capacity, cost=3: allows 3 requests (9 used), fails on 4th (1 < 3).
+        let o1 = limiter.try_consume("sw", &config, "/test").unwrap();
+        assert_eq!(o1.remaining, 7);
+        let o2 = limiter.try_consume("sw", &config, "/test").unwrap();
+        assert_eq!(o2.remaining, 4);
+        let o3 = limiter.try_consume("sw", &config, "/test").unwrap();
+        assert_eq!(o3.remaining, 1);
+        assert!(limiter.try_consume("sw", &config, "/test").is_err());
+    }
+
+    #[test]
+    fn sliding_window_separate_keys_independent() {
+        let limiter = RateLimiter::new();
+        let config = make_sliding_config(1, Window::Second);
+        assert!(limiter.try_consume("sw-a", &config, "/test").is_ok());
+        assert!(limiter.try_consume("sw-b", &config, "/test").is_ok());
+        assert!(limiter.try_consume("sw-a", &config, "/test").is_err());
+        assert!(limiter.try_consume("sw-b", &config, "/test").is_err());
+    }
+
+    #[test]
+    fn sliding_window_recovery_after_full_window() {
+        let t0 = Instant::now();
+        set_mock_time(t0);
+
+        let limiter = RateLimiter::new();
+        let config = make_sliding_config(5, Window::Second);
+
+        // Exhaust the window.
+        for _ in 0..5 {
+            assert!(limiter.try_consume("sw", &config, "/test").is_ok());
+        }
+        assert!(limiter.try_consume("sw", &config, "/test").is_err());
+
+        // Advance past the full window — all sub-windows expire.
+        set_mock_time(t0 + std::time::Duration::from_secs(2));
+        for _ in 0..5 {
+            assert!(limiter.try_consume("sw", &config, "/test").is_ok());
+        }
+
+        clear_mock_time();
+    }
+
+    #[test]
+    fn sliding_window_sub_window_granular_recovery() {
+        let t0 = Instant::now();
+        set_mock_time(t0);
+
+        let limiter = RateLimiter::new();
+        // 10 per second, 10 sub-windows → each sub-window is 100ms.
+        let config = make_sliding_config(10, Window::Second);
+
+        // Fill sub-window 0 with 5 requests, then advance to sub-window 1 and fill
+        // with 5 more. Total = 10, window is full.
+        for _ in 0..5 {
+            assert!(limiter.try_consume("sw", &config, "/test").is_ok());
+        }
+        set_mock_time(t0 + std::time::Duration::from_millis(100));
+        for _ in 0..5 {
+            assert!(limiter.try_consume("sw", &config, "/test").is_ok());
+        }
+        assert!(limiter.try_consume("sw", &config, "/test").is_err());
+
+        // Advance so sub-window 0 (with 5 counts) rotates out.
+        // We need to be at sub-window index 10 relative to start, which means
+        // 10 sub-windows = 1000ms from t0. But only 9 more sub-windows need to
+        // pass from the current position (sub-window 1). So advance to t0 + 1000ms.
+        set_mock_time(t0 + std::time::Duration::from_millis(1000));
+
+        // Sub-window 0's 5 counts have expired, freeing 5 capacity.
+        // Sub-window 1's 5 counts are still active. So we have 5 remaining.
+        for _ in 0..5 {
+            assert!(limiter.try_consume("sw", &config, "/test").is_ok());
+        }
+        assert!(limiter.try_consume("sw", &config, "/test").is_err());
+
+        clear_mock_time();
+    }
+
+    // -- Bucket::matches_config tests --
+
+    #[test]
+    fn matches_config_same_token_bucket() {
+        let config = make_config(100, Window::Second, Some(500));
+        let bucket = Bucket::Token(TokenBucket::new(&config));
+        assert!(bucket.matches_config(&config));
+    }
+
+    #[test]
+    fn matches_config_different_rate() {
+        let config = make_config(100, Window::Second, Some(500));
+        let bucket = Bucket::Token(TokenBucket::new(&config));
+
+        let changed = make_config(200, Window::Second, Some(500));
+        assert!(!bucket.matches_config(&changed));
+    }
+
+    #[test]
+    fn matches_config_different_window() {
+        let config = make_config(100, Window::Second, Some(500));
+        let bucket = Bucket::Token(TokenBucket::new(&config));
+
+        let changed = make_config(100, Window::Minute, Some(500));
+        assert!(!bucket.matches_config(&changed));
+    }
+
+    #[test]
+    fn matches_config_different_burst() {
+        let config = make_config(100, Window::Second, Some(500));
+        let bucket = Bucket::Token(TokenBucket::new(&config));
+
+        let changed = make_config(100, Window::Second, Some(1000));
+        assert!(!bucket.matches_config(&changed));
+    }
+
+    #[test]
+    fn matches_config_algorithm_change() {
+        let config = make_config(100, Window::Second, Some(500));
+        let bucket = Bucket::Token(TokenBucket::new(&config));
+
+        let mut sw_config = make_config(100, Window::Second, None);
+        sw_config.algorithm = RateLimitAlgorithm::SlidingWindow;
+        assert!(!bucket.matches_config(&sw_config));
+    }
+
+    #[test]
+    fn matches_config_sliding_window_same() {
+        let mut config = make_config(100, Window::Minute, None);
+        config.algorithm = RateLimitAlgorithm::SlidingWindow;
+        let bucket = Bucket::Sliding(SlidingWindowBucket::new(&config));
+        assert!(bucket.matches_config(&config));
+    }
+
+    #[test]
+    fn matches_config_sliding_window_different_rate() {
+        let mut config = make_config(100, Window::Minute, None);
+        config.algorithm = RateLimitAlgorithm::SlidingWindow;
+        let bucket = Bucket::Sliding(SlidingWindowBucket::new(&config));
+
+        let mut changed = make_config(200, Window::Minute, None);
+        changed.algorithm = RateLimitAlgorithm::SlidingWindow;
+        assert!(!bucket.matches_config(&changed));
+    }
+
+    #[test]
+    fn bucket_reinitializes_on_config_change() {
+        let limiter = RateLimiter::new();
+        let config = make_config(2, Window::Second, None);
+
+        // Exhaust the bucket.
+        assert!(limiter.try_consume("key", &config, "/test").is_ok());
+        assert!(limiter.try_consume("key", &config, "/test").is_ok());
+        assert!(limiter.try_consume("key", &config, "/test").is_err());
+
+        // Change config: higher capacity. Bucket should be reinitialized.
+        let new_config = make_config(10, Window::Second, None);
+        assert!(limiter.try_consume("key", &new_config, "/test").is_ok());
     }
 }

--- a/modules/system/oagw/oagw/src/domain/repo.rs
+++ b/modules/system/oagw/oagw/src/domain/repo.rs
@@ -49,6 +49,18 @@ pub trait UpstreamRepository: Send + Sync {
 
     /// Delete an upstream. Returns NotFound if it does not exist.
     async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<(), RepositoryError>;
+
+    /// List upstreams with the given alias restricted to a set of tenant IDs.
+    /// Used for budget validation where only descendants of a particular
+    /// ancestor are relevant.
+    ///
+    /// The provided `alias` must already be normalized (lowercase) as
+    /// implementations perform case-sensitive exact-string matching.
+    async fn list_by_alias_for_tenants(
+        &self,
+        alias: &str,
+        tenant_ids: &std::collections::HashSet<Uuid>,
+    ) -> Result<Vec<Upstream>, RepositoryError>;
 }
 
 /// Repository trait for route persistence.
@@ -84,10 +96,10 @@ pub trait RouteRepository: Send + Sync {
     /// Delete a route.
     async fn delete(&self, tenant_id: Uuid, id: Uuid) -> Result<(), RepositoryError>;
 
-    /// Delete all routes for a given upstream. Returns the count of deleted routes.
+    /// Delete all routes for a given upstream. Returns the IDs of deleted routes.
     async fn delete_by_upstream(
         &self,
         tenant_id: Uuid,
         upstream_id: Uuid,
-    ) -> Result<u64, RepositoryError>;
+    ) -> Result<Vec<Uuid>, RepositoryError>;
 }

--- a/modules/system/oagw/oagw/src/domain/services/client.rs
+++ b/modules/system/oagw/oagw/src/domain/services/client.rs
@@ -88,6 +88,7 @@ impl ServiceGatewayClientV1 for ServiceGatewayClientV1Facade {
         self.cp
             .delete_upstream(&ctx, id)
             .await
+            .map(|_| ())
             .map_err(domain_err_to_sdk)
     }
 
@@ -228,6 +229,7 @@ fn domain_err_to_sdk(err: DomainError) -> ServiceGatewayError {
             detail,
             instance,
             retry_after_secs,
+            ..
         } => ServiceGatewayError::RateLimitExceeded {
             detail,
             instance,
@@ -450,6 +452,15 @@ fn rate_limit_config_to_domain(v: oagw_sdk::RateLimitConfig) -> model::RateLimit
         burst: v.burst.map(|b| model::BurstConfig {
             capacity: b.capacity,
         }),
+        budget: v.budget.map(|b| model::BudgetConfig {
+            mode: match b.mode {
+                oagw_sdk::BudgetMode::Unlimited => model::BudgetMode::Unlimited,
+                oagw_sdk::BudgetMode::Allocated => model::BudgetMode::Allocated,
+                oagw_sdk::BudgetMode::Shared => model::BudgetMode::Shared,
+            },
+            total: b.total,
+            overcommit_ratio: b.overcommit_ratio,
+        }),
         scope: match v.scope {
             oagw_sdk::RateLimitScope::Global => model::RateLimitScope::Global,
             oagw_sdk::RateLimitScope::Tenant => model::RateLimitScope::Tenant,
@@ -463,6 +474,8 @@ fn rate_limit_config_to_domain(v: oagw_sdk::RateLimitConfig) -> model::RateLimit
             oagw_sdk::RateLimitStrategy::Degrade => model::RateLimitStrategy::Degrade,
         },
         cost: v.cost,
+        response_headers: v.response_headers,
+        pool_owner_id: None,
     }
 }
 
@@ -719,6 +732,15 @@ fn rate_limit_config_to_sdk(v: model::RateLimitConfig) -> oagw_sdk::RateLimitCon
         burst: v.burst.map(|b| oagw_sdk::BurstConfig {
             capacity: b.capacity,
         }),
+        budget: v.budget.map(|b| oagw_sdk::BudgetConfig {
+            mode: match b.mode {
+                model::BudgetMode::Unlimited => oagw_sdk::BudgetMode::Unlimited,
+                model::BudgetMode::Allocated => oagw_sdk::BudgetMode::Allocated,
+                model::BudgetMode::Shared => oagw_sdk::BudgetMode::Shared,
+            },
+            total: b.total,
+            overcommit_ratio: b.overcommit_ratio,
+        }),
         scope: match v.scope {
             model::RateLimitScope::Global => oagw_sdk::RateLimitScope::Global,
             model::RateLimitScope::Tenant => oagw_sdk::RateLimitScope::Tenant,
@@ -732,6 +754,7 @@ fn rate_limit_config_to_sdk(v: model::RateLimitConfig) -> oagw_sdk::RateLimitCon
             model::RateLimitStrategy::Degrade => oagw_sdk::RateLimitStrategy::Degrade,
         },
         cost: v.cost,
+        response_headers: v.response_headers,
     }
 }
 
@@ -839,6 +862,9 @@ mod tests {
             detail: "too fast".into(),
             instance: "/api".into(),
             retry_after_secs: Some(30),
+            limit: None,
+            remaining: None,
+            reset_epoch: None,
         };
         let sdk_err = domain_err_to_sdk(err);
         match sdk_err {

--- a/modules/system/oagw/oagw/src/domain/services/management.rs
+++ b/modules/system/oagw/oagw/src/domain/services/management.rs
@@ -78,6 +78,11 @@ impl ControlPlaneService for ControlPlaneServiceImpl {
         if let Some(ref cors) = req.cors {
             crate::domain::cors::validate_cors_config(cors)?;
         }
+        if let Some(ref rl) = req.rate_limit
+            && let Some(ref budget) = rl.budget
+        {
+            validate_budget_config(budget)?;
+        }
 
         // Enforce alias derivation / explicit rules.
         let alias = enforce_alias_create(req.alias.as_deref(), &req.server.endpoints)?;
@@ -100,6 +105,9 @@ impl ControlPlaneService for ControlPlaneServiceImpl {
             },
         )
         .await?;
+
+        self.validate_budget_allocation(ctx, &tenant_chain, &alias, req.rate_limit.as_ref())
+            .await?;
 
         let upstream = Upstream {
             id,
@@ -209,12 +217,42 @@ impl ControlPlaneService for ControlPlaneServiceImpl {
                 },
             )
             .await?;
+
+            self.validate_budget_allocation(
+                ctx,
+                &tenant_chain,
+                &existing.alias,
+                req.rate_limit.as_ref(),
+            )
+            .await?;
         }
 
         // Full replacement: directly assign all fields (None = unset).
         existing.auth = req.auth;
         existing.headers = req.headers;
         existing.plugins = req.plugins;
+        if let Some(ref rl) = req.rate_limit
+            && let Some(ref budget) = rl.budget
+        {
+            validate_budget_config(budget)?;
+        }
+
+        // If this upstream's budget is being tightened (lower total, lower
+        // overcommit_ratio, or mode changed to allocated), verify that existing
+        // descendant allocations still fit within the proposed budget.
+        if let Some(ref new_rl) = req.rate_limit {
+            let old_budget = existing
+                .rate_limit
+                .as_ref()
+                .and_then(|rl| rl.budget.as_ref());
+            let new_budget = new_rl.budget.as_ref();
+            let budget_changed = old_budget != new_budget;
+            if budget_changed {
+                self.validate_descendants_within_budget(ctx, &existing.alias, new_rl)
+                    .await?;
+            }
+        }
+
         existing.rate_limit = req.rate_limit;
         if let Some(ref cors) = req.cors {
             crate::domain::cors::validate_cors_config(cors)?;
@@ -229,17 +267,23 @@ impl ControlPlaneService for ControlPlaneServiceImpl {
             .map_err(DomainError::from)
     }
 
-    async fn delete_upstream(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), DomainError> {
+    async fn delete_upstream(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+    ) -> Result<Vec<Uuid>, DomainError> {
         let tenant_id = ctx.subject_tenant_id();
         // Cascade delete routes before removing the upstream.
-        self.routes
+        let deleted_route_ids = self
+            .routes
             .delete_by_upstream(tenant_id, id)
             .await
             .map_err(DomainError::from)?;
         self.upstreams
             .delete(tenant_id, id)
             .await
-            .map_err(|_| DomainError::not_found("upstream", id))
+            .map_err(|_| DomainError::not_found("upstream", id))?;
+        Ok(deleted_route_ids)
     }
 
     // -- Route CRUD --
@@ -478,6 +522,185 @@ impl ControlPlaneServiceImpl {
         Ok(())
     }
 
+    /// Validate that this child's rate limit allocation fits within the
+    /// ancestor's budget. Only runs when the closest ancestor with matching
+    /// alias has `budget.mode == Allocated`.
+    async fn validate_budget_allocation(
+        &self,
+        ctx: &SecurityContext,
+        tenant_chain: &[Uuid],
+        alias: &str,
+        child_rate_limit: Option<&crate::domain::model::RateLimitConfig>,
+    ) -> Result<(), DomainError> {
+        use crate::domain::model::BudgetMode;
+
+        let requesting_tenant = tenant_chain[0];
+
+        // Find the closest ancestor with this alias.
+        let ancestor = {
+            let mut found = None;
+            for &ancestor_tid in &tenant_chain[1..] {
+                if let Ok(u) = self.upstreams.get_by_alias(ancestor_tid, alias).await {
+                    found = Some(u);
+                    break;
+                }
+            }
+            match found {
+                Some(a) => a,
+                None => return Ok(()), // No ancestor with this alias — nothing to validate.
+            }
+        };
+
+        let ancestor_budget = match ancestor
+            .rate_limit
+            .as_ref()
+            .and_then(|rl| rl.budget.as_ref())
+        {
+            Some(b) if b.mode == BudgetMode::Allocated => b,
+            _ => return Ok(()), // Not allocated mode — no budget validation.
+        };
+
+        // Under allocated budget, children must specify an explicit rate_limit
+        // so their allocation is accounted for at write time.
+        if child_rate_limit.is_none() {
+            return Err(DomainError::validation(
+                "rate_limit is required when ancestor has budget.mode = 'allocated'",
+            ));
+        }
+
+        let budget_total = match ancestor_budget.total {
+            Some(t) => t,
+            None => return Ok(()), // No total specified — nothing to enforce.
+        };
+        let ratio = ancestor_budget.overcommit_ratio.unwrap_or(1.0);
+
+        // Get the ancestor's descendant tree first, then query only upstreams
+        // belonging to those tenants — avoids loading upstreams from unrelated trees.
+        let descendant_resp = self
+            .tenant_resolver
+            .get_descendants(
+                ctx,
+                tenant_resolver_sdk::TenantId(ancestor.tenant_id),
+                &tenant_resolver_sdk::GetDescendantsOptions::default(),
+            )
+            .await?;
+        let tree_ids: std::collections::HashSet<Uuid> =
+            descendant_resp.descendants.iter().map(|t| t.id.0).collect();
+
+        let siblings = self
+            .upstreams
+            .list_by_alias_for_tenants(alias, &tree_ids)
+            .await?;
+
+        let ancestor_rl = ancestor.rate_limit.as_ref().unwrap(); // safe: we checked above
+
+        let mut total_rps: f64 = 0.0;
+        for sibling in &siblings {
+            // Skip the ancestor itself and the requesting tenant (we'll add child_rate_limit separately).
+            if sibling.tenant_id == ancestor.tenant_id || sibling.tenant_id == requesting_tenant {
+                continue;
+            }
+            if let Some(ref rl) = sibling.rate_limit {
+                total_rps += rate_per_second(rl);
+            }
+        }
+
+        // Add this child's proposed rate.
+        if let Some(child_rl) = child_rate_limit {
+            total_rps += rate_per_second(child_rl);
+        }
+
+        let budget_rps = f64::from(budget_total)
+            / match ancestor_rl.sustained.window {
+                crate::domain::model::Window::Second => 1.0,
+                crate::domain::model::Window::Minute => 60.0,
+                crate::domain::model::Window::Hour => 3600.0,
+                crate::domain::model::Window::Day => 86400.0,
+            };
+        let allowed_rps = budget_rps * ratio;
+
+        if total_rps > allowed_rps {
+            return Err(DomainError::validation(format!(
+                "budget allocation exceeded: children total {total_rps:.2} req/s \
+                 exceeds ancestor budget {budget_rps:.2} req/s × {ratio} overcommit ratio \
+                 (allowed: {allowed_rps:.2} req/s)"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Validate that a parent's proposed budget still accommodates existing
+    /// descendant allocations. Called when `update_upstream` changes budget
+    /// parameters (total, overcommit_ratio, or mode) to prevent retroactively
+    /// exceeding the ceiling.
+    async fn validate_descendants_within_budget(
+        &self,
+        ctx: &SecurityContext,
+        alias: &str,
+        proposed_rl: &crate::domain::model::RateLimitConfig,
+    ) -> Result<(), DomainError> {
+        use crate::domain::model::BudgetMode;
+
+        let budget = match proposed_rl.budget.as_ref() {
+            Some(b) if b.mode == BudgetMode::Allocated => b,
+            _ => return Ok(()), // Not allocated mode — nothing to enforce.
+        };
+
+        let budget_total = match budget.total {
+            Some(t) => t,
+            None => return Ok(()), // No total specified — nothing to enforce.
+        };
+        let ratio = budget.overcommit_ratio.unwrap_or(1.0);
+
+        let tenant_id = ctx.subject_tenant_id();
+        let descendant_resp = self
+            .tenant_resolver
+            .get_descendants(
+                ctx,
+                tenant_resolver_sdk::TenantId(tenant_id),
+                &tenant_resolver_sdk::GetDescendantsOptions::default(),
+            )
+            .await?;
+        let tree_ids: std::collections::HashSet<Uuid> =
+            descendant_resp.descendants.iter().map(|t| t.id.0).collect();
+
+        if tree_ids.is_empty() {
+            return Ok(()); // No descendants — nothing to check.
+        }
+
+        let descendants = self
+            .upstreams
+            .list_by_alias_for_tenants(alias, &tree_ids)
+            .await?;
+
+        let mut total_rps: f64 = 0.0;
+        for descendant in &descendants {
+            if let Some(ref rl) = descendant.rate_limit {
+                total_rps += rate_per_second(rl);
+            }
+        }
+
+        let budget_rps = f64::from(budget_total)
+            / match proposed_rl.sustained.window {
+                crate::domain::model::Window::Second => 1.0,
+                crate::domain::model::Window::Minute => 60.0,
+                crate::domain::model::Window::Hour => 3600.0,
+                crate::domain::model::Window::Day => 86400.0,
+            };
+        let allowed_rps = budget_rps * ratio;
+
+        if total_rps > allowed_rps {
+            return Err(DomainError::validation(format!(
+                "cannot lower budget: existing descendant allocations total {total_rps:.2} req/s \
+                 which exceeds proposed budget {budget_rps:.2} req/s × {ratio} overcommit ratio \
+                 (allowed: {allowed_rps:.2} req/s)"
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Build the ordered tenant chain `[self, parent, ..., root]`.
     ///
     /// Index 0 is always the requesting tenant. Callers that only need
@@ -660,6 +883,35 @@ fn validate_match_rules(rules: &MatchRules) -> Result<(), DomainError> {
         )),
         _ => Ok(()),
     }
+}
+
+/// Validate budget configuration field constraints per ADR 0004 schema.
+fn validate_budget_config(budget: &crate::domain::model::BudgetConfig) -> Result<(), DomainError> {
+    use crate::domain::model::BudgetMode;
+
+    match budget.mode {
+        BudgetMode::Allocated | BudgetMode::Shared => {
+            let total = budget.total.ok_or_else(|| {
+                DomainError::validation(
+                    "budget.total is required when budget.mode is 'allocated' or 'shared'",
+                )
+            })?;
+            if total < 1 {
+                return Err(DomainError::validation("budget.total must be at least 1"));
+            }
+        }
+        BudgetMode::Unlimited => {}
+    }
+
+    if let Some(ratio) = budget.overcommit_ratio
+        && !(1.0..=2.0).contains(&ratio)
+    {
+        return Err(DomainError::validation(
+            "budget.overcommit_ratio must be between 1.0 and 2.0",
+        ));
+    }
+
+    Ok(())
 }
 
 /// Validate the endpoint list for a server configuration.
@@ -1258,7 +1510,7 @@ pub(crate) fn compute_effective_config(
     ancestor_chain: &[Upstream],
     route: Option<&Route>,
 ) -> Result<Upstream, DomainError> {
-    use crate::domain::model::SharingMode;
+    use crate::domain::model::{BudgetMode, SharingMode};
 
     if ancestor_chain.is_empty() {
         return Err(DomainError::Internal {
@@ -1298,6 +1550,19 @@ pub(crate) fn compute_effective_config(
         effective.protocol = layer.protocol.clone();
         effective.enabled = layer.enabled;
         effective.headers = layer.headers.clone().or(effective.headers);
+    }
+
+    // Defense-in-depth: if the effective config has a shared budget but
+    // pool_owner_id was never set (single-element chain or all layers were
+    // no-ops), initialize it to the effective upstream's ID.
+    if let Some(ref mut rl) = effective.rate_limit
+        && rl.pool_owner_id.is_none()
+        && rl
+            .budget
+            .as_ref()
+            .is_some_and(|b| b.mode == BudgetMode::Shared)
+    {
+        rl.pool_owner_id = Some(effective.id);
     }
 
     // Route-level overrides (route > upstream base per config layering).
@@ -1413,8 +1678,21 @@ fn merge_auth(effective: &mut Upstream, layer: &Upstream) {
 /// descendant `Private` cannot drop it — `min()` is applied instead.
 /// This is defense-in-depth; `validate_bind_constraints` also guards
 /// this at create/update time.
+///
+/// When the effective rate limit has `budget.mode == Shared`, the
+/// `pool_owner_id` is set to the effective upstream's ID so all
+/// descendants share one token bucket at runtime.
 fn merge_rate_limit(effective: &mut Upstream, layer: &Upstream) {
-    use crate::domain::model::SharingMode;
+    use crate::domain::model::{BudgetMode, SharingMode};
+
+    // Capture shared-pool owner before merging (the ancestor that defines
+    // the shared budget is the pool owner).
+    let pool_owner = effective
+        .rate_limit
+        .as_ref()
+        .and_then(|rl| rl.budget.as_ref())
+        .filter(|b| b.mode == BudgetMode::Shared)
+        .map(|_| effective.id);
 
     let effective_is_enforced = effective
         .rate_limit
@@ -1437,6 +1715,27 @@ fn merge_rate_limit(effective: &mut Upstream, layer: &Upstream) {
                     Some(min_rate_limit(effective.rate_limit.as_ref(), descendant_rl));
             }
         },
+    }
+
+    // Propagate shared-pool owner to descendants so the proxy uses
+    // the defining ancestor's rate limit key.  Only set once: the first
+    // ancestor that defines BudgetMode::Shared pins the owner; later
+    // merges must not overwrite it.
+    //
+    // Skip for non-enforced Private: the descendant opted out of the
+    // shared pool and should use its own independent bucket.
+    let is_private_override = layer
+        .rate_limit
+        .as_ref()
+        .is_some_and(|rl| rl.sharing == SharingMode::Private)
+        && !effective_is_enforced;
+
+    if !is_private_override
+        && let Some(owner_id) = pool_owner
+        && let Some(ref mut rl) = effective.rate_limit
+        && rl.pool_owner_id.is_none()
+    {
+        rl.pool_owner_id = Some(owner_id);
     }
 }
 
@@ -1513,7 +1812,13 @@ fn min_rate_limit(
             let a_rate = rate_per_second(a);
             let b_rate = rate_per_second(b);
             if b_rate < a_rate {
-                b.clone()
+                let mut winner = b.clone();
+                // Preserve pool_owner_id from the existing effective config so
+                // shared-pool keying is not lost when a stricter route wins.
+                if winner.pool_owner_id.is_none() {
+                    winner.pool_owner_id = a.pool_owner_id;
+                }
+                winner
             } else {
                 a.clone()
             }
@@ -2309,7 +2614,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_upstream_cascades_routes() {
+    async fn delete_upstream_cascades_routes_and_returns_ids() {
         let svc = make_service();
         let tenant = Uuid::new_v4();
         let ctx = test_ctx(tenant);
@@ -2318,15 +2623,41 @@ mod tests {
             .create_upstream(&ctx, make_create_upstream_ip("openai"))
             .await
             .unwrap();
-        let r = svc
+        let r1 = svc
             .create_route(&ctx, make_create_route(u.id))
             .await
             .unwrap();
 
-        svc.delete_upstream(&ctx, u.id).await.unwrap();
+        // Add a second route with a different path to avoid overlap.
+        let mut req2 = make_create_route(u.id);
+        req2.match_rules.http.as_mut().unwrap().methods = vec![HttpMethod::Get];
+        let r2 = svc.create_route(&ctx, req2).await.unwrap();
 
-        // Route should be gone.
-        assert!(svc.get_route(&ctx, r.id).await.is_err());
+        let deleted_route_ids = svc.delete_upstream(&ctx, u.id).await.unwrap();
+
+        // Both route IDs should be returned.
+        assert_eq!(deleted_route_ids.len(), 2);
+        assert!(deleted_route_ids.contains(&r1.id));
+        assert!(deleted_route_ids.contains(&r2.id));
+
+        // Routes should be gone.
+        assert!(svc.get_route(&ctx, r1.id).await.is_err());
+        assert!(svc.get_route(&ctx, r2.id).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn delete_upstream_no_routes_returns_empty_vec() {
+        let svc = make_service();
+        let tenant = Uuid::new_v4();
+        let ctx = test_ctx(tenant);
+
+        let u = svc
+            .create_upstream(&ctx, make_create_upstream_ip("openai"))
+            .await
+            .unwrap();
+
+        let deleted_route_ids = svc.delete_upstream(&ctx, u.id).await.unwrap();
+        assert!(deleted_route_ids.is_empty());
     }
 
     // -- Alias resolution tests --
@@ -2600,9 +2931,12 @@ mod tests {
             algorithm: RateLimitAlgorithm::TokenBucket,
             sustained: SustainedRate { rate, window },
             burst: None,
+            budget: None,
             scope: RateLimitScope::Tenant,
             strategy: RateLimitStrategy::Reject,
             cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
         }
     }
 
@@ -4799,6 +5133,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn update_upstream_rate_limit_change_reflected_in_result() {
+        use crate::domain::model::SharingMode;
+
+        let svc = make_service();
+        let tenant = Uuid::new_v4();
+        let ctx = test_ctx(tenant);
+
+        // Create without rate_limit.
+        let u = svc
+            .create_upstream(&ctx, make_create_upstream_ip("openai"))
+            .await
+            .unwrap();
+        assert!(u.rate_limit.is_none());
+
+        // Update: add a rate_limit.
+        let mut update_req = make_update_from_upstream(&u);
+        let rl1 = make_rate_limit(SharingMode::Private, 100, Window::Second);
+        update_req.rate_limit = Some(rl1.clone());
+        let updated = svc.update_upstream(&ctx, u.id, update_req).await.unwrap();
+        assert_eq!(updated.rate_limit.as_ref(), Some(&rl1));
+
+        // Update: change to a different rate.
+        let mut update_req = make_update_from_upstream(&updated);
+        let rl2 = make_rate_limit(SharingMode::Private, 500, Window::Minute);
+        update_req.rate_limit = Some(rl2.clone());
+        let updated = svc.update_upstream(&ctx, u.id, update_req).await.unwrap();
+        assert_eq!(updated.rate_limit.as_ref(), Some(&rl2));
+
+        // Update: remove rate_limit.
+        let mut update_req = make_update_from_upstream(&updated);
+        update_req.rate_limit = None;
+        let updated = svc.update_upstream(&ctx, u.id, update_req).await.unwrap();
+        assert!(updated.rate_limit.is_none());
+    }
+
+    #[tokio::test]
+    async fn update_route_rate_limit_change_reflected_in_result() {
+        use crate::domain::model::SharingMode;
+
+        let svc = make_service();
+        let tenant = Uuid::new_v4();
+        let ctx = test_ctx(tenant);
+
+        let u = svc
+            .create_upstream(&ctx, make_create_upstream_ip("openai"))
+            .await
+            .unwrap();
+        let r = svc
+            .create_route(&ctx, make_create_route(u.id))
+            .await
+            .unwrap();
+        assert!(r.rate_limit.is_none());
+
+        // Update: add a rate_limit.
+        let mut update_req = make_update_from_route(&r);
+        let rl1 = make_rate_limit(SharingMode::Private, 100, Window::Second);
+        update_req.rate_limit = Some(rl1.clone());
+        let updated = svc.update_route(&ctx, r.id, update_req).await.unwrap();
+        assert_eq!(updated.rate_limit.as_ref(), Some(&rl1));
+
+        // Update: change to a different rate.
+        let mut update_req = make_update_from_route(&updated);
+        let rl2 = make_rate_limit(SharingMode::Private, 500, Window::Minute);
+        update_req.rate_limit = Some(rl2.clone());
+        let updated = svc.update_route(&ctx, r.id, update_req).await.unwrap();
+        assert_eq!(updated.rate_limit.as_ref(), Some(&rl2));
+
+        // Update: remove rate_limit.
+        let mut update_req = make_update_from_route(&updated);
+        update_req.rate_limit = None;
+        let updated = svc.update_route(&ctx, r.id, update_req).await.unwrap();
+        assert!(updated.rate_limit.is_none());
+    }
+
+    #[tokio::test]
     async fn update_route_introducing_overlap_returns_conflict() {
         let svc = make_service();
         let tenant = Uuid::new_v4();
@@ -4895,6 +5304,828 @@ mod tests {
         assert!(
             matches!(err, DomainError::Conflict { .. }),
             "expected Conflict, got: {err:?}"
+        );
+    }
+
+    // -- validate_budget_config tests --
+
+    #[test]
+    fn budget_config_allocated_requires_total() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+        let budget = BudgetConfig {
+            mode: BudgetMode::Allocated,
+            total: None,
+            overcommit_ratio: None,
+        };
+        let err = validate_budget_config(&budget).unwrap_err();
+        assert!(matches!(err, DomainError::Validation { .. }));
+    }
+
+    #[test]
+    fn budget_config_shared_requires_total() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+        let budget = BudgetConfig {
+            mode: BudgetMode::Shared,
+            total: None,
+            overcommit_ratio: None,
+        };
+        let err = validate_budget_config(&budget).unwrap_err();
+        assert!(matches!(err, DomainError::Validation { .. }));
+    }
+
+    #[test]
+    fn budget_config_unlimited_skips_total_check() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+        let budget = BudgetConfig {
+            mode: BudgetMode::Unlimited,
+            total: None,
+            overcommit_ratio: None,
+        };
+        assert!(validate_budget_config(&budget).is_ok());
+    }
+
+    #[test]
+    fn budget_config_overcommit_ratio_must_be_in_range() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+        // Below range
+        let budget = BudgetConfig {
+            mode: BudgetMode::Unlimited,
+            total: None,
+            overcommit_ratio: Some(0.5),
+        };
+        assert!(validate_budget_config(&budget).is_err());
+
+        // Above range
+        let budget = BudgetConfig {
+            mode: BudgetMode::Unlimited,
+            total: None,
+            overcommit_ratio: Some(3.0),
+        };
+        assert!(validate_budget_config(&budget).is_err());
+
+        // Within range
+        let budget = BudgetConfig {
+            mode: BudgetMode::Allocated,
+            total: Some(100),
+            overcommit_ratio: Some(1.5),
+        };
+        assert!(validate_budget_config(&budget).is_ok());
+
+        // Boundaries
+        assert!(
+            validate_budget_config(&BudgetConfig {
+                mode: BudgetMode::Allocated,
+                total: Some(100),
+                overcommit_ratio: Some(1.0),
+            })
+            .is_ok()
+        );
+        assert!(
+            validate_budget_config(&BudgetConfig {
+                mode: BudgetMode::Allocated,
+                total: Some(100),
+                overcommit_ratio: Some(2.0),
+            })
+            .is_ok()
+        );
+    }
+
+    // -- Budget allocation validation (ADR example) --
+
+    #[tokio::test]
+    async fn budget_allocated_rejects_over_allocation() {
+        // ADR example: Parent 5000/min, A=2000, B=1000, C requests 3000.
+        // Sum=6000 > 5000 → REJECT
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let root = Uuid::new_v4();
+        let child_a = Uuid::new_v4();
+        let child_b = Uuid::new_v4();
+        let child_c = Uuid::new_v4();
+
+        let resolver = MockTenantResolverClient::with_siblings(
+            TenantId(root),
+            vec![TenantId(child_a), TenantId(child_b), TenantId(child_c)],
+        );
+        let svc = make_service_with_resolver(resolver);
+
+        // Root creates upstream with allocated budget.
+        let root_ctx = test_ctx(root);
+        let mut root_req = make_create_upstream_hostname();
+        root_req.rate_limit = Some(RateLimitConfig {
+            sharing: SharingMode::Inherit,
+            algorithm: RateLimitAlgorithm::TokenBucket,
+            sustained: SustainedRate {
+                rate: 5000,
+                window: Window::Minute,
+            },
+            burst: None,
+            budget: Some(BudgetConfig {
+                mode: BudgetMode::Allocated,
+                total: Some(5000),
+                overcommit_ratio: Some(1.0),
+            }),
+            scope: RateLimitScope::Tenant,
+            strategy: RateLimitStrategy::Reject,
+            cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
+        });
+        svc.create_upstream(&root_ctx, root_req).await.unwrap();
+
+        // Child A: 2000/min
+        let ctx_a = test_ctx(child_a);
+        let mut req_a = make_create_upstream_hostname();
+        req_a.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 2000, Window::Minute));
+        svc.create_upstream(&ctx_a, req_a).await.unwrap();
+
+        // Child B: 1000/min
+        let ctx_b = test_ctx(child_b);
+        let mut req_b = make_create_upstream_hostname();
+        req_b.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 1000, Window::Minute));
+        svc.create_upstream(&ctx_b, req_b).await.unwrap();
+
+        // Child C: 3000/min — sum = 6000 > 5000 → REJECT
+        let ctx_c = test_ctx(child_c);
+        let mut req_c = make_create_upstream_hostname();
+        req_c.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 3000, Window::Minute));
+        let err = svc.create_upstream(&ctx_c, req_c).await.unwrap_err();
+        assert!(
+            matches!(err, DomainError::Validation { .. }),
+            "expected Validation error for budget exceeded, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn budget_allocated_allows_within_overcommit_ratio() {
+        // ADR example: ratio=1.5, sum=6000 ≤ 5000*1.5=7500 → ALLOW
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let root = Uuid::new_v4();
+        let child_a = Uuid::new_v4();
+        let child_b = Uuid::new_v4();
+        let child_c = Uuid::new_v4();
+
+        let resolver = MockTenantResolverClient::with_siblings(
+            TenantId(root),
+            vec![TenantId(child_a), TenantId(child_b), TenantId(child_c)],
+        );
+        let svc = make_service_with_resolver(resolver);
+
+        let root_ctx = test_ctx(root);
+        let mut root_req = make_create_upstream_hostname();
+        root_req.rate_limit = Some(RateLimitConfig {
+            sharing: SharingMode::Inherit,
+            algorithm: RateLimitAlgorithm::TokenBucket,
+            sustained: SustainedRate {
+                rate: 5000,
+                window: Window::Minute,
+            },
+            burst: None,
+            budget: Some(BudgetConfig {
+                mode: BudgetMode::Allocated,
+                total: Some(5000),
+                overcommit_ratio: Some(1.5),
+            }),
+            scope: RateLimitScope::Tenant,
+            strategy: RateLimitStrategy::Reject,
+            cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
+        });
+        svc.create_upstream(&root_ctx, root_req).await.unwrap();
+
+        // Children: 2000 + 1000 + 3000 = 6000 ≤ 7500 → all allowed.
+        let ctx_a = test_ctx(child_a);
+        let mut req_a = make_create_upstream_hostname();
+        req_a.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 2000, Window::Minute));
+        svc.create_upstream(&ctx_a, req_a).await.unwrap();
+
+        let ctx_b = test_ctx(child_b);
+        let mut req_b = make_create_upstream_hostname();
+        req_b.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 1000, Window::Minute));
+        svc.create_upstream(&ctx_b, req_b).await.unwrap();
+
+        let ctx_c = test_ctx(child_c);
+        let mut req_c = make_create_upstream_hostname();
+        req_c.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 3000, Window::Minute));
+        svc.create_upstream(&ctx_c, req_c).await.unwrap(); // Should succeed.
+    }
+
+    #[tokio::test]
+    async fn budget_unlimited_skips_allocation_validation() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let root = Uuid::new_v4();
+        let child = Uuid::new_v4();
+
+        let resolver =
+            MockTenantResolverClient::with_siblings(TenantId(root), vec![TenantId(child)]);
+        let svc = make_service_with_resolver(resolver);
+
+        let root_ctx = test_ctx(root);
+        let mut root_req = make_create_upstream_hostname();
+        root_req.rate_limit = Some(RateLimitConfig {
+            sharing: SharingMode::Inherit,
+            algorithm: RateLimitAlgorithm::TokenBucket,
+            sustained: SustainedRate {
+                rate: 100,
+                window: Window::Minute,
+            },
+            burst: None,
+            budget: Some(BudgetConfig {
+                mode: BudgetMode::Unlimited,
+                total: None,
+                overcommit_ratio: None,
+            }),
+            scope: RateLimitScope::Tenant,
+            strategy: RateLimitStrategy::Reject,
+            cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
+        });
+        svc.create_upstream(&root_ctx, root_req).await.unwrap();
+
+        // Child can request any rate — no budget enforcement.
+        let ctx_c = test_ctx(child);
+        let mut req_c = make_create_upstream_hostname();
+        req_c.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 99999, Window::Minute));
+        svc.create_upstream(&ctx_c, req_c).await.unwrap(); // No budget rejection.
+    }
+
+    #[tokio::test]
+    async fn budget_shared_skips_allocation_validation() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let root = Uuid::new_v4();
+        let child = Uuid::new_v4();
+
+        let resolver =
+            MockTenantResolverClient::with_siblings(TenantId(root), vec![TenantId(child)]);
+        let svc = make_service_with_resolver(resolver);
+
+        let root_ctx = test_ctx(root);
+        let mut root_req = make_create_upstream_hostname();
+        root_req.rate_limit = Some(RateLimitConfig {
+            sharing: SharingMode::Inherit,
+            algorithm: RateLimitAlgorithm::TokenBucket,
+            sustained: SustainedRate {
+                rate: 100,
+                window: Window::Minute,
+            },
+            burst: None,
+            budget: Some(BudgetConfig {
+                mode: BudgetMode::Shared,
+                total: Some(100),
+                overcommit_ratio: None,
+            }),
+            scope: RateLimitScope::Tenant,
+            strategy: RateLimitStrategy::Reject,
+            cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
+        });
+        svc.create_upstream(&root_ctx, root_req).await.unwrap();
+
+        // Child can create — shared mode doesn't validate allocations.
+        let ctx_c = test_ctx(child);
+        let mut req_c = make_create_upstream_hostname();
+        req_c.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 99999, Window::Minute));
+        svc.create_upstream(&ctx_c, req_c).await.unwrap();
+    }
+
+    // -- Shared-pool merge --
+
+    #[test]
+    fn merge_rate_limit_shared_sets_pool_owner_id() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let root_id = Uuid::new_v4();
+        let child_id = Uuid::new_v4();
+
+        let mut root = make_upstream(
+            root_id,
+            "openai",
+            None,
+            Some(RateLimitConfig {
+                sharing: SharingMode::Enforce,
+                algorithm: RateLimitAlgorithm::TokenBucket,
+                sustained: SustainedRate {
+                    rate: 1000,
+                    window: Window::Minute,
+                },
+                burst: None,
+                budget: Some(BudgetConfig {
+                    mode: BudgetMode::Shared,
+                    total: Some(1000),
+                    overcommit_ratio: None,
+                }),
+                scope: RateLimitScope::Tenant,
+                strategy: RateLimitStrategy::Reject,
+                cost: 1,
+                response_headers: true,
+                pool_owner_id: None,
+            }),
+            None,
+            vec![],
+        );
+
+        let child = make_upstream(
+            child_id,
+            "openai",
+            None,
+            Some(make_rate_limit(SharingMode::Inherit, 500, Window::Minute)),
+            None,
+            vec![],
+        );
+
+        let root_upstream_id = root.id;
+        merge_rate_limit(&mut root, &child);
+
+        let effective_rl = root.rate_limit.as_ref().unwrap();
+        assert_eq!(
+            effective_rl.pool_owner_id,
+            Some(root_upstream_id),
+            "pool_owner_id should be set to root upstream's ID for shared budget"
+        );
+    }
+
+    #[test]
+    fn merge_rate_limit_shared_pool_owner_pinned_to_defining_ancestor() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let tenant = Uuid::new_v4();
+
+        // Root defines a Shared budget — it is the defining ancestor.
+        let mut effective = make_upstream(
+            tenant,
+            "openai",
+            None,
+            Some(RateLimitConfig {
+                sharing: SharingMode::Enforce,
+                algorithm: RateLimitAlgorithm::TokenBucket,
+                sustained: SustainedRate {
+                    rate: 1000,
+                    window: Window::Minute,
+                },
+                burst: None,
+                budget: Some(BudgetConfig {
+                    mode: BudgetMode::Shared,
+                    total: Some(1000),
+                    overcommit_ratio: None,
+                }),
+                scope: RateLimitScope::Tenant,
+                strategy: RateLimitStrategy::Reject,
+                cost: 1,
+                response_headers: true,
+                pool_owner_id: None,
+            }),
+            None,
+            vec![],
+        );
+        // Capture the auto-generated upstream id — this is the defining ancestor.
+        let root_upstream_id = effective.id;
+
+        let parent = make_upstream(
+            tenant,
+            "openai",
+            None,
+            Some(make_rate_limit(SharingMode::Inherit, 800, Window::Minute)),
+            None,
+            vec![],
+        );
+
+        let child = make_upstream(
+            tenant,
+            "openai",
+            None,
+            Some(make_rate_limit(SharingMode::Inherit, 500, Window::Minute)),
+            None,
+            vec![],
+        );
+
+        // Simulate compute_effective_config: merge parent, update id, merge child.
+        merge_rate_limit(&mut effective, &parent);
+        effective.id = parent.id; // mirrors line 1453 in the loop
+
+        merge_rate_limit(&mut effective, &child);
+        effective.id = child.id;
+
+        let effective_rl = effective.rate_limit.as_ref().unwrap();
+        assert_eq!(
+            effective_rl.pool_owner_id,
+            Some(root_upstream_id),
+            "pool_owner_id must stay pinned to the root that defined BudgetMode::Shared, \
+             not be overwritten to a middle layer"
+        );
+    }
+
+    #[test]
+    fn merge_rate_limit_private_non_enforced_does_not_inherit_pool_owner_id() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let tenant = Uuid::new_v4();
+
+        // Root has Shared budget with Inherit sharing (NOT Enforce).
+        let mut root = make_upstream(
+            tenant,
+            "openai",
+            None,
+            Some(RateLimitConfig {
+                sharing: SharingMode::Inherit,
+                algorithm: RateLimitAlgorithm::TokenBucket,
+                sustained: SustainedRate {
+                    rate: 1000,
+                    window: Window::Minute,
+                },
+                burst: None,
+                budget: Some(BudgetConfig {
+                    mode: BudgetMode::Shared,
+                    total: Some(1000),
+                    overcommit_ratio: None,
+                }),
+                scope: RateLimitScope::Tenant,
+                strategy: RateLimitStrategy::Reject,
+                cost: 1,
+                response_headers: true,
+                pool_owner_id: None,
+            }),
+            None,
+            vec![],
+        );
+
+        // Child declares Private — should get its own independent bucket.
+        let child = make_upstream(
+            tenant,
+            "openai",
+            None,
+            Some(make_rate_limit(SharingMode::Private, 500, Window::Minute)),
+            None,
+            vec![],
+        );
+
+        merge_rate_limit(&mut root, &child);
+
+        let effective_rl = root.rate_limit.as_ref().unwrap();
+        assert_eq!(
+            effective_rl.pool_owner_id, None,
+            "pool_owner_id must be None for Private (non-enforced) descendant — \
+             it should use its own bucket, not the ancestor's shared pool"
+        );
+        assert_eq!(
+            effective_rl.sustained.rate, 500,
+            "Private descendant's rate should replace, not merge"
+        );
+    }
+
+    #[test]
+    fn compute_effective_single_element_shared_sets_pool_owner_id() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let tenant = Uuid::new_v4();
+
+        let root = make_upstream(
+            tenant,
+            "openai",
+            None,
+            Some(RateLimitConfig {
+                sharing: SharingMode::Inherit,
+                algorithm: RateLimitAlgorithm::TokenBucket,
+                sustained: SustainedRate {
+                    rate: 1000,
+                    window: Window::Minute,
+                },
+                burst: None,
+                budget: Some(BudgetConfig {
+                    mode: BudgetMode::Shared,
+                    total: Some(1000),
+                    overcommit_ratio: None,
+                }),
+                scope: RateLimitScope::Tenant,
+                strategy: RateLimitStrategy::Reject,
+                cost: 1,
+                response_headers: true,
+                pool_owner_id: None,
+            }),
+            None,
+            vec![],
+        );
+
+        let effective = compute_effective_config(std::slice::from_ref(&root), None).unwrap();
+        let rl = effective.rate_limit.as_ref().unwrap();
+        assert_eq!(
+            rl.pool_owner_id,
+            Some(root.id),
+            "single-element chain with Shared budget should have pool_owner_id = own ID"
+        );
+    }
+
+    #[tokio::test]
+    async fn budget_allocated_ignores_cross_tree_upstreams() {
+        // Two independent trees share alias "openai". Tree A has budget=5000.
+        // Tree B's child has rate=4000. Tree A's child requests 4000.
+        // Without tree filtering: sum=8000 > 5000 → REJECT (wrong).
+        // With tree filtering: sum=4000 ≤ 5000 → ALLOW (correct).
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let root_a = Uuid::new_v4();
+        let child_a = Uuid::new_v4();
+        let root_b = Uuid::new_v4();
+        let child_b = Uuid::new_v4();
+
+        let resolver = MockTenantResolverClient::with_two_trees(
+            TenantId(root_a),
+            vec![TenantId(child_a)],
+            TenantId(root_b),
+            vec![TenantId(child_b)],
+        );
+        let svc = make_service_with_resolver(resolver);
+
+        // Tree A root: allocated budget of 5000/min.
+        let root_a_ctx = test_ctx(root_a);
+        let mut root_a_req = make_create_upstream_hostname();
+        root_a_req.rate_limit = Some(RateLimitConfig {
+            sharing: SharingMode::Inherit,
+            algorithm: RateLimitAlgorithm::TokenBucket,
+            sustained: SustainedRate {
+                rate: 5000,
+                window: Window::Minute,
+            },
+            burst: None,
+            budget: Some(BudgetConfig {
+                mode: BudgetMode::Allocated,
+                total: Some(5000),
+                overcommit_ratio: Some(1.0),
+            }),
+            scope: RateLimitScope::Tenant,
+            strategy: RateLimitStrategy::Reject,
+            cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
+        });
+        svc.create_upstream(&root_a_ctx, root_a_req).await.unwrap();
+
+        // Tree B root: same alias, different tree, no budget.
+        let root_b_ctx = test_ctx(root_b);
+        let mut root_b_req = make_create_upstream_hostname();
+        root_b_req.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 5000, Window::Minute));
+        svc.create_upstream(&root_b_ctx, root_b_req).await.unwrap();
+
+        // Tree B child: 4000/min — in a different tree, should not count.
+        let child_b_ctx = test_ctx(child_b);
+        let mut child_b_req = make_create_upstream_hostname();
+        child_b_req.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 4000, Window::Minute));
+        svc.create_upstream(&child_b_ctx, child_b_req)
+            .await
+            .unwrap();
+
+        // Tree A child: 4000/min — within tree A's budget of 5000.
+        // Without tree filtering this would fail (4000+4000=8000 > 5000).
+        let child_a_ctx = test_ctx(child_a);
+        let mut child_a_req = make_create_upstream_hostname();
+        child_a_req.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 4000, Window::Minute));
+        svc.create_upstream(&child_a_ctx, child_a_req)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn budget_allocated_rejects_child_without_rate_limit() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let root = Uuid::new_v4();
+        let child = Uuid::new_v4();
+
+        let resolver =
+            MockTenantResolverClient::with_siblings(TenantId(root), vec![TenantId(child)]);
+        let svc = make_service_with_resolver(resolver);
+
+        // Root creates upstream with allocated budget.
+        let root_ctx = test_ctx(root);
+        let mut root_req = make_create_upstream_hostname();
+        root_req.rate_limit = Some(RateLimitConfig {
+            sharing: SharingMode::Inherit,
+            algorithm: RateLimitAlgorithm::TokenBucket,
+            sustained: SustainedRate {
+                rate: 1000,
+                window: Window::Minute,
+            },
+            burst: None,
+            budget: Some(BudgetConfig {
+                mode: BudgetMode::Allocated,
+                total: Some(1000),
+                overcommit_ratio: None,
+            }),
+            scope: RateLimitScope::Tenant,
+            strategy: RateLimitStrategy::Reject,
+            cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
+        });
+        svc.create_upstream(&root_ctx, root_req).await.unwrap();
+
+        // Child with no rate_limit → should be rejected.
+        let ctx_child = test_ctx(child);
+        let mut req_child = make_create_upstream_hostname();
+        req_child.rate_limit = None;
+        let err = svc
+            .create_upstream(&ctx_child, req_child)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, DomainError::Validation { .. }),
+            "expected Validation error for missing rate_limit, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn budget_lowering_total_rejects_when_descendants_exceed() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let root = Uuid::new_v4();
+        let child = Uuid::new_v4();
+
+        let resolver =
+            MockTenantResolverClient::with_siblings(TenantId(root), vec![TenantId(child)]);
+        let svc = make_service_with_resolver(resolver);
+
+        // Root creates upstream with allocated budget of 5000/min.
+        let root_ctx = test_ctx(root);
+        let mut root_req = make_create_upstream_hostname();
+        root_req.rate_limit = Some(RateLimitConfig {
+            sharing: SharingMode::Inherit,
+            algorithm: RateLimitAlgorithm::TokenBucket,
+            sustained: SustainedRate {
+                rate: 5000,
+                window: Window::Minute,
+            },
+            burst: None,
+            budget: Some(BudgetConfig {
+                mode: BudgetMode::Allocated,
+                total: Some(5000),
+                overcommit_ratio: Some(1.0),
+            }),
+            scope: RateLimitScope::Tenant,
+            strategy: RateLimitStrategy::Reject,
+            cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
+        });
+        let root_upstream = svc.create_upstream(&root_ctx, root_req).await.unwrap();
+
+        // Child allocates 3000/min — fits within 5000.
+        let child_ctx = test_ctx(child);
+        let mut child_req = make_create_upstream_hostname();
+        child_req.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 3000, Window::Minute));
+        svc.create_upstream(&child_ctx, child_req).await.unwrap();
+
+        // Root lowers budget to 2000/min — child's 3000 exceeds it.
+        let mut update_req = make_update_from_upstream(&root_upstream);
+        update_req.rate_limit = Some(RateLimitConfig {
+            sharing: SharingMode::Inherit,
+            algorithm: RateLimitAlgorithm::TokenBucket,
+            sustained: SustainedRate {
+                rate: 2000,
+                window: Window::Minute,
+            },
+            burst: None,
+            budget: Some(BudgetConfig {
+                mode: BudgetMode::Allocated,
+                total: Some(2000),
+                overcommit_ratio: Some(1.0),
+            }),
+            scope: RateLimitScope::Tenant,
+            strategy: RateLimitStrategy::Reject,
+            cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
+        });
+        let err = svc
+            .update_upstream(&root_ctx, root_upstream.id, update_req)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, DomainError::Validation { .. }),
+            "expected Validation error when lowering budget below descendant allocations, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn budget_lowering_total_allows_when_descendants_fit() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let root = Uuid::new_v4();
+        let child = Uuid::new_v4();
+
+        let resolver =
+            MockTenantResolverClient::with_siblings(TenantId(root), vec![TenantId(child)]);
+        let svc = make_service_with_resolver(resolver);
+
+        // Root creates upstream with allocated budget of 5000/min.
+        let root_ctx = test_ctx(root);
+        let mut root_req = make_create_upstream_hostname();
+        root_req.rate_limit = Some(RateLimitConfig {
+            sharing: SharingMode::Inherit,
+            algorithm: RateLimitAlgorithm::TokenBucket,
+            sustained: SustainedRate {
+                rate: 5000,
+                window: Window::Minute,
+            },
+            burst: None,
+            budget: Some(BudgetConfig {
+                mode: BudgetMode::Allocated,
+                total: Some(5000),
+                overcommit_ratio: Some(1.0),
+            }),
+            scope: RateLimitScope::Tenant,
+            strategy: RateLimitStrategy::Reject,
+            cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
+        });
+        let root_upstream = svc.create_upstream(&root_ctx, root_req).await.unwrap();
+
+        // Child allocates 1000/min.
+        let child_ctx = test_ctx(child);
+        let mut child_req = make_create_upstream_hostname();
+        child_req.rate_limit = Some(make_rate_limit(SharingMode::Inherit, 1000, Window::Minute));
+        svc.create_upstream(&child_ctx, child_req).await.unwrap();
+
+        // Root lowers budget to 2000/min — child's 1000 still fits.
+        let mut update_req = make_update_from_upstream(&root_upstream);
+        update_req.rate_limit = Some(RateLimitConfig {
+            sharing: SharingMode::Inherit,
+            algorithm: RateLimitAlgorithm::TokenBucket,
+            sustained: SustainedRate {
+                rate: 2000,
+                window: Window::Minute,
+            },
+            burst: None,
+            budget: Some(BudgetConfig {
+                mode: BudgetMode::Allocated,
+                total: Some(2000),
+                overcommit_ratio: Some(1.0),
+            }),
+            scope: RateLimitScope::Tenant,
+            strategy: RateLimitStrategy::Reject,
+            cost: 1,
+            response_headers: true,
+            pool_owner_id: None,
+        });
+        svc.update_upstream(&root_ctx, root_upstream.id, update_req)
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn merge_rate_limit_allocated_does_not_set_pool_owner_id() {
+        use crate::domain::model::{BudgetConfig, BudgetMode};
+
+        let root_id = Uuid::new_v4();
+        let child_id = Uuid::new_v4();
+
+        let mut root = make_upstream(
+            root_id,
+            "openai",
+            None,
+            Some(RateLimitConfig {
+                sharing: SharingMode::Enforce,
+                algorithm: RateLimitAlgorithm::TokenBucket,
+                sustained: SustainedRate {
+                    rate: 1000,
+                    window: Window::Minute,
+                },
+                burst: None,
+                budget: Some(BudgetConfig {
+                    mode: BudgetMode::Allocated,
+                    total: Some(1000),
+                    overcommit_ratio: Some(1.0),
+                }),
+                scope: RateLimitScope::Tenant,
+                strategy: RateLimitStrategy::Reject,
+                cost: 1,
+                response_headers: true,
+                pool_owner_id: None,
+            }),
+            None,
+            vec![],
+        );
+
+        let child = make_upstream(
+            child_id,
+            "openai",
+            None,
+            Some(make_rate_limit(SharingMode::Inherit, 500, Window::Minute)),
+            None,
+            vec![],
+        );
+
+        merge_rate_limit(&mut root, &child);
+
+        let effective_rl = root.rate_limit.as_ref().unwrap();
+        assert_eq!(
+            effective_rl.pool_owner_id, None,
+            "pool_owner_id should NOT be set for allocated budget"
         );
     }
 }

--- a/modules/system/oagw/oagw/src/domain/services/mod.rs
+++ b/modules/system/oagw/oagw/src/domain/services/mod.rs
@@ -54,7 +54,14 @@ pub(crate) trait ControlPlaneService: Send + Sync {
         req: UpdateUpstreamRequest,
     ) -> Result<Upstream, DomainError>;
 
-    async fn delete_upstream(&self, ctx: &SecurityContext, id: Uuid) -> Result<(), DomainError>;
+    /// Delete an upstream and cascade-delete its routes.
+    /// Returns the IDs of deleted routes so callers can clean up route-scoped
+    /// rate-limit keys.
+    async fn delete_upstream(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+    ) -> Result<Vec<Uuid>, DomainError>;
 
     // -- Route CRUD --
 
@@ -107,8 +114,11 @@ pub(crate) trait DataPlaneService: Send + Sync {
         req: http::Request<Body>,
     ) -> Result<http::Response<Body>, DomainError>;
 
-    /// Remove a rate-limit bucket by key (e.g. `"upstream:{id}"` or `"route:{id}"`).
-    fn remove_rate_limit_key(&self, key: &str);
+    /// Remove all rate-limit buckets associated with an upstream (all scope variants).
+    fn remove_rate_limit_keys_for_upstream(&self, upstream_id: Uuid);
+
+    /// Remove all rate-limit buckets associated with a route.
+    fn remove_rate_limit_keys_for_route(&self, route_id: Uuid);
 }
 
 /// Endpoint selection abstraction for multi-endpoint load balancing.

--- a/modules/system/oagw/oagw/src/domain/test_support.rs
+++ b/modules/system/oagw/oagw/src/domain/test_support.rs
@@ -227,6 +227,83 @@ impl MockTenantResolverClient {
         }
     }
 
+    /// Create a resolver where `parent` has multiple direct `children`.
+    ///
+    /// Each child sees `[parent]` as its ancestor chain. Parent has no
+    /// ancestors (it's the root).
+    pub fn with_siblings(parent: TenantId, children: Vec<TenantId>) -> Self {
+        let mut tenants = HashMap::new();
+        let parent_info = TenantInfo {
+            id: parent,
+            name: format!("tenant-{}", &parent.to_string()[..8]),
+            status: TenantStatus::Active,
+            tenant_type: None,
+            parent_id: None,
+            self_managed: false,
+        };
+        tenants.insert(parent, (parent_info, vec![]));
+        for &child in &children {
+            let info = TenantInfo {
+                id: child,
+                name: format!("tenant-{}", &child.to_string()[..8]),
+                status: TenantStatus::Active,
+                tenant_type: None,
+                parent_id: Some(parent),
+                self_managed: false,
+            };
+            let ancestors = vec![TenantRef {
+                id: parent,
+                status: TenantStatus::Active,
+                tenant_type: None,
+                parent_id: None,
+                self_managed: false,
+            }];
+            tenants.insert(child, (info, ancestors));
+        }
+        Self { tenants }
+    }
+
+    /// Create a resolver with two independent trees (separate roots).
+    ///
+    /// Each root has its own set of direct children. The trees share no
+    /// ancestry. Used for testing cross-tree isolation.
+    pub fn with_two_trees(
+        root_a: TenantId,
+        children_a: Vec<TenantId>,
+        root_b: TenantId,
+        children_b: Vec<TenantId>,
+    ) -> Self {
+        let mut resolver = Self::with_siblings(root_a, children_a);
+        let parent_info = TenantInfo {
+            id: root_b,
+            name: format!("tenant-{}", &root_b.to_string()[..8]),
+            status: TenantStatus::Active,
+            tenant_type: None,
+            parent_id: None,
+            self_managed: false,
+        };
+        resolver.tenants.insert(root_b, (parent_info, vec![]));
+        for &child in &children_b {
+            let info = TenantInfo {
+                id: child,
+                name: format!("tenant-{}", &child.to_string()[..8]),
+                status: TenantStatus::Active,
+                tenant_type: None,
+                parent_id: Some(root_b),
+                self_managed: false,
+            };
+            let ancestors = vec![TenantRef {
+                id: root_b,
+                status: TenantStatus::Active,
+                tenant_type: None,
+                parent_id: None,
+                self_managed: false,
+            }];
+            resolver.tenants.insert(child, (info, ancestors));
+        }
+        resolver
+    }
+
     /// Create a resolver with an explicit hierarchy.
     ///
     /// `chain` is ordered root-first: `[root, parent, child]`.  Each entry

--- a/modules/system/oagw/oagw/src/infra/proxy/headers.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/headers.rs
@@ -285,6 +285,33 @@ pub fn set_host_header(headers: &mut HeaderMap, host: &str, port: u16) {
     }
 }
 
+/// Extract client IP from request headers for IP-scoped rate limiting.
+///
+/// Checks `X-Forwarded-For` (first IP in the chain) then `X-Real-IP`.
+/// Returns `None` if neither header is present or parseable.
+pub fn extract_client_ip(headers: &HeaderMap) -> Option<String> {
+    // Parse and validate as a real IP address to prevent arbitrary token injection.
+    // Only trusted when headers originate from a trusted proxy.
+    if let Some(xff) = headers.get("x-forwarded-for")
+        && let Ok(val) = xff.to_str()
+        && let Some(candidate) = val
+            .split(',')
+            .next()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        && let Ok(ip) = candidate.parse::<std::net::IpAddr>()
+    {
+        return Some(ip.to_string());
+    }
+    headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .and_then(|s| s.parse::<std::net::IpAddr>().ok())
+        .map(|ip| ip.to_string())
+}
+
 /// Convert an HTTP `HeaderMap` to a `HashMap<String, String>` for plugin contexts.
 ///
 /// Non-UTF-8 header values are silently dropped (they cannot be represented as
@@ -907,5 +934,40 @@ mod tests {
         headers.append("transfer-encoding", "chunked".parse().unwrap());
         headers.append("transfer-encoding", "chunked".parse().unwrap());
         assert!(!is_valid_transfer_encoding(&headers));
+    }
+
+    #[test]
+    fn extract_client_ip_from_xff() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4, 5.6.7.8".parse().unwrap());
+        assert_eq!(extract_client_ip(&headers), Some("1.2.3.4".to_string()));
+    }
+
+    #[test]
+    fn extract_client_ip_from_xff_single() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "10.0.0.1".parse().unwrap());
+        assert_eq!(extract_client_ip(&headers), Some("10.0.0.1".to_string()));
+    }
+
+    #[test]
+    fn extract_client_ip_from_real_ip() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-real-ip", "192.168.1.1".parse().unwrap());
+        assert_eq!(extract_client_ip(&headers), Some("192.168.1.1".to_string()));
+    }
+
+    #[test]
+    fn extract_client_ip_xff_takes_precedence() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "1.2.3.4".parse().unwrap());
+        headers.insert("x-real-ip", "5.6.7.8".parse().unwrap());
+        assert_eq!(extract_client_ip(&headers), Some("1.2.3.4".to_string()));
+    }
+
+    #[test]
+    fn extract_client_ip_none() {
+        let headers = HeaderMap::new();
+        assert_eq!(extract_client_ip(&headers), None);
     }
 }

--- a/modules/system/oagw/oagw/src/infra/proxy/service.rs
+++ b/modules/system/oagw/oagw/src/infra/proxy/service.rs
@@ -15,6 +15,8 @@ use pingora_proxy::HttpProxy;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::watch;
 
+use uuid::Uuid;
+
 use crate::config::TokenCacheConfig;
 use crate::domain::error::DomainError;
 use crate::domain::model::{
@@ -24,7 +26,9 @@ use crate::domain::plugin::{
     AuthContext, GuardContext, GuardDecision, TransformErrorContext, TransformRequestContext,
     TransformResponseContext,
 };
-use crate::domain::rate_limit::RateLimiter;
+use crate::domain::rate_limit::{
+    RateLimitKeyContext, RateLimitOutcome, RateLimitResource, RateLimiter, build_rate_limit_key,
+};
 use crate::domain::services::{
     ControlPlaneService, DataPlaneService, EndpointSelector, SelectedEndpoint,
 };
@@ -212,6 +216,16 @@ impl DataPlaneServiceImpl {
         // Apply response header rules (set/add/remove) from upstream config.
         if let Some(rules) = pipeline.response_header_rules {
             headers::apply_response_header_rules(&mut resp_headers, rules);
+        }
+
+        // Inject rate-limit response headers if configured.
+        if let Some((ref outcome, true)) = pipeline.rate_limit_outcome {
+            resp_headers.insert("x-ratelimit-limit", HeaderValue::from(outcome.limit));
+            resp_headers.insert(
+                "x-ratelimit-remaining",
+                HeaderValue::from(outcome.remaining),
+            );
+            resp_headers.insert("x-ratelimit-reset", HeaderValue::from(outcome.reset_epoch));
         }
 
         // Apply streaming lifecycle management for SSE responses:
@@ -682,14 +696,58 @@ impl DataPlaneService for DataPlaneServiceImpl {
 
         headers::set_host_header(&mut outbound_headers, &endpoint.host, endpoint.port);
 
-        // 6. Check rate limit (upstream then route).
+        // 6. Check rate limit (upstream then route) with scope-aware keying.
+        //    Both try_consume calls decrement their respective buckets
+        //    unconditionally — an upstream token is spent even when a stricter
+        //    route-level bucket later causes rejection.
+        let mut rate_limit_outcome: Option<(RateLimitOutcome, bool)> = None;
+        let client_ip = headers::extract_client_ip(&req_headers);
+        let client_ip_ref = client_ip.as_deref();
+        let tenant_id = ctx.subject_tenant_id();
+        let subject_id = ctx.subject_id();
+
         if let Some(ref rl) = upstream.rate_limit {
-            let key = format!("upstream:{}", upstream.id);
-            self.rate_limiter.try_consume(&key, rl, &instance_uri)?;
+            // For shared-pool budgets, use the pool owner's ID so all children
+            // sharing the pool consume from the same token bucket.
+            let effective_resource_id = rl.pool_owner_id.as_ref().unwrap_or(&upstream.id);
+            let key = build_rate_limit_key(&RateLimitKeyContext {
+                resource: RateLimitResource::Upstream,
+                resource_id: effective_resource_id,
+                scope: &rl.scope,
+                tenant_id: &tenant_id,
+                subject_id: &subject_id,
+                client_ip: client_ip_ref,
+                window: &rl.sustained.window,
+            });
+            let outcome = self.rate_limiter.try_consume(&key, rl, &instance_uri)?;
+            rate_limit_outcome = Some((outcome, rl.response_headers));
         }
         if let Some(ref rl) = route.rate_limit {
-            let key = format!("route:{}", route.id);
-            self.rate_limiter.try_consume(&key, rl, &instance_uri)?;
+            let key = build_rate_limit_key(&RateLimitKeyContext {
+                resource: RateLimitResource::Route,
+                resource_id: &route.id,
+                scope: &rl.scope,
+                tenant_id: &tenant_id,
+                subject_id: &subject_id,
+                client_ip: client_ip_ref,
+                window: &rl.sustained.window,
+            });
+            let outcome = self.rate_limiter.try_consume(&key, rl, &instance_uri)?;
+            match &rate_limit_outcome {
+                Some((existing, show_headers)) if existing.remaining <= outcome.remaining => {
+                    // Tighter (or equal) bucket wins for enforcement; on ties
+                    // upstream wins — both remaining counts are identical so the
+                    // allow/reject decision is the same either way.  OR the header
+                    // flags so headers are emitted if either scope enables them.
+                    if rl.response_headers && !show_headers {
+                        rate_limit_outcome = rate_limit_outcome.map(|(o, _)| (o, true));
+                    }
+                }
+                _ => {
+                    let prev_headers = rate_limit_outcome.as_ref().is_some_and(|(_, h)| *h);
+                    rate_limit_outcome = Some((outcome, rl.response_headers || prev_headers));
+                }
+            }
         }
 
         // 7. Build URL.
@@ -749,6 +807,7 @@ impl DataPlaneService for DataPlaneServiceImpl {
             cors_config: effective_cors.as_ref(),
             origin: request_origin,
             response_header_rules,
+            rate_limit_outcome,
         };
 
         // 8. WebSocket upgrade path: bypass the normal request/response bridge
@@ -813,6 +872,17 @@ impl DataPlaneService for DataPlaneServiceImpl {
             // Sanitize response headers, preserving Upgrade/Connection.
             let mut resp_headers = resp_headers;
             headers::sanitize_response_headers_for_upgrade(&mut resp_headers);
+
+            // Inject rate-limit response headers if configured (the normal path
+            // does this in finalize_response, which the upgrade path bypasses).
+            if let Some((ref outcome, true)) = pipeline.rate_limit_outcome {
+                resp_headers.insert("x-ratelimit-limit", HeaderValue::from(outcome.limit));
+                resp_headers.insert(
+                    "x-ratelimit-remaining",
+                    HeaderValue::from(outcome.remaining),
+                );
+                resp_headers.insert("x-ratelimit-reset", HeaderValue::from(outcome.reset_epoch));
+            }
 
             // Build the 101 response with the DuplexStream stashed in extensions.
             let mut resp = http::Response::builder()
@@ -1037,8 +1107,12 @@ impl DataPlaneService for DataPlaneServiceImpl {
         }
     }
 
-    fn remove_rate_limit_key(&self, key: &str) {
-        self.rate_limiter.remove_key(key);
+    fn remove_rate_limit_keys_for_upstream(&self, upstream_id: Uuid) {
+        self.rate_limiter.remove_keys_for_upstream(upstream_id);
+    }
+
+    fn remove_rate_limit_keys_for_route(&self, route_id: Uuid) {
+        self.rate_limiter.remove_keys_for_route(route_id);
     }
 }
 
@@ -1185,6 +1259,7 @@ struct ResponsePipelineCtx<'a> {
     cors_config: Option<&'a crate::domain::model::CorsConfig>,
     origin: Option<String>,
     response_header_rules: Option<&'a ResponseHeaderRules>,
+    rate_limit_outcome: Option<(RateLimitOutcome, bool)>,
 }
 
 /// Execute `on_error` for all transform bindings, logging errors without aborting.
@@ -1520,7 +1595,7 @@ mod tests {
                 &self,
                 _: &SecurityContext,
                 _: Uuid,
-            ) -> Result<(), DomainError> {
+            ) -> Result<Vec<Uuid>, DomainError> {
                 unimplemented!()
             }
             async fn create_route(

--- a/modules/system/oagw/oagw/src/infra/storage/route_repo.rs
+++ b/modules/system/oagw/oagw/src/infra/storage/route_repo.rs
@@ -196,26 +196,19 @@ impl RouteRepository for InMemoryRouteRepo {
         &self,
         tenant_id: Uuid,
         upstream_id: Uuid,
-    ) -> Result<u64, RepositoryError> {
+    ) -> Result<Vec<Uuid>, RepositoryError> {
         let route_ids: Vec<Uuid> = self
             .upstream_index
             .remove(&upstream_id)
             .map(|(_, ids)| ids)
             .unwrap_or_default();
 
-        let mut deleted = 0u64;
-        let mut surviving_ids: Vec<Uuid> = Vec::new();
+        let (to_delete, surviving_ids): (Vec<_>, Vec<_>) = route_ids
+            .into_iter()
+            .partition(|id| self.store.get(id).is_some_and(|r| r.tenant_id == tenant_id));
 
-        for id in route_ids {
-            if let Some((_, route)) = self.store.remove(&id) {
-                if route.tenant_id == tenant_id {
-                    deleted += 1;
-                } else {
-                    // Put it back — wrong tenant.
-                    self.store.insert(id, route);
-                    surviving_ids.push(id);
-                }
-            }
+        for id in &to_delete {
+            self.store.remove(id);
         }
 
         // Rebuild the upstream index for surviving routes.
@@ -223,7 +216,7 @@ impl RouteRepository for InMemoryRouteRepo {
             self.upstream_index.insert(upstream_id, surviving_ids);
         }
 
-        Ok(deleted)
+        Ok(to_delete)
     }
 }
 
@@ -437,8 +430,9 @@ mod tests {
         repo.create(route_b.clone()).await.unwrap();
 
         // Cascade delete for tenant_a should only remove tenant_a's route.
-        let deleted = repo.delete_by_upstream(tenant_a, upstream).await.unwrap();
-        assert_eq!(deleted, 1);
+        let deleted_ids = repo.delete_by_upstream(tenant_a, upstream).await.unwrap();
+        assert_eq!(deleted_ids.len(), 1);
+        assert!(deleted_ids.contains(&route_a.id));
 
         // tenant_a's route is gone.
         assert!(repo.get_by_id(tenant_a, route_a.id).await.is_err());
@@ -490,8 +484,10 @@ mod tests {
         repo.create(r1.clone()).await.unwrap();
         repo.create(r2.clone()).await.unwrap();
 
-        let deleted = repo.delete_by_upstream(tenant, upstream).await.unwrap();
-        assert_eq!(deleted, 2);
+        let deleted_ids = repo.delete_by_upstream(tenant, upstream).await.unwrap();
+        assert_eq!(deleted_ids.len(), 2);
+        assert!(deleted_ids.contains(&r1.id));
+        assert!(deleted_ids.contains(&r2.id));
 
         assert!(repo.get_by_id(tenant, r1.id).await.is_err());
         assert!(repo.get_by_id(tenant, r2.id).await.is_err());

--- a/modules/system/oagw/oagw/src/infra/storage/upstream_repo.rs
+++ b/modules/system/oagw/oagw/src/infra/storage/upstream_repo.rs
@@ -152,6 +152,19 @@ impl UpstreamRepository for InMemoryUpstreamRepo {
         self.alias_index.remove(&(tenant_id, upstream.alias));
         Ok(())
     }
+
+    async fn list_by_alias_for_tenants(
+        &self,
+        alias: &str,
+        tenant_ids: &std::collections::HashSet<Uuid>,
+    ) -> Result<Vec<Upstream>, RepositoryError> {
+        Ok(self
+            .alias_index
+            .iter()
+            .filter(|e| e.key().1 == alias && tenant_ids.contains(&e.key().0))
+            .filter_map(|e| self.store.get(e.value()).map(|u| u.value().clone()))
+            .collect())
+    }
 }
 
 #[cfg(test)]
@@ -371,5 +384,54 @@ mod tests {
 
         // Different tenant cannot see it.
         assert!(repo.get_by_id(t2, id).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn list_by_alias_for_tenants_filters_by_tenant_set() {
+        let repo = InMemoryUpstreamRepo::new();
+        let t1 = Uuid::new_v4();
+        let t2 = Uuid::new_v4();
+        let t3 = Uuid::new_v4();
+
+        repo.create(make_upstream(t1, "shared")).await.unwrap();
+        repo.create(make_upstream(t2, "shared")).await.unwrap();
+        repo.create(make_upstream(t3, "shared")).await.unwrap();
+
+        let filter: std::collections::HashSet<Uuid> = [t1, t2].into();
+        let results = repo
+            .list_by_alias_for_tenants("shared", &filter)
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|u| u.alias == "shared"));
+        assert!(results.iter().all(|u| u.tenant_id != t3));
+    }
+
+    #[tokio::test]
+    async fn list_by_alias_for_tenants_returns_empty_for_unknown_alias() {
+        let repo = InMemoryUpstreamRepo::new();
+        let t = Uuid::new_v4();
+        repo.create(make_upstream(t, "openai")).await.unwrap();
+
+        let filter: std::collections::HashSet<Uuid> = [t].into();
+        let results = repo
+            .list_by_alias_for_tenants("nonexistent", &filter)
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_by_alias_for_tenants_returns_empty_for_empty_tenant_set() {
+        let repo = InMemoryUpstreamRepo::new();
+        let t = Uuid::new_v4();
+        repo.create(make_upstream(t, "openai")).await.unwrap();
+
+        let filter: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
+        let results = repo
+            .list_by_alias_for_tenants("openai", &filter)
+            .await
+            .unwrap();
+        assert!(results.is_empty());
     }
 }

--- a/modules/system/oagw/oagw/src/infra/type_provisioning.rs
+++ b/modules/system/oagw/oagw/src/infra/type_provisioning.rs
@@ -198,11 +198,34 @@ struct RateLimitConfig {
     #[serde(default)]
     burst: Option<BurstConfig>,
     #[serde(default)]
+    budget: Option<BudgetConfig>,
+    #[serde(default)]
     scope: RateLimitScope,
     #[serde(default)]
     strategy: RateLimitStrategy,
     #[serde(default = "default_cost")]
     cost: u32,
+    #[serde(default = "default_true")]
+    response_headers: bool,
+}
+
+#[derive(Deserialize)]
+struct BudgetConfig {
+    #[serde(default)]
+    mode: BudgetMode,
+    #[serde(default)]
+    total: Option<u32>,
+    #[serde(default)]
+    overcommit_ratio: Option<f64>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+enum BudgetMode {
+    #[default]
+    Unlimited,
+    Allocated,
+    Shared,
 }
 
 #[derive(Deserialize)]
@@ -481,9 +504,32 @@ impl From<RateLimitConfig> for domain::RateLimitConfig {
             algorithm: v.algorithm.into(),
             sustained: v.sustained.into(),
             burst: v.burst.map(Into::into),
+            budget: v.budget.map(Into::into),
             scope: v.scope.into(),
             strategy: v.strategy.into(),
             cost: v.cost,
+            response_headers: v.response_headers,
+            pool_owner_id: None,
+        }
+    }
+}
+
+impl From<BudgetConfig> for domain::BudgetConfig {
+    fn from(v: BudgetConfig) -> Self {
+        Self {
+            mode: v.mode.into(),
+            total: v.total,
+            overcommit_ratio: v.overcommit_ratio,
+        }
+    }
+}
+
+impl From<BudgetMode> for domain::BudgetMode {
+    fn from(v: BudgetMode) -> Self {
+        match v {
+            BudgetMode::Unlimited => Self::Unlimited,
+            BudgetMode::Allocated => Self::Allocated,
+            BudgetMode::Shared => Self::Shared,
         }
     }
 }

--- a/modules/system/oagw/oagw/tests/e2e_smoke_test.rs
+++ b/modules/system/oagw/oagw/tests/e2e_smoke_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use oagw::test_support::{
     APIKEY_AUTH_PLUGIN_ID, AppHarness, CapturingAuthZResolverClient, DenyingAuthZResolverClient,
@@ -755,4 +756,498 @@ async fn e2e_authz_request_carries_tenant_context() {
     );
     assert_eq!(req.resource.resource_type, "gts.x.core.oagw.proxy.v1~");
     assert_eq!(req.action.name, "invoke");
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit response header tests (Scenario 18.1, 18.1.1, ADR-0004)
+// ---------------------------------------------------------------------------
+
+/// Helper: create upstream + route with the given rate_limit JSON.
+async fn setup_rate_limited_upstream(
+    h: &AppHarness,
+    alias: &str,
+    rate_limit: serde_json::Value,
+    route_path: &str,
+) {
+    let resp = h
+        .api_v1()
+        .post_upstream()
+        .with_body(serde_json::json!({
+            "server": {
+                "endpoints": [{"host": "127.0.0.1", "port": h.mock_port(), "scheme": "http"}]
+            },
+            "protocol": "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            "alias": alias,
+            "enabled": true,
+            "tags": [],
+            "rate_limit": rate_limit
+        }))
+        .expect_status(201)
+        .await;
+    let uid = resp.json()["id"].as_str().unwrap().to_string();
+
+    h.api_v1()
+        .post_route()
+        .with_body(serde_json::json!({
+            "upstream_id": &uid,
+            "match": { "http": { "methods": ["GET"], "path": route_path } },
+            "enabled": true,
+            "tags": [],
+            "priority": 0
+        }))
+        .expect_status(201)
+        .await;
+}
+
+// Scenario 18.1, inst-rl-12, dod-rate-limit-headers — success response includes X-RateLimit-* headers.
+#[tokio::test]
+async fn e2e_rate_limit_success_includes_response_headers() {
+    let h = AppHarness::builder().build().await;
+
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-headers",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 10, "window": "second"},
+            "burst": {"capacity": 10},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1,
+            "response_headers": true
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-headers", "v1/models")
+        .expect_status(200)
+        .await;
+
+    resp.assert_header("x-ratelimit-limit", "10");
+    resp.assert_header("x-ratelimit-remaining", "9");
+    assert!(
+        resp.headers().get("x-ratelimit-reset").is_some(),
+        "expected x-ratelimit-reset header on success"
+    );
+    assert!(
+        resp.headers().get("retry-after").is_none(),
+        "retry-after should not be present on success"
+    );
+}
+
+// Scenario 18.1, inst-rl-6a1, dod-rate-limit-headers, dod-token-bucket — 429 includes all required headers.
+#[tokio::test]
+async fn e2e_rate_limit_429_includes_all_headers() {
+    let h = AppHarness::builder().build().await;
+
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-429h",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 1, "window": "minute"},
+            "burst": {"capacity": 1},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1,
+            "response_headers": true
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    // Exhaust the bucket.
+    h.api_v1()
+        .proxy_get("e2e-rl-429h", "v1/models")
+        .expect_status(200)
+        .await;
+
+    // Second request triggers 429.
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-429h", "v1/models")
+        .expect_status(429)
+        .await;
+
+    resp.assert_header("x-oagw-error-source", "gateway");
+    assert!(
+        resp.headers().get("retry-after").is_some(),
+        "expected retry-after header on 429"
+    );
+    let retry_after: u64 = resp
+        .headers()
+        .get("retry-after")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .parse()
+        .expect("retry-after should be a positive integer");
+    assert!(retry_after > 0, "retry-after should be > 0");
+
+    resp.assert_header("x-ratelimit-limit", "1");
+    resp.assert_header("x-ratelimit-remaining", "0");
+    assert!(
+        resp.headers().get("x-ratelimit-reset").is_some(),
+        "expected x-ratelimit-reset on 429"
+    );
+
+    // RFC 9457 Problem Details body.
+    assert!(
+        resp.headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("application/problem+json"),
+        "expected application/problem+json content type"
+    );
+    let body = resp.json();
+    assert_eq!(body["status"], 429);
+    assert!(
+        body.get("type").is_some(),
+        "expected 'type' in problem JSON"
+    );
+    assert!(
+        body.get("detail").is_some(),
+        "expected 'detail' in problem JSON"
+    );
+    assert!(
+        body.get("instance").is_some(),
+        "expected 'instance' in problem JSON"
+    );
+}
+
+// Scenario 18.1.1, inst-rl-12 (negative) — response_headers=false suppresses headers on success.
+#[tokio::test]
+async fn e2e_rate_limit_response_headers_disabled_on_success() {
+    let h = AppHarness::builder().build().await;
+
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-nohdr",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 5, "window": "second"},
+            "burst": {"capacity": 5},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1,
+            "response_headers": false
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-nohdr", "v1/models")
+        .expect_status(200)
+        .await;
+
+    assert!(
+        resp.headers().get("x-ratelimit-limit").is_none(),
+        "x-ratelimit-limit should be absent when response_headers=false"
+    );
+    assert!(
+        resp.headers().get("x-ratelimit-remaining").is_none(),
+        "x-ratelimit-remaining should be absent when response_headers=false"
+    );
+    assert!(
+        resp.headers().get("x-ratelimit-reset").is_none(),
+        "x-ratelimit-reset should be absent when response_headers=false"
+    );
+}
+
+// Scenario 18.1.1, inst-rl-6a1 — 429 still includes retry-after even when response_headers=false.
+#[tokio::test]
+async fn e2e_rate_limit_headers_disabled_429_still_has_retry_after() {
+    let h = AppHarness::builder().build().await;
+
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-nohdr429",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 1, "window": "minute"},
+            "burst": {"capacity": 1},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1,
+            "response_headers": false
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    h.api_v1()
+        .proxy_get("e2e-rl-nohdr429", "v1/models")
+        .expect_status(200)
+        .await;
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-nohdr429", "v1/models")
+        .expect_status(429)
+        .await;
+
+    resp.assert_header("x-oagw-error-source", "gateway");
+    assert!(
+        resp.headers().get("retry-after").is_some(),
+        "retry-after must always be present on 429 regardless of response_headers flag"
+    );
+    assert!(
+        resp.headers().get("x-ratelimit-limit").is_none(),
+        "x-ratelimit-limit must be absent when response_headers is false"
+    );
+    assert!(
+        resp.headers().get("x-ratelimit-remaining").is_none(),
+        "x-ratelimit-remaining must be absent when response_headers is false"
+    );
+    assert!(
+        resp.headers().get("x-ratelimit-reset").is_none(),
+        "x-ratelimit-reset must be absent when response_headers is false"
+    );
+    assert!(
+        resp.headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("application/problem+json"),
+        "expected application/problem+json content type on 429"
+    );
+}
+
+// Scenario 18.1, inst-tb-1..5b, dod-token-bucket — full burst → exhaust → refill → recover flow.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn e2e_rate_limit_burst_then_recover() {
+    let h = AppHarness::builder().build().await;
+
+    // Use a low sustained rate (100/minute ≈ 1.67 tok/s) so token refill between
+    // sequential requests (~few ms each) is negligible, making remaining-count
+    // assertions deterministic. Previous rate of 10/second could refill tokens
+    // between requests, causing flaky assertions.
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-burst",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 100, "window": "minute"},
+            "burst": {"capacity": 3},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1,
+            "response_headers": true
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    // Exhaust burst capacity (3 tokens).
+    for expected_remaining in (0..=2).rev() {
+        let resp = h
+            .api_v1()
+            .proxy_get("e2e-rl-burst", "v1/models")
+            .expect_status(200)
+            .await;
+        resp.assert_header("x-ratelimit-remaining", &expected_remaining.to_string());
+    }
+
+    // 4th request should be rejected.
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-burst", "v1/models")
+        .expect_status(429)
+        .await;
+    assert!(resp.headers().get("retry-after").is_some());
+
+    // Wait for refill. At 100/minute ≈ 1.67 tok/s, 2 seconds yields ~3 tokens.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Should succeed again after refill.
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-burst", "v1/models")
+        .expect_status(200)
+        .await;
+    let remaining: u64 = resp
+        .headers()
+        .get("x-ratelimit-remaining")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(remaining > 0, "expected remaining > 0 after refill");
+}
+
+// ADR 0004 §response_headers default — response_headers defaults to true when omitted.
+#[tokio::test]
+async fn e2e_rate_limit_response_headers_default_true() {
+    let h = AppHarness::builder().build().await;
+
+    // Deliberately omit `response_headers` from the rate_limit JSON.
+    setup_rate_limited_upstream(
+        &h,
+        "e2e-rl-default",
+        serde_json::json!({
+            "algorithm": "token_bucket",
+            "sustained": {"rate": 5, "window": "second"},
+            "burst": {"capacity": 5},
+            "scope": "tenant",
+            "strategy": "reject",
+            "cost": 1
+        }),
+        "/v1/models",
+    )
+    .await;
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-default", "v1/models")
+        .expect_status(200)
+        .await;
+
+    assert!(
+        resp.headers().get("x-ratelimit-limit").is_some(),
+        "x-ratelimit-limit should be present when response_headers defaults to true"
+    );
+}
+
+// inst-rl-2, inst-rl-5, inst-merge-5a — route-level rate limit enforcement (no upstream limit).
+#[tokio::test]
+async fn e2e_rate_limit_route_level_enforcement() {
+    let h = AppHarness::builder().build().await;
+
+    // Create upstream WITHOUT rate_limit.
+    let resp = h
+        .api_v1()
+        .post_upstream()
+        .with_body(serde_json::json!({
+            "server": {
+                "endpoints": [{"host": "127.0.0.1", "port": h.mock_port(), "scheme": "http"}]
+            },
+            "protocol": "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            "alias": "e2e-rl-route",
+            "enabled": true,
+            "tags": []
+        }))
+        .expect_status(201)
+        .await;
+    let uid = resp.json()["id"].as_str().unwrap().to_string();
+
+    // Create route WITH rate_limit.
+    h.api_v1()
+        .post_route()
+        .with_body(serde_json::json!({
+            "upstream_id": &uid,
+            "match": { "http": { "methods": ["GET"], "path": "/v1/models" } },
+            "enabled": true,
+            "tags": [],
+            "priority": 0,
+            "rate_limit": {
+                "algorithm": "token_bucket",
+                "sustained": {"rate": 1, "window": "minute"},
+                "burst": {"capacity": 1},
+                "scope": "tenant",
+                "strategy": "reject",
+                "cost": 1,
+                "response_headers": true
+            }
+        }))
+        .expect_status(201)
+        .await;
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-route", "v1/models")
+        .expect_status(200)
+        .await;
+    resp.assert_header("x-ratelimit-limit", "1");
+    resp.assert_header("x-ratelimit-remaining", "0");
+
+    h.api_v1()
+        .proxy_get("e2e-rl-route", "v1/models")
+        .expect_status(429)
+        .await;
+}
+
+// inst-rl-2, inst-rl-5, inst-merge-5a — both upstream and route rate limits applied, tighter route wins.
+#[tokio::test]
+async fn e2e_rate_limit_upstream_and_route_both_applied() {
+    let h = AppHarness::builder().build().await;
+
+    // Upstream: generous limit.
+    let resp = h
+        .api_v1()
+        .post_upstream()
+        .with_body(serde_json::json!({
+            "server": {
+                "endpoints": [{"host": "127.0.0.1", "port": h.mock_port(), "scheme": "http"}]
+            },
+            "protocol": "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            "alias": "e2e-rl-dual",
+            "enabled": true,
+            "tags": [],
+            "rate_limit": {
+                "algorithm": "token_bucket",
+                "sustained": {"rate": 100, "window": "minute"},
+                "burst": {"capacity": 100},
+                "scope": "tenant",
+                "strategy": "reject",
+                "cost": 1,
+                "response_headers": true
+            }
+        }))
+        .expect_status(201)
+        .await;
+    let uid = resp.json()["id"].as_str().unwrap().to_string();
+
+    // Route: tight limit.
+    h.api_v1()
+        .post_route()
+        .with_body(serde_json::json!({
+            "upstream_id": &uid,
+            "match": { "http": { "methods": ["GET"], "path": "/v1/models" } },
+            "enabled": true,
+            "tags": [],
+            "priority": 0,
+            "rate_limit": {
+                "algorithm": "token_bucket",
+                "sustained": {"rate": 2, "window": "minute"},
+                "burst": {"capacity": 2},
+                "scope": "tenant",
+                "strategy": "reject",
+                "cost": 1,
+                "response_headers": true
+            }
+        }))
+        .expect_status(201)
+        .await;
+
+    // First two requests succeed; headers reflect tighter route limit.
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-dual", "v1/models")
+        .expect_status(200)
+        .await;
+    // After 1st request: upstream remaining=99, route remaining=1 → route wins (lower remaining).
+    resp.assert_header("x-ratelimit-limit", "2");
+    resp.assert_header("x-ratelimit-remaining", "1");
+
+    let resp = h
+        .api_v1()
+        .proxy_get("e2e-rl-dual", "v1/models")
+        .expect_status(200)
+        .await;
+    resp.assert_header("x-ratelimit-remaining", "0");
+
+    // Third request exceeds route limit.
+    h.api_v1()
+        .proxy_get("e2e-rl-dual", "v1/models")
+        .expect_status(429)
+        .await;
 }

--- a/modules/system/oagw/oagw/tests/proxy_integration.rs
+++ b/modules/system/oagw/oagw/tests/proxy_integration.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use http::{Method, StatusCode};
+use modkit_security::SecurityContext;
 use oagw::test_support::{
     APIKEY_AUTH_PLUGIN_ID, AppHarness, MockBody, MockGuard, MockResponse, MockUpstream,
     OAUTH2_CLIENT_CRED_AUTH_PLUGIN_ID,
@@ -407,6 +408,8 @@ async fn proxy_rate_limit_exceeded_returns_429() {
                 scope: RateLimitScope::Tenant,
                 strategy: RateLimitStrategy::Reject,
                 cost: 1,
+                response_headers: true,
+                budget: None,
             })
             .build(),
         )
@@ -454,6 +457,299 @@ async fn proxy_rate_limit_exceeded_returns_429() {
             oagw_sdk::error::ServiceGatewayError::RateLimitExceeded { .. }
         )),
         Ok(_) => panic!("expected rate limit error"),
+    }
+}
+
+// 18.3: Rate limit scope=user — different subjects within the same tenant get
+// separate buckets. Proves scope-aware keying works end-to-end.
+// Cross-tenant isolation is deferred to e2e tests requiring multi-tenant harness.
+#[tokio::test]
+async fn proxy_rate_limit_scope_user_isolates_by_subject() {
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+    let tenant_id = ctx.subject_tenant_id();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("scope-user")
+            .rate_limit(RateLimitConfig {
+                sharing: SharingMode::Private,
+                algorithm: RateLimitAlgorithm::TokenBucket,
+                sustained: SustainedRate {
+                    rate: 1,
+                    window: Window::Minute,
+                },
+                burst: Some(BurstConfig { capacity: 1 }),
+                scope: RateLimitScope::User,
+                strategy: RateLimitStrategy::Reject,
+                cost: 1,
+                response_headers: true,
+                budget: None,
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get],
+                        path: "/v1/models".into(),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Append,
+                    }),
+                    grpc: None,
+                },
+            )
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Two users in the same tenant.
+    let user_a = SecurityContext::builder()
+        .subject_tenant_id(tenant_id)
+        .subject_id(uuid::Uuid::new_v4())
+        .build()
+        .unwrap();
+    let user_b = SecurityContext::builder()
+        .subject_tenant_id(tenant_id)
+        .subject_id(uuid::Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    // User A — allowed (own bucket).
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/scope-user/v1/models")
+        .body(Body::Empty)
+        .unwrap();
+    let resp = h.facade().proxy_request(user_a.clone(), req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // User B — allowed (separate bucket).
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/scope-user/v1/models")
+        .body(Body::Empty)
+        .unwrap();
+    let resp = h.facade().proxy_request(user_b.clone(), req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // User A again — rejected (own bucket exhausted).
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/scope-user/v1/models")
+        .body(Body::Empty)
+        .unwrap();
+    match h.facade().proxy_request(user_a, req).await {
+        Err(err) => assert!(
+            matches!(
+                err,
+                oagw_sdk::error::ServiceGatewayError::RateLimitExceeded { .. }
+            ),
+            "expected RateLimitExceeded, got: {err:?}"
+        ),
+        Ok(resp) => panic!("expected rate limit error, got status {}", resp.status()),
+    }
+
+    // User B again — rejected (own bucket exhausted).
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/scope-user/v1/models")
+        .body(Body::Empty)
+        .unwrap();
+    match h.facade().proxy_request(user_b, req).await {
+        Err(err) => assert!(
+            matches!(
+                err,
+                oagw_sdk::error::ServiceGatewayError::RateLimitExceeded { .. }
+            ),
+            "expected RateLimitExceeded, got: {err:?}"
+        ),
+        Ok(resp) => panic!("expected rate limit error, got status {}", resp.status()),
+    }
+}
+
+// 18.4: Rate limit scope=route — different routes on the same upstream get
+// separate buckets. Proves route-scoped keying isolates per route.
+#[tokio::test]
+async fn proxy_rate_limit_scope_route_isolates_by_route() {
+    // Register a dynamic mock for the second route path.
+    let mut guard = MockGuard::new();
+    guard.mock(
+        "GET",
+        "/v1/embeddings",
+        MockResponse {
+            status: 200,
+            headers: vec![("content-type".into(), "application/json".into())],
+            body: MockBody::Json(json!({"object": "list", "data": []})),
+        },
+    );
+
+    let h = AppHarness::builder().build().await;
+    let ctx = h.security_context().clone();
+
+    let upstream = h
+        .facade()
+        .create_upstream(
+            ctx.clone(),
+            CreateUpstreamRequest::builder(
+                Server {
+                    endpoints: vec![Endpoint {
+                        scheme: Scheme::Http,
+                        host: "127.0.0.1".into(),
+                        port: h.mock_port(),
+                    }],
+                },
+                "gts.x.core.oagw.protocol.v1~x.core.oagw.http.v1",
+            )
+            .alias("scope-route")
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Route A — rate limited with scope=Route (uses static /v1/models mock).
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get],
+                        path: "/v1/models".into(),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Append,
+                    }),
+                    grpc: None,
+                },
+            )
+            .rate_limit(RateLimitConfig {
+                sharing: SharingMode::Private,
+                algorithm: RateLimitAlgorithm::TokenBucket,
+                sustained: SustainedRate {
+                    rate: 1,
+                    window: Window::Minute,
+                },
+                burst: Some(BurstConfig { capacity: 1 }),
+                scope: RateLimitScope::Route,
+                strategy: RateLimitStrategy::Reject,
+                cost: 1,
+                response_headers: true,
+                budget: None,
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    // Route B — same upstream, different path, same rate limit config
+    // (uses dynamic mock registered via MockGuard).
+    h.facade()
+        .create_route(
+            ctx.clone(),
+            CreateRouteRequest::builder(
+                upstream.id,
+                MatchRules {
+                    http: Some(HttpMatch {
+                        methods: vec![HttpMethod::Get],
+                        path: guard.path("/v1/embeddings"),
+                        query_allowlist: vec![],
+                        path_suffix_mode: PathSuffixMode::Append,
+                    }),
+                    grpc: None,
+                },
+            )
+            .rate_limit(RateLimitConfig {
+                sharing: SharingMode::Private,
+                algorithm: RateLimitAlgorithm::TokenBucket,
+                sustained: SustainedRate {
+                    rate: 1,
+                    window: Window::Minute,
+                },
+                burst: Some(BurstConfig { capacity: 1 }),
+                scope: RateLimitScope::Route,
+                strategy: RateLimitStrategy::Reject,
+                cost: 1,
+                response_headers: true,
+                budget: None,
+            })
+            .build(),
+        )
+        .await
+        .unwrap();
+
+    let route_b_path = format!("/scope-route{}", guard.path("/v1/embeddings"));
+
+    // Route A — allowed (own bucket).
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/scope-route/v1/models")
+        .body(Body::Empty)
+        .unwrap();
+    let resp = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Route B — allowed (separate bucket).
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri(&route_b_path)
+        .body(Body::Empty)
+        .unwrap();
+    let resp = h.facade().proxy_request(ctx.clone(), req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Route A again — rejected (own bucket exhausted).
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri("/scope-route/v1/models")
+        .body(Body::Empty)
+        .unwrap();
+    match h.facade().proxy_request(ctx.clone(), req).await {
+        Err(err) => assert!(
+            matches!(
+                err,
+                oagw_sdk::error::ServiceGatewayError::RateLimitExceeded { .. }
+            ),
+            "expected RateLimitExceeded, got: {err:?}"
+        ),
+        Ok(resp) => panic!("expected rate limit error, got status {}", resp.status()),
+    }
+
+    // Route B again — rejected (own bucket exhausted).
+    let req = http::Request::builder()
+        .method(Method::GET)
+        .uri(&route_b_path)
+        .body(Body::Empty)
+        .unwrap();
+    match h.facade().proxy_request(ctx, req).await {
+        Err(err) => assert!(
+            matches!(
+                err,
+                oagw_sdk::error::ServiceGatewayError::RateLimitExceeded { .. }
+            ),
+            "expected RateLimitExceeded, got: {err:?}"
+        ),
+        Ok(resp) => panic!("expected rate limit error, got status {}", resp.status()),
     }
 }
 
@@ -1775,6 +2071,8 @@ async fn proxy_websocket_rate_limit_on_handshake() {
                 scope: RateLimitScope::Tenant,
                 strategy: RateLimitStrategy::Reject,
                 cost: 1,
+                response_headers: true,
+                budget: None,
             })
             .build(),
         )

--- a/testing/e2e/modules/oagw/conftest.py
+++ b/testing/e2e/modules/oagw/conftest.py
@@ -35,6 +35,28 @@ def oagw_headers():
 
 
 # ---------------------------------------------------------------------------
+# Hierarchy tenant headers (for multi-tenant budget allocation tests)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def hierarchy_root_headers():
+    """Headers for hierarchy-root tenant (00000000-...001)."""
+    return {"Authorization": "Bearer e2e-token-hierarchy-root"}
+
+
+@pytest.fixture
+def hierarchy_l1a_headers():
+    """Headers for hierarchy-l1a tenant (00000000-...002), child of root."""
+    return {"Authorization": "Bearer e2e-token-hierarchy-l1a"}
+
+
+@pytest.fixture
+def hierarchy_l1b_headers():
+    """Headers for hierarchy-l1b tenant (00000000-...005), child of root."""
+    return {"Authorization": "Bearer e2e-token-hierarchy-l1b"}
+
+
+# ---------------------------------------------------------------------------
 # Session-scoped mock upstream server
 # ---------------------------------------------------------------------------
 

--- a/testing/e2e/modules/oagw/helpers.py
+++ b/testing/e2e/modules/oagw/helpers.py
@@ -111,25 +111,14 @@ def unique_alias(prefix: str = "e2e") -> str:
     short = uuid.uuid4().hex[:8]
     return f"{prefix}-{short}"
 
-async def create_upstream(
-    client: httpx.AsyncClient,
-    base_url: str,
-    headers: dict,
+
+def _build_upstream_body(
     mock_url: str,
     alias: Optional[str] = None,
     upstream_headers: Optional[dict] = None,
     **kwargs,
 ) -> dict:
-    """Create an upstream via the Management API and return the response JSON.
-
-    ``upstream_headers`` maps to the upstream resource ``headers`` field
-    (e.g., ``{"request": {"passthrough": "all"}}``).  It is accepted as a
-    separate parameter to avoid colliding with the HTTP ``headers`` argument.
-
-    ``kwargs`` are merged into the request body (e.g., ``enabled=False``,
-    ``auth={...}``, ``rate_limit={...}``).
-    """
-    # Parse host/port from mock_url.
+    """Build the upstream request body from a mock URL and optional overrides."""
     from urllib.parse import urlparse
     parsed = urlparse(mock_url)
     host = parsed.hostname or "127.0.0.1"
@@ -150,6 +139,28 @@ async def create_upstream(
         body["headers"] = upstream_headers
 
     body.update(kwargs)
+    return body
+
+
+async def create_upstream(
+    client: httpx.AsyncClient,
+    base_url: str,
+    headers: dict,
+    mock_url: str,
+    alias: Optional[str] = None,
+    upstream_headers: Optional[dict] = None,
+    **kwargs,
+) -> dict:
+    """Create an upstream via the Management API and return the response JSON.
+
+    ``upstream_headers`` maps to the upstream resource ``headers`` field
+    (e.g., ``{"request": {"passthrough": "all"}}``).  It is accepted as a
+    separate parameter to avoid colliding with the HTTP ``headers`` argument.
+
+    ``kwargs`` are merged into the request body (e.g., ``enabled=False``,
+    ``auth={...}``, ``rate_limit={...}``).
+    """
+    body = _build_upstream_body(mock_url, alias, upstream_headers, **kwargs)
 
     resp = await client.post(
         f"{base_url}/oagw/v1/upstreams",
@@ -158,6 +169,46 @@ async def create_upstream(
     )
     resp.raise_for_status()
     return resp.json()
+
+
+async def create_upstream_raw(
+    client: httpx.AsyncClient,
+    base_url: str,
+    headers: dict,
+    mock_url: str,
+    alias: Optional[str] = None,
+    **kwargs,
+) -> httpx.Response:
+    """Create an upstream and return the raw Response (no raise_for_status).
+
+    Use this when testing error paths (e.g., validation failures returning 400).
+    """
+    body = _build_upstream_body(mock_url, alias, **kwargs)
+
+    return await client.post(
+        f"{base_url}/oagw/v1/upstreams",
+        headers={**headers, "content-type": "application/json"},
+        json=body,
+    )
+
+
+async def update_upstream_raw(
+    client: httpx.AsyncClient,
+    base_url: str,
+    headers: dict,
+    upstream_id: str,
+    mock_url: str,
+    alias: Optional[str] = None,
+    **kwargs,
+) -> httpx.Response:
+    """Replace an upstream via PUT and return the raw Response (no raise_for_status)."""
+    body = _build_upstream_body(mock_url, alias, **kwargs)
+
+    return await client.put(
+        f"{base_url}/oagw/v1/upstreams/{upstream_id}",
+        headers={**headers, "content-type": "application/json"},
+        json=body,
+    )
 
 
 async def create_route(
@@ -208,24 +259,7 @@ async def update_upstream(
     ``create_upstream``).  ``kwargs`` are merged into the body
     (e.g., ``enabled=False``, ``auth={...}``).
     """
-    from urllib.parse import urlparse
-    parsed = urlparse(mock_url)
-    host = parsed.hostname or "127.0.0.1"
-    scheme = parsed.scheme or "http"
-    port = parsed.port or (443 if scheme == "https" else 80)
-
-    body: dict = {
-        "server": {
-            "endpoints": [{"host": host, "port": port, "scheme": scheme}],
-        },
-        "protocol": HTTP_PROTOCOL_ID,
-        "enabled": True,
-        "tags": [],
-    }
-    if alias is not None:
-        body["alias"] = alias
-
-    body.update(kwargs)
+    body = _build_upstream_body(mock_url, alias, **kwargs)
 
     resp = await client.put(
         f"{base_url}/oagw/v1/upstreams/{upstream_id}",

--- a/testing/e2e/modules/oagw/test_budget_allocation.py
+++ b/testing/e2e/modules/oagw/test_budget_allocation.py
@@ -1,0 +1,530 @@
+"""E2E tests for OAGW budget allocation subsystem.
+
+Tests cover:
+- Category A: Budget config field validation (single-tenant)
+- Category B: Budget allocation validation across tenant hierarchy
+- Category C: Shared pool config acceptance
+- Category D: Unlimited / no-budget defaults
+"""
+import pytest
+import httpx
+
+from .helpers import (
+    create_upstream,
+    create_upstream_raw,
+    delete_upstream,
+    unique_alias,
+    update_upstream_raw,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _rl(rate: int, window: str = "minute", budget: dict | None = None,
+        sharing: str | None = None, **extra) -> dict:
+    """Build a rate_limit payload."""
+    rl: dict = {
+        "algorithm": "token_bucket",
+        "sustained": {"rate": rate, "window": window},
+        "burst": {"capacity": rate},
+        "scope": "tenant",
+        "strategy": "reject",
+    }
+    if sharing is not None:
+        rl["sharing"] = sharing
+    if budget is not None:
+        rl["budget"] = budget
+    rl.update(extra)
+    return rl
+
+
+# ===================================================================
+# Category A: Budget config validation (single-tenant, existing token)
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_budget_allocated_requires_total(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Allocated mode without total is rejected."""
+    alias = unique_alias("ba-a1")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await create_upstream_raw(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            rate_limit=_rl(100, budget={"mode": "allocated"}),
+        )
+        assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text[:500]}"
+        assert "budget.total is required" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_budget_shared_requires_total(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Shared mode without total is rejected."""
+    alias = unique_alias("ba-a2")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await create_upstream_raw(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            rate_limit=_rl(100, budget={"mode": "shared"}),
+        )
+        assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text[:500]}"
+        assert "budget.total is required" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_budget_overcommit_ratio_below_range(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Overcommit ratio below 1.0 is rejected."""
+    alias = unique_alias("ba-a3")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await create_upstream_raw(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            rate_limit=_rl(100, budget={"mode": "allocated", "total": 100, "overcommit_ratio": 0.5}),
+        )
+        assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text[:500]}"
+        assert "overcommit_ratio must be between" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_budget_overcommit_ratio_above_range(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Overcommit ratio above 2.0 is rejected."""
+    alias = unique_alias("ba-a4")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await create_upstream_raw(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            rate_limit=_rl(100, budget={"mode": "allocated", "total": 100, "overcommit_ratio": 2.5}),
+        )
+        assert resp.status_code == 400, f"Expected 400, got {resp.status_code}: {resp.text[:500]}"
+        assert "overcommit_ratio must be between" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_budget_unlimited_accepts_no_total(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Unlimited mode does not require total."""
+    alias = unique_alias("ba-a5")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            rate_limit=_rl(100, budget={"mode": "unlimited"}),
+        )
+        await delete_upstream(client, oagw_base_url, oagw_headers, upstream["id"])
+
+
+@pytest.mark.asyncio
+async def test_budget_allocated_valid_config_accepted(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Valid allocated budget config is accepted."""
+    alias = unique_alias("ba-a6")
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+            rate_limit=_rl(100, budget={"mode": "allocated", "total": 1000, "overcommit_ratio": 1.5}),
+        )
+        await delete_upstream(client, oagw_base_url, oagw_headers, upstream["id"])
+
+
+# ===================================================================
+# Category B: Budget allocation validation (multi-tenant hierarchy)
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_allocated_child_within_budget(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    mock_upstream_url, mock_upstream,
+):
+    """Child allocation within parent budget succeeds."""
+    alias = unique_alias("ba-b1")
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(100, sharing="inherit",
+                               budget={"mode": "allocated", "total": 100}),
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            child = await create_upstream(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(50),
+            )
+            uids.append((hierarchy_l1a_headers, child["id"]))
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+@pytest.mark.asyncio
+async def test_allocated_two_children_within_budget(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    hierarchy_l1b_headers, mock_upstream_url, mock_upstream,
+):
+    """Two children whose rates sum within budget both succeed."""
+    alias = unique_alias("ba-b2")
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(100, sharing="inherit",
+                               budget={"mode": "allocated", "total": 100}),
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            child_a = await create_upstream(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(40),
+            )
+            uids.append((hierarchy_l1a_headers, child_a["id"]))
+
+            child_b = await create_upstream(
+                client, oagw_base_url, hierarchy_l1b_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(40),
+            )
+            uids.append((hierarchy_l1b_headers, child_b["id"]))
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+@pytest.mark.asyncio
+async def test_allocated_exceeded_rejected(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    hierarchy_l1b_headers, mock_upstream_url, mock_upstream,
+):
+    """Second child that pushes sum over budget is rejected."""
+    alias = unique_alias("ba-b3")
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(100, sharing="inherit",
+                               budget={"mode": "allocated", "total": 100, "overcommit_ratio": 1.0}),
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            child_a = await create_upstream(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(60),
+            )
+            uids.append((hierarchy_l1a_headers, child_a["id"]))
+
+            # This should fail: 60 + 50 = 110 > 100
+            resp = await create_upstream_raw(
+                client, oagw_base_url, hierarchy_l1b_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(50),
+            )
+            assert resp.status_code == 400, (
+                f"Expected 400 for over-budget, got {resp.status_code}: {resp.text[:500]}"
+            )
+            assert "budget allocation exceeded" in resp.text
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+@pytest.mark.asyncio
+async def test_allocated_overcommit_allows_excess(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    hierarchy_l1b_headers, mock_upstream_url, mock_upstream,
+):
+    """Overcommit ratio 1.5 allows children to sum above nominal total."""
+    alias = unique_alias("ba-b4")
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(100, sharing="inherit",
+                               budget={"mode": "allocated", "total": 100, "overcommit_ratio": 1.5}),
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            # 80 + 60 = 140 <= 100 * 1.5 = 150 → allowed
+            child_a = await create_upstream(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(80),
+            )
+            uids.append((hierarchy_l1a_headers, child_a["id"]))
+
+            child_b = await create_upstream(
+                client, oagw_base_url, hierarchy_l1b_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(60),
+            )
+            uids.append((hierarchy_l1b_headers, child_b["id"]))
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+@pytest.mark.asyncio
+async def test_allocated_overcommit_still_has_limit(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    hierarchy_l1b_headers, mock_upstream_url, mock_upstream,
+):
+    """Even with overcommit, exceeding total * ratio is rejected."""
+    alias = unique_alias("ba-b5")
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(100, sharing="inherit",
+                               budget={"mode": "allocated", "total": 100, "overcommit_ratio": 1.5}),
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            child_a = await create_upstream(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(100),
+            )
+            uids.append((hierarchy_l1a_headers, child_a["id"]))
+
+            # 100 + 60 = 160 > 100 * 1.5 = 150 → rejected
+            resp = await create_upstream_raw(
+                client, oagw_base_url, hierarchy_l1b_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(60),
+            )
+            assert resp.status_code == 400, (
+                f"Expected 400 for over-budget, got {resp.status_code}: {resp.text[:500]}"
+            )
+            assert "budget allocation exceeded" in resp.text
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+@pytest.mark.asyncio
+async def test_allocated_update_revalidates(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    mock_upstream_url, mock_upstream,
+):
+    """Updating a child's rate to exceed budget is rejected."""
+    alias = unique_alias("ba-b6")
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(100, sharing="inherit",
+                               budget={"mode": "allocated", "total": 100}),
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            child = await create_upstream(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(50),
+            )
+            uids.append((hierarchy_l1a_headers, child["id"]))
+
+            # Update child to 120/min → exceeds budget of 100
+            resp = await update_upstream_raw(
+                client, oagw_base_url, hierarchy_l1a_headers,
+                child["id"], mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(120),
+            )
+            assert resp.status_code == 400, (
+                f"Expected 400 on update, got {resp.status_code}: {resp.text[:500]}"
+            )
+            assert "budget allocation exceeded" in resp.text
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+@pytest.mark.asyncio
+async def test_allocated_different_windows_normalized(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    mock_upstream_url, mock_upstream,
+):
+    """Rates are normalized to req/s: child 2/s exceeds parent 60/min budget."""
+    alias = unique_alias("ba-b7")
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            # Parent: 60/min = 1 req/s budget
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(60, window="minute", sharing="inherit",
+                               budget={"mode": "allocated", "total": 60}),
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            # Child: 2/second = 2 req/s → exceeds 1 req/s budget
+            resp = await create_upstream_raw(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(2, window="second"),
+            )
+            assert resp.status_code == 400, (
+                f"Expected 400 for cross-window over-budget, got {resp.status_code}: {resp.text[:500]}"
+            )
+            assert "budget allocation exceeded" in resp.text
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+@pytest.mark.asyncio
+async def test_allocated_rejects_child_without_rate_limit(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    mock_upstream_url, mock_upstream,
+):
+    """Allocated budget rejects child that omits rate_limit entirely."""
+    alias = unique_alias("ba-b8")
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(100, sharing="inherit",
+                               budget={"mode": "allocated", "total": 100}),
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            # Child with no rate_limit → rejected under allocated budget.
+            resp = await create_upstream_raw(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+            )
+            assert resp.status_code == 400, (
+                f"Expected 400 for missing rate_limit, got {resp.status_code}: {resp.text[:500]}"
+            )
+            assert "rate_limit is required" in resp.text
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+# ===================================================================
+# Category C: Shared pool config acceptance
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_shared_budget_config_accepted(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    mock_upstream_url, mock_upstream,
+):
+    """Shared budget mode: parent and child creation succeeds."""
+    alias = unique_alias("ba-c1")
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(100, sharing="inherit",
+                               budget={"mode": "shared", "total": 100}),
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            # Child binds without overriding rate_limit → no allocation check
+            child = await create_upstream(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+            )
+            uids.append((hierarchy_l1a_headers, child["id"]))
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+# ===================================================================
+# Category D: Unlimited / no-budget defaults
+# ===================================================================
+
+
+@pytest.mark.asyncio
+async def test_unlimited_no_child_validation(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    mock_upstream_url, mock_upstream,
+):
+    """Unlimited budget mode skips allocation validation for children."""
+    alias = unique_alias("ba-d1")
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(100, sharing="inherit",
+                               budget={"mode": "unlimited"}),
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            # Any rate is fine — no budget validation
+            child = await create_upstream(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(9999),
+            )
+            uids.append((hierarchy_l1a_headers, child["id"]))
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+@pytest.mark.asyncio
+async def test_no_budget_defaults_unlimited(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    mock_upstream_url, mock_upstream,
+):
+    """No budget field on parent defaults to unlimited — child accepted."""
+    alias = unique_alias("ba-d2")
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(100, sharing="inherit"),  # no budget field
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            child = await create_upstream(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+                rate_limit=_rl(9999),
+            )
+            uids.append((hierarchy_l1a_headers, child["id"]))
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)

--- a/testing/e2e/modules/oagw/test_rate_limiting.py
+++ b/testing/e2e/modules/oagw/test_rate_limiting.py
@@ -1,4 +1,4 @@
-"""E2E tests for OAGW rate limiting (token bucket)."""
+"""E2E tests for OAGW rate limiting — token bucket, sliding window, scoping."""
 import httpx
 import pytest
 
@@ -79,5 +79,446 @@ async def test_rate_limit_exceeded_returns_429(
         )
         assert resp2.headers.get("x-oagw-error-source") == "gateway"
         assert "retry-after" in resp2.headers, "Missing Retry-After header on 429"
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_burst_capacity_and_headers(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Scenario 18.1: burst allows requests up to capacity; response includes
+    X-RateLimit-* headers; 11th request returns 429 with Retry-After."""
+    alias = unique_alias("rl-burst")
+    rate_limit = {
+        "algorithm": "token_bucket",
+        "sustained": {"rate": 5, "window": "hour"},
+        "burst": {"capacity": 10},
+        "scope": "tenant",
+        "strategy": "reject",
+        "response_headers": True,
+    }
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias, rate_limit=rate_limit,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid, ["GET"], "/v1/models",
+        )
+
+        # Send 10 requests — all should succeed (burst capacity = 10).
+        for i in range(10):
+            resp = await client.get(
+                f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+                headers=oagw_headers,
+            )
+            assert resp.status_code == 200, (
+                f"Request {i+1}/10 should succeed, got {resp.status_code}"
+            )
+
+        # Verify rate limit headers on the last success.
+        assert "x-ratelimit-limit" in resp.headers, "Missing X-RateLimit-Limit"
+        assert "x-ratelimit-remaining" in resp.headers, "Missing X-RateLimit-Remaining"
+        assert "x-ratelimit-reset" in resp.headers, "Missing X-RateLimit-Reset"
+
+        # 11th request — should be rate limited.
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 429, (
+            f"Expected 429 on 11th request, got {resp.status_code}"
+        )
+        assert "retry-after" in resp.headers, "Missing Retry-After on 429"
+        assert resp.headers.get("x-oagw-error-source") == "gateway"
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_response_headers_disabled(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Scenario 18.1.1: response_headers=false suppresses X-RateLimit-* on
+    success but Retry-After is still sent on 429."""
+    alias = unique_alias("rl-nohdr")
+    rate_limit = {
+        "algorithm": "token_bucket",
+        "sustained": {"rate": 1, "window": "minute"},
+        "burst": {"capacity": 1},
+        "scope": "tenant",
+        "strategy": "reject",
+        "response_headers": False,
+    }
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias, rate_limit=rate_limit,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid, ["GET"], "/v1/models",
+        )
+
+        # First request succeeds — no X-RateLimit-* headers.
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 200
+        assert "x-ratelimit-limit" not in resp.headers, (
+            "X-RateLimit-Limit should be absent when response_headers=false"
+        )
+        assert "x-ratelimit-remaining" not in resp.headers
+        assert "x-ratelimit-reset" not in resp.headers
+
+        # Second request — 429 with Retry-After (always present).
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 429
+        assert "retry-after" in resp.headers, (
+            "Retry-After must be present on 429 even with response_headers=false"
+        )
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_sliding_window_basic_enforcement(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Scenario 18.2 (adapted): sliding window algorithm enforces rate limit.
+    Uses minute-scale window to avoid sub-second timing sensitivity."""
+    alias = unique_alias("rl-sw")
+    rate_limit = {
+        "algorithm": "sliding_window",
+        "sustained": {"rate": 2, "window": "minute"},
+        "scope": "tenant",
+        "strategy": "reject",
+    }
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias, rate_limit=rate_limit,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid, ["GET"], "/v1/models",
+        )
+
+        # First two requests succeed.
+        for i in range(2):
+            resp = await client.get(
+                f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+                headers=oagw_headers,
+            )
+            assert resp.status_code == 200, (
+                f"Request {i+1}/2 should succeed, got {resp.status_code}"
+            )
+
+        # Third request — rejected by sliding window.
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 429, (
+            f"Expected 429 on 3rd request, got {resp.status_code}"
+        )
+        assert resp.headers.get("x-oagw-error-source") == "gateway"
+        assert "retry-after" in resp.headers
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_scope_global(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    hierarchy_l1b_headers, mock_upstream_url, mock_upstream,
+):
+    """Scenario 18.3: scope=global is accepted and enforces a shared counter.
+
+    Global scope means the counter key omits tenant/user/IP, so all requests
+    to this upstream share one bucket regardless of caller identity.
+    Proved by exhausting the bucket with requests from two different tenants.
+    """
+    alias = unique_alias("rl-global")
+    rate_limit = {
+        "algorithm": "token_bucket",
+        "sustained": {"rate": 2, "window": "minute"},
+        "burst": {"capacity": 2},
+        "scope": "global",
+        "strategy": "reject",
+        "sharing": "inherit",
+        "budget": {"mode": "shared", "total": 2},
+    }
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            # Parent upstream with global-scoped rate limit.
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias, rate_limit=rate_limit,
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            # Children bind to the same alias (inherit parent rate limit).
+            child_a = await create_upstream(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+            )
+            uids.append((hierarchy_l1a_headers, child_a["id"]))
+
+            child_b = await create_upstream(
+                client, oagw_base_url, hierarchy_l1b_headers, mock_upstream_url,
+                alias=alias,
+            )
+            uids.append((hierarchy_l1b_headers, child_b["id"]))
+
+            await create_route(
+                client, oagw_base_url, hierarchy_root_headers,
+                parent["id"], ["GET"], "/v1/models",
+            )
+
+            # Tenant l1a: first request succeeds (1 of 2 tokens consumed).
+            resp = await client.get(
+                f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+                headers=hierarchy_l1a_headers,
+            )
+            assert resp.status_code == 200
+
+            # Tenant l1b: request succeeds (2 of 2 tokens consumed).
+            resp = await client.get(
+                f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+                headers=hierarchy_l1b_headers,
+            )
+            assert resp.status_code == 200
+
+            # Tenant l1a again: 429 — proves the global bucket is shared
+            # across tenants, not isolated per-tenant.
+            resp = await client.get(
+                f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+                headers=hierarchy_l1a_headers,
+            )
+            assert resp.status_code == 429, (
+                f"Global scope should share one bucket across tenants, got {resp.status_code}"
+            )
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+@pytest.mark.asyncio
+async def test_scope_route_isolation(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Scenario 18.3: scope=route gives each route its own rate-limit bucket."""
+    alias = unique_alias("rl-route")
+    route_rl = {
+        "algorithm": "token_bucket",
+        "sustained": {"rate": 1, "window": "minute"},
+        "burst": {"capacity": 1},
+        "scope": "route",
+        "strategy": "reject",
+    }
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        # Upstream without rate limit; rate limit lives on each route.
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid,
+            ["GET"], "/v1/models", rate_limit=route_rl,
+        )
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid,
+            ["GET"], "/health", rate_limit=route_rl,
+        )
+
+        # Route A — allowed (own bucket).
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 200
+
+        # Route B — allowed (separate bucket).
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/health",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 200
+
+        # Route A again — rejected (exhausted).
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 429, "Route A should be rate-limited"
+
+        # Route B again — rejected (exhausted).
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/health",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 429, "Route B should be rate-limited"
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_scope_tenant_isolation(
+    oagw_base_url, hierarchy_root_headers, hierarchy_l1a_headers,
+    hierarchy_l1b_headers, mock_upstream_url, mock_upstream,
+):
+    """Tenant-scoped rate limits give each tenant an independent bucket."""
+    alias = unique_alias("rl-tenant-iso")
+    rate_limit = {
+        "algorithm": "token_bucket",
+        "sustained": {"rate": 1, "window": "minute"},
+        "burst": {"capacity": 1},
+        "scope": "tenant",
+        "strategy": "reject",
+        "sharing": "inherit",
+    }
+    uids: list[tuple[dict, str]] = []
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            # Parent upstream with inheritable rate limit.
+            parent = await create_upstream(
+                client, oagw_base_url, hierarchy_root_headers, mock_upstream_url,
+                alias=alias, rate_limit=rate_limit,
+            )
+            uids.append((hierarchy_root_headers, parent["id"]))
+
+            # Children bind to the same alias (inherit parent rate limit).
+            child_a = await create_upstream(
+                client, oagw_base_url, hierarchy_l1a_headers, mock_upstream_url,
+                alias=alias,
+            )
+            uids.append((hierarchy_l1a_headers, child_a["id"]))
+
+            child_b = await create_upstream(
+                client, oagw_base_url, hierarchy_l1b_headers, mock_upstream_url,
+                alias=alias,
+            )
+            uids.append((hierarchy_l1b_headers, child_b["id"]))
+
+            await create_route(
+                client, oagw_base_url, hierarchy_root_headers,
+                parent["id"], ["GET"], "/v1/models",
+            )
+
+            # Tenant l1a: first request succeeds, second is rate-limited.
+            resp = await client.get(
+                f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+                headers=hierarchy_l1a_headers,
+            )
+            assert resp.status_code == 200
+
+            resp = await client.get(
+                f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+                headers=hierarchy_l1a_headers,
+            )
+            assert resp.status_code == 429, (
+                f"Tenant l1a should be rate-limited, got {resp.status_code}"
+            )
+
+            # Tenant l1b: first request still succeeds (independent bucket).
+            resp = await client.get(
+                f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+                headers=hierarchy_l1b_headers,
+            )
+            assert resp.status_code == 200, (
+                f"Tenant l1b should have its own bucket, got {resp.status_code}"
+            )
+        finally:
+            for hdrs, uid in reversed(uids):
+                await delete_upstream(client, oagw_base_url, hdrs, uid)
+
+
+@pytest.mark.asyncio
+async def test_weighted_cost(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Scenario 18.4: cost=10 consumes entire 10-token budget in one request."""
+    alias = unique_alias("rl-cost")
+    rate_limit = {
+        "algorithm": "token_bucket",
+        "sustained": {"rate": 10, "window": "minute"},
+        "burst": {"capacity": 10},
+        "scope": "tenant",
+        "strategy": "reject",
+        "cost": 10,
+    }
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias, rate_limit=rate_limit,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid, ["GET"], "/v1/models",
+        )
+
+        # First request consumes all 10 tokens.
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 200
+
+        # Second request — no tokens left.
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 429
+
+        await delete_upstream(client, oagw_base_url, oagw_headers, uid)
+
+
+@pytest.mark.asyncio
+async def test_route_level_rate_limit(
+    oagw_base_url, oagw_headers, mock_upstream_url, mock_upstream,
+):
+    """Rate limit configured on the route (not upstream) is enforced."""
+    alias = unique_alias("rl-rtlvl")
+    route_rl = {
+        "algorithm": "token_bucket",
+        "sustained": {"rate": 1, "window": "minute"},
+        "burst": {"capacity": 1},
+        "scope": "tenant",
+        "strategy": "reject",
+    }
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        # Upstream has no rate limit.
+        upstream = await create_upstream(
+            client, oagw_base_url, oagw_headers, mock_upstream_url,
+            alias=alias,
+        )
+        uid = upstream["id"]
+        await create_route(
+            client, oagw_base_url, oagw_headers, uid,
+            ["GET"], "/v1/models", rate_limit=route_rl,
+        )
+
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get(
+            f"{oagw_base_url}/oagw/v1/proxy/{alias}/v1/models",
+            headers=oagw_headers,
+        )
+        assert resp.status_code == 429, "Route-level rate limit should enforce"
+        assert resp.headers.get("x-oagw-error-source") == "gateway"
 
         await delete_upstream(client, oagw_base_url, oagw_headers, uid)


### PR DESCRIPTION
Wire token bucket and sliding window rate limiters into the proxy data plane with scope-aware keys (global/tenant/user/ip/route), x-ratelimit-* and retry-after response headers, cost-based deduction, and hierarchical budget allocation. Add e2e tests for budget allocation across hierarchy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hierarchical rate-limit budgets (Allocated/Shared/Unlimited), sliding-window algorithm, weighted costs, per-scope enforcement, and configurable X-RateLimit-* header emission.

* **Bug Fixes**
  * Safer, prefix-based cleanup of rate-limit keys on resource changes; more complete and consistent 429 responses (Retry-After plus optional X-RateLimit-* headers).

* **Documentation**
  * Updated rate-limiting key format and cleanup guidance.

* **Tests**
  * Expanded unit/integration/e2e coverage and added e2e fixtures/tokens for hierarchy, scope, budget, header, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->