### PR TITLE
feat(tenant-resolver): adopt single-root tree topology

### DIFF
--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -123,15 +123,16 @@ modules:
       vendor: "hyperspot"
       priority: 20
       tenants:
-        # Root tenant used by oagw + credstore e2e tests
+        # Root tenant used by oagw + credstore e2e tests. The tenant tree has
+        # exactly one root; the hierarchy sub-root below hangs off this anchor.
         - id: "00000000-df51-5b42-9538-d2b56b7ee953"
           name: "e2e-root"
           parent_id: null
           status: active
-        # Hierarchy tenants
+        # Hierarchy sub-root
         - id: "00000000-0000-0000-0000-000000000001"
           name: "hierarchy-root"
-          parent_id: null
+          parent_id: "00000000-df51-5b42-9538-d2b56b7ee953"
           status: active
         - id: "00000000-0000-0000-0000-000000000002"
           name: "hierarchy-l1a"

--- a/config/quickstart.yaml
+++ b/config/quickstart.yaml
@@ -248,16 +248,18 @@ modules:
       priority: 20
       # Tenant tree configuration (example: company with 2 divisions, each with departments)
       tenants:
-        # Default tenant for auth-disabled mode (must match DEFAULT_TENANT_ID in modkit-security)
+        # Root tenant — structural anchor, also used by auth-disabled mode
+        # (must match DEFAULT_TENANT_ID in modkit-security). The tenant tree
+        # has exactly one root.
         - id: "00000000-df51-5b42-9538-d2b56b7ee953"
           name: "default"
           parent_id: null
           status: active
 
-        # Root tenant (company level)
+        # Business sub-root (company level) under the structural root
         - id: "00000000-0000-0000-0000-000000000001"
           name: "company-root"
-          parent_id: null
+          parent_id: "00000000-df51-5b42-9538-d2b56b7ee953"
           status: active
 
         # Division 1: Engineering

--- a/docs/arch/authorization/ADR/0004-single-root-tenant-model-topology.md
+++ b/docs/arch/authorization/ADR/0004-single-root-tenant-model-topology.md
@@ -1,0 +1,115 @@
+---
+status: accepted
+date: 2026-04-17
+decision-makers: Cyber Fabric Architects Committee
+---
+
+# Adopt Single-Root Tree Topology for the Tenant Model
+
+## Context and Problem Statement
+
+Cyber Fabric models its tenants hierarchically. Modules rely on that hierarchy for ownership scoping, subtree queries in the Secure ORM, barrier enforcement, and resolution of "act as" semantics in service-to-service (S2S) flows. Before committing to a particular shape we must choose the canonical topology and record the reasoning.
+
+Three shapes were considered:
+
+1. **Single-root tree** — Every tenant descends from exactly one shared root; the root is the only tenant with `parent_id = NULL`.
+2. **Multi-root forest** — Several independent trees coexist; each tree has its own root tenant with `parent_id = NULL`.
+3. **DAG** — A tenant may have more than one parent, expressing shared ownership across sub-trees.
+
+The choice affects several concrete engineering concerns:
+
+- **S2S tenant-scoped OAuth credentials.** Some services do not expose tenant-less objects — every object they manage has a tenant owner — yet they still need to perform calls under the top-level tenant while obeying the standard tenant-scoped authorization machinery. Such calls are authenticated via an OAuth client registered at the vendor's IdP. The number of roots determines the number of OAuth clients that must be provisioned and routed between. (Operations on tenant-less objects use a different flow and are outside the scope of this decision.)
+- **Deployment shape.** The platform must work both for multi-tenant vendor deployments and for single-user consumer products built on Cyber Fabric. The same tenant topology must be interpretable in both.
+- **Reasoning and tooling cost.** Closure tables, barriers, and `get_ancestors` / `get_descendants` semantics are substantially simpler for a tree than for a DAG.
+
+## Decision Drivers
+
+- **S2S tenant-scoped OAuth client management** — Minimize the number of OAuth clients required at the vendor IdP for flows that need to act as the top-level tenant.
+- **Unambiguous "act as root" semantics** — There must be exactly one tenant the platform can address as "the root".
+- **Operator mental model** — The topology should be easy to reason about for both platform operators and module authors.
+- **Avoid DAG complexity** — Closure-table maintenance, conflicting barriers, and ancestry queries on a DAG add substantial complexity without a concrete use case demanding them today.
+- **Autonomy of business sub-trees** — Multi-tenant deployments must be able to host independent organizations with strong isolation.
+- **Support consumer / single-user deployments** — Products built on Cyber Fabric for a single end user must not be forced to invent an artificial second tenant just to satisfy topology rules.
+
+## Considered Options
+
+- **Option A**: Single-root tree (one shared root, every other tenant has a parent)
+- **Option B**: Multi-root forest (several independent trees, each with its own root)
+- **Option C**: DAG (a tenant may have multiple parents)
+
+## Decision Outcome
+
+Chosen option: **Option A — Single-root tree**, because it gives us a single canonical "act as root" identity for S2S tenant-scoped flows, keeps closure-table and barrier reasoning tree-shaped, and cleanly covers both multi-tenant and single-user deployment shapes without requiring a dedicated "system root" field on the tenant record.
+
+**Interpretation by deployment shape:**
+
+- **Multi-tenant deployment.** Independent organizations are modelled as *sub-roots* directly under the root. The root itself holds no business objects; it acts as a structural anchor.
+- **Single-user / consumer deployment of a Cyber-Fabric-based product.** The root *is* the tenant that owns all business objects. No sub-roots are created.
+
+Both shapes satisfy the same topology invariant: the hierarchy has exactly one tenant with `parent_id = NULL`. What differs is whether business objects live on the root or only below it.
+
+**Root identification is by convention only.** The root is the unique tenant with `parent_id = NULL`. No `is_system` / `is_root` flag and no reserved `tenant_type` value are introduced. The root is not referred to as a "system tenant".
+
+### Consequences
+
+**Good:**
+
+- **One OAuth client is sufficient** for S2S tenant-scoped flows that need to act as the root — no per-root credential fan-out.
+- **Unambiguous root** — `get_root_tenant(ctx)` is a well-defined operation with exactly one answer.
+- **Tree-shaped reasoning** — Closure-table rows, barriers, `get_ancestors`, and `get_descendants` are all defined on a tree, which keeps their semantics simple and local.
+- **Deployment-neutral** — The same topology supports multi-tenant vendor deployments and single-user consumer deployments.
+- **Minimal schema surface** — `parent_id: UUID?` suffices to express the hierarchy; the invariant "exactly one tenant has `NULL` parent" is enforced at the plugin layer rather than via extra columns or flags.
+
+**Bad:**
+
+- **No native shared-ownership expression.** A tenant cannot belong to two sub-trees simultaneously. Cross-tree sharing must be modelled via explicit resource-group / policy mechanics, not via tenant parentage.
+
+## Pros and Cons of the Options
+
+### Option A: Single-Root Tree (CHOSEN)
+
+One shared root; every other tenant has exactly one parent.
+
+- Good, because **one OAuth client covers root-level S2S tenant-scoped flows** — no fan-out at the IdP.
+- Good, because **root identity is unambiguous** — platform-level tenant-scoped operations always address the same tenant.
+- Good, because **tree reasoning is simple** — closure-table rows, barrier semantics, and ancestry queries are straightforward.
+- Good, because **the same topology serves both multi-tenant and consumer deployments** without special-casing.
+- Good, because **minimal schema surface** — `parent_id: Option<TenantId>` on the tenant record is enough; no `is_root` / `is_system` flag or reserved `tenant_type` value is needed.
+- Bad, because **the invariant must be enforced at plugin load time** — zero-root and multi-root configurations must be rejected.
+
+### Option B: Multi-Root Forest
+
+Several independent trees coexist; each has its own root.
+
+- Good, because supports multiple vendors/organizations as first-class independent trees with no shared anchor.
+- Good, because each tree can in principle carry its own policies and configurations — though in practice barriers already give us this under a single root.
+- Bad, because **requires one OAuth client per root** for S2S tenant-scoped flows that need to act as a top-level tenant — and a mechanism to decide which root a given flow should use.
+- Bad, because **"the root" is ambiguous** for platform-level tenant-scoped operations — the caller must know and choose a root.
+- Bad, because **no expressive power gained over single-root** — everything a forest can model, a tree with sub-roots can also model (and the forest is simply the sub-tree of a conceptual parent).
+
+### Option C: DAG
+
+A tenant may have more than one parent, allowing shared ownership across sub-trees.
+
+- Good, because can natively express shared ownership ("tenant X belongs to both org A and org B").
+- Bad, because **closure-table maintenance becomes substantially more complex** — a descendant may be reachable via several paths, each with different barrier compositions.
+- Bad, because **barrier semantics become non-local** — "is there a barrier between ancestor and descendant?" is no longer a single yes/no when multiple paths exist.
+- Bad, because **ancestry queries lose a canonical ordering** — "parent chain to the root" is not unique.
+- Bad, because **no real-world use case currently justifies the additional complexity** — shared ownership can be modelled at the resource-group / policy layer without touching tenant parentage.
+
+## More Information
+
+**Related Documentation:**
+
+- [TENANT_MODEL.md](../TENANT_MODEL.md) — Tenant topology, barriers, closure tables
+- [DESIGN.md](../DESIGN.md) — Authorization design (tenant context, subtree queries)
+- [RESOURCE_GROUP_MODEL.md](../RESOURCE_GROUP_MODEL.md) — Resource group topology and its relationship to the tenant model
+- [ADR 0001: PDP/PEP Authorization Model](./0001-pdp-pep-authorization-model.md)
+- [ADR 0002: Split AuthN and AuthZ Resolvers](./0002-split-authn-authz-resolvers.md)
+- [ADR 0003: AuthN Resolver Minimalist Interface](./0003-authn-resolver-minimalist-interface.md)
+
+**Implementation Notes:**
+
+- Tenant-resolver plugins validate the single-root invariant at load time and return a configuration error if the source of truth exposes zero or more than one root.
+- The public trait `TenantResolverClient` and the plugin trait `TenantResolverPluginClient` expose `get_root_tenant(ctx) -> TenantInfo` so consumers can obtain the root without knowing its id up front.
+- The hierarchy APIs (`get_ancestors`, `get_descendants`, `is_ancestor`) operate naturally on a single-root tree: ancestry is a single chain to the root, and descendants form a single subtree per starting node.

