### PR TITLE
feat(resource-group): REST API + OpenAPI + plugin activation [4/6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -2979,7 +2979,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3134,7 +3134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5076,7 +5076,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6895,7 +6895,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8104,7 +8104,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9383,7 +9383,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/apps/hyperspot-server/Cargo.toml
+++ b/apps/hyperspot-server/Cargo.toml
@@ -1,3 +1,4 @@
+# Updated: 2026-04-16 by Constructor Tech
 [package]
 name = "hyperspot-server"
 version = "0.6.1"
@@ -19,6 +20,8 @@ single-tenant = ["dep:single-tenant-tr-plugin"]
 static-tenants = ["dep:static-tr-plugin"]
 static-authn = ["dep:static-authn-plugin"]
 static-authz = ["dep:static-authz-plugin"]
+tr-authz = ["dep:tr-authz-plugin"]
+tenant-resolver-rg = ["dep:rg-tr-plugin"]
 static-credstore = ["dep:static-credstore-plugin"]
 mini-chat = ["dep:mini-chat"]
 k8s = ["mini-chat/k8s"]
@@ -40,7 +43,6 @@ types_registry = { package = "cf-types-registry", path = "../../modules/system/t
 tenant-resolver = { package = "cf-tenant-resolver", path = "../../modules/system/tenant-resolver/tenant-resolver" }
 authn-resolver = { package = "cf-authn-resolver", path = "../../modules/system/authn-resolver/authn-resolver" }
 authz-resolver = { package = "cf-authz-resolver", path = "../../modules/system/authz-resolver/authz-resolver" }
-resource_group = { package = "cf-resource-group", path = "../../modules/system/resource-group/resource-group" }
 
 # Optional tenant resolver plugins
 single-tenant-tr-plugin = { package = "cf-single-tenant-tr-plugin", path = "../../modules/system/tenant-resolver/plugins/single-tenant-tr-plugin", optional = true }
@@ -54,6 +56,8 @@ tr-authz-plugin = { package = "cf-tr-authz-plugin", path = "../../modules/system
 
 # Optional credstore plugins
 static-credstore-plugin = { package = "cf-static-credstore-plugin", path = "../../modules/credstore/plugins/static-credstore-plugin", optional = true }
+
+resource_group = { package = "cf-resource-group", path = "../../modules/system/resource-group/resource-group" }
 
 # user modules
 file_parser = { package = "cf-file-parser", path = "../../modules/file-parser" }

--- a/apps/hyperspot-server/src/registered_modules.rs
+++ b/apps/hyperspot-server/src/registered_modules.rs
@@ -1,3 +1,4 @@
+// Updated: 2026-04-16 by Constructor Tech
 // This file is used to ensure that all modules are linked and registered via inventory
 // In future we can simply DX via build.rs which will collect all crates in ./modules and generate this file.
 // But for now we will manually maintain this file.
@@ -26,11 +27,17 @@ use single_tenant_tr_plugin as _;
 #[cfg(feature = "static-tenants")]
 use static_tr_plugin as _;
 
+#[cfg(feature = "tenant-resolver-rg")]
+use rg_tr_plugin as _;
+
 #[cfg(feature = "static-authn")]
 use static_authn_plugin as _;
 
 #[cfg(feature = "static-authz")]
 use static_authz_plugin as _;
+
+#[cfg(feature = "tr-authz")]
+use tr_authz_plugin as _;
 
 #[cfg(feature = "static-credstore")]
 use static_credstore_plugin as _;

--- a/config/e2e-local.yaml
+++ b/config/e2e-local.yaml
@@ -1,3 +1,4 @@
+# Updated: 2026-04-16 by Constructor Tech
 # HyperSpot Server Configuration
 #
 # Database Architecture Overview:
@@ -245,6 +246,11 @@ modules:
             subject_id: "22222222-0000-0000-0000-000000000005"
             subject_tenant_id: "00000000-0000-0000-0000-000000000005"
             token_scopes: ["*"]
+        - token: "e2e-token-tenant-b"
+          identity:
+            subject_id: "22222222-6a88-4768-9dfc-6bcd5187d9ed"
+            subject_tenant_id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+            token_scopes: ["*"]
         # Nil-tenant token: static-authz denies requests with the nil UUID
         # tenant, producing a clean 403 Forbidden. Used by
         # testing/e2e/modules/oagw/test_authz.py::test_proxy_authz_forbidden_nil_tenant
@@ -275,6 +281,12 @@ modules:
         client_secret: "mini-chat-dev-secret"
 
 
+  resource-group:
+    database:
+      server: "sqlite_users"
+      file: "resource_group.db"
+    config: {}
+
   simple-user-settings:
     # Module-specific database configuration
     database:
@@ -290,12 +302,6 @@ modules:
     config:
       proxy_timeout_secs: 2
       allow_http_upstream: true # Only for testing - do not enable in production without proper security controls
-
-  resource-group:
-    database:
-      server: "sqlite_users"
-      file: "resource_group.db"
-    config: {}
 
 # OpenTelemetry configuration (resource identity, tracing, metrics)
 opentelemetry:

--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -437,6 +437,35 @@
         ],
         "type": "object"
       },
+      "CreateGroupDto": {
+        "description": "REST DTO for creating a new resource group.",
+        "properties": {
+          "metadata": {
+            "description": "Type-specific metadata."
+          },
+          "name": {
+            "description": "Display name (1..255 characters).",
+            "type": "string"
+          },
+          "parent_id": {
+            "description": "Parent group ID (null for root groups).",
+            "format": "uuid",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": {
+            "description": "GTS chained type path. Must have prefix `gts.cf.core.rg.type.v1~`.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "name"
+        ],
+        "type": "object"
+      },
       "CreateRouteRequest": {
         "properties": {
           "cors": {
@@ -492,6 +521,41 @@
         "required": [
           "upstream_id",
           "match"
+        ],
+        "type": "object"
+      },
+      "CreateTypeDto": {
+        "description": "REST DTO for creating a new GTS type.",
+        "properties": {
+          "allowed_membership_types": {
+            "description": "GTS type paths of allowed membership resource types.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "allowed_parent_types": {
+            "description": "GTS type paths of allowed parent types.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "can_be_root": {
+            "description": "Whether groups of this type can be root nodes.",
+            "type": "boolean"
+          },
+          "code": {
+            "description": "GTS type path. Must have prefix `gts.cf.core.rg.type.v1~`.\n\nWhether the type creates a new tenant scope is derived from the code:\nany path starting with the tenant RG type prefix is a tenant type.",
+            "type": "string"
+          },
+          "metadata_schema": {
+            "description": "Optional JSON Schema for instance metadata."
+          }
+        },
+        "required": [
+          "code",
+          "can_be_root"
         ],
         "type": "object"
       },
@@ -768,6 +832,70 @@
         ],
         "type": "object"
       },
+      "GroupDto": {
+        "description": "REST DTO for resource group representation.\n\nGroup responses do NOT include `created_at`/`updated_at` (per DESIGN).",
+        "properties": {
+          "hierarchy": {
+            "$ref": "#/components/schemas/HierarchyDto",
+            "description": "Hierarchy context."
+          },
+          "id": {
+            "description": "Group identifier.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Type-specific metadata."
+          },
+          "name": {
+            "description": "Display name.",
+            "type": "string"
+          },
+          "type": {
+            "description": "GTS chained type path.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "name",
+          "hierarchy"
+        ],
+        "type": "object"
+      },
+      "GroupWithDepthDto": {
+        "description": "REST DTO for resource group with depth (hierarchy queries).",
+        "properties": {
+          "hierarchy": {
+            "$ref": "#/components/schemas/HierarchyWithDepthDto",
+            "description": "Hierarchy context with depth."
+          },
+          "id": {
+            "description": "Group identifier.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "metadata": {
+            "description": "Type-specific metadata."
+          },
+          "name": {
+            "description": "Display name.",
+            "type": "string"
+          },
+          "type": {
+            "description": "GTS chained type path.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "name",
+          "hierarchy"
+        ],
+        "type": "object"
+      },
       "GrpcMatch": {
         "properties": {
           "method": {
@@ -884,6 +1012,58 @@
             ]
           }
         },
+        "type": "object"
+      },
+      "HierarchyDto": {
+        "description": "REST DTO for hierarchy context in group responses.",
+        "properties": {
+          "parent_id": {
+            "description": "Parent group ID (null for root groups).",
+            "format": "uuid",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tenant_id": {
+            "description": "Tenant scope.",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "parent_id",
+          "tenant_id"
+        ],
+        "type": "object"
+      },
+      "HierarchyWithDepthDto": {
+        "description": "REST DTO for hierarchy context with depth in group responses.",
+        "properties": {
+          "depth": {
+            "description": "Relative distance from reference group.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "parent_id": {
+            "description": "Parent group ID (null for root groups).",
+            "format": "uuid",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tenant_id": {
+            "description": "Tenant scope.",
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "parent_id",
+          "tenant_id",
+          "depth"
+        ],
         "type": "object"
       },
       "HostInfoDto": {
@@ -1115,6 +1295,30 @@
             ]
           }
         },
+        "type": "object"
+      },
+      "MembershipDto": {
+        "description": "REST DTO for membership representation.\n\nMembership responses do NOT include `tenant_id` (derived from group).",
+        "properties": {
+          "group_id": {
+            "description": "Group identifier.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "resource_id": {
+            "description": "Resource identifier.",
+            "type": "string"
+          },
+          "resource_type": {
+            "description": "GTS type path of the resource type.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "group_id",
+          "resource_type",
+          "resource_id"
+        ],
         "type": "object"
       },
       "MemoryInfoDto": {
@@ -1518,11 +1722,83 @@
         ],
         "type": "object"
       },
+      "Page_GroupDto": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/GroupDto"
+            },
+            "type": "array"
+          },
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
+          }
+        },
+        "required": [
+          "items",
+          "page_info"
+        ],
+        "type": "object"
+      },
+      "Page_GroupWithDepthDto": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/GroupWithDepthDto"
+            },
+            "type": "array"
+          },
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
+          }
+        },
+        "required": [
+          "items",
+          "page_info"
+        ],
+        "type": "object"
+      },
+      "Page_MembershipDto": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/MembershipDto"
+            },
+            "type": "array"
+          },
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
+          }
+        },
+        "required": [
+          "items",
+          "page_info"
+        ],
+        "type": "object"
+      },
       "Page_MessageDto": {
         "properties": {
           "items": {
             "items": {
               "$ref": "#/components/schemas/MessageDto"
+            },
+            "type": "array"
+          },
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
+          }
+        },
+        "required": [
+          "items",
+          "page_info"
+        ],
+        "type": "object"
+      },
+      "Page_TypeDto": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TypeDto"
             },
             "type": "array"
           },
@@ -2974,6 +3250,43 @@
         ],
         "type": "string"
       },
+      "TypeDto": {
+        "description": "REST DTO for GTS type representation.",
+        "properties": {
+          "allowed_membership_types": {
+            "description": "GTS type paths of allowed membership resource types",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "allowed_parent_types": {
+            "description": "GTS type paths of allowed parent types",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "can_be_root": {
+            "description": "Whether groups of this type can be root nodes",
+            "type": "boolean"
+          },
+          "code": {
+            "description": "GTS type path",
+            "type": "string"
+          },
+          "metadata_schema": {
+            "description": "Optional JSON Schema for instance metadata"
+          }
+        },
+        "required": [
+          "code",
+          "can_be_root",
+          "allowed_parent_types",
+          "allowed_membership_types"
+        ],
+        "type": "object"
+      },
       "UpdateChatReq": {
         "description": "Request DTO for updating a chat title.",
         "properties": {
@@ -3002,6 +3315,32 @@
             ]
           }
         },
+        "type": "object"
+      },
+      "UpdateGroupDto": {
+        "description": "REST DTO for updating a resource group (full replacement via PUT).\n\n**The group's GTS type is immutable after creation.** The payload\ndeliberately does not carry a `type` field — to change a group's type,\ndelete the existing group and create a new one. See the SDK\n`UpdateGroupRequest` doc for the full rationale.\n\nEvery replaceable field is **required** so an omitted field cannot be\nconfused with \"preserve previous value\". Nullable fields (`parent_id`,\n`metadata`) must be sent explicitly as `null` to clear them — for\nexample, moving a group to root requires `\"parent_id\": null`, not an\nomitted key.",
+        "properties": {
+          "metadata": {
+            "description": "Type-specific metadata (`null` to clear)."
+          },
+          "name": {
+            "description": "Display name (1..255 characters).",
+            "type": "string"
+          },
+          "parent_id": {
+            "description": "Parent group ID (`null` for root groups).",
+            "format": "uuid",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "parent_id",
+          "metadata"
+        ],
         "type": "object"
       },
       "UpdateRouteRequest": {
@@ -3073,6 +3412,39 @@
         "required": [
           "theme",
           "language"
+        ],
+        "type": "object"
+      },
+      "UpdateTypeDto": {
+        "description": "REST DTO for updating a GTS type (full replacement via PUT).\n\nEvery replaceable field is **required** so an omitted field cannot be\nconfused with \"preserve previous value\". Nullable fields\n(`metadata_schema`) must be sent explicitly as `null` to clear them.",
+        "properties": {
+          "allowed_membership_types": {
+            "description": "GTS type paths of allowed membership resource types.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "allowed_parent_types": {
+            "description": "GTS type paths of allowed parent types.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "can_be_root": {
+            "description": "Whether groups of this type can be root nodes.",
+            "type": "boolean"
+          },
+          "metadata_schema": {
+            "description": "JSON Schema for instance metadata (`null` to clear)."
+          }
+        },
+        "required": [
+          "can_be_root",
+          "allowed_parent_types",
+          "allowed_membership_types",
+          "metadata_schema"
         ],
         "type": "object"
       },
@@ -7879,6 +8251,924 @@
         ]
       }
     },
+    "/resource-group/v1/groups": {
+      "get": {
+        "description": "Retrieve a paginated list of resource groups with OData filtering",
+        "operationId": "resource_group.list_groups",
+        "parameters": [
+          {
+            "description": "Maximum number of groups to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Cursor for pagination",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "OData v4 filter expression\n- type: eq|ne|contains|startswith|endswith|in\n- hierarchy/parent_id: eq|ne|in\n- id: eq|ne|in\n- name: eq|ne|contains|startswith|endswith|in",
+            "in": "query",
+            "name": "$filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_GroupDto"
+                }
+              }
+            },
+            "description": "Paginated list of resource groups"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List resource groups",
+        "tags": [
+          "Resource Groups"
+        ],
+        "x-odata-filter": {
+          "allowedFields": {
+            "hierarchy/parent_id": [
+              "eq",
+              "ne",
+              "in"
+            ],
+            "id": [
+              "eq",
+              "ne",
+              "in"
+            ],
+            "name": [
+              "eq",
+              "ne",
+              "contains",
+              "startswith",
+              "endswith",
+              "in"
+            ],
+            "type": [
+              "eq",
+              "ne",
+              "contains",
+              "startswith",
+              "endswith",
+              "in"
+            ]
+          }
+        }
+      },
+      "post": {
+        "description": "Create a new resource group with the provided type, name, and optional parent",
+        "operationId": "resource_group.create_group",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateGroupDto"
+              }
+            }
+          },
+          "description": "Group creation data",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupDto"
+                }
+              }
+            },
+            "description": "Created resource group"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create a new resource group",
+        "tags": [
+          "Resource Groups"
+        ]
+      }
+    },
+    "/resource-group/v1/groups/{group_id}": {
+      "delete": {
+        "description": "Delete a resource group. Use ?force=true to cascade delete subtree and memberships.",
+        "operationId": "resource_group.delete_group",
+        "parameters": [
+          {
+            "description": "Group UUID",
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Force cascade delete of subtree and memberships",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Group deleted successfully"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Delete resource group",
+        "tags": [
+          "Resource Groups"
+        ]
+      },
+      "get": {
+        "description": "Retrieve a specific resource group by its UUID",
+        "operationId": "resource_group.get_group",
+        "parameters": [
+          {
+            "description": "Group UUID",
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupDto"
+                }
+              }
+            },
+            "description": "Resource group found"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get resource group by ID",
+        "tags": [
+          "Resource Groups"
+        ]
+      },
+      "put": {
+        "description": "Update a resource group (full replacement via PUT, including parent move)",
+        "operationId": "resource_group.update_group",
+        "parameters": [
+          {
+            "description": "Group UUID",
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateGroupDto"
+              }
+            }
+          },
+          "description": "Group update data",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupDto"
+                }
+              }
+            },
+            "description": "Updated resource group"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update resource group",
+        "tags": [
+          "Resource Groups"
+        ]
+      }
+    },
+    "/resource-group/v1/groups/{group_id}/ancestors": {
+      "get": {
+        "description": "Get ancestors of a reference group (depth <= 0) with OData filtering",
+        "operationId": "resource_group.get_group_ancestors",
+        "parameters": [
+          {
+            "description": "Reference group UUID",
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum entries to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Cursor for pagination",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "OData v4 filter expression\n- hierarchy/depth: eq|ne|gt|ge|lt|le|in\n- type: eq|ne|contains|startswith|endswith|in",
+            "in": "query",
+            "name": "$filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_GroupWithDepthDto"
+                }
+              }
+            },
+            "description": "Paginated ancestors with relative depth"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get group ancestors",
+        "tags": [
+          "Resource Groups"
+        ],
+        "x-odata-filter": {
+          "allowedFields": {
+            "hierarchy/depth": [
+              "eq",
+              "ne",
+              "gt",
+              "ge",
+              "lt",
+              "le",
+              "in"
+            ],
+            "type": [
+              "eq",
+              "ne",
+              "contains",
+              "startswith",
+              "endswith",
+              "in"
+            ]
+          }
+        }
+      }
+    },
+    "/resource-group/v1/groups/{group_id}/descendants": {
+      "get": {
+        "description": "Get descendants of a reference group (depth >= 0) with OData filtering",
+        "operationId": "resource_group.get_group_descendants",
+        "parameters": [
+          {
+            "description": "Reference group UUID",
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum entries to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Cursor for pagination",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "OData v4 filter expression\n- hierarchy/depth: eq|ne|gt|ge|lt|le|in\n- type: eq|ne|contains|startswith|endswith|in",
+            "in": "query",
+            "name": "$filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_GroupWithDepthDto"
+                }
+              }
+            },
+            "description": "Paginated descendants with relative depth"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get group descendants",
+        "tags": [
+          "Resource Groups"
+        ],
+        "x-odata-filter": {
+          "allowedFields": {
+            "hierarchy/depth": [
+              "eq",
+              "ne",
+              "gt",
+              "ge",
+              "lt",
+              "le",
+              "in"
+            ],
+            "type": [
+              "eq",
+              "ne",
+              "contains",
+              "startswith",
+              "endswith",
+              "in"
+            ]
+          }
+        }
+      }
+    },
+    "/resource-group/v1/memberships": {
+      "get": {
+        "description": "Retrieve a paginated list of memberships with OData filtering on group_id, resource_type, resource_id",
+        "operationId": "resource_group.list_memberships",
+        "parameters": [
+          {
+            "description": "Maximum number of memberships to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Cursor for pagination",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "OData v4 filter expression\n- group_id: eq|ne|in\n- resource_type: eq|ne|contains|startswith|endswith|in\n- resource_id: eq|ne|contains|startswith|endswith|in",
+            "in": "query",
+            "name": "$filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_MembershipDto"
+                }
+              }
+            },
+            "description": "Paginated list of memberships"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List memberships",
+        "tags": [
+          "Resource Group Memberships"
+        ],
+        "x-odata-filter": {
+          "allowedFields": {
+            "group_id": [
+              "eq",
+              "ne",
+              "in"
+            ],
+            "resource_id": [
+              "eq",
+              "ne",
+              "contains",
+              "startswith",
+              "endswith",
+              "in"
+            ],
+            "resource_type": [
+              "eq",
+              "ne",
+              "contains",
+              "startswith",
+              "endswith",
+              "in"
+            ]
+          }
+        }
+      }
+    },
+    "/resource-group/v1/memberships/{group_id}/{resource_type}/{resource_id}": {
+      "delete": {
+        "description": "Remove a membership link between a resource group and a resource",
+        "operationId": "resource_group.remove_membership",
+        "parameters": [
+          {
+            "description": "Group UUID",
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "GTS type path of the resource type",
+            "in": "path",
+            "name": "resource_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Resource identifier",
+            "in": "path",
+            "name": "resource_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Membership removed successfully"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Remove membership",
+        "tags": [
+          "Resource Group Memberships"
+        ]
+      },
+      "post": {
+        "description": "Add a membership link between a resource group and a resource",
+        "operationId": "resource_group.add_membership",
+        "parameters": [
+          {
+            "description": "Group UUID",
+            "in": "path",
+            "name": "group_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "GTS type path of the resource type",
+            "in": "path",
+            "name": "resource_type",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Resource identifier",
+            "in": "path",
+            "name": "resource_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MembershipDto"
+                }
+              }
+            },
+            "description": "Membership created"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Add membership",
+        "tags": [
+          "Resource Group Memberships"
+        ]
+      }
+    },
     "/simple-user-settings/v1/settings": {
       "get": {
         "description": "Retrieve settings for the authenticated user",
@@ -8502,6 +9792,371 @@
         "summary": "Get GTS entity by ID",
         "tags": [
           "Types Registry"
+        ]
+      }
+    },
+    "/types-registry/v1/types": {
+      "get": {
+        "description": "Retrieve a list of GTS resource group type definitions with OData filtering",
+        "operationId": "resource_group.list_types",
+        "parameters": [
+          {
+            "description": "Maximum number of types to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Cursor for pagination",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "OData v4 filter expression\n- code: eq|ne|contains|startswith|endswith|in",
+            "in": "query",
+            "name": "$filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Page_TypeDto"
+                }
+              }
+            },
+            "description": "List of GTS types"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List GTS types",
+        "tags": [
+          "Resource Group Types"
+        ],
+        "x-odata-filter": {
+          "allowedFields": {
+            "code": [
+              "eq",
+              "ne",
+              "contains",
+              "startswith",
+              "endswith",
+              "in"
+            ]
+          }
+        }
+      },
+      "post": {
+        "description": "Create a new GTS resource group type definition",
+        "operationId": "resource_group.create_type",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTypeDto"
+              }
+            }
+          },
+          "description": "Type creation data",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TypeDto"
+                }
+              }
+            },
+            "description": "Created type"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create a new GTS type",
+        "tags": [
+          "Resource Group Types"
+        ]
+      }
+    },
+    "/types-registry/v1/types/{code}": {
+      "delete": {
+        "description": "Delete a GTS resource group type definition",
+        "operationId": "resource_group.delete_type",
+        "parameters": [
+          {
+            "description": "GTS type path",
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Type deleted successfully"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Delete GTS type",
+        "tags": [
+          "Resource Group Types"
+        ]
+      },
+      "get": {
+        "description": "Retrieve a specific GTS type definition by its GTS type path",
+        "operationId": "resource_group.get_type",
+        "parameters": [
+          {
+            "description": "GTS type path",
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TypeDto"
+                }
+              }
+            },
+            "description": "Type found"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get GTS type by code",
+        "tags": [
+          "Resource Group Types"
+        ]
+      },
+      "put": {
+        "description": "Update a GTS resource group type definition (full replacement)",
+        "operationId": "resource_group.update_type",
+        "parameters": [
+          {
+            "description": "GTS type path",
+            "in": "path",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTypeDto"
+              }
+            }
+          },
+          "description": "Type update data",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TypeDto"
+                }
+              }
+            },
+            "description": "Updated type"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Update GTS type",
+        "tags": [
+          "Resource Group Types"
         ]
       }
     },

