### PR TITLE
feat(resource-group): add SDK crate + contracts + documentation [1/6]

### DIFF
--- a/.cypilot/config/artifacts.toml
+++ b/.cypilot/config/artifacts.toml
@@ -6,6 +6,14 @@ reason = "Ignore rust-traits.md — reference document for planned Rust SDK cont
 patterns = ["modules/system/resource-group/docs/rust-traits.md"]
 
 [[ignore]]
+reason = "Temporarily ignore resource-group codebase — SDK in place, module impl lands in a later PR. Remove when module code + cpt markers are added."
+patterns = [
+  "modules/system/resource-group/resource-group/*",
+  "modules/system/resource-group/resource-group-sdk/*",
+]
+
+
+[[ignore]]
 reason = "Ignore 'modules/system' parent directory — not a module, only a grouping for system submodules."
 patterns = ["modules/system"]
 
@@ -34,16 +42,18 @@ reason = "Ignore module 'nodes-registry' (not SDLC-documented yet: missing requi
 patterns = ["modules/system/nodes-registry/*"]
 
 [[ignore]]
-reason = "Ignore oagw codebase — code traceability markers reverted, pending re-add. Docs still validated (DOCS-ONLY effective: all feature tasks unchecked)."
+reason = "Ignore oagw codebase and features — code traceability markers reverted, pending re-add. PRD/DESIGN/ADR/DECOMPOSITION still validated via autodetect."
 patterns = [
   "modules/system/oagw/oagw/src/*",
   "modules/system/oagw/oagw/tests/*",
   "modules/system/oagw/oagw-sdk/src/*",
+  "modules/system/oagw/docs/features/*",
 ]
 
 [[ignore]]
 reason = "Ignore legacy (pre-Cypilot) ADR files in oagw/docs root — converted copies live under docs/ADR/."
 patterns = ["modules/system/oagw/docs/adr-*.md"]
+
 
 [[ignore]]
 reason = "Ignore module 'tenant-resolver' (not SDLC-documented yet: missing required PRD/DESIGN)."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,6 +1847,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-resource-group-sdk"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cf-modkit",
+ "cf-modkit-odata",
+ "cf-modkit-odata-macros",
+ "cf-modkit-sdk",
+ "cf-modkit-security",
+ "gts",
+ "gts-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "cf-rustracing"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ members = [
     "modules/system/grpc-hub",
     "modules/system/nodes-registry/nodes-registry",
     "modules/system/nodes-registry/nodes-registry-sdk",
+    "modules/system/resource-group/resource-group-sdk",
     "modules/system/module-orchestrator",
     "examples/modkit/users-info/users-info-sdk",
     "examples/modkit/users-info/users-info",

--- a/docs/arch/authorization/DESIGN.md
+++ b/docs/arch/authorization/DESIGN.md
@@ -924,6 +924,37 @@ The `barrier_mode` and `tenant_status` parameters apply to any scope source — 
 // INSERT INTO events ...
 ```
 
+**CREATE with tenant provisioning** (Resource Group module -- `is_tenant` property):
+
+When creating a group whose GTS type has `is_tenant = true` (from `x-gts-traits`), the RG handler passes `"is_tenant": true` in `resource.properties`. This signals to the PDP that the operation creates a new tenant scope (`tenant_id = group.id`), not a regular group.
+
+Note: `is_tenant` is orthogonal to `can_be_root`. A type with `can_be_root = true` but `is_tenant = false` (e.g., "Organization") is a root group that belongs to the caller's tenant, not a new tenant scope.
+
+```jsonc
+// PEP -> PDP (tenant group creation)
+{
+  "action": { "name": "create" },
+  "resource": {
+    "type": "gts.cf.core.rg.group.v1~",
+    "properties": { "is_tenant": true, "parent_id": null }
+  },
+  "context": { "require_constraints": true }
+  // ... subject, tenant_context
+}
+
+// PDP policy for create:
+// - is_tenant=true + parent_id=null (root tenant): NOT created via API.
+//   Root tenants are seeded directly in DB (deployment operation).
+// - is_tenant=true + parent_id present (sub-tenant): verify caller in
+//   parent hierarchy, allow.
+// - is_tenant absent/false: standard hierarchy check.
+```
+
+The `is_tenant` + `parent_id` properties enable PDP to differentiate between:
+- **Root tenant provisioning** (`is_tenant=true`, no parent) -- created via direct DB seeding, not through the API
+- **Sub-tenant provisioning** (`is_tenant=true`, with parent) -- verify caller in parent hierarchy
+- **Regular group creation** (`is_tenant=false`) -- requires existing hierarchy for scope resolution
+
 **LIST** (constraints required):
 ```jsonc
 // PEP -> PDP

--- a/docs/arch/authorization/INTEGRATION_TEST_PLAN.md
+++ b/docs/arch/authorization/INTEGRATION_TEST_PLAN.md
@@ -12,14 +12,16 @@ For background on how AuthZ uses RG data, see [RESOURCE_GROUP_MODEL.md](./RESOUR
 
 | Component | Status | Notes |
 |-----------|--------|-------|
-| RG Module | Planned | This branch documents the intended `ClientHub` contracts (`dyn ResourceGroupClient` + `dyn ResourceGroupReadHierarchy`) but does not add implementation code yet |
+| RG Module | **Done** | `ResourceGroupClient` + `ResourceGroupReadHierarchy` traits, `get_group_descendants` / `get_group_ancestors` endpoints |
 | AuthZ Resolver | Existing | Plugin discovery, `PolicyEnforcer`, `AccessScope` → SecureORM already exist in the platform |
 | Static AuthZ Plugin | Existing | Returns `In(owner_tenant_id, [tid])` — tenant predicates only |
-| **PolicyEnforcer in RG handlers** | **Planned** | Target design: `GroupService` will call `enforcer.access_scope()` for list/get/hierarchy |
-| **AccessScope → SecureORM in RG repo** | **Planned** | Target design: `GroupRepository.list_groups`, `find_by_id`, `list_hierarchy` will accept `&AccessScope` |
-| **Rust integration tests** | **Planned** | Target inventory: 24 tests covering enforcer flow + tenant scoping + full-chain verification |
-| **E2E HTTP tests** | **Planned** | Target inventory: pytest CRUD, hierarchy, membership, tenant isolation |
-| Group predicates (`in_group`, `in_group_subtree`) | Planned | Requires new predicate types and RG-aware PDP behavior |
+| **RG AuthZ Plugin** | **Done** | Reference plugin: resolves hierarchy via RG, barrier filtering, fail-closed. Feature: `rg-authz` |
+| **PolicyEnforcer in RG handlers** | **Done** | `GroupService` calls `enforcer.access_scope()` for all operations |
+| **AccessScope → SecureORM in RG repo** | **Done** | `GroupRepository.list_groups`, `find_by_id`, `get_descendants`, `get_ancestors` accept `&AccessScope` |
+| **Rust integration tests** | **Done** | 324 unit tests + 7 rg-authz-plugin tests + 8 tr-authz-plugin tests |
+| **E2E HTTP tests** | **Partial** | 214 e2e tests (static-authz); rg-authz e2e blocked on tenant provisioning |
+| **Tenant provisioning** | **Planned** | `is_tenant` trait (from `x-gts-traits`): `tenant_id = group.id` for tenant groups. Required for rg-authz e2e |
+| Group predicates (`in_group`, `in_group_subtree`) | Planned | Requires RG-aware PDP behavior |
 
 ---
 
@@ -104,8 +106,8 @@ E2E_BASE_URL=http://localhost:8087 pytest testing/e2e/modules/resource_group/ -v
 The intended AuthZ → RG chain is:
 
 1. **Module init** (`module.rs`): resolves `dyn AuthZResolverClient` from ClientHub, creates `PolicyEnforcer`
-2. **GroupService** (`group_service.rs`): receives `PolicyEnforcer`; all CRUD methods (`list_groups`, `get_group`, `update_group`, `delete_group`, `list_group_hierarchy`) call `enforcer.access_scope(&ctx, &RG_GROUP_RESOURCE, action, resource_id)`
-3. **GroupRepository** (`group_repo.rs`): `list_groups`, `find_by_id`, `list_hierarchy` accept `&AccessScope` and pass it to `SecureORM` via `.secure().scope_with(scope)`
+2. **GroupService** (`group_service.rs`): receives `PolicyEnforcer`; all CRUD methods (`list_groups`, `get_group`, `update_group`, `delete_group`, `get_group_descendants`, `get_group_ancestors`) call `enforcer.access_scope(&ctx, &RG_GROUP_RESOURCE, action, resource_id)`
+3. **GroupRepository** (`group_repo.rs`): `list_groups`, `find_by_id`, `get_descendants`, `get_ancestors` accept `&AccessScope` and pass it to `SecureORM` via `.secure().scope_with(scope)`
 4. **Handlers** (`handlers/groups.rs`): pass `&ctx` to service methods (no longer `_ctx`)
 5. **Error handling** (`error.rs`): `DomainError::AccessDenied` → HTTP 403
 
@@ -253,7 +255,9 @@ modules:
         allowed_clients: ["authz-resolver-plugin"]
         allowed_endpoints:
           - method: GET
-            path: "/api/resource-group/v1/groups/{group_id}/hierarchy"
+            path: "/api/resource-group/v1/groups/{group_id}/descendants"
+          - method: GET
+            path: "/api/resource-group/v1/groups/{group_id}/ancestors"
 ```
 
 #### 3.3 API Gateway TLS termination
@@ -263,19 +267,24 @@ Configure API Gateway to forward client certificate CN header to RG module for M
 ### Test scenario
 
 ```bash
-# MTLS request to allowed endpoint (hierarchy) — AuthZ bypassed
+# MTLS request to allowed endpoint (descendants) — AuthZ bypassed
 curl --cert plugin.pem --key plugin-key.pem --cacert ca.pem \
-  https://127.0.0.1:8087/cf/resource-group/v1/groups/{group_id}/hierarchy
-# Expected: 200 OK with hierarchy data
+  https://127.0.0.1:8087/cf/resource-group/v1/groups/{group_id}/descendants
+# Expected: 200 OK with descendants data
+
+# MTLS request to allowed endpoint (ancestors) — AuthZ bypassed
+curl --cert plugin.pem --key plugin-key.pem --cacert ca.pem \
+  https://127.0.0.1:8087/cf/resource-group/v1/groups/{group_id}/ancestors
+# Expected: 200 OK with ancestors data
 
 # MTLS request to disallowed endpoint (POST groups) — rejected
 curl --cert plugin.pem --key plugin-key.pem --cacert ca.pem \
   -X POST https://127.0.0.1:8087/cf/resource-group/v1/groups
 # Expected: 403 Forbidden
 
-# JWT request to hierarchy endpoint — full AuthZ applied
+# JWT request to descendants endpoint — full AuthZ applied
 curl -H "Authorization: Bearer test" \
-  http://127.0.0.1:8087/cf/resource-group/v1/groups/{group_id}/hierarchy
+  http://127.0.0.1:8087/cf/resource-group/v1/groups/{group_id}/descendants
 # Expected: 200 OK with AuthZ-scoped results
 ```
 
@@ -285,6 +294,67 @@ curl -H "Authorization: Bearer test" \
 - MTLS + disallowed endpoint → 403
 - JWT + same endpoint → 200, AuthZ evaluation logged
 - Invalid cert CN → 403
+
+---
+
+## E2E Test Hierarchy Fixture (AuthZ plugins)
+
+E2E tests using AuthZ plugins (config: `config/e2e-rg-authz.yaml`) require a pre-seeded tenant hierarchy. A session-scoped pytest fixture creates the hierarchy via REST API before any tests run, then all tests reuse it.
+
+**Available AuthZ plugins:**
+- `rg-authz-plugin` (priority 200) — resolves tenants directly via `ResourceGroupReadHierarchy`
+- `tr-authz-plugin` (priority 50) — resolves tenants via `TenantResolverClient` (recommended, no direct RG dependency)
+
+### Fixture: `tenant_hierarchy`
+
+```
+T1 (root tenant, is_tenant=true, can_be_root=true, token-a subject_tenant_id)
+├── T_normal (child tenant, is_tenant=true)
+├── T_barrier (tenant with metadata.self_managed=true, is_tenant=true)
+│   └── T_behind (child of barrier, is_tenant=true)
+└── Dept1 (department, is_tenant=false, can_be_root=false, inherits T1 tenant_id)
+
+T2 (root tenant, token-b subject_tenant_id)
+```
+
+**Setup steps** (all via REST API, executed once per session):
+
+1. Create tenant type (`is_tenant=true`, `can_be_root=true`, `allowed_parent_types=[self]`)
+2. Create department type (`is_tenant=false`, `can_be_root=false`, `allowed_parent_types=[tenant_type]`)
+3. **Seed T1 root tenant** directly in SQLite (`id` = token-a `subject_tenant_id`). Root tenants are created via DB seeding, not API.
+4. `POST /groups` -- T_normal (parent=T1) -- `tenant_id = T_normal.id`
+5. `POST /groups` -- T_barrier (parent=T1, metadata=`{"self_managed": true}`) -- `tenant_id = T_barrier.id`
+6. `POST /groups` -- T_behind (parent=T_barrier) -- `tenant_id = T_behind.id`
+7. `POST /groups` -- Dept1 (parent=T1, dept type) -- `tenant_id = T1.id` (inherited, `is_tenant=false`)
+8. **Seed T2 root tenant** directly in SQLite (`id` = token-b `subject_tenant_id`)
+
+**Prerequisites**:
+- Tenant provisioning feature (`is_tenant` trait): sub-tenant groups set `tenant_id = group.id`
+- Root tenants seeded in DB before server start or via conftest SQLite fixture
+
+### Test coverage using fixture
+
+| Test | Fixture data used | Verifies |
+|------|-------------------|----------|
+| Barrier metadata in descendants | T1, T_barrier, T_behind | RG returns barrier data without filtering |
+| AuthZ tenant filter | T1, Dept1 | AuthZ plugin resolves hierarchy, scopes correctly |
+| Cross-tenant invisible | T1, T2 | T2 cannot see T1 data via AuthZ plugin |
+| Barrier exclusion from scope | T1, T_barrier, T_behind | AuthZ plugin excludes barrier subtree from AccessScope |
+| Sub-tenant provisioning | T_normal | Verify `tenant_id == group.id` for sub-tenants |
+| Normal group inherits tenant | Dept1 | Verify `tenant_id == parent.tenant_id` |
+
+### Running
+
+```bash
+# Build with both authz plugins
+make build
+
+# Run RG + AuthZ e2e tests (uses whichever authz plugin has higher priority)
+make e2e-rg-authz
+
+# Or manually:
+python3 scripts/ci.py e2e-local --config config/e2e-rg-authz.yaml -- -k "resource_group"
+```
 
 ---
 

--- a/modules/system/resource-group/docs/ADR/ADR-001-gts-type-system.md
+++ b/modules/system/resource-group/docs/ADR/ADR-001-gts-type-system.md
@@ -239,7 +239,7 @@ Base contract for all RG type definitions. Traits define topology rules; propert
     "id": { "type": "string", "format": "uuid" },
     "name": { "type": "string", "minLength": 1, "maxLength": 255 },
     "custom_domain": { "type": "string", "format": "hostname" },
-    "barrier": { "type": "boolean", "default": false }
+    "self_managed": { "type": "boolean", "default": false }
   }
 }
 ```
@@ -331,7 +331,7 @@ When a type is registered as an RG type, it chains with the base contract via a 
           "additionalProperties": false,
           "properties": {
             "custom_domain": { "type": "string", "format": "hostname" },
-            "barrier": { "type": "boolean", "default": false }
+            "self_managed": { "type": "boolean", "default": false }
           }
         }
       },