--- a/docs/arch/authorization/AUTHZ_USAGE_SCENARIOS.md
+++ b/docs/arch/authorization/AUTHZ_USAGE_SCENARIOS.md
@@ -11,7 +11,7 @@ All examples use a Task Management domain:
 - **Resource:** `tasks` table with `id`, `owner_tenant_id`, `owner_id`, `title`, `status`
 - **Owner:** `owner_id` references the subject (user) who owns/is assigned the task
 - **Resource Groups:** Projects (tasks belong to projects)
-- **Tenant Model:** Hierarchical multi-tenancy — see [TENANT_MODEL.md](./TENANT_MODEL.md) for details on topology, barriers, and closure tables
+- **Tenant Model:** Hierarchical multi-tenancy on a single-root tree — see [TENANT_MODEL.md](./TENANT_MODEL.md) for details on topology, barriers, and closure tables
 
 ---
 

--- a/docs/arch/authorization/RESOURCE_GROUP_MODEL.md
+++ b/docs/arch/authorization/RESOURCE_GROUP_MODEL.md
@@ -87,7 +87,7 @@ AuthZ plugin reads RG hierarchy via `ResourceGroupReadHierarchy` trait (narrow, 
 | **Purpose** | Ownership, isolation, billing | Grouping for access control |
 | **Scope** | System-wide | Per-tenant |
 | **Resource relationship** | Ownership (1:N) | Membership (M:N) |
-| **Hierarchy** | Forest (multiple roots) | Forest (multiple roots per tenant) |
+| **Hierarchy** | Single-root tree | Forest (multiple roots per tenant) |
 | **Type system** | Fixed (built-in tenant type) | Dynamic (GTS-based, vendor-defined types) |
 
 Resource groups operate **within** tenant boundaries — groups are tenant-scoped, cross-tenant groups are forbidden, and authorization always includes a tenant constraint alongside group predicates.

--- a/docs/arch/authorization/TENANT_MODEL.md
+++ b/docs/arch/authorization/TENANT_MODEL.md
@@ -7,7 +7,7 @@ This document describes Cyber Fabric's multi-tenancy model, tenant topology, and
 - [Tenant Model](#tenant-model)
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
-  - [Tenant Topology: Forest](#tenant-topology-forest)
+  - [Tenant Topology: Single-Root Tree](#tenant-topology-single-root-tree)
   - [Tenant Properties](#tenant-properties)
   - [Barriers (Self-Managed Tenants)](#barriers-self-managed-tenants)
   - [Context Tenant vs Subject Tenant](#context-tenant-vs-subject-tenant)
@@ -19,10 +19,10 @@ This document describes Cyber Fabric's multi-tenancy model, tenant topology, and
 
 ## Overview
 
-Cyber Fabric uses a **hierarchical multi-tenancy** model where tenants form a forest (multiple independent trees). Each tenant can have child tenants, creating organizational structures like:
+Cyber Fabric uses a **hierarchical multi-tenancy** model where tenants form a single-root tree. Every tenant except the root has exactly one parent, and all tenants descend from a single shared root. Tenants can have child tenants, creating organizational structures like:
 
 ```
-Vendor
+Root
 ├── Organization A
 │   ├── Team A1
 │   └── Team A2
@@ -38,29 +38,43 @@ Key principles:
 
 ---
 
-## Tenant Topology: Forest
+## Tenant Topology: Single-Root Tree
 
-The tenant structure is a **forest** — a collection of independent trees with no single global root.
+The tenant structure is a **single-root tree** — every tenant except the root has exactly one parent, and all tenants descend from a single shared root.
 
 ```
-       [T1]              [T5]           ← Root tenants (no parent)
-      /    \               |
-   [T2]    [T3]          [T6]
+           [Root]          ← The only tenant with no parent
+          /      \
+       [T1]      [T5]
+      /    \       |
+   [T2]    [T3]  [T6]
      |
    [T4]
 ```
 
 **Properties:**
-- Each tree has exactly one root tenant (`parent_id = NULL`)
-- A tenant belongs to exactly one tree
-- Trees are completely isolated from each other
-- Depth is unlimited (but deep hierarchies may impact performance)
+- Exactly one tenant in the whole hierarchy has `parent_id = NULL`; this tenant is the root.
+- Every other tenant has exactly one parent.
+- Depth is not bounded by the tenant model itself; any limits on hierarchy depth come from the concrete Account/Tenant Management service implementation (operational policy, performance envelope, storage constraints).
+- The root is identified by convention (the single tenant with `parent_id = NULL`). There is no `is_system` field, and the root is not referred to as a "system tenant".
 
-**Why forest, not single tree?**
-- Supports multiple independent vendors/organizations
-- No artificial "super-root" that would complicate access control
-- Each tree can have different policies and configurations
-- Enables datacenter migration — vendor can gradually move tenant trees between regions/datacenters without cross-tree dependencies
+**Why single-root tree?**
+- **One OAuth client is enough** for S2S tenant-scoped flows that need to act as the root — no per-root credential fan-out at the vendor IdP.
+- **Unambiguous "act as root" semantics** — platform-level tenant-scoped operations always address the same tenant.
+- **Organizational autonomy is preserved via sub-roots** — in multi-tenant deployments each independent organization is modelled as its own sub-root directly under the root; barriers continue to provide isolation between sub-trees.
+- **Works naturally for single-user / consumer deployments** of Cyber-Fabric-based products — the root *is* the tenant that owns all business objects, and no sub-roots are created.
+- **Avoids the accidental complexity of DAGs** — closure-table rows, barriers, and ancestry queries stay tree-shaped.
+
+**Deployment shapes:**
+
+Both shapes satisfy the same topology invariant (exactly one `parent_id = NULL`); what differs is whether business objects live on the root.
+
+| Deployment | Role of the root | Business objects on the root? |
+|------------|------------------|-------------------------------|
+| Multi-tenant vendor deployment | Structural anchor above organization sub-roots | No — they live on sub-roots and below |
+| Single-user / consumer deployment | Owner of all platform data for the sole user | Yes |
+
+See [ADR 0004](./ADR/0004-single-root-tenant-model-topology.md) for the rationale and the rejected alternatives (forest, DAG).
 
 ---
 
@@ -69,7 +83,7 @@ The tenant structure is a **forest** — a collection of independent trees with 
 | Property | Type | Description |
 |----------|------|-------------|
 | `id` | UUID | Unique tenant identifier |
-| `parent_id` | UUID? | Parent tenant (NULL for root tenants) |
+| `parent_id` | UUID? | Parent tenant. `NULL` for exactly one tenant: the root. |
 | `status` | enum | `active`, `suspended`, `deleted` |
 | `self_managed` | bool | If true, creates a barrier — parent cannot access this subtree |
 
@@ -233,6 +247,7 @@ T1
 - `T1 → T2`: barrier = 1 because T2 (self_managed) is on the path
 - `T1 → T3`: barrier = 1 because T2 is on the path from T1 to T3
 - `T2 → T2` and `T2 → T3`: barrier = 0 because T2 is the **ancestor**, not between T2 and its descendants
+- Because the hierarchy has a single root, that root appears as `ancestor_id` of every tenant in the table (subject to the barrier rules above).
 
 **Query: "All tenants in T1's subtree, with `barrier_mode: "all"`"**
 
@@ -265,3 +280,4 @@ Result: T2, T3 (barrier = 0 for both rows because T2 is the ancestor, not betwee
 - [DESIGN.md](./DESIGN.md) — Core authorization design
 - [RESOURCE_GROUP_MODEL.md](./RESOURCE_GROUP_MODEL.md) — Resource group topology, membership, hierarchy
 - [AUTHZ_USAGE_SCENARIOS.md](./AUTHZ_USAGE_SCENARIOS.md) — Authorization scenarios with tenant examples
+- [ADR 0004: Single-Root Tenant Model Topology](./ADR/0004-single-root-tenant-model-topology.md) — Rationale for single-root tree vs. forest vs. DAG

--- a/docs/security/SECURITY.md
+++ b/docs/security/SECURITY.md
@@ -154,7 +154,7 @@ Constraints **OR** across alternatives, **AND** predicates within each constrain
 
 > Source: [`TENANT_MODEL.md`](../arch/authorization/TENANT_MODEL.md) · [`modules/system/tenant-resolver/`](../../modules/system/tenant-resolver/)
 
-Hierarchical multi-tenancy with a **forest topology** (multiple independent trees, no synthetic super-root):
+Hierarchical multi-tenancy with a **single-root tree topology** (exactly one tenant with no parent; all others descend from it):
 
 - **Isolation by default** — every resource carries `owner_tenant_id` as the primary partition key; tenants cannot access each other's data.
 - **Hierarchical access** — parent tenants may access child data. Subject tenant (home identity) and context tenant (operational scope) are distinguished, enabling scoped admin patterns.

--- a/modules/system/oagw/oagw/src/domain/test_support.rs
+++ b/modules/system/oagw/oagw/src/domain/test_support.rs
@@ -269,6 +269,30 @@ impl TenantResolverClient for MockTenantResolverClient {
         })
     }
 
+    async fn get_root_tenant(
+        &self,
+        _ctx: &SecurityContext,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        // The SDK contract says `get_root_tenant` MUST return a tenant with
+        // `parent_id == None`. If no configured tenant has `parent_id == None`
+        // we surface an Internal error instead of silently synthesizing one,
+        // so tests that expect a root tenant fail loudly when the mock is
+        // set up without one.
+        self.tenants
+            .values()
+            .find(|(info, _)| info.parent_id.is_none())
+            .map(|(info, _)| TenantInfo {
+                parent_id: None,
+                ..info.clone()
+            })
+            .ok_or_else(|| {
+                TenantResolverError::Internal(
+                    "MockTenantResolverClient: no configured tenant has parent_id = None"
+                        .to_owned(),
+                )
+            })
+    }
+
     async fn get_tenants(
         &self,
         ctx: &SecurityContext,

--- a/modules/system/tenant-resolver/README.md
+++ b/modules/system/tenant-resolver/README.md
@@ -20,6 +20,7 @@ block hierarchy traversal from parent tenants (unless explicitly ignored).
 The module registers [`TenantResolverClient`](tenant_resolver-sdk/src/api.rs) in ClientHub:
 
 - `get_tenant(ctx, id)` — Retrieve single tenant by ID
+- `get_root_tenant(ctx)` — Retrieve the root tenant (the unique tenant with no parent)
 - `get_tenants(ctx, ids, options)` — Retrieve multiple tenants by IDs (batch)
 - `get_ancestors(ctx, id, options)` — Get parent chain from tenant to root
 - `get_descendants(ctx, id, options)` — Get children subtree; `response.tenant` contains the starting tenant, `response.descendants` contains the subtree
@@ -37,7 +38,7 @@ T1 (root)
 └── T4
 ```
 
-- **`parent_id`**: Links a tenant to its parent (None for root tenants)
+- **`parent_id`**: Links a tenant to its parent (`None` for the root tenant — exactly one tenant in a single-root tree)
 - **`self_managed`**: When true, this tenant is a barrier that blocks parent traversal into its subtree
 
 ### Status Filtering
@@ -155,7 +156,7 @@ See [`models.rs`](tenant_resolver-sdk/src/models.rs): `TenantId`, `TenantInfo`, 
 - `name` — Human-readable tenant name
 - `status` — Lifecycle status (`Active`, `Suspended`, `Deleted`)
 - `tenant_type` — Optional classification string (e.g., `"enterprise"`, `"trial"`)
-- `parent_id` — Parent tenant ID (None for root tenants)
+- `parent_id` — Parent tenant ID (`None` for the root tenant — exactly one tenant in a single-root tree)
 - `self_managed` — True if this tenant is a barrier
 
 **`TenantRef`** — Tenant reference without name (for `get_ancestors`, `get_descendants`):

--- a/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/src/domain/client.rs
+++ b/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/src/domain/client.rs
@@ -63,6 +63,21 @@ impl TenantResolverPluginClient for Service {
         }
     }
 
+    async fn get_root_tenant(
+        &self,
+        ctx: &SecurityContext,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        // In single-tenant mode the sole tenant IS the root by definition.
+        let ctx_tenant = TenantId(ctx.subject_tenant_id());
+        if ctx_tenant.is_nil() {
+            return Err(TenantResolverError::Internal(
+                "single-tenant-tr-plugin: no root tenant -- security context has nil tenant id"
+                    .to_owned(),
+            ));
+        }
+        Ok(build_tenant_info(ctx_tenant))
+    }
+
     async fn get_tenants(
         &self,
         ctx: &SecurityContext,

--- a/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/src/domain/client_tests.rs
+++ b/modules/system/tenant-resolver/plugins/single-tenant-tr-plugin/src/domain/client_tests.rs
@@ -334,3 +334,32 @@ async fn is_ancestor_error_for_different_descendant() {
         other => panic!("Expected TenantNotFound, got: {other:?}"),
     }
 }
+
+// ==================== get_root_tenant tests ====================
+
+#[tokio::test]
+async fn get_root_tenant_returns_context_tenant() {
+    let service = Service;
+    let tenant_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
+    let ctx = ctx_for_tenant(tenant_id);
+
+    let root = service
+        .get_root_tenant(&ctx)
+        .await
+        .expect("single-tenant root should succeed for non-nil context");
+    assert_eq!(root.id, tenant_id);
+    assert!(root.parent_id.is_none());
+    assert_eq!(root.status, TenantStatus::Active);
+}
+
+#[tokio::test]
+async fn get_root_tenant_internal_for_nil_context() {
+    let service = Service;
+    let ctx = ctx_for_tenant(TenantId::nil());
+
+    let err = service
+        .get_root_tenant(&ctx)
+        .await
+        .expect_err("nil-tenant context should produce Internal");
+    assert!(matches!(err, TenantResolverError::Internal(_)));
+}

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/src/config.rs
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/src/config.rs
@@ -1,5 +1,6 @@
 //! Configuration for the static tenant resolver plugin.
 
+use anyhow::{Context, bail};
 use serde::Deserialize;
 use tenant_resolver_sdk::TenantStatus;
 use uuid::Uuid;
@@ -28,6 +29,115 @@ impl Default for StaticTrPluginConfig {
     }
 }
 
+impl StaticTrPluginConfig {
+    /// Validates the single-root tree topology invariant.
+    ///
+    /// Enforces that the configured tenants form a single-root tree:
+    /// - exactly one tenant has `parent_id == None`;
+    /// - tenant ids are unique;
+    /// - no tenant references itself via `parent_id`;
+    /// - every referenced `parent_id` belongs to a configured tenant;
+    /// - every tenant's parent chain reaches the unique root (no cycles and
+    ///   no disconnected components).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any of the invariants above are violated.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        let roots: Vec<Uuid> = self
+            .tenants
+            .iter()
+            .filter(|t| t.parent_id.is_none())
+            .map(|t| t.id)
+            .collect();
+
+        let root_id = match roots.len() {
+            0 => bail!(
+                "static-tr-plugin: no root tenant configured -- exactly one tenant must have \
+                 no parent_id (single-root tree topology)"
+            ),
+            1 => roots[0],
+            n => bail!(
+                "static-tr-plugin: {n} root tenants configured ({roots:?}) -- exactly one \
+                 tenant must have no parent_id (single-root tree topology)"
+            ),
+        };
+
+        let mut parent_by_id: std::collections::HashMap<Uuid, Option<Uuid>> =
+            std::collections::HashMap::with_capacity(self.tenants.len());
+        for tenant in &self.tenants {
+            if parent_by_id.insert(tenant.id, tenant.parent_id).is_some() {
+                return Err(anyhow::anyhow!(
+                    "static-tr-plugin: duplicate tenant id {} in configuration",
+                    tenant.id,
+                ))
+                .context("invalid tenant hierarchy configuration");
+            }
+        }
+
+        for tenant in &self.tenants {
+            let Some(parent_id) = tenant.parent_id else {
+                continue;
+            };
+            if parent_id == tenant.id {
+                return Err(anyhow::anyhow!(
+                    "static-tr-plugin: tenant {} lists itself as parent_id",
+                    tenant.id,
+                ))
+                .context("invalid tenant hierarchy configuration");
+            }
+            if !parent_by_id.contains_key(&parent_id) {
+                return Err(anyhow::anyhow!(
+                    "static-tr-plugin: tenant {} references parent_id {parent_id} which is not \
+                     in the configured tenants",
+                    tenant.id,
+                ))
+                .context("invalid tenant hierarchy configuration");
+            }
+        }
+
+        // Every tenant must be reachable from the unique root by walking
+        // parent_id. Catches cycles among non-root tenants (e.g. A->B, B->A)
+        // that the checks above let through.
+        for tenant in &self.tenants {
+            let mut seen = std::collections::HashSet::new();
+            let mut current = tenant.id;
+            while current != root_id {
+                if !seen.insert(current) {
+                    return Err(anyhow::anyhow!(
+                        "static-tr-plugin: tenant {} is in a parent_id cycle and does not \
+                         descend from root {}",
+                        tenant.id,
+                        root_id,
+                    ))
+                    .context("invalid tenant hierarchy configuration");
+                }
+                // parent_by_id[current] is Some for every non-root tenant at
+                // this point (unique-root + dangling-parent checks above);
+                // the None arm is defensive.
+                match parent_by_id.get(&current).copied().flatten() {
+                    Some(parent_id) => current = parent_id,
+                    None => {
+                        return Err(anyhow::anyhow!(
+                            "static-tr-plugin: tenant {} does not descend from root {}",
+                            tenant.id,
+                            root_id,
+                        ))
+                        .context("invalid tenant hierarchy configuration");
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;
+
 /// Configuration for a single tenant.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -46,7 +156,8 @@ pub struct TenantConfig {
     #[serde(rename = "type", default)]
     pub tenant_type: Option<String>,
 
-    /// Parent tenant ID. `None` for root tenants.
+    /// Parent tenant ID. `None` for the root tenant. Exactly one configured
+    /// tenant is expected to have `parent_id == None` (single-root tree).
     #[serde(default)]
     pub parent_id: Option<Uuid>,
 

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/src/config_tests.rs
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/src/config_tests.rs
@@ -1,0 +1,122 @@
+// Created: 2026-04-20 by Constructor Tech
+use super::*;
+use tenant_resolver_sdk::TenantStatus;
+use uuid::Uuid;
+
+const TENANT_A: &str = "11111111-1111-1111-1111-111111111111";
+const TENANT_B: &str = "22222222-2222-2222-2222-222222222222";
+const TENANT_C: &str = "33333333-3333-3333-3333-333333333333";
+
+fn tenant(id: &str, parent: Option<&str>) -> TenantConfig {
+    TenantConfig {
+        id: Uuid::parse_str(id).unwrap(),
+        name: id.to_owned(),
+        status: TenantStatus::Active,
+        tenant_type: None,
+        parent_id: parent.map(|p| Uuid::parse_str(p).unwrap()),
+        self_managed: false,
+    }
+}
+
+#[test]
+fn validate_accepts_single_root_with_children() {
+    let cfg = StaticTrPluginConfig {
+        tenants: vec![
+            tenant(TENANT_A, None),
+            tenant(TENANT_B, Some(TENANT_A)),
+            tenant(TENANT_C, Some(TENANT_B)),
+        ],
+        ..Default::default()
+    };
+    cfg.validate().expect("valid single-root tree should pass");
+}
+
+#[test]
+fn validate_accepts_single_root_alone() {
+    let cfg = StaticTrPluginConfig {
+        tenants: vec![tenant(TENANT_A, None)],
+        ..Default::default()
+    };
+    cfg.validate().expect("lone root should pass");
+}
+
+#[test]
+fn validate_rejects_zero_roots() {
+    let cfg = StaticTrPluginConfig {
+        tenants: Vec::new(),
+        ..Default::default()
+    };
+    let err = cfg.validate().expect_err("empty config must fail");
+    assert!(err.to_string().contains("no root tenant"));
+}
+
+#[test]
+fn validate_rejects_multiple_roots() {
+    let cfg = StaticTrPluginConfig {
+        tenants: vec![tenant(TENANT_A, None), tenant(TENANT_B, None)],
+        ..Default::default()
+    };
+    let err = cfg.validate().expect_err("two roots must fail");
+    assert!(err.to_string().contains("2 root tenants"));
+}
+
+#[test]
+fn validate_rejects_dangling_parent_reference() {
+    let cfg = StaticTrPluginConfig {
+        tenants: vec![tenant(TENANT_A, None), tenant(TENANT_B, Some(TENANT_C))],
+        ..Default::default()
+    };
+    let err = cfg.validate().expect_err("dangling parent must fail");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("invalid tenant hierarchy configuration"));
+}
+
+#[test]
+fn validate_rejects_duplicate_ids() {
+    let cfg = StaticTrPluginConfig {
+        tenants: vec![
+            tenant(TENANT_A, None),
+            // Same id, different parent — HashMap would silently drop this
+            // without validation.
+            tenant(TENANT_A, Some(TENANT_A)),
+        ],
+        ..Default::default()
+    };
+    let err = cfg.validate().expect_err("duplicate ids must fail");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("duplicate tenant id"), "got: {msg}");
+}
+
+#[test]
+fn validate_rejects_self_referential_parent() {
+    let cfg = StaticTrPluginConfig {
+        tenants: vec![tenant(TENANT_A, None), tenant(TENANT_B, Some(TENANT_B))],
+        ..Default::default()
+    };
+    let err = cfg
+        .validate()
+        .expect_err("self-referential parent must fail");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("lists itself as parent_id"), "got: {msg}");
+}
+
+#[test]
+fn validate_rejects_disconnected_cycle() {
+    // C is the unique root; A and B form a two-node cycle that never
+    // reaches C. The single-root / duplicate / self-ref / dangling checks
+    // all pass — only the reachability check catches this.
+    let cfg = StaticTrPluginConfig {
+        tenants: vec![
+            tenant(TENANT_C, None),
+            tenant(TENANT_A, Some(TENANT_B)),
+            tenant(TENANT_B, Some(TENANT_A)),
+        ],
+        ..Default::default()
+    };
+    let err = cfg.validate().expect_err("disconnected cycle must fail");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("parent_id cycle") && msg.contains("does not descend from root"),
+        "got: {msg}"
+    );
+}

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/src/domain/client.rs
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/src/domain/client.rs
@@ -26,6 +26,13 @@ impl TenantResolverPluginClient for Service {
             .ok_or(TenantResolverError::TenantNotFound { tenant_id: id })
     }
 
+    async fn get_root_tenant(
+        &self,
+        _ctx: &SecurityContext,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        Ok(self.root.clone())
+    }
+
     async fn get_tenants(
         &self,
         _ctx: &SecurityContext,

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/src/domain/client_tests.rs
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/src/domain/client_tests.rs
@@ -62,7 +62,7 @@ async fn get_tenant_existing() {
         tenants: vec![tenant(TENANT_A, "Tenant A", TenantStatus::Active)],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let result = service
@@ -81,7 +81,7 @@ async fn get_tenant_nonexistent() {
         tenants: vec![tenant(TENANT_A, "Tenant A", TenantStatus::Active)],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
     let nonexistent_id = TenantId(Uuid::parse_str(NONEXISTENT).unwrap());
 
@@ -103,12 +103,16 @@ async fn get_tenants_all_found() {
     let cfg = StaticTrPluginConfig {
         tenants: vec![
             tenant(TENANT_A, "A", TenantStatus::Active),
-            tenant(TENANT_B, "B", TenantStatus::Active),
-            tenant(TENANT_C, "C", TenantStatus::Suspended),
+            tenant_with_parent(TENANT_B, "B", TENANT_A),
+            {
+                let mut t = tenant_with_parent(TENANT_C, "C", TENANT_A);
+                t.status = TenantStatus::Suspended;
+                t
+            },
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let ids = vec![
@@ -130,7 +134,7 @@ async fn get_tenants_some_missing() {
         tenants: vec![tenant(TENANT_A, "A", TenantStatus::Active)],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let ids = vec![
@@ -151,13 +155,14 @@ async fn get_tenants_some_missing() {
 #[tokio::test]
 async fn get_tenants_with_filter() {
     let cfg = StaticTrPluginConfig {
-        tenants: vec![
-            tenant(TENANT_A, "A", TenantStatus::Active),
-            tenant(TENANT_B, "B", TenantStatus::Suspended),
-        ],
+        tenants: vec![tenant(TENANT_A, "A", TenantStatus::Active), {
+            let mut t = tenant_with_parent(TENANT_B, "B", TENANT_A);
+            t.status = TenantStatus::Suspended;
+            t
+        }],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let ids = vec![
@@ -184,7 +189,7 @@ async fn get_ancestors_root_tenant() {
         tenants: vec![tenant(TENANT_A, "Root", TenantStatus::Active)],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let result = service
@@ -215,7 +220,7 @@ async fn get_ancestors_with_hierarchy() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_C);
 
     let result = service
@@ -254,7 +259,7 @@ async fn get_ancestors_with_barrier() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_C);
 
     // Default (BarrierMode::Respect) - stops at barrier
@@ -289,8 +294,11 @@ async fn get_ancestors_with_barrier() {
 
 #[tokio::test]
 async fn get_ancestors_nonexistent() {
-    let cfg = StaticTrPluginConfig::default();
-    let service = Service::from_config(&cfg);
+    let cfg = StaticTrPluginConfig {
+        tenants: vec![tenant(TENANT_A, "Root", TenantStatus::Active)],
+        ..Default::default()
+    };
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let result = service
@@ -319,7 +327,7 @@ async fn get_ancestors_starting_tenant_is_barrier() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_B);
 
     // Default (BarrierMode::Respect) - B cannot see its parent chain
@@ -364,7 +372,7 @@ async fn get_descendants_no_children() {
         tenants: vec![tenant(TENANT_A, "Root", TenantStatus::Active)],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let result = service
@@ -395,7 +403,7 @@ async fn get_descendants_with_hierarchy() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     // Unlimited depth
@@ -446,7 +454,7 @@ async fn get_descendants_with_barrier() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     // Default (BarrierMode::Respect) - only D is visible
@@ -482,8 +490,11 @@ async fn get_descendants_with_barrier() {
 
 #[tokio::test]
 async fn get_descendants_nonexistent() {
-    let cfg = StaticTrPluginConfig::default();
-    let service = Service::from_config(&cfg);
+    let cfg = StaticTrPluginConfig {
+        tenants: vec![tenant(TENANT_A, "Root", TenantStatus::Active)],
+        ..Default::default()
+    };
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let result = service
@@ -520,7 +531,7 @@ async fn get_descendants_filter_stops_traversal() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     // Without filter: all 3 descendants (pre-order: B, C, D)
@@ -565,7 +576,7 @@ async fn get_descendants_pre_order() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let result = service
@@ -597,7 +608,7 @@ async fn is_ancestor_self_returns_false() {
         tenants: vec![tenant(TENANT_A, "Root", TenantStatus::Active)],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
 
@@ -617,7 +628,7 @@ async fn is_ancestor_direct_parent() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
@@ -649,7 +660,7 @@ async fn is_ancestor_with_barrier() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
@@ -687,7 +698,7 @@ async fn is_ancestor_direct_barrier_child() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
@@ -713,7 +724,7 @@ async fn is_ancestor_nonexistent() {
         tenants: vec![tenant(TENANT_A, "Root", TenantStatus::Active)],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let ctx = ctx_for_tenant(TENANT_A);
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
@@ -730,4 +741,29 @@ async fn is_ancestor_nonexistent() {
         .is_ancestor(&ctx, a_id, nonexistent, &IsAncestorOptions::default())
         .await;
     assert!(result.is_err());
+}
+
+// ==================== get_root_tenant tests ====================
+
+#[tokio::test]
+async fn get_root_tenant_returns_cached_root() {
+    // A (root) -> B -> C — exactly one root.
+    let cfg = StaticTrPluginConfig {
+        tenants: vec![
+            tenant(TENANT_A, "Root", TenantStatus::Active),
+            tenant_with_parent(TENANT_B, "Child", TENANT_A),
+            tenant_with_parent(TENANT_C, "Grandchild", TENANT_B),
+        ],
+        ..Default::default()
+    };
+    let service = Service::from_config(&cfg).expect("valid config");
+    let ctx = ctx_for_tenant(TENANT_A);
+
+    let root = service
+        .get_root_tenant(&ctx)
+        .await
+        .expect("root should be cached for single-root config");
+    assert_eq!(root.id, TenantId(Uuid::parse_str(TENANT_A).unwrap()));
+    assert_eq!(root.name, "Root");
+    assert!(root.parent_id.is_none());
 }

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/src/domain/service.rs
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/src/domain/service.rs
@@ -21,12 +21,24 @@ pub struct Service {
 
     /// Children index: `parent_id` -> list of child tenant IDs.
     pub(super) children: HashMap<TenantId, Vec<TenantId>>,
+
+    /// Cached root tenant (the unique tenant with `parent_id == None`).
+    pub(super) root: TenantInfo,
 }
 
 impl Service {
     /// Creates a new service from configuration.
-    #[must_use]
-    pub fn from_config(cfg: &StaticTrPluginConfig) -> Self {
+    ///
+    /// Validates the single-root tree invariant up front and fails fast on
+    /// invalid configurations (zero or multiple roots, dangling `parent_id`
+    /// references).
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`StaticTrPluginConfig::validate`] errors.
+    pub fn from_config(cfg: &StaticTrPluginConfig) -> anyhow::Result<Self> {
+        cfg.validate()?;
+
         let tenants: HashMap<TenantId, TenantInfo> = cfg
             .tenants
             .iter()
@@ -53,7 +65,23 @@ impl Service {
             }
         }
 
-        Self { tenants, children }
+        // validate() has already guaranteed that exactly one tenant has
+        // parent_id == None, so this search always finds it.
+        let root = tenants
+            .values()
+            .find(|t| t.parent_id.is_none())
+            .cloned()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "static-tr-plugin: internal error -- validate() succeeded but no root found"
+                )
+            })?;
+
+        Ok(Self {
+            tenants,
+            children,
+            root,
+        })
     }
 
     /// Check if a tenant matches the status filter.

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/src/domain/service_tests.rs
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/src/domain/service_tests.rs
@@ -47,16 +47,15 @@ const TENANT_D: &str = "44444444-4444-4444-4444-444444444444";
 // ==================== from_config tests ====================
 
 #[test]
-fn from_config_empty() {
+fn from_config_empty_rejects() {
+    // Zero roots violates the single-root invariant.
     let cfg = StaticTrPluginConfig::default();
-    let service = Service::from_config(&cfg);
-
-    assert!(service.tenants.is_empty());
-    assert!(service.children.is_empty());
+    assert!(Service::from_config(&cfg).is_err());
 }
 
 #[test]
-fn from_config_with_tenants_only() {
+fn from_config_multiple_roots_rejects() {
+    // Two tenants with no parent violates the single-root invariant.
     let cfg = StaticTrPluginConfig {
         tenants: vec![
             tenant(TENANT_A, "Tenant A", TenantStatus::Active),
@@ -64,10 +63,21 @@ fn from_config_with_tenants_only() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    assert!(Service::from_config(&cfg).is_err());
+}
+
+#[test]
+fn from_config_single_root_with_child() {
+    let cfg = StaticTrPluginConfig {
+        tenants: vec![
+            tenant(TENANT_A, "Tenant A", TenantStatus::Active),
+            tenant_with_parent(TENANT_B, "Tenant B", TENANT_A),
+        ],
+        ..Default::default()
+    };
+    let service = Service::from_config(&cfg).expect("valid config");
 
     assert_eq!(service.tenants.len(), 2);
-    assert!(service.children.is_empty()); // No parent-child relationships
 
     let a = service
         .tenants
@@ -77,6 +87,7 @@ fn from_config_with_tenants_only() {
     assert_eq!(a.status, TenantStatus::Active);
     assert!(a.parent_id.is_none());
     assert!(!a.self_managed);
+    assert_eq!(service.root.id, a.id);
 }
 
 #[test]
@@ -90,7 +101,7 @@ fn from_config_with_hierarchy() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     assert_eq!(service.tenants.len(), 3);
 
@@ -119,7 +130,7 @@ fn collect_ancestors_root_tenant() {
         tenants: vec![tenant(TENANT_A, "Root", TenantStatus::Active)],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
 
     let ancestors = service.collect_ancestors(a_id, BarrierMode::Respect);
@@ -137,7 +148,7 @@ fn collect_ancestors_linear_hierarchy() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let b_id = TenantId(Uuid::parse_str(TENANT_B).unwrap());
@@ -166,7 +177,7 @@ fn collect_ancestors_with_barrier() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let b_id = TenantId(Uuid::parse_str(TENANT_B).unwrap());
@@ -195,7 +206,7 @@ fn collect_ancestors_starting_tenant_is_barrier() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let b_id = TenantId(Uuid::parse_str(TENANT_B).unwrap());
@@ -218,7 +229,7 @@ fn collect_descendants_no_children() {
         tenants: vec![tenant(TENANT_A, "Root", TenantStatus::Active)],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
 
     let descendants = service.collect_descendants(a_id, &[], BarrierMode::Respect, None);
@@ -236,7 +247,7 @@ fn collect_descendants_linear_hierarchy() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let b_id = TenantId(Uuid::parse_str(TENANT_B).unwrap());
@@ -266,7 +277,7 @@ fn collect_descendants_with_barrier() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let b_id = TenantId(Uuid::parse_str(TENANT_B).unwrap());
@@ -296,7 +307,7 @@ fn collect_descendants_mixed_barrier() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let d_id = TenantId(Uuid::parse_str(TENANT_D).unwrap());
@@ -315,7 +326,7 @@ fn is_ancestor_of_self() {
         tenants: vec![tenant(TENANT_A, "Root", TenantStatus::Active)],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
 
     // Self is NOT an ancestor of self
@@ -335,7 +346,7 @@ fn is_ancestor_of_direct_parent() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let b_id = TenantId(Uuid::parse_str(TENANT_B).unwrap());
@@ -363,7 +374,7 @@ fn is_ancestor_of_grandparent() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let c_id = TenantId(Uuid::parse_str(TENANT_C).unwrap());
@@ -386,7 +397,7 @@ fn is_ancestor_of_with_barrier() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let b_id = TenantId(Uuid::parse_str(TENANT_B).unwrap());
@@ -426,7 +437,7 @@ fn is_ancestor_of_direct_barrier_child() {
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let b_id = TenantId(Uuid::parse_str(TENANT_B).unwrap());
@@ -459,7 +470,7 @@ fn is_ancestor_of_nonexistent() {
         tenants: vec![tenant(TENANT_A, "Root", TenantStatus::Active)],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let nonexistent = TenantId(Uuid::parse_str(TENANT_B).unwrap());
@@ -477,106 +488,37 @@ fn is_ancestor_of_nonexistent() {
     ));
 }
 
-#[test]
-fn collect_ancestors_cycle_terminates() {
-    // Create a cycle: A -> B -> A (via parent_id)
-    let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
-    let b_id = TenantId(Uuid::parse_str(TENANT_B).unwrap());
+// Cycle termination used to be tested here, but `StaticTrPluginConfig::validate`
+// now rejects disconnected cycles at load time (see `validate_rejects_disconnected_cycle`
+// in config_tests.rs), so no cycle-shaped `Service` can be built through
+// `Service::from_config`. The `visited` guards in `collect_ancestors` and
+// `is_ancestor_of` remain as defense-in-depth but are unreachable from the
+// public API.
 
+#[test]
+fn is_ancestor_of_unrelated() {
+    // A is the root; B and C are siblings under A (unrelated to each other).
     let cfg = StaticTrPluginConfig {
         tenants: vec![
-            TenantConfig {
-                id: a_id.0,
-                name: "A".to_owned(),
-                status: TenantStatus::Active,
-                tenant_type: None,
-                parent_id: Some(b_id.0),
-                self_managed: false,
-            },
-            TenantConfig {
-                id: b_id.0,
-                name: "B".to_owned(),
-                status: TenantStatus::Active,
-                tenant_type: None,
-                parent_id: Some(a_id.0),
-                self_managed: false,
-            },
+            tenant(TENANT_A, "Root", TenantStatus::Active),
+            tenant_with_parent(TENANT_B, "Sibling B", TENANT_A),
+            tenant_with_parent(TENANT_C, "Sibling C", TENANT_A),
         ],
         ..Default::default()
     };
-    let service = Service::from_config(&cfg);
+    let service = Service::from_config(&cfg).expect("valid config");
 
-    // Should terminate (not loop forever) and return at most 2 ancestors
-    let ancestors = service.collect_ancestors(a_id, BarrierMode::Ignore);
-    assert!(ancestors.len() <= 2);
-}
-
-#[test]
-fn is_ancestor_of_cycle_terminates() {
-    // Create a cycle: A -> B -> A (via parent_id)
     let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
     let b_id = TenantId(Uuid::parse_str(TENANT_B).unwrap());
     let c_id = TenantId(Uuid::parse_str(TENANT_C).unwrap());
 
-    let cfg = StaticTrPluginConfig {
-        tenants: vec![
-            TenantConfig {
-                id: a_id.0,
-                name: "A".to_owned(),
-                status: TenantStatus::Active,
-                tenant_type: None,
-                parent_id: Some(b_id.0),
-                self_managed: false,
-            },
-            TenantConfig {
-                id: b_id.0,
-                name: "B".to_owned(),
-                status: TenantStatus::Active,
-                tenant_type: None,
-                parent_id: Some(a_id.0),
-                self_managed: false,
-            },
-            TenantConfig {
-                id: c_id.0,
-                name: "C".to_owned(),
-                status: TenantStatus::Active,
-                tenant_type: None,
-                parent_id: None,
-                self_managed: false,
-            },
-        ],
-        ..Default::default()
-    };
-    let service = Service::from_config(&cfg);
-
-    // Should terminate (not loop forever), C is not in the cycle
+    // Siblings are not ancestors of each other.
     assert!(
         !service
-            .is_ancestor_of(c_id, a_id, BarrierMode::Ignore)
+            .is_ancestor_of(b_id, c_id, BarrierMode::Respect)
             .unwrap()
     );
-}
-
-#[test]
-fn is_ancestor_of_unrelated() {
-    // A and B are both roots (unrelated)
-    let cfg = StaticTrPluginConfig {
-        tenants: vec![
-            tenant(TENANT_A, "Root A", TenantStatus::Active),
-            tenant(TENANT_B, "Root B", TenantStatus::Active),
-        ],
-        ..Default::default()
-    };
-    let service = Service::from_config(&cfg);
-
-    let a_id = TenantId(Uuid::parse_str(TENANT_A).unwrap());
-    let b_id = TenantId(Uuid::parse_str(TENANT_B).unwrap());
-
-    assert!(
-        !service
-            .is_ancestor_of(a_id, b_id, BarrierMode::Respect)
-            .unwrap()
-    );
+    // A child is not an ancestor of the root.
     assert!(
         !service
             .is_ancestor_of(b_id, a_id, BarrierMode::Respect)

--- a/modules/system/tenant-resolver/plugins/static-tr-plugin/src/module.rs
+++ b/modules/system/tenant-resolver/plugins/static-tr-plugin/src/module.rs
@@ -41,6 +41,10 @@ impl Default for StaticTrPlugin {
 #[async_trait]
 impl Module for StaticTrPlugin {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        if self.service.get().is_some() {
+            anyhow::bail!("{} module already initialized", Self::MODULE_NAME);
+        }
+
         // Load configuration
         let cfg: StaticTrPluginConfig = ctx.config_or_default()?;
         info!(
@@ -49,6 +53,8 @@ impl Module for StaticTrPlugin {
             tenant_count = cfg.tenants.len(),
             "Loaded plugin configuration"
         );
+
+        let service = Arc::new(Service::from_config(&cfg)?);
 
         // Generate plugin instance ID
         let instance_id = TenantResolverPluginSpecV1::gts_make_instance_id(
@@ -68,8 +74,6 @@ impl Module for StaticTrPlugin {
         let results = registry.register(vec![instance_json]).await?;
         RegisterResult::ensure_all_ok(&results)?;
 
-        // Create service from config
-        let service = Arc::new(Service::from_config(&cfg));
         self.service
             .set(service.clone())
             .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;

--- a/modules/system/tenant-resolver/tenant-resolver-sdk/README.md
+++ b/modules/system/tenant-resolver/tenant-resolver-sdk/README.md
@@ -31,6 +31,14 @@ let tenant = resolver.get_tenant(&ctx, tenant_id).await?;
 println!("Name: {}, Status: {:?}", tenant.name, tenant.status);
 ```
 
+### Get Root Tenant
+
+```rust
+// The unique tenant with no parent (single-root tree).
+let root = resolver.get_root_tenant(&ctx).await?;
+println!("Root: {} ({})", root.id, root.name);
+```
+
 ### Batch Get
 
 ```rust
@@ -82,7 +90,7 @@ pub struct TenantInfo {
     pub name: String,              // Human-readable name
     pub status: TenantStatus,      // Active, Suspended, or Deleted
     pub tenant_type: Option<String>, // Classification
-    pub parent_id: Option<TenantId>, // None for root tenants
+    pub parent_id: Option<TenantId>, // None for the root tenant (single-root tree)
     pub self_managed: bool,        // Barrier flag
 }
 ```

--- a/modules/system/tenant-resolver/tenant-resolver-sdk/src/api.rs
+++ b/modules/system/tenant-resolver/tenant-resolver-sdk/src/api.rs
@@ -61,6 +61,26 @@ pub trait TenantResolverClient: Send + Sync {
         id: TenantId,
     ) -> Result<TenantInfo, TenantResolverError>;
 
+    /// Get the root tenant (the unique tenant with no parent).
+    ///
+    /// In the single-root tree topology, exactly one tenant in the whole
+    /// hierarchy has `parent_id == None`. This helper fetches it without
+    /// requiring the caller to know its id up front.
+    ///
+    /// # Errors
+    ///
+    /// - `Internal` if the backing plugin cannot determine the root tenant
+    ///   at call time (for example, the invariant is enforced at runtime and
+    ///   the data source is currently inconsistent)
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Security context
+    async fn get_root_tenant(
+        &self,
+        ctx: &SecurityContext,
+    ) -> Result<TenantInfo, TenantResolverError>;
+
     /// Get multiple tenants by IDs (batch).
     ///
     /// Returns only found tenants - missing IDs are silently skipped.

--- a/modules/system/tenant-resolver/tenant-resolver-sdk/src/models.rs
+++ b/modules/system/tenant-resolver/tenant-resolver-sdk/src/models.rs
@@ -43,7 +43,7 @@ pub struct TenantInfo {
     /// Tenant type classification.
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub tenant_type: Option<String>,
-    /// Parent tenant ID. `None` for root tenants.
+    /// Parent tenant ID. `None` for the root tenant (single-root tree: exactly one such tenant).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<TenantId>,
     /// Whether this tenant is self-managed (barrier).
@@ -67,7 +67,7 @@ pub struct TenantRef {
     /// Tenant type classification.
     #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub tenant_type: Option<String>,
-    /// Parent tenant ID. `None` for root tenants.
+    /// Parent tenant ID. `None` for the root tenant (single-root tree: exactly one such tenant).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<TenantId>,
     /// Whether this tenant is self-managed (barrier).
@@ -278,7 +278,7 @@ pub struct GetAncestorsResponse {
     /// The requested tenant (without name).
     pub tenant: TenantRef,
     /// Parent chain ordered from direct parent to root.
-    /// Empty if the tenant is a root tenant.
+    /// Empty if the tenant is the root tenant.
     pub ancestors: Vec<TenantRef>,
 }
 

--- a/modules/system/tenant-resolver/tenant-resolver-sdk/src/plugin_api.rs
+++ b/modules/system/tenant-resolver/tenant-resolver-sdk/src/plugin_api.rs
@@ -46,6 +46,27 @@ pub trait TenantResolverPluginClient: Send + Sync {
         id: TenantId,
     ) -> Result<TenantInfo, TenantResolverError>;
 
+    /// Get the root tenant (the unique tenant with no parent).
+    ///
+    /// Plugins MUST expose exactly one tenant with `parent_id == None` and
+    /// return it here. It is up to the plugin whether to enforce this
+    /// invariant at load time or at runtime.
+    ///
+    /// # Errors
+    ///
+    /// - `Internal` if the plugin cannot determine the root tenant at call
+    ///   time (e.g., the invariant is enforced at runtime and the data
+    ///   source is currently inconsistent, or the context lacks the
+    ///   information needed to derive it)
+    ///
+    /// # Arguments
+    ///
+    /// * `ctx` - Security context
+    async fn get_root_tenant(
+        &self,
+        ctx: &SecurityContext,
+    ) -> Result<TenantInfo, TenantResolverError>;
+
     /// Get multiple tenants by IDs (batch).
     ///
     /// Returns only found tenants - missing IDs are silently skipped.

--- a/modules/system/tenant-resolver/tenant-resolver/src/domain/local_client.rs
+++ b/modules/system/tenant-resolver/tenant-resolver/src/domain/local_client.rs
@@ -46,6 +46,16 @@ impl TenantResolverClient for TenantResolverLocalClient {
             .map_err(|e| log_and_convert("get_tenant", e))
     }
 
+    async fn get_root_tenant(
+        &self,
+        ctx: &SecurityContext,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        self.svc
+            .get_root_tenant(ctx)
+            .await
+            .map_err(|e| log_and_convert("get_root_tenant", e))
+    }
+
     async fn get_tenants(
         &self,
         ctx: &SecurityContext,

--- a/modules/system/tenant-resolver/tenant-resolver/src/domain/service.rs
+++ b/modules/system/tenant-resolver/tenant-resolver/src/domain/service.rs
@@ -130,6 +130,22 @@ impl Service {
         plugin.get_tenant(ctx, id).await.map_err(DomainError::from)
     }
 
+    /// Get the root tenant (the unique tenant with no parent).
+    ///
+    /// This forwards to the selected plugin's `get_root_tenant`; the
+    /// single-root invariant is enforced by plugins themselves (e.g. the
+    /// static plugin validates its config during `Service::from_config`).
+    ///
+    /// # Errors
+    ///
+    /// - Plugin resolution errors
+    /// - Any error surfaced by the plugin
+    #[tracing::instrument(skip_all)]
+    pub async fn get_root_tenant(&self, ctx: &SecurityContext) -> Result<TenantInfo, DomainError> {
+        let plugin = self.get_plugin().await?;
+        plugin.get_root_tenant(ctx).await.map_err(DomainError::from)
+    }
+
     /// Get multiple tenants by IDs (batch).
     ///
     /// Returns only found tenants - missing IDs are silently skipped.


### PR DESCRIPTION
- Add ADR 0004 recording the single-root tree topology decision (vs multi-root forest and DAG) and update TENANT_MODEL.md, RESOURCE_GROUP_MODEL.md, AUTHZ_USAGE_SCENARIOS.md, and docs/security/SECURITY.md to match.
- Add get_root_tenant(ctx) -> TenantInfo to TenantResolverClient and TenantResolverPluginClient; wire it through the gateway service, local client, both built-in plugins, and the OAGW test mock.
- Validate the single-root invariant at static-tr-plugin load time and cache the root in the domain service; adjust example configs so they conform to the invariant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to fetch the single root tenant.

* **Documentation**
  * Added ADR and updated tenant model, usage, and security docs to define a single-root tree topology and clarify parent_id semantics.

* **Chores**
  * Updated example/quickstart configs to a single-root structure and added runtime validation to enforce exactly one root tenant.

* **Tests**
  * Added and updated unit tests to cover single-root validation, root lookup, and hierarchy invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #1527