--- a/docs/arch/authorization/INTEGRATION_TEST_PLAN.md
+++ b/docs/arch/authorization/INTEGRATION_TEST_PLAN.md
@@ -3,7 +3,7 @@
 
 # AuthZ + Resource Group Integration Test Plan
 
-Design-time test plan for verifying the RG ↔ AuthZ interaction locally in hyperspot-server. Covers three phases: tenant scoping, group-based predicates, and MTLS bypass.
+Design-time test plan for verifying the RG ↔ AuthZ interaction locally in hyperspot-server. Covers three phases: tenant scoping (`p1`), group-based predicates (`p1`), and MTLS bypass (`p2` — deferred, not implemented yet).
 
 For background on how AuthZ uses RG data, see [RESOURCE_GROUP_MODEL.md](./RESOURCE_GROUP_MODEL.md). For concrete SQL-level scenarios, see [AUTHZ_USAGE_SCENARIOS.md](./AUTHZ_USAGE_SCENARIOS.md) scenarios S14–S21.
 
@@ -207,7 +207,13 @@ WHERE owner_tenant_id IN ('T1')
 
 ---
 
-## Phase 3: MTLS Authentication Mode _(Planned)_
+## Phase 3: MTLS Authentication Mode (`p2` — deferred, not implemented yet)
+
+> **Status: `p2` — designed, not implemented yet.** Phase 3 is reserved
+> for the future microservice split that moves the AuthZ plugin out of
+> the RG process. Do not run/implement this phase in the current
+> iteration; the in-process `ResourceGroupReadHierarchy` path covers the
+> AuthZ ↔ RG dependency in the monolith.
 
 **Goal**: Verify that AuthZ plugin can read RG hierarchy via MTLS-authenticated request (microservice deployment mode), bypassing AuthZ evaluation.
 
@@ -361,11 +367,11 @@ python3 scripts/ci.py e2e-local --config config/e2e-tr-authz.yaml -- -k "resourc
 
 ## Effort Estimate
 
-| Phase | Scope | Effort | Status |
-|-------|-------|--------|--------|
-| Phase 1 | Tenant scoping via PolicyEnforcer | 2–3 hours | **Planned** |
-| Phase 2 | Group predicates (in_group/in_group_subtree) | 1–2 days | **Planned** |
-| Phase 3 | MTLS verification | 2–3 hours | **Planned** |
+| Phase | Scope | Effort | Priority | Status |
+|-------|-------|--------|----------|--------|
+| Phase 1 | Tenant scoping via PolicyEnforcer | 2–3 hours | `p1` | **Planned** |
+| Phase 2 | Group predicates (in_group/in_group_subtree) | 1–2 days | `p1` | **Planned** |
+| Phase 3 | MTLS verification | 2–3 hours | `p2` | **Deferred — not implemented yet** |
 
 ---
 

--- a/docs/arch/authorization/RESOURCE_GROUP_MODEL.md
+++ b/docs/arch/authorization/RESOURCE_GROUP_MODEL.md
@@ -74,7 +74,7 @@ PEP within the RG module compiles `in_group`/`in_group_subtree` predicates into 
 
 ### Integration Path
 
-AuthZ plugin reads RG hierarchy via `ResourceGroupReadHierarchy` trait (narrow, hierarchy-only read contract). In microservice deployments, this uses MTLS-authenticated requests to the RG service; in monolith deployments, it's a direct in-process call via ClientHub. See [RG DESIGN §RG Authentication Modes](../../../modules/system/resource-group/docs/DESIGN.md#rg-authentication-modes-jwt-vs-mtls).
+AuthZ plugin reads RG hierarchy via `ResourceGroupReadHierarchy` trait (narrow, hierarchy-only read contract). In monolith deployments (current `p1` reality), it's a direct in-process call via `ClientHub` and the trait surface itself bypasses `PolicyEnforcer` (the plugin cannot evaluate itself). In a future microservice deployment (`p2`, deferred / not implemented yet), the same trait will be backed by an MTLS-authenticated request to the RG service. See [RG DESIGN §RG Authentication Modes: JWT vs MTLS](../../../modules/system/resource-group/docs/DESIGN.md#rg-authentication-modes-jwt-vs-mtls).
 
 ---
 

--- a/docs/modkit_unified_system/12_unit_testing.md
+++ b/docs/modkit_unified_system/12_unit_testing.md
@@ -1,4 +1,5 @@
 <!-- Created: 2026-04-07 by Constructor Tech -->
+<!-- Updated: 2026-04-28 by Constructor Tech -->
 
 # Unit & Integration Testing Guide
 
@@ -57,7 +58,7 @@ Every test must pass all three:
 - HTTP routing, middleware wiring, header serialization → E2E tests
 - PostgreSQL-specific behavior (FK RESTRICT, SERIALIZABLE isolation, domain types) → E2E tests
 - Real AuthN/AuthZ pipeline with tokens → E2E tests
-- MTLS certificate verification → E2E tests
+- MTLS certificate verification → E2E tests _(p2 — deferred, not implemented yet)_
 - Cursor codec encode/decode over HTTP → E2E tests
 - Performance, load, concurrency under contention → out of scope
 

--- a/docs/modkit_unified_system/13_e2e_testing.md
+++ b/docs/modkit_unified_system/13_e2e_testing.md
@@ -1,4 +1,5 @@
 <!-- Created: 2026-04-07 by Constructor Tech -->
+<!-- Updated: 2026-04-28 by Constructor Tech -->
 
 # E2E Testing Guide
 
@@ -268,7 +269,7 @@ Never use `pytest-rerunfailures` as a permanent fix. Retrying a flaky test hides
 testing/e2e/modules/<module_name>/
 ├── conftest.py                   ← helpers, timeout config, factory fixtures
 ├── test_authz_tenant_scoping.py  ← AuthZ + tenant isolation seams (if applicable)
-├── test_mtls_auth.py             ← MTLS certificate verification (if applicable)
+├── test_mtls_auth.py             ← MTLS certificate verification (if applicable; p2 — deferred, not implemented yet)
 ├── test_integration_seams.py     ← Core integration seam tests (per module)
 ```
 
@@ -528,7 +529,7 @@ Some E2E tests are conditional on infrastructure availability:
 | Suite | Skip condition | Description |
 |-------|---------------|-------------|
 | **Cross-tenant isolation** | `E2E_AUTH_TOKEN_TENANT_B` not set | Tests requiring two real tokens from different tenants |
-| **MTLS** | `E2E_MTLS_CERT_DIR` not set | Certificate-based authentication verification |
+| **MTLS** _(p2 — deferred, not implemented yet)_ | `E2E_MTLS_CERT_DIR` not set | Certificate-based authentication verification |
 
 All core integration seam tests run with a single token, no special infrastructure.
 
@@ -571,7 +572,7 @@ A test that can be removed without reducing integration confidence should not ex
 
 **Isolation:**
 - Each test creates its own data — no cross-test dependencies
-- Optional tests (cross-tenant, MTLS) skip gracefully when infrastructure unavailable
+- Optional tests (cross-tenant, MTLS — the latter is `p2`, deferred / not implemented yet) skip gracefully when infrastructure unavailable
 - No test duplicates unit test domain logic — if removing the test doesn't reduce integration confidence, the test shouldn't exist
 
 > Design guided by [Google SMURF (2024)](https://testing.googleblog.com/2024/10/smurf-beyond-test-pyramid.html): each test justified by high **Fidelity** (real PG + real AuthZ) that compensates for lower **Speed** vs unit tests.

--- a/libs/modkit/src/api/openapi_registry.rs
+++ b/libs/modkit/src/api/openapi_registry.rs
@@ -1,3 +1,4 @@
+// Updated: 2026-04-28 by Constructor Tech
 //! `OpenAPI` registry for schema and operation management
 //!
 //! This module provides a standalone `OpenAPI` registry that collects operation specs
@@ -250,6 +251,14 @@ impl OpenApiRegistryImpl {
             // Responses
             let mut responses = ResponsesBuilder::new();
             for r in &spec.responses {
+                // Body-less response (e.g. 204 No Content) is signalled by an
+                // empty `content_type`. Emit just `description` — attaching a
+                // `content` block would make code-generators expect a body.
+                if r.content_type.is_empty() {
+                    let resp = ResponseBuilder::new().description(&r.description).build();
+                    responses = responses.response(r.status.to_string(), resp);
+                    continue;
+                }
                 let is_json_like = r.content_type == "application/json"
                     || r.content_type == problem::APPLICATION_PROBLEM_JSON
                     || r.content_type == "text/event-stream";

--- a/libs/modkit/src/api/operation_builder.rs
+++ b/libs/modkit/src/api/operation_builder.rs
@@ -1,3 +1,4 @@
+// Updated: 2026-04-28 by Constructor Tech
 //! Type-safe API operation builder with compile-time guarantees
 //!
 //! This module implements a type-state builder pattern that ensures:
@@ -1073,6 +1074,35 @@ where
         }
     }
 
+    /// Add a body-less response (e.g. `204 No Content`) — transitions from
+    /// Missing to Present.
+    ///
+    /// `OpenAPI` consumers and code-generators treat a `204` response with a
+    /// `content` block as advertising a body, which is incorrect. Use this
+    /// helper for any handler that intentionally returns no payload (typical
+    /// for `DELETE` / `PUT` semantics).
+    pub fn no_content_response(
+        mut self,
+        status: http::StatusCode,
+        description: impl Into<String>,
+    ) -> OperationBuilder<H, Present, S, A, L> {
+        self.spec.responses.push(ResponseSpec {
+            status: status.as_u16(),
+            content_type: "",
+            description: description.into(),
+            schema_name: None,
+        });
+        OperationBuilder {
+            spec: self.spec,
+            method_router: self.method_router,
+            _has_handler: self._has_handler,
+            _has_response: PhantomData::<Present>,
+            _state: self._state,
+            _auth_state: self._auth_state,
+            _license_state: self._license_state,
+        }
+    }
+
     /// Add a JSON response with a registered schema (transitions from Missing to Present).
     pub fn json_response_with_schema<T>(
         mut self,
@@ -1231,6 +1261,21 @@ where
         self.spec.responses.push(ResponseSpec {
             status: status.as_u16(),
             content_type: "application/json",
+            description: description.into(),
+            schema_name: None,
+        });
+        self
+    }
+
+    /// Add a body-less response (e.g. `204 No Content`) — additional variant.
+    pub fn no_content_response(
+        mut self,
+        status: http::StatusCode,
+        description: impl Into<String>,
+    ) -> Self {
+        self.spec.responses.push(ResponseSpec {
+            status: status.as_u16(),
+            content_type: "",
             description: description.into(),
             schema_name: None,
         });

--- a/modules/system/resource-group/docs/DECOMPOSITION.md
+++ b/modules/system/resource-group/docs/DECOMPOSITION.md
@@ -299,7 +299,7 @@ The Resource Group DESIGN is decomposed into seven features organized around the
 
 - [x] `p1` - **ID**: `cpt-cf-resource-group-feature-integration-auth`
 
-- **Purpose**: Expose the integration read service for external consumers (AuthZ plugin via `ResourceGroupReadHierarchy`), implement dual authentication modes (JWT with full AuthZ evaluation, MTLS with hierarchy-only bypass), enforce tenant scope for ownership-graph profile writes, and configure plugin gateway routing for vendor-specific provider support.
+- **Purpose**: Expose the integration read service for external consumers (AuthZ plugin via `ResourceGroupReadHierarchy`), implement JWT authentication with full AuthZ evaluation (and, deferred to `p2`, the future MTLS hierarchy-only bypass for the microservice split), enforce tenant scope for ownership-graph profile writes, and configure plugin gateway routing for vendor-specific provider support.
 
 - **Depends On**: `cpt-cf-resource-group-feature-entity-hierarchy`, `cpt-cf-resource-group-feature-membership`
 
@@ -307,11 +307,11 @@ The Resource Group DESIGN is decomposed into seven features organized around the
   - Integration read service: expose `ResourceGroupReadHierarchy` via ClientHub for AuthZ plugin consumption, returning hierarchy data without policy or SQL semantics
   - Plugin gateway routing: built-in provider (local persistence path) vs vendor-specific provider (resolve plugin instance by configured vendor, delegate to `ResourceGroupReadPluginClient`) with SecurityContext passthrough
   - JWT authentication: standard AuthZ evaluation via `PolicyEnforcer.access_scope()` on all REST endpoints, `AccessScope` applied via SecureORM for tenant-scoped queries
-  - MTLS authentication: client certificate verification against trusted CA bundle, endpoint allowlist (only `GET /groups/{group_id}/hierarchy`), AuthZ bypass for trusted system principals, system SecurityContext creation
-  - MTLS configuration: `ca_cert`, `allowed_clients` (by certificate CN), `allowed_endpoints` (method + path pairs)
+  - MTLS authentication _(p2 — deferred, not implemented yet)_: client certificate verification against trusted CA bundle, endpoint allowlist (only `GET /groups/{group_id}/hierarchy`), AuthZ bypass for trusted system principals, system SecurityContext creation
+  - MTLS configuration _(p2 — deferred, not implemented yet)_: `ca_cert`, `allowed_clients` (by certificate CN), `allowed_endpoints` (method + path pairs)
   - Tenant scope enforcement for ownership-graph profile: parent-child edges and membership writes validated for tenant-hierarchy compatibility, platform-admin provisioning exception for cross-tenant management, tenant-scoped reads via `SecurityContext.subject_tenant_id`
   - Barrier as data: `metadata.self_managed` stored in group metadata JSONB without enforcement by RG, returned in API responses within `metadata` object for consumption by Tenant Resolver and AuthZ
-  - In-process vs out-of-process: ClientHub direct call (monolith, no MTLS needed) vs MTLS-authenticated remote call (microservices)
+  - In-process vs out-of-process: ClientHub direct call (monolith, no MTLS needed) — current `p1`; MTLS-authenticated remote call (microservices) — `p2`, deferred / not implemented yet
   - SecurityContext propagation: `ctx` passed through gateway to selected provider without policy interpretation
 
 - **Out of scope**:
@@ -323,7 +323,8 @@ The Resource Group DESIGN is decomposed into seven features organized around the
 - **Requirements Covered**:
 
   - [x] `p1` - `cpt-cf-resource-group-fr-integration-read-port`
-  - [x] `p1` - `cpt-cf-resource-group-fr-dual-auth-modes`
+  - [x] `p1` - `cpt-cf-resource-group-fr-jwt-auth`
+  - [ ] `p2` - `cpt-cf-resource-group-fr-dual-auth-modes` _(deferred, not implemented yet)_
   - [x] `p1` - `cpt-cf-resource-group-fr-tenant-scope-ownership-graph`
 
 - **Design Principles Covered**:
@@ -344,15 +345,15 @@ The Resource Group DESIGN is decomposed into seven features organized around the
   - [x] `p1` - `cpt-cf-resource-group-component-integration-read-service`
 
 - **API**:
-  - GET /api/resource-group/v1/groups/{group_id}/hierarchy (JWT + MTLS)
-  - All other endpoints (JWT only, MTLS returns 403)
+  - GET /api/resource-group/v1/groups/{group_id}/hierarchy (JWT; additionally over MTLS — `p2`, deferred / not implemented yet)
+  - All other endpoints (JWT only; MTLS path returns 403 — `p2`, deferred / not implemented yet)
 
 - **Sequences**:
 
   - `cpt-cf-resource-group-seq-authz-rg-sql-split`
   - `cpt-cf-resource-group-seq-e2e-authz-flow`
   - `cpt-cf-resource-group-seq-auth-modes`
-  - `cpt-cf-resource-group-seq-mtls-authz-read`
+  - `cpt-cf-resource-group-seq-mtls-authz-read` _(p2 — deferred, not implemented yet)_
   - `cpt-cf-resource-group-seq-jwt-rg-request`
 
 ---

--- a/modules/system/resource-group/docs/DESIGN.md
+++ b/modules/system/resource-group/docs/DESIGN.md
@@ -110,7 +110,8 @@ For AuthZ-facing deployments aligned with current platform architecture, `owners
 | `cpt-cf-resource-group-fr-no-authz-and-sql-logic`             | Hard separation: RG returns data only; AuthZ/PEP own constraints/SQL.                                                                 |
 | `cpt-cf-resource-group-fr-deterministic-errors`               | Unified error mapper translates domain/infrastructure failures to stable public categories.                                           |
 | `cpt-cf-resource-group-fr-force-delete`                       | Delete orchestration supports optional `force` parameter for cascade deletion of subtree and memberships.                             |