@@ -478,7 +478,7 @@ Instances are anonymous (UUID `id`, separate `type` field). Derived type fields 
   "tenant_id": "77777777-7777-7777-7777-777777777777",
   "depth": 1,
   "metadata": {
-    "barrier": true
+    "self_managed": true
   }
 }
 ```
@@ -534,7 +534,7 @@ tenant T9 (depth 0) {metadata: {custom_domain: "t9.example.com"}}
 ```
 
 Notes:
-- T7 has `metadata.barrier: true` — RG stores it in metadata JSONB. Tenant Resolver (`BarrierMode`) + AuthZ enforce it
+- T7 has `metadata.self_managed: true` — RG stores it in metadata JSONB. Tenant Resolver (`BarrierMode`) + AuthZ enforce it
 - R4 appears twice: as **course** in B3 and as **user** in T1 (different `gts_type_id`)
 - R8 appears twice: as **user** in D8 and T7 (same type, two group memberships)
 
@@ -667,7 +667,7 @@ This matches exactly 4 name tokens per segment — the DB constraint and the `gt
 - Chained type narrows `metadata` via `allOf` merge — `additionalProperties: false` applies only within the `metadata` sub-object
 - Unknown metadata fields rejected (e.g. `metadata: {foo: "bar"}` → error)
 - Entity-specific constraints enforced (e.g. `metadata.category` maxLength: 100 → validated)
-- Top-level field isolation: `metadata.barrier` can never clash with a future base field `barrier`
+- Top-level field isolation: `metadata.self_managed` can never clash with a future base field `barrier`
 
 **Test results** (33 tests, all passing):
 
@@ -675,9 +675,9 @@ This matches exactly 4 name tokens per segment — the DB constraint and the `gt
 |-----------|----------|--------|
 | Department `metadata.category` 101 chars | rejected | rejected |
 | Department `metadata.short_description` 501 chars | rejected | rejected |
-| Tenant `metadata.barrier: "yes"` (string) | rejected | rejected |
+| Tenant `metadata.self_managed: "yes"` (string) | rejected | rejected |
 | Tenant `metadata: {foo: "bar"}` (unknown field) | rejected | rejected |
-| Tenant `metadata.barrier: true` | accepted | accepted |
+| Tenant `metadata.self_managed: true` | accepted | accepted |
 | Tenant `metadata.custom_domain: "t9.example.com"` | accepted | accepted |
 | Branch `metadata.location: "..."` | accepted | accepted |
 | Top-level `barrier: true` (no metadata wrapper) | accepted by GTS* | accepted* |

--- a/modules/system/resource-group/docs/DECOMPOSITION.md
+++ b/modules/system/resource-group/docs/DECOMPOSITION.md
@@ -308,7 +308,7 @@ The Resource Group DESIGN is decomposed into seven features organized around the
   - MTLS authentication: client certificate verification against trusted CA bundle, endpoint allowlist (only `GET /groups/{group_id}/hierarchy`), AuthZ bypass for trusted system principals, system SecurityContext creation
   - MTLS configuration: `ca_cert`, `allowed_clients` (by certificate CN), `allowed_endpoints` (method + path pairs)
   - Tenant scope enforcement for ownership-graph profile: parent-child edges and membership writes validated for tenant-hierarchy compatibility, platform-admin provisioning exception for cross-tenant management, tenant-scoped reads via `SecurityContext.subject_tenant_id`
-  - Barrier as data: `metadata.barrier` stored in group metadata JSONB without enforcement by RG, returned in API responses within `metadata` object for consumption by Tenant Resolver and AuthZ
+  - Barrier as data: `metadata.self_managed` stored in group metadata JSONB without enforcement by RG, returned in API responses within `metadata` object for consumption by Tenant Resolver and AuthZ
   - In-process vs out-of-process: ClientHub direct call (monolith, no MTLS needed) vs MTLS-authenticated remote call (microservices)
   - SecurityContext propagation: `ctx` passed through gateway to selected provider without policy interpretation
 

--- a/modules/system/resource-group/docs/DESIGN.md
+++ b/modules/system/resource-group/docs/DESIGN.md
@@ -198,12 +198,12 @@ In ownership-graph usage, groups are tenant-scoped and links must be tenant-hier
 
 - [x] `p1` - **ID**: `cpt-cf-resource-group-principle-barrier-as-data`
 
-`barrier` is not a dedicated database column. For GTS types that support barrier semantics (e.g. tenant types), `barrier` is stored inside the `metadata` JSONB field as `metadata.barrier` (boolean). **ADRs**: `cpt-cf-resource-group-adr-p1-gts-type-system`. **RG stores and returns it without enforcement** — RG does not filter, restrict, or alter query results based on the barrier value. RG stores it in `metadata` and returns it in API responses within the `metadata` object, nothing more.
+`barrier` is not a dedicated database column. For GTS types that support barrier semantics (e.g. tenant types), `barrier` is stored inside the `metadata` JSONB field as `metadata.self_managed` (boolean). **ADRs**: `cpt-cf-resource-group-adr-p1-gts-type-system`. **RG stores and returns it without enforcement** — RG does not filter, restrict, or alter query results based on the barrier value. RG stores it in `metadata` and returns it in API responses within the `metadata` object, nothing more.
 
 Barrier enforcement is a **joint responsibility of Tenant Resolver and AuthZ**:
 
-- **RG does not enforce barriers**: all RG queries (hierarchy, groups, memberships) return data regardless of barrier values. If a caller has an `AccessScope` that includes `tenant_id = T7`, RG will return T7's data even if T7 has `metadata.barrier = true`.
-- **Tenant Resolver enforces barriers in hierarchy traversal**: TR SDK defines `BarrierMode` (`Respect` / `Ignore`). The static-tr-plugin's `collect_descendants` skips barrier tenants (`self_managed = true`) and their entire subtrees. `collect_ancestors` from a barrier tenant returns empty. RG's `metadata.barrier` maps to TR's `TenantInfo.self_managed`.
+- **RG does not enforce barriers**: all RG queries (hierarchy, groups, memberships) return data regardless of barrier values. If a caller has an `AccessScope` that includes `tenant_id = T7`, RG will return T7's data even if T7 has `metadata.self_managed = true`.
+- **Tenant Resolver enforces barriers in hierarchy traversal**: TR SDK defines `BarrierMode` (`Respect` / `Ignore`). The static-tr-plugin's `collect_descendants` skips barrier tenants (`self_managed = true`) and their entire subtrees. `collect_ancestors` from a barrier tenant returns empty. RG's `metadata.self_managed` maps to TR's `TenantInfo.self_managed`.
 - **AuthZ integrates barriers into SQL constraints**: the `in_tenant_subtree` predicate supports `barrier_mode: "all"` (default, reads `metadata->>'barrier'` from the closure query) or `"none"` (ignores barriers for billing, provisioning).
 - **Each layer is vendor-replaceable**: vendors can implement custom TR plugins and AuthZ plugins with different barrier semantics. RG remains policy-agnostic.
 
