### PR TITLE
fix(bootstrap): unify crypto provider init in main() for both FIPS and non-FIPS modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3909,7 +3909,6 @@ dependencies = [
  "cf-types-registry",
  "clap",
  "mimalloc",
- "rustls",
  "serde-saphyr 0.0.16",
  "serde_json",
  "tempfile",

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -62,7 +62,6 @@ anyhow = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 clap = { workspace = true }
-rustls = { workspace = true }
 
 # Optional mini-chat module
 mini-chat = { package = "cf-mini-chat", path = "../../modules/mini-chat/mini-chat", optional = true }

--- a/apps/hyperspot-server/src/main.rs
+++ b/apps/hyperspot-server/src/main.rs
@@ -64,14 +64,11 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Install aws-lc-rs as the default rustls CryptoProvider before any TLS
-    // config is constructed. Required because both `ring` and `aws-lc-rs`
-    // providers are compiled in (ring via aliri/pingora-rustls), and rustls
-    // 0.23 panics if it cannot auto-detect a single provider.
-    // Skip in FIPS mode — init_procedure() installs the FIPS provider instead.
-    #[cfg(not(feature = "fips"))]
-    if let Err(_e) = rustls::crypto::aws_lc_rs::default_provider().install_default() {
-        // Another provider was already installed — safe to continue.
+    // Install the crypto provider before anything else.
+    // Must run before any TLS config, HTTP client, DB connection, or JWT operation.
+    if let Err(e) = modkit::bootstrap::init_crypto_provider() {
+        eprintln!("fatal: failed to install TLS crypto provider: {e}");
+        return Err(e.into());
     }
 
     let cli = Cli::parse();

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -22,7 +22,7 @@ workspace = true
 default = ["otel", "db"]
 coverage_nightly = []
 # FIPS-140-3: install the AWS-LC FIPS-validated crypto provider at bootstrap
-fips = ["dep:rustls", "rustls/fips"]
+fips = ["rustls/fips"]
 
 # Database integration (modkit-db, migrations, DbManager/DbHandle in contexts/runtime)
 db = ["dep:modkit-db", "dep:sea-orm-migration"]
@@ -74,7 +74,7 @@ chrono = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 dsn = { workspace = true, optional = true }
 modkit-utils = { workspace = true }
-rustls = { workspace = true, optional = true }
+rustls = { workspace = true }
 
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/libs/modkit/src/bootstrap/crypto.rs
+++ b/libs/modkit/src/bootstrap/crypto.rs
@@ -1,29 +1,54 @@
 use std::sync::Once;
 
+/// Error returned when the crypto provider cannot be installed.
+#[derive(Debug, thiserror::Error)]
+pub enum CryptoProviderError {
+    /// Another crypto provider was already installed (FIPS mode).
+    #[error("failed to install FIPS crypto provider - another provider is already installed")]
+    FipsProviderConflict,
+}
+
 static INSTALLED: Once = Once::new();
 
-/// Install the FIPS-validated AWS-LC crypto provider as the process-wide default.
+/// Install the process-wide default rustls [`CryptoProvider`](rustls::crypto::CryptoProvider).
+///
+/// - **FIPS mode** (`fips` feature): installs the FIPS-validated AWS-LC provider
+///   (`aws-lc-fips-sys`, NIST Certificate #4816).
+/// - **Standard mode**: installs the `aws-lc-rs` provider explicitly. This is
+///   required because both `ring` and `aws-lc-rs` are compiled into the binary
+///   (ring via `aliri`/`pingora-rustls`), and rustls 0.23 panics when it cannot
+///   auto-detect a single provider.
 ///
 /// This **must** be called before any TLS configuration, HTTP client, database
-/// connection, or JWT operation is created. It sets the global [`rustls::crypto::CryptoProvider`]
-/// that all downstream consumers (rustls, sqlx, jsonwebtoken, pingora, etc.) will use.
+/// connection, or JWT operation is created.
 ///
-/// Outputs to stderr (always visible, even before tracing is initialized) and
-/// to `tracing::info!` (visible in structured logs if a subscriber is active).
+/// Safe to call multiple times — only the first invocation has an effect.
 ///
-/// # Process exit
+/// # Errors
 ///
-/// Exits with code 1 if another crypto provider has already been installed.
-pub fn init_fips_crypto_provider() {
+/// Returns [`CryptoProviderError::FipsProviderConflict`] if the `fips` feature is
+/// enabled and another crypto provider has already been installed.
+pub fn init_crypto_provider() -> Result<(), CryptoProviderError> {
+    let mut result = Ok(());
+
     INSTALLED.call_once(|| {
-        if let Err(_existing) = rustls::crypto::default_fips_provider().install_default() {
-            eprintln!(
-                "[FIPS] FATAL: failed to install FIPS crypto provider - another provider is already installed"
-            );
-            std::process::exit(1);
+        #[cfg(feature = "fips")]
+        {
+            if rustls::crypto::default_fips_provider()
+                .install_default()
+                .is_err()
+            {
+                result = Err(CryptoProviderError::FipsProviderConflict);
+                return;
+            }
+            tracing::info!("FIPS-140-3 crypto provider installed (AWS-LC FIPS module)");
         }
 
-        eprintln!("[FIPS] FIPS-140-3 crypto provider installed (AWS-LC FIPS module)");
-        tracing::info!("FIPS-140-3 crypto provider installed (AWS-LC FIPS module)");
+        #[cfg(not(feature = "fips"))]
+        {
+            let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        }
     });
+
+    result
 }

--- a/libs/modkit/src/bootstrap/mod.rs
+++ b/libs/modkit/src/bootstrap/mod.rs
@@ -15,7 +15,6 @@
 //! Backend types for spawning `OoP` modules have been moved to `modkit::backends`.
 
 pub mod config;
-#[cfg(feature = "fips")]
 mod crypto;
 pub mod host;
 
@@ -35,5 +34,4 @@ pub use oop::{OopRunOptions, run_oop_with_options};
 mod run;
 pub use run::{run_migrate, run_server};
 
-#[cfg(feature = "fips")]
-pub use crypto::init_fips_crypto_provider;
+pub use crypto::{CryptoProviderError, init_crypto_provider};

--- a/libs/modkit/src/bootstrap/run.rs
+++ b/libs/modkit/src/bootstrap/run.rs
@@ -43,6 +43,11 @@ fn spawn_signal_handler(cancel: CancellationToken, context: &str) {
 /// - There was a critical error during initialization of the modules
 /// - Problems with the database or third-party services
 /// - An issue during runtime or shutdown
+///
+/// # Preconditions
+///
+/// The TLS crypto provider must be installed before calling this function
+/// (see [`super::init_crypto_provider`]).
 pub async fn run_server(config: AppConfig) -> Result<()> {
     init_procedure(&config).map_err(|e| {
         tracing::error!(error = %e, "Initialization failed");
@@ -113,6 +118,11 @@ pub async fn run_server(config: AppConfig) -> Result<()> {
 /// - Module discovery fails
 /// - Pre-init phase fails
 /// - Migration phase fails
+///
+/// # Preconditions
+///
+/// The TLS crypto provider must be installed before calling this function
+/// (see [`super::init_crypto_provider`]).
 pub async fn run_migrate(config: AppConfig) -> Result<()> {
     init_procedure(&config).map_err(|e| {
         tracing::error!(error = %e, "Initialization failed");
@@ -262,19 +272,18 @@ fn try_build_oop_module_config(
 ///
 /// Steps performed:
 ///
-/// - installs the FIPS crypto provider when that feature is enabled
 /// - initializes tracing/logging (once, guarded by a process-wide `Once`) and metrics
 ///   when OpenTelemetry is enabled
 /// - registers the panic hook used to route panics through tracing
 /// - emits a small startup span and version metadata for diagnostics
 ///
+/// **Note:** the crypto provider must already be installed before calling this
+/// function (see [`super::init_crypto_provider`]).
+///
 /// # Errors
 ///
 /// Returns an error if OpenTelemetry tracing initialization fails while tracing is enabled.
 pub fn init_procedure(config: &AppConfig) -> Result<()> {
-    #[cfg(feature = "fips")]
-    super::init_fips_crypto_provider();
-
     // Build OpenTelemetry layer before logging
     #[cfg(feature = "otel")]
     let otel_layer = if config.opentelemetry.tracing.enabled {


### PR DESCRIPTION
After the streamline refactor (#1331) moved FIPS crypto init from main() into init_procedure(), the provider was installed too late — after config loading. For non-FIPS mode, no provider was installed at all, causing a rustls panic when both ring and aws-lc-rs are compiled in (#1502 patched non-FIPS only).

Consolidate both cases into a single init_crypto_provider() function in modkit::bootstrap, called as the first line of main(). This ensures the crypto provider is always installed before any TLS, DB, or JWT operation regardless of the feature flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified crypto provider initialization into a single, unconditional startup path.
  * Exposed initialization outcome so callers can handle failures.

* **Bug Fixes**
  * Startup now fails loudly on crypto provider initialization errors instead of proceeding silently.

* **Documentation**
  * Added precondition notes clarifying that the TLS crypto provider must be installed before running server/migration routines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->