-| `cpt-cf-resource-group-fr-dual-auth-modes`                    | RG Gateway supports JWT (all endpoints, AuthZ-evaluated) and MTLS (hierarchy-only, AuthZ-bypassed) authentication paths.             |
+| `cpt-cf-resource-group-fr-jwt-auth`                           | Public RG HTTP/gRPC endpoints authenticate every request via JWT and run `PolicyEnforcer`. The AuthZ plugin's in-process `ResourceGroupReadHierarchy` reader is hierarchy-only and uses `AccessScope::allow_all()`, so it does **not** invoke `PolicyEnforcer` — this resolves the AuthZ ↔ RG circular dependency; the plugin still emits its own AuthZ constraints from the returned hierarchy. |
+| `cpt-cf-resource-group-fr-dual-auth-modes` _(p2 — deferred, not implemented yet)_ | **Future / not implemented yet.** RG Gateway will additionally support MTLS (hierarchy-only, AuthZ-bypassed) for service-to-service callers when the AuthZ plugin is split out of the RG process. Tracked as `p2`. |
 
 
 #### NFR Allocation
@@ -257,11 +258,11 @@ SMALLINT surrogate IDs (`gts_type.id`, `gts_type_id` FK columns) are a **DB-inte
 - `allowed_memberships` in type create/update requests
 - `resource_type` in membership operations (`POST /memberships/...`)
 
-If a referenced type does not exist, the operation **MUST** return a validation error. Each chained type (e.g., `gts.x.system.rg.type.v1~y.system.tn.tenant.v1~`) is a distinct type that must be registered separately — chaining does not auto-create constituent types. Registration order matters: base/resource types first, then chained RG types that reference them. Base types (including `gts.x.system.rg.type.v1~`) must be created before use — via seeding, API calls, or manual DB administration.
+If a referenced type does not exist, the operation **MUST** return a validation error. Each chained type (e.g., `gts.cf.core.rg.type.v1~y.system.tn.tenant.v1~`) is a distinct type that must be registered separately — chaining does not auto-create constituent types. Registration order matters: base/resource types first, then chained RG types that reference them. Base types (including `gts.cf.core.rg.type.v1~`) must be created before use — via seeding, API calls, or manual DB administration.
 
-**RG type prefix requirement (`gts.x.system.rg.type.v1~`)**:
-- **`type` in group operations**: `POST /groups`, `PUT /groups/{id}` — **MUST** have `gts.x.system.rg.type.v1~` prefix. Rejected without it.
-- **`allowed_parents`**: **MUST** have `gts.x.system.rg.type.v1~` prefix — parent groups are always RG types.
+**RG type prefix requirement (`gts.cf.core.rg.type.v1~`)**:
+- **`type` in group operations**: `POST /groups`, `PUT /groups/{id}` — **MUST** have `gts.cf.core.rg.type.v1~` prefix. Rejected without it.
+- **`allowed_parents`**: **MUST** have `gts.cf.core.rg.type.v1~` prefix — parent groups are always RG types.
 - **`allowed_memberships`**: **NO prefix requirement** — membership resource types are external domain types (e.g., `gts.z.system.idp.user.v1~`, `gts.z.system.lms.course.v1~`) that do not need to be RG types.
 
 This ensures the hierarchy is always governed by the RG type contract (`can_be_root`, `allowed_parents`, `allowed_memberships`), while membership resources can be any registered GTS type.
@@ -653,7 +654,7 @@ Client initialization: AuthZ plugin resolves `dyn ResourceGroupReadHierarchy` fr
 | SQL database                          | SeaORM repositories             | durable canonical + closure storage                           |
 | AuthZ Resolver SDK                    | `PolicyEnforcer` / `AuthZResolverClient` | AuthZ evaluation for JWT-authenticated RG API requests (write + read) |
 | Vendor-specific RG backend (optional) | `ResourceGroupReadPluginClient` | alternative hierarchy/membership source for integration reads |
-| AuthZ plugin consumer (optional)      | `ResourceGroupReadHierarchy`    | read hierarchy context in PDP logic (narrow, hierarchy-only, MTLS/in-process) |
+| AuthZ plugin consumer (optional)      | `ResourceGroupReadHierarchy`    | read hierarchy context in PDP logic (narrow, hierarchy-only; in-process via `ClientHub` — `p1`; MTLS transport — `p2`, deferred / not implemented yet) |
 | General consumers (optional)          | `ResourceGroupClient`           | full read+write access to types/entities/memberships/hierarchy |
 
 
@@ -861,7 +862,7 @@ Key separation of concerns:
 
 RG Module exposes its REST/gRPC API with **two authentication modes**. The mode determines whether the request passes through AuthZ evaluation.
 
-##### Mode 1: JWT (public API — all endpoints)
+##### Mode 1: JWT (public API — all endpoints) — implemented (`p1`)
 
 Standard user/service requests authenticated via JWT bearer token. **All** RG REST API endpoints are available. Every request goes through AuthZ evaluation via `PolicyEnforcer`, same as any other domain service (e.g. courses). JWT token lifecycle (expiry, refresh, revocation) is managed by the AuthN Resolver and API Gateway — RG delegates token validation entirely to the platform authentication layer and does not implement its own session timeout or token renewal logic.
 
@@ -874,7 +875,28 @@ Applies to:
 - `GET /api/resource-group/v1/memberships` — list memberships
 - `POST/DELETE /api/resource-group/v1/memberships/{...}` — membership lifecycle
 
-##### Mode 2: MTLS (private API — hierarchy endpoint only)
+In the current monolith deployment, the AuthZ plugin reads hierarchy via the in-process
+`ResourceGroupReadHierarchy` trait registered in `ClientHub`. That path
+**bypasses `PolicyEnforcer` invocation** by construction — the plugin
+cannot evaluate itself (circular dependency), so the trait
+implementation in `RgReadService` delegates to unscoped reads
+(`AccessScope::allow_all()`) without going through `PolicyEnforcer`.
+The bypass is on the *invocation* side only: AuthZ enforcement is
+still produced by the plugin **after** it receives the hierarchy data,
+in the form of tenant / subtree constraints attached to the original
+caller's request. The `dyn ResourceGroupReadHierarchy` type narrows
+the surface to hierarchy-only operations, so the plugin cannot reach
+non-hierarchy reads or any write paths through this channel.
+
+##### Mode 2: MTLS (private API — hierarchy endpoint only) — deferred (`p2`, not implemented yet)
+
+> **Status: `p2` — designed, not implemented yet.** The MTLS path is the
+> service-to-service authentication mode planned for a future microservice
+> deployment that splits the AuthZ plugin out of the RG process. The
+> current monolith uses the in-process `ResourceGroupReadHierarchy` path
+> described above and does not need this transport. The design is kept
+> here so the future split has a documented contract; do not implement
+> this in the current iteration.
 
 Service-to-service requests authenticated via mutual TLS client certificate. Used exclusively by AuthZ plugin to read tenant hierarchy. **Only one endpoint** is available in MTLS mode:
 
@@ -887,24 +909,27 @@ MTLS requests **bypass AuthZ evaluation entirely** — no `PolicyEnforcer` call,
 2. MTLS certificate identity is a trusted system principal — access is granted by transport-level authentication
 3. The single allowed endpoint returns read-only hierarchy data — minimal attack surface
 
-##### Authentication Decision Flow
+##### Authentication Decision Flow (`p2` — covers the future MTLS path)
+
+> **Status: `p2` — applies only when the deferred MTLS path lands.** Today
+> all traffic goes through the JWT branch.
 
 RG Gateway receives requests from two types of callers and routes them through different authentication paths:
 
-- **JWT path** — Admin (Instance/Tenant) or App sends a request with a bearer token. RG Gateway delegates authentication to AuthN Resolver, then runs AuthZ evaluation via `PolicyEnforcer` before executing the query.
-- **MTLS path** — AuthZ Plugin (in microservice deployment) sends a request with a client certificate. RG Gateway verifies the certificate against a trusted CA bundle, checks the endpoint allowlist, and executes directly without AuthZ evaluation.
+- **JWT path** (`p1`) — Admin (Instance/Tenant) or App sends a request with a bearer token. RG Gateway delegates authentication to AuthN Resolver, then runs AuthZ evaluation via `PolicyEnforcer` before executing the query.
+- **MTLS path** (`p2`, deferred) — AuthZ Plugin (in microservice deployment) sends a request with a client certificate. RG Gateway verifies the certificate against a trusted CA bundle, checks the endpoint allowlist, and executes directly without AuthZ evaluation.
 
 ```mermaid
 flowchart TD
     REQ["Incoming request to RG REST API<br/>(from Admin, App, or AuthZ Plugin)"] --> AUTH_CHECK{RG Gateway:<br/>authentication method?}
 
-    AUTH_CHECK -->|"JWT bearer token<br/>(Admin / App)"| JWT_PATH[AuthN Resolver validates JWT]
+    AUTH_CHECK -->|"JWT bearer token<br/>(Admin / App) — p1"| JWT_PATH[AuthN Resolver validates JWT]
     JWT_PATH --> SEC_CTX[SecurityContext extracted from token]
     SEC_CTX --> AUTHZ["RG Gateway calls<br/>PolicyEnforcer.access_scope()"]
     AUTHZ --> CONSTRAINTS[RG Gateway applies<br/>AccessScope to query]
     CONSTRAINTS --> EXEC["RG Service executes<br/>query with SQL predicates"]
 
-    AUTH_CHECK -->|"MTLS client cert<br/>(AuthZ Plugin)"| MTLS_PATH["RG Gateway verifies client cert<br/>against trusted CA bundle"]
+    AUTH_CHECK -->|"MTLS client cert<br/>(AuthZ Plugin) — p2 deferred"| MTLS_PATH["RG Gateway verifies client cert<br/>against trusted CA bundle"]
     MTLS_PATH --> ENDPOINT_CHECK{RG Gateway:<br/>endpoint in MTLS allowlist?}
     ENDPOINT_CHECK -->|"Yes: /groups/{id}/hierarchy"| SYSTEM_CTX["RG Gateway creates<br/>System SecurityContext"]
     SYSTEM_CTX --> EXEC_DIRECT["RG Hierarchy Service executes<br/>directly — no AuthZ evaluation"]
@@ -915,9 +940,12 @@ flowchart TD
     style EXEC fill:#6b6,color:#fff
 ```
 
-##### Sequence: MTLS request from AuthZ plugin
+##### Sequence: MTLS request from AuthZ plugin (`p2` — deferred, not implemented yet)
 
 **ID**: `cpt-cf-resource-group-seq-mtls-authz-read`
