### PR TITLE
docs(modkit-contract-binding): PRD, DESIGN, and ADRs for cross-boundary contract binding

### DIFF
--- a/docs/arch/modkit-contract-binding/ADR/0001-cpt-cf-binding-adr-contract-source-of-truth.md
+++ b/docs/arch/modkit-contract-binding/ADR/0001-cpt-cf-binding-adr-contract-source-of-truth.md
@@ -1,0 +1,154 @@
+---
+status: accepted
+date: 2026-04-10
+---
+
+# Use Rust Trait as Contract Source of Truth, with Macro Generation and Manual Implementation Both Supported
+
+**ID**: `cpt-cf-binding-adr-contract-source-of-truth`
+
+## Context and Problem Statement
+
+The contract-binding system needs a single source of truth for module contracts. The source of truth determines how contracts are authored, how clients are produced, how OpenAPI specs are generated, and how the system evolves. The choice affects every module author, every plugin implementer, and every third-party integrator.
+
+Four realistic approaches are available, ranging from "trait-first with code generation" to "IDL-first with generated Rust types." Each has tradeoffs for compile-time safety, boilerplate, multi-language support, developer ergonomics, and evolution cost.
+
+## Decision Drivers
+
+* **Compile-time safety** — contract violations should be caught at `cargo check`, not at runtime or in production
+* **Zero-cost in-process path** — compile-time plugins must not pay any overhead compared to a direct trait method call
+* **Rust-native developer experience** — the primary audience is Rust developers; the happy path must feel idiomatic
+* **Third-party language support** — external teams must be able to implement contracts in Go, Java, Python without compiling Rust
+* **Evolution cost** — adding fields, methods, or transport projections must be non-breaking for existing plugins and consumers
+* **Escape hatch** — when the common-case generator does not cover a specific need, authors must be able to write the client by hand
+* **Tooling maturity** — prefer approaches with mature Rust ecosystem support over those requiring bespoke tooling
+* **Readability** — a developer reading the SDK crate should understand the contract without chasing macro expansions or external files
+
+## Considered Options
+
+* **Option A**: Contract trait + macro generation + manual implementation allowed (current design)
+* **Option B**: Contract trait + manual implementations only
+* **Option C**: OpenAPI-first — OpenAPI YAML as source, generate Rust traits and clients
+* **Option D**: IDL-first — proto / Smithy / TypeSpec as source, generate Rust types and clients
+
+## Decision Outcome
+
+Chosen option: **Option A — Contract trait as source of truth, with `#[modkit_rest_contract]` macro generating clients for the common case and manual implementation explicitly supported as an escape hatch.**
+
+The Rust trait is the authoritative definition of the domain contract. Consumers depend on the base trait (`Arc<dyn NotificationBackend>`). The macro reads the optional protocol projection trait (`NotificationBackendRest`) and generates a REST client that implements the base trait with HTTP dispatch. For cases the macro does not cover (complex path templates, query parameter composition, custom auth, bespoke retry), authors write the client by hand — the consumer interface is identical either way.
+
+This option was chosen because it is the only one that satisfies all decision drivers simultaneously. Option B solves nothing — it just codifies the status quo of every SDK reinventing HTTP clients. Option C forces the team to maintain OpenAPI YAML alongside Rust code, creating drift. Option D fails because no IDL captures REST and gRPC faithfully at the same time (see evidence report `docs/research/rest-grpc-unification-evidence.html`), and the generated Rust types would be second-class citizens.
+
+### Consequences
+
+* All module SDK crates define contracts as plain Rust traits with zero transport annotations
+* Protocol projections are separate traits annotated with `#[modkit_rest_contract]` that extend the base via `: Base`
+* The `cf-modkit-contract-macros` crate owns the proc macros and must be maintained for the platform's lifetime
+* The `cf-modkit-contract-runtime` crate provides `ProblemDetails`, `ClientConfig`, SSE parser, retry helper — all dependencies of generated clients
+* OpenAPI specs are a **derived artifact** generated at runtime from the trait via `schemars`, not a hand-written source
+* Third-party implementors consume the generated OpenAPI spec at `/.well-known/openapi.json` to build clients in other languages
+* Manual client implementations must implement the same base trait; the consumer cannot tell the difference
+* The macro intentionally covers the common case only (POST + JSON, SSE via `#[streaming]`, retry via `#[retryable]`); complex REST semantics are handled by hand-written clients
+* Adding a gRPC projection is purely additive — new trait `*Grpc`, new macro `#[modkit_grpc_contract]`, new generated client; the base trait and REST projection are untouched
+* Signature drift between base and projection is a compile error (`: Base` supertrait bound + redeclaration)
+* The evolution story relies on `#[non_exhaustive]` types and default trait methods — authors must discipline themselves to use both
+
+### Confirmation
+
+The PoC at `striped-zebra-dev/modkit-binding-poc` validates the approach end-to-end: `NotificationBackend` base trait + `NotificationBackendRest` projection with `#[modkit_rest_contract]`, generated `NotificationBackendRestClient`, working OpenAPI spec, SSE streaming, round-trip error mapping. All 8 tests pass. `make demo` shows identical behavior via compile-time plugin and REST proxy.
+
+## Pros and Cons of the Options
+
+### Option A: Contract Trait + Macro Generation + Manual Implementation Allowed
+
+The Rust trait is the source of truth. A proc macro (`#[modkit_rest_contract]`) reads a protocol projection trait and generates a REST client. Authors can bypass the macro and write clients by hand when needed.
+
+**Advantages:**
+
+* The Rust trait is what consumers already depend on — zero indirection for the common case.
+* The Rust compiler enforces contract conformance through supertrait bounds and method signature matching.
+* Compile-time plugins implement the base trait directly with zero overhead.
+* The macro covers the 80% case and hand-written clients cover the rest — no lock-in.
+* Adding a new transport (gRPC, other) is purely additive — a new projection trait, a new macro, no changes to the base or the REST projection.
+* The OpenAPI specification is generated from the same trait consumed by the Rust client; the specification cannot drift from the implementation.
+
+**Tradeoffs:**
+
+* Procedural macros are opaque; debugging requires `cargo expand` to inspect generated code.
+* The macro must cover many edge cases over time (generics, lifetimes, complex return types) or defer them to hand-written clients.
+
+**Disadvantages:**
+
+* The approach is Rust-specific; third parties depend on the generated OpenAPI specification to work in other languages.
+* The macro adds a compile-time dependency on `syn`, `quote`, and `schemars` in SDK crates.
+
+### Option B: Contract Trait + Manual Implementations Only
+
+Rust trait defines the contract; every REST client is hand-written. No procedural macro, no code generation. Authors write `impl NotificationBackend for NotificationBackendRestClient` directly with `reqwest` calls, error mapping, retry logic.
+
+**Advantages:**
+
+* No macro indirection — every line of code is visible and debuggable with standard Rust tools.
+* Authors retain full control over HTTP details (paths, methods, headers, authentication).
+* SDK crates have no dependency on `cf-modkit-contract-macros`.
+
+**Disadvantages:**
+
+* Every SDK reinvents the same boilerplate (HTTP client setup, error reconstruction, retry with backoff, SSE parsing), producing substantial duplication.
+* No automatic OpenAPI specification generation — authors must hand-write YAML and keep it synchronized with the trait, which will inevitably drift.
+* Third-party integrators have no language-neutral contract to target.
+* Error mapping across module boundaries is inconsistent — each SDK implements `ContractError` differently.
+* This is effectively the current state of the platform, which is the problem this change exists to resolve.
+
+### Option C: OpenAPI-First — OpenAPI YAML as Source, Generate Rust Types
+
+The contract is authored as an OpenAPI YAML file. A build step generates Rust traits, request/response types, and clients. Manual implementations work against the generated traits.
+
+**Advantages:**
+
+* OpenAPI is a mature, widely-understood standard with substantial tooling support.
+* Third-party integrators receive the source of truth directly, without a derivation step.
+* REST concerns (paths, methods, query parameters, headers) are first-class in the IDL.
+
+**Disadvantages:**
+
+* Rust developers edit YAML to modify a contract, losing Rust-native ergonomics.
+* Generated Rust types are second-class citizens — `Debug` derivations, custom implementations, and newtype wrappers are awkward to introduce.
+* Compile-time plugins must work against generated traits rather than hand-written ones; plugin authors are forced to depend on codegen artifacts.
+* OpenAPI has no canonical representation of streaming; SSE is expressed via the `text/event-stream` media type, but event schemas are lossy.
+* OpenAPI does not cover gRPC; adding a gRPC projection requires a separate source of truth, reintroducing the problem of Option D.
+* The build step slows the edit loop (YAML change → codegen → compile) compared to a direct trait edit.
+* Maintaining the YAML source in alignment with actual Rust business logic requires discipline; in practice, drift occurs.
+
+### Option D: IDL-First — Protobuf, Smithy, or TypeSpec as Source
+
+The contract is authored in an external IDL (protobuf, Smithy, TypeSpec, or similar). A code generator produces Rust types, traits, and clients. The IDL is the portable source; Rust is one of many targets.
+
+**Advantages:**
+
+* The IDL is language-neutral by design; every target language receives first-class support.
+* gRPC, REST, and (with Smithy/TypeSpec) other protocols can be derived from the same source.
+* Mature ecosystems (protobuf, buf, Smithy) provide stable tooling, schema evolution rules, and backwards-compatibility checks.
+
+**Tradeoffs:**
+
+* IDL-native versioning (protobuf field numbers, Smithy member indexes) is rigorous but imposes discipline.
+
+**Disadvantages:**
+
+* No IDL captures REST and gRPC faithfully simultaneously; forcing both into one model produces a lowest-common-denominator surface that is worse at being REST than a purpose-built REST API and worse at being gRPC than native gRPC (evidence report, 11 sources).
+* Rust developers author contracts in a non-Rust language, losing the language's type system, trait system, and IDE integration.
+* Generated Rust code is verbose, difficult to read, and impractical to hand-edit.
+* Compile-time plugins must work against generated traits, creating a layer of indirection the current platform does not have.
+* IDL build steps are slow (protoc, smithy-build) and complicate CI.
+* Rust ecosystem idioms (newtype wrappers, `#[non_exhaustive]`, custom serde attributes) must be re-applied on top of generated code, often awkwardly.
+* The team has Rust expertise rather than IDL expertise; adopting an IDL imposes a learning curve across the whole organization.
+
+## More Information
+
+* PRD: [`../PRD.md`](../PRD.md)
+* DESIGN: [`../DESIGN.md`](../DESIGN.md)
+* ADR-0002 — OpenAPI spec generation limits: [`./0002-cpt-cf-binding-adr-openapi-spec-limits.md`](./0002-cpt-cf-binding-adr-openapi-spec-limits.md)
+* Evidence report on IDL unification: [rest-grpc-unification-evidence.html](https://github.com/striped-zebra-dev/modkit-binding-poc/blob/main/docs/research/rest-grpc-unification-evidence.html)
+* PoC repository: [striped-zebra-dev/modkit-binding-poc](https://github.com/striped-zebra-dev/modkit-binding-poc)
+* Module/plugin declaration and resolution: [PR #1380](https://github.com/cyberfabric/cyberfabric-core/pull/1380) (complementary, not alternative)

--- a/docs/arch/modkit-contract-binding/ADR/0002-cpt-cf-binding-adr-openapi-spec-limits.md
+++ b/docs/arch/modkit-contract-binding/ADR/0002-cpt-cf-binding-adr-openapi-spec-limits.md
@@ -1,0 +1,181 @@
+---
+status: accepted
+date: 2026-04-10
+---
+
+# Treat Generated OpenAPI Spec as Minimum Conformance Contract, Not Exhaustive Specification
+
+**ID**: `cpt-cf-binding-adr-openapi-spec-limits`
+
+## Context and Problem Statement
+
+ADR-0001 chose the Rust trait as the contract source of truth, with `#[modkit_rest_contract]` generating clients and OpenAPI specs via `schemars`. This decision inherits a structural limitation: a Rust trait signature plus `schemars`-derived JSON schemas cannot faithfully express the full REST surface. The generator cannot represent union request bodies (oneOf/anyOf with discriminators), content-type negotiation (e.g., `application/vnd.foo+json`), multiple response schemas per status code, non-body content (multipart, form, octet-stream), path parameters with regex/range validation, response headers, custom security schemes, complex query parameter serialization (arrays, deep objects), or responses that vary by input.
+
+Option D (IDL-first) was rejected in ADR-0001 because no IDL captures REST and gRPC faithfully at once. The trait-first approach has a symmetric problem: Rust traits plus `schemars` cannot faithfully express everything REST permits. If the generated spec is treated as the authoritative specification for third-party implementors, two failure modes appear:
+
+1. Third parties implementing richer REST surfaces (multipart uploads, content negotiation, per-status schemas) fail registration even when their service is correct.
+2. Services that match path, method, and the narrow generated schema pass validation while serving payloads the Rust client cannot decode.
+
+This ADR defines the role of the generated spec and the policy for everything it cannot express.
+
+## Decision Drivers
+
+* **Honesty over coverage** — the platform must not pretend the generated spec is exhaustive when it is not
+* **Compile-time safety for the common case** — POST/GET/DELETE with JSON bodies and SSE streams must be fully machine-verifiable
+* **Escape hatch preserved** — authors must retain the ability to implement contracts manually when the generator is too narrow (ADR-0001 Option A promise)
+* **Third-party clarity** — external integrators must know which parts of the contract are generator-derived and which parts are hand-authored
+* **Directory validation correctness** — service registration must not falsely reject valid richer implementations, and must not falsely accept narrower ones
+* **Tooling maturity** — prefer the idiomatic output of mature Rust crates (`schemars`) over a bespoke annotation language
+* **Macro surface simplicity** — the attribute vocabulary must remain small enough to learn in an afternoon
+* **Failure visibility** — if a trait asks for something the generator cannot express, the build must fail fast, not emit a silently-broken spec
+
+## Considered Options
+
+* **Option A**: Narrow but honest — generator covers the common case, manual implementation fills the gaps, generated OpenAPI is declared the minimum conformance contract (current design)
+* **Option B**: Aggressive annotation vocabulary — extend `#[modkit_rest_contract]` with `#[content_type]`, `#[response_header]`, `#[multipart]`, `#[response(status=404, schema=…)]`, `#[path(pattern="…")]`, and similar attributes until the macro covers ~95% of REST
+* **Option C**: OpenAPI-first with augmentation — hand-write the spec, generate Rust types from it
+* **Option D**: Dual source — authors write both the Rust trait and the OpenAPI YAML, CI verifies they agree
+
+## Decision Outcome
+
+Chosen option: **Option A — Narrow but honest.** The `#[modkit_rest_contract]` macro covers a deliberate subset of REST, the generated OpenAPI spec is documented as the **minimum conformance contract** (services may offer strictly more, never strictly less), and anything outside the subset is handled by manual implementation — authors write `impl Base for MyCustomRestClient` with full HTTP control, and the consumer interface (`Arc<dyn Base>`) is identical to the macro-generated case.
+
+Option B was rejected because the attribute vocabulary required to cover 95% of REST approaches the complexity of a bespoke IDL embedded in Rust attribute syntax, reintroducing the "lowest common denominator" problem ADR-0001 used to reject IDL-first. Option C was rejected for the same reasons as ADR-0001 Option C. Option D was rejected because dual sources drift in practice regardless of CI discipline, and because it forces every author to learn two authoring surfaces.
+
+### Phase 1 scope — what the macro generates
+
+The `#[modkit_rest_contract]` macro supports:
+
+* `POST`, `GET`, `DELETE` with a single JSON request body (where applicable)
+* Path parameter extraction via the future `#[path]` annotation on method arguments
+* Query parameter serialization via the future `#[query]` annotation (scalar and flat-struct forms only)
+* A single success response schema per method, derived from the `Ok` type of the method's `Result<T, E>`
+* Error responses in RFC 9457 Problem Details form with `error_code` + `error_domain` extensions (see ADR-0001 in the errors directory)
+* Server-sent events via `#[streaming]`, rendered as `text/event-stream` in the OpenAPI spec
+* Standard retry, timeout, and base URL configuration via `ClientConfig`
+
+### Phase 1 scope — what is explicitly out of scope
+
+* Union request bodies (oneOf / anyOf with discriminators)
+* Multiple response content types per status code
+* Response headers beyond the standard platform set (`Content-Type`, `Content-Length`, tracing headers injected by middleware)
+* Multipart, URL-encoded-form, and octet-stream request or response bodies
+* Regex patterns and integer ranges on path parameters
+* Custom security schemes in the OpenAPI spec (authentication is carried by `SecurityContext` as the first method argument — see DESIGN)
+* Webhooks (modelled as separate push contracts, not as REST callbacks)
+* Hypermedia / HATEOAS link generation
+
+### Escape hatch
+
+For any contract method that needs a feature outside the Phase 1 scope, authors write a manual client:
+
+```rust
+impl NotificationBackend for MyCustomRestClient {
+    // full control over reqwest, content negotiation, multipart, headers, etc.
+}
+```
+
+The consumer continues to depend on `Arc<dyn NotificationBackend>`; it cannot tell whether the implementation was macro-generated or hand-written. For these methods, the OpenAPI spec is either hand-authored or the generated spec is augmented with vendor extensions (`x-modkit-*`) that describe the manual surface.
+
+### Consequences
+
+* Macro documentation must enumerate the supported subset exactly, with a dedicated "Not supported — use manual implementation" section; no feature may be tacitly supported.
+* CI must fail fast when a trait asks for an unsupported pattern (e.g., a method returning `Result<EnumWithMultipleVariants, _>` without a discriminator strategy). The macro must emit a compile error, not a silently-broken spec.
+* The directory's OpenAPI validator treats the registered spec as the **minimum conformance contract**: remote services may legitimately expose additional paths, headers, content types, or schema fields beyond what the spec declares, but they must honor every path, method, required field, and response shape the spec does declare.
+* Third-party integrators receive a **starting-point spec**, not a complete specification. Where a service uses manual implementation, the README for that SDK crate must state which methods are hand-written and how the OpenAPI spec was produced (generated, augmented, or hand-written).
+* The generator emits a top-level `x-modkit-spec-scope: minimum-conformance` vendor extension so downstream tooling can distinguish a generator-derived spec from a hand-curated one.
+* When a trait mixes macro-supported and manual methods, the macro generates the spec for its subset and the author appends the rest; the DESIGN document defines the merge strategy.
+* Extending the macro's scope later (e.g., adding `#[content_type]` in Phase 2) is a non-breaking change provided the attribute is optional and the default behavior remains the Phase 1 semantics.
+* The test suite must include a "rejected trait" fixture for every unsupported pattern listed above; each fixture must produce a compile error with a message pointing at the manual-implementation escape hatch.
+
+### Confirmation
+
+The PoC at `~/projects/modkit-binding-poc/` validates the narrow-but-honest approach on the `notification-sdk` crate: `NotificationBackend` with POST+JSON and SSE streaming, a generated OpenAPI spec, and a manual-implementation path exercised by a secondary fixture. Anything more complex (multipart upload, header-driven response variants) falls to a hand-written client in the PoC. The evidence report `~/projects/modkit-binding-poc/docs/research/rest-grpc-unification-evidence.html` (referenced from the PoC README) documents the reasoning for keeping the generator narrow rather than attempting to model the full REST surface in Rust attributes.
+
+## Pros and Cons of the Options
+
+### Option A: Narrow but Honest
+
+The macro covers a declared subset of REST. Everything outside the subset is handled by manual `impl Base for …`. The generated OpenAPI is published as the minimum conformance contract.
+
+**Advantages:**
+
+* Keeps the macro small and learnable; the full attribute vocabulary fits on one page.
+* The generated spec is always correct for what it claims to describe; it simply claims less than a hand-authored spec.
+* The escape hatch promised by ADR-0001 is preserved and exercised, not vestigial.
+* Directory validation is well-defined: a remote may offer more, never less.
+* Phase-2 scope extensions are additive and non-breaking.
+
+**Tradeoffs:**
+
+* Authors must know which methods fall inside the subset and which require manual implementation; the boundary must be documented and taught.
+* Third-party integrators cannot treat the spec as exhaustive and must consult the SDK README for manual methods.
+
+**Disadvantages:**
+
+* SDKs mixing macro-generated and manual methods produce a split OpenAPI spec that must be merged, adding a small amount of build-time tooling.
+* Some useful REST features (per-status schemas, response headers) require falling out of the macro entirely rather than adding one attribute.
+
+### Option B: Aggressive Annotation Vocabulary
+
+Extend the macro with attributes for every REST feature: `#[content_type]`, `#[response_header]`, `#[multipart]`, `#[response(status=404, schema=…)]`, `#[path(pattern="…")]`, `#[query(style="deepObject")]`, `#[security(scheme="bearer")]`, and so on. The macro aims to cover ~95% of REST.
+
+**Advantages:**
+
+* A larger fraction of SDKs can be macro-generated end-to-end.
+* The generated OpenAPI spec is closer to a complete specification.
+* Manual implementation remains an escape hatch but is reached far less often.
+
+**Tradeoffs:**
+
+* The attribute vocabulary grows into a small embedded DSL; authors must learn it in addition to Rust traits, OpenAPI, and HTTP semantics.
+
+**Disadvantages:**
+
+* The attribute surface reintroduces the "lowest common denominator IDL" problem that ADR-0001 used to reject Option D — REST semantics are encoded in attribute syntax that must be parsed, validated, and maintained.
+* Procedural-macro complexity balloons; `cf-modkit-contract-macros` becomes a non-trivial artifact with its own changelog and release cadence.
+* Each new attribute is a new failure mode at macro-expansion time, with error messages that must point back into the author's trait.
+* Attributes interact (`#[multipart]` with `#[response_header]` with `#[streaming]`) producing combinatorial edge cases.
+* The incremental return diminishes sharply past ~80% coverage; the last 15% still requires manual implementation, which now must coexist with a much larger macro surface.
+
+### Option C: OpenAPI-First with Augmentation
+
+Hand-write the OpenAPI spec. Generate Rust types and client stubs from it. Authors extend the generated Rust with business logic.
+
+**Advantages:**
+
+* Third-party integrators receive the source of truth directly.
+* Full REST expressiveness is available by construction.
+
+**Disadvantages:**
+
+* Rejected in ADR-0001 for the same reasons (Rust developers editing YAML, generated Rust as second-class, no gRPC story, slow edit loop, YAML-to-logic drift). Restating the same rejection.
+
+### Option D: Dual Source
+
+Authors write the Rust trait and the OpenAPI YAML. CI verifies the two agree on paths, methods, request/response schemas.
+
+**Advantages:**
+
+* Both constituencies (Rust developers, third-party integrators) get a first-class source.
+* The OpenAPI spec can use the full REST vocabulary without constraining the Rust trait.
+
+**Tradeoffs:**
+
+* CI consistency checks become the contract between the two sources; their strictness determines how much drift is tolerated.
+
+**Disadvantages:**
+
+* Every author learns two authoring surfaces and must keep them in sync for every change.
+* Drift between trait and YAML is the default state; CI catches divergence but cannot decide which side is correct when they disagree.
+* Review burden doubles — every contract change is reviewed in both representations.
+* The platform inherits the authoring cost of IDL-first and the ambiguity of trait-first without gaining the benefits of either.
+
+## More Information
+
+* PRD: [`../PRD.md`](../PRD.md)
+* DESIGN: [`../DESIGN.md`](../DESIGN.md)
+* ADR-0001 — contract source of truth: [`./0001-cpt-cf-binding-adr-contract-source-of-truth.md`](./0001-cpt-cf-binding-adr-contract-source-of-truth.md)
+* Evidence report on REST/gRPC unification limits: [rest-grpc-unification-evidence.html](https://github.com/striped-zebra-dev/modkit-binding-poc/blob/main/docs/research/rest-grpc-unification-evidence.html)
+* PoC repository: [striped-zebra-dev/modkit-binding-poc](https://github.com/striped-zebra-dev/modkit-binding-poc) (the README links the evidence report)
+* RFC 9457 Problem Details: https://www.rfc-editor.org/rfc/rfc9457

--- a/docs/arch/modkit-contract-binding/DESIGN.md
+++ b/docs/arch/modkit-contract-binding/DESIGN.md
@@ -1,0 +1,757 @@
+# Technical Design — ModKit Contract Binding
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+The contract-binding system introduces a two-layer trait architecture for ModKit modules. The first layer is the **base trait** -- a plain Rust trait with zero annotations that defines the domain contract. The second layer is the **transport projection** -- a trait that extends the base and carries transport-specific annotations (HTTP paths, methods, streaming). A proc macro processes the projection and generates a REST client, OpenAPI spec, and any transport-specific logic.
+
+Four **contract types** encode operational semantics directly in the trait name. The contract type determines the failure domain, transaction scope, timeout requirements, and error handling strategy. There is no configuration file, no annotation, and no runtime flag that overrides what the name declares.
+
+- **Api** -- the module offers this across a boundary. Remote. Caller handles timeouts, retries, circuit breakers.
+- **Embedded** -- the module offers this in-process. Local. Shares the caller's failure domain and transaction scope.
+- **Backend** -- the module needs a plugin that operates across a boundary. Remote-capable. Transport projections provide the remote binding.
+- **Extension** -- the module needs a plugin that operates in-process. Local. Fast, deterministic, no transport.
+
+Consumers always depend on the base trait (`Arc<dyn NotificationBackend>`). Whether the underlying implementation is a compile-time plugin or a generated REST client is invisible to the consumer.
+
+```text
+  Module SDK crate
+  ┌──────────────────────────────────────────────────────────────────┐
+  │                                                                  │
+  │  trait NotificationBackend          (base contract, zero annot.) │
+  │    deliver()                                                     │
+  │    stream_delivery()                                             │
+  │                                                                  │
+  │  #[modkit_rest_contract]                                         │
+  │  trait NotificationBackendRest: NotificationBackend              │
+  │    #[post("/v1/deliver")]           (transport projection)       │
+  │    deliver()                                                     │
+  │    #[streaming] #[post("/v1/delivery/stream")]                   │
+  │    stream_delivery()                                             │
+  │                                                                  │
+  └────────────┬──────────────────────────────┬──────────────────────┘
+               │                              │
+               │  compile-time plugin         │  macro-generated
+               │  impl NotificationBackend    │  NotificationBackendRestClient
+               │  directly                    │  impl NotificationBackend (HTTP dispatch)
+               v                              v
+  ┌─────────────────────┐       ┌──────────────────────────────────┐
+  │  In-process plugin  │       │  REST client (feature-gated)     │
+  │  (inventory reg.)   │       │  + OpenAPI spec function         │
+  └─────────────────────┘       │  + SSE stream support            │
+                                │  + Retry with backoff            │
+                                └──────────────────────────────────┘
+               │                              │
+               └──────────────┬───────────────┘
+                              │
+                              v
+                 ┌─────────────────────────┐
+                 │  ClientHub              │
+                 │  Arc<dyn Backend>       │
+                 │  (binding-mode agnostic)│
+                 └─────────────────────────┘
+                              │
+                              v
+                 ┌─────────────────────────┐
+                 │  Module business logic  │
+                 │  (same code regardless  │
+                 │   of binding mode)      │
+                 └─────────────────────────┘
+```
+
+### 1.2 Glossary
+
+| Term | Definition |
+|------|------------|
+| Contract | A Rust trait that defines an interface between a module and its consumers or plugins. Always a plain trait with zero transport annotations. |
+| Transport projection | A trait that extends a contract with transport-specific annotations (HTTP paths, methods, streaming). Generates a client and OpenAPI spec via proc macro. Named `{Base}Rest` or `{Base}Grpc`. |
+| Api | A contract the module **offers** across a boundary. Caller assumes independent failure domain, timeouts, retries, error mapping. Cannot participate in the caller's ACID transaction. Trait name ends with `Api`. Example: `NotificationApi`. |
+| Embedded | A contract the module **offers** in-process. Shares the caller's failure domain and can participate in the caller's transaction. Has lifecycle (start/stop), state, background workers. If it fails, the caller fails. No timeout/retry needed. Trait name ends with `Embedded`. Example: `EventProducerEmbedded`. |
+| Backend | A contract the module **needs**, satisfied across a boundary. Same operational semantics as Api: independent failure domain, timeout, retry, circuit breaker. Cannot participate in the module's ACID transaction. Trait name ends with `Backend`. Example: `NotificationBackend`. |
+| Extension | A contract the module **needs**, satisfied in-process. Shares the module's failure domain. Can participate in the module's transaction. Fast, deterministic, no retry. If it fails, the module fails. Trait name ends with `Extension`. Example: `NotificationFormatterExtension`. |
+| Offers | The module implements the trait and serves it to consumers. |
+| Needs | The module depends on the trait and expects a plugin to implement it. |
+| Base trait | The first layer -- a plain Rust trait defining the domain contract with no transport annotations. |
+| Projection trait | The second layer -- extends the base with transport annotations. Processed by a proc macro to generate client code. |
+| Binding mode | Whether a contract is satisfied by a compile-time plugin or a generated REST/gRPC client. Determined by which traits exist, not by an annotation. |
+
+### 1.3 Operational Semantics
+
+The four contract types are distinguished by their operational semantics, not deployment topology. The following table defines the invariants that each contract type carries:
+
+| Dimension | Local contracts (Embedded / Extension) | Remote-capable contracts (Api / Backend) |
+|-----------|----------------------------------------|------------------------------------------|
+| Transaction scope | Can participate in caller's ACID transaction | Cannot participate -- independent transaction boundary |
+| Failure domain | Same as caller -- if it fails, you fail | Independent -- the callee can fail without crashing the caller |
+| Timeout / retry | Not applicable -- in-process call | Required -- network may be slow or unreachable |
+| Circuit breaker | Not applicable | Recommended -- protect against cascading failure |
+| Error mapping | Rust errors directly | Problem Details over the wire, reconstructed via `ContractError` |
+| Serialization | None (zero-copy, shared memory) | JSON / protobuf -- all data crosses a serialization boundary |
+| Lifecycle | Shared with host process | Independent process with own lifecycle |
+| Settings | Shared config context | Own config (URL, timeout, retry policy) via `ClientConfig` |
+| Dependencies | Shared DI context (ClientHub) | Own connection / HTTP client |
+
+### 1.4 Naming Convention Matrix
+
+Every trait name ends with its contract type suffix. One glance at the name tells you the operational semantics.
+
+```text
+              Local (in-process,           Remote-capable (boundary,
+               tx-aware, shared fate)       independent failure domain)
+              ----------------------       ---------------------------
+
+Offers        {Noun}Embedded               {Noun}Api
+              EventProducerEmbedded        NotificationApi
+              (outbox, workers,            NotificationApiRest
+               can participate in tx)      NotificationApiGrpc (future)
+
+Needs         {Noun}Extension              {Noun}Backend
+              NotificationFmtExtension     NotificationBackend
+              (fast, in caller's tx,       NotificationBackendRest
+               no timeout)                 NotificationBackendGrpc (future)
+```
+
+**Hard rules:**
+- Every trait name ends with `Api`, `Embedded`, `Backend`, or `Extension`
+- Transport projections append `Rest` or `Grpc` to the base name
+- `Api` means remote-capable -- always. There is no "local Api"
+- `Embedded` means local -- always. There is no "remote Embedded"
+- `Backend` means remote-capable -- a `*Rest` projection may exist
+- `Extension` means local -- always. No transport projections
+
+**Transaction participation is a real capability, not aspirational.**
+
+The claim "Embedded and Extension can participate in the caller's transaction" is grounded in concrete Rust patterns that already work today — it does not depend on any new compile-time machinery. Specifically:
+
+- The outbox pattern is a direct application: an `EventProducerEmbedded` implementation writes to an `outbox` table using the caller's `&mut sqlx::Transaction<'_>` (or `&mut sea_orm::DatabaseTransaction`). The write commits atomically with the caller's business data. A background worker later relays the outbox rows to the external broker. The in-process contract *is* the transactional boundary.
+- `sqlx::Transaction<'a>`, `sea_orm::DatabaseTransaction`, `tokio_postgres::Transaction` — all of these are ordinary Rust types passed by mutable reference with a lifetime bound to the enclosing scope. A method signature `fn produce(&self, tx: &mut Transaction<'_>, event: &Event)` cannot be called without a transaction. Rust's type and lifetime systems do the enforcement without any platform-level magic.
+- Closure-table libraries, materialized-path libraries, and any read operation that must observe the caller's uncommitted state rely on the same mechanism. They pass the transaction handle through the call chain.
+
+Remote contracts cannot participate in a local database transaction because the remote process does not have access to the handle. A remote method signature cannot accept `&mut Transaction<'_>` — there is no way to marshal a transaction across a process boundary in this design. This is the structural reason Api/Backend cannot claim tx participation, and it is why the split exists.
+
+**TxGuard (see §7) is a separate idea** — a proposed compile-time mechanism that would *forbid* remote calls inside a transaction scope, as opposed to merely *allowing* local calls to participate in one. The tx-participation capability is already real. TxGuard would add the inverse enforcement: "inside a transaction, no remote calls allowed." The two are complementary, not the same.
+
+**Segregation is based on signature, not implementation freedom.**
+
+The hard rules above are about what the **signature promises** to the caller, not about what implementations are allowed to do. A signature-level promise is a subset relation:
+
+- **Remote-capable → local is allowed.** A remote signature (Api, Backend) promises the caller will get timeout handling, retry, error mapping, independent failure domain. An implementation is free to skip the network entirely and do the work in-process — the caller's code is still correct because the remote promise is a *superset* of local behavior. This is the in-process plugin scenario.
+
+- **Local → remote is NOT allowed.** A local signature (Embedded, Extension) promises the caller zero serialization overhead, shared failure domain, the ability to pass transaction handles, synchronous or near-synchronous latency. An implementation cannot secretly call over the network without breaking these promises. The caller did not write defensive code because none was needed; a hidden network call introduces timeouts, partial failures, and serialization semantics the caller never consented to.
+
+The four-type segregation encodes this asymmetry in the type system. A migration from Embedded to Api is intentional — it changes the caller's contract and every caller must acknowledge the new obligations. A migration from Api to Embedded is implementation-level and requires no caller changes. Code reviewers and static analysis can trust the trait name as a contract, not as a hint.
+
+**Alternative considered: umbrella interface (Java EE `@Local`/`@Remote` pattern).** A single interface with both local and remote views. Rejected because the umbrella obscures the operational contract at the call site — a caller holding `Arc<dyn FooService>` cannot tell whether defensive code is needed. Four explicit types force the caller to know what they are calling.
+
+### 1.5 Architecture Drivers
+
+| Requirement | Design Response |
+|-------------|-----------------|
+| `cpt-cf-binding-fr-base-trait-purity` | Base traits are plain Rust with zero annotations. No transport, no macros, no binding modes. Compile-time plugins implement the base trait directly. |
+| `cpt-cf-binding-fr-transport-projection` | Transport traits extend the base and carry HTTP annotations. The `#[modkit_rest_contract]` macro generates the REST client, OpenAPI spec, and SSE support. |
+| `cpt-cf-binding-fr-compile-time-safety` | Redeclared methods in the transport trait are checked by the Rust compiler against the base trait signatures. Missing methods, wrong param types, wrong return types are caught at compile time. |
+| `cpt-cf-binding-fr-contract-types` | Four contract types (Api, Embedded, Backend, Extension) encode operational semantics in the trait name suffix. The name IS the contract. |
+| `cpt-cf-binding-fr-naming-convention` | Every trait ends with its contract type suffix. Transport projections append `Rest` or `Grpc`. Hard rules enforced by convention and future lint. |
+| `cpt-cf-binding-fr-rest-client-gen` | `#[modkit_rest_contract]` generates a `{Trait}Client` struct implementing both the base trait (HTTP dispatch) and the transport trait (default delegation). |
+| `cpt-cf-binding-fr-openapi-gen` | The macro generates an `{trait}_openapi_spec()` function returning a valid OpenAPI 3.1 spec with endpoint paths, HTTP methods, and JSON schemas (via `schemars`). |
+| `cpt-cf-binding-fr-sse-streaming` | Methods annotated with `#[streaming]` generate SSE-aware client code: `Accept: text/event-stream` header, SSE parser into typed `Stream`. |
+| `cpt-cf-binding-fr-retryable` | Methods annotated with `#[retryable]` generate retry logic with exponential backoff. Retry policy configured via `ClientConfig`. |
+| `cpt-cf-binding-fr-contract-error` | `#[derive(ContractError)]` generates Problem Details conversion with `error_code` (UPPER_SNAKE_CASE from variant name) and `error_domain` (from attribute). Round-trip serialization preserves the original variant. |
+| `cpt-cf-binding-fr-problem-details` | Runtime provides `ProblemDetails` struct for RFC 9457 wire format with `error_code` and `error_domain` extension fields. |
+| `cpt-cf-binding-fr-client-config` | Runtime provides `ClientConfig` carrying base URL, timeout, and retry policy. Generated clients accept `ClientConfig` for construction. |
+| `cpt-cf-binding-fr-feature-gated` | REST client and its dependencies (`reqwest`, `schemars`) are behind a `rest-client` feature flag. SDK crates without the feature compile with no HTTP dependencies. |
+| `cpt-cf-binding-fr-directory-contract` | Service directory trait defined for GTS ID resolution and OpenAPI validation at registration. Implementation out of scope (cluster work). |
+| `cpt-cf-binding-fr-openapi-validation` | Directory fetches `/.well-known/openapi.json` from remote services and validates endpoint presence, HTTP methods, and content types before registration. |
+| `cpt-cf-binding-fr-clienthub-fallback` | ClientHub supports fallback resolution: compile-time registration takes priority, REST proxy instantiated from directory when no compile-time plugin exists. |
+| `cpt-cf-binding-fr-proxy-wiring` | Module lifecycle includes a proxy wiring phase after plugin discovery and before post-init. REST proxies instantiated only for traits with no compile-time registration. |
+| `cpt-cf-binding-fr-consumer-agnostic` | Consumer code is binding-mode-agnostic. `hub.get::<dyn NotificationBackend>()` works identically whether backed by a compile-time plugin or a REST proxy. |
+| `cpt-cf-binding-fr-versioning` | `#[non_exhaustive]` on request/response structs. Default trait methods for new methods. Breaking changes require new major version. |
+
+### 1.6 Architecture Layers
+
+```text
+  Module business logic
+         │
+         │  hub.get::<dyn NotificationBackend>()
+         v
+  ┌──────────────────────┐
+  │  ClientHub           │  binding-mode agnostic resolution
+  │  (fallback: compile  │
+  │   → REST proxy)      │
+  └──────┬───────────────┘
+         │
+    ┌────┴────────────────────────────────────┐
+    │                                         │
+    v                                         v
+  ┌──────────────────┐           ┌─────────────────────────────┐
+  │ Compile-time     │           │ REST proxy (generated)      │
+  │ plugin           │           │ impl NotificationBackend    │
+  │ impl Base trait  │           │ via HTTP dispatch           │
+  └──────────────────┘           └──────────┬──────────────────┘
+                                            │
+                                            │ HTTP + JSON
+                                            v
+                                 ┌─────────────────────────────┐
+                                 │ Remote service              │
+                                 │ /.well-known/openapi.json   │
+                                 │ validated by directory      │
+                                 └─────────────────────────────┘
+```
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Contract Type Encodes Operational Semantics
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-principle-contract-type-semantics`
+
+The contract type suffix (Api, Embedded, Backend, Extension) is the operational contract. The name tells the caller what to expect: failure domain, transaction scope, timeout requirements. There is no configuration override. `Api` means remote -- always. `Extension` means local -- always. This is a hard rule, not a guideline.
+
+**Decisions**: `cpt-cf-binding-decision-four-contract-types`
+
+#### Base Trait Purity
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-principle-base-trait-purity`
+
+Base traits carry zero transport annotations, zero macros, zero binding-mode awareness. They define the domain contract in pure Rust. A base trait is usable without any macro crate dependency. Compile-time plugins implement the base trait directly without pulling in HTTP, serialization, or schema libraries.
+
+**Decisions**: `cpt-cf-binding-decision-two-layer-architecture`
+
+#### Transport Is Additive
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-principle-transport-additive`
+
+Adding a transport projection (`NotificationBackendRest`) is a non-breaking change. The base trait, all existing compile-time plugins, and all consumers are unaffected. Removing a transport projection is also non-breaking for consumers (they depend on the base trait). Transport is layered on top, never baked in.
+
+**Decisions**: `cpt-cf-binding-decision-two-layer-architecture`
+
+#### Structural Enforcement
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-principle-structural-enforcement`
+
+The absence of a transport projection is a compile-time guarantee that the contract is local-only. If `NotificationFormatterExtension` has no `*Rest` trait, no REST client can be generated for it. The structure of the code enforces the constraint -- no runtime check, no configuration flag, no lint. An Extension with no projection is provably local.
+
+**Decisions**: `cpt-cf-binding-decision-four-contract-types`
+
+#### Consumer Binding-Mode Ignorance
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-principle-consumer-ignorance`
+
+Consumer code never knows or cares whether the underlying implementation is a compile-time plugin or a REST proxy. The consumer depends on `Arc<dyn NotificationBackend>` and calls methods on it. ClientHub resolves the implementation. This enables swapping between binding modes without any consumer code change.
+
+**Decisions**: `cpt-cf-binding-decision-clienthub-fallback`
+
+### 2.2 Constraints
+
+#### Compile-Time Signature Checking
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-constraint-signature-checking`
+
+Every method redeclared in a transport projection must match the corresponding method in the base trait. Enforcement is two-tiered:
+
+1. **Delegation-time check** (automatic): the macro generates a default method body `Base::method(self, params).await`. If the projection's signature diverges from the base, this delegation fails to type-check and the code does not compile. This catches most drift.
+
+2. **Witness functions** (macro-generated, explicit): the macro also emits `const _` witness blocks that assert exact signature equality between projection and base methods. A witness block looks like:
+
+```rust
+const _: () = {
+    fn _witness_deliver<T: NotificationBackendRest>(
+        this: &T,
+        req: &DeliverRequest,
+    ) -> impl ::core::future::Future<Output = Result<DeliverResponse, GreeterError>> + '_ {
+        <T as NotificationBackend>::deliver(this, req)
+    }
+};
+```
+
+If the projection's parameter types or return type diverge from the base, the witness fails with a clear error message naming the mismatch. This gives us true compile-time signature conformance — not just "catch-by-delegation."
+
+**Note on the Rust trait system:** A `: Base` supertrait bound alone does NOT force signature equality for methods with shared names. Redeclared methods in the subtrait are distinct methods that happen to share a name with the base. The witness functions close this gap.
+
+#### Feature-Gated HTTP Dependencies
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-constraint-feature-gated-http`
+
+All HTTP dependencies (`reqwest`, `schemars`) are behind a `rest-client` Cargo feature flag. SDK crates without the feature compile with zero network dependencies. This ensures that compile-time-only consumers do not pay for transport they do not use.
+
+#### RFC 9457 Error Wire Format
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-constraint-rfc9457-errors`
+
+All error responses from generated REST clients use RFC 9457 Problem Details with the `error_code` and `error_domain` extension fields. `error_code` is UPPER_SNAKE_CASE derived from the Rust enum variant name. `error_domain` is a dot-separated module namespace. Round-trip serialization preserves the original error variant.
+
+#### No Server Generation
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-constraint-no-server-gen`
+
+Only the client is generated from the transport projection. Remote services implement their REST endpoints independently. The generated OpenAPI spec serves as the conformance contract validated by the directory. This preserves server flexibility -- services may extend the API, support version coexistence, and use any HTTP framework.
+
+#### Async Trait Strategy
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-constraint-async-trait`
+
+All contract traits use `#[async_trait]` from the `async-trait` crate. This includes base traits, transport projections, and manually-implemented client structs. Rationale:
+
+- **Trait objects are required.** The entire design rests on consumers holding `Arc<dyn Backend>`. Native `async fn in Trait` (stable since Rust 1.75) is not dyn-compatible without boxing the returned future, which `async_trait` does transparently.
+- **The macro generates `async_trait`-compatible code.** The generated REST client is annotated `#[async_trait::async_trait]` and boxes returned futures accordingly. Native `async fn` in the same trait would require `#[trait_variant]` or `#[allow(async_fn_in_trait)]` gymnastics and would not be dyn-compatible.
+- **Consistency across the codebase.** ModKit SDK crates already use `async_trait`. This design keeps that convention.
+
+The cost is one `Box<dyn Future>` allocation per async method call — negligible compared to HTTP serialization or network I/O. When native dyn-compatible `async fn` is stable and ergonomic, the platform can migrate, but that is not today.
+
+#### Security Context on Remote Contracts
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-constraint-security-context`
+
+Every method on a remote-capable contract (Api, Backend, and their `*Rest`/`*Grpc` projections) MUST accept `&SecurityContext` as its first non-self argument. This is a hard rule enforced by convention and validated by the macro and by CI.
+
+```rust
+// Remote-capable — SecurityContext required.
+pub trait NotificationBackend: Send + Sync {
+    async fn deliver(
+        &self,
+        ctx: &SecurityContext,            // required first arg
+        req: &DeliverRequest,
+    ) -> Result<DeliverResponse, NotificationError>;
+}
+
+// Local — SecurityContext optional (caller already has it in scope).
+pub trait NotificationFormatterExtension: Send + Sync {
+    async fn format(&self, message: &str, channel: &Channel) -> Result<String, FormatError>;
+}
+```
+
+**Rationale:** Every cross-boundary call carries some authorization context — a bearer token, a service identity, a tenant scope. Making it the first parameter ensures:
+
+1. Authors cannot forget it. Missing `ctx` is a compile error at every call site.
+2. The macro generates consistent propagation. The generated REST client maps `ctx` into the appropriate transport-level carrier (Authorization header, metadata, etc.) in one place.
+3. Code review and audit are mechanical. Every remote call has `ctx` visible in the signature; calls without it are locally scoped by construction.
+4. Middleware composes cleanly. Layers that inject tenant context, validate tokens, or emit audit logs hook into a single, uniform slot.
+
+Local contracts (Embedded, Extension) do not require `SecurityContext` because they run in the caller's scope and inherit the caller's context directly (task-local storage, explicit parameters, or module-owned state). Authors MAY pass `SecurityContext` explicitly to local methods when the contract needs it.
+
+#### OpenAPI at Well-Known Path
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-constraint-openapi-well-known`
+
+Remote services expose their OpenAPI spec at `/.well-known/openapi.json`. The service directory fetches and validates this spec at registration time. This is the single integration point between the generated contract and the remote implementation.
+
+## 3. Key Decisions
+
+### D1: Two-Layer Trait Architecture
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-decision-two-layer-architecture`
+
+**Decision**: Separate base traits (domain contract, zero annotations) from transport projections (annotated traits extending the base). The Rust compiler checks that redeclared method signatures in the projection match the base trait.
+
+**Rationale**: Decouples domain contracts from transport concerns. Compile-time plugins depend only on the base trait and never pull in HTTP or schema dependencies. Transport projections are additive and independently versionable.
+
+**Alternatives considered**:
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Single-trait annotations (`#[modkit_contract(binding = [compile, rest])]`) | Mixes transport with domain. REST annotations do not apply to gRPC. Compile-time plugins carry unnecessary annotation weight. Cannot add a new transport without modifying the base trait. |
+| Separate module for transport mapping (not a trait) | Loses compile-time signature checking. The mapping between base methods and HTTP endpoints would be a configuration file or a separate struct, not compiler-verified. A method rename in the base trait would silently break the mapping. |
+
+### D2: Four Contract Types
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-decision-four-contract-types`
+
+**Decision**: Four contract types -- Api (offers, remote), Embedded (offers, local), Backend (needs, remote-capable), Extension (needs, local). The suffix is the contract. The name encodes operational semantics.
+
+**Rationale**: The distinction is not about deployment topology. It is about operational semantics. A `TokenValidator` doing local JWT parsing (microseconds, in your transaction) and one calling remote OAuth (network, timeout, own failure domain) have fundamentally different caller requirements. Collapsing to two types forces the caller to add timeout handling and retry for a local function call, or removes the signal that a remote call requires defensive code.
+
+**Alternatives considered**:
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Two types (Api + Backend) | Collapses local and remote semantics. An `EventProducerEmbedded` with an internal outbox (participates in your DB transaction, commits atomically) gets the same contract as a remote HTTP ingestion endpoint. Retry logic wrapping a transactional commit is wrong. |
+| No types (just traits) | No readability signal for operational semantics. The caller must read documentation or trace the implementation to know whether a call can timeout, whether it participates in a transaction, whether retry is needed. |
+
+### D3: Transport Projection Default Delegation
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-decision-default-delegation`
+
+**Decision**: The contract and its protocol projection are **two distinct Rust traits** in the SDK crate. The base trait (e.g., `NotificationBackend`) carries the domain contract with zero transport annotations. The protocol projection (e.g., `NotificationBackendRest`) **extends** the base via a `: Base` supertrait bound and redeclares each method with protocol-specific annotations (`#[post]`, `#[streaming]`, `#[retryable]`). The `#[modkit_rest_contract]` macro converts the redeclared methods into default methods that delegate to the base trait via fully-qualified call syntax: `Base::method(self, ...)`. The generated REST client provides a single HTTP dispatch implementation of the base trait; the projection trait's empty impl picks up the delegating defaults.
+
+**Why two traits, not one**:
+
+1. **The contract is the domain, the projection is the wire format**. A compile-time plugin or an in-process implementation depends only on the base trait. It does not import `reqwest`, `axum`, or any transport crate. The base trait is what consumers write against (`Arc<dyn NotificationBackend>`). Mixing HTTP path annotations and streaming markers into the domain trait would pollute the plugin author's world with transport they don't care about.
+
+2. **The projection is protocol-specific**. Multiple projections can coexist on the same base: `NotificationBackendRest` (HTTP), `NotificationBackendGrpc` (protobuf, future). Each lives in its own file, feature-gated independently. Adding a projection is non-breaking — it introduces a new trait extending the existing base, leaves the base untouched, and generates its own client struct.
+
+3. **Compile-time enforcement, not runtime convention**. Because the projection uses `: Base` as a supertrait, the Rust trait system enforces that implementors of the projection also implement the base. Because each method is redeclared, the compiler verifies that parameter types, return types, and error types in the projection match the base exactly. Drift between the two is impossible — the code will not compile.
+
+4. **The generated client implements both traits**. The base impl is the real work (HTTP dispatch, error reconstruction, retry, SSE parsing). The projection impl is empty; it inherits the default methods the macro synthesized, which call back into the base. A consumer holding `Arc<dyn NotificationBackend>` gets direct HTTP dispatch. A caller who needs the protocol-specific surface (e.g., REST-only batch endpoints declared only in the projection) can also access it through the same concrete client type.
+
+**What the developer writes vs what the macro emits:**
+
+```rust
+// 1. The contract — plain Rust trait, domain only, no transport awareness.
+//    Lives in the SDK crate. This is what consumers and compile-time plugins depend on.
+pub trait NotificationBackend: Send + Sync {
+    async fn deliver(&self, req: &DeliverRequest) -> Result<DeliverResponse, Err>;
+}
+
+// 2. The protocol projection — extends the base with REST annotations.
+//    Lives alongside the contract, feature-gated behind `rest-client` if needed.
+#[modkit_rest_contract]
+pub trait NotificationBackendRest: NotificationBackend {
+    #[post("/v1/deliver")]
+    async fn deliver(&self, req: &DeliverRequest) -> Result<DeliverResponse, Err>;
+}
+```
+
+After macro expansion:
+
+```rust
+// The projection trait after the macro processes it — methods now have defaults
+// that delegate to the base via fully-qualified call syntax.
+pub trait NotificationBackendRest: NotificationBackend {
+    async fn deliver(&self, req: &DeliverRequest) -> Result<DeliverResponse, Err> {
+        NotificationBackend::deliver(self, req).await
+    }
+}
+
+// The generated REST client struct carries config + HTTP client.
+pub struct NotificationBackendRestClient {
+    config: ClientConfig,   // base_url, timeout, retry policy
+    http: reqwest::Client,
+}
+
+// Single source of actual HTTP dispatch — on the BASE trait.
+impl NotificationBackend for NotificationBackendRestClient {
+    async fn deliver(&self, req: &DeliverRequest) -> Result<DeliverResponse, Err> {
+        let resp = self.http.post(format!("{}/v1/deliver", self.config.base_url))
+            .json(req).send().await?;
+        if !resp.status().is_success() { return Err(self.parse_error(resp).await); }
+        resp.json().await.map_err(Err::from_transport)
+    }
+}
+
+// The projection impl is EMPTY. Default methods inherited from the trait
+// delegate back to NotificationBackend::deliver, which is the HTTP dispatch above.
+impl NotificationBackendRest for NotificationBackendRestClient {}
+```
+
+**Three call scenarios, three perspectives:**
+
+The three diagrams below each answer a different question. They share a common vocabulary: the **base trait** (`NotificationBackend`) is the domain contract, the **projection trait** (`NotificationBackendRest`) is the protocol surface, and `*Client` is the macro-generated struct.
+
+---
+
+**Scenario 1: Consumer holding a trait object.** *Shows that the consumer calls the base trait and never sees the REST transport — the same code works for compile-time and REST bindings.*
+
+```
+  // Consumer code (e.g., the notification module using a delivery plugin)
+  let backend: Arc<dyn NotificationBackend> = hub.get();
+  backend.deliver(&req).await;
+            │
+            │   dynamic dispatch through Arc<dyn NotificationBackend>
+            v
+  impl NotificationBackend for NotificationBackendRestClient
+      reqwest POST /v1/deliver → response → deserialize → error mapping
+      (this is the only place HTTP actually happens)
+```
+
+Perspective: **consumer**. Point: the consumer sees one trait. Whether the implementation behind the trait object is a compile-time plugin or a macro-generated REST client is invisible.
+
+---
+
+**Scenario 2: A caller that needs the protocol surface.** *Shows that calling through the projection trait ends up in the same base impl — the default delegation prevents code duplication.*
+
+```
+  // Caller holding the concrete generated client type (rare — usually tests or
+  // code that needs protocol-specific methods declared only on the projection)
+  let client: NotificationBackendRestClient = ...;
+  <_ as NotificationBackendRest>::deliver(&client, &req).await;
+            │
+            │   dispatches to the projection trait
+            v
+  default method in NotificationBackendRest (synthesized by the macro):
+      fn deliver(&self, req) -> ... {
+          NotificationBackend::deliver(self, req).await
+      }
+            │
+            │   delegates via fully-qualified call syntax
+            v
+  impl NotificationBackend for NotificationBackendRestClient
+      (same HTTP POST /v1/deliver as Scenario 1 — ONE implementation)
+```
+
+Perspective: **code that uses the protocol-specific surface** (projection-only methods, testing hooks). Point: there is one real implementation of `deliver`, on the base trait. The projection trait's methods are thin delegating shims that the macro generates — no hand-written duplication, no drift.
+
+---
+
+**Scenario 3: A compile-time plugin.** *Shows that in-process plugins depend only on the base trait and know nothing about REST.*
+
+```
+  // Plugin crate — does NOT depend on reqwest, modkit-contract-runtime, or the
+  // projection trait. Depends only on the SDK crate's base trait.
+  struct InProcEmailPlugin { /* SMTP client, whatever */ }
+
+  impl NotificationBackend for InProcEmailPlugin {
+      async fn deliver(&self, req) -> ... {
+          // direct function call — no serialization, no HTTP, no retry wrapper
+      }
+  }
+
+  // At wiring time:
+  hub.register::<dyn NotificationBackend>(Arc::new(InProcEmailPlugin::new()));
+```
+
+Perspective: **plugin author**. Point: the plugin implements the base trait like any regular Rust trait. It has no awareness of transport projections, no macro involvement, no REST dependencies. This is the zero-cost path.
+
+**What this guarantees:**
+
+- Consumer code is identical regardless of binding mode (`Arc<dyn NotificationBackend>` always).
+- The contract author writes the domain trait once; the protocol author writes the projection once. Neither has to duplicate the other's work.
+- Signature drift between the contract and the projection is a compile error.
+- Adding a gRPC projection later is purely additive — a new trait `NotificationBackendGrpc: NotificationBackend`, a new macro `#[modkit_grpc_contract]`, a new generated client. The base trait and existing REST projection are untouched.
+- A compile-time plugin that only implements the base trait works everywhere — because the projection trait's default delegation bridges the gap automatically.
+
+**Manual implementation is always allowed.** The macro generates a default client for the common case (POST + JSON, SSE streaming, exponential-backoff retry). When a module needs behavior the macro does not express — complex path templates, query parameter composition, custom authentication, connection pooling with per-tenant routing, bespoke retry strategies, request signing — the author can write a hand-crafted client that implements the same base trait directly. The consumer still gets `Arc<dyn NotificationBackend>`; the generated client and the hand-written client are indistinguishable from the consumer's perspective. The macro is a convenience for the common case, not a lock-in. Hand-written clients can coexist with macro-generated ones in the same codebase.
+
+### D4: ContractError Derive
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-decision-contract-error`
+
+**Decision**: `#[derive(ContractError)]` on an error enum generates RFC 9457 Problem Details conversion with `error_code` (UPPER_SNAKE_CASE from variant name) and `error_domain` (from `#[contract_error(domain = "...")]` attribute). The generated code supports round-trip serialization: `to_problem_details()` and `from_problem_details()` preserve the original variant including all structured context fields.
+
+**Rationale**: Machine-readable error reconstruction across module boundaries. The `error_code` + `error_domain` pair uniquely identifies the error variant. Unknown codes or domains fall back to an `Internal` variant, ensuring the system never panics on unrecognized errors.
+
+```rust
+#[derive(Debug, Clone, ContractError)]
+#[contract_error(domain = "cf.notification")]
+pub enum NotificationError {
+    #[error(status = 404, problem_type = "not-found")]
+    NotificationNotFound { notification_id: String },
+
+    #[error(status = 503, problem_type = "service-unavailable")]
+    DeliveryUnavailable { channel: String, retry_after_seconds: Option<u64> },
+
+    #[error(status = 500, problem_type = "internal")]
+    Internal { description: String },
+}
+```
+
+Generated `error_code` values: `NOTIFICATION_NOT_FOUND`, `DELIVERY_UNAVAILABLE`, `INTERNAL`.
+
+### D5: OpenAPI at /.well-known/openapi.json
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-decision-openapi-well-known`
+
+**Decision**: Remote services expose their OpenAPI spec at `/.well-known/openapi.json`. The service directory validates this spec at registration time by checking endpoint presence, HTTP methods, and content types against the expected contract spec generated by the macro.
+
+**Rationale**: A single, predictable discovery point for the contract spec. Validation at registration time catches mismatches before any request is routed, not at runtime when the first call fails. The generated spec serves as a minimum conformance contract -- remote services may extend the API with additional endpoints.
+
+### D6: Naming Convention as Hard Rule
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-decision-naming-convention`
+
+**Decision**: Every trait name ends with `Api`, `Embedded`, `Backend`, or `Extension`. Transport projections append `Rest` or `Grpc`. `Api` means remote -- always, with no exceptions. There is no "local Api".
+
+**Rationale**: The name IS the operational contract. A developer reading `fn process(backend: &dyn NotificationBackend)` knows immediately: this can timeout, this can fail independently, this needs retry logic, this cannot participate in my transaction. No need to open another file, check a configuration, or read documentation. The naming convention eliminates an entire class of architectural misunderstandings.
+
+**Enforcement**: Currently by convention. Future work may add a Dylint lint that rejects traits with incorrect suffixes or transport projections on Extension/Embedded types.
+
+## 4. Crate Structure
+
+| Crate | Type | Responsibility |
+|-------|------|----------------|
+| `cf-modkit-contract-macros` | proc-macro | `#[modkit_rest_contract]` -- generates REST client struct, OpenAPI spec function, SSE streaming, retryable methods. `#[derive(ContractError)]` -- generates Problem Details conversion with `error_code` + `error_domain`. Method annotations: `#[get]`, `#[post]`, `#[put]`, `#[delete]`, `#[patch]`. Parameter annotations: `#[path]`, `#[query]`, `#[header]`, `#[streaming]`, `#[retryable]`. |
+| `cf-modkit-contract-runtime` | lib | `ProblemDetails` struct (RFC 9457 with extension fields). SSE stream parser (byte stream to typed events). `ClientConfig` (base URL, timeout, retry policy). `RetryConfig` and `with_retry()` helper for exponential backoff. |
+| Module SDK crates (e.g., `notification-sdk`) | lib | Base traits (zero annotations, no macro dependency). Transport projection traits (behind `rest-client` feature). Feature-gated: `rest-client` enables `reqwest`, `schemars`, and the generated REST client. Without the feature, only the base trait is available. |
+| `cf-modkit` (modified) | lib | ClientHub: fallback resolution (compile-time first, then REST proxy from directory). Module lifecycle: new proxy wiring phase after plugin discovery, before post-init. |
+| `cf-modkit-macros` (modified) | proc-macro | Alignment with ADR-0004 module/plugin declaration macros. |
+
+### SDK Crate Layout (per module)
+
+```text
+notification-sdk/
+  src/
+    lib.rs              -- re-exports
+    types.rs            -- request/response structs (#[non_exhaustive])
+    error.rs            -- #[derive(ContractError)] enum
+    api.rs              -- NotificationApi (base) + NotificationApiRest (projection)
+    backend.rs          -- NotificationBackend (base) + NotificationBackendRest (projection)
+    extension.rs        -- NotificationFormatterExtension (base only, no projection)
+  Cargo.toml
+    [features]
+    rest-client = ["reqwest", "schemars", "cf-modkit-contract-macros", "cf-modkit-contract-runtime"]
+```
+
+## 5. Contract Enforcement
+
+Contract integrity is enforced at multiple levels, from compile-time through to service registration:
+
+| Tier | When | Mechanism | What It Catches |
+|------|------|-----------|-----------------|
+| 1. Compile-time | `cargo build` | Rust trait system (`: Base` supertrait), typed enums, `#[non_exhaustive]` on request/response structs | Signature mismatches between base and projection, missing methods, wrong param/return/error types, direct struct construction outside the crate |
+| 2. Macro-time | `cargo build` | `#[modkit_rest_contract]` macro validates that annotated methods cover the base trait surface | Missing REST annotations for base trait methods |
+| 3. Test-time | `cargo test` | Round-trip tests for `ContractError` (serialize to Problem Details, deserialize back, assert variant match) | Error code drift, serialization schema changes, lost context fields |
+| 4. Registration-time | Service boot | Directory fetches `/.well-known/openapi.json` and validates endpoint presence, HTTP methods, content types against the expected spec | Missing endpoints on remote services, wrong HTTP methods, content type mismatches |
+| 5. Design-time | Architecture | Naming convention (suffix = operational semantics), structural enforcement (no projection = local-only) | Architectural misuse (calling a remote contract in a transaction, adding a projection to an Extension) |
+
+## 6. Risks / Trade-offs
+
+### [Risk] Method Redeclaration Is Duplication
+
+Every base trait method must be redeclared in the transport projection with HTTP annotations. This is textual duplication.
+
+**Mitigation**: The Rust compiler rejects mismatches immediately. The duplication is enforced, not accidental. If the base trait changes a signature, the projection fails to compile until updated. This is strictly safer than a mapping file or configuration that can silently drift.
+
+### [Risk] Proc Macro Complexity
+
+The `#[modkit_rest_contract]` macro must parse trait definitions, generate client structs, produce OpenAPI specs, handle SSE streaming, and implement retry logic. Proc macros are notoriously hard to debug.
+
+**Mitigation**: The PoC (`modkit-binding-poc`) proves feasibility for the common patterns: POST/GET endpoints, streaming, retryable methods, ContractError round-trip. Edge cases (generics, lifetimes, complex associated types) are explicitly out of scope for phase 1.
+
+### [Risk] schemars Dependency
+
+OpenAPI schema generation requires `schemars` as a dependency on all request/response types. This adds a transitive dependency tree.
+
+**Mitigation**: Feature-gated behind `rest-client`. Compile-time-only consumers never pull in `schemars`. The dependency is paid only by crates that actually generate or consume OpenAPI specs.
+
+### [Trade-off] Four Types Add Naming Ceremony
+
+Developers must choose the correct suffix for every trait. This adds cognitive overhead compared to "just write a trait."
+
+**Justification**: Intentional friction. The name IS the operational contract. The alternative -- implicit semantics where you must trace the implementation to know if a call can timeout -- is worse for every subsequent reader of the code. The ceremony pays for itself on the first code review.
+
+### [Trade-off] No Server Generation
+
+Only the client is generated. Remote services must implement their REST endpoints manually.
+
+**Justification**: Preserves server flexibility. Remote services may be written in any language, use any HTTP framework, support multiple API versions, and extend the API surface beyond what the contract specifies. The generated OpenAPI spec serves as a minimum conformance contract, not a straitjacket.
+
+### [Trade-off] No gRPC in Phase 1
+
+Only REST transport projections are supported. gRPC follows the same pattern but is deferred.
+
+**Justification**: REST covers the immediate need (out-of-process plugins, third-party integrations). The two-layer architecture is transport-agnostic by design -- adding `#[modkit_grpc_contract]` later requires no changes to base traits, consumers, or the contract type system.
+
+### [Constraint] Observability Hooks
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-constraint-observability`
+
+The generated REST client carries retry, timeout, and error mapping. Without traces, metrics, and logs it is unusable in production. Bolting observability on later is an API break because the hook points live on `ClientConfig`. Observability is therefore wired in from day one.
+
+**Tracing (spans).** Every generated method call opens a span that carries the method name (e.g., `NotificationBackendRest::deliver`), target URL, HTTP method, status code, retry attempt number, request duration, and a correlation ID propagated outbound via the `traceparent` header.
+
+**Metrics.** The generated client emits: request count (labeled by method, status), request duration histogram, retry count, error count (labeled by `error_code`, `error_domain`), and an in-flight requests gauge.
+
+**Structured logs.** Request initiated at `debug`, retry attempts at `warn`, errors with full Problem Details context at `error`.
+
+**Where the hooks live.** `ClientConfig` gains an optional parent `tracing::Span` and an optional `MetricsRegistry` handle. A new `ContractObservability` trait abstracts all three channels so platforms on OpenTelemetry, Prometheus, or a bespoke stack can supply their own wiring. A default implementation backed by the `tracing` and `metrics` crates ships with the runtime.
+
+```rust
+// Runtime crate: cf-modkit-contract-runtime
+pub struct ClientConfig {
+    pub base_url: String,
+    pub timeout: Duration,
+    pub retry: RetryConfig,
+    pub parent_span: Option<tracing::Span>,
+    pub metrics: Option<MetricsRegistry>,
+    pub observability: Option<Arc<dyn ContractObservability>>, // None = default impl
+}
+
+pub trait ContractObservability: Send + Sync {
+    fn on_request_start(&self, method: &'static str, url: &str) -> RequestScope;
+    fn on_retry(&self, scope: &RequestScope, attempt: u32, reason: &dyn std::fmt::Display);
+    fn on_response(&self, scope: RequestScope, status: u16, duration: Duration);
+    fn on_error(&self, scope: RequestScope, err: &ProblemDetails, duration: Duration);
+}
+```
+
+The macro expands each method into a span-wrapped dispatch:
+
+```rust
+impl NotificationBackend for NotificationBackendRestClient {
+    async fn deliver(&self, ctx: &SecurityContext, req: &DeliverRequest)
+        -> Result<DeliverResponse, NotificationError>
+    {
+        let obs = self.config.observability();
+        let scope = obs.on_request_start("NotificationBackendRest::deliver", &url);
+        let span = tracing::info_span!(
+            parent: self.config.parent_span.as_ref(),
+            "NotificationBackendRest::deliver",
+            http.method = "POST", http.url = %url,
+            http.status_code = tracing::field::Empty,
+            retry.attempt = tracing::field::Empty,
+        );
+        async move {
+            tracing::debug!(?req, "request initiated");
+            let started = Instant::now();
+            match self.dispatch_with_retry(ctx, req, &scope, &span).await {
+                Ok(resp) => { obs.on_response(scope, 200, started.elapsed()); Ok(resp) }
+                Err(e)   => {
+                    tracing::error!(error_code = %e.error_code(), error_domain = %e.error_domain(), "request failed");
+                    obs.on_error(scope, &e.to_problem_details(), started.elapsed());
+                    Err(e)
+                }
+            }
+        }.instrument(span).await
+    }
+}
+```
+
+**Design decision.** Observability is not optional. The generated client always emits at least tracing spans. Metrics and structured logs can be silenced by supplying a no-op `ContractObservability`, but the hook points exist from day one. Adding them later would change `ClientConfig`'s public surface -- an API break for every consumer.
+
+**Consumer transparency.** Consumers never interact with observability directly. `backend.deliver(&ctx, &req).await` automatically produces spans and metrics. Whether telemetry is enabled, disabled, or routed to a custom backend is a construction-time concern for `ClientConfig`; call-site code is unchanged.
+
+## 7. Open Questions
+
+### TxGuard -- Compile-Time Transaction Scope Restriction
+
+A type-state mechanism that restricts which contracts can be called inside a transaction scope. Within a `TxGuard<'tx>`, only Embedded/Extension contracts are callable -- the compiler rejects calls to Api/Backend traits. This turns the operational semantics table from a naming convention into a compile-time guarantee.
+
+```rust
+async fn process_order(tx: &mut TxGuard<'_>, producer: &dyn EventProducerEmbedded) {
+    // This compiles -- Embedded can participate in the transaction
+    producer.produce_in_tx(tx, &event).await?;
+
+    // This would NOT compile -- Backend cannot be called in a tx scope
+    // payment_backend.charge(tx, &amount).await?;  // compile error
+}
+```
+
+The guard would enforce that remote-capable contracts (Api, Backend) are never invoked within a transaction boundary, preventing a class of bugs where a remote call inside a transaction holds locks while waiting on the network. Needs its own ADR to design the type-state mechanism and how it interacts with database transactions (SeaORM/SQLx).
+
+### Versioning and v1/v2 Coexistence
+
+This design covers non-breaking evolution (`#[non_exhaustive]` types, default trait methods, new enum variants) but does not yet specify how Rust traits coexist across major versions. The reasonable strategies are:
+
+- **Parallel traits**: `NotificationBackendV1` and `NotificationBackendV2` as separate traits. ClientHub resolves by type. Consumers choose at compile time. Plugins may implement both during a transition window.
+- **Trait inheritance**: `trait NotificationBackendV2: NotificationBackendV1` with additive methods only. Works for extensions, fails for breaking changes.
+- **Separate SDK crates per major version**: `notification-sdk-v1` and `notification-sdk-v2` published independently. Maximum isolation, maximum duplication.
+
+The **remote-side requirement** is clear: remote services MUST preserve backwards compatibility within a major version. A service exposing `/v1/deliver` must continue to accept requests that the Rust `V1` trait generates for as long as `V1` is supported. This is an operational requirement, not a code-generation concern.
+
+The Rust-side strategy is deferred to an ADR. Whichever strategy is chosen must support: simultaneous presence of V1 and V2 traits in the same SDK crate, a migration window where plugins implement both, and clear deprecation of V1 on a documented timeline.
+
+### Remote Backend Unavailability
+
+Circuit breakers, fallback methods, and degraded-mode behavior when remote plugins are temporarily unavailable. The `#[retryable]` annotation handles transient failures, but sustained unavailability (minutes, not seconds) requires a different strategy: circuit breaker state, fallback to a default implementation, or graceful degradation with cached data. Needs a separate ADR.
+
+### gRPC Transport Projection
+
+`#[modkit_grpc_contract]` macro design following the same two-layer pattern. Open questions include: proto-first vs. code-first generation, interaction with `tonic`, streaming semantics (server-streaming, client-streaming, bidirectional), and whether the gRPC projection can coexist with the REST projection on the same base trait.
+
+### Complex REST Annotations
+
+Path variables (`#[path]`), query parameters (`#[query]`), header injection (`#[header]`), and multi-part request bodies are supported in the annotation vocabulary but their full semantics need implementation-phase design. The PoC covers `#[post]` and `#[get]` with JSON body; path variable extraction and query parameter mapping are deferred.
+
+### Method Annotation Naming Collision
+
+`#[post]`, `#[get]`, `#[streaming]` are short attribute names that may collide with other proc macro crates. If collisions arise, the annotations may need namespacing: `#[modkit_post]`, `#[modkit_get]`, `#[modkit_streaming]`. The PoC uses the short names without issue, but production may require the longer forms depending on the dependency graph.
+
+## 8. Traceability
+
+- **PRD**: [`./PRD.md`](./PRD.md)
+- **DESIGN** (this document): [`./DESIGN.md`](./DESIGN.md)
+- **ADR-0001** — contract source of truth: [`./ADR/0001-cpt-cf-binding-adr-contract-source-of-truth.md`](./ADR/0001-cpt-cf-binding-adr-contract-source-of-truth.md)
+- **ADR-0002** — OpenAPI spec limits: [`./ADR/0002-cpt-cf-binding-adr-openapi-spec-limits.md`](./ADR/0002-cpt-cf-binding-adr-openapi-spec-limits.md)
+- **PoC**: [striped-zebra-dev/modkit-binding-poc](https://github.com/striped-zebra-dev/modkit-binding-poc)
+- **Module/plugin declaration and resolution**: [PR #1380](https://github.com/cyberfabric/cyberfabric-core/pull/1380)

--- a/docs/arch/modkit-contract-binding/PRD.md
+++ b/docs/arch/modkit-contract-binding/PRD.md
@@ -1,0 +1,572 @@
+# PRD -- ModKit Contract Binding System
+
+## 1. Overview
+
+### 1.1 Purpose
+
+A two-layer contract-binding system for CyberFabric ModKit that separates module contracts (plain Rust traits) from their transport projections (transport-annotated traits), enabling modules to expose and consume interfaces across process boundaries without coupling domain logic to transport details.
+
+### 1.2 Background / Problem Statement
+
+ModKit modules define Rust traits as their extension points. Today, binding an implementation to a trait requires compiling it into the same binary -- a Cargo dependency on the SDK crate, a direct `impl Trait`, and registration into ClientHub via `inventory`. This works for in-process plugins but breaks when:
+
+- The implementation lives in a separate process (out-of-process plugin, sidecar, external service).
+- The implementation is written in another language.
+- The implementer has an independent release cycle and cannot be compiled into the host binary.
+
+There is no mechanism to generate REST clients from a trait definition, no way to validate that a remote service actually implements the expected contract, and no lifecycle phase in which the platform can wire REST proxies for unsatisfied traits. Each SDK crate that needs remote binding reinvents HTTP client code, error mapping, and retry logic independently.
+
+### 1.3 Goals (Business Outcomes)
+
+- Module developers define contracts once as plain Rust traits and get remote bindings (REST clients, OpenAPI specs) generated automatically.
+- Consumers of a contract interact with it identically whether the backing implementation is compile-time or remote -- binding-mode-agnostic code.
+- Four contract types with distinct operational semantics (Api, Embedded, Backend, Extension) make the caller's obligations explicit from the trait name alone.
+- Compile-time enforcement prevents signature drift between base traits and transport projections.
+- OpenAPI spec validation at registration time prevents incompatible remote services from entering the cluster.
+
+### 1.4 Glossary
+
+| Term | Definition |
+|------|------------|
+| Contract | A plain Rust trait with zero transport annotations that defines an interface between a module and its consumers or plugins. Always named with one of the four suffixes: `Api`, `Embedded`, `Backend`, `Extension`. |
+| Transport projection | A trait that extends a contract with transport-specific annotations (HTTP paths, methods, streaming). Named `{Base}Rest` or `{Base}Grpc`. Generates a client implementation and OpenAPI spec via proc macro. |
+| Api | A contract the module **offers** across a boundary. Trait name ends with `Api`. Caller assumes independent failure domain, timeouts, retries, error mapping. Cannot participate in the caller's ACID transaction. Remote always -- there is no "local Api". |
+| Embedded | A contract the module **offers** in-process. Trait name ends with `Embedded`. Shares the caller's failure domain and can participate in the caller's transaction. Has managed lifecycle (start/stop, background workers). Local always -- there is no "remote Embedded". No transport projections. |
+| Backend | A contract the module **needs**, satisfied across a boundary. Trait name ends with `Backend`. Same operational semantics as Api: independent failure domain, timeout, retry, circuit breaker. Cannot participate in the module's ACID transaction. Transport projections (`BackendRest`, `BackendGrpc`) provide the remote binding. |
+| Extension | A contract the module **needs**, satisfied in-process. Trait name ends with `Extension`. Shares the module's failure domain. Can participate in the module's transaction. Fast, deterministic, no timeout. Local always -- no transport projections. |
+| Offers | The module implements the trait and serves it to consumers. Contracts with `Api` or `Embedded` suffix. |
+| Needs | The module depends on the trait and expects a plugin to implement it. Contracts with `Backend` or `Extension` suffix. |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Module Developer
+
+**ID**: `cpt-cf-binding-actor-module-developer`
+
+- **Role**: Defines base contract traits and transport projection traits for modules. Writes handler code that implements or consumes contracts.
+- **Needs**: A simple, type-safe mechanism to define contracts once and get remote bindings generated without writing HTTP client code, error mapping, or retry logic by hand.
+
+#### Plugin Developer
+
+**ID**: `cpt-cf-binding-actor-plugin-developer`
+
+- **Role**: Implements Backend or Extension contracts either as compile-time plugins or as standalone remote services.
+- **Needs**: Clear contract definitions with compile-time enforcement, generated OpenAPI specs as the conformance target for remote implementations.
+
+#### API Consumer
+
+**ID**: `cpt-cf-binding-actor-api-consumer`
+
+- **Role**: Calls module APIs exposed via transport projections.
+- **Needs**: Consistent error responses (Problem Details), discoverable endpoints (OpenAPI), and reliable retry semantics.
+
+### 2.2 System Actors
+
+#### CI Pipeline
+
+**ID**: `cpt-cf-binding-actor-ci-pipeline`
+
+- **Role**: Runs automated checks on every PR to detect signature drift, schema changes, and contract violations.
+
+#### Module Host Runtime
+
+**ID**: `cpt-cf-binding-actor-host-runtime`
+
+- **Role**: Executes the module lifecycle including plugin discovery, compile-time registration, proxy wiring, and post-init phases.
+
+#### Service Directory
+
+**ID**: `cpt-cf-binding-actor-service-directory`
+
+- **Role**: Resolves GTS IDs to client configurations and validates remote service compatibility via OpenAPI spec comparison.
+
+#### LLM Agent
+
+**ID**: `cpt-cf-binding-actor-llm-agent`
+
+- **Role**: Generates module code that defines or consumes contracts.
+- **Needs**: Discoverable naming conventions, finite contract vocabulary, compile-time safety.
+
+## 3. Operational Concept & Environment
+
+The contract-binding system operates within the standard CyberFabric ModKit runtime. Contracts are defined at compile time as Rust traits. Transport projections generate REST clients and OpenAPI specs via proc macros during compilation. At runtime, the module host executes a lifecycle with a dedicated proxy wiring phase that instantiates REST proxies for unsatisfied Backend traits using the service directory.
+
+The four contract types encode fundamentally different operational semantics that affect how callers write code:
+
+```
+                      Local contracts              Remote-capable contracts
+                      (Embedded / Extension)       (Api / Backend)
+----------------------------------------------------------------------
+Transaction scope     can participate in caller's   cannot participate (ACID)
+Failure domain        same as caller               independent
+Timeout / retry       not applicable               required
+Circuit breaker       not applicable               recommended
+Error mapping         Rust errors directly          Problem Details over wire
+Serialization         none (zero-copy)             JSON / protobuf
+Lifecycle             shared with host             independent process
+Settings              shared config                own config (url, timeout, retry)
+Dependencies          shared DI context            own connection / client
+```
+
+Collapsing to fewer contract types would force callers into unnecessary defensive code (timeout/retry for local calls) or mask critical operational differences (transactional participation for remote calls).
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Four contract types (Api, Embedded, Backend, Extension) with naming convention enforcement
+- Base trait definition as plain Rust traits with zero transport annotations
+- REST transport projection via `#[modkit_rest_contract]` proc macro
+- REST client code generation implementing both base and transport traits
+- OpenAPI 3.1 spec generation from transport projection traits
+- SSE streaming support via `#[streaming]` annotation
+- Retryable method support via `#[retryable]` annotation with exponential backoff
+- Error mapping via `#[derive(ContractError)]` generating RFC 9457 Problem Details with `error_code` and `error_domain`
+- Runtime support crate: `ProblemDetails` type, SSE parser, `ClientConfig`, `with_retry()` helper
+- Service directory trait definition (interface only, implementation out of scope)
+- OpenAPI spec validation at service registration time
+- ClientHub fallback resolution: compile-time registration priority, REST proxy fallback
+- Proxy wiring lifecycle phase in module host
+- Feature-gated REST client dependencies (`rest-client` feature flag)
+- `#[non_exhaustive]` on request/response structs for additive non-breaking changes
+- Default trait methods for new transport projection methods
+
+### 4.2 Out of Scope
+
+- gRPC transport projection (`#[modkit_grpc_contract]`) -- future work, same pattern
+- Service directory implementation -- delivered by cluster service discovery workstream
+- Transaction guard (TxGuard) compile-time mechanism -- open design question, separate ADR
+- Transaction context propagation for Embedded/Extension contracts -- separate ADR
+- Circuit breaker implementation -- future work
+- Remote backend unavailability / degraded-mode behavior -- future work
+- Compile-only and REST-only enforcement at build/boot time -- future work
+
+## 5. Functional Requirements
+
+### 5.1 Contract Types & Naming Convention
+
+#### Four Contract Types
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-four-contract-types`
+
+The system MUST support exactly four contract type suffixes: `Api`, `Embedded`, `Backend`, and `Extension`. Every contract trait name MUST end with one of these suffixes. The suffix determines the operational semantics of the contract.
+
+- **Rationale**: The four types encode fundamentally different caller obligations (transaction participation, failure domain, timeout/retry). The suffix makes these obligations readable from the trait name alone.
+- **Actors**: `cpt-cf-binding-actor-module-developer`, `cpt-cf-binding-actor-llm-agent`
+
+#### Naming Convention Matrix
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-naming-convention`
+
+The system MUST enforce the following naming convention:
+
+```
+              Local (in-process,           Remote-capable (boundary,
+               tx-aware, shared fate)       independent failure domain)
+              ----------------------       ---------------------------
+Offers        {Noun}Embedded               {Noun}Api
+Needs         {Noun}Extension              {Noun}Backend
+```
+
+Transport projections MUST append `Rest` or `Grpc` to the base name (e.g., `NotificationBackendRest`, `NotificationApiRest`).
+
+- **Rationale**: One glance at the trait name tells you the operational semantics -- no need to check other files or follow implicit conventions.
+- **Actors**: `cpt-cf-binding-actor-module-developer`, `cpt-cf-binding-actor-plugin-developer`
+
+#### Api Means Remote Always
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-api-remote-always`
+
+A trait with `Api` suffix MUST represent a remote-capable contract. There is no "local Api". If the module offers an in-process interface, it MUST use the `Embedded` suffix instead.
+
+- **Rationale**: Hard rule prevents ambiguity. When a caller sees `Api`, they know to write defensive code (timeout, retry, error mapping).
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+#### Embedded Means Local Always
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-embedded-local-always`
+
+A trait with `Embedded` suffix MUST represent an in-process contract. It MUST NOT have transport projections. The implementation shares the caller's failure domain and can participate in the caller's ACID transaction.
+
+- **Rationale**: Hard rule prevents accidental remote calls inside transaction scopes.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+#### Extension Means Local Always
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-extension-local-always`
+
+A trait with `Extension` suffix MUST represent an in-process contract. It MUST NOT have transport projections. The implementation shares the module's failure domain.
+
+- **Rationale**: Extensions are fast, deterministic, in-process plugins (request transforms, credential resolution, message formatting). No transport overhead.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+### 5.2 Base Trait (Layer 1)
+
+#### Base Trait as Plain Rust Trait
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-base-trait-plain`
+
+Base contract traits MUST be plain Rust traits with zero transport annotations, zero macros, and zero binding-mode concerns. They define the domain contract -- what the module needs or provides.
+
+- **Rationale**: Clean separation of domain logic from transport. Compile-time plugins implement the base trait directly. Consumers depend on `Arc<dyn Trait>`.
+- **Actors**: `cpt-cf-binding-actor-module-developer`, `cpt-cf-binding-actor-plugin-developer`
+
+#### Base Trait Send + Sync Bound
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-base-trait-send-sync`
+
+All base contract traits MUST have `Send + Sync` supertraits to support sharing across async tasks and thread-safe registration in ClientHub.
+
+- **Rationale**: Required for `Arc<dyn Trait>` usage in async contexts.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+### 5.3 Transport Projection (Layer 2)
+
+#### REST Transport Projection Macro
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-rest-macro`
+
+The `#[modkit_rest_contract]` proc macro SHALL generate a REST client struct and OpenAPI spec function from a trait that extends a base contract trait. When a trait annotated with `#[modkit_rest_contract]` extends a base trait (e.g., `trait FooApiRest: FooApi`), the macro SHALL generate a `FooApiRestClient` struct that implements both the base trait (with HTTP dispatch logic) and the transport trait.
+
+- **Rationale**: Eliminates hand-written HTTP client code, ensures generated clients conform to the contract.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+#### Compiler-Checked Signature Conformance
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-signature-check`
+
+Redeclared methods in the transport projection trait MUST be compile-time checked against the base trait signatures. If a transport projection redeclares a method with a different parameter type, return type, or error type than the base trait, the Rust compiler MUST reject the code with a type mismatch error.
+
+- **Rationale**: Prevents silent signature drift between the domain contract and its transport binding.
+- **Actors**: `cpt-cf-binding-actor-module-developer`, `cpt-cf-binding-actor-ci-pipeline`
+
+#### Missing Method Handling
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-missing-method`
+
+When a base trait has a method that is not redeclared in the transport projection, the macro SHALL either generate a default delegation or emit a compile error.
+
+- **Rationale**: Ensures complete coverage -- no base trait method silently lacks a transport binding.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+#### HTTP Method and Path Annotations
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-http-annotations`
+
+Transport projection methods MUST declare their HTTP method and path via annotations: `#[get(...)]`, `#[post(...)]`, `#[put(...)]`, `#[patch(...)]`, `#[delete(...)]`. The generated client SHALL dispatch to the configured base URL plus the declared path.
+
+- **Rationale**: HTTP routing is explicit in the trait, not in configuration or convention.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+#### Parameter Annotations
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-param-annotations`
+
+Transport projection methods MUST support parameter annotations: `#[path]`, `#[query]`, `#[header]`. Annotations are on the actual parameters with real types, not separate strings.
+
+- **Rationale**: Type-safe parameter binding prevents runtime mismatches between path templates and parameter types.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+#### Annotation Stripping
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-annotation-stripping`
+
+The macro MUST read transport annotations (`#[post(...)]`, `#[get(...)]`, `#[streaming]`, `#[retryable]`) for code generation and strip them from the emitted trait definition.
+
+- **Rationale**: Annotations are metadata for the macro, not part of the trait's Rust interface.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+#### REST-Only Methods via Default Implementations
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-rest-only-methods`
+
+The transport projection trait MAY add methods with default implementations that are not in the base trait (e.g., `deliver_batch` that delegates to `deliver` in a loop). These methods SHALL be available on the generated REST client. Compile-time plugins implementing only the base trait SHALL NOT be affected.
+
+- **Rationale**: Enables REST-specific convenience endpoints (batch, pagination) without polluting the domain contract.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+### 5.4 OpenAPI Generation
+
+#### OpenAPI 3.1 Spec Generation
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-openapi-generation`
+
+The `#[modkit_rest_contract]` macro SHALL generate a function (e.g., `foo_api_rest_openapi_spec()`) returning a `serde_json::Value` with a valid OpenAPI 3.1 spec. The spec SHALL include endpoint paths, HTTP methods, request/response schemas (via `schemars`), and error schemas.
+
+- **Rationale**: OpenAPI spec is the conformance target for remote implementations and enables spec validation at registration.
+- **Actors**: `cpt-cf-binding-actor-module-developer`, `cpt-cf-binding-actor-service-directory`
+
+#### OpenAPI Spec Validation at Registration
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-openapi-validation`
+
+The service directory SHALL validate remote service compatibility at registration time by fetching `/.well-known/openapi.json` from the service and checking that all required endpoints exist with correct HTTP methods and content types. Registration SHALL be rejected if validation fails, with a clear error listing missing endpoints.
+
+- **Rationale**: Prevents incompatible remote services from entering the cluster and causing runtime failures.
+- **Actors**: `cpt-cf-binding-actor-service-directory`
+
+#### Validation Report
+
+- [ ] `p2` - **ID**: `cpt-cf-binding-fr-validation-report`
+
+The service directory SHALL produce a detailed validation report listing each check (endpoint presence, HTTP method, content type) with pass/fail status and total checks passed.
+
+- **Rationale**: Enables operators to diagnose registration failures quickly.
+- **Actors**: `cpt-cf-binding-actor-service-directory`
+
+#### Optional Endpoint Handling
+
+- [ ] `p2` - **ID**: `cpt-cf-binding-fr-optional-endpoints`
+
+Endpoints marked as optional (description contains "MAY omit") SHALL NOT cause registration failure when absent from the remote service's OpenAPI spec.
+
+- **Rationale**: Allows progressive implementation of optional transport-only methods.
+- **Actors**: `cpt-cf-binding-actor-service-directory`
+
+### 5.5 Error Mapping
+
+#### ContractError Derive Macro
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-contract-error-derive`
+
+The `#[derive(ContractError)]` macro SHALL generate RFC 9457 Problem Details conversion from an annotated error enum. The error code SHALL be derived from the variant name in UPPER_SNAKE_CASE. The error domain SHALL be specified via `#[contract_error(domain = "...")]` attribute.
+
+- **Rationale**: Consistent, machine-readable error responses across all module boundaries without hand-written conversion code.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+#### Error Round-Trip Serialization
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-error-round-trip`
+
+A `ContractError` converted to Problem Details JSON via `to_problem_details()` and deserialized back via `from_problem_details()` MUST result in the same error variant with all structured context fields preserved.
+
+- **Rationale**: Enables reliable error reconstruction on the client side without lossy manual mapping.
+- **Actors**: `cpt-cf-binding-actor-api-consumer`
+
+#### Unknown Error Fallback
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-unknown-error-fallback`
+
+When `from_problem_details()` receives an `error_code` or `error_domain` that does not match any known variant, it SHALL return a fallback error variant (typically `Internal`) with the unknown code or domain in the description.
+
+- **Rationale**: Graceful degradation when the server adds new error variants that the client does not yet know about.
+- **Actors**: `cpt-cf-binding-actor-api-consumer`
+
+#### Variant HTTP Status and Problem Type
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-variant-annotations`
+
+Each error enum variant SHALL be annotated with HTTP status code and problem type URI suffix (e.g., `#[error(status = 404, problem_type = "not-found")]`). The macro SHALL generate `status_code()` and `problem_type()` methods from these annotations.
+
+- **Rationale**: HTTP status mapping is explicit in the error definition, not in framework middleware.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+#### Structured Context in Problem Details
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-structured-context`
+
+The `context` field in Problem Details SHALL carry the variant's associated data as a JSON object. Named fields SHALL be serialized to context, and `from_problem_details()` SHALL deserialize the context back into the variant's fields.
+
+- **Rationale**: Machine-readable error context enables programmatic error handling beyond status code matching.
+- **Actors**: `cpt-cf-binding-actor-api-consumer`
+
+### 5.6 SSE Streaming
+
+#### Streaming Method Generation
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-streaming`
+
+Methods annotated with `#[streaming]` in a transport projection SHALL generate SSE-aware REST client code. The generated client SHALL send `Accept: text/event-stream` header, parse server-sent events into a native Rust `Stream`, and the OpenAPI spec SHALL declare the endpoint with `text/event-stream` content type. SSE comment lines (`:keepalive`) SHALL be silently discarded.
+
+- **Rationale**: Streaming is a first-class transport concern for event-driven modules (chat, notifications, telemetry).
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+### 5.7 Retryable Methods
+
+#### Retryable Method Generation
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-retryable`
+
+Methods annotated with `#[retryable]` SHALL generate retry logic with exponential backoff. On transient HTTP failures (429, 502, 503, 504), the generated client SHALL retry. Retry policy (max retries, base delay, max delay) SHALL be configured via `ClientConfig`. Methods NOT annotated with `#[retryable]` SHALL return errors immediately without retrying.
+
+- **Rationale**: Retry semantics are a property of the method, not the caller. Declaring retryability at the contract level prevents inconsistent retry behavior across callers.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+### 5.8 Runtime Support
+
+#### ProblemDetails Type
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-problem-details-type`
+
+The runtime crate SHALL provide a `ProblemDetails` struct for RFC 9457 wire format with fields: `type`, `title`, `status`, `detail`, `error_code`, `error_domain`, `context` (when non-null), and `trace_id` (when present).
+
+- **Rationale**: Shared type for generated client error deserialization and server error serialization.
+- **Actors**: `cpt-cf-binding-actor-module-developer`, `cpt-cf-binding-actor-api-consumer`
+
+#### SSE Stream Parser
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-sse-parser`
+
+The runtime crate SHALL provide an SSE stream parser that converts a `reqwest` byte stream into typed deserialized events. The parser SHALL handle multi-line `data:` fields and silently discard comment lines.
+
+- **Rationale**: Shared parser for all generated streaming clients, avoiding per-client SSE implementation.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+#### ClientConfig
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-client-config`
+
+The runtime crate SHALL provide a `ClientConfig` carrying base URL, timeout, and retry policy (`RetryConfig`). Generated REST clients SHALL accept `ClientConfig` for construction (e.g., `FooApiRestClient::from_config(config)`).
+
+- **Rationale**: Uniform configuration for all generated clients. Service directory produces `ClientConfig`, clients consume it.
+- **Actors**: `cpt-cf-binding-actor-module-developer`, `cpt-cf-binding-actor-service-directory`
+
+#### Retry Helper
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-retry-helper`
+
+The runtime crate SHALL provide a `with_retry()` function implementing exponential backoff. It SHALL respect `max_retries` and `max_delay` from `RetryConfig`. Non-retryable errors SHALL fail immediately without waiting.
+
+- **Rationale**: Shared retry logic for generated clients and manual usage.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+#### REST Client Feature Gate
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-feature-gate`
+
+The generated REST client and its dependencies (`reqwest`, `schemars`) SHALL be behind a `rest-client` Cargo feature flag. Consumers depending on the SDK crate without the `rest-client` feature SHALL NOT compile HTTP dependencies.
+
+- **Rationale**: Compile-time-only consumers should not pay for HTTP dependencies they do not use.
+- **Actors**: `cpt-cf-binding-actor-module-developer`, `cpt-cf-binding-actor-plugin-developer`
+
+### 5.9 ClientHub Fallback & Proxy Wiring
+
+#### ClientHub Fallback Resolution
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-clienthub-fallback`
+
+ClientHub SHALL support fallback resolution: compile-time registration takes priority. When no compile-time plugin exists for a Backend trait, the platform SHALL instantiate the generated REST client using the service directory's `ClientConfig` and register it as `Arc<dyn Trait>` in ClientHub.
+
+- **Rationale**: Seamless transition from compile-time to remote binding without consumer code changes.
+- **Actors**: `cpt-cf-binding-actor-host-runtime`
+
+#### Missing Required Backend Fails Startup
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-missing-backend-fail`
+
+When no compile-time plugin AND no service directory entry exist for a required Backend trait, the platform SHALL fail startup with a clear error naming the unsatisfied trait.
+
+- **Rationale**: Fail-fast prevents runtime surprises from unsatisfied dependencies.
+- **Actors**: `cpt-cf-binding-actor-host-runtime`
+
+#### Proxy Wiring Lifecycle Phase
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-proxy-wiring-phase`
+
+The module host runtime SHALL include a proxy wiring phase in the lifecycle: plugin discovery (inventory) -> compile-time registrations (init) -> proxy wiring -> post-init. Proxy wiring SHALL only instantiate REST proxies for traits with no compile-time registration.
+
+- **Rationale**: Deterministic lifecycle ordering ensures compile-time plugins always take precedence.
+- **Actors**: `cpt-cf-binding-actor-host-runtime`
+
+#### Binding-Mode-Agnostic Consumer Code
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-binding-agnostic`
+
+Consumers of a contract trait SHALL interact with it identically via `hub.get::<dyn Trait>()` regardless of whether the underlying implementation is compile-time or REST-based. The consumer SHALL NOT need to handle or be aware of the binding mode.
+
+- **Rationale**: Decouples consumer code from deployment topology decisions.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+### 5.10 Service Directory Contract
+
+#### Service Directory Trait
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-directory-trait`
+
+The system SHALL define a trait for service directory resolution. Given a GTS ID (or prefix), the directory SHALL return a `ClientConfig` if a matching service is registered, or `None` otherwise. Implementation is out of scope -- delivered by cluster service discovery.
+
+- **Rationale**: The binding system needs a well-defined interface to the directory without coupling to its implementation.
+- **Actors**: `cpt-cf-binding-actor-service-directory`, `cpt-cf-binding-actor-host-runtime`
+
+### 5.11 Versioning & Non-Exhaustive Types
+
+#### Non-Exhaustive Request/Response Types
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-non-exhaustive`
+
+All request and response structs used in contracts MUST be annotated with `#[non_exhaustive]`. Additive field changes are non-breaking. Breaking changes require a new major version.
+
+- **Rationale**: Prevents downstream compile failures when new fields are added to shared types.
+- **Actors**: `cpt-cf-binding-actor-module-developer`, `cpt-cf-binding-actor-plugin-developer`
+
+#### Default Methods for New Transport Methods
+
+- [ ] `p1` - **ID**: `cpt-cf-binding-fr-default-methods`
+
+New methods added to transport projection traits MUST have default implementations. Existing plugins that implement only the base trait SHALL compile unchanged.
+
+- **Rationale**: Additive transport methods must not break existing in-process plugins.
+- **Actors**: `cpt-cf-binding-actor-module-developer`
+
+## 6. Non-Functional Requirements
+
+### 6.1 Module-Specific NFRs
+
+#### Macro Expansion Transparency
+
+- [ ] `p2` - **ID**: `cpt-cf-binding-nfr-macro-transparency`
+
+The generated code from `#[modkit_rest_contract]` MUST be inspectable via `cargo expand`. Generated struct names, method names, and trait implementations MUST follow predictable naming conventions (e.g., `{Trait}Client` for the client struct).
+
+- **Rationale**: Developers and LLM agents must be able to understand and debug generated code.
+
+#### Feature-Gated Compile Time
+
+- [ ] `p2` - **ID**: `cpt-cf-binding-nfr-compile-time`
+
+SDK crates with the `rest-client` feature disabled MUST NOT incur additional compile time from HTTP-related dependencies (`reqwest`, `schemars`, `openapiv3`).
+
+- **Rationale**: Compile-time-only consumers should have the same build performance as before the binding system is introduced.
+
+## 7. Constraints & Assumptions
+
+### 7.1 Constraints
+
+- The system is built on CyberFabric's ModKit framework and uses its ClientHub, inventory-based plugin discovery, and module lifecycle.
+- REST is the first transport. gRPC is a future transport following the same two-layer pattern.
+- The service directory implementation is delivered by a separate workstream. This change defines only the interface trait.
+- Alignment with ADR-0004 (PR #1380) module/plugin declaration macros is required.
+
+### 7.2 Assumptions
+
+- Module developers adopt the four-suffix naming convention for all new contract traits.
+- Remote services expose `/.well-known/openapi.json` for spec validation.
+- `schemars` can derive JSON schemas for all request/response types used in contracts.
+- The module host runtime supports adding new lifecycle phases (proxy wiring) without breaking existing modules.
+
+### 7.3 Open Design Questions
+
+- **Transaction guard (TxGuard)**: A compile-time mechanism that restricts which contracts can be called inside a transaction scope. Within a `TxGuard<'tx>`, only Embedded/Extension contracts would be callable -- the compiler would reject calls to Api/Backend traits. This would enforce the operational semantics table at the type level, not just by naming convention. Needs its own ADR to design the type-state mechanism and interaction with database transactions (SeaORM/SQLx). Not a requirement for this change.
+- **Remote backend unavailability**: Circuit breakers, fallback methods, degraded-mode behavior when remote plugins are temporarily down.
+- **gRPC transport projection**: `#[modkit_grpc_contract]` macro design, proto generation approach, interaction with tonic.
+- **Transaction context propagation**: How Embedded/Extension contracts receive and participate in the caller's transaction scope.
+
+## 8. Prior Art
+
+| Reference | Relevance |
+|-----------|-----------|
+| Working PoC: [striped-zebra-dev/modkit-binding-poc](https://github.com/striped-zebra-dev/modkit-binding-poc) | Validated the two-layer approach, transport projection generation, and ClientHub fallback resolution |
+| Module/plugin declaration and resolution: [PR #1380](https://github.com/cyberfabric/cyberfabric-core/pull/1380) | Typed module/plugin resolution -- the binding system complements this |
+| WCF (Windows Communication Foundation) | Two-layer contract/binding model: service contract (interface) + binding (transport). Similar separation of domain interface from transport projection |
+| OSGi Remote Services | Service interfaces published locally, discovered and proxied remotely via generated stubs. Similar compile-time-first with remote fallback pattern |
+| Hexagonal Architecture (Ports and Adapters) | Contracts as ports, transport projections as adapters. The base trait is the port; the REST projection is an adapter |
+
+## 9. Traceability
+
+- **PRD** (this document): [`./PRD.md`](./PRD.md)
+- **Design**: [`./DESIGN.md`](./DESIGN.md)
+- **ADR-0001** — contract source of truth: [`./ADR/0001-cpt-cf-binding-adr-contract-source-of-truth.md`](./ADR/0001-cpt-cf-binding-adr-contract-source-of-truth.md)
+- **ADR-0002** — OpenAPI spec limits: [`./ADR/0002-cpt-cf-binding-adr-openapi-spec-limits.md`](./ADR/0002-cpt-cf-binding-adr-openapi-spec-limits.md)
+- **PoC**: [striped-zebra-dev/modkit-binding-poc](https://github.com/striped-zebra-dev/modkit-binding-poc)


### PR DESCRIPTION
## Summary

Introduces the design for a **two-layer contract-binding system** that lets ModKit module traits be bound either in-process (compile-time, zero-cost) or across a boundary (REST today, gRPC later), with OpenAPI as the language-neutral contract.

This PR contains design documents only — no runtime code. A validated PoC lives at [`striped-zebra-dev/modkit-binding-poc`](https://github.com/striped-zebra-dev/modkit-binding-poc).

## What's in this PR

- **PRD** (`docs/arch/modkit-contract-binding/PRD.md`) — purpose, actors, scope, 30+ functional requirements, glossary with four contract types
- **DESIGN** (`docs/arch/modkit-contract-binding/DESIGN.md`) — two-layer trait architecture, operational semantics, key decisions D1–D6, constraints, observability hooks, open questions (TxGuard, versioning)
- **ADR-0001** — contract source of truth (Rust trait + macro generation + manual escape hatch vs manual-only vs OpenAPI-first vs IDL-first)
- **ADR-0002** — OpenAPI spec generation limits and what falls back to hand-written clients

## Key design decisions

- **Four contract types** encoded in trait name suffix: `Api`, `Embedded`, `Backend`, `Extension`. The name carries operational semantics (failure domain, transaction scope, timeout requirements).
- **Base trait is domain-only** (plain Rust, zero annotations). Transport projections (`{Base}Rest`, `{Base}Grpc`) extend the base and carry transport-specific annotations.
- **Macro-generated client** for the common case; hand-written clients supported as first-class escape hatch for anything the macro does not express.
- **Compile-time signature enforcement** via witness functions generated by the macro (supertrait bound alone is not enough).
- **\`SecurityContext\` is mandatory** as the first argument on all remote-capable contract methods.
- **\`async_trait\`** committed to as the async-in-trait strategy (dyn-compatibility is load-bearing).

## Informed by

- Working PoC at [`striped-zebra-dev/modkit-binding-poc`](https://github.com/striped-zebra-dev/modkit-binding-poc) — both binding modes demonstrated end-to-end, 5 mocking test cases
- Independent architect review (hardening captured in commit history)
- Research on REST+gRPC unification failures (evidence report bundled with the PoC)

## Out of scope for this PR

- Runtime implementation (\`cf-modkit-contract-macros\`, \`cf-modkit-contract-runtime\` crates)
- gRPC transport projection (future, same two-layer pattern)
- Service directory implementation (delivered by cluster service discovery work)
- Integration with ClientHub, GTS, and ADR-0004 module/plugin declaration

## Alignment

Complementary to ADR-0004 (#1380) — typed module/plugin references compose with the four-type contract binding model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural documentation for the ModKit contract-binding system, including design specifications and architecture decision records covering contract types, trait interfaces, REST integration, and error handling standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->