### PR TITLE
chore(deps): reduce feature footprint and remove duplicate crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
  "aliri_braid",
  "aliri_clock",
  "async-trait",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "thiserror 1.0.69",
  "tokio",
@@ -198,17 +198,6 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
-name = "annotate-snippets"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
-dependencies = [
- "anstyle",
- "memchr",
- "unicode-width",
-]
 
 [[package]]
 name = "anstream"
@@ -482,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -494,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -522,7 +511,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "multer",
@@ -826,18 +815,7 @@ checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor 2.5.1",
-]
-
-[[package]]
-name = "brotli"
-version = "8.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor 5.0.0",
+ "brotli-decompressor",
 ]
 
 [[package]]
@@ -845,16 +823,6 @@ name = "brotli-decompressor"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1098,7 +1066,7 @@ dependencies = [
  "http",
  "http-body",
  "inventory",
- "matchit 0.9.2",
+ "matchit",
  "nanoid",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1394,7 +1362,7 @@ dependencies = [
  "schemars 1.2.1",
  "sea-orm-migration",
  "serde",
- "serde-saphyr 0.0.16",
+ "serde-saphyr",
  "serde_json",
  "supports-color",
  "temp-env",
@@ -1416,7 +1384,7 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "uuid",
- "zip 2.4.2",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -1493,7 +1461,7 @@ dependencies = [
  "sea-orm",
  "sea-orm-migration",
  "serde",
- "serde-saphyr 0.0.16",
+ "serde-saphyr",
  "serde_json",
  "sqlx",
  "temp-env",
@@ -1988,7 +1956,7 @@ dependencies = [
  "cf-types-registry-sdk",
  "inventory",
  "serde",
- "serde-saphyr 0.0.16",
+ "serde-saphyr",
  "serde_json",
  "tokio",
  "tracing",
@@ -2221,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2243,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2304,7 +2272,6 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
- "brotli 8.0.2",
  "compression-core",
  "flate2",
  "memchr",
@@ -3053,12 +3020,12 @@ dependencies = [
 
 [[package]]
 name = "ferroid"
-version = "0.8.9"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
 dependencies = [
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.10.1",
  "web-time",
 ]
 
@@ -3435,7 +3402,7 @@ dependencies = [
  "jsonschema",
  "schemars 1.2.1",
  "serde",
- "serde-saphyr 0.0.10",
+ "serde-saphyr",
  "serde_json",
  "shellexpand",
  "thiserror 2.0.18",
@@ -3486,7 +3453,7 @@ dependencies = [
  "gts",
  "regex",
  "serde",
- "serde-saphyr 0.0.10",
+ "serde-saphyr",
  "serde_json",
  "walkdir",
 ]
@@ -3826,7 +3793,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3910,7 +3877,7 @@ dependencies = [
  "clap",
  "mimalloc",
  "rustls",
- "serde-saphyr 0.0.16",
+ "serde-saphyr",
  "serde_json",
  "tempfile",
  "tokio",
@@ -4663,12 +4630,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "matchit"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4783,7 +4744,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4953,7 +4914,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec 1.15.1",
  "zeroize",
 ]
@@ -5532,7 +5493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5598,7 +5559,7 @@ dependencies = [
  "pingora-http",
  "pingora-lru",
  "pingora-timeout",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "rmp",
  "rmp-serde",
@@ -5615,7 +5576,7 @@ checksum = "08973c4853cef4c682f7a592907e81a32dcad69476c4846e5de079f16448b177"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
- "brotli 3.5.0",
+ "brotli",
  "bstr",
  "bytes",
  "chrono",
@@ -5644,7 +5605,7 @@ dependencies = [
  "pingora-rustls",
  "pingora-timeout",
  "prometheus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "serde",
  "serde_yaml",
@@ -5721,7 +5682,7 @@ dependencies = [
  "pingora-http",
  "pingora-ketama",
  "pingora-runtime",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -5734,7 +5695,7 @@ dependencies = [
  "arrayvec",
  "hashbrown 0.17.0",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5786,7 +5747,7 @@ dependencies = [
  "pingora-core",
  "pingora-error",
  "pingora-http",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "tokio",
 ]
@@ -5798,7 +5759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e371315b1c44c2e5a8788fdc61577527b785e121e6ff49144755f40d86511430"
 dependencies = [
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thread_local",
  "tokio",
 ]
@@ -5919,9 +5880,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -6176,9 +6137,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoi"
@@ -6249,9 +6210,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6639,7 +6600,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -6789,17 +6750,6 @@ checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
 dependencies = [
  "arraydeque",
  "hashlink",
-]
-
-[[package]]
-name = "saphyr-parser-bw"
-version = "0.0.605"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1aee7486406df3541b5a657204a11be97175a467d77bc98e6d94a66289fb80"
-dependencies = [
- "arraydeque",
- "smallvec 2.0.0-alpha.12",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7107,26 +7057,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-saphyr"
-version = "0.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
-dependencies = [
- "ahash 0.8.12",
- "annotate-snippets",
- "base64 0.22.1",
- "encoding_rs_io",
- "nohash-hasher",
- "num-traits",
- "regex",
- "saphyr-parser-bw",
- "serde",
- "serde_json",
- "smallvec 2.0.0-alpha.12",
- "zmij",
-]
-
-[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7173,7 +7103,6 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -7577,7 +7506,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "rust_decimal",
  "serde",
@@ -7619,7 +7548,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -7885,9 +7814,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd36b06a2a6c0c3c81a83be1ab05fe86460d054d4d51bf513bc56b3e15bdc22"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",
@@ -8078,9 +8007,9 @@ checksum = "b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -8866,9 +8795,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -9076,14 +9005,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,7 +252,7 @@ grpc_hub = { package = "cf-grpc-hub", version = "0.1.19", path = "modules/system
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde-saphyr = "0.0.16"
+serde-saphyr = "0.0.10"
 secrecy = { version = "0.10", features = ["serde"] }
 serde_urlencoded = "0.7"
 schemars = { version = "1.2", features = ["derive", "uuid1"] }
@@ -262,7 +262,18 @@ anyhow = "1.0"
 thiserror = "2.0"
 
 # Async runtime
-tokio = { version = "1.47", features = ["full"] }
+tokio = { version = "1.47", features = [
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+    "macros",
+    "io-util",
+    "fs",
+    "signal",
+    "process",
+    "net",
+] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tokio-stream = { version = "0.1", features = ["sync", "net"] }
 futures = "0.3"
@@ -275,7 +286,9 @@ arc-swap = "1.7"
 
 # Security
 zeroize = { version = "1", features = ["derive"] }
-aliri_tokens = { version = "0.3", default-features = false, features = ["rand"] }
+aliri_tokens = { version = "0.3", default-features = false, features = [
+    "rand",
+] }
 aliri_clock = "0.1"
 
 # Logging
@@ -292,7 +305,11 @@ tracing-error = "0.2"
 tracing-appender = "0.2"
 tracing-test = "0.2"
 opentelemetry = { version = "0.31", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.31", features = ["trace", "rt-tokio", "metrics"] }
+opentelemetry_sdk = { version = "0.31", features = [
+    "trace",
+    "rt-tokio",
+    "metrics",
+] }
 opentelemetry-otlp = { version = "0.31", features = [
     "grpc-tonic",
     "http-proto",
@@ -309,7 +326,6 @@ tower-http = { version = "0.6", features = [
     "util",
     "timeout",
     "decompression-gzip",
-    "decompression-br",
     "decompression-deflate",
     "follow-redirect",
     "catch-panic",
@@ -336,16 +352,23 @@ hyper-rustls = { version = "0.27", default-features = false, features = [
     "native-tokio",
     "webpki-tokio",
 ] }
-rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "std", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = [
+    "aws_lc_rs",
+    "std",
+    "tls12",
+] }
 rustls-native-certs = "0.8"
 rustls-pki-types = "1"
-tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
-rcgen = { version = "0.13", default-features = false, features = ["aws_lc_rs", "pem"] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "aws-lc-rs",
+] }
+rcgen = { version = "0.13", default-features = false, features = [
+    "aws_lc_rs",
+    "pem",
+] }
 http-body-util = "0.1"
 http-body = "1"
 
-# HTTP client (default-tls = rustls + aws-lc-rs in 0.13)
-reqwest = { version = "0.13", features = ["stream"] }
 rand = "0.9"
 
 # Synchronous locks for better performance
@@ -378,7 +401,10 @@ sea-orm-migration = { version = "1.1", default-features = false, features = [
 # sqlx: TLS via aws-lc-rs; runtime-tokio for async.  This is the sole TLS entry
 # point for the DB stack -- sea-orm/sea-orm-migration intentionally use runtime-tokio
 # (not runtime-tokio-rustls) to avoid pulling in ring.
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "tls-rustls-aws-lc-rs"] }
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio",
+    "tls-rustls-aws-lc-rs",
+] }
 
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
@@ -429,7 +455,10 @@ sha2 = "0.10"
 hex = "0.4"
 
 # JWT and authentication
-jsonwebtoken = { version = "10.3", default-features = false, features = ["aws_lc_rs", "use_pem"] }
+jsonwebtoken = { version = "10.3", default-features = false, features = [
+    "aws_lc_rs",
+    "use_pem",
+] }
 
 # Configuration management
 figment = { version = "0.10", features = ["yaml", "env"] }
@@ -456,7 +485,12 @@ nvml-wrapper = "0.11"
 psl = "2"
 
 # Image processing (thumbnail generation)
-image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
+image = { version = "0.25", default-features = false, features = [
+    "jpeg",
+    "png",
+    "gif",
+    "webp",
+] }
 
 # Text processing
 base64 = "0.22"
@@ -484,8 +518,14 @@ proc-macro-error2 = "2.0"
 # Testing utilities
 trybuild = "1"
 criterion = { version = "0.5", default-features = false }
-testcontainers = { version = "0.27", default-features = false, features = ["aws-lc-rs"] }
-testcontainers-modules = { version = "0.15", default-features = false, features = ["aws-lc-rs", "postgres", "mysql"] }
+testcontainers = { version = "0.27", default-features = false, features = [
+    "aws-lc-rs",
+] }
+testcontainers-modules = { version = "0.15", default-features = false, features = [
+    "aws-lc-rs",
+    "postgres",
+    "mysql",
+] }
 httpmock = "0.8"
 flate2 = "1"
 
@@ -497,12 +537,13 @@ pin-project-lite = "0.2"
 # HTTP types and web utilities
 http = "1.3"
 httpdate = "1"
-matchit = "0.9"
+matchit = "=0.8.4"
 
 # Document and file handling
 rust-embed = "8"
 bytes = "1.11"
 mime = "0.3"
+multer = "3.1"
 
 # Document parsing libraries
 tl = "0.7"

--- a/libs/modkit-http/Cargo.toml
+++ b/libs/modkit-http/Cargo.toml
@@ -48,7 +48,7 @@ pin-project-lite = { workspace = true }
 
 # Tower middleware
 tower = { workspace = true, features = ["timeout", "limit", "util", "load-shed", "buffer"] }
-tower-http = { workspace = true, features = ["decompression-gzip", "decompression-br", "decompression-deflate", "follow-redirect"] }
+tower-http = { workspace = true, features = ["decompression-gzip", "decompression-deflate", "follow-redirect"] }
 
 # HTTP client helpers
 serde_urlencoded = { workspace = true }

--- a/libs/modkit-http/README.md
+++ b/libs/modkit-http/README.md
@@ -11,7 +11,7 @@ HTTP client library for ModKit, built on hyper and tower.
 - User-Agent header injection
 - Concurrency limiting with fail-fast load shedding
 - Response body size limits (applied after decompression)
-- **Transparent response decompression** (gzip, brotli, deflate)
+- **Transparent response decompression** (gzip, deflate)
 - **Secure redirect following** with SSRF protection and credential leakage prevention
 
 ## What it does NOT do
@@ -71,7 +71,7 @@ let token: TokenResponse = client
 
 The client automatically handles compressed responses:
 
-- **Sends `Accept-Encoding: gzip, br, deflate`** on all requests
+- **Sends `Accept-Encoding: gzip, deflate`** on all requests
 - **Decompresses response bodies** based on `Content-Encoding` header
 - **Body size limit applies to decompressed bytes**, protecting against "zip bombs"
 

--- a/libs/modkit-http/src/client.rs
+++ b/libs/modkit-http/src/client.rs
@@ -1302,7 +1302,7 @@ mod tests {
 
     /// Test that Accept-Encoding header is automatically set by the client.
     ///
-    /// The `DecompressionLayer` automatically adds `Accept-Encoding: gzip, br, deflate`
+    /// The `DecompressionLayer` automatically adds `Accept-Encoding: gzip, deflate`
     /// to outgoing requests.
     #[tokio::test]
     async fn test_accept_encoding_header_sent() {

--- a/libs/modkit-http/src/lib.rs
+++ b/libs/modkit-http/src/lib.rs
@@ -10,13 +10,13 @@
 //! - Automatic retries with exponential backoff
 //! - User-Agent header injection
 //! - Concurrency limiting
-//! - **Transparent response decompression** (gzip, brotli, deflate)
+//! - **Transparent response decompression** (gzip, deflate)
 //! - Optional OpenTelemetry tracing (feature-gated)
 //!
 //! # Transparent Decompression
 //!
 //! The client automatically:
-//! - Sends `Accept-Encoding: gzip, br, deflate` header on all requests
+//! - Sends `Accept-Encoding: gzip, deflate` header on all requests
 //! - Decompresses response bodies based on `Content-Encoding` header
 //! - Applies body size limits to **decompressed** bytes (protecting against zip bombs)
 //!

--- a/libs/modkit-http/src/response.rs
+++ b/libs/modkit-http/src/response.rs
@@ -48,7 +48,7 @@ fn parse_http_date(value: &str) -> Option<Duration> {
 
 /// Type alias for the boxed response body that supports decompression.
 ///
-/// This type can hold either a raw body or a decompressed body (gzip/br/deflate).
+/// This type can hold either a raw body or a decompressed body (gzip/deflate).
 /// The body is type-erased to allow the decompression layer to work transparently.
 pub type ResponseBody =
     http_body_util::combinators::BoxBody<Bytes, Box<dyn std::error::Error + Send + Sync>>;

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -96,7 +96,7 @@ schemars = { workspace = true, features = ["derive"] }
 # GTS support
 gts = { workspace = true }
 gts-macros = { workspace = true }
-zip = { version = "2.3", default-features = false, features = ["deflate"] }
+zip = { version = "4", default-features = false, features = ["deflate"] }
 
 # Performance / lock-free structures
 parking_lot = { workspace = true }
@@ -125,7 +125,7 @@ tonic = { workspace = true, optional = true }
 nix = { version = "0.29", default-features = false, features = ["signal"] }
 
 [build-dependencies]
-zip = { version = "2.3", default-features = false, features = ["deflate"] }
+zip = { version = "4", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tower = { workspace = true }

--- a/modules/mini-chat/mini-chat/Cargo.toml
+++ b/modules/mini-chat/mini-chat/Cargo.toml
@@ -51,7 +51,7 @@ pin-project-lite = { workspace = true }
 futures = { workspace = true }
 bytes = { workspace = true }
 regex = { workspace = true }
-multer = "3.1"
+multer = { workspace = true }
 
 # Encoding
 base64 = { workspace = true }
@@ -86,7 +86,7 @@ opentelemetry = { workspace = true }
 
 # Local dependencies
 modkit = { workspace = true }
-modkit-db = { workspace = true, features = ["sqlite", "pg", "preview-outbox"] }
+modkit-db = { workspace = true, features = ["pg", "preview-outbox"] }
 modkit-db-macros = { workspace = true }
 modkit-security = { workspace = true }
 modkit-macros = { workspace = true }
@@ -102,5 +102,6 @@ k8s-openapi = { workspace = true, features = ["latest"], optional = true }
 chrono = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 temp-env = { workspace = true }
+modkit-db = { workspace = true, features = ["sqlite"] }
 
 


### PR DESCRIPTION
- tokio: drop unused `io-std` and `test-util` features from workspace
- mini-chat: move modkit-db sqlite feature to dev-dependencies only
- multer: consolidate to workspace version
- serde-saphyr: downgrade 0.0.16→0.0.10 to unify with gts requirement
- matchit: pin =0.8.4 to match axum's exact requirement
- zip: upgrade 2.3→4 in modkit, use `deflate` feature to match calamine/docx-rust
- tower-http: drop decompression-br, removing brotli v8 dep chain
- Remove dead reqwest workspace entry (no consumer)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted several dependency versions and reformatted dependency declarations across the project.
* **Documentation**
  * Removed Brotli from decompression docs; client now advertises Accept-Encoding: gzip, deflate.
* **New Features**
  * Added multipart upload support via a new dependency to improve file upload handling in the mini-chat module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->