+
+> **Status: `p2` — design retained for the future microservice split. Not
+> implemented in the current monolith.**
 
 ```mermaid
 sequenceDiagram
@@ -964,7 +992,7 @@ sequenceDiagram
 
     RG_GW->>PE: access_scope(ctx, RESOURCE_GROUP, "list")
     PE->>AZ: evaluate(EvaluationRequest)
-    AZ->>RG_HIER: list_group_depth(system_ctx, T1, ...) [via MTLS/ClientHub]
+    AZ->>RG_HIER: list_group_depth(system_ctx, T1, ...) [in-process via ClientHub; MTLS variant: p2 — deferred]
     RG_HIER-->>AZ: [{T1, depth:0, barrier:false}, {T7, depth:1, barrier:true}]
     Note over AZ: TR: BarrierMode::Respect → T7 skipped<br/>AuthZ: exclude T7 from AccessScope
     AZ-->>PE: decision=true, constraints=[owner_tenant_id IN (T1)]
@@ -981,13 +1009,17 @@ Note: when a user calls RG REST API with JWT, the AuthZ flow is **identical** to
 1. API Gateway authenticates JWT → `SecurityContext`
 2. RG gateway calls `PolicyEnforcer.access_scope()` → AuthZ evaluates → constraints returned
 3. RG applies `AccessScope` to its own query via SecureORM (SecureORM maps AuthZ property `owner_tenant_id` to actual column `tenant_id` in `resource_group` table)
-4. AuthZ plugin internally reads hierarchy via `ResourceGroupReadHierarchy` (MTLS or in-process ClientHub) — this internal read bypasses AuthZ
+4. AuthZ plugin internally reads hierarchy via `ResourceGroupReadHierarchy` — in-process via `ClientHub` (`p1`) today, with the MTLS transport variant (`p2`, deferred / not implemented yet) reserved for the future microservice split — this internal read bypasses AuthZ
 
-The key insight: RG is simultaneously a **consumer** of AuthZ (for its own JWT-authenticated endpoints) and a **data provider** for AuthZ (via MTLS/ClientHub hierarchy reads). The MTLS bypass prevents the circular call.
+The key insight: RG is simultaneously a **consumer** of AuthZ (for its own JWT-authenticated endpoints) and a **data provider** for AuthZ (via in-process ClientHub hierarchy reads; an MTLS variant is `p2` — deferred). The bypass at the trait/transport level prevents the circular call.
 
-##### MTLS Configuration and Certificate Verification
+##### MTLS Configuration and Certificate Verification (`p2` — deferred, not implemented yet)
 
-MTLS authentication is configured at the RG gateway level and includes two parts: certificate trust and endpoint allowlist.
+> **Status: `p2` — designed, not implemented yet.** Configuration shape
+> retained for the future microservice split; do not wire this in the
+> current monolith.
+
+MTLS authentication will be configured at the RG gateway level and includes two parts: certificate trust and endpoint allowlist.
 
 **Certificate verification process** (performed by RG Gateway on every MTLS request):
 
@@ -1017,12 +1049,12 @@ Only explicitly listed method+path combinations are reachable via MTLS. Any requ
 
 ##### In-Process vs Out-of-Process
 
-| Deployment | AuthZ → RG hierarchy read | Auth mechanism |
-| ---------- | ------------------------- | -------------- |
-| Monolith (single process) | `hub.get::<dyn ResourceGroupReadHierarchy>()` — direct in-process call via ClientHub | No network auth needed — trusted in-process call, system `SecurityContext` |
-| Microservices (separate processes) | gRPC/REST call to RG service | MTLS client certificate — only `/groups/{id}/hierarchy` endpoint allowed |
+| Deployment | AuthZ → RG hierarchy read | Auth mechanism | Status |
+| ---------- | ------------------------- | -------------- | ------ |
+| Monolith (single process) | `hub.get::<dyn ResourceGroupReadHierarchy>()` — direct in-process call via ClientHub | No network auth needed — trusted in-process call, system `SecurityContext` | `p1` — implemented |
+| Microservices (separate processes) | gRPC/REST call to RG service | MTLS client certificate — only `/groups/{id}/hierarchy` endpoint allowed | `p2` — deferred, not implemented yet |
 
-In both cases, the AuthZ plugin uses `ResourceGroupReadHierarchy` trait. The trait implementation is either a direct local call (monolith) or an MTLS-authenticated remote call (microservices). The RG gateway applies the same allowlist logic in both cases — but in monolith mode, the in-process ClientHub path skips the gateway entirely (no HTTP, no MTLS, no allowlist check needed — the type system enforces that only `list_group_depth` is callable via `dyn ResourceGroupReadHierarchy`).
+In both cases, the AuthZ plugin uses `ResourceGroupReadHierarchy` trait. The trait implementation is either a direct local call (monolith — `p1`) or an MTLS-authenticated remote call (microservices — `p2`, deferred / not implemented yet). The RG gateway applies the same allowlist logic in both cases — but in monolith mode, the in-process ClientHub path skips the gateway entirely (no HTTP, no MTLS, no allowlist check needed — the type system enforces that only `list_group_depth` is callable via `dyn ResourceGroupReadHierarchy`).
 
 ### 3.7 Database schemas & tables
 
@@ -1256,7 +1288,8 @@ RG relies on database-level performance rather than application-level caching:
 Notes:
   - `resource.type` and `action.name` are illustrative names following CyberFabric AuthZ conventions. Actual GTS type paths and action names are configured in the AuthZ policy.
   - Standard action vocabulary: `list` (collection), `read` (single resource), `create`, `update`, `delete` — aligned with [AuthZ usage scenarios](../../../docs/arch/authorization/AUTHZ_USAGE_SCENARIOS.md).
-  - MTLS-authenticated requests (AuthZ plugin only) bypass `PolicyEnforcer` entirely — see [RG Authentication Modes](#rg-authentication-modes-jwt-vs-mtls).
+  - The AuthZ plugin reads hierarchy in-process via `ResourceGroupReadHierarchy` registered in `ClientHub` and **bypasses `PolicyEnforcer` invocation** on those reads (`AccessScope::allow_all()`); the plugin still produces AuthZ tenant/subtree constraints from the returned hierarchy — see [RG Authentication Modes: JWT vs MTLS](#rg-authentication-modes-jwt-vs-mtls).
+  - MTLS-authenticated requests (AuthZ plugin only) **also** bypass `PolicyEnforcer` entirely — `p2`, **deferred / not implemented yet**, planned for the future microservice split — see [RG Authentication Modes: JWT vs MTLS](#rg-authentication-modes-jwt-vs-mtls).
   - `listGroupHierarchy` shares `resource_group` + `read` permission with `getGroup` — both are group read operations; the AuthZ policy may differentiate them if needed.
 
 ### Reliability Architecture

--- a/modules/system/resource-group/docs/PRD.md
+++ b/modules/system/resource-group/docs/PRD.md
@@ -52,7 +52,7 @@
   - [8.1 Types](#81-types)
   - [8.2 Groups](#82-groups)
   - [8.3 Membership](#83-membership)
-  - [8.4 Group Hierarchy (MTLS AuthZ)](#84-group-hierarchy-mtls-authz)
+  - [8.4 Group Hierarchy (AuthZ Plugin Read Path)](#84-group-hierarchy-authz-plugin-read-path)
 - [9. Acceptance Criteria](#9-acceptance-criteria)
 - [10. Dependencies](#10-dependencies)
 - [11. Assumptions](#11-assumptions)
@@ -313,7 +313,7 @@ A type includes:
 - `schema_id` (unique GTS type path, case-insensitive)
 - `can_be_root` (boolean; `true` means the type permits root placement — no `parent_id`). Resolved from `x-gts-traits` in the registered GTS schema.
 - `allowed_parents` (allowed parent type codes; may be empty if the type is root-only). Invariant: `can_be_root OR len(allowed_parents) >= 1` — a type must have at least one valid placement
-- `allowed_memberships` (GTS type paths of resource types allowed as members of groups of this type, e.g. `["gts.x.system.idp.user.v1~"]`)
+- `allowed_memberships` (GTS type paths of resource types allowed as members of groups of this type, e.g. `["gts.cf.core.idp.user.v1~"]`)
 - `metadata_schema` (optional JSON Schema — defines the structure and validation rules for the `metadata` field on group instances of this type)
 
 #### Validate Type Code Format
@@ -390,7 +390,7 @@ The module **MUST** provide API operations for:
 Entity fields (GTS-aligned naming):
 
 - `id` (UUID) — group identifier
-- `type` (GTS chained type path, e.g. `gts.x.system.rg.type.v1~w.system.org.department.v1~`)
+- `type` (GTS chained type path, e.g. `gts.cf.core.rg.type.v1~w.system.org.department.v1~`)
 - `name` (1..255) — display name
 - `metadata` (object) — type-specific fields defined by the chained RG type schema. Examples: `metadata.self_managed`, `metadata.custom_domain`, `metadata.category`. For types supporting barrier semantics, `metadata.self_managed` (boolean) is included here.
 - `hierarchy` (object) — RG hierarchy context:
@@ -646,20 +646,27 @@ The module **MUST** map all failures to deterministic categories:
 
 ### 5.9 Authentication Modes
 
-- [x] `p1` - **ID**: `cpt-cf-resource-group-fr-dual-auth-modes`
+- [x] `p1` - **ID**: `cpt-cf-resource-group-fr-jwt-auth`
 
-RG REST API supports two authentication modes:
+Every public RG REST/gRPC endpoint authenticates via JWT bearer token and goes through AuthZ evaluation via `PolicyEnforcer` — identical flow to any other domain service (courses, users, etc.). The AuthZ plugin reads RG hierarchy via the in-process `ResourceGroupReadHierarchy` trait registered in `ClientHub`; that path uses `AccessScope::allow_all()` and **does not** invoke `PolicyEnforcer` (resolving the AuthZ ↔ RG circular dependency at the type level). The plugin still emits its own AuthZ tenant/subtree constraints from the returned hierarchy.
 
-**JWT (public, all endpoints)**: standard user/service requests via bearer token. All endpoints available. Every request goes through AuthZ evaluation via `PolicyEnforcer` — identical flow to any other domain service (courses, users, etc.).
+- [ ] `p2` - **ID**: `cpt-cf-resource-group-fr-dual-auth-modes`
+
+> **Status: `p2` — designed, not implemented yet.** Planned for the
+> future microservice deployment that splits the AuthZ plugin out of the
+> RG process. The design is retained in this PRD so the future split has
+> a documented contract; do not implement this in the current iteration.
+
+In addition to JWT, RG REST API will support an MTLS path:
 
 **MTLS (private, hierarchy endpoint only)**: service-to-service requests via mutual TLS client certificate. Used by AuthZ plugin to read tenant hierarchy. Only `GET /groups/{group_id}/hierarchy` is allowed — all other endpoints return `403 Forbidden`. MTLS requests **bypass AuthZ evaluation entirely** because:
 - AuthZ plugin is the caller and cannot evaluate itself (circular dependency)
 - MTLS certificate identity is a trusted system principal
 - Single read-only endpoint — minimal attack surface
 
-In monolith deployment, AuthZ uses `ResourceGroupReadHierarchy` via in-process ClientHub — no network, no MTLS, type system enforces hierarchy-only access. In microservice deployment, the same trait is backed by an MTLS-authenticated gRPC/REST call.
+In monolith deployment, AuthZ uses `ResourceGroupReadHierarchy` via in-process ClientHub — no network, no MTLS, type system enforces hierarchy-only access. In a future microservice deployment (`p2`), the same trait will be backed by an MTLS-authenticated gRPC/REST call.
 
-See DESIGN.md `cpt-cf-resource-group-seq-auth-modes` for detailed sequence diagrams.
+See DESIGN.md `cpt-cf-resource-group-seq-auth-modes` for detailed sequence diagrams (the MTLS sub-sequence is `p2` — deferred).
 
 ## 6. Non-Functional Requirements
 
@@ -780,7 +787,7 @@ See DESIGN.md for full Rust trait definitions, SDK schemas, and usage examples.
 
 ### 7.2 Authentication Modes
 
-See `cpt-cf-resource-group-fr-dual-auth-modes` in section 5.9 for the full authentication modes requirement.
+See `cpt-cf-resource-group-fr-jwt-auth` in section 5.9 for the implemented JWT authentication, and `cpt-cf-resource-group-fr-dual-auth-modes` _(p2 — deferred, not implemented yet)_ for the future MTLS service-to-service path.
 
 ## 8. Use Cases
 
@@ -1065,9 +1072,9 @@ See `cpt-cf-resource-group-fr-dual-auth-modes` in section 5.9 for the full authe
 - **AND** group existence and tenant compatibility are validated during seeding
 - **AND** seeding is idempotent — repeated runs produce the same result
 
-### 8.4 Group Hierarchy (MTLS AuthZ)
+### 8.4 Group Hierarchy (AuthZ Plugin Read Path)
 
-#### Scenario: AuthZ Plugin Resolves Tenant Hierarchy Downward
+#### Scenario: AuthZ Plugin Resolves Tenant Hierarchy Downward (in-process via `ClientHub`)
 
 - **GIVEN** stored hierarchy (all groups of type `tenant` or `group`):
   ```
@@ -1079,7 +1086,7 @@ See `cpt-cf-resource-group-fr-dual-auth-modes` in section 5.9 for the full authe
       └── G21 (group, tenant_id=T7)
   ```
 - **AND** AuthZ plugin needs to resolve which tenants/groups are visible to a user whose `subject_tenant_id = T1`
-- **WHEN** plugin calls `list_group_depth(ctx, T1, filter="hierarchy/depth ge 0 and type in ('tenant','group')")` via MTLS
+- **WHEN** plugin calls `get_group_descendants(ctx, T1, &ODataQuery::filter("type in ('tenant','group')"))` via the in-process `ResourceGroupReadHierarchy` trait registered in `ClientHub` (the MTLS transport variant is `p2` — deferred, not implemented yet)
 - **THEN** RG returns:
   | id  | type   | hierarchy.tenant_id | hierarchy.depth |
   |-----|--------|---------------------|-----------------|
@@ -1092,7 +1099,11 @@ See `cpt-cf-resource-group-fr-dual-auth-modes` in section 5.9 for the full authe
 - **AND** plugin uses `tenant_id` from each row to build tenant-scoped AuthZ constraints
 - **AND** RG returns no policy decisions — only data rows
 
-#### Scenario: MTLS Request to Non-Hierarchy Endpoint
+#### Scenario: MTLS Request to Non-Hierarchy Endpoint (`p2` — deferred, not implemented yet)
+
+> **Status: `p2` — designed, not implemented yet.** This scenario applies
+> only when the deferred MTLS path lands in a future microservice
+> deployment.
 
 - **GIVEN** caller authenticates via MTLS client certificate
 - **WHEN** caller sends request to `POST /api/resource-group/v1/groups` (non-hierarchy endpoint)

--- a/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
+++ b/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
@@ -281,7 +281,7 @@ In-source `#[cfg(test)]` tests for filter field definitions and DTO conversions:
 ## 6. Acceptance Criteria
 
 - [x] SDK crate (`resource-group-sdk`) compiles with all model types, trait contracts, and error types defined
-- [x] `GtsTypePath::new("gts.x.system.rg.type.v1~")` succeeds; `GtsTypePath::new("invalid")` returns validation error
+- [x] `GtsTypePath::new("gts.cf.core.rg.type.v1~")` succeeds; `GtsTypePath::new("invalid")` returns validation error
 - [x] All 6 DB tables are created by migration scripts with correct constraints and indexes
 - [x] SeaORM entities compile and map to the DB schema without runtime errors
 - [x] Module registers `dyn ResourceGroupClient` and `dyn ResourceGroupReadHierarchy` in ClientHub during Phase 1 init
@@ -305,7 +305,7 @@ Other modules (`nodes-registry`, `types-registry`) place pure-logic tests direct
 
 #### TC-SDK-01: GtsTypePath::new() valid path [P1]
 - **Covers**: G36, 0001-AC-2
-- **Input**: `"gts.x.system.rg.type.v1~"`
+- **Input**: `"gts.cf.core.rg.type.v1~"`
 - **Assert**: `Ok(GtsTypePath)`, `as_str()` returns lowercase
 
 #### TC-SDK-02: GtsTypePath::new() empty string [P1]
@@ -328,32 +328,32 @@ Other modules (`nodes-registry`, `types-registry`) place pure-logic tests direct
 
 #### TC-SDK-06: GtsTypePath::new() invalid format - uppercase chars [P1]
 - **Covers**: G38
-- **Input**: `"gts.x.system.rg.type.v1~"` with uppercase -> trimmed/lowercased
+- **Input**: `"gts.cf.core.rg.type.v1~"` with uppercase -> trimmed/lowercased
 
 #### TC-SDK-07: GtsTypePath::new() trims whitespace and lowercases [P2]
 - **Covers**: G36
 - **Input**: `"  GTS.X.System.RG.Type.V1~  "`
-- **Assert**: `Ok`, `as_str() == "gts.x.system.rg.type.v1~"`
+- **Assert**: `Ok`, `as_str() == "gts.x.system.rg.type.v1~"` (`new` only normalizes case/whitespace; it does not rewrite the GTS namespace)
 
 #### TC-SDK-08: GtsTypePath::new() chained path (multi-segment) [P1]
 - **Covers**: G38
-- **Input**: `"gts.x.system.rg.type.v1~x.test.v1~"`
+- **Input**: `"gts.cf.core.rg.type.v1~x.test.v1~"`
 - **Assert**: `Ok`
 
 #### TC-SDK-09: GtsTypePath::new() double tilde (empty segment) [P2]
 - **Covers**: G38
-- **Input**: `"gts.x.system.rg.type.v1~~"`
+- **Input**: `"gts.cf.core.rg.type.v1~~"`
 - **Assert**: `Err` (empty segment between tildes)
 
 #### TC-SDK-10: GtsTypePath::new() special chars in segment [P2]
 - **Covers**: G38
-- **Input**: `"gts.x.system.rg.type.v1~hello-world~"` (hyphen not allowed)
+- **Input**: `"gts.cf.core.rg.type.v1~hello-world~"` (hyphen not allowed)
 - **Assert**: `Err`
 
 #### TC-SDK-11: GtsTypePath serde round-trip (JSON) [P1]
 - **Covers**: G37
 - **Setup**: Serialize `GtsTypePath` to JSON string, deserialize back
-- **Assert**: `serde_json::to_string(&path)` produces `"gts.x.system.rg.type.v1~"`, deserialize back equals original
+- **Assert**: `serde_json::to_string(&path)` produces `"gts.cf.core.rg.type.v1~"`, deserialize back equals original
 
 #### TC-SDK-12: GtsTypePath serde invalid JSON string [P1]
 - **Covers**: G37