@@ -571,7 +571,7 @@ The integration read contract returns **data rows only** (no policy/decision fie
 | `id`          | UUID        | Yes      | Group identifier                                                             |
 | `type`        | string      | Yes      | GTS chained type path                                                        |
 | `name`        | string      | Yes      | Display name                                                                 |
-| `metadata`     | object | No   | Type-specific fields nested in `metadata` object (e.g. `metadata.barrier`, `metadata.category`). Stored in DB `metadata` JSONB. Schema defined by chained GTS type. |
+| `metadata`     | object | No   | Type-specific fields nested in `metadata` object (e.g. `metadata.self_managed`, `metadata.category`). Stored in DB `metadata` JSONB. Schema defined by chained GTS type. |
 | `hierarchy`   | object      | Yes      | RG hierarchy context                                                         |
 | `hierarchy.parent_id` | UUID / null | No | Parent group (null for root groups)                                    |
 | `hierarchy.tenant_id` | UUID  | Yes    | Tenant scope (can differ per row under tenant hierarchy scope)               |
@@ -810,8 +810,8 @@ sequenceDiagram
     Note right of AZ: subject.properties.tenant_id = T1<br/>action.name = "list"<br/>resource.type = "gts.x.lms.course.v1~"<br/>context.require_constraints = true<br/>context.supported_properties = ["owner_tenant_id"]
 
     AZ->>RG: list_group_depth(system_ctx, T1, filter: "hierarchy/depth ge 0 and type eq 'tenant'")
-    RG-->>AZ: [{T1, depth:0, metadata:{}}, {T7, depth:1, metadata:{barrier:true}}]
-    Note right of AZ: AuthZ policy logic (not RG):<br/>T7.metadata.barrier=true, caller≠T7<br/>→ exclude T7 scope from AccessScope
+    RG-->>AZ: [{T1, depth:0, metadata:{}}, {T7, depth:1, metadata:{self_managed:true}}]
+    Note right of AZ: AuthZ policy logic (not RG):<br/>T7.metadata.self_managed=true, caller≠T7<br/>→ exclude T7 scope from AccessScope
 
     AZ-->>PE: decision=true, constraints=[{owner_tenant_id IN (T1)}]
     PE->>PE: compile_to_access_scope()
@@ -1077,7 +1077,7 @@ Constraints:
 | `parent_id`   | UUID NULL   | parent entity (FK to `resource_group.id`)         |
 | `gts_type_id` | SMALLINT    | type reference (FK to `gts_type.id`)              |
 | `name`        | TEXT        | display name                                      |
-| `metadata`    | JSONB NULL  | type-specific fields for group instance, validated against the chained GTS type schema. For types supporting barrier semantics, includes `metadata.barrier` (boolean). |
+| `metadata`    | JSONB NULL  | type-specific fields for group instance, validated against the chained GTS type schema. For types supporting barrier semantics, includes `metadata.self_managed` (boolean). |
 | `tenant_id`   | UUID        | tenant scope                                      |
 | `created_at`     | TIMESTAMPTZ | creation time                                     |
 | `updated_at`    | TIMESTAMPTZ | update time (nullable)                            |
@@ -1335,7 +1335,7 @@ Test dataset: 100K groups, 200K memberships, 359K closure rows:
 
 #### Column Widths (avg bytes, measured via pg_stats in test environment)
 
-**resource_group** (~100 B/row): `id` 16 B (UUID), `parent_id` 16 B (UUID nullable), `gts_type_id` 2 B (SMALLINT), `name` 14 B (TEXT avg), `metadata` variable (JSONB nullable, typically 20–60 B when present; includes `barrier` for applicable types), `tenant_id` 16 B (UUID), `created_at`/`updated_at` 8 B each, row overhead ~20 B. Note: `barrier` is not a separate column — it is stored inside `metadata` JSONB as `metadata.barrier` (see `cpt-cf-resource-group-principle-barrier-as-data`).
+**resource_group** (~100 B/row): `id` 16 B (UUID), `parent_id` 16 B (UUID nullable), `gts_type_id` 2 B (SMALLINT), `name` 14 B (TEXT avg), `metadata` variable (JSONB nullable, typically 20–60 B when present; includes `barrier` for applicable types), `tenant_id` 16 B (UUID), `created_at`/`updated_at` 8 B each, row overhead ~20 B. Note: `barrier` is not a separate column — it is stored inside `metadata` JSONB as `metadata.self_managed` (see `cpt-cf-resource-group-principle-barrier-as-data`).
 
 **resource_group_closure** (68 B/row): `ancestor_id` 16 B, `descendant_id` 16 B, `depth` 4 B, row overhead ~32 B.
 

--- a/modules/system/resource-group/docs/PRD.md
+++ b/modules/system/resource-group/docs/PRD.md
@@ -220,9 +220,9 @@ This aligns RG behavior with `docs/arch/authorization/RESOURCE_GROUP_MODEL.md`.
 
 #### Responsibility Split: RG stores, Tenant Resolver + AuthZ enforce
 
-**RG treats `barrier` purely as data — RG does not filter, restrict, or alter query results based on the barrier value.** For GTS types that support barrier semantics (e.g. tenant types), `barrier` is stored inside the `metadata` field as `metadata.barrier` (boolean). RG returns it in API responses within `metadata`, nothing more. All RG queries return data regardless of barrier values — barrier enforcement is entirely outside RG's scope.
+**RG treats `barrier` purely as data — RG does not filter, restrict, or alter query results based on the barrier value.** For GTS types that support barrier semantics (e.g. tenant types), `barrier` is stored inside the `metadata` field as `metadata.self_managed` (boolean). RG returns it in API responses within `metadata`, nothing more. All RG queries return data regardless of barrier values — barrier enforcement is entirely outside RG's scope.
 
-**Tenant Resolver enforces barrier during hierarchy traversal.** TR applies barrier logic when collecting ancestors and descendants. RG's `metadata.barrier` maps to TR's `self_managed` flag.
+**Tenant Resolver enforces barrier during hierarchy traversal.** TR applies barrier logic when collecting ancestors and descendants. RG's `metadata.self_managed` maps to TR's `self_managed` flag.
 
 **AuthZ integrates barrier into access constraints.** AuthZ supports `barrier_mode` parameter (`respect` / `ignore`). When respecting barriers, barrier tenants and their subtrees are excluded from access scope.
 
@@ -392,7 +392,7 @@ Entity fields (GTS-aligned naming):
 - `id` (UUID) — group identifier
 - `type` (GTS chained type path, e.g. `gts.x.system.rg.type.v1~w.system.org.department.v1~`)
 - `name` (1..255) — display name
-- `metadata` (object) — type-specific fields defined by the chained RG type schema. Examples: `metadata.barrier`, `metadata.custom_domain`, `metadata.category`. For types supporting barrier semantics, `metadata.barrier` (boolean) is included here.
+- `metadata` (object) — type-specific fields defined by the chained RG type schema. Examples: `metadata.self_managed`, `metadata.custom_domain`, `metadata.category`. For types supporting barrier semantics, `metadata.self_managed` (boolean) is included here.
 - `hierarchy` (object) — RG hierarchy context:
   - `parent_id` (optional) — direct parent group
   - `tenant_id` (required) — tenant scope

--- a/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
+++ b/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
@@ -529,7 +529,7 @@ No data setup needed. Fastest possible test.
 
 ```
 POST /types → create type
-POST /groups → create group with metadata: {"barrier": true}
+POST /groups → create group with metadata: {"self_managed": true}
 GET  /groups/{id} → 200
 
 Assert JSON keys:
@@ -539,7 +539,7 @@ Assert JSON keys:
   "tenant_id"  — string, UUID format
   "parent_id"  — null (root group)
   "depth"      — integer, == 0
-  "metadata"   — {"barrier": true} (JSONB roundtrip)
+  "metadata"   — {"self_managed": true} (JSONB roundtrip)
   "created_at" — string, ISO 8601
   "updated_at" — null or absent (fresh create)
 

--- a/modules/system/resource-group/docs/features/0002-type-management.md
+++ b/modules/system/resource-group/docs/features/0002-type-management.md
@@ -79,32 +79,32 @@ Types define the structural rules for the resource group hierarchy — which par
 **Actor**: `cpt-cf-resource-group-actor-instance-administrator`
 
 **Success Scenarios**:
-- Type is created with schema_id, allowed_parents, allowed_memberships, and metadata_schema
+- Type is created with schema_id, allowed_parent_types, allowed_membership_types, and metadata_schema
 - Type is immediately available for group creation
 
 **Error Scenarios**:
 - Invalid GTS type path format → Validation error
 - Duplicate schema_id → TypeAlreadyExists
-- Referenced allowed_parents type does not exist → Validation error
-- Referenced allowed_memberships type does not exist → Validation error
-- Placement invariant violated (not can_be_root AND no allowed_parents) → Validation error
+- Referenced allowed_parent_types type does not exist → Validation error
+- Referenced allowed_membership_types type does not exist → Validation error
+- Placement invariant violated (not can_be_root AND no allowed_parent_types) → Validation error
 
 **Steps**:
 1. [x] - `p1` - Actor sends POST /api/types-registry/v1/types with type definition payload - `inst-create-type-1`
 2. [x] - `p1` - Validate GTS type path format via `GtsTypePath` value object - `inst-create-type-2`
-3. [x] - `p1` - Validate placement invariant: `can_be_root OR len(allowed_parents) >= 1` - `inst-create-type-3`
-4. [x] - `p1` - **IF** allowed_parents is non-empty - `inst-create-type-4`
-   1. [x] - `p1` - DB: SELECT id FROM gts_type WHERE schema_id IN (allowed_parents) — verify all referenced parent types exist - `inst-create-type-4a`
+3. [x] - `p1` - Validate placement invariant: `can_be_root OR len(allowed_parent_types) >= 1` - `inst-create-type-3`
+4. [x] - `p1` - **IF** allowed_parent_types is non-empty - `inst-create-type-4`
+   1. [x] - `p1` - DB: SELECT id FROM gts_type WHERE schema_id IN (allowed_parent_types) — verify all referenced parent types exist - `inst-create-type-4a`
    2. [x] - `p1` - **IF** any parent type not found → **RETURN** Validation error with missing type paths - `inst-create-type-4b`
-5. [x] - `p1` - **IF** allowed_memberships is non-empty - `inst-create-type-5`
-   1. [x] - `p1` - DB: SELECT id FROM gts_type WHERE schema_id IN (allowed_memberships) — verify all referenced membership types exist - `inst-create-type-5a`
+5. [x] - `p1` - **IF** allowed_membership_types is non-empty - `inst-create-type-5`
+   1. [x] - `p1` - DB: SELECT id FROM gts_type WHERE schema_id IN (allowed_membership_types) — verify all referenced membership types exist - `inst-create-type-5a`
    2. [x] - `p1` - **IF** any membership type not found → **RETURN** Validation error with missing type paths - `inst-create-type-5b`
 6. [x] - `p1` - Resolve GTS type path to SMALLINT surrogate ID at persistence boundary - `inst-create-type-6`
 7. [x] - `p1` - DB: INSERT INTO gts_type (schema_id, metadata_schema) — with uniqueness constraint on schema_id - `inst-create-type-7`
 8. [x] - `p1` - **IF** unique constraint violation → **RETURN** TypeAlreadyExists with conflicting schema_id - `inst-create-type-8`
 9. [x] - `p1` - DB: INSERT INTO gts_type_allowed_parent (type_id, parent_type_id) for each allowed parent - `inst-create-type-9`
 10. [x] - `p1` - DB: INSERT INTO gts_type_allowed_membership (type_id, membership_type_id) for each allowed membership - `inst-create-type-10`
-11. [x] - `p1` - **RETURN** created ResourceGroupType with schema_id, allowed_parents, allowed_memberships, can_be_root, metadata_schema - `inst-create-type-11`
+11. [x] - `p1` - **RETURN** created ResourceGroupType with schema_id, allowed_parent_types, allowed_membership_types, can_be_root, is_tenant, metadata_schema - `inst-create-type-11`
 
 ### Update Type
 
@@ -113,13 +113,13 @@ Types define the structural rules for the resource group hierarchy — which par
 **Actor**: `cpt-cf-resource-group-actor-instance-administrator`
 
 **Success Scenarios**:
-- Type definition updated (allowed_parents, allowed_memberships, metadata_schema)
+- Type definition updated (allowed_parent_types, allowed_membership_types, metadata_schema)
 - Existing groups remain valid under new rules
 
 **Error Scenarios**:
 - Type not found → NotFound
-- Removing allowed_parent that is in use by existing groups → AllowedParentsViolation
-- Setting can_be_root=false when root groups of this type exist → AllowedParentsViolation
+- Removing allowed_parent that is in use by existing groups → AllowedParentTypesViolation
+- Setting can_be_root=false when root groups of this type exist → AllowedParentTypesViolation
 - Referenced type does not exist → Validation error
 - Placement invariant violated → Validation error
 
@@ -128,9 +128,9 @@ Types define the structural rules for the resource group hierarchy — which par
 2. [x] - `p1` - DB: SELECT FROM gts_type WHERE schema_id = {code} — load existing type - `inst-update-type-2`
 3. [x] - `p1` - **IF** type not found → **RETURN** NotFound - `inst-update-type-3`
 4. [x] - `p1` - Validate placement invariant on new values - `inst-update-type-4`
-5. [x] - `p1` - Validate all referenced allowed_parents and allowed_memberships types exist - `inst-update-type-5`
-6. [x] - `p1` - Invoke hierarchy safety check algorithm for allowed_parents and can_be_root changes - `inst-update-type-6`
-7. [x] - `p1` - **IF** hierarchy safety check fails → **RETURN** AllowedParentsViolation with violating group details - `inst-update-type-7`
+5. [x] - `p1` - Validate all referenced allowed_parent_types and allowed_membership_types types exist - `inst-update-type-5`
+6. [x] - `p1` - Invoke hierarchy safety check algorithm for allowed_parent_types and can_be_root changes - `inst-update-type-6`
+7. [x] - `p1` - **IF** hierarchy safety check fails → **RETURN** AllowedParentTypesViolation with violating group details - `inst-update-type-7`
 8. [x] - `p1` - DB: DELETE FROM gts_type_allowed_parent WHERE type_id = {id} — clear old parents - `inst-update-type-8`
 9. [x] - `p1` - DB: INSERT INTO gts_type_allowed_parent — insert new parents - `inst-update-type-9`
 10. [x] - `p1` - DB: DELETE FROM gts_type_allowed_membership WHERE type_id = {id} — clear old memberships - `inst-update-type-10`
@@ -166,43 +166,43 @@ Types define the structural rules for the resource group hierarchy — which par
 
 - [x] `p1` - **ID**: `cpt-cf-resource-group-algo-type-mgmt-validate-type-input`
 
-**Input**: Type create/update payload (`schema_id`, `allowed_parents`, `allowed_memberships`, `can_be_root`, `metadata_schema`)
+**Input**: Type create/update payload (`schema_id`, `allowed_parent_types`, `allowed_membership_types`, `can_be_root`, `is_tenant` (default `false`), `metadata_schema`)
 
 **Output**: Validated type definition or validation error with field-level details
 
 **Steps**:
 1. [x] - `p1` - Validate `schema_id` via GtsTypePath value object (format, length, non-empty) - `inst-val-input-1`
-2. [x] - `p1` - **IF** `schema_id` does not have RG type prefix `gts.x.system.rg.type.v1~` - `inst-val-input-2`
+2. [x] - `p1` - **IF** `schema_id` does not have RG type prefix `gts.cf.core.rg.type.v1~` - `inst-val-input-2`
    1. [x] - `p1` - **RETURN** Validation error: "Type schema_id must have RG type prefix" - `inst-val-input-2a`
-3. [x] - `p1` - Validate placement invariant: `can_be_root == true OR len(allowed_parents) >= 1` - `inst-val-input-3`
+3. [x] - `p1` - Validate placement invariant: `can_be_root == true OR len(allowed_parent_types) >= 1` - `inst-val-input-3`
 4. [x] - `p1` - **IF** invariant violated - `inst-val-input-4`
    1. [x] - `p1` - **RETURN** Validation error: "Type must allow root placement or have at least one allowed parent" - `inst-val-input-4a`
-5. [x] - `p1` - **FOR EACH** parent_path in allowed_parents - `inst-val-input-5`
-   1. [x] - `p1` - Validate parent_path has RG type prefix `gts.x.system.rg.type.v1~` - `inst-val-input-5a`
+5. [x] - `p1` - **FOR EACH** parent_path in allowed_parent_types - `inst-val-input-5`
+   1. [x] - `p1` - Validate parent_path has RG type prefix `gts.cf.core.rg.type.v1~` - `inst-val-input-5a`
    2. [x] - `p1` - Verify parent_path exists in gts_type table - `inst-val-input-5b`
-6. [x] - `p1` - **FOR EACH** membership_path in allowed_memberships - `inst-val-input-6`
+6. [x] - `p1` - **FOR EACH** membership_path in allowed_membership_types - `inst-val-input-6`
    1. [x] - `p1` - Validate membership_path is a valid GtsTypePath (no RG prefix requirement) - `inst-val-input-6a`
    2. [x] - `p1` - Verify membership_path exists in gts_type table - `inst-val-input-6b`
-7. [x] - `p1` - **IF** metadata_schema provided, validate it is a valid JSON Schema via `jsonschema::validator_for()`. Returns validation error if the schema cannot be compiled. - `inst-val-input-7`
+7. [x] - `p1` - **IF** metadata_schema provided, validate it is a valid JSON Schema via `jsonschema::validator_for()` (compile-check). Runtime metadata validation against group instances uses `validate_metadata_via_gts()` through `TypesRegistryClient`. - `inst-val-input-7`
 8. [x] - `p1` - **RETURN** validated type definition - `inst-val-input-8`
 
 ### Hierarchy Safety Check for Type Update
 
 - [x] `p1` - **ID**: `cpt-cf-resource-group-algo-type-mgmt-check-hierarchy-safety`
 
-**Input**: Existing type definition, proposed new `allowed_parents` and `can_be_root` values
+**Input**: Existing type definition, proposed new `allowed_parent_types` and `can_be_root` values
 
-**Output**: Pass or AllowedParentsViolation with conflicting group details
+**Output**: Pass or AllowedParentTypesViolation with conflicting group details
 
 **Steps**:
-1. [x] - `p1` - Compute removed parent types: `old_allowed_parents - new_allowed_parents` - `inst-hier-check-1`
+1. [x] - `p1` - Compute removed parent types: `old_allowed_parent_types - new_allowed_parent_types` - `inst-hier-check-1`
 2. [x] - `p1` - **FOR EACH** removed_parent_type in removed set - `inst-hier-check-2`
    1. [x] - `p1` - DB: SELECT rg.id, rg.name FROM resource_group rg JOIN resource_group parent ON rg.parent_id = parent.id WHERE rg.gts_type_id = {this_type_id} AND parent.gts_type_id = {removed_parent_type_id} - `inst-hier-check-2a`
    2. [x] - `p1` - **IF** any groups found → collect as violations - `inst-hier-check-2b`
 3. [x] - `p1` - **IF** can_be_root changed from true to false - `inst-hier-check-3`
    1. [x] - `p1` - DB: SELECT id, name FROM resource_group WHERE gts_type_id = {this_type_id} AND parent_id IS NULL - `inst-hier-check-3a`
    2. [x] - `p1` - **IF** any root groups found → collect as violations - `inst-hier-check-3b`
-4. [x] - `p1` - **IF** violations collected → **RETURN** AllowedParentsViolation with violating group IDs, names, and constraint details - `inst-hier-check-4`
+4. [x] - `p1` - **IF** violations collected → **RETURN** AllowedParentTypesViolation with violating group IDs, names, and constraint details - `inst-hier-check-4`
 5. [x] - `p1` - **RETURN** pass - `inst-hier-check-5`
 
 ### Type Seeding
@@ -301,7 +301,7 @@ The system **MUST** provide an idempotent type seeding mechanism for deployment 
 - [x] `p1` - **ID**: `cpt-cf-resource-group-dod-testing-type-mgmt`
 
 All acceptance criteria from feature 0002 are covered by automated tests:
-- Create with valid/invalid `allowed_parents` and `allowed_memberships`
+- Create with valid/invalid `allowed_parent_types` and `allowed_membership_types`
 - Placement invariant enforcement
 - Update with hierarchy safety checks (removed parent in use, can_be_root toggle)
 - Delete with active group references blocked
@@ -326,12 +326,12 @@ Extend `domain_unit_test.rs` with FROM-direction error conversions:
 
 ## 6. Acceptance Criteria
 
-- [x] Type with valid schema_id and allowed_parents is created and persisted with junction table entries
+- [x] Type with valid schema_id and allowed_parent_types is created and persisted with junction table entries
 - [x] Creating type with duplicate schema_id returns `TypeAlreadyExists` (409)
 - [x] Creating type with invalid GTS type path format returns validation error (400) with field details
-- [x] Creating type without `can_be_root` and without `allowed_parents` returns validation error (placement invariant)
-- [x] Updating type to remove allowed_parent that is in use by existing groups returns `AllowedParentsViolation` (409)
-- [x] Updating type to set `can_be_root=false` when root groups exist returns `AllowedParentsViolation` (409)
+- [x] Creating type without `can_be_root` and without `allowed_parent_types` returns validation error (placement invariant)
+- [x] Updating type to remove allowed_parent that is in use by existing groups returns `AllowedParentTypesViolation` (409)
+- [x] Updating type to set `can_be_root=false` when root groups exist returns `AllowedParentTypesViolation` (409)
 - [x] Updating type to add new allowed_parent succeeds when no existing groups violate new rules
 - [x] Deleting unused type succeeds (204) and removes junction table entries via CASCADE
 - [x] Deleting type with existing groups returns `ConflictActiveReferences` (409) with response body including entity count so the caller can display what prevents deletion
@@ -352,40 +352,40 @@ Extend `domain_unit_test.rs` with FROM-direction error conversions:
 
 Test setup: SQLite in-memory + TypeService + GroupService (for hierarchy safety tests).
 
-#### TC-TYP-01: Create type with valid allowed_parents [P1]
+#### TC-TYP-01: Create type with valid allowed_parent_types [P1]
 - **Covers**: G4 (positive path), 0002-AC-1
 - **Setup**: Create parent type first, then create child type referencing it
-- **Assert**: Child type created, `allowed_parents` contains parent code
+- **Assert**: Child type created, `allowed_parent_types` contains parent code
 
-#### TC-TYP-02: Create type with non-existent allowed_parents [P1]
+#### TC-TYP-02: Create type with non-existent allowed_parent_types [P1]
 - **Covers**: G4
-- **Setup**: Create type with `allowed_parents: ["gts.x.system.rg.type.v1~nonexistent.v1~"]`
+- **Setup**: Create type with `allowed_parent_types: ["gts.cf.core.rg.type.v1~nonexistent.v1~"]`
 - **Assert**: `DomainError::TypeNotFound` or `DomainError::Validation`
 
-#### TC-TYP-03: Create type with non-existent allowed_memberships [P1]
+#### TC-TYP-03: Create type with non-existent allowed_membership_types [P1]
 - **Covers**: G5
-- **Setup**: Create type with `allowed_memberships: ["gts.x.system.rg.type.v1~nonexistent.v1~"]`
+- **Setup**: Create type with `allowed_membership_types: ["gts.cf.core.rg.type.v1~nonexistent.v1~"]`
 - **Assert**: Error (type not found)
 
 #### TC-TYP-04: Placement invariant violation (can_be_root=false, no parents) [P1]
 - **Covers**: G6, 0002-AC-4
-- **Setup**: `CreateTypeRequest { can_be_root: false, allowed_parents: [] }`
+- **Setup**: `CreateTypeRequest { can_be_root: false, allowed_parent_types: [] }`
 - **Assert**: `DomainError::Validation` with "root placement or" message
 
 #### TC-TYP-05: Update type happy path [P1]
 - **Covers**: G1, 0002-AC-7
-- **Setup**: Create type, then update with new `allowed_parents`
+- **Setup**: Create type, then update with new `allowed_parent_types`
 - **Assert**: Updated type returned with new parents
 
 #### TC-TYP-06: Update type - remove allowed_parent in use by groups [P1]
 - **Covers**: G2, 0002-AC-5
-- **Setup**: Create parent type P, child type C (allowed_parents=[P]), create group of type P, create child group of type C under P group. Then update type C removing P from allowed_parents.
-- **Assert**: `DomainError::AllowedParentsViolation` with violating group names
+- **Setup**: Create parent type P, child type C (allowed_parent_types=[P]), create group of type P, create child group of type C under P group. Then update type C removing P from allowed_parent_types.
+- **Assert**: `DomainError::AllowedParentTypesViolation` with violating group names
 
 #### TC-TYP-07: Update type - set can_be_root=false with existing root groups [P1]
 - **Covers**: G3, 0002-AC-6
 - **Setup**: Create type with can_be_root=true, create root group of that type. Then update type setting can_be_root=false.
-- **Assert**: `DomainError::AllowedParentsViolation` with root group names
+- **Assert**: `DomainError::AllowedParentTypesViolation` with root group names
 
 #### TC-TYP-08: Update type - not found [P2]
 - **Covers**: G1
@@ -398,15 +398,15 @@ Test setup: SQLite in-memory + TypeService + GroupService (for hierarchy safety 
 
 #### TC-TYP-10: Update type - placement invariant on new values [P2]
 - **Covers**: G1
-- **Setup**: Update type with can_be_root=false and allowed_parents=[]
+- **Setup**: Update type with can_be_root=false and allowed_parent_types=[]
 - **Assert**: `DomainError::Validation`
 
-#### TC-TYP-11: Create type with self-reference in allowed_parents [P2]
+#### TC-TYP-11: Create type with self-reference in allowed_parent_types [P2]
 - Type A lists itself as allowed_parent, but A doesn't exist yet during resolve_ids
 - **Assert**: Error (type not found for self-reference)
 
-#### TC-TYP-12: Create type with invalid format in allowed_parents[i] [P2]
-- allowed_parents: `["wrong.prefix"]` — each parent validated via validate_type_code
+#### TC-TYP-12: Create type with invalid format in allowed_parent_types[i] [P2]
+- allowed_parent_types: `["wrong.prefix"]` — each parent validated via validate_type_code
 - **Assert**: `DomainError::Validation` (prefix error)
 
 #### TC-TYP-13: Delete nonexistent type [P2]
@@ -416,12 +416,12 @@ Test setup: SQLite in-memory + TypeService + GroupService (for hierarchy safety 
 - Create type with `metadata_schema: Some(json_schema)`, get type, verify schema stored
 - **Assert**: Returned type has matching metadata_schema
 
-#### TC-TYP-15: Update type replaces allowed_memberships [P2]
+#### TC-TYP-15: Update type replaces allowed_membership_types [P2]
 - Create type with memberships [A, B], update to [B, C]
 - **Assert**: Updated type has only [B, C], A removed
 
 #### TC-TYP-16: Update type - hierarchy check skips deleted parent type [P3]
-- Remove parent type from allowed_parents, but the parent type itself was already deleted from system
+- Remove parent type from allowed_parent_types, but the parent type itself was already deleted from system
 - **Assert**: No error (resolve_id returns None → skip)
 
 ### Error Conversions
@@ -452,7 +452,7 @@ Existing tests cover `DomainError -> ResourceGroupError` and `DomainError -> Pro
 
 **File**: `type_service_test.rs` (service-level with DB)
 
-`type_repo.rs` transforms metadata_schema on write (inject `__can_be_root`) and on read (strip `__` keys, derive `can_be_root`). This logic has **0 tests**.
+`type_service.rs` transforms metadata_schema on write (inject `__can_be_root` via `build_stored_schema`) and `type_repo.rs` transforms on read (strip `__` keys, derive `can_be_root`). This logic has **0 tests**.
 
 #### TC-META-01: Type with metadata_schema Object — round-trip [P1]
 - **Setup**: Create type with `metadata_schema: Some(json!({"type": "object", "properties": {"x": {"type": "string"}}}))`
@@ -501,8 +501,8 @@ Existing tests cover `DomainError -> ResourceGroupError` and `DomainError -> Pro
 
 #### TC-META-10: can_be_root fallback when __can_be_root missing from stored JSON [P1]
 - Manually insert gts_type row with `metadata_schema = '{}'` (no __can_be_root key)
-- Type has allowed_parents → `can_be_root = false` (fallback: `allowed_parents.is_empty()`)
-- Type has no allowed_parents → `can_be_root = true`
+- Type has allowed_parent_types → `can_be_root = false` (fallback: `allowed_parent_types.is_empty()`)
+- Type has no allowed_parent_types → `can_be_root = true`
 
 #### TC-META-11: metadata_schema not validated as JSON Schema [P2]
 - Feature 0002 says "validate it is valid JSON Schema" (inst-val-input-7)
@@ -515,7 +515,7 @@ Existing tests cover `DomainError -> ResourceGroupError` and `DomainError -> Pro
 These tests verify the system is resilient to adversarial metadata_schema payloads. The key attack surface is `build_stored_schema()` which clones user input into the storage JSONB.
 
 #### TC-META-ATK-01: Overwrite `__can_be_root` via metadata_schema to escalate privileges [P1]
-- Create type with `can_be_root: false, allowed_parents: [P], metadata_schema: {"__can_be_root": true}`
+- Create type with `can_be_root: false, allowed_parent_types: [P], metadata_schema: {"__can_be_root": true}`
 - **Attack**: user tries to force `can_be_root=true` via injected internal key
 - **Assert**: `get_type().can_be_root == false` (system wins, user's `__can_be_root` overwritten by `build_stored_schema`)
 
@@ -523,7 +523,7 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 - `metadata_schema: {"__can_be_root": "maybe", "x": 1}`
 - `build_stored_schema` overwrites with `Bool(can_be_root)` → no issue
 - But what if stored JSONB was manually corrupted to `{"__can_be_root": "not-a-bool"}`?
-- `load_full_type` calls `.as_bool()` → `None` → fallback to `allowed_parents.is_empty()`
+- `load_full_type` calls `.as_bool()` → `None` → fallback to `allowed_parent_types.is_empty()`
 - **Assert**: Verify fallback works, no panic
 
 #### TC-META-ATK-03: Inject multiple `__` prefixed keys to pollute internal storage [P1]
@@ -570,7 +570,7 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 - Create type, verify `resolve_id(code)` returns `Some(id)` where id is `i16`
 
 #### TC-GTS-02: resolve_id returns None for nonexistent path [P1]
-- `resolve_id("gts.x.system.rg.type.v1~nonexistent.v1~")` → `None`
+- `resolve_id("gts.cf.core.rg.type.v1~nonexistent.v1~")` → `None`
 
 #### TC-GTS-03: resolve_ids batch — all found [P1]
 - Create 3 types, `resolve_ids([code1, code2, code3])` → `Ok(vec![id1, id2, id3])`
@@ -590,14 +590,14 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 - Create type with code X, resolve to ID, resolve back to path
 - **Assert**: returned path == X (exact string equality)
 
-#### TC-GTS-08: load_allowed_parents resolves junction → IDs → paths [P1]
-- Create parent type P, child type C(allowed_parents=[P])
-- load_allowed_parents(C.id) → `vec!["gts.x...P..."]`
+#### TC-GTS-08: load_allowed_parent_types resolves junction → IDs → paths [P1]
+- Create parent type P, child type C(allowed_parent_types=[P])
+- load_allowed_parent_types(C.id) → `vec!["gts.cf...P..."]`
 - **Assert**: returned path == P's code
 
-#### TC-GTS-09: load_allowed_memberships resolves junction → IDs → paths [P1]
-- Create member type M, group type G(allowed_memberships=[M])
-- load_allowed_memberships(G.id) → `vec!["gts.x...M..."]`
+#### TC-GTS-09: load_allowed_membership_types resolves junction → IDs → paths [P1]
+- Create member type M, group type G(allowed_membership_types=[M])
+- load_allowed_membership_types(G.id) → `vec!["gts.cf...M..."]`
 
 #### can_be_root Derivation & Internal Key Handling
 
@@ -610,7 +610,7 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 
 #### TC-GTS-11: can_be_root fallback when __can_be_root key missing [P1]
 - Manually insert row in gts_type with metadata_schema without `__can_be_root` key
-- load_full_type → `can_be_root` should default to `allowed_parents.is_empty()`
+- load_full_type → `can_be_root` should default to `allowed_parent_types.is_empty()`
 - **Scenario**: type with parents → false; type without parents → true
 
 #### TC-GTS-12: Internal keys stripped from metadata_schema response [P1]
@@ -630,8 +630,8 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 - Create type with no metadata_schema
 - DB has `{"__can_be_root": true}` → after stripping __ keys → empty object → `None`
 
-#### TC-GTS-19: allowed_parents.contains() exact string match after roundtrip [P1]
-- Create parent type P, child type C(allowed_parents=[P])
+#### TC-GTS-19: allowed_parent_types.contains() exact string match after roundtrip [P1]
+- Create parent type P, child type C(allowed_parent_types=[P])
 - Create group of type P (root), create child group of type C under it
 - **Assert**: success — proves the path stored for P matches P's code exactly during comparison
 
@@ -660,7 +660,7 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 
 #### TC-SEED-03: seed_types updates changed type [P1]
 - **Covers**: G46, 0002-AC-10
-- **Setup**: Seed type with can_be_root=true, then seed again with can_be_root=false + allowed_parents.
+- **Setup**: Seed type with can_be_root=true, then seed again with can_be_root=false + allowed_parent_types.
 - **Assert**: `result.updated == 1`, type in DB reflects new values
 
 #### TC-SEED-04: seed_types idempotent (3 runs) [P2]
@@ -689,7 +689,7 @@ These tests verify the system is resilient to adversarial metadata_schema payloa
 
 | Operation | Required DB Assertions |
 |-----------|----------------------|
-| **Create type with parents** | Junction rows COUNT = `len(allowed_parents)`. Each `parent_type_id` correctly resolved from GTS path to SMALLINT. |
-| **Update type (replace parents)** | Old junction rows **deleted**. New rows match new list. COUNT = `len(new_allowed_parents)`. |
+| **Create type with parents** | Junction rows COUNT = `len(allowed_parent_types)`. Each `parent_type_id` correctly resolved from GTS path to SMALLINT. |
+| **Update type (replace parents)** | Old junction rows **deleted**. New rows match new list. COUNT = `len(new_allowed_parent_types)`. |
 | **Update type (replace memberships)** | `gts_type_allowed_membership` contains only new entries. |
 | **Delete type (CASCADE)** | `gts_type_allowed_parent WHERE type_id` → 0. `gts_type_allowed_membership WHERE type_id` → 0. |

--- a/modules/system/resource-group/docs/features/0003-entity-hierarchy.md
+++ b/modules/system/resource-group/docs/features/0003-entity-hierarchy.md
@@ -637,7 +637,7 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 - This is NOT InvalidParentType — it's a separate Validation branch (line 379-384)
 
 #### TC-GRP-24: Create group with metadata (JSONB) [P2]
-- Create with `metadata: Some(json!({"barrier": true}))`, verify stored and returned
+- Create with `metadata: Some(json!({"self_managed": true}))`, verify stored and returned
 
 #### TC-GRP-25: Multiple root groups of same type [P2]
 - Create 2 root groups of same can_be_root=true type, both succeed
@@ -693,13 +693,13 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 **File**: `group_service_test.rs` (service-level), `api_rest_test.rs` (REST-level)
 
 #### TC-META-12: Group with metadata barrier stored and returned [P1]
-- Create group with `metadata: Some(json!({"barrier": true}))`
-- Get group → `metadata.barrier == true`
+- Create group with `metadata: Some(json!({"self_managed": true}))`
+- Get group → `metadata.self_managed == true`
 - **Covers**: PRD 3.4, Feature 0005-AC "barrier as data"
-- **DB assert**: `resource_group.metadata` JSONB column contains `{"barrier": true}`
+- **DB assert**: `resource_group.metadata` JSONB column contains `{"self_managed": true}`
 
 #### TC-META-13: Group with rich metadata — multiple fields [P1]
-- `metadata: Some(json!({"barrier": true, "label": "Partner", "category": "premium"}))`
+- `metadata: Some(json!({"self_managed": true, "label": "Partner", "category": "premium"}))`
 - **Assert**: all fields preserved in round-trip
 
 #### TC-META-14: Group metadata update replaces entirely (not merge) [P1]
@@ -708,14 +708,14 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 - **DB assert**: confirm in `resource_group` table
 
 #### TC-META-15: Group metadata None → update with metadata → get returns metadata [P2]
-- Create with None, update with `{"barrier": false}`, get → `{"barrier": false}`
+- Create with None, update with `{"self_managed": false}`, get → `{"self_managed": false}`
 
 #### TC-META-16: Group metadata set → update with None → metadata gone [P2]
 - Create with `{"x": 1}`, update with `metadata: None`
 - **Assert**: get returns metadata = None, JSON response has no `metadata` key
 
 #### TC-META-17: Barrier group visible in hierarchy (RG does NOT filter) [P1]
-- Create parent → child with `metadata: {"barrier": true}` → grandchild
+- Create parent → child with `metadata: {"self_managed": true}` → grandchild
 - `list_group_hierarchy(parent)` → returns ALL 3 including barrier child
 - **Covers**: PRD "RG does not filter based on barrier", Feature 0005-AC
 - **Assert**: barrier group present in results, depth correct
@@ -734,8 +734,8 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 - **Assert**: 201, response body has `"metadataSchema"` key (camelCase)
 
 #### TC-META-20: REST create group with metadata in body [P1]
-- POST body: `{"type": "...", "name": "X", "metadata": {"barrier": true}}`
-- **Assert**: 201, response body has `"metadata": {"barrier": true}`
+- POST body: `{"type": "...", "name": "X", "metadata": {"self_managed": true}}`
+- **Assert**: 201, response body has `"metadata": {"self_managed": true}`
 
 #### TC-META-21: REST response omits metadata when null [P2]
 - Create group without metadata
@@ -888,20 +888,20 @@ GTS-level validation (33 tests in `rg_gts_type_system_tests.rs`) validates at sc
 
 ##### Tenant metadata (`barrier: boolean`, `custom_domain: hostname`)
 
-#### TC-ADR-09: Tenant — valid metadata.barrier=true accepted [P1]
-- Create tenant group with `metadata: {"barrier": true}`
+#### TC-ADR-09: Tenant — valid metadata.self_managed=true accepted [P1]
+- Create tenant group with `metadata: {"self_managed": true}`
 - **Assert**: 201 success
 
 #### TC-ADR-10: Tenant — barrier wrong type (string) rejected [P1]
-- Create tenant group with `metadata: {"barrier": "yes"}`
+- Create tenant group with `metadata: {"self_managed": "yes"}`
 - **Assert**: 400 Validation error — `barrier` must be boolean
 
 #### TC-ADR-11: Tenant — barrier wrong type (number) rejected [P1]
-- `metadata: {"barrier": 42}`
+- `metadata: {"self_managed": 42}`
 - **Assert**: 400
 
 #### TC-ADR-12: Tenant — unknown metadata field rejected [P1]
-- `metadata: {"barrier": true, "foo": "bar"}`
+- `metadata: {"self_managed": true, "foo": "bar"}`
 - **Assert**: 400 — `additionalProperties: false` rejects unknown fields
 
 #### TC-ADR-13: Tenant — valid custom_domain accepted [P1]
@@ -967,7 +967,7 @@ GTS-level validation (33 tests in `rg_gts_type_system_tests.rs`) validates at sc
 ##### Cross-type metadata isolation
 
 #### TC-ADR-27: Tenant metadata fields on department → rejected [P1]
-- Create department group with `metadata: {"barrier": true}`
+- Create department group with `metadata: {"self_managed": true}`
 - Department schema does NOT have `barrier` → `additionalProperties: false` rejects
 - **Assert**: 400
 

--- a/modules/system/resource-group/docs/features/0004-membership.md
+++ b/modules/system/resource-group/docs/features/0004-membership.md
@@ -41,7 +41,7 @@
 
 ### 1.1 Overview
 
-Membership lifecycle (add, remove, list) with composite key semantics `(group_id, resource_type, resource_id)`, deterministic lookups by group and by resource, allowed_memberships type validation, tenant compatibility enforcement, and idempotent membership seeding.
+Membership lifecycle (add, remove, list) with composite key semantics `(group_id, resource_type, resource_id)`, deterministic lookups by group and by resource, allowed_membership_types type validation, tenant compatibility enforcement, and idempotent membership seeding.
 
 ### 1.2 Purpose
 
@@ -80,7 +80,7 @@ Memberships link resources (users, courses, documents, etc.) to groups in the hi
 **Error Scenarios**:
 - Group not found → NotFound
 - Duplicate membership (same composite key) → Conflict
-- resource_type not in group type's allowed_memberships → Validation error
+- resource_type not in group type's allowed_membership_types → Validation error
 - resource_type GTS path not registered → Validation error
 - Tenant-incompatible: resource already linked in incompatible tenant → TenantIncompatibility
 
@@ -91,8 +91,8 @@ Memberships link resources (users, courses, documents, etc.) to groups in the hi
 4. [x] - `p1` - **IF** group not found → **RETURN** NotFound - `inst-add-memb-4`
 5. [x] - `p1` - Resolve resource_type GTS path to surrogate ID; verify type exists in gts_type - `inst-add-memb-5`
 6. [x] - `p1` - **IF** resource_type not registered → **RETURN** Validation error - `inst-add-memb-6`
-7. [x] - `p1` - Load group type's allowed_memberships from gts_type_allowed_membership junction - `inst-add-memb-7`
-8. [x] - `p1` - **IF** resource_type not in allowed_memberships → **RETURN** Validation error: "resource_type not permitted for this group type" - `inst-add-memb-8`
+7. [x] - `p1` - Load group type's allowed_membership_types from gts_type_allowed_membership junction - `inst-add-memb-7`
+8. [x] - `p1` - **IF** resource_type not in allowed_membership_types → **RETURN** Validation error: "resource_type not permitted for this group type" - `inst-add-memb-8`
 9. [x] - `p1` - Invoke tenant compatibility check for resource across existing memberships - `inst-add-memb-9`
 10. [x] - `p1` - **IF** tenant incompatible → **RETURN** TenantIncompatibility - `inst-add-memb-10`
 11. [x] - `p1` - DB: INSERT INTO resource_group_membership (group_id, gts_type_id, resource_id, created_at) with UNIQUE constraint - `inst-add-memb-11`
@@ -184,7 +184,7 @@ Not applicable. Memberships are stateless links — they exist or do not exist. 
 The system **MUST** implement a Membership Service that provides add, remove, and list operations for membership links with composite key semantics and tenant compatibility enforcement.
 
 **Required behavior**:
-- Add: validate group existence, validate resource_type exists and is in allowed_memberships, check tenant compatibility, persist with unique constraint
+- Add: validate group existence, validate resource_type exists and is in allowed_membership_types, check tenant compatibility, persist with unique constraint
 - Remove: delete by composite key, return NotFound if absent
 - List: paginated query with OData `$filter` on `resource_id`, `resource_type`, `group_id`; cursor-based pagination
 - Tenant compatibility: derive tenant scope from group's tenant_id; reject if resource already linked in incompatible tenant
@@ -244,7 +244,7 @@ The system **MUST** provide an idempotent membership seeding mechanism for deplo
 
 All acceptance criteria from feature 0004 are covered by automated tests:
 - Add/remove lifecycle with composite key semantics
-- allowed_memberships validation
+- allowed_membership_types validation
 - Tenant compatibility enforcement
 - Duplicate detection
 
@@ -254,7 +254,7 @@ All acceptance criteria from feature 0004 are covered by automated tests:
 - [x] Adding membership to nonexistent group returns `NotFound` (404)
 - [x] Adding duplicate membership `(G1, User, R1)` returns `Conflict` (409)
 - [x] Adding membership with unregistered resource_type GTS path returns validation error (400)
-- [x] Adding membership with resource_type not in group type's allowed_memberships returns validation error (400)
+- [x] Adding membership with resource_type not in group type's allowed_membership_types returns validation error (400)
 - [x] Multiple resource types can coexist in the same group: `(G1, User, U1)` and `(G1, Document, D1)` both succeed
 - [x] Adding membership for resource already linked in incompatible tenant returns `TenantIncompatibility` (409)
 - [x] Removing existing membership returns 204 No Content
@@ -280,7 +280,7 @@ Test setup: SQLite in-memory + TypeService + GroupService + MembershipService.
 
 #### TC-MBR-01: Add membership happy path [P1]
 - **Covers**: G25, 0004-AC-1
-- **Setup**: Create type with allowed_memberships=[member_type], create group. Add membership.
+- **Setup**: Create type with allowed_membership_types=[member_type], create group. Add membership.
 - **Assert**: Membership returned with group_id, resource_type, resource_id
 
 #### TC-MBR-02: Add membership to nonexistent group [P1]
@@ -296,10 +296,10 @@ Test setup: SQLite in-memory + TypeService + GroupService + MembershipService.
 - **Covers**: G28, 0004-AC-4
 - **Assert**: `DomainError::Validation` with "Unknown resource type"
 
-#### TC-MBR-05: Add membership with resource_type not in allowed_memberships [P1]
+#### TC-MBR-05: Add membership with resource_type not in allowed_membership_types [P1]
 - **Covers**: G29, 0004-AC-5
-- **Setup**: Create group of type that does NOT include resource_type in allowed_memberships
-- **Assert**: `DomainError::Validation` with "not in allowed_memberships"
+- **Setup**: Create group of type that does NOT include resource_type in allowed_membership_types
+- **Assert**: `DomainError::Validation` with "not in allowed_membership_types"
 
 #### TC-MBR-06: Tenant compatibility violation [P1]
 - **Covers**: G30, 0004-AC-7
@@ -317,7 +317,7 @@ Test setup: SQLite in-memory + TypeService + GroupService + MembershipService.
 
 #### TC-MBR-09: Multiple resource types in same group [P2]
 - **Covers**: 0004-AC-6
-- **Setup**: Type with allowed_memberships=[typeA, typeB]. Create group. Add (group, typeA, R1) and (group, typeB, R2).
+- **Setup**: Type with allowed_membership_types=[typeA, typeB]. Create group. Add (group, typeA, R1) and (group, typeB, R2).
 - **Assert**: Both succeed, list_memberships returns both
 
 #### TC-MBR-10: Tenant compatibility - first membership always allowed [P2]
@@ -332,9 +332,9 @@ Test setup: SQLite in-memory + TypeService + GroupService + MembershipService.
 #### TC-MBR-12: Remove membership with unregistered resource_type [P2]
 - resolve_id returns None → `DomainError::Validation("Unknown resource type")`
 
-#### TC-MBR-13: Add membership to group with empty allowed_memberships [P1]
-- Group type has `allowed_memberships: []` — any resource_type should be rejected
-- **Assert**: `DomainError::Validation("not in allowed_memberships")`
+#### TC-MBR-13: Add membership to group with empty allowed_membership_types [P1]
+- Group type has `allowed_membership_types: []` — any resource_type should be rejected
+- **Assert**: `DomainError::Validation("not in allowed_membership_types")`
 
 #### TC-MBR-14: Same resource linked in multiple groups of same tenant [P1]
 - Resource (type, R1) added to Group A (tenant T), then to Group B (tenant T)
@@ -390,7 +390,7 @@ Test setup: SQLite in-memory + TypeService + GroupService + MembershipService.
 **Why not in unit tests**: TC-ODATA-05 verifies that `MembershipFilterField` maps `group_id` to the correct column name and kind. The full chain — HTTP `$filter=group_id eq '{id}'` → OData parser → FilterField lookup → SQL `WHERE group_id = ?` — is never tested end-to-end. A mismatch between the parser's expected field name and the FilterField impl breaks filtering silently (returns all rows instead of filtered).
 
 ```
-POST type (with allowed_memberships)
+POST type (with allowed_membership_types)
 POST group_a, group_b
 
 PUT /groups/{a.id}/memberships/{type}/res-1     → 201

--- a/modules/system/resource-group/docs/features/0005-integration-auth.md
+++ b/modules/system/resource-group/docs/features/0005-integration-auth.md
@@ -252,13 +252,13 @@ The system **MUST** enforce tenant-hierarchy-compatible writes in ownership-grap
 - Membership writes validated against target group's tenant scope
 - Platform-admin provisioning exception: privileged calls may bypass caller tenant scoping for cross-tenant management, but data invariants (parent-child type compat, tenant hierarchy rules) remain strict
 - Tenant-scoped reads: in AuthZ query path, `SecurityContext.subject_tenant_id` determines effective tenant scope
-- Barrier as data: `metadata.barrier` stored in group metadata JSONB, returned in API responses within `metadata` object. RG does not filter, restrict, or alter query results based on barrier value.
+- Barrier as data: `metadata.self_managed` stored in group metadata JSONB, returned in API responses within `metadata` object. RG does not filter, restrict, or alter query results based on barrier value.
 
 **Implements**:
 - `cpt-cf-resource-group-algo-integration-auth-tenant-scope-enforcement`
 
 **Touches**:
-- DB: `resource_group` (tenant_id validation, metadata.barrier storage)
+- DB: `resource_group` (tenant_id validation, metadata.self_managed storage)
 
 ### Unit Test Coverage for Integration Auth
 
@@ -283,7 +283,7 @@ In-source `#[cfg(test)]` tests covering auth-mode decision and tenant-scope enfo
 - [x] SecurityContext is passed through gateway to provider without policy interpretation
 - [x] Parent-child edge in ownership-graph profile with incompatible tenants is rejected with TenantIncompatibility
 - [x] Platform-admin provisioning call bypasses caller tenant scoping but still validates data invariants
-- [x] Group with `metadata.barrier = true` is stored and returned in API responses — RG does not filter based on barrier
+- [x] Group with `metadata.self_managed = true` is stored and returned in API responses — RG does not filter based on barrier
 - [x] In monolith deployment, AuthZ plugin uses ClientHub direct call (no MTLS needed)
 - [x] In microservice deployment, AuthZ plugin uses MTLS-authenticated remote call to hierarchy endpoint
 

--- a/modules/system/resource-group/resource-group-sdk/Cargo.toml
+++ b/modules/system/resource-group/resource-group-sdk/Cargo.toml
@@ -1,0 +1,53 @@
+# Created: 2026-04-16 by Constructor Tech
+[package]
+name = "cf-resource-group-sdk"
+version = "0.1.0"
+publish = false
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "SDK for resource-group module: API trait, types, and error definitions"
+
+[lints]
+workspace = true
+
+[features]
+default = ["odata"]
+odata = [
+    "dep:modkit-odata-macros",
+    "dep:modkit-sdk",
+]
+
+[dependencies]
+# Core dependencies for API trait
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+
+# OData macros (for #[derive(ODataFilterable)])
+modkit-odata-macros = { workspace = true, optional = true }
+
+# UUID support
+uuid = { workspace = true }
+
+# Security context for API methods
+modkit-security = { workspace = true }
+
+# SDK utilities (typed OData queries)
+modkit-sdk = { workspace = true, optional = true }
+
+# OData support for pagination and query types (required for API trait)
+modkit-odata = { workspace = true }
+
+# GTS type system — ID parsing and validation
+gts = { workspace = true }
+
+# GTS macros — struct_to_gts_schema for GTS schema definitions
+gts-macros = { workspace = true }
+
+# JSON Schema (required by struct_to_gts_schema)
+schemars = { workspace = true }
+
+# ModKit — BaseModkitPluginV1 for plugin spec base type
+modkit = { workspace = true }

--- a/modules/system/resource-group/resource-group-sdk/src/api.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/api.rs
@@ -1,0 +1,188 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-traits:p1
+//! SDK trait contracts for the resource-group module.
+
+use async_trait::async_trait;
+use modkit_security::SecurityContext;
+
+use modkit_odata::{ODataQuery, Page};
+use uuid::Uuid;
+
+use crate::error::ResourceGroupError;
+use crate::models::{
+    CreateGroupRequest, CreateTypeRequest, ResourceGroup, ResourceGroupMembership,
+    ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest, UpdateTypeRequest,
+};
+
+/// Client trait for resource-group type management.
+///
+/// Consumers obtain this from `ClientHub`:
+/// ```ignore
+/// let client = hub.get::<dyn ResourceGroupClient>()?;
+/// let rg_type = client.get_type(&ctx, "gts.cf.core.rg.type.v1~...").await?;
+/// ```
+#[async_trait]
+pub trait ResourceGroupClient: Send + Sync {
+    // -- Type lifecycle --
+
+    /// Create a new GTS type definition.
+    async fn create_type(
+        &self,
+        ctx: &SecurityContext,
+        request: CreateTypeRequest,
+    ) -> Result<ResourceGroupType, ResourceGroupError>;
+
+    /// Get a GTS type definition by its code (GTS type path).
+    async fn get_type(
+        &self,
+        ctx: &SecurityContext,
+        code: &str,
+    ) -> Result<ResourceGroupType, ResourceGroupError>;
+
+    /// List GTS type definitions with `OData` filtering and cursor-based pagination.
+    async fn list_types(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupType>, ResourceGroupError>;
+
+    /// Update a GTS type definition (full replacement).
+    async fn update_type(
+        &self,
+        ctx: &SecurityContext,
+        code: &str,
+        request: UpdateTypeRequest,
+    ) -> Result<ResourceGroupType, ResourceGroupError>;
+
+    /// Delete a GTS type definition. Fails if groups of this type exist.
+    async fn delete_type(
+        &self,
+        ctx: &SecurityContext,
+        code: &str,
+    ) -> Result<(), ResourceGroupError>;
+
+    // -- Group lifecycle --
+
+    /// Create a new resource group.
+    async fn create_group(
+        &self,
+        ctx: &SecurityContext,
+        request: CreateGroupRequest,
+    ) -> Result<ResourceGroup, ResourceGroupError>;
+
+    /// Get a resource group by ID.
+    async fn get_group(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+    ) -> Result<ResourceGroup, ResourceGroupError>;
+
+    /// List resource groups with `OData` filtering and cursor-based pagination.
+    async fn list_groups(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroup>, ResourceGroupError>;
+
+    /// Update a resource group (full replacement).
+    async fn update_group(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        request: UpdateGroupRequest,
+    ) -> Result<ResourceGroup, ResourceGroupError>;
+
+    /// Delete a resource group.
+    /// When `force` is false, fails with `ConflictActiveReferences` if child groups
+    /// or memberships exist. When `force` is true, recursively deletes the entire
+    /// subtree (all descendants and their memberships).
+    async fn delete_group(
+        &self,
+        ctx: &SecurityContext,
+        id: Uuid,
+        force: bool,
+    ) -> Result<(), ResourceGroupError>;
+
+    /// Get descendants of a reference group (depth >= 0).
+    async fn get_group_descendants(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+
+    /// Get ancestors of a reference group (depth <= 0).
+    async fn get_group_ancestors(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+
+    // -- Membership lifecycle --
+
+    /// Add a membership link between a resource and a group.
+    async fn add_membership(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Result<ResourceGroupMembership, ResourceGroupError>;
+
+    /// Remove a membership link.
+    async fn remove_membership(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        resource_type: &str,
+        resource_id: &str,
+    ) -> Result<(), ResourceGroupError>;
+
+    /// List memberships with `OData` filtering and cursor-based pagination.
+    async fn list_memberships(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError>;
+}
+
+// @cpt-dod:cpt-cf-resource-group-dod-integration-auth-read-service:p1
+/// Narrow read-only trait for hierarchy data, used by `AuthZ` plugin.
+///
+/// This trait provides the integration read port that external consumers
+/// (such as the `AuthZ` plugin) use to query group hierarchy data without
+/// depending on the full `ResourceGroupClient`.
+#[async_trait]
+pub trait ResourceGroupReadHierarchy: Send + Sync {
+    /// Get descendants of a reference group (depth >= 0).
+    async fn get_group_descendants(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+
+    /// Get ancestors of a reference group (depth <= 0).
+    async fn get_group_ancestors(
+        &self,
+        ctx: &SecurityContext,
+        group_id: Uuid,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError>;
+}
+
+// @cpt-flow:cpt-cf-resource-group-flow-integration-auth-plugin-routing:p1
+/// Extended read trait for vendor-specific plugin gateway routing.
+///
+/// Extends `ResourceGroupReadHierarchy` with membership listing for
+/// plugin consumers that need both hierarchy and membership data.
+#[async_trait]
+pub trait ResourceGroupReadPluginClient: ResourceGroupReadHierarchy {
+    /// List memberships for plugin consumers.
+    async fn list_memberships(
+        &self,
+        ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupMembership>, ResourceGroupError>;
+}

--- a/modules/system/resource-group/resource-group-sdk/src/error.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/error.rs
@@ -1,0 +1,151 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-errors:p1
+//! Public error types for the resource-group module.
+//!
+//! These errors are safe to expose to other modules and consumers.
+
+use thiserror::Error;
+
+/// Errors that can be returned by the `ResourceGroupClient`.
+#[derive(Error, Debug, Clone)]
+pub enum ResourceGroupError {
+    /// Resource with the specified identifier was not found.
+    #[error("Resource not found: {code}")]
+    NotFound { code: String },
+
+    /// A resource with the specified code already exists.
+    #[error("Resource already exists: {code}")]
+    TypeAlreadyExists { code: String },
+
+    /// Validation error with the provided data.
+    #[error("Validation error: {message}")]
+    Validation { message: String },
+
+    /// Removing allowed parents or disabling root placement would break
+    /// existing group hierarchy relationships.
+    #[error("Allowed parents violation: {message}")]
+    AllowedParentTypesViolation { message: String },
+
+    /// Cannot delete a type because groups of this type still exist.
+    #[error("Active references exist: {message}")]
+    ConflictActiveReferences { message: String },
+
+    /// A generic conflict (e.g. a concurrency or state conflict not related to references).
+    #[error("Conflict: {message}")]
+    Conflict { message: String },
+
+    /// Parent type is not allowed by the type's `allowed_parent_types` configuration.
+    #[error("Invalid parent type: {message}")]
+    InvalidParentType { message: String },
+
+    /// A cycle would be created in the group hierarchy.
+    #[error("Cycle detected: {message}")]
+    CycleDetected { message: String },
+
+    /// A configured limit (depth, width, etc.) would be exceeded.
+    #[error("Limit violation: {message}")]
+    LimitViolation { message: String },
+
+    /// Tenant scope incompatibility.
+    #[error("Tenant incompatibility: {message}")]
+    TenantIncompatibility { message: String },
+
+    /// Service is temporarily unavailable.
+    #[error("Service unavailable: {message}")]
+    ServiceUnavailable { message: String },
+
+    /// Access was denied by the authorization policy (PDP denial).
+    #[error("Access denied")]
+    AccessDenied,
+
+    /// An internal error occurred.
+    #[error("Internal error")]
+    Internal,
+}
+
+impl ResourceGroupError {
+    /// Create a `NotFound` error.
+    pub fn not_found(code: impl Into<String>) -> Self {
+        Self::NotFound { code: code.into() }
+    }
+
+    /// Create a `TypeAlreadyExists` error.
+    pub fn type_already_exists(code: impl Into<String>) -> Self {
+        Self::TypeAlreadyExists { code: code.into() }
+    }
+
+    /// Create a `Validation` error.
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self::Validation {
+            message: message.into(),
+        }
+    }
+
+    /// Create an `AllowedParentTypesViolation` error.
+    pub fn allowed_parent_types_violation(message: impl Into<String>) -> Self {
+        Self::AllowedParentTypesViolation {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `ConflictActiveReferences` error.
+    pub fn conflict_active_references(message: impl Into<String>) -> Self {
+        Self::ConflictActiveReferences {
+            message: message.into(),
+        }
+    }
+
+    /// Create a generic `Conflict` error.
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::Conflict {
+            message: message.into(),
+        }
+    }
+
+    /// Create an `InvalidParentType` error.
+    pub fn invalid_parent_type(message: impl Into<String>) -> Self {
+        Self::InvalidParentType {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `CycleDetected` error.
+    pub fn cycle_detected(message: impl Into<String>) -> Self {
+        Self::CycleDetected {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `LimitViolation` error.
+    pub fn limit_violation(message: impl Into<String>) -> Self {
+        Self::LimitViolation {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `TenantIncompatibility` error.
+    pub fn tenant_incompatibility(message: impl Into<String>) -> Self {
+        Self::TenantIncompatibility {
+            message: message.into(),
+        }
+    }
+
+    /// Create a `ServiceUnavailable` error.
+    pub fn service_unavailable(message: impl Into<String>) -> Self {
+        Self::ServiceUnavailable {
+            message: message.into(),
+        }
+    }
+
+    /// Create an `AccessDenied` error.
+    #[must_use]
+    pub fn access_denied() -> Self {
+        Self::AccessDenied
+    }
+
+    /// Create an `Internal` error.
+    #[must_use]
+    pub fn internal() -> Self {
+        Self::Internal
+    }
+}

--- a/modules/system/resource-group/resource-group-sdk/src/gts.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/gts.rs
@@ -1,0 +1,49 @@
+//! GTS schema definitions for the Resource Group type system.
+
+use gts_macros::struct_to_gts_schema;
+
+/// GTS base type schema for Resource Group types.
+///
+/// Defines the `x-gts-traits-schema` contract: `can_be_root`, `is_tenant`,
+/// `allowed_parent_types`, `allowed_membership_types`.
+///
+/// All chained RG types (tenant, department, branch, etc.) inherit from this
+/// base contract via `allOf` + `$ref`.
+///
+/// # TODO: replace manual DTOs when `gts-macros` supports `x-gts-traits-schema`
+///
+/// Currently `gts-macros` (`struct_to_gts_schema`) does not generate
+/// `x-gts-traits-schema` in the output JSON Schema. Once it does, this struct
+/// should replace:
+/// - `models::ResourceGroupType` (response DTO)
+/// - `models::CreateTypeRequest` (create request DTO)
+/// - `models::UpdateTypeRequest` (update request DTO)
+///
+/// Blockers: `gts-macros` needs camelCase serde support, `x-gts-traits-schema`
+/// generation, `metadata_schema` field support, and `Clone`/`Debug`/`Default`
+/// derives.
+///
+/// # Schema ID
+///
+/// ```text
+/// gts.cf.core.rg.type.v1~
+/// ```
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = true,
+    schema_id = "gts.cf.core.rg.type.v1~",
+    description = "Resource Group base type — defines placement and tenant scope traits",
+    properties = "id,can_be_root,is_tenant,allowed_parent_types,allowed_membership_types"
+)]
+pub struct ResourceGroupTypeV1 {
+    /// GTS type path (schema identifier).
+    pub id: gts::GtsInstanceId,
+    /// Whether groups of this type can be root nodes (no parent). Default `false`.
+    pub can_be_root: bool,
+    /// Whether instances create their own tenant scope (`tenant_id = group.id`). Default `false`.
+    pub is_tenant: bool,
+    /// GTS type paths of allowed parent types.
+    pub allowed_parent_types: Vec<String>,
+    /// GTS type paths of allowed membership resource types.
+    pub allowed_membership_types: Vec<String>,
+}

--- a/modules/system/resource-group/resource-group-sdk/src/lib.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/lib.rs
@@ -1,0 +1,30 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+//! Resource Group SDK
+//!
+//! This crate provides the public API for the `resource-group` module:
+//! - `ResourceGroupClient` trait
+//! - Model types for GTS types, groups, memberships
+//! - Error type (`ResourceGroupError`)
+//! - `OData` filter field definitions (behind `odata` feature)
+
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms)]
+
+pub mod api;
+pub mod error;
+pub mod gts;
+pub mod models;
+
+// OData filter field definitions (feature-gated)
+#[cfg(feature = "odata")]
+pub mod odata;
+
+// Re-export main types at crate root for convenience
+pub use api::{ResourceGroupClient, ResourceGroupReadHierarchy, ResourceGroupReadPluginClient};
+pub use error::ResourceGroupError;
+pub use models::{
+    CreateGroupRequest, CreateTypeRequest, GroupHierarchy, GroupHierarchyWithDepth, GtsTypePath,
+    ResourceGroup, ResourceGroupMembership, ResourceGroupType, ResourceGroupWithDepth,
+    UpdateGroupRequest, UpdateTypeRequest,
+};

--- a/modules/system/resource-group/resource-group-sdk/src/models.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/models.rs
@@ -1,0 +1,297 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-begin:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1:inst-full
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1
+//! SDK model types for the resource-group module.
+//!
+//! These types form the public contract between the resource-group module
+//! and its consumers. They are transport-agnostic and use string-based
+//! GTS type paths (no surrogate SMALLINT IDs).
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// -- GtsTypePath value object --
+
+// @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-1
+/// Maximum length of a GTS type path.
+const GTS_TYPE_PATH_MAX_LEN: usize = 1024;
+
+/// Validated GTS type path value object.
+///
+/// A GTS type path follows the pattern `gts.<segment>~(<segment>~)*` where
+/// each segment consists of lowercase alphanumeric characters, underscores,
+/// and dots. Examples: `gts.cf.core.rg.type.v1~`, `gts.cf.core.rg.type.v1~x.system.tn.tenant.v1~`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct GtsTypePath(String);
+
+impl GtsTypePath {
+    /// Create a new `GtsTypePath` from a raw string, applying validation.
+    ///
+    /// # Errors
+    /// Returns an error if the string is empty, exceeds 1024 characters,
+    /// or does not match the GTS type path format.
+    pub fn new(raw: impl Into<String>) -> Result<Self, String> {
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-2
+        let raw = raw.into();
+        let s = raw.trim().to_lowercase();
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-2
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3
+        if s.is_empty() {
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3a
+            return Err("GTS type path must not be empty".to_owned());
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3a
+        }
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-3
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5
+        if s.len() > GTS_TYPE_PATH_MAX_LEN {
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5a
+            return Err("GTS type path exceeds maximum length".to_owned());
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5a
+        }
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-5
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4
+        // Validate format using the canonical gts crate parser.
+        // Each tilde-separated segment must be a valid GTS ID with 5+ tokens
+        // (vendor.package.namespace.type.vMAJOR).
+        if gts::GtsID::new(&s).is_err() {
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4a
+            return Err("Invalid GTS type path format".to_owned());
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4a
+        }
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-4
+
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-6
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-7
+        Ok(Self(s))
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-7
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-6
+    }
+
+    /// Return the inner string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for GtsTypePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<GtsTypePath> for String {
+    fn from(p: GtsTypePath) -> Self {
+        p.0
+    }
+}
+
+impl TryFrom<String> for GtsTypePath {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        Self::new(s)
+    }
+}
+
+impl AsRef<str> for GtsTypePath {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+// @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-validate-gts-type-path:p1:inst-gts-val-1
+
+// -- Type --
+
+/// A GTS resource group type definition.
+///
+/// Matches the REST `Type` schema. All references use string GTS type paths;
+/// surrogate SMALLINT IDs are internal to the persistence layer.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroupType {
+    /// GTS type path (e.g. `gts.cf.core.rg.type.v1~x.system.tn.tenant.v1~`)
+    pub code: String,
+    /// Whether groups of this type can be root nodes (no parent).
+    pub can_be_root: bool,
+    /// Whether instances create their own tenant scope (`tenant_id = group.id`).
+    #[serde(default)]
+    pub is_tenant: bool,
+    /// GTS type paths of types allowed as parents.
+    pub allowed_parent_types: Vec<String>,
+    /// GTS type paths of resource types allowed as members.
+    pub allowed_membership_types: Vec<String>,
+    /// Optional JSON Schema for the metadata object of instances of this type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+/// Request body for creating a new GTS type.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateTypeRequest {
+    /// GTS type path. Must have prefix `gts.cf.core.rg.type.v1~`.
+    pub code: String,
+    /// Whether groups of this type can be root nodes.
+    pub can_be_root: bool,
+    /// Whether instances create their own tenant scope. Default `false`.
+    #[serde(default)]
+    pub is_tenant: bool,
+    /// GTS type paths of allowed parent types.
+    #[serde(default)]
+    pub allowed_parent_types: Vec<String>,
+    /// GTS type paths of allowed membership resource types.
+    #[serde(default)]
+    pub allowed_membership_types: Vec<String>,
+    /// Optional JSON Schema for instance metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+/// Request body for updating an existing GTS type (full replacement via PUT).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateTypeRequest {
+    /// Whether groups of this type can be root nodes.
+    pub can_be_root: bool,
+    /// Whether instances create their own tenant scope. Default `false`.
+    #[serde(default)]
+    pub is_tenant: bool,
+    /// GTS type paths of allowed parent types.
+    #[serde(default)]
+    pub allowed_parent_types: Vec<String>,
+    /// GTS type paths of allowed membership resource types.
+    #[serde(default)]
+    pub allowed_membership_types: Vec<String>,
+    /// Optional JSON Schema for instance metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+// -- Group --
+
+/// Hierarchy context for a resource group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupHierarchy {
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Tenant scope.
+    pub tenant_id: Uuid,
+}
+
+/// Hierarchy context for a resource group with depth information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupHierarchyWithDepth {
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Tenant scope.
+    pub tenant_id: Uuid,
+    /// Relative distance from reference group.
+    pub depth: i32,
+}
+
+/// A resource group entity.
+///
+/// Group responses do NOT include `created_at`/`updated_at` (per DESIGN).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroup {
+    /// Group identifier.
+    pub id: Uuid,
+    /// GTS chained type path.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name.
+    pub name: String,
+    /// Hierarchy context.
+    pub hierarchy: GroupHierarchy,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// A resource group entity with depth information (for hierarchy queries).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroupWithDepth {
+    /// Group identifier.
+    pub id: Uuid,
+    /// GTS chained type path.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name.
+    pub name: String,
+    /// Hierarchy context with depth.
+    pub hierarchy: GroupHierarchyWithDepth,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Request body for creating a new resource group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateGroupRequest {
+    /// Optional caller-supplied ID (used by seeding for stable identity).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Uuid>,
+    /// GTS chained type path. Must have prefix `gts.cf.core.rg.type.v1~`.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name (1..255 characters).
+    pub name: String,
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Request body for updating a resource group (full replacement via PUT).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateGroupRequest {
+    /// GTS chained type path. Must have prefix `gts.cf.core.rg.type.v1~`.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name (1..255 characters).
+    pub name: String,
+    /// Parent group ID (null for root groups).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<Uuid>,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+// -- Membership --
+
+/// A membership link between a resource and a group.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceGroupMembership {
+    /// Group this resource belongs to.
+    pub group_id: Uuid,
+    /// GTS type path of the resource.
+    pub resource_type: String,
+    /// External resource identifier.
+    pub resource_id: String,
+}
+
+// @cpt-dod:cpt-cf-resource-group-dod-testing-sdk-models:p1
+#[cfg(test)]
+#[path = "models_tests.rs"]
+mod models_tests;
+
+// @cpt-end:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1:inst-full

--- a/modules/system/resource-group/resource-group-sdk/src/models_tests.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/models_tests.rs
@@ -1,0 +1,213 @@
+// Created: 2026-04-16 by Constructor Tech
+use super::*;
+
+// -- GtsTypePath: valid cases (table-driven) -- TC-SDK-01, 06, 07, 08, 19, 20
+
+#[test]
+fn gts_type_path_valid_cases() {
+    let valid = vec![
+        // TC-SDK-01: basic valid path
+        ("gts.cf.core.rg.type.v1~", "gts.cf.core.rg.type.v1~"),
+        // TC-SDK-06: uppercase is lowered
+        ("GTS.CF.CORE.RG.TYPE.V1~", "gts.cf.core.rg.type.v1~"),
+        // TC-SDK-07: trimmed + lowered
+        ("  GTS.CF.CORE.RG.TYPE.V1~  ", "gts.cf.core.rg.type.v1~"),
+        // TC-SDK-08: multi-segment
+        (
+            "gts.cf.core.rg.type.v1~x.test.unit.root.v1~",
+            "gts.cf.core.rg.type.v1~x.test.unit.root.v1~",
+        ),
+        // TC-SDK-19: numeric version in segment
+        ("gts.cf.core.rg.type.v2~", "gts.cf.core.rg.type.v2~"),
+        // TC-SDK-20: underscores in segments
+        ("gts.cf.core.rg.my_type.v1~", "gts.cf.core.rg.my_type.v1~"),
+    ];
+    for (input, expected) in valid {
+        let path = GtsTypePath::new(input);
+        assert!(path.is_ok(), "should be valid: {input}");
+        assert_eq!(path.unwrap().as_str(), expected, "for input: {input}");
+    }
+}
+
+// -- GtsTypePath: invalid cases (table-driven) -- TC-SDK-02..05, 09, 10, 18, 21
+
+#[test]
+fn gts_type_path_invalid_cases() {
+    let cases = vec![
+        // TC-SDK-02: empty
+        ("", "must not be empty"),
+        // TC-SDK-04: wrong prefix
+        ("invalid.path~", "Invalid GTS type path format"),
+        // TC-SDK-05: no trailing tilde
+        ("gts.cf.core.rg.type.v1", "Invalid GTS type path format"),
+        // TC-SDK-09: double tilde
+        ("gts.cf.core.rg.type.v1~~", "Invalid GTS type path format"),
+        // TC-SDK-10: hyphen in segment
+        (
+            "gts.cf.core.rg.type.v1~hello-world~",
+            "Invalid GTS type path format",
+        ),
+        // TC-SDK-18: empty segment after gts.
+        ("gts.~", "Invalid GTS type path format"),
+        // TC-SDK-21: whitespace-only
+        ("   ", "must not be empty"),
+    ];
+    for (input, expected_msg) in cases {
+        let result = GtsTypePath::new(input);
+        assert!(result.is_err(), "should be invalid: '{input}'");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains(expected_msg),
+            "for input '{input}': expected '{expected_msg}' in error, got: {err}"
+        );
+    }
+}
+
+// -- GtsTypePath: length boundary tests -- TC-SDK-03, 22, 23
+
+#[test]
+#[allow(unknown_lints, de0901_gts_string_pattern)]
+fn gts_type_path_max_length_boundary() {
+    // TC-SDK-22: exactly 1024 chars -> Ok
+    // Base: "gts.cf.core.rg.type.v1~" = 24 chars.
+    // Pad the type name to fill remaining: 1024 - 24 = 1000 chars in first segment.
+    // "gts.cf.core.rg." (15) + padded_name + ".v1~" (4) = 1024
+    // padded_name = 1024 - 15 - 4 = 1005 chars
+    let name = "a".repeat(1005);
+    let path_1024 = format!("gts.cf.core.rg.{name}.v1~");
+    assert_eq!(path_1024.len(), 1024);
+    assert!(
+        GtsTypePath::new(&path_1024).is_ok(),
+        "exactly 1024 chars should be valid: {:?}",
+        GtsTypePath::new(&path_1024)
+    );
+
+    // TC-SDK-23: > 1024 chars -> Err (exceeds max length)
+    let name_long = "a".repeat(1006);
+    let path_1025 = format!("gts.cf.core.rg.{name_long}.v1~");
+    assert_eq!(path_1025.len(), 1025);
+    let result = GtsTypePath::new(&path_1025);
+    assert!(result.is_err(), "1025 chars should exceed max length");
+    assert!(result.unwrap_err().contains("exceeds maximum length"));
+}
+
+// -- GtsTypePath: serde round-trip -- TC-SDK-11, 12
+
+#[test]
+fn gts_type_path_serde_round_trip() {
+    // TC-SDK-11: serialize then deserialize
+    let original = GtsTypePath::new("gts.cf.core.rg.type.v1~").unwrap();
+    let json = serde_json::to_string(&original).unwrap();
+    let deserialized: GtsTypePath = serde_json::from_str(&json).unwrap();
+    assert_eq!(original, deserialized);
+}
+
+#[test]
+fn gts_type_path_serde_invalid_rejects() {
+    // TC-SDK-12: invalid value during deserialization
+    let result = serde_json::from_str::<GtsTypePath>("\"invalid\"");
+    assert!(result.is_err(), "invalid path should fail deserialization");
+}
+
+// -- GtsTypePath: Display / Into<String> -- TC-SDK-13
+
+#[test]
+fn gts_type_path_display_and_into_string() {
+    let path = GtsTypePath::new("gts.cf.core.rg.type.v1~").unwrap();
+    let display = path.to_string();
+    let into_string: String = path.into();
+    assert_eq!(display, into_string);
+}
+
+// -- ResourceGroupType serialization -- TC-SDK-14
+
+#[test]
+fn resource_group_type_camel_case_keys() {
+    let rgt = ResourceGroupType {
+        code: "gts.cf.core.rg.type.v1~".to_owned(),
+        can_be_root: true,
+        allowed_parent_types: vec!["gts.parent~".to_owned()],
+        allowed_membership_types: vec!["gts.member~".to_owned()],
+        metadata_schema: None,
+        ..Default::default()
+    };
+    let json = serde_json::to_value(&rgt).unwrap();
+    assert!(
+        json.get("canBeRoot").is_some(),
+        "expected camelCase 'canBeRoot'"
+    );
+    assert!(
+        json.get("allowedParentTypes").is_some(),
+        "expected camelCase 'allowedParentTypes'"
+    );
+    assert!(
+        json.get("allowedMembershipTypes").is_some(),
+        "expected camelCase 'allowedMembershipTypes'"
+    );
+    assert!(
+        json.get("metadataSchema").is_none(),
+        "metadataSchema should be absent when None"
+    );
+}
+
+// -- ResourceGroup serialization -- TC-SDK-15, 16
+
+#[test]
+fn resource_group_type_field_renamed() {
+    // TC-SDK-15: "type" not "type_path"
+    let group = ResourceGroup {
+        id: Uuid::nil(),
+        type_path: "gts.cf.core.rg.type.v1~".to_owned(),
+        name: "Test".to_owned(),
+        hierarchy: GroupHierarchy {
+            parent_id: None,
+            tenant_id: Uuid::nil(),
+        },
+        metadata: Some(serde_json::json!({"key": "val"})),
+    };
+    let json = serde_json::to_value(&group).unwrap();
+    assert!(
+        json.get("type").is_some(),
+        "expected 'type' key, not 'type_path'"
+    );
+    assert!(
+        json.get("type_path").is_none(),
+        "'type_path' should not appear in JSON"
+    );
+}
+
+#[test]
+fn resource_group_metadata_absent_when_none() {
+    // TC-SDK-16: metadata: None -> no "metadata" key
+    let group = ResourceGroup {
+        id: Uuid::nil(),
+        type_path: "gts.cf.core.rg.type.v1~".to_owned(),
+        name: "Test".to_owned(),
+        hierarchy: GroupHierarchy {
+            parent_id: None,
+            tenant_id: Uuid::nil(),
+        },
+        metadata: None,
+    };
+    let json = serde_json::to_value(&group).unwrap();
+    assert!(
+        json.get("metadata").is_none(),
+        "metadata should be absent when None, got: {json}"
+    );
+}
+
+// -- GtsTypePath normalization -- TC-SDK-24
+
+#[test]
+fn gts_type_path_trims_and_lowercases() {
+    // TC-SDK-24: GtsTypePath::new trims whitespace and lowercases.
+    // validate_type_code (in the domain crate) also trims and lowercases,
+    // ensuring consistent normalization across SDK and domain layers.
+    let input = "  GTS.CF.CORE.RG.TYPE.V1~  ";
+    let path = GtsTypePath::new(input);
+    assert!(
+        path.is_ok(),
+        "GtsTypePath::new should accept trimmed/lowered input"
+    );
+    assert_eq!(path.unwrap().as_str(), "gts.cf.core.rg.type.v1~");
+}

--- a/modules/system/resource-group/resource-group-sdk/src/odata/groups.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/groups.rs
@@ -1,0 +1,51 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for resource group entities.
+//!
+//! Group list `$filter` fields: `type` (eq, ne, in), `hierarchy/parent_id` (eq, ne, in),
+//! `id` (eq, ne, in), `name` (eq, ne, in).
+//!
+//! The `hierarchy/parent_id` field uses `OData` nested path syntax; since the
+//! `ODataFilterable` derive macro does not support slash-separated names,
+//! the `FilterField` trait is implemented manually.
+
+use modkit_odata::filter::{FieldKind, FilterField};
+
+/// Filter field enum for group list queries.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum GroupFilterField {
+    /// Filter by GTS type path.
+    Type,
+    /// Filter by parent group ID (direct parent only).
+    HierarchyParentId,
+    /// Filter by group ID.
+    Id,
+    /// Filter by group name.
+    Name,
+}
+
+impl FilterField for GroupFilterField {
+    const FIELDS: &'static [Self] = &[Self::Type, Self::HierarchyParentId, Self::Id, Self::Name];
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Type => "type",
+            Self::HierarchyParentId => "hierarchy/parent_id",
+            Self::Id => "id",
+            Self::Name => "name",
+        }
+    }
+
+    fn kind(&self) -> FieldKind {
+        match self {
+            // Type is a GTS type path string in the public API; the persistence
+            // layer resolves string paths to SMALLINT IDs after OData validation.
+            Self::Type | Self::Name => FieldKind::String,
+            Self::HierarchyParentId | Self::Id => FieldKind::Uuid,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "groups_tests.rs"]
+mod groups_tests;

--- a/modules/system/resource-group/resource-group-sdk/src/odata/groups_tests.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/groups_tests.rs
@@ -1,0 +1,29 @@
+// Created: 2026-04-16 by Constructor Tech
+use super::*;
+
+// TC-ODATA-01: GroupFilterField names
+#[test]
+fn group_filter_field_names_correct() {
+    assert_eq!(GroupFilterField::Type.name(), "type");
+    assert_eq!(
+        GroupFilterField::HierarchyParentId.name(),
+        "hierarchy/parent_id"
+    );
+    assert_eq!(GroupFilterField::Id.name(), "id");
+    assert_eq!(GroupFilterField::Name.name(), "name");
+}
+
+// TC-ODATA-02: GroupFilterField kinds
+#[test]
+fn group_filter_field_kinds_correct() {
+    assert_eq!(GroupFilterField::Type.kind(), FieldKind::String);
+    assert_eq!(GroupFilterField::HierarchyParentId.kind(), FieldKind::Uuid);
+    assert_eq!(GroupFilterField::Id.kind(), FieldKind::Uuid);
+    assert_eq!(GroupFilterField::Name.kind(), FieldKind::String);
+}
+
+// TC-ODATA-03: FIELDS completeness
+#[test]
+fn group_filter_field_completeness() {
+    assert_eq!(GroupFilterField::FIELDS.len(), 4);
+}

--- a/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy.rs
@@ -1,0 +1,41 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for group hierarchy queries.
+//!
+//! Hierarchy `$filter` fields: `hierarchy/depth` (eq, ne, gt, ge, lt, le),
+//! `type` (eq, ne, in).
+
+use modkit_odata::filter::{FieldKind, FilterField};
+
+/// Filter field enum for group hierarchy queries.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum HierarchyFilterField {
+    /// Filter by relative depth from reference group.
+    HierarchyDepth,
+    /// Filter by GTS type path.
+    Type,
+}
+
+impl FilterField for HierarchyFilterField {
+    const FIELDS: &'static [Self] = &[Self::HierarchyDepth, Self::Type];
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::HierarchyDepth => "hierarchy/depth",
+            Self::Type => "type",
+        }
+    }
+
+    fn kind(&self) -> FieldKind {
+        match self {
+            Self::HierarchyDepth => FieldKind::I64,
+            // Type is a GTS type path string in the public API; the persistence
+            // layer resolves string paths to SMALLINT IDs after OData validation.
+            Self::Type => FieldKind::String,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "hierarchy_tests.rs"]
+mod hierarchy_tests;

--- a/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy_tests.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/hierarchy_tests.rs
@@ -1,0 +1,17 @@
+// Created: 2026-04-16 by Constructor Tech
+use super::*;
+
+// TC-ODATA-04: HierarchyFilterField names + kinds
+#[test]
+fn hierarchy_filter_field_names_and_kinds() {
+    assert_eq!(
+        HierarchyFilterField::HierarchyDepth.name(),
+        "hierarchy/depth"
+    );
+    assert_eq!(HierarchyFilterField::HierarchyDepth.kind(), FieldKind::I64);
+
+    assert_eq!(HierarchyFilterField::Type.name(), "type");
+    assert_eq!(HierarchyFilterField::Type.kind(), FieldKind::String);
+
+    assert_eq!(HierarchyFilterField::FIELDS.len(), 2);
+}

--- a/modules/system/resource-group/resource-group-sdk/src/odata/memberships.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/memberships.rs
@@ -1,0 +1,42 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for membership entities.
+//!
+//! Membership list `$filter` fields: `group_id` (eq, ne, in), `resource_type` (eq, ne, in),
+//! `resource_id` (eq, ne, in).
+
+use modkit_odata::filter::{FieldKind, FilterField};
+
+/// Filter field enum for membership list queries.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum MembershipFilterField {
+    /// Filter by group ID.
+    GroupId,
+    /// Filter by resource type (GTS type path).
+    ResourceType,
+    /// Filter by resource ID.
+    ResourceId,
+}
+
+impl FilterField for MembershipFilterField {
+    const FIELDS: &'static [Self] = &[Self::GroupId, Self::ResourceType, Self::ResourceId];
+
+    fn name(&self) -> &'static str {
+        match self {
+            Self::GroupId => "group_id",
+            Self::ResourceType => "resource_type",
+            Self::ResourceId => "resource_id",
+        }
+    }
+
+    fn kind(&self) -> FieldKind {
+        match self {
+            Self::GroupId => FieldKind::Uuid,
+            Self::ResourceType | Self::ResourceId => FieldKind::String,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "memberships_tests.rs"]
+mod memberships_tests;

--- a/modules/system/resource-group/resource-group-sdk/src/odata/memberships_tests.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/memberships_tests.rs
@@ -1,0 +1,20 @@
+// Created: 2026-04-16 by Constructor Tech
+use super::*;
+
+// TC-ODATA-05: MembershipFilterField names + kinds
+#[test]
+fn membership_filter_field_names_and_kinds() {
+    assert_eq!(MembershipFilterField::GroupId.name(), "group_id");
+    assert_eq!(MembershipFilterField::GroupId.kind(), FieldKind::Uuid);
+
+    assert_eq!(MembershipFilterField::ResourceType.name(), "resource_type");
+    assert_eq!(
+        MembershipFilterField::ResourceType.kind(),
+        FieldKind::String
+    );
+
+    assert_eq!(MembershipFilterField::ResourceId.name(), "resource_id");
+    assert_eq!(MembershipFilterField::ResourceId.kind(), FieldKind::String);
+
+    assert_eq!(MembershipFilterField::FIELDS.len(), 3);
+}

--- a/modules/system/resource-group/resource-group-sdk/src/odata/mod.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/mod.rs
@@ -1,0 +1,13 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for resource-group resources.
+
+mod groups;
+mod hierarchy;
+mod memberships;
+mod types;
+
+pub use groups::GroupFilterField;
+pub use hierarchy::HierarchyFilterField;
+pub use memberships::MembershipFilterField;
+pub use types::{TypeFilterField, TypeQuery, TypeQueryFilterField};

--- a/modules/system/resource-group/resource-group-sdk/src/odata/types.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/types.rs
@@ -1,0 +1,18 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! `OData` filter field definitions for GTS type resources.
+
+use modkit_odata_macros::ODataFilterable;
+
+/// Type filterable fields schema.
+///
+/// This struct defines which fields can be used in `OData` `$filter` queries
+/// for GTS type resources. The field names match the wire format.
+#[derive(ODataFilterable)]
+pub struct TypeQuery {
+    #[odata(filter(kind = "String"))]
+    pub code: String,
+}
+
+/// Type alias for the generated filter field enum.
+pub use TypeQueryFilterField as TypeFilterField;

--- a/modules/system/tenant-resolver/tenant-resolver-sdk/src/gts.rs
+++ b/modules/system/tenant-resolver/tenant-resolver-sdk/src/gts.rs
@@ -45,3 +45,14 @@ use modkit::gts::BaseModkitPluginV1;
     properties = ""
 )]
 pub struct TenantResolverPluginSpecV1;
+
+/// GTS type path for the tenant resource group type.
+///
+/// This type path identifies RG groups that represent tenants.
+/// The tenant RG type is created externally (via API/config) with:
+/// - `is_tenant: true` (instances create their own tenant scope)
+/// - `can_be_root: true` (root tenants allowed)
+/// - `metadata_schema` with `status` (`TenantStatus`) and `self_managed` (barrier) fields
+///
+/// The `rg-tr-plugin` only reads groups of this type — it does not seed the type itself.
+pub const TENANT_RG_TYPE_PATH: &str = "gts.cf.core.rg.type.v1~x.system.tn.tenant.v1~";

--- a/modules/system/tenant-resolver/tenant-resolver-sdk/src/lib.rs
+++ b/modules/system/tenant-resolver/tenant-resolver-sdk/src/lib.rs
@@ -46,7 +46,7 @@ pub mod plugin_api;
 // Re-export main types at crate root
 pub use api::TenantResolverClient;
 pub use error::TenantResolverError;
-pub use gts::TenantResolverPluginSpecV1;
+pub use gts::{TENANT_RG_TYPE_PATH, TenantResolverPluginSpecV1};
 pub use models::{
     BarrierMode, GetAncestorsOptions, GetAncestorsResponse, GetDescendantsOptions,
     GetDescendantsResponse, GetTenantsOptions, HasStatus, IsAncestorOptions, TenantId, TenantInfo,


### PR DESCRIPTION
## Summary

First PR in the **train 1/6** that splits the full resource-group module + plugin chain from #1408. This PR introduces public contracts — **no implementation yet**.

### What lands

- **`cf-resource-group-sdk`** — new crate with public traits, models, errors, and OData filter fields:
  - `ResourceGroupClient` / `ResourceGroupReadHierarchy` / `ResourceGroupReadPluginClient` traits
  - `ResourceGroup`, `ResourceGroupType`, `GroupHierarchy`, `GtsTypePath`, etc.
  - `ResourceGroupError` with variants for all domain-level failures
  - GTS type constants
- **`tenant-resolver-sdk`** gets `TENANT_RG_TYPE_PATH` constant identifying RG groups that represent tenants
- **Documentation**: PRD, DESIGN, DECOMPOSITION, ADR, feature specs, openapi for the resource-group module
- **Authorization docs update**: `docs/arch/authorization/DESIGN.md` and `INTEGRATION_TEST_PLAN.md`

### What's deferred

Module implementation (domain + infra + REST), plugins, tests, and OpenAPI regeneration land in PRs 2–6 of this train.

A temporary `[[ignore]]` entry in `.cypilot/config/artifacts.toml` is added for the RG code paths; it will be removed in PR 4 once the module code with `cpt-*` markers is in place.

## PR Train 🚂

Target order (DAG with a diamond at PR 2/3):
1. **you are here** — pr/rg-1-sdk
2. pr/rg-2-plugins (plugin crates, compile-only)
3. pr/rg-3-backend (RG domain + infra + module)
4. pr/rg-4-rest (REST + OpenAPI + plugin activation)
5. pr/rg-5-tests-svc (service-layer integration tests)
6. pr/rg-6-tests-rest (REST tests + E2E)

PR 2 and PR 3 depend only on PR 1 and can be reviewed in parallel.

## Test plan

- [x] `cargo build -p cf-resource-group-sdk` — green
- [x] `make all` — green locally
- [x] `make cypilot-validate` — 82 artifacts / 0 errors
- [ ] CI green on all 24 checks