@@ -495,7 +495,7 @@ Tests S1, S2, S8, S9 verify integration seams that unit tests (TC-DTO-*, TC-SDK-
 testing/e2e/modules/resource_group/
 ├── conftest.py                          ← helpers, timeout config
 ├── test_authz_tenant_scoping.py         ← existing (9 tests) — keep as-is
-├── test_mtls_auth.py                    ← existing (4 tests) — keep as-is
+├── test_mtls_auth.py                    ← (p2 — deferred, not implemented yet) 4 MTLS tests; do not run in current iteration
 ├── test_integration_seams.py            ← 10 integration seam tests
 ```
 

--- a/modules/system/resource-group/docs/features/0003-entity-hierarchy.md
+++ b/modules/system/resource-group/docs/features/0003-entity-hierarchy.md
@@ -460,7 +460,7 @@ The plan was originally based on a gap analysis against acceptance criteria defi
 
 **Scope**: Domain service tests with SQLite in-memory, in-source `#[cfg(test)]` for pure logic, metadata validation against `metadata_schema`.
 
-**Out of scope**: E2E tests (Feature 0007), PostgreSQL-specific tests, MTLS, performance.
+**Out of scope**: E2E tests (Feature 0007), PostgreSQL-specific tests, MTLS (`p2` — deferred, not implemented yet), performance.
 
 ### Coverage Summary
 
@@ -470,7 +470,7 @@ The plan was originally based on a gap analysis against acceptance criteria defi
 
 | File | Tests | Covers |
 |------|-------|--------|
-| In-source `#[cfg(test)]` (lib.rs) | 23 | Inline tests in `auth.rs` (MTLS/JWT mode routing, path matching), `dto.rs` (DTO serde attributes, `type` rename, camelCase), `odata_mapper.rs` (Type/Group/Hierarchy/Membership ODataMapper field→column) |
+| In-source `#[cfg(test)]` (lib.rs) | 23 | Inline tests in `auth.rs` (JWT mode routing — `p1`; MTLS mode routing and path matching — `p2`, deferred / not implemented yet), `dto.rs` (DTO serde attributes, `type` rename, camelCase), `odata_mapper.rs` (Type/Group/Hierarchy/Membership ODataMapper field→column) |
 | `api_rest_test.rs` | 54 | Type CRUD REST (create 201, dup 409, invalid 400, list 200, get 200/404, delete 204), Group REST (create/list/get/update/delete/hierarchy), Membership REST (add/remove/list), RFC 9457 error format + Content-Type verification (TC-REST-10), deserialization errors, SMALLINT non-exposure, metadata in REST responses, route smoke all 14 endpoints (RG7) |
 | `authz_integration_test.rs` | 9 | PolicyEnforcer tenant scoping, deny-all, allow-all, resource_id passing, all CRUD actions, full chain list_groups/deny |
 | `domain_unit_test.rs` | 79 | `validate_type_code` (5 cases), `DomainError` construction (13 variants), `DomainError` → `ResourceGroupError` mapping, `DomainError` → `Problem` mapping, serialization failure detection, `EnforcerError` → `DomainError` conversions, `DbErr` → `DomainError`, ADR-001 hierarchy reproduction, GTS-specific logic, invalid/non-GTS input validation |
@@ -793,7 +793,7 @@ Test setup: SQLite in-memory + TypeService + GroupService with configurable Quer
 - **Assert**: 400/422
 
 #### TC-DESER-03: Create type with `can_be_root` missing [P1]
-- Body: `{"code": "gts.x.system.rg.type.v1~test.v1~"}`
+- Body: `{"code": "gts.cf.core.rg.type.v1~test.v1~"}`
 - **Assert**: 400/422 (required field missing — no `#[serde(default)]` on `can_be_root`)
 
 #### TC-DESER-04: Create group with `type` field missing [P1]
@@ -1003,7 +1003,7 @@ GTS-level validation (33 tests in `rg_gts_type_system_tests.rs`) validates at sc
 
 #### TC-ADR-16: Chained type path format in RG [P1]
 - ADR uses: `gts.x.core.rg.type.v1~y.core.tn.tenant.v1~` (multi-segment)
-- Code validates prefix: `gts.x.system.rg.type.v1~` (different namespace!)
+- Code validates prefix: `gts.cf.core.rg.type.v1~` (different namespace!)
 - **Assert**: Verify which prefix the code actually requires. If `system` not `core` → document discrepancy with ADR.
 
 #### TC-ADR-17: Type response contains no SMALLINT IDs [P1]
@@ -1064,7 +1064,7 @@ GTS-level validation (33 tests in `rg_gts_type_system_tests.rs`) validates at sc
   - GET /groups/{random-uuid} → 404 Not Found
   - POST /types {duplicate code} → 409 Conflict
   - POST /types {invalid body} → 400 Bad Request
-  - POST /groups {type "gts.x.system.rg.type.v1~nonexistent.v1~"} → 404 (TypeNotFound)
+  - POST /groups {type "gts.cf.core.rg.type.v1~nonexistent.v1~"} → 404 (TypeNotFound)
 - **Assert per response**:
   - HTTP status code matches expected
   - `Content-Type` header contains `application/problem+json`

--- a/modules/system/resource-group/docs/features/0005-integration-auth.md
+++ b/modules/system/resource-group/docs/features/0005-integration-auth.md
@@ -16,7 +16,8 @@
   - [1.4 References](#14-references)
 - [2. Actor Flows (CDSL)](#2-actor-flows-cdsl)
   - [JWT Request to RG REST API](#jwt-request-to-rg-rest-api)
-  - [MTLS Request from AuthZ Plugin](#mtls-request-from-authz-plugin)
+  - [In-Process Hierarchy Read by AuthZ Plugin](#in-process-hierarchy-read-by-authz-plugin)
+  - [MTLS Request from AuthZ Plugin (`p2` — deferred, not implemented yet)](#mtls-request-from-authz-plugin-p2--deferred-not-implemented-yet)
   - [Plugin Gateway Routing](#plugin-gateway-routing)
 - [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
   - [Tenant Scope Enforcement for Ownership-Graph Writes](#tenant-scope-enforcement-for-ownership-graph-writes)
@@ -49,7 +50,7 @@ Expose the integration read service (`ResourceGroupReadHierarchy`) for external 
 
 This feature bridges RG with the AuthZ ecosystem. The integration read port provides a stable, policy-agnostic data contract for hierarchy reads. Dual auth modes resolve the circular dependency between RG (needs AuthZ for its own endpoints) and AuthZ (needs RG for hierarchy data). Tenant scope enforcement ensures ownership-graph integrity for AuthZ-facing deployments.
 
-**Requirements**: `cpt-cf-resource-group-fr-integration-read-port`, `cpt-cf-resource-group-fr-dual-auth-modes`, `cpt-cf-resource-group-fr-tenant-scope-ownership-graph`
+**Requirements**: `cpt-cf-resource-group-fr-integration-read-port`, `cpt-cf-resource-group-fr-jwt-auth`, `cpt-cf-resource-group-fr-tenant-scope-ownership-graph`, `cpt-cf-resource-group-fr-dual-auth-modes` _(p2 — deferred, not implemented yet)_
 
 **Principles**: `cpt-cf-resource-group-principle-tenant-scope-ownership-graph`, `cpt-cf-resource-group-principle-barrier-as-data`
 
@@ -57,8 +58,8 @@ This feature bridges RG with the AuthZ ecosystem. The integration read port prov
 
 | Actor | Role in Feature |
 |-------|-----------------|
-| `cpt-cf-resource-group-actor-authz-plugin-consumer` | Reads hierarchy data via `ResourceGroupReadHierarchy` (MTLS or in-process ClientHub) |
-| `cpt-cf-resource-group-actor-instance-administrator` | Configures MTLS settings, manages tenant hierarchy |
+| `cpt-cf-resource-group-actor-authz-plugin-consumer` | Reads hierarchy data via `ResourceGroupReadHierarchy` (in-process via `ClientHub`; MTLS path is `p2` — deferred / not implemented yet) |
+| `cpt-cf-resource-group-actor-instance-administrator` | Manages tenant hierarchy. _Configures MTLS settings: `p2` — deferred, not implemented yet._ |
 | `cpt-cf-resource-group-actor-tenant-administrator` | Operates within tenant scope; JWT-authenticated requests go through AuthZ |
 | `cpt-cf-resource-group-actor-apps` | General consumers using `ResourceGroupClient` via JWT |
 
@@ -91,16 +92,41 @@ This feature bridges RG with the AuthZ ecosystem. The integration read port prov
 2. [x] - `p1` - API Gateway: authenticate JWT via AuthNResolverClient → SecurityContext {subject_id, subject_tenant_id} - `inst-jwt-2`
 3. [x] - `p1` - RG Gateway: call PolicyEnforcer.access_scope(ctx, resource_type, action) - `inst-jwt-3`
 4. [x] - `p1` - PolicyEnforcer → AuthZ Resolver: evaluate(EvaluationRequest) - `inst-jwt-4`
-5. [x] - `p1` - AuthZ plugin internally: call ResourceGroupReadHierarchy.list_group_depth() for tenant hierarchy resolution (via MTLS or in-process ClientHub — bypasses AuthZ) - `inst-jwt-5`
+5. [x] - `p1` - AuthZ plugin internally: call ResourceGroupReadHierarchy.list_group_depth() for tenant hierarchy resolution (in-process via `ClientHub` — bypasses AuthZ to break the circular dependency; the MTLS transport variant is `p2` — deferred, not implemented yet) - `inst-jwt-5`
 6. [x] - `p1` - AuthZ plugin: produce constraints (e.g., owner_tenant_id IN (...)) - `inst-jwt-6`
 7. [x] - `p1` - PolicyEnforcer: compile_to_access_scope() → AccessScope - `inst-jwt-7`
 8. [x] - `p1` - RG Gateway: apply AccessScope via SecureORM (WHERE tenant_id IN (...)) to query - `inst-jwt-8`
 9. [x] - `p1` - RG Service: execute query with SQL predicates, return results - `inst-jwt-9`
 10. [x] - `p1` - **RETURN** response to actor - `inst-jwt-10`
 
-### MTLS Request from AuthZ Plugin
+### In-Process Hierarchy Read by AuthZ Plugin
 
-- [x] `p1` - **ID**: `cpt-cf-resource-group-flow-integration-auth-mtls-request`
+- [x] `p1` - **ID**: `cpt-cf-resource-group-flow-integration-auth-plugin-read`
+
+**Actor**: `cpt-cf-resource-group-actor-authz-plugin-consumer`
+
+**Success Scenarios**:
+- AuthZ plugin reads hierarchy data via the in-process `ResourceGroupReadHierarchy` trait registered in `ClientHub`; AuthZ evaluation is bypassed by construction (the plugin cannot evaluate itself)
+
+**Error Scenarios**:
+- Group not found (or inaccessible root) → domain not-found error surfaced by `RgReadService` (mirrors `GroupService::get_group_descendants` / `get_group_ancestors`, which perform a scope-aware preflight lookup and map missing/cross-tenant root to `GroupNotFound` → HTTP 404 on the REST path)
+- DB unavailable → infrastructure error surfaced via `DomainError::Database`
+
+**Steps**:
+1. [x] - `p1` - AuthZ plugin resolves `dyn ResourceGroupReadHierarchy` from `ClientHub` - `inst-plugin-read-1`
+2. [x] - `p1` - Plugin invokes `list_group_depth(system_ctx, group_id, query)` - `inst-plugin-read-2`
+3. [x] - `p1` - `RgReadService` delegates to `GroupService` unscoped read methods (`AccessScope::allow_all()`) — no AuthZ evaluation - `inst-plugin-read-3`
+4. [x] - `p1` - `GroupService` executes the closure-table query against the RG database - `inst-plugin-read-4`
+5. [x] - `p1` - **RETURN** `Page<ResourceGroupWithDepth>` — hierarchy rows with `tenant_id` per group and `metadata` (including `self_managed`); the trait surface restricts the plugin to hierarchy-only operations - `inst-plugin-read-5`
+
+### MTLS Request from AuthZ Plugin (`p2` — deferred, not implemented yet)
+
+- [ ] `p2` - **ID**: `cpt-cf-resource-group-flow-integration-auth-mtls-request`
+
+> **Status: `p2` — designed, not implemented yet.** Planned for a future
+> microservice deployment that splits the AuthZ plugin out of the RG
+> process. The current monolith uses the in-process flow above; do not
+> implement this path in the current iteration.
 
 **Actor**: `cpt-cf-resource-group-actor-authz-plugin-consumer`
 
@@ -113,16 +139,16 @@ This feature bridges RG with the AuthZ ecosystem. The integration read port prov
 - Endpoint not in MTLS allowlist → 403 Forbidden
 
 **Steps**:
-1. [x] - `p1` - AuthZ plugin sends GET /api/resource-group/v1/groups/{group_id}/hierarchy with MTLS client certificate - `inst-mtls-1`
-2. [x] - `p1` - RG Gateway: extract client certificate from TLS handshake - `inst-mtls-2`
-3. [x] - `p1` - Validate certificate against trusted CA bundle (ca_cert): chain, expiration, revocation - `inst-mtls-3`
-4. [x] - `p1` - Match client identity (certificate CN/SAN) against allowed_clients list - `inst-mtls-4`
-5. [x] - `p1` - **IF** client not in allowed_clients → **RETURN** 403 Forbidden - `inst-mtls-5`
-6. [x] - `p1` - Check endpoint against allowed_endpoints allowlist (method + path) - `inst-mtls-6`
-7. [x] - `p1` - **IF** endpoint not in allowlist → **RETURN** 403 Forbidden - `inst-mtls-7`
-8. [x] - `p1` - Create system SecurityContext (no AuthZ evaluation — trusted system principal) - `inst-mtls-8`
-9. [x] - `p1` - RG Hierarchy Service: execute list_group_depth(system_ctx, group_id, query) directly - `inst-mtls-9`
-10. [x] - `p1` - **RETURN** Page<ResourceGroupWithDepth> — hierarchy data with tenant_id per group, metadata including `self_managed` - `inst-mtls-10`
+1. [ ] - `p2` - AuthZ plugin sends GET /api/resource-group/v1/groups/{group_id}/hierarchy with MTLS client certificate - `inst-mtls-1`
+2. [ ] - `p2` - RG Gateway: extract client certificate from TLS handshake - `inst-mtls-2`
+3. [ ] - `p2` - Validate certificate against trusted CA bundle (ca_cert): chain, expiration, revocation - `inst-mtls-3`
+4. [ ] - `p2` - Match client identity (certificate CN/SAN) against allowed_clients list - `inst-mtls-4`
+5. [ ] - `p2` - **IF** client not in allowed_clients → **RETURN** 403 Forbidden - `inst-mtls-5`
+6. [ ] - `p2` - Check endpoint against allowed_endpoints allowlist (method + path) - `inst-mtls-6`
+7. [ ] - `p2` - **IF** endpoint not in allowlist → **RETURN** 403 Forbidden - `inst-mtls-7`
+8. [ ] - `p2` - Create system SecurityContext (no AuthZ evaluation — trusted system principal) - `inst-mtls-8`
+9. [ ] - `p2` - RG Hierarchy Service: execute list_group_depth(system_ctx, group_id, query) directly - `inst-mtls-9`
+10. [ ] - `p2` - **RETURN** Page<ResourceGroupWithDepth> — hierarchy data with tenant_id per group, metadata including `self_managed` - `inst-mtls-10`
 
 ### Plugin Gateway Routing
 
@@ -161,22 +187,27 @@ This feature bridges RG with the AuthZ ecosystem. The integration read port prov
 5. [x] - `p1` - **IF** tenant-incompatible → **RETURN** TenantIncompatibility with tenant details - `inst-tenant-enforce-5`
 6. [x] - `p1` - **RETURN** pass - `inst-tenant-enforce-6`
 
-### Authentication Mode Decision
+### Authentication Mode Decision (`p2` — deferred, not implemented yet)
 
-- [x] `p1` - **ID**: `cpt-cf-resource-group-algo-integration-auth-auth-mode-decision`
+- [ ] `p2` - **ID**: `cpt-cf-resource-group-algo-integration-auth-auth-mode-decision`
+
+> **Status: `p2` — applies only when the deferred MTLS path lands in a
+> future microservice deployment. The current monolith only handles the
+> JWT branch (and the in-process plugin read path which does not flow
+> through this decision).**
 
 **Input**: Incoming request with authentication credentials
 
 **Output**: Authentication mode (JWT or MTLS) and resulting SecurityContext
 
 **Steps**:
-1. [x] - `p1` - Inspect request for authentication method - `inst-auth-decide-1`
-2. [x] - `p1` - **IF** request has MTLS client certificate - `inst-auth-decide-2`
-   1. [x] - `p1` - Verify certificate against CA bundle - `inst-auth-decide-2a`
-   2. [x] - `p1` - Match CN against allowed_clients - `inst-auth-decide-2b`
-   3. [x] - `p1` - Check endpoint in MTLS allowlist - `inst-auth-decide-2c`
-   4. [x] - `p1` - **IF** all checks pass → create system SecurityContext, skip AuthZ → **RETURN** MTLS mode - `inst-auth-decide-2d`
-   5. [x] - `p1` - **ELSE** → **RETURN** 403 Forbidden - `inst-auth-decide-2e`
+1. [ ] - `p2` - Inspect request for authentication method - `inst-auth-decide-1`
+2. [ ] - `p2` - **IF** request has MTLS client certificate - `inst-auth-decide-2`
+   1. [ ] - `p2` - Verify certificate against CA bundle - `inst-auth-decide-2a`
+   2. [ ] - `p2` - Match CN against allowed_clients - `inst-auth-decide-2b`
+   3. [ ] - `p2` - Check endpoint in MTLS allowlist - `inst-auth-decide-2c`
+   4. [ ] - `p2` - **IF** all checks pass → create system SecurityContext, skip AuthZ → **RETURN** MTLS mode - `inst-auth-decide-2d`
+   5. [ ] - `p2` - **ELSE** → **RETURN** 403 Forbidden - `inst-auth-decide-2e`
 3. [x] - `p1` - **IF** request has JWT bearer token - `inst-auth-decide-3`
    1. [x] - `p1` - Authenticate via AuthNResolverClient → SecurityContext - `inst-auth-decide-3a`
    2. [x] - `p1` - Run PolicyEnforcer.access_scope() → AccessScope - `inst-auth-decide-3b`
@@ -200,7 +231,7 @@ The system **MUST** implement an Integration Read Service that exposes `Resource
 - Responses are policy-agnostic: no AuthZ decisions, no SQL fragments, no constraint objects
 - Plugin gateway routing: resolve configured provider (built-in vs vendor-specific), delegate with SecurityContext passthrough
 - In-process mode (monolith): direct ClientHub call, no network auth needed
-- Out-of-process mode (microservices): MTLS-authenticated remote call
+- Out-of-process mode (microservices): MTLS-authenticated remote call _(p2 — deferred, not implemented yet)_
 - SecurityContext propagated without policy interpretation across gateway layer
 
 **Implements**:
@@ -209,17 +240,33 @@ The system **MUST** implement an Integration Read Service that exposes `Resource
 **Touches**:
 - Entities: `ResourceGroupWithDepth`, `ResourceGroupMembership`
 
-### Dual Authentication Mode Routing
+### JWT Authentication Routing
 
-- [x] `p1` - **ID**: `cpt-cf-resource-group-dod-integration-auth-dual-auth`
+- [x] `p1` - **ID**: `cpt-cf-resource-group-dod-integration-auth-jwt`
 
-The system **MUST** implement dual authentication mode routing in the RG gateway.
+The system **MUST** authenticate every public RG REST/gRPC endpoint via JWT and run AuthZ evaluation.
 
 **JWT mode (all endpoints)**:
 - Authenticate via AuthNResolverClient → SecurityContext
 - Run PolicyEnforcer.access_scope() for AuthZ evaluation
 - Apply AccessScope via SecureORM to all queries
 - Identical flow to any other domain service (courses, users, etc.)
+
+**Implements**:
+- `cpt-cf-resource-group-flow-integration-auth-jwt-request`
+- `cpt-cf-resource-group-flow-integration-auth-plugin-read`
+
+**Touches**:
+- API: all RG REST endpoints (JWT)
+
+### Dual Authentication Mode Routing (`p2` — deferred, not implemented yet)
+
+- [ ] `p2` - **ID**: `cpt-cf-resource-group-dod-integration-auth-dual-auth`
+
+> **Status: `p2` — designed, not implemented yet.** Planned for the
+> future microservice split. Do not implement in the current iteration.
+
+The system **WILL** additionally implement an MTLS authentication mode in the RG gateway when the AuthZ plugin is split out of the RG process.
 
 **MTLS mode (hierarchy endpoint only)**:
 - Verify client certificate against trusted CA bundle
@@ -235,12 +282,11 @@ The system **MUST** implement dual authentication mode routing in the RG gateway
 - `allowed_endpoints`: list of method+path pairs (e.g., `GET /api/resource-group/v1/groups/{group_id}/hierarchy`)
 
 **Implements**:
-- `cpt-cf-resource-group-flow-integration-auth-jwt-request`
-- `cpt-cf-resource-group-flow-integration-auth-mtls-request`
-- `cpt-cf-resource-group-algo-integration-auth-auth-mode-decision`
+- `cpt-cf-resource-group-flow-integration-auth-mtls-request` _(p2)_
+- `cpt-cf-resource-group-algo-integration-auth-auth-mode-decision` _(p2)_
 
 **Touches**:
-- API: `GET /api/resource-group/v1/groups/{group_id}/hierarchy` (JWT + MTLS), all other endpoints (JWT only)
+- API: `GET /api/resource-group/v1/groups/{group_id}/hierarchy` (additionally over MTLS)
 
 ### Tenant Scope Enforcement for Ownership-Graph Profile
 
@@ -266,8 +312,8 @@ The system **MUST** enforce tenant-hierarchy-compatible writes in ownership-grap
 - [x] `p1` - **ID**: `cpt-cf-resource-group-dod-testing-integration-auth`
 
 In-source `#[cfg(test)]` tests covering auth-mode decision and tenant-scope enforcement:
-- Auth mode decision: JWT path dispatches to PolicyEnforcer; MTLS path bypasses AuthZ with system SecurityContext
-- MTLS validation: valid CN in allowed_clients passes; unknown CN returns 403; expired certificate returns 403; endpoint not in allowlist returns 403
+- Auth mode decision: JWT path dispatches to PolicyEnforcer (`p1`); MTLS path bypasses AuthZ with system SecurityContext (`p2` — deferred, not implemented yet)
+- MTLS validation (`p2` — deferred, not implemented yet): valid CN in allowed_clients passes; unknown CN returns 403; expired certificate returns 403; endpoint not in allowlist returns 403
 - Tenant-scope enforcement: compatible tenant passes; incompatible tenant returns TenantIncompatibility; platform-admin provisioning exception bypasses caller scope but enforces data invariants
 - Integration read service: policy-agnostic response (no AuthZ fields in output); plugin gateway routes to built-in vs vendor-specific provider
 
@@ -276,17 +322,17 @@ In-source `#[cfg(test)]` tests covering auth-mode decision and tenant-scope enfo
 - [x] AuthZ plugin resolves `dyn ResourceGroupReadHierarchy` from ClientHub and successfully calls `list_group_depth`
 - [x] Integration read responses include `tenant_id` per group and `metadata` (including `self_managed`) but no AuthZ decision fields
 - [x] JWT request to any RG endpoint goes through AuthN → AuthZ (PolicyEnforcer) → AccessScope → SecureORM pipeline
-- [x] MTLS request to `/groups/{group_id}/hierarchy` bypasses AuthZ and returns hierarchy data
-- [x] MTLS request to any other endpoint (e.g., `POST /groups`) returns 403 Forbidden
-- [x] MTLS request with invalid certificate returns 403 Forbidden
-- [x] MTLS request with valid certificate but client CN not in allowed_clients returns 403 Forbidden
+- [ ] _(p2 — deferred, not implemented yet)_ MTLS request to `/groups/{group_id}/hierarchy` bypasses AuthZ and returns hierarchy data
+- [ ] _(p2 — deferred, not implemented yet)_ MTLS request to any other endpoint (e.g., `POST /groups`) returns 403 Forbidden
+- [ ] _(p2 — deferred, not implemented yet)_ MTLS request with invalid certificate returns 403 Forbidden
+- [ ] _(p2 — deferred, not implemented yet)_ MTLS request with valid certificate but client CN not in allowed_clients returns 403 Forbidden
 - [x] Plugin gateway routes to built-in provider by default; routes to vendor-specific plugin when configured
 - [x] SecurityContext is passed through gateway to provider without policy interpretation
 - [x] Parent-child edge in ownership-graph profile with incompatible tenants is rejected with TenantIncompatibility
 - [x] Platform-admin provisioning call bypasses caller tenant scoping but still validates data invariants
 - [x] Group with `metadata.self_managed = true` is stored and returned in API responses — RG does not filter based on barrier
 - [x] In monolith deployment, AuthZ plugin uses ClientHub direct call (no MTLS needed)
-- [x] In microservice deployment, AuthZ plugin uses MTLS-authenticated remote call to hierarchy endpoint
+- [ ] _(p2 — deferred, not implemented yet)_ In microservice deployment, AuthZ plugin uses MTLS-authenticated remote call to hierarchy endpoint
 
 ---
 
@@ -294,14 +340,18 @@ In-source `#[cfg(test)]` tests covering auth-mode decision and tenant-scope enfo
 
 ### Auth Mode Decision
 
-| TC | Scenario | Assert |
-|----|----------|--------|
-| TC-AUTH-01 | Request with valid MTLS cert + CN in allowed_clients + endpoint in allowlist | system SecurityContext created, AuthZ bypassed |
-| TC-AUTH-02 | Request with valid MTLS cert but CN not in allowed_clients | Returns 403 Forbidden |
-| TC-AUTH-03 | Request with expired MTLS certificate | Returns 403 Forbidden |
-| TC-AUTH-04 | MTLS request to endpoint not in allowed_endpoints | Returns 403 Forbidden |
-| TC-AUTH-05 | Request with JWT bearer token | AuthNResolverClient called, PolicyEnforcer evaluated |
-| TC-AUTH-06 | Request with no credentials | Returns 401 Unauthorized |
+> TC-AUTH-01..04 are scoped to the deferred MTLS path (`p2` — not
+> implemented yet) and are kept here as a forward-looking specification.
+> Only TC-AUTH-05 and TC-AUTH-06 must pass in the current iteration.
+
+| TC | Priority | Scenario | Assert |
+|----|----------|----------|--------|
+| TC-AUTH-01 | `p2` (deferred) | Request with valid MTLS cert + CN in allowed_clients + endpoint in allowlist | system SecurityContext created, AuthZ bypassed |
+| TC-AUTH-02 | `p2` (deferred) | Request with valid MTLS cert but CN not in allowed_clients | Returns 403 Forbidden |
+| TC-AUTH-03 | `p2` (deferred) | Request with expired MTLS certificate | Returns 403 Forbidden |
+| TC-AUTH-04 | `p2` (deferred) | MTLS request to endpoint not in allowed_endpoints | Returns 403 Forbidden |
+| TC-AUTH-05 | `p1` | Request with JWT bearer token | AuthNResolverClient called, PolicyEnforcer evaluated |
+| TC-AUTH-06 | `p1` | Request with no credentials | Returns 401 Unauthorized |
 
 ### Tenant Scope Enforcement
 

--- a/modules/system/resource-group/docs/rust-traits.md
+++ b/modules/system/resource-group/docs/rust-traits.md
@@ -265,7 +265,7 @@ let descendants = rg_hierarchy
 let group = rg
     .create_group(&ctx, CreateGroupRequest {
         id: None,
-        r#type: "gts.x.system.rg.type.v1~y.system.tn.tenant.v1~".into(),
+        r#type: "gts.cf.core.rg.type.v1~y.system.tn.tenant.v1~".into(),
         name: "Acme Corp".into(),
         parent_id: None,
         metadata: Default::default(),

--- a/modules/system/resource-group/resource-group-sdk/src/models.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/models.rs
@@ -1,4 +1,5 @@
 // Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
 // @cpt-begin:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1:inst-full
 // @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-sdk-models:p1
 //! SDK model types for the resource-group module.
@@ -153,19 +154,20 @@ pub struct CreateTypeRequest {
 }
 
 /// Request body for updating an existing GTS type (full replacement via PUT).
+///
+/// Every replaceable field is **required** so an omitted field cannot be
+/// confused with "preserve previous value". Nullable fields
+/// (`metadata_schema`) must be sent explicitly as `null` to clear them.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UpdateTypeRequest {
     /// Whether groups of this type can be root nodes.
     pub can_be_root: bool,
     /// GTS type paths of allowed parent types.
-    #[serde(default)]
     pub allowed_parent_types: Vec<String>,
     /// GTS type paths of allowed membership resource types.
-    #[serde(default)]
     pub allowed_membership_types: Vec<String>,
-    /// Optional JSON Schema for instance metadata.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// JSON Schema for instance metadata (`null` to clear).
     pub metadata_schema: Option<serde_json::Value>,
 }
 
@@ -266,13 +268,12 @@ pub struct CreateGroupRequest {
 pub struct UpdateGroupRequest {
     /// Display name (1..255 characters).
     pub name: String,
-    /// Parent group ID (null for root groups). Reparenting is allowed only
+    /// Parent group ID (`null` for root groups). Reparenting is allowed only
     /// within the same tenant scope; cross-tenant moves are rejected by the
-    /// service layer.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// service layer. Send explicit `null` to move a group to root — an
+    /// omitted key is rejected as a malformed payload.
     pub parent_id: Option<Uuid>,
-    /// Type-specific metadata.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Type-specific metadata (`null` to clear).
     pub metadata: Option<serde_json::Value>,
 }
 

--- a/modules/system/resource-group/resource-group/src/api/mod.rs
+++ b/modules/system/resource-group/resource-group/src/api/mod.rs
@@ -1,0 +1,4 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+pub mod rest;

--- a/modules/system/resource-group/resource-group/src/api/rest/dto.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/dto.rs
@@ -1,0 +1,294 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+//! REST DTOs for resource-group type and group management.
+
+use resource_group_sdk::models::{
+    CreateGroupRequest, CreateTypeRequest, ResourceGroup, ResourceGroupMembership,
+    ResourceGroupType, ResourceGroupWithDepth, UpdateGroupRequest, UpdateTypeRequest,
+};
+use uuid::Uuid;
+
+/// REST DTO for GTS type representation.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request, response)]
+pub struct TypeDto {
+    /// GTS type path
+    pub code: String,
+    /// Whether groups of this type can be root nodes
+    pub can_be_root: bool,
+    /// GTS type paths of allowed parent types
+    pub allowed_parent_types: Vec<String>,
+    /// GTS type paths of allowed membership resource types
+    pub allowed_membership_types: Vec<String>,
+    /// Optional JSON Schema for instance metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+/// REST DTO for creating a new GTS type.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request)]
+pub struct CreateTypeDto {
+    /// GTS type path. Must have prefix `gts.cf.core.rg.type.v1~`.
+    ///
+    /// Whether the type creates a new tenant scope is derived from the code:
+    /// any path starting with the tenant RG type prefix is a tenant type.
+    pub code: String,
+    /// Whether groups of this type can be root nodes.
+    pub can_be_root: bool,
+    /// GTS type paths of allowed parent types.
+    #[serde(default)]
+    pub allowed_parent_types: Vec<String>,
+    /// GTS type paths of allowed membership resource types.
+    #[serde(default)]
+    pub allowed_membership_types: Vec<String>,
+    /// Optional JSON Schema for instance metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+/// REST DTO for updating a GTS type (full replacement via PUT).
+///
+/// Every replaceable field is **required** so an omitted field cannot be
+/// confused with "preserve previous value". Nullable fields
+/// (`metadata_schema`) must be sent explicitly as `null` to clear them.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request)]
+pub struct UpdateTypeDto {
+    /// Whether groups of this type can be root nodes.
+    pub can_be_root: bool,
+    /// GTS type paths of allowed parent types.
+    pub allowed_parent_types: Vec<String>,
+    /// GTS type paths of allowed membership resource types.
+    pub allowed_membership_types: Vec<String>,
+    /// JSON Schema for instance metadata (`null` to clear).
+    #[schema(required)]
+    pub metadata_schema: Option<serde_json::Value>,
+}
+
+// -- Conversions --
+
+impl From<ResourceGroupType> for TypeDto {
+    fn from(t: ResourceGroupType) -> Self {
+        Self {
+            code: t.code,
+            can_be_root: t.can_be_root,
+            allowed_parent_types: t.allowed_parent_types,
+            allowed_membership_types: t.allowed_membership_types,
+            metadata_schema: t.metadata_schema,
+        }
+    }
+}
+
+impl From<CreateTypeDto> for CreateTypeRequest {
+    fn from(dto: CreateTypeDto) -> Self {
+        Self {
+            code: dto.code,
+            can_be_root: dto.can_be_root,
+            allowed_parent_types: dto.allowed_parent_types,
+            allowed_membership_types: dto.allowed_membership_types,
+            metadata_schema: dto.metadata_schema,
+        }
+    }
+}
+
+impl From<UpdateTypeDto> for UpdateTypeRequest {
+    fn from(dto: UpdateTypeDto) -> Self {
+        Self {
+            can_be_root: dto.can_be_root,
+            allowed_parent_types: dto.allowed_parent_types,
+            allowed_membership_types: dto.allowed_membership_types,
+            metadata_schema: dto.metadata_schema,
+        }
+    }
+}
+
+// -- Group DTOs --
+
+/// REST DTO for hierarchy context in group responses.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request, response)]
+pub struct HierarchyDto {
+    /// Parent group ID (null for root groups).
+    #[schema(required)]
+    pub parent_id: Option<Uuid>,
+    /// Tenant scope.
+    pub tenant_id: Uuid,
+}
+
+/// REST DTO for hierarchy context with depth in group responses.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request, response)]
+pub struct HierarchyWithDepthDto {
+    /// Parent group ID (null for root groups).
+    #[schema(required)]
+    pub parent_id: Option<Uuid>,
+    /// Tenant scope.
+    pub tenant_id: Uuid,
+    /// Relative distance from reference group.
+    pub depth: i32,
+}
+
+/// REST DTO for resource group representation.
+///
+/// Group responses do NOT include `created_at`/`updated_at` (per DESIGN).
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request, response)]
+pub struct GroupDto {
+    /// Group identifier.
+    pub id: Uuid,
+    /// GTS chained type path.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name.
+    pub name: String,
+    /// Hierarchy context.
+    pub hierarchy: HierarchyDto,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// REST DTO for resource group with depth (hierarchy queries).
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request, response)]
+pub struct GroupWithDepthDto {
+    /// Group identifier.
+    pub id: Uuid,
+    /// GTS chained type path.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name.
+    pub name: String,
+    /// Hierarchy context with depth.
+    pub hierarchy: HierarchyWithDepthDto,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// REST DTO for creating a new resource group.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request)]
+pub struct CreateGroupDto {
+    /// GTS chained type path. Must have prefix `gts.cf.core.rg.type.v1~`.
+    #[serde(rename = "type")]
+    pub type_path: String,
+    /// Display name (1..255 characters).
+    pub name: String,
+    /// Parent group ID (null for root groups).
+    pub parent_id: Option<Uuid>,
+    /// Type-specific metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// REST DTO for updating a resource group (full replacement via PUT).
+///
+/// **The group's GTS type is immutable after creation.** The payload
+/// deliberately does not carry a `type` field — to change a group's type,
+/// delete the existing group and create a new one. See the SDK
+/// `UpdateGroupRequest` doc for the full rationale.
+///
+/// Every replaceable field is **required** so an omitted field cannot be
+/// confused with "preserve previous value". Nullable fields (`parent_id`,
+/// `metadata`) must be sent explicitly as `null` to clear them — for
+/// example, moving a group to root requires `"parent_id": null`, not an
+/// omitted key.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request)]
+pub struct UpdateGroupDto {
+    /// Display name (1..255 characters).
+    pub name: String,
+    /// Parent group ID (`null` for root groups).
+    #[schema(required)]
+    pub parent_id: Option<Uuid>,
+    /// Type-specific metadata (`null` to clear).
+    #[schema(required)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+// -- Group conversions --
+
+impl From<ResourceGroup> for GroupDto {
+    fn from(g: ResourceGroup) -> Self {
+        Self {
+            id: g.id,
+            type_path: g.code,
+            name: g.name,
+            hierarchy: HierarchyDto {
+                parent_id: g.hierarchy.parent_id,
+                tenant_id: g.hierarchy.tenant_id,
+            },
+            metadata: g.metadata,
+        }
+    }
+}
+
+impl From<ResourceGroupWithDepth> for GroupWithDepthDto {
+    fn from(g: ResourceGroupWithDepth) -> Self {
+        Self {
+            id: g.id,
+            type_path: g.code,
+            name: g.name,
+            hierarchy: HierarchyWithDepthDto {
+                parent_id: g.hierarchy.parent_id,
+                tenant_id: g.hierarchy.tenant_id,
+                depth: g.hierarchy.depth,
+            },
+            metadata: g.metadata,
+        }
+    }
+}
+
+impl From<CreateGroupDto> for CreateGroupRequest {
+    fn from(dto: CreateGroupDto) -> Self {
+        Self {
+            id: None,
+            code: dto.type_path,
+            name: dto.name,
+            parent_id: dto.parent_id,
+            metadata: dto.metadata,
+        }
+    }
+}
+
+impl From<UpdateGroupDto> for UpdateGroupRequest {
+    fn from(dto: UpdateGroupDto) -> Self {
+        Self {
+            name: dto.name,
+            parent_id: dto.parent_id,
+            metadata: dto.metadata,
+        }
+    }
+}
+
+// -- Membership DTOs --
+
+/// REST DTO for membership representation.
+///
+/// Membership responses do NOT include `tenant_id` (derived from group).
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct MembershipDto {
+    /// Group identifier.
+    pub group_id: Uuid,
+    /// GTS type path of the resource type.
+    pub resource_type: String,
+    /// Resource identifier.
+    pub resource_id: String,
+}
+
+// -- Membership conversions --
+
+impl From<ResourceGroupMembership> for MembershipDto {
+    fn from(m: ResourceGroupMembership) -> Self {
+        Self {
+            group_id: m.group_id,
+            resource_type: m.resource_type,
+            resource_id: m.resource_id,
+        }
+    }
+}
+
+// @cpt-dod:cpt-cf-resource-group-dod-testing-odata-dto:p1

--- a/modules/system/resource-group/resource-group/src/api/rest/error.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/error.rs
@@ -1,0 +1,133 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+// @cpt-begin:cpt-cf-resource-group-dod-sdk-foundation-sdk-errors:p1:inst-full
+// @cpt-algo:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1
+//! Map domain errors to RFC 9457 Problem Details for REST responses.
+
+use modkit::api::problem::Problem;
+
+use crate::domain::error::DomainError;
+
+/// Implement `Into<Problem>` for `DomainError` so `?` works in handlers.
+impl From<DomainError> for Problem {
+    fn from(e: DomainError) -> Self {
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-1
+        // Receive DomainError variant
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-1
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-3
+        #[allow(clippy::let_and_return)]
+        let problem = match &e {
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2a
+            DomainError::Validation { message } => {
+                Problem::new(http::StatusCode::BAD_REQUEST, "Validation error", message)
+            }
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2a
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2b
+            DomainError::TypeNotFound { code } => Problem::new(
+                http::StatusCode::NOT_FOUND,
+                "Type not found",
+                format!("GTS type with code '{code}' was not found"),
+            ),
+            DomainError::GroupNotFound { id } => Problem::new(
+                http::StatusCode::NOT_FOUND,
+                "Group not found",
+                format!("Resource group with id '{id}' was not found"),
+            ),
+            DomainError::MembershipNotFound { key } => Problem::new(
+                http::StatusCode::NOT_FOUND,
+                "Membership not found",
+                format!("Membership '{key}' was not found"),
+            ),
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2b
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2c
+            DomainError::TypeAlreadyExists { code } => Problem::new(
+                http::StatusCode::CONFLICT,
+                "Type already exists",
+                format!("GTS type with code '{code}' already exists"),
+            ),
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2c
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2d
+            DomainError::InvalidParentType { message } => Problem::new(
+                http::StatusCode::BAD_REQUEST,
+                "Invalid parent type",
+                message,
+            ),
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2d
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2e
+            DomainError::AllowedParentTypesViolation { message } => Problem::new(
+                http::StatusCode::CONFLICT,
+                "Allowed parents violation",
+                message,
+            ),
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2e
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2f
+            DomainError::CycleDetected { message } => {
+                Problem::new(http::StatusCode::CONFLICT, "Cycle detected", message)
+            }
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2f
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2g
+            DomainError::ConflictActiveReferences { message } => Problem::new(
+                http::StatusCode::CONFLICT,
+                "Active references exist",
+                message,
+            ),
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2g
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2h
+            DomainError::LimitViolation { message } => {
+                Problem::new(http::StatusCode::CONFLICT, "Limit violation", message)
+            }
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2h
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2i
+            DomainError::TenantIncompatibility { message } => Problem::new(
+                http::StatusCode::CONFLICT,
+                "Tenant incompatibility",
+                message,
+            ),
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2i
+            DomainError::DuplicateMembership { message } => {
+                Problem::new(http::StatusCode::CONFLICT, "Duplicate membership", message)
+            }
+            DomainError::Conflict { message } => {
+                Problem::new(http::StatusCode::CONFLICT, "Conflict", message)
+            }
+            DomainError::TenantRootAlreadyExists { message } => Problem::new(
+                http::StatusCode::CONFLICT,
+                "Tenant root already exists",
+                message,
+            ),
+            DomainError::AccessDenied { message } => {
+                Problem::new(http::StatusCode::FORBIDDEN, "Access denied", message)
+            }
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2j
+            // ServiceUnavailable: no dedicated variant — DB / infra failures fall through to the
+            // Database arm below and surface as 500 Internal Server Error. A genuine 503
+            // (e.g. AuthZ Resolver unreachable) is produced by platform middleware upstream
+            // of this mapper, not here.
+            // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2j
+            // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2k
+            DomainError::Database(_) => {
+                tracing::error!(error = ?e, "Database error occurred");
+                Problem::new(
+                    http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal error",
+                    "An internal database error occurred",
+                )
+            }
+            DomainError::InternalError => {
+                tracing::error!(error = ?e, "Internal error occurred");
+                Problem::new(
+                    http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal error",
+                    "An internal error occurred",
+                )
+            } // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2k
+        };
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-3
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-2
+        // @cpt-begin:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-4
+        problem
+        // @cpt-end:cpt-cf-resource-group-algo-sdk-foundation-map-domain-error:p1:inst-err-map-4
+    }
+}
+// @cpt-end:cpt-cf-resource-group-dod-sdk-foundation-sdk-errors:p1:inst-full

--- a/modules/system/resource-group/resource-group/src/api/rest/handlers/groups.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/handlers/groups.rs
@@ -1,0 +1,177 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-entity-hier-rest-handlers:p1
+use std::sync::Arc;
+
+use axum::Extension;
+use axum::extract::{Path, Query};
+use axum::http::Uri;
+use axum::response::IntoResponse;
+use tracing::field::Empty;
+
+use modkit::api::odata::OData;
+use modkit::api::prelude::*;
+
+use super::{CreateGroupDto, GroupDto, GroupWithDepthDto, SecurityContext, UpdateGroupDto, info};
+use crate::module::ConcreteGroupService;
+
+/// Query parameters for delete endpoint.
+#[derive(Debug, serde::Deserialize)]
+pub struct DeleteGroupQuery {
+    #[serde(default)]
+    pub force: Option<bool>,
+}
+
+/// List resource groups with optional `OData` filtering and pagination.
+#[tracing::instrument(
+    skip(svc, ctx, query),
+    fields(request_id = Empty)
+)]
+pub async fn list_groups(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteGroupService>>,
+    OData(query): OData,
+) -> ApiResult<Json<modkit_odata::Page<GroupDto>>> {
+    info!("Listing resource groups");
+
+    let page = svc.list_groups(&ctx, &query).await?;
+    let dto_page = page.map_items(GroupDto::from);
+
+    Ok(Json(dto_page))
+}
+
+/// Create a new resource group.
+#[tracing::instrument(
+    skip(svc, req_body, ctx, uri),
+    fields(
+        group.name = %req_body.name,
+        request_id = Empty,
+    )
+)]
+pub async fn create_group(
+    uri: Uri,
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteGroupService>>,
+    Json(req_body): Json<CreateGroupDto>,
+) -> ApiResult<impl IntoResponse> {
+    info!(
+        name = %req_body.name,
+        "Creating new resource group"
+    );
+
+    // Derive tenant_id from SecurityContext
+    let tenant_id = ctx.subject_tenant_id();
+
+    let group = svc.create_group(&ctx, req_body.into(), tenant_id).await?;
+    let id_str = group.id.to_string();
+    let dto = GroupDto::from(group);
+
+    Ok(created_json(dto, &uri, &id_str).into_response())
+}
+
+/// Get a resource group by ID.
+#[tracing::instrument(
+    skip(svc, ctx),
+    fields(
+        group.id = %group_id,
+        request_id = Empty,
+    )
+)]
+pub async fn get_group(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteGroupService>>,
+    Path(group_id): Path<uuid::Uuid>,
+) -> ApiResult<Json<GroupDto>> {
+    info!(
+        group_id = %group_id,
+        "Getting resource group"
+    );
+
+    let group = svc.get_group(&ctx, group_id).await?;
+    Ok(Json(GroupDto::from(group)))
+}
+
+/// Update a resource group (full replacement via PUT).
+#[tracing::instrument(
+    skip(svc, req_body, ctx),
+    fields(
+        group.id = %group_id,
+        request_id = Empty,
+    )
+)]
+pub async fn update_group(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteGroupService>>,
+    Path(group_id): Path<uuid::Uuid>,
+    Json(req_body): Json<UpdateGroupDto>,
+) -> ApiResult<Json<GroupDto>> {
+    info!(
+        group_id = %group_id,
+        "Updating resource group"
+    );
+
+    let group = svc.update_group(&ctx, group_id, req_body.into()).await?;
+    Ok(Json(GroupDto::from(group)))
+}
+
+/// Delete a resource group.
+#[tracing::instrument(
+    skip(svc, ctx, params),
+    fields(
+        group.id = %group_id,
+        request_id = Empty,
+    )
+)]
+pub async fn delete_group(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteGroupService>>,
+    Path(group_id): Path<uuid::Uuid>,
+    Query(params): Query<DeleteGroupQuery>,
+) -> ApiResult<impl IntoResponse> {
+    let force = params.force.unwrap_or(false);
+    info!(
+        group_id = %group_id,
+        force = force,
+        "Deleting resource group"
+    );
+
+    svc.delete_group(&ctx, group_id, force).await?;
+    Ok(no_content().into_response())
+}
+
+/// List hierarchy for a resource group.
+#[tracing::instrument(
+    skip(svc, ctx, query),
+    fields(
+        group.id = %group_id,
+        request_id = Empty,
+    )
+)]
+pub async fn get_group_descendants(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteGroupService>>,
+    Path(group_id): Path<uuid::Uuid>,
+    OData(query): OData,
+) -> ApiResult<Json<modkit_odata::Page<GroupWithDepthDto>>> {
+    info!(group_id = %group_id, "Getting group descendants");
+    let page = svc.get_group_descendants(&ctx, group_id, &query).await?;
+    Ok(Json(page.map_items(GroupWithDepthDto::from)))
+}
+
+#[tracing::instrument(
+    skip(svc, ctx, query),
+    fields(
+        group.id = %group_id,
+        request_id = Empty,
+    )
+)]
+pub async fn get_group_ancestors(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteGroupService>>,
+    Path(group_id): Path<uuid::Uuid>,
+    OData(query): OData,
+) -> ApiResult<Json<modkit_odata::Page<GroupWithDepthDto>>> {
+    info!(group_id = %group_id, "Getting group ancestors");
+    let page = svc.get_group_ancestors(&ctx, group_id, &query).await?;
+    Ok(Json(page.map_items(GroupWithDepthDto::from)))
+}

--- a/modules/system/resource-group/resource-group/src/api/rest/handlers/memberships.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/handlers/memberships.rs
@@ -1,0 +1,108 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+// @cpt-begin:cpt-cf-resource-group-dod-membership-rest-handlers:p1:inst-full
+// @cpt-dod:cpt-cf-resource-group-dod-membership-rest-handlers:p1
+
+use std::sync::Arc;
+
+use axum::Extension;
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use tracing::field::Empty;
+
+use modkit::api::odata::OData;
+use modkit::api::prelude::*;
+
+use super::{MembershipDto, SecurityContext, debug, info};
+use crate::module::ConcreteMembershipService;
+
+/// Path parameters for membership add/remove endpoints.
+#[derive(Debug, serde::Deserialize)]
+pub struct MembershipPathParams {
+    pub group_id: uuid::Uuid,
+    pub resource_type: String,
+    pub resource_id: String,
+}
+
+/// List memberships with optional `OData` filtering and pagination.
+#[tracing::instrument(
+    skip(svc, ctx, query),
+    fields(request_id = Empty)
+)]
+pub async fn list_memberships(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteMembershipService>>,
+    OData(query): OData,
+) -> ApiResult<Json<modkit_odata::Page<MembershipDto>>> {
+    info!("Listing memberships");
+
+    let page = svc.list_memberships(&ctx, &query).await?;
+    let dto_page = page.map_items(MembershipDto::from);
+
+    Ok(Json(dto_page))
+}
+
+/// Add a membership link between a group and a resource.
+#[tracing::instrument(
+    skip(svc, ctx),
+    fields(
+        membership.group_id = %params.group_id,
+        membership.resource_type = %params.resource_type,
+        request_id = Empty,
+    )
+)]
+// @cpt-begin:cpt-cf-resource-group-flow-membership-add:p1:inst-add-memb-1
+pub async fn add_membership(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteMembershipService>>,
+    Path(params): Path<MembershipPathParams>,
+) -> ApiResult<impl IntoResponse> {
+    debug!(
+        resource_id = %params.resource_id,
+        "Adding membership"
+    );
+
+    let membership = svc
+        .add_membership(
+            &ctx,
+            params.group_id,
+            &params.resource_type,
+            &params.resource_id,
+        )
+        .await?;
+    let dto = MembershipDto::from(membership);
+
+    Ok((StatusCode::CREATED, Json(dto)).into_response())
+}
+// @cpt-end:cpt-cf-resource-group-flow-membership-add:p1:inst-add-memb-1
+
+/// Remove a membership link.
+#[tracing::instrument(
+    skip(svc, ctx),
+    fields(
+        membership.group_id = %params.group_id,
+        membership.resource_type = %params.resource_type,
+        request_id = Empty,
+    )
+)]
+pub async fn remove_membership(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteMembershipService>>,
+    Path(params): Path<MembershipPathParams>,
+) -> ApiResult<impl IntoResponse> {
+    debug!(
+        resource_id = %params.resource_id,
+        "Removing membership"
+    );
+
+    svc.remove_membership(
+        &ctx,
+        params.group_id,
+        &params.resource_type,
+        &params.resource_id,
+    )
+    .await?;
+    Ok(no_content().into_response())
+}
+// @cpt-end:cpt-cf-resource-group-dod-membership-rest-handlers:p1:inst-full

--- a/modules/system/resource-group/resource-group/src/api/rest/handlers/mod.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/handlers/mod.rs
@@ -1,0 +1,30 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+use crate::api::rest::dto::{
+    CreateGroupDto, CreateTypeDto, GroupDto, GroupWithDepthDto, MembershipDto, TypeDto,
+    UpdateGroupDto, UpdateTypeDto,
+};
+
+use modkit_security::SecurityContext;
+use tracing::{debug, info};
+
+mod groups;
+mod memberships;
+mod types;
+
+pub(crate) use groups::create_group;
+pub(crate) use groups::delete_group;
+pub(crate) use groups::get_group;
+pub(crate) use groups::get_group_ancestors;
+pub(crate) use groups::get_group_descendants;
+pub(crate) use groups::list_groups;
+pub(crate) use groups::update_group;
+pub(crate) use memberships::add_membership;
+pub(crate) use memberships::list_memberships;
+pub(crate) use memberships::remove_membership;
+pub(crate) use types::create_type;
+pub(crate) use types::delete_type;
+pub(crate) use types::get_type;
+pub(crate) use types::list_types;
+pub(crate) use types::update_type;

--- a/modules/system/resource-group/resource-group/src/api/rest/handlers/types.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/handlers/types.rs
@@ -1,0 +1,127 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-type-mgmt-rest-handlers:p1
+use std::sync::Arc;
+
+use axum::Extension;
+use axum::extract::Path;
+use axum::http::Uri;
+use axum::response::IntoResponse;
+use tracing::field::Empty;
+
+use modkit::api::odata::OData;
+use modkit::api::prelude::*;
+
+use super::{CreateTypeDto, SecurityContext, TypeDto, UpdateTypeDto, info};
+use crate::module::ConcreteTypeService;
+
+/// List GTS types with optional `OData` filtering and pagination.
+#[tracing::instrument(
+    skip(svc, _ctx, query),
+    fields(request_id = Empty)
+)]
+pub async fn list_types(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteTypeService>>,
+    OData(query): OData,
+) -> ApiResult<Json<modkit_odata::Page<TypeDto>>> {
+    info!("Listing GTS types");
+
+    let page = svc.list_types(&query).await?;
+    let dto_page = page.map_items(TypeDto::from);
+
+    Ok(Json(dto_page))
+}
+
+/// Create a new GTS type definition.
+#[tracing::instrument(
+    skip(svc, req_body, _ctx, uri),
+    fields(
+        type.code = %req_body.code,
+        request_id = Empty,
+    )
+)]
+pub async fn create_type(
+    uri: Uri,
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteTypeService>>,
+    Json(req_body): Json<CreateTypeDto>,
+) -> ApiResult<impl IntoResponse> {
+    info!(
+        code = %req_body.code,
+        "Creating new GTS type"
+    );
+
+    let code = req_body.code.clone();
+    let rg_type = svc.create_type(req_body.into()).await?;
+    let dto = TypeDto::from(rg_type);
+
+    Ok(created_json(dto, &uri, &code).into_response())
+}
+
+/// Get a GTS type definition by code.
+#[tracing::instrument(
+    skip(svc, _ctx),
+    fields(
+        type.code = %code,
+        request_id = Empty,
+    )
+)]
+pub async fn get_type(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteTypeService>>,
+    Path(code): Path<String>,
+) -> ApiResult<Json<TypeDto>> {
+    info!(
+        code = %code,
+        "Getting GTS type"
+    );
+
+    let rg_type = svc.get_type(&code).await?;
+    Ok(Json(TypeDto::from(rg_type)))
+}
+
+/// Update a GTS type definition (full replacement).
+#[tracing::instrument(
+    skip(svc, req_body, _ctx),
+    fields(
+        type.code = %code,
+        request_id = Empty,
+    )
+)]
+pub async fn update_type(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteTypeService>>,
+    Path(code): Path<String>,
+    Json(req_body): Json<UpdateTypeDto>,
+) -> ApiResult<Json<TypeDto>> {
+    info!(
+        code = %code,
+        "Updating GTS type"
+    );
+
+    let rg_type = svc.update_type(&code, req_body.into()).await?;
+    Ok(Json(TypeDto::from(rg_type)))
+}
+
+/// Delete a GTS type definition.
+#[tracing::instrument(
+    skip(svc, _ctx),
+    fields(
+        type.code = %code,
+        request_id = Empty,
+    )
+)]
+pub async fn delete_type(
+    Extension(_ctx): Extension<SecurityContext>,
+    Extension(svc): Extension<Arc<ConcreteTypeService>>,
+    Path(code): Path<String>,
+) -> ApiResult<impl IntoResponse> {
+    info!(
+        code = %code,
+        "Deleting GTS type"
+    );
+
+    svc.delete_type(&code).await?;
+    Ok(no_content().into_response())
+}

--- a/modules/system/resource-group/resource-group/src/api/rest/mod.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/mod.rs
@@ -1,0 +1,7 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
+pub mod dto;
+pub mod error;
+pub mod handlers;
+pub mod routes;

--- a/modules/system/resource-group/resource-group/src/api/rest/routes/groups.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/routes/groups.rs
@@ -1,0 +1,177 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-entity-hier-rest-handlers:p1
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+use super::{dto, handlers};
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::api::operation_builder::{OperationBuilder, OperationBuilderODataExt};
+use resource_group_sdk::odata::{GroupFilterField, HierarchyFilterField};
+
+const API_TAG: &str = "Resource Groups";
+
+pub(super) fn register_group_routes(mut router: Router, openapi: &dyn OpenApiRegistry) -> Router {
+    // GET /resource-group/v1/groups - List groups with cursor-based pagination
+    router = OperationBuilder::get("/resource-group/v1/groups")
+        .operation_id("resource_group.list_groups")
+        .summary("List resource groups")
+        .description("Retrieve a paginated list of resource groups with OData filtering")
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .query_param_typed(
+            "limit",
+            false,
+            "Maximum number of groups to return",
+            "integer",
+        )
+        .query_param("cursor", false, "Cursor for pagination")
+        .handler(handlers::list_groups)
+        .json_response_with_schema::<modkit_odata::Page<dto::GroupDto>>(
+            openapi,
+            http::StatusCode::OK,
+            "Paginated list of resource groups",
+        )
+        .with_odata_filter::<GroupFilterField>()
+        .error_400(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // POST /resource-group/v1/groups - Create a new group
+    router = OperationBuilder::post("/resource-group/v1/groups")
+        .operation_id("resource_group.create_group")
+        .summary("Create a new resource group")
+        .description(
+            "Create a new resource group with the provided type, name, and optional parent",
+        )
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .json_request::<dto::CreateGroupDto>(openapi, "Group creation data")
+        .handler(handlers::create_group)
+        .json_response_with_schema::<dto::GroupDto>(
+            openapi,
+            http::StatusCode::CREATED,
+            "Created resource group",
+        )
+        .error_400(openapi)
+        .error_404(openapi)
+        .error_409(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // GET /resource-group/v1/groups/{group_id} - Get a specific group
+    router = OperationBuilder::get("/resource-group/v1/groups/{group_id}")
+        .operation_id("resource_group.get_group")
+        .summary("Get resource group by ID")
+        .description("Retrieve a specific resource group by its UUID")
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .path_param("group_id", "Group UUID")
+        .handler(handlers::get_group)
+        .json_response_with_schema::<dto::GroupDto>(
+            openapi,
+            http::StatusCode::OK,
+            "Resource group found",
+        )
+        .error_400(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // PUT /resource-group/v1/groups/{group_id} - Update a group
+    router = OperationBuilder::put("/resource-group/v1/groups/{group_id}")
+        .operation_id("resource_group.update_group")
+        .summary("Update resource group")
+        .description("Update a resource group (full replacement via PUT, including parent move)")
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .path_param("group_id", "Group UUID")
+        .json_request::<dto::UpdateGroupDto>(openapi, "Group update data")
+        .handler(handlers::update_group)
+        .json_response_with_schema::<dto::GroupDto>(
+            openapi,
+            http::StatusCode::OK,
+            "Updated resource group",
+        )
+        .error_400(openapi)
+        .error_404(openapi)
+        .error_409(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // DELETE /resource-group/v1/groups/{group_id} - Delete a group
+    router = OperationBuilder::delete("/resource-group/v1/groups/{group_id}")
+        .operation_id("resource_group.delete_group")
+        .summary("Delete resource group")
+        .description(
+            "Delete a resource group. Use ?force=true to cascade delete subtree and memberships.",
+        )
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .path_param("group_id", "Group UUID")
+        .query_param_typed(
+            "force",
+            false,
+            "Force cascade delete of subtree and memberships",
+            "boolean",
+        )
+        .handler(handlers::delete_group)
+        .no_content_response(http::StatusCode::NO_CONTENT, "Group deleted successfully")
+        .error_400(openapi)
+        .error_404(openapi)
+        .error_409(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // GET /resource-group/v1/groups/{group_id}/descendants
+    router = OperationBuilder::get("/resource-group/v1/groups/{group_id}/descendants")
+        .operation_id("resource_group.get_group_descendants")
+        .summary("Get group descendants")
+        .description("Get descendants of a reference group (depth >= 0) with OData filtering")
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .path_param("group_id", "Reference group UUID")
+        .query_param_typed("limit", false, "Maximum entries to return", "integer")
+        .query_param("cursor", false, "Cursor for pagination")
+        .handler(handlers::get_group_descendants)
+        .json_response_with_schema::<modkit_odata::Page<dto::GroupWithDepthDto>>(
+            openapi,
+            http::StatusCode::OK,
+            "Paginated descendants with relative depth",
+        )
+        .with_odata_filter::<HierarchyFilterField>()
+        .error_400(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // GET /resource-group/v1/groups/{group_id}/ancestors
+    router = OperationBuilder::get("/resource-group/v1/groups/{group_id}/ancestors")
+        .operation_id("resource_group.get_group_ancestors")
+        .summary("Get group ancestors")
+        .description("Get ancestors of a reference group (depth <= 0) with OData filtering")
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .path_param("group_id", "Reference group UUID")
+        .query_param_typed("limit", false, "Maximum entries to return", "integer")
+        .query_param("cursor", false, "Cursor for pagination")
+        .handler(handlers::get_group_ancestors)
+        .json_response_with_schema::<modkit_odata::Page<dto::GroupWithDepthDto>>(
+            openapi,
+            http::StatusCode::OK,
+            "Paginated ancestors with relative depth",
+        )
+        .with_odata_filter::<HierarchyFilterField>()
+        .error_400(openapi)
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    router
+}

--- a/modules/system/resource-group/resource-group/src/api/rest/routes/memberships.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/routes/memberships.rs
@@ -1,0 +1,93 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-membership-rest-handlers:p1
+
+use super::{dto, handlers};
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::api::operation_builder::{OperationBuilder, OperationBuilderODataExt};
+use resource_group_sdk::odata::MembershipFilterField;
+
+const API_TAG: &str = "Resource Group Memberships";
+
+pub(super) fn register_membership_routes(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+) -> Router {
+    // GET /resource-group/v1/memberships - List memberships with OData filtering
+    router = OperationBuilder::get("/resource-group/v1/memberships")
+        .operation_id("resource_group.list_memberships")
+        .summary("List memberships")
+        .description(
+            "Retrieve a paginated list of memberships with OData filtering on group_id, resource_type, resource_id",
+        )
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .query_param_typed(
+            "limit",
+            false,
+            "Maximum number of memberships to return",
+            "integer",
+        )
+        .query_param("cursor", false, "Cursor for pagination")
+        .handler(handlers::list_memberships)
+        .json_response_with_schema::<modkit_odata::Page<dto::MembershipDto>>(
+            openapi,
+            http::StatusCode::OK,
+            "Paginated list of memberships",
+        )
+        .with_odata_filter::<MembershipFilterField>()
+        .error_400(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // POST /resource-group/v1/memberships/{group_id}/{resource_type}/{resource_id} - Add membership
+    router = OperationBuilder::post(
+        "/resource-group/v1/memberships/{group_id}/{resource_type}/{resource_id}",
+    )
+    .operation_id("resource_group.add_membership")
+    .summary("Add membership")
+    .description("Add a membership link between a resource group and a resource")
+    .tag(API_TAG)
+    .authenticated()
+    .no_license_required()
+    .path_param("group_id", "Group UUID")
+    .path_param("resource_type", "GTS type path of the resource type")
+    .path_param("resource_id", "Resource identifier")
+    .handler(handlers::add_membership)
+    .json_response_with_schema::<dto::MembershipDto>(
+        openapi,
+        http::StatusCode::CREATED,
+        "Membership created",
+    )
+    .error_400(openapi)
+    .error_404(openapi)
+    .error_409(openapi)
+    .error_500(openapi)
+    .register(router, openapi);
+
+    // DELETE /resource-group/v1/memberships/{group_id}/{resource_type}/{resource_id} - Remove membership
+    router = OperationBuilder::delete(
+        "/resource-group/v1/memberships/{group_id}/{resource_type}/{resource_id}",
+    )
+    .operation_id("resource_group.remove_membership")
+    .summary("Remove membership")
+    .description("Remove a membership link between a resource group and a resource")
+    .tag(API_TAG)
+    .authenticated()
+    .no_license_required()
+    .path_param("group_id", "Group UUID")
+    .path_param("resource_type", "GTS type path of the resource type")
+    .path_param("resource_id", "Resource identifier")
+    .handler(handlers::remove_membership)
+    .json_response(
+        http::StatusCode::NO_CONTENT,
+        "Membership removed successfully",
+    )
+    .error_404(openapi)
+    .error_500(openapi)
+    .register(router, openapi);
+
+    router
+}

--- a/modules/system/resource-group/resource-group/src/api/rest/routes/mod.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/routes/mod.rs
@@ -1,0 +1,35 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
+//! REST API route definitions using `OperationBuilder`.
+
+use crate::api::rest::{dto, handlers};
+use crate::module::{ConcreteGroupService, ConcreteMembershipService, ConcreteTypeService};
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use std::sync::Arc;
+
+mod groups;
+mod memberships;
+mod types;
+
+/// Register all routes for the resource-group module.
+#[allow(clippy::needless_pass_by_value)]
+pub fn register_routes(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    type_service: Arc<ConcreteTypeService>,
+    group_service: Arc<ConcreteGroupService>,
+    membership_service: Arc<ConcreteMembershipService>,
+) -> Router {
+    router = types::register_type_routes(router, openapi);
+    router = groups::register_group_routes(router, openapi);
+    router = memberships::register_membership_routes(router, openapi);
+
+    router = router
+        .layer(axum::Extension(type_service))
+        .layer(axum::Extension(group_service))
+        .layer(axum::Extension(membership_service));
+
+    router
+}

--- a/modules/system/resource-group/resource-group/src/api/rest/routes/types.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/routes/types.rs
@@ -1,0 +1,109 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-type-mgmt-rest-handlers:p1
+use super::{dto, handlers};
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::api::operation_builder::{OperationBuilder, OperationBuilderODataExt};
+use resource_group_sdk::odata::TypeFilterField;
+
+const API_TAG: &str = "Resource Group Types";
+
+pub(super) fn register_type_routes(mut router: Router, openapi: &dyn OpenApiRegistry) -> Router {
+    // GET /types-registry/v1/types - List types with cursor-based pagination
+    router = OperationBuilder::get("/types-registry/v1/types")
+        .operation_id("resource_group.list_types")
+        .summary("List GTS types")
+        .description("Retrieve a list of GTS resource group type definitions with OData filtering")
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .query_param_typed(
+            "limit",
+            false,
+            "Maximum number of types to return",
+            "integer",
+        )
+        .query_param("cursor", false, "Cursor for pagination")
+        .handler(handlers::list_types)
+        .json_response_with_schema::<modkit_odata::Page<dto::TypeDto>>(
+            openapi,
+            http::StatusCode::OK,
+            "List of GTS types",
+        )
+        .with_odata_filter::<TypeFilterField>()
+        .error_400(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // POST /types-registry/v1/types - Create a new type
+    router = OperationBuilder::post("/types-registry/v1/types")
+        .operation_id("resource_group.create_type")
+        .summary("Create a new GTS type")
+        .description("Create a new GTS resource group type definition")
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .json_request::<dto::CreateTypeDto>(openapi, "Type creation data")
+        .handler(handlers::create_type)
+        .json_response_with_schema::<dto::TypeDto>(
+            openapi,
+            http::StatusCode::CREATED,
+            "Created type",
+        )
+        .error_400(openapi)
+        .error_409(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // GET /types-registry/v1/types/{code} - Get a specific type
+    router = OperationBuilder::get("/types-registry/v1/types/{code}")
+        .operation_id("resource_group.get_type")
+        .summary("Get GTS type by code")
+        .description("Retrieve a specific GTS type definition by its GTS type path")
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .path_param("code", "GTS type path")
+        .handler(handlers::get_type)
+        .json_response_with_schema::<dto::TypeDto>(openapi, http::StatusCode::OK, "Type found")
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // PUT /types-registry/v1/types/{code} - Update a type
+    router = OperationBuilder::put("/types-registry/v1/types/{code}")
+        .operation_id("resource_group.update_type")
+        .summary("Update GTS type")
+        .description("Update a GTS resource group type definition (full replacement)")
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .path_param("code", "GTS type path")
+        .json_request::<dto::UpdateTypeDto>(openapi, "Type update data")
+        .handler(handlers::update_type)
+        .json_response_with_schema::<dto::TypeDto>(openapi, http::StatusCode::OK, "Updated type")
+        .error_400(openapi)
+        .error_404(openapi)
+        .error_409(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    // DELETE /types-registry/v1/types/{code} - Delete a type
+    router = OperationBuilder::delete("/types-registry/v1/types/{code}")
+        .operation_id("resource_group.delete_type")
+        .summary("Delete GTS type")
+        .description("Delete a GTS resource group type definition")
+        .tag(API_TAG)
+        .authenticated()
+        .no_license_required()
+        .path_param("code", "GTS type path")
+        .handler(handlers::delete_type)
+        .json_response(http::StatusCode::NO_CONTENT, "Type deleted successfully")
+        .error_404(openapi)
+        .error_409(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    router
+}

--- a/modules/system/resource-group/resource-group/src/domain/group_service.rs
+++ b/modules/system/resource-group/resource-group/src/domain/group_service.rs
@@ -1,4 +1,5 @@
 // Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
 // @cpt-begin:cpt-cf-resource-group-dod-entity-hier-entity-service:p1:inst-full
 // @cpt-dod:cpt-cf-resource-group-dod-testing-entity-hierarchy:p1
 //! Domain service for resource group entity management.
@@ -32,7 +33,7 @@ use crate::domain::validation;
 
 /// `AuthZ` resource type descriptor for resource groups.
 pub const RG_GROUP_RESOURCE: ResourceType = ResourceType {
-    name: "gts.x.system.rg.group.v1~",
+    name: "gts.cf.core.rg.group.v1~",
     supported_properties: &[pep_properties::OWNER_TENANT_ID, pep_properties::RESOURCE_ID],
 };
 
@@ -396,9 +397,8 @@ impl<GR: GroupRepositoryTrait, TR: TypeRepositoryTrait> GroupService<GR, TR> {
     // They use `AccessScope::allow_all()` — no tenant WHERE clause.
     //
     // This is by design (DESIGN §3.6): the AuthZ plugin is the primary
-    // consumer of these reads. It cannot evaluate itself (circular dep).
-    // In microservice deployments these endpoints are MTLS-only; in
-    // monolith mode the in-process ClientHub path skips AuthZ entirely.
+    // consumer of these reads. It cannot evaluate itself (circular dep),
+    // so the in-process ClientHub path skips AuthZ entirely.
     //
     // SECURITY: do NOT expose these methods via REST handlers.
     // REST uses the scoped variants (`get_group_descendants` / `get_group_ancestors`).

--- a/modules/system/resource-group/resource-group/src/domain/read_service.rs
+++ b/modules/system/resource-group/resource-group/src/domain/read_service.rs
@@ -1,4 +1,5 @@
 // Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
 // @cpt-begin:cpt-cf-resource-group-dod-integration-auth-read-service:p1:inst-full
 //! Integration read service for external consumers (e.g., `AuthZ` plugin).
 //!
@@ -30,8 +31,8 @@ use crate::domain::repo::{GroupRepositoryTrait, MembershipRepositoryTrait, TypeR
 /// **Bypasses `AuthZ` enforcement** — delegates to `GroupService` unscoped
 /// methods which use `AccessScope::allow_all()`. This is by design
 /// (see DESIGN §3.6): `AuthZ` plugin is the caller, and it cannot evaluate
-/// itself (circular dependency). MTLS and in-process `ClientHub` paths both
-/// skip `AuthZ`.
+/// itself (circular dependency). The in-process `ClientHub` path therefore
+/// skips `AuthZ`.
 #[allow(unknown_lints, de0309_must_have_domain_model)]
 pub struct RgReadService<
     GR: GroupRepositoryTrait,

--- a/modules/system/resource-group/resource-group/src/infra/storage/group_repo.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/group_repo.rs
@@ -1,4 +1,5 @@
 // Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
 // @cpt-begin:cpt-cf-resource-group-dod-entity-hier-hierarchy-engine:p1:inst-full
 //! Persistence layer for resource group entity management.
 //!
@@ -466,7 +467,7 @@ impl GroupRepositoryTrait for GroupRepository {
     /// List groups with `OData` filtering and pagination.
     ///
     /// The `type` filter field accepts GTS type path strings from the API
-    /// (e.g. `$filter=type eq 'gts.x.system.rg.type.v1~x.test.org.v1~'`).
+    /// (e.g. `$filter=type eq 'gts.cf.core.rg.type.v1~x.test.org.v1~'`).
     /// Before passing to `SeaORM`, string values for the `type` field are
     /// resolved to SMALLINT surrogate IDs at the persistence boundary.
     /// List groups with `OData` filtering and pagination.

--- a/modules/system/resource-group/resource-group/src/lib.rs
+++ b/modules/system/resource-group/resource-group/src/lib.rs
@@ -1,4 +1,5 @@
 // Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
 // @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-module-scaffold:p1
 //! Resource Group Module — contracts and domain types.
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
@@ -8,6 +9,8 @@ pub mod module;
 pub use module::ResourceGroup;
 
 // === INTERNAL MODULES ===
+#[doc(hidden)]
+pub mod api;
 #[doc(hidden)]
 pub mod domain;
 #[doc(hidden)]

--- a/modules/system/resource-group/resource-group/src/module.rs
+++ b/modules/system/resource-group/resource-group/src/module.rs
@@ -1,16 +1,19 @@
 // Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-28 by Constructor Tech
 // @cpt-dod:cpt-cf-resource-group-dod-e2e-test-suite:p1
 use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use authz_resolver_sdk::{AuthZResolverClient, PolicyEnforcer};
-use modkit::{DatabaseCapability, Module, ModuleCtx};
+use modkit::api::OpenApiRegistry;
+use modkit::{DatabaseCapability, Module, ModuleCtx, RestApiCapability};
 use modkit_db::DBProvider;
 use modkit_db::DbError;
 use resource_group_sdk::{ResourceGroupClient, ResourceGroupReadHierarchy};
 use sea_orm_migration::MigrationTrait;
 use tracing::info;
 
+use crate::api::rest::routes;
 use crate::domain::group_service::{GroupService, QueryProfile};
 use crate::domain::membership_service::MembershipService;
 use crate::domain::read_service::RgReadService;
@@ -31,7 +34,7 @@ pub type ConcreteRgService = RgService<GroupRepository, TypeRepository, Membersh
 #[modkit::module(
     name = "resource-group",
     deps = ["authz-resolver", "types-registry"],
-    capabilities = [db]
+    capabilities = [db, rest]
 )]
 #[allow(clippy::struct_field_names)]
 pub struct ResourceGroup {
@@ -148,4 +151,42 @@ impl DatabaseCapability for ResourceGroup {
     }
 }
 
-// REST capability and route registration are added in a follow-up PR.
+impl RestApiCapability for ResourceGroup {
+    fn register_rest(
+        &self,
+        _ctx: &ModuleCtx,
+        router: axum::Router,
+        openapi: &dyn OpenApiRegistry,
+    ) -> anyhow::Result<axum::Router> {
+        info!("Registering resource_group REST routes");
+
+        let type_service = self
+            .type_service
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("TypeService not initialized"))?
+            .clone();
+
+        let group_service = self
+            .group_service
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("GroupService not initialized"))?
+            .clone();
+
+        let membership_service = self
+            .membership_service
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("MembershipService not initialized"))?
+            .clone();
+
+        let router = routes::register_routes(
+            router,
+            openapi,
+            type_service,
+            group_service,
+            membership_service,
+        );
+
+        info!("Resource Group REST routes registered successfully");
+        Ok(router)
+    }
+}


### PR DESCRIPTION
## Summary

PR **4/6**. HTTP surface for the resource-group module, plus runtime activation of the plugin chain from #1550.

### Auth pivot — JWT-only, no mTLS

The initial design carried a **dual-auth path** (JWT for public callers + mTLS for the AuthZ plugin's hierarchy reads). After moving the AuthZ-plugin → RG read path to **in-process `ResourceGroupReadHierarchy` via `ClientHub`** (`tr-authz-plugin`), the mTLS surface lost its only consumer and was a placeholder in code with no middleware, no header parser, and no config loader behind it. **All mTLS code, config, docs, tests, e2e cert scaffolding, and CPT markers have been removed** in this PR. Public REST is JWT-only, evaluated by `PolicyEnforcer`; the AuthZ plugin reads hierarchy in-process with `AccessScope::allow_all()` (bypasses `PolicyEnforcer` invocation only — the plugin still emits its own AuthZ constraints from the returned hierarchy).

### What this PR actually implements

**REST API (`src/api/rest/`)**
- Route modules for `types`, `groups`, `memberships` registered via `OperationBuilder` (`routes/{types,groups,memberships}.rs`).
- Request/response DTOs with OpenAPI-driven serialization (camelCase, `type` / `hierarchy` nesting, GTS type-path validation, `parent_id` required-and-nullable on response shapes, full-replacement PUT contracts on `Update*Dto`/`Update*Request`).
- Handlers for full CRUD + hierarchy reads (`handlers/{groups,types,memberships}.rs`): list/get/create/update/delete/descendants/ancestors with depth & type filters, scope-aware preflight that maps missing/cross-tenant root to `GroupNotFound` (404).
- RFC 9457 problem-detail error mapping (`DomainError` → HTTP status + `Problem`); 400 declared for ID-routes (extractor failures), 204 emitted as body-less.
- All public routes go through `.authenticated()` (JWT + AuthZ via `PolicyEnforcer.access_scope()`).

**Modkit framework support**
- `OperationBuilder::no_content_response(..)` — body-less 204 (helper added so the OpenAPI emitter no longer attaches a `content` block on 204 responses; consumed by RG `DELETE /groups/{id}`).
- OpenAPI emitter in `openapi_registry.rs` skips `content` when `content_type` is empty.

**Module wiring (`module.rs`, `lib.rs`)**
- `module.rs` declares `RestApiCapability` alongside the existing `DatabaseCapability`; HTTP plane is registered when the module is enabled.
- `src/lib.rs` exposes the `api` module; `src/api/mod.rs` + `src/api/rest/mod.rs` plumbed.

**Plugin activation (`apps/hyperspot-server/`)**
- `Cargo.toml` — 3 optional features: `rg-authz`, `tr-authz`, `tenant-resolver-rg`.
- `registered_modules.rs` — cfg-gated `use` lines pulling the plugin crates into the binary when their feature is enabled.
- `Makefile` — build target for the RG-AuthZ e2e profile; `config/e2e-rg-authz.yaml` (413 lines) end-to-end profile exercising the RG-backed AuthZ chain; `config/e2e-local.yaml`, `e2e-features.txt` — feature toggles.

**GTS namespace alignment**
- Replaced legacy `gts.x.system.*` references with the canonical `gts.cf.core.*` (matching `ResourceGroupTypeV1::schema_id` and `TENANT_RG_TYPE_PATH` in the SDK) across DTO docs, AuthZ resource-type identifiers, and module/feature documentation.

**OpenAPI**
- `docs/api/api.json` regenerated end-to-end (`make openapi`). Notable contract bits: `parent_id` required-and-nullable on response shapes; `force` query is `boolean`; `DELETE /groups/{id}` returns 204 with no body; `Update*Dto` carry every replaceable field as required.

**CI**
- The `arduino/setup-protoc@v3.0.0` action was temporarily replaced by a hermetic local composite action during a transient GitHub-API outage; that workaround was rolled back so the workflow surface matches `main` again. Non-CI changes from the same commit train (e.g. mTLS removal, OpenAPI fixes) remain.

## PR Train

| # | PR | Branch | Base | Lines |
|---|------|--------|------|-------|
| 1 | #1552 | pr/rg-1-sdk | main | ~1000 |
| 2 | #1550 | pr/rg-2-plugins | pr/rg-1-sdk | ~2000 |
| 3 | #1553 | pr/rg-3-backend | pr/rg-2-plugins | ~5600 |
| 4 | **this** — #1554 | pr/rg-4-rest | pr/rg-3-backend | ~4000 |
| 5 | #1555 | pr/rg-5-tests-svc | pr/rg-4-rest | ~7300 |
| 6 | #1556 | pr/rg-6-tests-rest | pr/rg-5-tests-svc | ~6000 |

Stacked linearly. Merge order: 1 → 2 → 3 → 4 → 5 → 6.

## Test plan

- [x] `cargo build` / `cargo check --workspace --all-targets` green
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf` green
- [x] `make fmt` (cargo fmt --check) clean
- [x] `make openapi` regeneration reproducible
- [x] `cpt validate` workspace-wide — `status: PASS, errors: 0` (6 pre-existing `ref-target-not-in-scope` warnings about `FEATURE` artifact-kind not registered, unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full REST API for Resource Groups and Types: CRUD, hierarchy (ancestors/descendants), memberships (add/remove/list), and type management endpoints.
* **API Improvements**
  * OpenAPI spec updated with new resource-group/types endpoints and DTOs; supports body-less (204) responses and consistent pagination/filters.
* **Documentation**
  * Shifted to JWT-first authentication for current deployment; MTLS behavior deferred to a future phase; multiple docs and test plans updated.
* **Chores**
  * Added optional feature flags and a static E2E auth token for local testing; updated file timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->