### PR TITLE
test(resource-group): integration tests for service layer [5/6]

### DIFF
--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -8275,7 +8275,7 @@
             }
           },
           {
-            "description": "OData v4 filter expression\n- type: eq|ne|contains|startswith|endswith|in\n- hierarchy/parent_id: eq|ne|in\n- id: eq|ne|in\n- name: eq|ne|contains|startswith|endswith|in",
+            "description": "OData v4 filter expression\n- type: eq|ne|contains|startswith|endswith|in\n- hierarchy/parent_id: eq|ne|in\n- tenant_id: eq|ne|in\n- id: eq|ne|in\n- name: eq|ne|contains|startswith|endswith|in",
             "in": "query",
             "name": "$filter",
             "required": false,
@@ -8343,6 +8343,11 @@
               "contains",
               "startswith",
               "endswith",
+              "in"
+            ],
+            "tenant_id": [
+              "eq",
+              "ne",
               "in"
             ],
             "type": [

--- a/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/client.rs
+++ b/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/client.rs
@@ -1,3 +1,6 @@
+// Created: 2026-02-09 by Constructor Tech
+// Updated: 2026-04-29 by Constructor Tech
+
 //! Client implementation for the TR `AuthZ` resolver plugin.
 
 use async_trait::async_trait;
@@ -16,3 +19,7 @@ impl AuthZResolverPluginClient for Service {
         Ok(self.evaluate(&request).await)
     }
 }
+
+#[cfg(test)]
+#[path = "client_tests.rs"]
+mod client_tests;

--- a/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/client_tests.rs
+++ b/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/client_tests.rs
@@ -1,0 +1,49 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-29 by Constructor Tech
+
+use std::sync::Arc;
+
+use authz_resolver_sdk::AuthZResolverPluginClient;
+use authz_resolver_sdk::models::{
+    Action, EvaluationRequest, EvaluationRequestContext, Resource, Subject,
+};
+use uuid::Uuid;
+
+use crate::domain::service::Service;
+use crate::domain::test_support::MockTr;
+
+#[tokio::test]
+async fn client_trait_delegates_to_service() {
+    let svc = Arc::new(Service::new(Arc::new(MockTr::empty())));
+    let client: Arc<dyn AuthZResolverPluginClient> = svc;
+
+    let req = EvaluationRequest {
+        subject: Subject {
+            id: Uuid::now_v7(),
+            subject_type: None,
+            properties: std::collections::HashMap::default(),
+        },
+        action: Action {
+            name: "list".to_owned(),
+        },
+        resource: Resource {
+            resource_type: "test".to_owned(),
+            id: None,
+            properties: std::collections::HashMap::default(),
+        },
+        context: EvaluationRequestContext {
+            tenant_context: None,
+            token_scopes: vec![],
+            require_constraints: false,
+            capabilities: vec![],
+            supported_properties: vec![],
+            bearer_token: None,
+        },
+    };
+
+    let resp = client
+        .evaluate(req)
+        .await
+        .expect("evaluate should not error");
+    assert!(!resp.decision, "no tenant -> deny");
+}

--- a/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/mod.rs
+++ b/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/mod.rs
@@ -1,4 +1,10 @@
+// Created: 2026-02-24 by Constructor Tech
+// Updated: 2026-04-29 by Constructor Tech
+
 pub mod client;
 pub mod service;
+
+#[cfg(test)]
+mod test_support;
 
 pub use service::Service;

--- a/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/service.rs
+++ b/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/service.rs
@@ -1,3 +1,6 @@
+// Created: 2026-04-23 by Constructor Tech
+// Updated: 2026-04-29 by Constructor Tech
+
 //! Service implementation for the TR `AuthZ` resolver plugin.
 //!
 //! Implements the 8 access-check rules (R1–R8) from the tenant-based access
@@ -459,3 +462,7 @@ impl Service {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "service_tests.rs"]
+mod service_tests;

--- a/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/service_tests.rs
+++ b/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/service_tests.rs
@@ -1,0 +1,725 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-29 by Constructor Tech
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use authz_resolver_sdk::models::{Action, Resource, Subject};
+use authz_resolver_sdk::{
+    EvaluationRequest, EvaluationRequestContext, EvaluationResponse, Predicate, TenantContext,
+};
+use modkit_security::SecurityContext;
+use tenant_resolver_sdk::{
+    GetAncestorsOptions, GetAncestorsResponse, GetDescendantsOptions, GetDescendantsResponse,
+    GetTenantsOptions, IsAncestorOptions, TenantId, TenantInfo, TenantRef, TenantResolverClient,
+    TenantResolverError, TenantStatus,
+};
+use uuid::Uuid;
+
+use crate::domain::service::Service;
+
+// -- Mock Tenant Resolver --
+
+struct MockTenantResolver {
+    descendants: Vec<TenantRef>,
+    root: Option<TenantRef>,
+}
+
+impl MockTenantResolver {
+    fn with_tenants(root_id: Uuid, descendant_ids: Vec<Uuid>) -> Self {
+        let root = TenantRef {
+            id: TenantId(root_id),
+            status: TenantStatus::Active,
+            tenant_type: None,
+            parent_id: None,
+            self_managed: false,
+        };
+        let descendants = descendant_ids
+            .into_iter()
+            .map(|id| TenantRef {
+                id: TenantId(id),
+                status: TenantStatus::Active,
+                tenant_type: None,
+                parent_id: Some(TenantId(root_id)),
+                self_managed: false,
+            })
+            .collect();
+        Self {
+            descendants,
+            root: Some(root),
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            descendants: vec![],
+            root: None,
+        }
+    }
+}
+
+#[async_trait]
+impl TenantResolverClient for MockTenantResolver {
+    async fn get_tenant(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        if self.root.as_ref().is_some_and(|r| r.id == id) {
+            Ok(TenantInfo {
+                id,
+                name: format!("T-{}", id.0),
+                status: TenantStatus::Active,
+                tenant_type: None,
+                parent_id: None,
+                self_managed: false,
+            })
+        } else {
+            Err(TenantResolverError::TenantNotFound { tenant_id: id })
+        }
+    }
+
+    async fn get_root_tenant(
+        &self,
+        _ctx: &SecurityContext,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        unimplemented!("not used by tr-authz-plugin")
+    }
+
+    async fn get_tenants(
+        &self,
+        _ctx: &SecurityContext,
+        _ids: &[TenantId],
+        _options: &GetTenantsOptions,
+    ) -> Result<Vec<TenantInfo>, TenantResolverError> {
+        Ok(vec![])
+    }
+
+    async fn get_ancestors(
+        &self,
+        _ctx: &SecurityContext,
+        _id: TenantId,
+        _options: &GetAncestorsOptions,
+    ) -> Result<GetAncestorsResponse, TenantResolverError> {
+        unimplemented!("not used by tr-authz-plugin")
+    }
+
+    async fn get_descendants(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+        _options: &GetDescendantsOptions,
+    ) -> Result<GetDescendantsResponse, TenantResolverError> {
+        match &self.root {
+            Some(root) if root.id == id => Ok(GetDescendantsResponse {
+                tenant: root.clone(),
+                descendants: self.descendants.clone(),
+            }),
+            _ => Err(TenantResolverError::TenantNotFound { tenant_id: id }),
+        }
+    }
+
+    async fn is_ancestor(
+        &self,
+        _ctx: &SecurityContext,
+        _ancestor_id: TenantId,
+        _descendant_id: TenantId,
+        _options: &IsAncestorOptions,
+    ) -> Result<bool, TenantResolverError> {
+        unimplemented!("not used by tr-authz-plugin")
+    }
+}
+
+fn make_request(tenant_id: Uuid) -> EvaluationRequest {
+    // `subject.properties["tenant_id"] = tenant_id` mirrors the PEP-injected
+    // home tenant for a caller whose subject tenant equals `root_id`. That
+    // matches the original intent of these legacy tests (subject is allowed
+    // to see its own tenant's subtree — R6-style).
+    let mut subject_props = std::collections::HashMap::default();
+    subject_props.insert(
+        "tenant_id".to_owned(),
+        serde_json::Value::String(tenant_id.to_string()),
+    );
+    EvaluationRequest {
+        subject: Subject {
+            id: Uuid::now_v7(),
+            subject_type: None,
+            properties: subject_props,
+        },
+        action: Action {
+            name: "list".to_owned(),
+        },
+        resource: Resource {
+            resource_type: "gts.cf.test.v1~".to_owned(),
+            id: None,
+            properties: std::collections::HashMap::default(),
+        },
+        context: EvaluationRequestContext {
+            tenant_context: Some(TenantContext {
+                root_id: Some(tenant_id),
+                ..Default::default()
+            }),
+            token_scopes: vec![],
+            require_constraints: true,
+            capabilities: vec![],
+            supported_properties: vec![],
+            bearer_token: None,
+        },
+    }
+}
+
+fn make_request_no_tenant() -> EvaluationRequest {
+    EvaluationRequest {
+        subject: Subject {
+            id: Uuid::now_v7(),
+            subject_type: None,
+            properties: std::collections::HashMap::default(),
+        },
+        action: Action {
+            name: "list".to_owned(),
+        },
+        resource: Resource {
+            resource_type: "gts.cf.test.v1~".to_owned(),
+            id: None,
+            properties: std::collections::HashMap::default(),
+        },
+        context: EvaluationRequestContext {
+            tenant_context: None,
+            token_scopes: vec![],
+            require_constraints: false,
+            capabilities: vec![],
+            supported_properties: vec![],
+            bearer_token: None,
+        },
+    }
+}
+
+// -- Tests --
+
+#[tokio::test]
+async fn tenant_subtree_resolved_to_in_predicate() {
+    let t1 = Uuid::now_v7();
+    let t2 = Uuid::now_v7();
+    let mock = MockTenantResolver::with_tenants(t1, vec![t2]);
+    let svc = Service::new(Arc::new(mock));
+    let resp = svc.evaluate(&make_request(t1)).await;
+
+    assert!(resp.decision);
+    assert_eq!(resp.context.constraints.len(), 1);
+    let preds = &resp.context.constraints[0].predicates;
+    assert_eq!(preds.len(), 1);
+    assert!(
+        matches!(&preds[0], Predicate::In(p) if p.property == "owner_tenant_id"),
+        "expected In(owner_tenant_id), got: {preds:?}"
+    );
+    // Should have both t1 (root) and t2 (descendant)
+    if let Predicate::In(p) = &preds[0] {
+        assert_eq!(p.values.len(), 2, "root + 1 descendant");
+    }
+}
+
+#[tokio::test]
+async fn barrier_handled_by_tr_only_visible_returned() {
+    // Barrier filtering is delegated to TR (BarrierMode::Respect): the mock
+    // simulates the post-filter view — TR has already dropped t_barrier and
+    // t_behind, so they never reach the authz plugin. The plugin must trust
+    // that view and return exactly what TR exposed.
+    let t1 = Uuid::now_v7();
+    let t_normal = Uuid::now_v7();
+    let t_barrier = Uuid::now_v7(); // absent — would-be barrier tenant
+    let t_behind = Uuid::now_v7(); // absent — would-be descendant of t_barrier
+    // Mock: TR already filtered out t_barrier + t_behind
+    let mock = MockTenantResolver::with_tenants(t1, vec![t_normal]);
+    let svc = Service::new(Arc::new(mock));
+    let resp = svc.evaluate(&make_request(t1)).await;
+
+    assert!(resp.decision);
+    let preds = &resp.context.constraints[0].predicates;
+    if let Predicate::In(p) = &preds[0] {
+        let got: std::collections::HashSet<_> = p.values.iter().map(parse_uuid_value).collect();
+        let expected: std::collections::HashSet<_> = [t1, t_normal].into_iter().collect();
+        assert_eq!(
+            got, expected,
+            "predicate must contain exactly the tenants TR returned",
+        );
+        assert!(
+            !got.contains(&t_barrier),
+            "barrier tenant must be excluded (TR dropped it)",
+        );
+        assert!(
+            !got.contains(&t_behind),
+            "behind-barrier tenant must be excluded (TR dropped it)",
+        );
+    } else {
+        panic!("expected In predicate");
+    }
+}
+
+#[tokio::test]
+async fn no_tenant_in_request_denies() {
+    let mock = MockTenantResolver::empty();
+    let svc = Service::new(Arc::new(mock));
+    let resp = svc.evaluate(&make_request_no_tenant()).await;
+    assert!(!resp.decision, "no tenant -> deny");
+}
+
+#[tokio::test]
+async fn nil_tenant_denies() {
+    let mock = MockTenantResolver::empty();
+    let svc = Service::new(Arc::new(mock));
+    let resp = svc.evaluate(&make_request(Uuid::default())).await;
+    assert!(!resp.decision, "nil tenant -> deny");
+}
+
+#[tokio::test]
+async fn tenant_not_found_denies() {
+    let mock = MockTenantResolver::empty();
+    let svc = Service::new(Arc::new(mock));
+    let resp = svc.evaluate(&make_request(Uuid::now_v7())).await;
+    assert!(!resp.decision, "tenant not found -> deny (fail-closed)");
+}
+
+#[tokio::test]
+async fn tr_error_denies() {
+    struct FailingTr;
+
+    #[async_trait]
+    impl TenantResolverClient for FailingTr {
+        async fn get_tenant(
+            &self,
+            _ctx: &SecurityContext,
+            id: TenantId,
+        ) -> Result<TenantInfo, TenantResolverError> {
+            Err(TenantResolverError::Internal(format!("fail {id}")))
+        }
+
+        async fn get_root_tenant(
+            &self,
+            _ctx: &SecurityContext,
+        ) -> Result<TenantInfo, TenantResolverError> {
+            Err(TenantResolverError::Internal("fail".to_owned()))
+        }
+
+        async fn get_tenants(
+            &self,
+            _ctx: &SecurityContext,
+            _ids: &[TenantId],
+            _options: &GetTenantsOptions,
+        ) -> Result<Vec<TenantInfo>, TenantResolverError> {
+            Err(TenantResolverError::Internal("fail".to_owned()))
+        }
+
+        async fn get_ancestors(
+            &self,
+            _ctx: &SecurityContext,
+            _id: TenantId,
+            _options: &GetAncestorsOptions,
+        ) -> Result<GetAncestorsResponse, TenantResolverError> {
+            Err(TenantResolverError::Internal("fail".to_owned()))
+        }
+
+        async fn get_descendants(
+            &self,
+            _ctx: &SecurityContext,
+            _id: TenantId,
+            _options: &GetDescendantsOptions,
+        ) -> Result<GetDescendantsResponse, TenantResolverError> {
+            Err(TenantResolverError::Internal("fail".to_owned()))
+        }
+
+        async fn is_ancestor(
+            &self,
+            _ctx: &SecurityContext,
+            _a: TenantId,
+            _d: TenantId,
+            _options: &IsAncestorOptions,
+        ) -> Result<bool, TenantResolverError> {
+            Err(TenantResolverError::Internal("fail".to_owned()))
+        }
+    }
+
+    let svc = Service::new(Arc::new(FailingTr));
+    let resp = svc.evaluate(&make_request(Uuid::now_v7())).await;
+    assert!(!resp.decision, "TR error -> deny (fail-closed)");
+}
+
+#[tokio::test]
+async fn group_predicates_from_request_properties() {
+    let t1 = Uuid::now_v7();
+    let mock = MockTenantResolver::with_tenants(t1, vec![]);
+    let svc = Service::new(Arc::new(mock));
+
+    let g1 = Uuid::now_v7();
+    let g2 = Uuid::now_v7();
+    let mut req = make_request(t1);
+    req.resource.properties.insert(
+        "group_ids".to_owned(),
+        serde_json::json!([g1.to_string(), g2.to_string()]),
+    );
+    req.resource.properties.insert(
+        "ancestor_group_ids".to_owned(),
+        serde_json::json!([g1.to_string()]),
+    );
+
+    let resp = svc.evaluate(&req).await;
+    assert!(resp.decision);
+
+    let preds = &resp.context.constraints[0].predicates;
+    assert_eq!(preds.len(), 3, "In + InGroup + InGroupSubtree");
+    assert!(matches!(&preds[0], Predicate::In(_)));
+    assert!(matches!(&preds[1], Predicate::InGroup(_)));
+    assert!(matches!(&preds[2], Predicate::InGroupSubtree(_)));
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// R1–R8 decision matrix tests
+// ──────────────────────────────────────────────────────────────────────
+//
+// Hierarchy used by the R-tests (as in aviator5's review comment on PR #1550):
+//
+//     r (root)
+//     └── t1 (partner)
+//         └── t2 (partner)
+//             ├── t3 (customer)
+//             └── t4 (customer)
+//
+// `HierarchyMock` implements `is_ancestor` and `get_descendants` against this
+// shape; `get_tenant` / `get_ancestors` / `get_root_tenant` / `get_tenants`
+// are unused by `tr-authz-plugin::evaluate`.
+
+// `HierarchyMock`, `FailingOnDescendants`, and `EmptyTr` (in `client_tests`)
+// previously implemented `TenantResolverClient` three times with overlapping
+// skeletons. The configurable mock now lives in
+// `crate::domain::test_support::MockTr` and is instantiated via the constructors
+// `with_hierarchy` / `failing_descendants` / `empty`.
+use crate::domain::test_support::{MockTr, setup_svc};
+
+/// Wrapper around `svc.evaluate(&build_r_request(...)).await` to collapse the
+/// 8-line call into a single line per test. Same arguments as `build_r_request`.
+async fn evaluate_r(
+    svc: &Service,
+    subject_tid: Uuid,
+    action: &str,
+    resource_id: Option<Uuid>,
+    owner_tenant_id: Option<Uuid>,
+    root_id: Option<Uuid>,
+    mode: Option<authz_resolver_sdk::TenantMode>,
+) -> EvaluationResponse {
+    svc.evaluate(&build_r_request(
+        subject_tid,
+        action,
+        resource_id,
+        owner_tenant_id,
+        root_id,
+        mode,
+    ))
+    .await
+}
+
+/// Generic request builder for R-rule tests.
+fn build_r_request(
+    subject_tid: Uuid,
+    action: &str,
+    resource_id: Option<Uuid>,
+    owner_tenant_id: Option<Uuid>,
+    root_id: Option<Uuid>,
+    mode: Option<authz_resolver_sdk::TenantMode>,
+) -> EvaluationRequest {
+    let mut subject_props = std::collections::HashMap::default();
+    subject_props.insert(
+        "tenant_id".to_owned(),
+        serde_json::Value::String(subject_tid.to_string()),
+    );
+    let mut resource_props = std::collections::HashMap::default();
+    if let Some(owner) = owner_tenant_id {
+        resource_props.insert(
+            "owner_tenant_id".to_owned(),
+            serde_json::Value::String(owner.to_string()),
+        );
+    }
+    let tenant_context = if root_id.is_some() || mode.is_some() {
+        Some(TenantContext {
+            root_id,
+            mode: mode.unwrap_or_default(),
+            ..Default::default()
+        })
+    } else {
+        None
+    };
+    EvaluationRequest {
+        subject: Subject {
+            id: Uuid::now_v7(),
+            subject_type: None,
+            properties: subject_props,
+        },
+        action: Action {
+            name: action.to_owned(),
+        },
+        resource: Resource {
+            resource_type: "gts.cf.test.v1~".to_owned(),
+            id: resource_id,
+            properties: resource_props,
+        },
+        context: EvaluationRequestContext {
+            tenant_context,
+            token_scopes: vec![],
+            require_constraints: true,
+            capabilities: vec![],
+            supported_properties: vec![],
+            bearer_token: None,
+        },
+    }
+}
+
+/// Assert that the response is `allow` with a single `In(owner_tenant_id, …)`
+/// predicate whose values equal `expected` as a set.
+///
+/// UUID parsing is strict: a non-string predicate value or a malformed UUID
+/// fails the test (rather than being silently dropped) — otherwise tests
+/// could pass with bad predicate payloads.
+fn assert_allow_in(resp: &EvaluationResponse, expected: &[Uuid]) {
+    assert!(resp.decision, "expected allow, got deny");
+    let preds = &resp.context.constraints[0].predicates;
+    assert_eq!(preds.len(), 1);
+    let Predicate::In(p) = &preds[0] else {
+        panic!("expected In predicate");
+    };
+    let got: std::collections::HashSet<_> = p.values.iter().map(parse_uuid_value).collect();
+    let want: std::collections::HashSet<_> = expected.iter().copied().collect();
+    assert_eq!(got, want, "predicate values mismatch");
+}
+
+/// Strict UUID parser for test predicate values. Panics with a descriptive
+/// message on non-string values or invalid UUIDs.
+fn parse_uuid_value(v: &serde_json::Value) -> Uuid {
+    let s = v
+        .as_str()
+        .unwrap_or_else(|| panic!("expected predicate value to be a string, got: {v:?}"));
+    Uuid::parse_str(s).unwrap_or_else(|e| panic!("invalid UUID in predicate values: {s:?} ({e})"))
+}
+
+// ── R1: single, root_id, root_only ─────────────────────────────────────
+#[tokio::test]
+async fn r1_partner_reads_customer_task_root_only() {
+    let (svc, [_r, t1, t2, _t3, _t4]) = setup_svc();
+    let resp = evaluate_r(
+        &svc,
+        t1,
+        "get",
+        Some(Uuid::now_v7()),
+        Some(t2),
+        Some(t2),
+        Some(authz_resolver_sdk::TenantMode::RootOnly),
+    )
+    .await;
+    assert_allow_in(&resp, &[t2]);
+}
+
+#[tokio::test]
+async fn r1_deny_when_owner_differs_from_root_id() {
+    let (svc, [_r, t1, t2, t3, _t4]) = setup_svc();
+    // owner_tenant_id=t3 but root_id=t2 → mismatch → deny.
+    let resp = evaluate_r(
+        &svc,
+        t1,
+        "get",
+        Some(Uuid::now_v7()),
+        Some(t3),
+        Some(t2),
+        Some(authz_resolver_sdk::TenantMode::RootOnly),
+    )
+    .await;
+    assert!(!resp.decision);
+}
+
+// ── R2: single, root_id, subtree (default) ─────────────────────────────
+#[tokio::test]
+async fn r2_partner_reads_task_from_customer_subtree() {
+    let (svc, [_r, t1, t2, t3, _t4]) = setup_svc();
+    let resp = evaluate_r(
+        &svc,
+        t1,
+        "get",
+        Some(Uuid::now_v7()),
+        Some(t3),
+        Some(t2),
+        None, // default: Subtree
+    )
+    .await;
+    assert_allow_in(&resp, &[t3]);
+}
+
+#[tokio::test]
+async fn r2_deny_when_owner_outside_root_subtree() {
+    let (svc, [_r, t1, _t2, _t3, _t4]) = setup_svc();
+    // subject=t1, root_id=t1, but owner=non-existent → not in t1's subtree.
+    let alien = Uuid::now_v7();
+    let resp = evaluate_r(
+        &svc,
+        t1,
+        "get",
+        Some(Uuid::now_v7()),
+        Some(alien),
+        Some(t1),
+        None,
+    )
+    .await;
+    assert!(!resp.decision);
+}
+
+// ── R3: single, no root_id, root_only ─────────────────────────────────
+#[tokio::test]
+async fn r3_user_reads_own_task_root_only() {
+    let (svc, [_r, _t1, _t2, t3, _t4]) = setup_svc();
+    let resp = evaluate_r(
+        &svc,
+        t3,
+        "get",
+        Some(Uuid::now_v7()),
+        Some(t3),
+        None,
+        Some(authz_resolver_sdk::TenantMode::RootOnly),
+    )
+    .await;
+    assert_allow_in(&resp, &[t3]);
+}
+
+#[tokio::test]
+async fn r3_deny_when_owner_differs_from_subject() {
+    let (svc, [_r, _t1, _t2, t3, t4]) = setup_svc();
+    let resp = evaluate_r(
+        &svc,
+        t3,
+        "get",
+        Some(Uuid::now_v7()),
+        Some(t4),
+        None,
+        Some(authz_resolver_sdk::TenantMode::RootOnly),
+    )
+    .await;
+    assert!(!resp.decision);
+}
+
+// ── R4: single, no root_id, subtree (default) ─────────────────────────
+#[tokio::test]
+async fn r4_partner_reads_task_from_own_subtree() {
+    let (svc, [_r, t1, _t2, t3, _t4]) = setup_svc();
+    let resp = evaluate_r(&svc, t1, "get", Some(Uuid::now_v7()), Some(t3), None, None).await;
+    assert_allow_in(&resp, &[t3]);
+}
+
+#[tokio::test]
+async fn r4_allow_when_owner_equals_subject_reflexive() {
+    let (svc, [_r, t1, _t2, _t3, _t4]) = setup_svc();
+    // Reflexive: owner == subject — `is_in_subtree(subject, owner)` short-circuits.
+    let resp = evaluate_r(&svc, t1, "get", Some(Uuid::now_v7()), Some(t1), None, None).await;
+    assert_allow_in(&resp, &[t1]);
+}
+
+#[tokio::test]
+async fn r4_deny_when_owner_outside_subject_subtree() {
+    let (svc, [_r, _t1, _t2, t3, t4]) = setup_svc();
+    // subject=t3, owner=t4 → siblings, neither is ancestor of the other.
+    let resp = evaluate_r(&svc, t3, "get", Some(Uuid::now_v7()), Some(t4), None, None).await;
+    assert!(!resp.decision);
+}
+
+// ── R5: list, root_id, root_only ──────────────────────────────────────
+#[tokio::test]
+async fn r5_partner_lists_customer_tasks_root_only() {
+    let (svc, [_r, t1, t2, _t3, _t4]) = setup_svc();
+    let resp = evaluate_r(
+        &svc,
+        t1,
+        "list",
+        None,
+        None,
+        Some(t2),
+        Some(authz_resolver_sdk::TenantMode::RootOnly),
+    )
+    .await;
+    assert_allow_in(&resp, &[t2]);
+}
+
+#[tokio::test]
+async fn r5_deny_when_subject_cannot_see_root_id() {
+    let (svc, [_r, _t1, _t2, t3, t4]) = setup_svc();
+    // subject=t3 (customer), root_id=t4 (sibling) → subject not an ancestor of t4.
+    let resp = evaluate_r(
+        &svc,
+        t3,
+        "list",
+        None,
+        None,
+        Some(t4),
+        Some(authz_resolver_sdk::TenantMode::RootOnly),
+    )
+    .await;
+    assert!(!resp.decision);
+}
+
+// ── R6: list, root_id, subtree ────────────────────────────────────────
+#[tokio::test]
+async fn r6_partner_lists_customer_subtree() {
+    let (svc, [_r, t1, t2, t3, t4]) = setup_svc();
+    let resp = evaluate_r(&svc, t1, "list", None, None, Some(t2), None).await;
+    assert_allow_in(&resp, &[t2, t3, t4]);
+}
+
+#[tokio::test]
+async fn r6_deny_when_subject_cannot_see_root_id() {
+    let (svc, [_r, _t1, _t2, t3, t4]) = setup_svc();
+    // subject=t3 (customer), root_id=t4 (sibling) → subject not an ancestor of t4 → deny.
+    let resp = evaluate_r(&svc, t3, "list", None, None, Some(t4), None).await;
+    assert!(!resp.decision);
+}
+
+// ── R7: list, no root_id, root_only ───────────────────────────────────
+#[tokio::test]
+async fn r7_user_lists_own_tasks_root_only() {
+    let (svc, [_r, _t1, _t2, t3, _t4]) = setup_svc();
+    let resp = evaluate_r(
+        &svc,
+        t3,
+        "list",
+        None,
+        None,
+        None,
+        Some(authz_resolver_sdk::TenantMode::RootOnly),
+    )
+    .await;
+    assert_allow_in(&resp, &[t3]);
+}
+
+// ── R8: list, no root_id, subtree ─────────────────────────────────────
+#[tokio::test]
+async fn r8_partner_lists_own_subtree() {
+    let (svc, [_r, t1, t2, t3, t4]) = setup_svc();
+    let resp = evaluate_r(&svc, t1, "list", None, None, None, None).await;
+    assert_allow_in(&resp, &[t1, t2, t3, t4]);
+}
+
+#[tokio::test]
+async fn r8_deny_on_tr_error() {
+    // Dedicated R8 fail-path: `get_descendants(subject)` TR failure → deny.
+    let svc = Service::new(Arc::new(MockTr::failing_descendants()));
+    let resp = evaluate_r(&svc, Uuid::now_v7(), "list", None, None, None, None).await;
+    assert!(!resp.decision, "R8: TR error on get_descendants -> deny");
+}
+
+// ── Fail-closed: single-resource missing owner_tenant_id ───────────────
+#[tokio::test]
+async fn single_resource_missing_owner_tenant_id_denies() {
+    let (svc, [_r, t1, _t2, _t3, _t4]) = setup_svc();
+    let resp = evaluate_r(
+        &svc,
+        t1,
+        "get",
+        Some(Uuid::now_v7()),
+        None, // missing owner_tenant_id in properties
+        None,
+        None,
+    )
+    .await;
+    assert!(!resp.decision);
+}

--- a/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/test_support.rs
+++ b/modules/system/authz-resolver/plugins/tr-authz-plugin/src/domain/test_support.rs
@@ -1,0 +1,212 @@
+// Created: 2026-04-29 by Constructor Tech
+//! Shared test helpers for `tr-authz-plugin`.
+//!
+//! Consolidates the previously-duplicated `HierarchyMock`, `FailingOnDescendants`,
+//! and `EmptyTr` mock implementations into a single configurable `MockTr` so
+//! that the trait-method skeleton is implemented once.
+
+#![cfg(test)]
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit_security::SecurityContext;
+use tenant_resolver_sdk::{
+    GetAncestorsOptions, GetAncestorsResponse, GetDescendantsOptions, GetDescendantsResponse,
+    GetTenantsOptions, IsAncestorOptions, TenantId, TenantInfo, TenantRef, TenantResolverClient,
+    TenantResolverError, TenantStatus,
+};
+use uuid::Uuid;
+
+use crate::domain::service::Service;
+
+/// Configurable `TenantResolverClient` mock used by both `service_tests` and
+/// `client_tests`.
+///
+/// Behavior is selected via the field configuration:
+///
+/// - `parent` empty → `EmptyTr`-style:
+///     * `get_tenant` and `get_root_tenant` return `TenantNotFound`.
+///     * `get_tenants` returns an empty vector.
+///     * `get_descendants` returns an empty descendant list.
+///     * `is_ancestor` returns `false` (no relationships).
+///     * `get_ancestors` is the one exception: it returns the requested id
+///       wrapped in a synthetic active `TenantRef` with an empty ancestor
+///       chain. The legacy `EmptyTr` did the same; treating it as
+///       "not found" would break the AuthZ-plugin code path that walks
+///       the ancestor chain to find a tenant root.
+/// - `parent` populated → `HierarchyMock`-style: `get_descendants` and
+///   `is_ancestor` traverse the in-memory parent map.
+/// - `descendants_error == true` → `FailingOnDescendants`-style: every
+///   `get_descendants` call returns `TenantResolverError::Internal`.
+pub struct MockTr {
+    pub all: Vec<Uuid>,
+    pub parent: HashMap<Uuid, Option<Uuid>>,
+    pub descendants_error: bool,
+}
+
+impl MockTr {
+    /// All trait methods return "not found" / empty. Matches the legacy
+    /// `EmptyTr` mock used by `client_tests`.
+    pub fn empty() -> Self {
+        Self {
+            all: Vec::new(),
+            parent: HashMap::new(),
+            descendants_error: false,
+        }
+    }
+
+    /// Hierarchy traversal mock. Tests pass an explicit parent map.
+    pub fn with_hierarchy(all: Vec<Uuid>, parent: HashMap<Uuid, Option<Uuid>>) -> Self {
+        Self {
+            all,
+            parent,
+            descendants_error: false,
+        }
+    }
+
+    /// Mock that always fails `get_descendants` with `Internal`. Matches the
+    /// legacy `FailingOnDescendants` mock used by `r8_deny_on_tr_error`.
+    pub fn failing_descendants() -> Self {
+        Self {
+            all: Vec::new(),
+            parent: HashMap::new(),
+            descendants_error: true,
+        }
+    }
+
+    fn is_ancestor_of(&self, anc: Uuid, desc: Uuid) -> bool {
+        let mut cur = Some(desc);
+        while let Some(c) = cur {
+            match self.parent.get(&c).copied().flatten() {
+                Some(p) if p == anc => return true,
+                Some(p) => cur = Some(p),
+                None => return false,
+            }
+        }
+        false
+    }
+
+    fn collect_descendants(&self, root: Uuid) -> Vec<Uuid> {
+        self.all
+            .iter()
+            .copied()
+            .filter(|&t| t != root && self.is_ancestor_of(root, t))
+            .collect()
+    }
+}
+
+#[async_trait]
+impl TenantResolverClient for MockTr {
+    async fn get_tenant(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        Err(TenantResolverError::TenantNotFound { tenant_id: id })
+    }
+
+    async fn get_root_tenant(
+        &self,
+        _ctx: &SecurityContext,
+    ) -> Result<TenantInfo, TenantResolverError> {
+        Err(TenantResolverError::TenantNotFound {
+            tenant_id: TenantId(Uuid::nil()),
+        })
+    }
+
+    async fn get_tenants(
+        &self,
+        _ctx: &SecurityContext,
+        _ids: &[TenantId],
+        _options: &GetTenantsOptions,
+    ) -> Result<Vec<TenantInfo>, TenantResolverError> {
+        Ok(vec![])
+    }
+
+    async fn get_ancestors(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+        _options: &GetAncestorsOptions,
+    ) -> Result<GetAncestorsResponse, TenantResolverError> {
+        Ok(GetAncestorsResponse {
+            tenant: TenantRef {
+                id,
+                status: TenantStatus::Active,
+                tenant_type: None,
+                parent_id: None,
+                self_managed: false,
+            },
+            ancestors: vec![],
+        })
+    }
+
+    async fn get_descendants(
+        &self,
+        _ctx: &SecurityContext,
+        id: TenantId,
+        _options: &GetDescendantsOptions,
+    ) -> Result<GetDescendantsResponse, TenantResolverError> {
+        if self.descendants_error {
+            return Err(TenantResolverError::Internal(
+                "simulated TR failure".to_owned(),
+            ));
+        }
+        let tenant_ref = TenantRef {
+            id,
+            status: TenantStatus::Active,
+            tenant_type: None,
+            parent_id: self.parent.get(&id.0).copied().flatten().map(TenantId),
+            self_managed: false,
+        };
+        let descendants = self
+            .collect_descendants(id.0)
+            .into_iter()
+            .map(|d| TenantRef {
+                id: TenantId(d),
+                status: TenantStatus::Active,
+                tenant_type: None,
+                parent_id: self.parent.get(&d).copied().flatten().map(TenantId),
+                self_managed: false,
+            })
+            .collect();
+        Ok(GetDescendantsResponse {
+            tenant: tenant_ref,
+            descendants,
+        })
+    }
+
+    async fn is_ancestor(
+        &self,
+        _ctx: &SecurityContext,
+        ancestor_id: TenantId,
+        descendant_id: TenantId,
+        _options: &IsAncestorOptions,
+    ) -> Result<bool, TenantResolverError> {
+        Ok(self.is_ancestor_of(ancestor_id.0, descendant_id.0))
+    }
+}
+
+/// Build the canonical `r → t1 → t2 → {t3, t4}` hierarchy and wrap it in a
+/// ready-to-use `Service`. Used by every R-rule test in `service_tests`.
+pub fn setup_svc() -> (Service, [Uuid; 5]) {
+    let r = Uuid::now_v7();
+    let t1 = Uuid::now_v7();
+    let t2 = Uuid::now_v7();
+    let t3 = Uuid::now_v7();
+    let t4 = Uuid::now_v7();
+    let parent: HashMap<Uuid, Option<Uuid>> = [
+        (r, None),
+        (t1, Some(r)),
+        (t2, Some(t1)),
+        (t3, Some(t2)),
+        (t4, Some(t2)),
+    ]
+    .into_iter()
+    .collect();
+    let mock = MockTr::with_hierarchy(vec![r, t1, t2, t3, t4], parent);
+    (Service::new(Arc::new(mock)), [r, t1, t2, t3, t4])
+}

--- a/modules/system/resource-group/docs/features/0005-integration-auth.md
+++ b/modules/system/resource-group/docs/features/0005-integration-auth.md
@@ -3,7 +3,7 @@
 
 # Feature: Integration Read Port & Dual Authentication Modes
 
-- [x] `p1` - **ID**: `cpt-cf-resource-group-featstatus-integration-auth`
+- [ ] `p1` - **ID**: `cpt-cf-resource-group-featstatus-integration-auth`
 
 - [x] `p1` - `cpt-cf-resource-group-feature-integration-auth`
 
@@ -21,11 +21,12 @@
   - [Plugin Gateway Routing](#plugin-gateway-routing)
 - [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
   - [Tenant Scope Enforcement for Ownership-Graph Writes](#tenant-scope-enforcement-for-ownership-graph-writes)
-  - [Authentication Mode Decision](#authentication-mode-decision)
+  - [Authentication Mode Decision (`p2` — deferred, not implemented yet)](#authentication-mode-decision-p2--deferred-not-implemented-yet)
 - [4. States (CDSL)](#4-states-cdsl)
 - [5. Definitions of Done](#5-definitions-of-done)
   - [Integration Read Service](#integration-read-service)
-  - [Dual Authentication Mode Routing](#dual-authentication-mode-routing)
+  - [JWT Authentication Routing](#jwt-authentication-routing)
+  - [Dual Authentication Mode Routing (`p2` — deferred, not implemented yet)](#dual-authentication-mode-routing-p2--deferred-not-implemented-yet)
   - [Tenant Scope Enforcement for Ownership-Graph Profile](#tenant-scope-enforcement-for-ownership-graph-profile)
   - [Unit Test Coverage for Integration Auth](#unit-test-coverage-for-integration-auth)
 - [6. Acceptance Criteria](#6-acceptance-criteria)

--- a/modules/system/resource-group/resource-group/src/api/rest/dto.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/dto.rs
@@ -1,5 +1,5 @@
 // Created: 2026-04-16 by Constructor Tech
-// Updated: 2026-04-28 by Constructor Tech
+// Updated: 2026-04-29 by Constructor Tech
 //! REST DTOs for resource-group type and group management.
 
 use resource_group_sdk::models::{
@@ -292,3 +292,7 @@ impl From<ResourceGroupMembership> for MembershipDto {
 }
 
 // @cpt-dod:cpt-cf-resource-group-dod-testing-odata-dto:p1
+
+#[cfg(test)]
+#[path = "dto_tests.rs"]
+mod tests;

--- a/modules/system/resource-group/resource-group/src/api/rest/dto_tests.rs
+++ b/modules/system/resource-group/resource-group/src/api/rest/dto_tests.rs
@@ -1,0 +1,127 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-testing-rest-api:p2
+use super::*;
+use uuid::Uuid;
+
+// TC-DTO-01: ResourceGroupType -> TypeDto
+#[test]
+fn dto_type_from_resource_group_type() {
+    let rgt = ResourceGroupType {
+        code: "gts.x.system.rg.type.v1~x.test.dto.mytype.v1~".to_owned(),
+        can_be_root: true,
+        allowed_parent_types: vec!["gts.parent~".to_owned()],
+        allowed_membership_types: vec!["gts.member~".to_owned()],
+        metadata_schema: Some(serde_json::json!({"type": "object"})),
+    };
+    let dto: TypeDto = rgt.into();
+    assert_eq!(dto.code, "gts.x.system.rg.type.v1~x.test.dto.mytype.v1~");
+    assert!(dto.can_be_root);
+    assert_eq!(dto.allowed_parent_types, vec!["gts.parent~"]);
+    assert_eq!(dto.allowed_membership_types, vec!["gts.member~"]);
+    assert!(dto.metadata_schema.is_some());
+}
+
+// TC-DTO-02: CreateTypeDto -> CreateTypeRequest
+#[test]
+fn dto_create_type_to_request() {
+    let dto = CreateTypeDto {
+        code: "gts.x.system.rg.type.v1~x.test.dto.mytype.v1~".to_owned(),
+        can_be_root: false,
+        allowed_parent_types: vec!["gts.parent~".to_owned()],
+        allowed_membership_types: vec![],
+        metadata_schema: None,
+    };
+    let req: CreateTypeRequest = dto.into();
+    assert_eq!(req.code, "gts.x.system.rg.type.v1~x.test.dto.mytype.v1~");
+    assert!(!req.can_be_root);
+    assert_eq!(req.allowed_parent_types, vec!["gts.parent~"]);
+    assert!(req.allowed_membership_types.is_empty());
+    assert!(req.metadata_schema.is_none());
+}
+
+// TC-DTO-03: ResourceGroup -> GroupDto
+#[test]
+fn dto_group_from_resource_group() {
+    let parent_id = Uuid::now_v7();
+    let tenant_id = Uuid::now_v7();
+    let group = ResourceGroup {
+        id: Uuid::now_v7(),
+        code: "gts.x.system.rg.type.v1~".to_owned(),
+        name: "My Group".to_owned(),
+        hierarchy: resource_group_sdk::models::GroupHierarchy {
+            parent_id: Some(parent_id),
+            tenant_id,
+        },
+        metadata: Some(serde_json::json!({"k": "v"})),
+    };
+    let dto: GroupDto = group.clone().into();
+    assert_eq!(dto.id, group.id);
+    assert_eq!(dto.type_path, "gts.x.system.rg.type.v1~");
+    assert_eq!(dto.name, "My Group");
+    assert_eq!(dto.hierarchy.parent_id, Some(parent_id));
+    assert_eq!(dto.hierarchy.tenant_id, tenant_id);
+    assert!(dto.metadata.is_some());
+}
+
+// TC-DTO-04: ResourceGroupWithDepth -> GroupWithDepthDto
+#[test]
+fn dto_group_with_depth_from_resource_group() {
+    let tenant_id = Uuid::now_v7();
+    let gwd = ResourceGroupWithDepth {
+        id: Uuid::now_v7(),
+        code: "gts.x.system.rg.type.v1~".to_owned(),
+        name: "Depth Group".to_owned(),
+        hierarchy: resource_group_sdk::models::GroupHierarchyWithDepth {
+            parent_id: None,
+            tenant_id,
+            depth: 3,
+        },
+        metadata: None,
+    };
+    let dto: GroupWithDepthDto = gwd.into();
+    assert_eq!(dto.name, "Depth Group");
+    assert_eq!(dto.hierarchy.depth, 3);
+    assert!(dto.hierarchy.parent_id.is_none());
+    assert_eq!(dto.hierarchy.tenant_id, tenant_id);
+}
+
+// TC-DTO-05: Deserialize {"type": "gts...", "name": "X"} into CreateGroupDto
+#[test]
+fn dto_create_group_deserialize_type_key() {
+    let json = r#"{"type": "gts.x.system.rg.type.v1~x.test.dto.mytype.v1~", "name": "X"}"#;
+    let dto: CreateGroupDto = serde_json::from_str(json).unwrap();
+    assert_eq!(
+        dto.type_path,
+        "gts.x.system.rg.type.v1~x.test.dto.mytype.v1~"
+    );
+    assert_eq!(dto.name, "X");
+    assert!(dto.parent_id.is_none());
+}
+
+// TC-DTO-06: Deserialize with no vectors -> defaults to empty
+#[test]
+fn dto_create_type_deserialize_missing_vectors_default_empty() {
+    let json = r#"{"code": "gts.x.system.rg.type.v1~x.test.dto.mytype.v1~", "can_be_root": true}"#;
+    let dto: CreateTypeDto = serde_json::from_str(json).unwrap();
+    assert!(dto.allowed_parent_types.is_empty());
+    assert!(dto.allowed_membership_types.is_empty());
+}
+
+// TC-DTO-07: MembershipDto serialization has no tenant_id key
+#[test]
+fn dto_membership_serialize_no_tenant_id() {
+    let membership = ResourceGroupMembership {
+        group_id: Uuid::now_v7(),
+        resource_type: "gts.x.system.rg.type.v1~".to_owned(),
+        resource_id: "res-001".to_owned(),
+    };
+    let dto: MembershipDto = membership.into();
+    let json = serde_json::to_value(&dto).unwrap();
+    assert!(
+        json.get("tenant_id").is_none(),
+        "MembershipDto should not contain tenant_id, got: {json}"
+    );
+    assert!(json.get("group_id").is_some());
+    assert!(json.get("resource_type").is_some());
+    assert!(json.get("resource_id").is_some());
+}

--- a/modules/system/resource-group/resource-group/src/infra/storage/odata_mapper.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/odata_mapper.rs
@@ -1,4 +1,5 @@
 // Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-29 by Constructor Tech
 // @cpt-dod:cpt-cf-resource-group-dod-sdk-foundation-rest-odata:p1
 //! Infrastructure layer mapping from type-safe `FilterNode` to `SeaORM` Conditions.
 //!
@@ -137,3 +138,7 @@ impl ODataFieldMapping<MembershipFilterField> for MembershipODataMapper {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "odata_mapper_tests.rs"]
+mod tests;

--- a/modules/system/resource-group/resource-group/src/infra/storage/odata_mapper_tests.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/odata_mapper_tests.rs
@@ -1,0 +1,90 @@
+// Created: 2026-04-16 by Constructor Tech
+use super::*;
+
+// TC-ODATA-06: TypeODataMapper field -> column
+#[test]
+fn type_odata_mapper_field_to_column() {
+    let col = TypeODataMapper::map_field(TypeFilterField::Code);
+    assert!(
+        matches!(col, TypeColumn::SchemaId),
+        "Expected TypeColumn::SchemaId, got: {col:?}"
+    );
+}
+
+// TC-ODATA-07: GroupODataMapper field -> column
+#[test]
+fn group_odata_mapper_field_to_column() {
+    assert!(
+        matches!(
+            GroupODataMapper::map_field(GroupFilterField::Type),
+            GroupColumn::GtsTypeId
+        ),
+        "Type -> GtsTypeId"
+    );
+    assert!(
+        matches!(
+            GroupODataMapper::map_field(GroupFilterField::HierarchyParentId),
+            GroupColumn::ParentId
+        ),
+        "HierarchyParentId -> ParentId"
+    );
+    assert!(
+        matches!(
+            GroupODataMapper::map_field(GroupFilterField::Id),
+            GroupColumn::Id
+        ),
+        "Id -> Id"
+    );
+    assert!(
+        matches!(
+            GroupODataMapper::map_field(GroupFilterField::Name),
+            GroupColumn::Name
+        ),
+        "Name -> Name"
+    );
+}
+
+// TC-ODATA-08a: HierarchyODataMapper field -> column
+#[test]
+fn hierarchy_odata_mapper_field_to_column() {
+    assert!(
+        matches!(
+            HierarchyODataMapper::map_field(HierarchyFilterField::HierarchyDepth),
+            GroupColumn::Id
+        ),
+        "HierarchyDepth -> Id (placeholder)"
+    );
+    assert!(
+        matches!(
+            HierarchyODataMapper::map_field(HierarchyFilterField::Type),
+            GroupColumn::GtsTypeId
+        ),
+        "Type -> GtsTypeId"
+    );
+}
+
+// TC-ODATA-08: MembershipODataMapper field -> column
+#[test]
+fn membership_odata_mapper_field_to_column() {
+    assert!(
+        matches!(
+            MembershipODataMapper::map_field(MembershipFilterField::GroupId),
+            MembershipColumn::GroupId
+        ),
+        "GroupId -> GroupId"
+    );
+    assert!(
+        matches!(
+            MembershipODataMapper::map_field(MembershipFilterField::ResourceType),
+            MembershipColumn::GtsTypeId
+        ),
+        "ResourceType -> GtsTypeId"
+    );
+    assert!(
+        matches!(
+            MembershipODataMapper::map_field(MembershipFilterField::ResourceId),
+            MembershipColumn::ResourceId
+        ),
+        "ResourceId -> ResourceId"
+    );
+}

--- a/modules/system/resource-group/resource-group/tests/common/mod.rs
+++ b/modules/system/resource-group/resource-group/tests/common/mod.rs
@@ -1,0 +1,349 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-e2e-test-suite:p1
+#![allow(dead_code, clippy::expect_used, clippy::doc_markdown)]
+//! Shared test helpers for resource-group integration tests.
+//!
+//! Provides database setup, service construction, security context helpers,
+//! and assertion utilities. Used by Phases 2-5 of the unit test plan.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use authz_resolver_sdk::{
+    AuthZResolverClient, AuthZResolverError, EvaluationRequest, EvaluationResponse,
+    EvaluationResponseContext, PolicyEnforcer,
+    constraints::{Constraint, InPredicate, Predicate},
+};
+use modkit_db::{
+    ConnectOpts, DBProvider, DbError, connect_db, migration_runner::run_migrations_for_testing,
+};
+use modkit_security::{SecurityContext, pep_properties};
+use sea_orm_migration::MigratorTrait;
+
+use cf_resource_group::domain::group_service::{GroupService, QueryProfile};
+use cf_resource_group::domain::membership_service::MembershipService;
+use cf_resource_group::domain::type_service::TypeService;
+use cf_resource_group::infra::storage::group_repo::GroupRepository;
+use cf_resource_group::infra::storage::membership_repo::MembershipRepository;
+use cf_resource_group::infra::storage::migrations::Migrator;
+use cf_resource_group::infra::storage::type_repo::TypeRepository;
+use resource_group_sdk::{
+    CreateGroupRequest, CreateTypeRequest, ResourceGroup as ResourceGroupModel, ResourceGroupType,
+};
+
+// -- Stub TypesRegistryClient (returns NotFound for all types — metadata validation skipped) --
+
+struct StubTypesRegistry;
+
+#[async_trait]
+impl types_registry_sdk::TypesRegistryClient for StubTypesRegistry {
+    async fn register(
+        &self,
+        _entities: Vec<serde_json::Value>,
+    ) -> Result<Vec<types_registry_sdk::RegisterResult>, types_registry_sdk::TypesRegistryError>
+    {
+        Ok(vec![])
+    }
+
+    async fn list(
+        &self,
+        _query: types_registry_sdk::ListQuery,
+    ) -> Result<Vec<types_registry_sdk::GtsEntity>, types_registry_sdk::TypesRegistryError> {
+        Ok(vec![])
+    }
+
+    async fn get(
+        &self,
+        gts_id: &str,
+    ) -> Result<types_registry_sdk::GtsEntity, types_registry_sdk::TypesRegistryError> {
+        Err(types_registry_sdk::TypesRegistryError::not_found(gts_id))
+    }
+}
+
+/// Build stub `TypesRegistryClient` for tests.
+pub fn make_types_registry() -> Arc<dyn types_registry_sdk::TypesRegistryClient> {
+    Arc::new(StubTypesRegistry)
+}
+
+// -- AllowAll AuthZ mock --
+
+struct AllowAllAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for AllowAllAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let tenant_id = request
+            .subject
+            .properties
+            .get("tenant_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+            .unwrap_or(Uuid::nil());
+
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext {
+                constraints: vec![Constraint {
+                    predicates: vec![Predicate::In(InPredicate::new(
+                        pep_properties::OWNER_TENANT_ID,
+                        [tenant_id],
+                    ))],
+                }],
+                deny_reason: None,
+            },
+        })
+    }
+}
+
+/// Build a `SecurityContext` for anonymous (nil tenant) -- matches `SecurityContext::anonymous()`.
+pub fn make_anon_ctx() -> SecurityContext {
+    SecurityContext::anonymous()
+}
+
+// -- Database setup --
+
+/// Create an in-memory SQLite database with migrations applied.
+pub async fn test_db() -> Arc<DBProvider<DbError>> {
+    let opts = ConnectOpts {
+        max_conns: Some(1),
+        min_conns: Some(1),
+        ..Default::default()
+    };
+    let db = connect_db("sqlite::memory:", opts)
+        .await
+        .expect("connect to in-memory SQLite");
+
+    run_migrations_for_testing(&db, Migrator::migrations())
+        .await
+        .expect("run migrations");
+
+    Arc::new(DBProvider::new(db))
+}
+
+// -- Security context --
+
+/// Build a `SecurityContext` for the given tenant.
+pub fn make_ctx(tenant_id: Uuid) -> SecurityContext {
+    SecurityContext::builder()
+        .subject_id(Uuid::now_v7())
+        .subject_tenant_id(tenant_id)
+        .build()
+        .expect("valid SecurityContext")
+}
+
+/// Build an allow-all `PolicyEnforcer` with tenant scoping.
+pub fn make_enforcer() -> PolicyEnforcer {
+    let authz: Arc<dyn AuthZResolverClient> = Arc::new(AllowAllAuthZ);
+    PolicyEnforcer::new(authz)
+}
+
+// -- Type helpers --
+
+/// Create a root type (can_be_root = true, no parents, no memberships).
+pub async fn create_root_type(
+    svc: &TypeService<TypeRepository>,
+    suffix: &str,
+) -> ResourceGroupType {
+    let code = format!(
+        "gts.cf.core.rg.type.v1~x.test.{}{}.v1~",
+        suffix,
+        Uuid::now_v7().as_simple()
+    );
+    svc.create_type(CreateTypeRequest {
+        code,
+        can_be_root: true,
+        allowed_parent_types: vec![],
+        allowed_membership_types: vec![],
+        metadata_schema: None,
+    })
+    .await
+    .expect("create root type")
+}
+
+/// Create a child type with specified allowed parents and memberships.
+pub async fn create_child_type(
+    svc: &TypeService<TypeRepository>,
+    suffix: &str,
+    parents: &[&str],
+    memberships: &[&str],
+) -> ResourceGroupType {
+    let code = format!(
+        "gts.cf.core.rg.type.v1~x.test.{}{}.v1~",
+        suffix,
+        Uuid::now_v7().as_simple()
+    );
+    svc.create_type(CreateTypeRequest {
+        code,
+        can_be_root: false,
+        allowed_parent_types: parents.iter().map(|s| (*s).to_owned()).collect(),
+        allowed_membership_types: memberships.iter().map(|s| (*s).to_owned()).collect(),
+        metadata_schema: None,
+    })
+    .await
+    .expect("create child type")
+}
+
+// -- Group helpers --
+
+/// Create a root group of the given type.
+pub async fn create_root_group(
+    svc: &GroupService<GroupRepository, TypeRepository>,
+    ctx: &SecurityContext,
+    type_code: &str,
+    name: &str,
+    tenant_id: Uuid,
+) -> ResourceGroupModel {
+    svc.create_group(
+        ctx,
+        CreateGroupRequest {
+            id: None,
+            code: type_code.to_owned(),
+            name: name.to_owned(),
+            parent_id: None,
+            metadata: None,
+        },
+        tenant_id,
+    )
+    .await
+    .expect("create root group")
+}
+
+/// Create a child group under the given parent.
+pub async fn create_child_group(
+    svc: &GroupService<GroupRepository, TypeRepository>,
+    ctx: &SecurityContext,
+    type_code: &str,
+    parent_id: Uuid,
+    name: &str,
+    tenant_id: Uuid,
+) -> ResourceGroupModel {
+    svc.create_group(
+        ctx,
+        CreateGroupRequest {
+            id: None,
+            code: type_code.to_owned(),
+            name: name.to_owned(),
+            parent_id: Some(parent_id),
+            metadata: None,
+        },
+        tenant_id,
+    )
+    .await
+    .expect("create child group")
+}
+
+// -- Closure table assertions --
+
+/// Assert that the closure table contains exactly the expected (ancestor, depth)
+/// pairs for a given descendant.
+#[allow(clippy::disallowed_methods)]
+pub async fn assert_closure_rows(
+    conn: &impl modkit_db::secure::DBRunner,
+    descendant_id: Uuid,
+    expected: &[(Uuid, i32)],
+) {
+    use cf_resource_group::infra::storage::entity::resource_group_closure::{
+        Column, Entity as ClosureEntity,
+    };
+    use modkit_db::secure::SecureEntityExt;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let scope = modkit_security::AccessScope::allow_all();
+    let rows = ClosureEntity::find()
+        .filter(Column::DescendantId.eq(descendant_id))
+        .secure()
+        .scope_with(&scope)
+        .all(conn)
+        .await
+        .expect("query closure table");
+
+    let mut actual: Vec<(Uuid, i32)> = rows.iter().map(|r| (r.ancestor_id, r.depth)).collect();
+    actual.sort_by_key(|(id, d)| (*id, *d));
+
+    let mut exp: Vec<(Uuid, i32)> = expected.to_vec();
+    exp.sort_by_key(|(id, d)| (*id, *d));
+
+    assert_eq!(
+        actual, exp,
+        "Closure rows for descendant {descendant_id} mismatch.\n  actual:   {actual:?}\n  expected: {exp:?}"
+    );
+}
+
+/// Assert that the total number of closure rows for a set of group IDs
+/// matches the expected count.
+#[allow(clippy::disallowed_methods)]
+pub async fn assert_closure_count(
+    conn: &impl modkit_db::secure::DBRunner,
+    group_ids: &[Uuid],
+    expected_total: usize,
+) {
+    use cf_resource_group::infra::storage::entity::resource_group_closure::{
+        Column, Entity as ClosureEntity,
+    };
+    use modkit_db::secure::SecureEntityExt;
+    use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+
+    let scope = modkit_security::AccessScope::allow_all();
+    let rows = ClosureEntity::find()
+        .filter(Column::DescendantId.is_in(group_ids.iter().copied()))
+        .secure()
+        .scope_with(&scope)
+        .all(conn)
+        .await
+        .expect("query closure table");
+
+    assert_eq!(
+        rows.len(),
+        expected_total,
+        "Expected {expected_total} closure rows for groups {group_ids:?}, got {}",
+        rows.len()
+    );
+}
+
+/// Assert that a JSON value contains no surrogate integer IDs
+/// (e.g. `gts_type_id` SMALLINT fields should not leak to the API).
+pub fn assert_no_surrogate_ids(json: &serde_json::Value) {
+    let text = json.to_string();
+    assert!(
+        !text.contains("gts_type_id"),
+        "JSON should not contain surrogate 'gts_type_id': {text}"
+    );
+    assert!(
+        !text.contains("schema_id"),
+        "JSON should not contain surrogate 'schema_id': {text}"
+    );
+}
+
+// -- Service construction helpers --
+
+/// Build a `GroupService` from a DB provider using the allow-all enforcer.
+pub fn make_group_service(
+    db: Arc<DBProvider<DbError>>,
+) -> GroupService<GroupRepository, TypeRepository> {
+    GroupService::new(
+        db,
+        QueryProfile::default(),
+        make_enforcer(),
+        Arc::new(GroupRepository),
+        Arc::new(TypeRepository),
+        make_types_registry(),
+    )
+}
+
+/// Build a `MembershipService` from a DB provider using the allow-all enforcer.
+pub fn make_membership_service(
+    db: Arc<DBProvider<DbError>>,
+) -> MembershipService<GroupRepository, TypeRepository, MembershipRepository> {
+    MembershipService::new(
+        db,
+        make_enforcer(),
+        Arc::new(GroupRepository),
+        Arc::new(TypeRepository),
+        Arc::new(MembershipRepository),
+    )
+}

--- a/modules/system/resource-group/resource-group/tests/group_service_test.rs
+++ b/modules/system/resource-group/resource-group/tests/group_service_test.rs
@@ -1,0 +1,2683 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-testing-entity-hierarchy:p1
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::doc_markdown)]
+//! Phase 3 tests: Entity hierarchy operations.
+//!
+//! Covers TC-GRP-01..38, TC-META-12..18.
+//! Group CRUD, parent-child with closure table verification, move with subtree
+//! rebuild, cycle detection, type compatibility, query profile enforcement,
+//! delete with reference checks, force cascade, hierarchy depth traversal,
+//! and group metadata (barrier) storage and retrieval.
+
+mod common;
+
+use std::sync::Arc;
+
+use serde_json::json;
+use uuid::Uuid;
+
+use cf_resource_group::domain::error::DomainError;
+use cf_resource_group::domain::group_service::{GroupService, QueryProfile};
+use cf_resource_group::domain::type_service::TypeService;
+use cf_resource_group::infra::storage::entity::gts_type::{
+    Column as GtsTypeColumn, Entity as GtsTypeEntity,
+};
+use cf_resource_group::infra::storage::entity::resource_group::{
+    Column as RgColumn, Entity as RgEntity,
+};
+use cf_resource_group::infra::storage::entity::resource_group_membership::{
+    self as membership_entity, Entity as MembershipEntity,
+};
+use cf_resource_group::infra::storage::group_repo::GroupRepository;
+use cf_resource_group::infra::storage::type_repo::TypeRepository;
+use modkit_db::secure::{SecureEntityExt, secure_insert};
+use modkit_odata::ODataQuery;
+use modkit_security::AccessScope;
+use resource_group_sdk::{CreateGroupRequest, CreateTypeRequest, UpdateGroupRequest};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
+
+/// Build a `GroupService` with custom `QueryProfile`.
+fn make_group_service_with_profile(
+    db: std::sync::Arc<modkit_db::DBProvider<modkit_db::DbError>>,
+    profile: QueryProfile,
+) -> GroupService<GroupRepository, TypeRepository> {
+    GroupService::new(
+        db,
+        profile,
+        common::make_enforcer(),
+        Arc::new(GroupRepository),
+        Arc::new(TypeRepository),
+        common::make_types_registry(),
+    )
+}
+
+// =========================================================================
+// Group creation tests (TC-GRP-01, 02, 03, 04, 22, 23, 24, 25)
+// =========================================================================
+
+/// TC-GRP-01: Create child group with parent -- closure rows.
+/// Child has parent_id, closure: self(0) + ancestor(1).
+#[tokio::test]
+async fn group_create_child_with_closure() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    // Create a root type and a child type that allows it as parent
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+
+    // Create root group
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+
+    // Create child group
+    let child = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child",
+        tenant_id,
+    )
+    .await;
+
+    // Verify child fields
+    assert_eq!(child.hierarchy.parent_id, Some(root.id));
+    assert_eq!(child.hierarchy.tenant_id, tenant_id);
+    assert_eq!(child.name, "Child");
+
+    // Verify closure table: root has self-row only
+    let conn = db.conn().expect("conn");
+    common::assert_closure_rows(&conn, root.id, &[(root.id, 0)]).await;
+
+    // Verify closure table: child has self-row + ancestor at depth 1
+    common::assert_closure_rows(&conn, child.id, &[(child.id, 0), (root.id, 1)]).await;
+}
+
+/// TC-GRP-02: 3-level hierarchy -- closure completeness.
+/// Child: grandparent(2), parent(1), self(0). Total 6 rows.
+#[tokio::test]
+async fn group_three_level_hierarchy_closure() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+    // Grandchild type allows child_type as parent
+    let grandchild_type =
+        common::create_child_type(&type_svc, "team", &[&child_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+    let child = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child",
+        tenant_id,
+    )
+    .await;
+    let grandchild = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &grandchild_type.code,
+        child.id,
+        "Grandchild",
+        tenant_id,
+    )
+    .await;
+
+    let conn = db.conn().expect("conn");
+
+    // Root: self only
+    common::assert_closure_rows(&conn, root.id, &[(root.id, 0)]).await;
+    // Child: self + root at depth 1
+    common::assert_closure_rows(&conn, child.id, &[(child.id, 0), (root.id, 1)]).await;
+    // Grandchild: self + child(1) + root(2)
+    common::assert_closure_rows(
+        &conn,
+        grandchild.id,
+        &[(grandchild.id, 0), (child.id, 1), (root.id, 2)],
+    )
+    .await;
+
+    // Total closure rows for all 3 groups = 1 + 2 + 3 = 6
+    common::assert_closure_count(&conn, &[root.id, child.id, grandchild.id], 6).await;
+}
+
+/// TC-GRP-03: Create group with incompatible parent type.
+#[tokio::test]
+async fn group_create_incompatible_parent_type() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let other_root_type = common::create_root_type(&type_svc, "other").await;
+    // unrelated_type allows only other_root_type as parent, NOT root_type
+    let unrelated_type =
+        common::create_child_type(&type_svc, "unrelated", &[&other_root_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: unrelated_type.code.clone(),
+                name: "Bad".to_owned(),
+                parent_id: Some(root.id),
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::InvalidParentType { .. }),
+        "Expected InvalidParentType, got: {err:?}"
+    );
+}
+
+/// TC-GRP-04: Create root when can_be_root=false.
+#[tokio::test]
+async fn group_create_root_when_cannot_be_root() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: child_type.code.clone(),
+                name: "Rootless".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::InvalidParentType { ref message } if message.contains("cannot be a root group")),
+        "Expected InvalidParentType with 'cannot be a root group', got: {err:?}"
+    );
+}
+
+/// TC-GRP-22: Create group with nonexistent type_path.
+#[tokio::test]
+async fn group_create_nonexistent_type() {
+    let db = common::test_db().await;
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: "gts.cf.core.rg.type.v1~x.test.nonexistent.v1~".to_owned(),
+                name: "Ghost".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::TypeNotFound { .. }),
+        "Expected TypeNotFound, got: {err:?}"
+    );
+}
+
+/// TC-GRP-23: Child group cross-tenant parent.
+#[tokio::test]
+async fn group_create_cross_tenant_parent() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+
+    let tenant_a = Uuid::now_v7();
+    let tenant_b = Uuid::now_v7();
+    let ctx_a = common::make_ctx(tenant_a);
+    let ctx_b = common::make_ctx(tenant_b);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+
+    // Create root under tenant A
+    let root_a =
+        common::create_root_group(&group_svc, &ctx_a, &root_type.code, "RootA", tenant_a).await;
+
+    // Try to create child under tenant B with parent in tenant A
+    let err = group_svc
+        .create_group(
+            &ctx_b,
+            CreateGroupRequest {
+                id: None,
+                code: child_type.code.clone(),
+                name: "CrossTenant".to_owned(),
+                parent_id: Some(root_a.id),
+                metadata: None,
+            },
+            tenant_b,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::Validation { ref message } if message.contains("must match parent tenant_id")),
+        "Expected Validation with tenant mismatch, got: {err:?}"
+    );
+}
+
+/// TC-GRP-24: Create group with metadata JSONB.
+#[tokio::test]
+async fn group_create_with_metadata() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+
+    let meta = json!({"department": "engineering", "code": 42});
+    let group = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: "WithMeta".to_owned(),
+                parent_id: None,
+                metadata: Some(meta.clone()),
+            },
+            tenant_id,
+        )
+        .await
+        .expect("create group with metadata");
+
+    assert_eq!(group.metadata, Some(meta.clone()));
+
+    // Verify DB directly
+    let conn = db.conn().expect("conn");
+    let scope = AccessScope::allow_all();
+    let model = RgEntity::find()
+        .filter(RgColumn::Id.eq(group.id))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("found");
+    assert_eq!(model.metadata, Some(meta));
+}
+
+/// TC-GRP-25: Multiple root groups same type.
+#[tokio::test]
+async fn group_multiple_roots_same_type() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+
+    let root1 =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root1", tenant_id).await;
+    let root2 =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root2", tenant_id).await;
+
+    assert_ne!(root1.id, root2.id);
+    assert_eq!(root1.code, root2.code);
+
+    // Both have self-row closure only
+    let conn = db.conn().expect("conn");
+    common::assert_closure_rows(&conn, root1.id, &[(root1.id, 0)]).await;
+    common::assert_closure_rows(&conn, root2.id, &[(root2.id, 0)]).await;
+}
+
+// =========================================================================
+// Group move tests (TC-GRP-05, 06, 07, 08, 29, 30, 31, 32, 33)
+// =========================================================================
+
+/// TC-GRP-05: Move group -- closure rebuild.
+/// Child.parent_id==Root2. Old paths to Root1 removed. New paths correct.
+#[tokio::test]
+async fn group_move_closure_rebuild() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+    let grandchild_type =
+        common::create_child_type(&type_svc, "team", &[&child_type.code], &[]).await;
+
+    let root1 =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root1", tenant_id).await;
+    let root2 =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root2", tenant_id).await;
+    let child = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root1.id,
+        "Child",
+        tenant_id,
+    )
+    .await;
+    let grandchild = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &grandchild_type.code,
+        child.id,
+        "Grandchild",
+        tenant_id,
+    )
+    .await;
+
+    // Move child (and its subtree) from root1 to root2
+    let moved = group_svc
+        .move_group(child.id, Some(root2.id))
+        .await
+        .expect("move group");
+
+    assert_eq!(moved.hierarchy.parent_id, Some(root2.id));
+
+    let conn = db.conn().expect("conn");
+
+    // Root1 untouched: still just self-row
+    common::assert_closure_rows(&conn, root1.id, &[(root1.id, 0)]).await;
+
+    // Root2 still just self-row
+    common::assert_closure_rows(&conn, root2.id, &[(root2.id, 0)]).await;
+
+    // Child: now has self + root2(1), no root1
+    common::assert_closure_rows(&conn, child.id, &[(child.id, 0), (root2.id, 1)]).await;
+
+    // Grandchild: self + child(1) + root2(2), no root1
+    common::assert_closure_rows(
+        &conn,
+        grandchild.id,
+        &[(grandchild.id, 0), (child.id, 1), (root2.id, 2)],
+    )
+    .await;
+
+    // Verify entity state: parent_id changed, name and tenant_id unchanged
+    let scope = AccessScope::allow_all();
+    let model = RgEntity::find()
+        .filter(RgColumn::Id.eq(child.id))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("found");
+    assert_eq!(model.parent_id, Some(root2.id));
+    assert_eq!(model.tenant_id, tenant_id);
+    assert_eq!(model.name, "Child");
+}
+
+/// TC-GRP-06: Move under descendant -> CycleDetected.
+#[tokio::test]
+async fn group_move_under_descendant_cycle() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+    let child = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child",
+        tenant_id,
+    )
+    .await;
+
+    // Try to move root under its child
+    let err = group_svc
+        .move_group(root.id, Some(child.id))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::CycleDetected { .. }),
+        "Expected CycleDetected, got: {err:?}"
+    );
+}
+
+/// TC-GRP-07: Self-parent -> CycleDetected.
+#[tokio::test]
+async fn group_move_self_parent_cycle() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+
+    let err = group_svc
+        .move_group(root.id, Some(root.id))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::CycleDetected { .. }),
+        "Expected CycleDetected, got: {err:?}"
+    );
+}
+
+/// TC-GRP-08: Move to incompatible parent type.
+#[tokio::test]
+async fn group_move_incompatible_parent_type() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let type_a = common::create_root_type(&type_svc, "orgA").await;
+    let type_b = common::create_root_type(&type_svc, "orgB").await;
+    // child type only allows type_a as parent
+    let child_type = common::create_child_type(&type_svc, "dept", &[&type_a.code], &[]).await;
+
+    let root_a =
+        common::create_root_group(&group_svc, &ctx, &type_a.code, "RootA", tenant_id).await;
+    let root_b =
+        common::create_root_group(&group_svc, &ctx, &type_b.code, "RootB", tenant_id).await;
+    let child = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root_a.id,
+        "Child",
+        tenant_id,
+    )
+    .await;
+
+    // Move child to root_b (incompatible)
+    let err = group_svc
+        .move_group(child.id, Some(root_b.id))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::InvalidParentType { .. }),
+        "Expected InvalidParentType, got: {err:?}"
+    );
+}
+
+/// TC-GRP-29: Move child to root (detach).
+/// parent_id=None, closure rebuilt (self-row only).
+#[tokio::test]
+async fn group_move_child_to_root() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    // Create a type that can be both root and child
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_code = format!(
+        "gts.cf.core.rg.type.v1~x.test.flexible{}.v1~",
+        Uuid::now_v7().as_simple()
+    );
+    let _flexible_type = type_svc
+        .create_type(CreateTypeRequest {
+            code: child_code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![root_type.code.clone()],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create flexible type");
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+    let child =
+        common::create_child_group(&group_svc, &ctx, &child_code, root.id, "Child", tenant_id)
+            .await;
+
+    // Move child to root (detach from parent)
+    let moved = group_svc
+        .move_group(child.id, None)
+        .await
+        .expect("move to root");
+
+    assert_eq!(moved.hierarchy.parent_id, None);
+
+    let conn = db.conn().expect("conn");
+    // Child should have only self-row now
+    common::assert_closure_rows(&conn, child.id, &[(child.id, 0)]).await;
+    common::assert_closure_count(&conn, &[child.id], 1).await;
+}
+
+/// TC-GRP-30: Move to root when can_be_root=false.
+#[tokio::test]
+async fn group_move_to_root_cannot_be_root() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+    let child = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child",
+        tenant_id,
+    )
+    .await;
+
+    let err = group_svc.move_group(child.id, None).await.unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::InvalidParentType { ref message } if message.contains("cannot be a root group")),
+        "Expected InvalidParentType with 'cannot be a root group', got: {err:?}"
+    );
+}
+
+/// TC-GRP-31: Move nonexistent group.
+#[tokio::test]
+async fn group_move_nonexistent() {
+    let db = common::test_db().await;
+    let group_svc = common::make_group_service(db.clone());
+
+    let err = group_svc
+        .move_group(Uuid::now_v7(), None)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::GroupNotFound { .. }),
+        "Expected GroupNotFound, got: {err:?}"
+    );
+}
+
+/// TC-GRP-32: Move to nonexistent parent.
+#[tokio::test]
+async fn group_move_to_nonexistent_parent() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+
+    let err = group_svc
+        .move_group(root.id, Some(Uuid::now_v7()))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::GroupNotFound { .. }),
+        "Expected GroupNotFound, got: {err:?}"
+    );
+}
+
+/// TC-GRP-33: max_width enforcement on move.
+#[tokio::test]
+async fn group_move_max_width_exceeded() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let profile = QueryProfile {
+        max_depth: None,
+        max_width: Some(1),
+    };
+    let group_svc = make_group_service_with_profile(db.clone(), profile);
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_code = format!(
+        "gts.cf.core.rg.type.v1~x.test.flex{}.v1~",
+        Uuid::now_v7().as_simple()
+    );
+    type_svc
+        .create_type(CreateTypeRequest {
+            code: child_code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![root_type.code.clone()],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create flexible child type");
+
+    let root1 =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root1", tenant_id).await;
+    let root2 =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root2", tenant_id).await;
+
+    // Create one child under root1 (fills max_width=1)
+    common::create_child_group(&group_svc, &ctx, &child_code, root1.id, "Child1", tenant_id).await;
+
+    // Create a standalone group, then try to move it under root1
+    let standalone =
+        common::create_root_group(&group_svc, &ctx, &child_code, "Standalone", tenant_id).await;
+
+    let err = group_svc
+        .move_group(standalone.id, Some(root1.id))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::LimitViolation { ref message } if message.contains("Width limit exceeded")),
+        "Expected LimitViolation with 'Width limit exceeded', got: {err:?}"
+    );
+
+    // Verify root2 is unaffected
+    let conn = db.conn().expect("conn");
+    common::assert_closure_rows(&conn, root2.id, &[(root2.id, 0)]).await;
+}
+
+// =========================================================================
+// Group update tests (TC-GRP-09, 10, 11, 26, 27, 28)
+// =========================================================================
+
+/// TC-GRP-09: Update group name and metadata.
+#[tokio::test]
+async fn group_update_name_and_metadata() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "OldName", tenant_id).await;
+
+    let new_meta = json!({"updated": true});
+    let updated = group_svc
+        .update_group(
+            &ctx,
+            root.id,
+            UpdateGroupRequest {
+                name: "NewName".to_owned(),
+                parent_id: None,
+                metadata: Some(new_meta.clone()),
+            },
+        )
+        .await
+        .expect("update group");
+
+    assert_eq!(updated.name, "NewName");
+    assert_eq!(updated.metadata, Some(new_meta.clone()));
+    // parent_id and type unchanged
+    assert_eq!(updated.hierarchy.parent_id, None);
+    assert_eq!(updated.code, root_type.code);
+
+    // Verify DB directly
+    let conn = db.conn().expect("conn");
+    let scope = AccessScope::allow_all();
+    let model = RgEntity::find()
+        .filter(RgColumn::Id.eq(root.id))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("found");
+    assert_eq!(model.name, "NewName");
+    assert_eq!(model.metadata, Some(new_meta));
+}
+
+// Removed: TC-GRP-10 (`group_update_type_parent_incompatible`) and TC-GRP-11
+// (`group_update_type_children_incompatible`) were authored when
+// `UpdateGroupRequest` carried a `code` field. Now that the group's GTS type
+// is immutable post-creation (per DESIGN: "The group's type is immutable
+// after creation"), these scenarios are physically unreachable through the
+// SDK — `update_group` cannot trigger a parent/children type-compatibility
+// failure because the type never changes. Coverage of the underlying
+// invariant lives in the `create_group` and `move_group` paths instead.
+
+// Removed: TC-GRP-26 (`group_update_simultaneous_type_and_parent`),
+// TC-GRP-27 (`group_update_root_to_nonroot_type`), TC-GRP-28
+// (`group_update_nonexistent_type`) — the same reason as TC-GRP-10/11
+// above. All three exercised the now-impossible "type changes via
+// `update_group`" scenario; with `UpdateGroupRequest` carrying only
+// `name` / `parent_id` / `metadata`, none of these cases are
+// physically reachable. Parent change in isolation is already
+// covered by TC-GRP-09 (`group_update`).
+
+// =========================================================================
+// Group delete tests (TC-GRP-12, 13, 14, 15, 34, 35)
+// =========================================================================
+
+/// TC-GRP-12: Delete leaf group.
+/// Success, no group, closure rows removed.
+#[tokio::test]
+async fn group_delete_leaf() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+    let child = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child",
+        tenant_id,
+    )
+    .await;
+
+    // Delete the child (leaf)
+    group_svc
+        .delete_group(&ctx, child.id, false)
+        .await
+        .expect("delete leaf");
+
+    let conn = db.conn().expect("conn");
+
+    // Child's closure rows gone
+    common::assert_closure_count(&conn, &[child.id], 0).await;
+
+    // Group entity gone
+    let scope = AccessScope::allow_all();
+    let model = RgEntity::find()
+        .filter(RgColumn::Id.eq(child.id))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query");
+    assert!(model.is_none(), "Group should be deleted");
+
+    // Parent's closure untouched
+    common::assert_closure_rows(&conn, root.id, &[(root.id, 0)]).await;
+}
+
+/// TC-GRP-13: Delete with children no force.
+#[tokio::test]
+async fn group_delete_with_children_no_force() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+    let _child = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child",
+        tenant_id,
+    )
+    .await;
+
+    let err = group_svc
+        .delete_group(&ctx, root.id, false)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::ConflictActiveReferences { ref message } if message.contains("child group(s)")),
+        "Expected ConflictActiveReferences with 'child group(s)', got: {err:?}"
+    );
+}
+
+/// TC-GRP-14: Delete with memberships no force.
+/// Insert membership rows directly via SeaORM.
+#[tokio::test]
+async fn group_delete_with_memberships_no_force() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+
+    // Insert membership directly. Resolve the surrogate `gts_type_id` from the
+    // type we just created instead of hard-coding `1` — that hard-code would
+    // silently break if `common::test_db()` ever seeds base types or if the
+    // SMALLINT IDENTITY sequence behaviour changes.
+    let conn = db.conn().expect("conn");
+    let scope = AccessScope::allow_all();
+    let root_type_id = GtsTypeEntity::find()
+        .filter(GtsTypeColumn::SchemaId.eq(&root_type.code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query gts_type")
+        .expect("type row exists")
+        .id;
+    let membership = membership_entity::ActiveModel {
+        group_id: Set(root.id),
+        gts_type_id: Set(root_type_id),
+        resource_id: Set("resource-1".to_owned()),
+        ..Default::default()
+    };
+    secure_insert::<MembershipEntity>(membership, &scope, &conn)
+        .await
+        .expect("insert membership");
+
+    let err = group_svc
+        .delete_group(&ctx, root.id, false)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::ConflictActiveReferences { ref message } if message.contains("memberships")),
+        "Expected ConflictActiveReferences with 'memberships', got: {err:?}"
+    );
+}
+
+/// TC-GRP-15: Force delete subtree.
+/// All 3 groups + memberships + closure gone.
+#[tokio::test]
+async fn group_force_delete_subtree() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+    let grandchild_type =
+        common::create_child_type(&type_svc, "team", &[&child_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+    let child = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child",
+        tenant_id,
+    )
+    .await;
+    let grandchild = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &grandchild_type.code,
+        child.id,
+        "Grandchild",
+        tenant_id,
+    )
+    .await;
+
+    // Add a membership to child (direct insert). Resolve the surrogate
+    // `gts_type_id` from the actual type row instead of hard-coding `1`.
+    let conn = db.conn().expect("conn");
+    let scope = AccessScope::allow_all();
+    let root_type_id = GtsTypeEntity::find()
+        .filter(GtsTypeColumn::SchemaId.eq(&root_type.code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query gts_type")
+        .expect("type row exists")
+        .id;
+    let membership = membership_entity::ActiveModel {
+        group_id: Set(child.id),
+        gts_type_id: Set(root_type_id),
+        resource_id: Set("resource-m".to_owned()),
+        ..Default::default()
+    };
+    secure_insert::<MembershipEntity>(membership, &scope, &conn)
+        .await
+        .expect("insert membership");
+
+    // Force delete root subtree
+    group_svc
+        .delete_group(&ctx, root.id, true)
+        .await
+        .expect("force delete");
+
+    // All 3 groups gone
+    for gid in &[root.id, child.id, grandchild.id] {
+        let model = RgEntity::find()
+            .filter(RgColumn::Id.eq(*gid))
+            .secure()
+            .scope_with(&scope)
+            .one(&conn)
+            .await
+            .expect("query");
+        assert!(model.is_none(), "Group {gid} should be deleted");
+    }
+
+    // All closure rows gone
+    common::assert_closure_count(&conn, &[root.id, child.id, grandchild.id], 0).await;
+
+    // Memberships gone
+    let mem_count = MembershipEntity::find()
+        .filter(membership_entity::Column::GroupId.eq(child.id))
+        .secure()
+        .scope_with(&scope)
+        .count(&conn)
+        .await
+        .expect("query memberships");
+    assert_eq!(mem_count, 0, "Memberships should be deleted");
+}
+
+/// TC-GRP-34: Delete nonexistent group.
+#[tokio::test]
+async fn group_delete_nonexistent() {
+    let db = common::test_db().await;
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let err = group_svc
+        .delete_group(&ctx, Uuid::now_v7(), false)
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::GroupNotFound { .. }),
+        "Expected GroupNotFound, got: {err:?}"
+    );
+}
+
+/// TC-GRP-35: Force delete leaf (no descendants).
+#[tokio::test]
+async fn group_force_delete_leaf() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+
+    group_svc
+        .delete_group(&ctx, root.id, true)
+        .await
+        .expect("force delete leaf");
+
+    let conn = db.conn().expect("conn");
+    let scope = AccessScope::allow_all();
+    let model = RgEntity::find()
+        .filter(RgColumn::Id.eq(root.id))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query");
+    assert!(model.is_none(), "Group should be deleted");
+    common::assert_closure_count(&conn, &[root.id], 0).await;
+}
+
+// =========================================================================
+// Hierarchy endpoint tests (TC-GRP-16, 36)
+// =========================================================================
+
+/// TC-GRP-16: Hierarchy endpoint depth traversal.
+/// A(depth=-1), B(depth=0), C(depth=1).
+#[tokio::test]
+async fn group_hierarchy_depth_traversal() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+    let grandchild_type =
+        common::create_child_type(&type_svc, "team", &[&child_type.code], &[]).await;
+
+    let a = common::create_root_group(&group_svc, &ctx, &root_type.code, "A", tenant_id).await;
+    let b =
+        common::create_child_group(&group_svc, &ctx, &child_type.code, a.id, "B", tenant_id).await;
+    let c = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &grandchild_type.code,
+        b.id,
+        "C",
+        tenant_id,
+    )
+    .await;
+
+    let query = ODataQuery::default();
+
+    // Descendants of B: should return B (depth=0) and C (depth=1)
+    let desc_page = group_svc
+        .get_group_descendants(&ctx, b.id, &query)
+        .await
+        .expect("get descendants");
+    assert_eq!(desc_page.items.len(), 2, "Descendants should return B, C");
+    let item_b = desc_page
+        .items
+        .iter()
+        .find(|i| i.id == b.id)
+        .expect("B present");
+    let item_c = desc_page
+        .items
+        .iter()
+        .find(|i| i.id == c.id)
+        .expect("C present");
+    assert_eq!(item_b.hierarchy.depth, 0, "B should be at depth 0");
+    assert_eq!(item_c.hierarchy.depth, 1, "C should be at depth 1");
+
+    // Ancestors of B: should return B (depth=0) and A (depth=-1)
+    let anc_page = group_svc
+        .get_group_ancestors(&ctx, b.id, &query)
+        .await
+        .expect("get ancestors");
+    assert_eq!(anc_page.items.len(), 2, "Ancestors should return A, B");
+    let item_a = anc_page
+        .items
+        .iter()
+        .find(|i| i.id == a.id)
+        .expect("A present");
+    let item_b = anc_page
+        .items
+        .iter()
+        .find(|i| i.id == b.id)
+        .expect("B present in ancestors");
+    assert_eq!(item_a.hierarchy.depth, -1, "A should be at depth -1");
+    assert_eq!(item_b.hierarchy.depth, 0, "B should be at depth 0");
+
+    // All nodes have tenant_id and parent_id
+    assert_eq!(item_a.hierarchy.tenant_id, tenant_id);
+    assert_eq!(item_b.hierarchy.tenant_id, tenant_id);
+    assert_eq!(item_c.hierarchy.tenant_id, tenant_id);
+    assert_eq!(item_a.hierarchy.parent_id, None);
+    assert_eq!(item_b.hierarchy.parent_id, Some(a.id));
+    assert_eq!(item_c.hierarchy.parent_id, Some(b.id));
+}
+
+/// TC-GRP-36: get_group_descendants nonexistent group.
+#[tokio::test]
+async fn group_hierarchy_nonexistent() {
+    let db = common::test_db().await;
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let err = group_svc
+        .get_group_descendants(&ctx, Uuid::now_v7(), &ODataQuery::default())
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::GroupNotFound { .. }),
+        "Expected GroupNotFound, got: {err:?}"
+    );
+}
+
+// =========================================================================
+// Query profile tests (TC-GRP-17, 18, 19, 37, 38)
+// =========================================================================
+
+/// TC-GRP-17: max_depth enforcement on create.
+#[tokio::test]
+async fn group_create_max_depth_exceeded() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let profile = QueryProfile {
+        max_depth: Some(1), // only root allowed (depth 0), child at depth 1 is >= max
+        max_width: None,
+    };
+    let group_svc = make_group_service_with_profile(db.clone(), profile);
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: child_type.code.clone(),
+                name: "TooDeep".to_owned(),
+                parent_id: Some(root.id),
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::LimitViolation { ref message } if message.contains("Depth limit exceeded")),
+        "Expected LimitViolation with 'Depth limit exceeded', got: {err:?}"
+    );
+}
+
+/// TC-GRP-18: max_width enforcement on create.
+#[tokio::test]
+async fn group_create_max_width_exceeded() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let profile = QueryProfile {
+        max_depth: None,
+        max_width: Some(1),
+    };
+    let group_svc = make_group_service_with_profile(db.clone(), profile);
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+
+    // First child ok
+    common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child1",
+        tenant_id,
+    )
+    .await;
+
+    // Second child exceeds max_width
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: child_type.code.clone(),
+                name: "Child2".to_owned(),
+                parent_id: Some(root.id),
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::LimitViolation { ref message } if message.contains("Width limit exceeded")),
+        "Expected LimitViolation with 'Width limit exceeded', got: {err:?}"
+    );
+}
+
+/// TC-GRP-19: max_depth enforcement on move.
+#[tokio::test]
+async fn group_move_max_depth_exceeded() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    // max_depth=2: root(0), child(1) ok, but grandchild(2) would be >= max
+    let profile = QueryProfile {
+        max_depth: Some(2),
+        max_width: None,
+    };
+    let group_svc = make_group_service_with_profile(db.clone(), profile);
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    // child_type allows root_type as parent, can also be root
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+    // sub_type allows child_type as parent, can also be root
+    let sub_code = format!(
+        "gts.cf.core.rg.type.v1~x.test.sub{}.v1~",
+        Uuid::now_v7().as_simple()
+    );
+    type_svc
+        .create_type(CreateTypeRequest {
+            code: sub_code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![child_type.code.clone()],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create sub type");
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+    let child = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child",
+        tenant_id,
+    )
+    .await;
+
+    // Create a standalone root with a sub-child (standalone -> sub)
+    // standalone is child_type (can be root=false, but we need it as root -- use sub_code which can be root)
+    let standalone =
+        common::create_root_group(&group_svc, &ctx, &sub_code, "Standalone", tenant_id).await;
+    // sub needs a type that allows sub_code as parent -- create another type for that
+    let subsub_code = format!(
+        "gts.cf.core.rg.type.v1~x.test.subsub{}.v1~",
+        Uuid::now_v7().as_simple()
+    );
+    type_svc
+        .create_type(CreateTypeRequest {
+            code: subsub_code.clone(),
+            can_be_root: false,
+            allowed_parent_types: vec![sub_code.clone()],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create subsub type");
+
+    let _sub = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &subsub_code,
+        standalone.id,
+        "Sub",
+        tenant_id,
+    )
+    .await;
+
+    // Try to move standalone under child: standalone would be at depth 2, sub at depth 3
+    // max_depth=2, so deepest = 1+1+1 = 3 >= 2 triggers violation
+    // But standalone's type (sub_code) must allow child_type as parent.
+    // Actually sub_code allows child_type as parent, so the move is type-compatible.
+    let err = group_svc
+        .move_group(standalone.id, Some(child.id))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::LimitViolation { ref message } if message.contains("Depth limit")),
+        "Expected LimitViolation, got: {err:?}"
+    );
+}
+
+/// TC-GRP-37: Depth exact boundary (parent_depth+1 == max_depth).
+/// LimitViolation (>= comparison).
+#[tokio::test]
+async fn group_create_depth_exact_boundary() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    // max_depth=2: root is at depth 0, child at depth 1 (parent_depth=0, 0+1=1 < 2 ok)
+    // grandchild at depth 2 (parent_depth=1, 1+1=2 >= 2 -> violation)
+    let profile = QueryProfile {
+        max_depth: Some(2),
+        max_width: None,
+    };
+    let group_svc = make_group_service_with_profile(db.clone(), profile);
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+    let grandchild_type =
+        common::create_child_type(&type_svc, "team", &[&child_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+    let child = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child",
+        tenant_id,
+    )
+    .await;
+
+    // Grandchild at depth 2 should trigger exact boundary violation
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: grandchild_type.code.clone(),
+                name: "Grandchild".to_owned(),
+                parent_id: Some(child.id),
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::LimitViolation { ref message } if message.contains("Depth limit exceeded")),
+        "Expected LimitViolation at exact boundary, got: {err:?}"
+    );
+}
+
+/// TC-GRP-38: Width exact boundary (sibling_count == max_width).
+#[tokio::test]
+async fn group_create_width_exact_boundary() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let profile = QueryProfile {
+        max_depth: None,
+        max_width: Some(2),
+    };
+    let group_svc = make_group_service_with_profile(db.clone(), profile);
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+
+    // Fill to max_width=2
+    common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child1",
+        tenant_id,
+    )
+    .await;
+    common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        root.id,
+        "Child2",
+        tenant_id,
+    )
+    .await;
+
+    // Third child triggers exact boundary (count=2 >= max_width=2)
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: child_type.code.clone(),
+                name: "Child3".to_owned(),
+                parent_id: Some(root.id),
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::LimitViolation { ref message } if message.contains("Width limit exceeded")),
+        "Expected LimitViolation at exact boundary, got: {err:?}"
+    );
+}
+
+// =========================================================================
+// Name validation tests (TC-GRP-20, 21)
+// =========================================================================
+
+/// TC-GRP-20: Group name empty.
+#[tokio::test]
+async fn group_create_name_empty() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: String::new(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::Validation { ref message } if message.contains("between 1 and 255")),
+        "Expected Validation with 'between 1 and 255', got: {err:?}"
+    );
+}
+
+/// TC-GRP-21: Group name >255 chars.
+#[tokio::test]
+async fn group_create_name_too_long() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+
+    let long_name = "x".repeat(256);
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: long_name,
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::Validation { ref message } if message.contains("between 1 and 255")),
+        "Expected Validation with 'between 1 and 255', got: {err:?}"
+    );
+}
+
+// =========================================================================
+// Metadata tests (TC-META-12..18)
+// =========================================================================
+
+/// TC-META-12: Group with metadata self_managed stored/returned.
+/// metadata.self_managed == true, DB JSONB matches.
+#[tokio::test]
+async fn group_metadata_barrier_stored() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+
+    let meta = json!({"self_managed": true});
+    let group = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: "BarrierGroup".to_owned(),
+                parent_id: None,
+                metadata: Some(meta.clone()),
+            },
+            tenant_id,
+        )
+        .await
+        .expect("create barrier group");
+
+    assert_eq!(group.metadata.as_ref().unwrap()["self_managed"], true);
+
+    // Verify DB directly
+    let conn = db.conn().expect("conn");
+    let scope = AccessScope::allow_all();
+    let model = RgEntity::find()
+        .filter(RgColumn::Id.eq(group.id))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("found");
+    assert_eq!(model.metadata, Some(meta));
+}
+
+/// TC-META-13: Group with rich metadata -- multiple fields.
+/// All fields preserved.
+#[tokio::test]
+async fn group_metadata_rich_multiple_fields() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+
+    let meta = json!({
+        "barrier": false,
+        "region": "eu-west-1",
+        "tags": ["prod", "critical"],
+        "nested": {"level": 2, "active": true}
+    });
+    let group = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: "RichMeta".to_owned(),
+                parent_id: None,
+                metadata: Some(meta.clone()),
+            },
+            tenant_id,
+        )
+        .await
+        .expect("create rich metadata group");
+
+    assert_eq!(group.metadata, Some(meta));
+}
+
+/// TC-META-14: Group metadata update replaces entirely (not merge).
+/// Old keys gone.
+#[tokio::test]
+async fn group_metadata_update_replaces_entirely() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+
+    let old_meta = json!({"old_key": "old_value", "shared": 1});
+    let group = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: "ReplaceMe".to_owned(),
+                parent_id: None,
+                metadata: Some(old_meta),
+            },
+            tenant_id,
+        )
+        .await
+        .expect("create group");
+
+    let new_meta = json!({"new_key": "new_value"});
+    let updated = group_svc
+        .update_group(
+            &ctx,
+            group.id,
+            UpdateGroupRequest {
+                name: "ReplaceMe".to_owned(),
+                parent_id: None,
+                metadata: Some(new_meta.clone()),
+            },
+        )
+        .await
+        .expect("update group");
+
+    assert_eq!(updated.metadata, Some(new_meta.clone()));
+    // Old key gone
+    assert!(updated.metadata.as_ref().unwrap().get("old_key").is_none());
+
+    // Verify DB directly
+    let conn = db.conn().expect("conn");
+    let scope = AccessScope::allow_all();
+    let model = RgEntity::find()
+        .filter(RgColumn::Id.eq(group.id))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("found");
+    assert_eq!(model.metadata, Some(new_meta));
+}
+
+/// TC-META-15: Group metadata None -> update with metadata.
+/// Returns new metadata.
+#[tokio::test]
+async fn group_metadata_none_to_some() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+
+    let group = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: "NoMeta".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .expect("create group");
+
+    assert!(group.metadata.is_none());
+
+    let meta = json!({"added": true});
+    let updated = group_svc
+        .update_group(
+            &ctx,
+            group.id,
+            UpdateGroupRequest {
+                name: "NoMeta".to_owned(),
+                parent_id: None,
+                metadata: Some(meta.clone()),
+            },
+        )
+        .await
+        .expect("update group");
+
+    assert_eq!(updated.metadata, Some(meta));
+}
+
+/// TC-META-16: Group metadata set -> update with None.
+/// Metadata gone.
+#[tokio::test]
+async fn group_metadata_some_to_none() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+
+    let meta = json!({"initial": true});
+    let group = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: "WithMeta".to_owned(),
+                parent_id: None,
+                metadata: Some(meta),
+            },
+            tenant_id,
+        )
+        .await
+        .expect("create group");
+
+    let updated = group_svc
+        .update_group(
+            &ctx,
+            group.id,
+            UpdateGroupRequest {
+                name: "WithMeta".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+        )
+        .await
+        .expect("update group");
+
+    assert!(updated.metadata.is_none(), "Metadata should be cleared");
+}
+
+/// TC-META-17: Barrier group visible in hierarchy.
+/// All 3 groups returned including barrier.
+#[tokio::test]
+async fn group_metadata_barrier_in_hierarchy() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+    let grandchild_type =
+        common::create_child_type(&type_svc, "team", &[&child_type.code], &[]).await;
+
+    let root =
+        common::create_root_group(&group_svc, &ctx, &root_type.code, "Root", tenant_id).await;
+
+    // Child is a barrier group
+    let barrier = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: child_type.code.clone(),
+                name: "BarrierChild".to_owned(),
+                parent_id: Some(root.id),
+                metadata: Some(json!({"self_managed": true})),
+            },
+            tenant_id,
+        )
+        .await
+        .expect("create barrier child");
+
+    let _leaf = common::create_child_group(
+        &group_svc,
+        &ctx,
+        &grandchild_type.code,
+        barrier.id,
+        "Leaf",
+        tenant_id,
+    )
+    .await;
+
+    // Query descendants from root — should include root, barrier, leaf
+    let query = ODataQuery::default();
+    let page = group_svc
+        .get_group_descendants(&ctx, root.id, &query)
+        .await
+        .expect("get descendants");
+
+    assert_eq!(
+        page.items.len(),
+        3,
+        "All 3 groups returned including barrier"
+    );
+
+    // Verify barrier is present as a descendant of root
+    let barrier_item = page
+        .items
+        .iter()
+        .find(|i| i.id == barrier.id)
+        .expect("barrier present");
+    assert_eq!(barrier_item.hierarchy.depth, 1, "barrier is child of root");
+}
+
+/// TC-META-18: Group metadata in hierarchy endpoint response.
+/// Each GroupWithDepthDto has metadata.
+#[tokio::test]
+async fn group_metadata_in_hierarchy_response() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "org").await;
+    let child_type = common::create_child_type(&type_svc, "dept", &[&root_type.code], &[]).await;
+
+    let root_meta = json!({"level": "root"});
+    let root = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: "Root".to_owned(),
+                parent_id: None,
+                metadata: Some(root_meta.clone()),
+            },
+            tenant_id,
+        )
+        .await
+        .expect("create root");
+
+    let child_meta = json!({"level": "child", "barrier": false});
+    let child = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: child_type.code.clone(),
+                name: "Child".to_owned(),
+                parent_id: Some(root.id),
+                metadata: Some(child_meta.clone()),
+            },
+            tenant_id,
+        )
+        .await
+        .expect("create child");
+
+    let query = ODataQuery::default();
+    let page = group_svc
+        .get_group_descendants(&ctx, root.id, &query)
+        .await
+        .expect("get descendants");
+
+    let root_item = page
+        .items
+        .iter()
+        .find(|i| i.id == root.id)
+        .expect("root present");
+    let child_item = page
+        .items
+        .iter()
+        .find(|i| i.id == child.id)
+        .expect("child present");
+
+    assert_eq!(root_item.metadata, Some(root_meta));
+    assert_eq!(child_item.metadata, Some(child_meta));
+}
+
+// =========================================================================
+// ADR-001 Hierarchy Reproduction (TC-ADR-01..08)
+// =========================================================================
+
+/// Helper: build the ADR-001 type ecosystem.
+/// Returns (tenant_type, dept_type, branch_type, user_type, course_type).
+async fn create_adr_types(
+    type_svc: &cf_resource_group::domain::type_service::TypeService<TypeRepository>,
+) -> (
+    resource_group_sdk::ResourceGroupType,
+    resource_group_sdk::ResourceGroupType,
+    resource_group_sdk::ResourceGroupType,
+    resource_group_sdk::ResourceGroupType,
+    resource_group_sdk::ResourceGroupType,
+) {
+    let user_type = common::create_root_type(type_svc, "adruser").await;
+    let course_type = common::create_root_type(type_svc, "adrcourse").await;
+
+    let suffix_t = format!("adrtenant{}", uuid::Uuid::now_v7().as_simple());
+    let tenant_code = format!("gts.cf.core.rg.type.v1~x.test.{suffix_t}.v1~");
+
+    // Tenant type: create first without self-reference, then update
+    type_svc
+        .create_type(CreateTypeRequest {
+            code: tenant_code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![user_type.code.clone()],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create tenant type");
+
+    let tenant_type = type_svc
+        .update_type(
+            &tenant_code,
+            resource_group_sdk::UpdateTypeRequest {
+                can_be_root: true,
+                allowed_parent_types: vec![tenant_code.clone()],
+                allowed_membership_types: vec![user_type.code.clone()],
+                metadata_schema: None,
+            },
+        )
+        .await
+        .expect("update tenant type with self-reference");
+
+    // Dept type: NOT root, parent=tenant, allows users+courses
+    let dept_type = common::create_child_type(
+        type_svc,
+        "adrdept",
+        &[&tenant_type.code],
+        &[&user_type.code, &course_type.code],
+    )
+    .await;
+
+    // Branch type: NOT root, parent=dept, allows users+courses
+    let branch_type = common::create_child_type(
+        type_svc,
+        "adrbranch",
+        &[&dept_type.code],
+        &[&user_type.code, &course_type.code],
+    )
+    .await;
+
+    (tenant_type, dept_type, branch_type, user_type, course_type)
+}
+
+/// TC-ADR-01: Full ADR hierarchy reproduction.
+/// Creates T1, D2, B3, T7, D8, T9 with types + memberships.
+#[tokio::test]
+async fn adr_full_hierarchy_reproduction() {
+    let db = common::test_db().await;
+    let type_svc = cf_resource_group::domain::type_service::TypeService::new(
+        db.clone(),
+        Arc::new(TypeRepository),
+    );
+    let group_svc = common::make_group_service(db.clone());
+    let membership_svc = common::make_membership_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let (tenant_type, dept_type, branch_type, user_type, course_type) =
+        create_adr_types(&type_svc).await;
+
+    // T1: root tenant
+    let t1 = common::create_root_group(&group_svc, &ctx, &tenant_type.code, "T1", tenant_id).await;
+    // D2: dept under T1
+    let d2 =
+        common::create_child_group(&group_svc, &ctx, &dept_type.code, t1.id, "D2", tenant_id).await;
+    // B3: branch under D2
+    let b3 =
+        common::create_child_group(&group_svc, &ctx, &branch_type.code, d2.id, "B3", tenant_id)
+            .await;
+    // T7: tenant under T1 (self-nesting)
+    let t7 =
+        common::create_child_group(&group_svc, &ctx, &tenant_type.code, t1.id, "T7", tenant_id)
+            .await;
+    // D8: dept under T7
+    let d8 =
+        common::create_child_group(&group_svc, &ctx, &dept_type.code, t7.id, "D8", tenant_id).await;
+    // T9: root tenant (independent)
+    let t9 = common::create_root_group(&group_svc, &ctx, &tenant_type.code, "T9", tenant_id).await;
+
+    // Verify hierarchy positions
+    assert!(t1.hierarchy.parent_id.is_none());
+    assert_eq!(d2.hierarchy.parent_id, Some(t1.id));
+    assert_eq!(b3.hierarchy.parent_id, Some(d2.id));
+    assert_eq!(t7.hierarchy.parent_id, Some(t1.id));
+    assert_eq!(d8.hierarchy.parent_id, Some(t7.id));
+    assert!(t9.hierarchy.parent_id.is_none());
+
+    // Verify closure table depths
+    let conn = db.conn().expect("conn");
+    // T1: self(0)
+    common::assert_closure_rows(&conn, t1.id, &[(t1.id, 0)]).await;
+    // D2: self(0), T1(1)
+    common::assert_closure_rows(&conn, d2.id, &[(d2.id, 0), (t1.id, 1)]).await;
+    // B3: self(0), D2(1), T1(2)
+    common::assert_closure_rows(&conn, b3.id, &[(b3.id, 0), (d2.id, 1), (t1.id, 2)]).await;
+    // T7: self(0), T1(1)
+    common::assert_closure_rows(&conn, t7.id, &[(t7.id, 0), (t1.id, 1)]).await;
+    // D8: self(0), T7(1), T1(2)
+    common::assert_closure_rows(&conn, d8.id, &[(d8.id, 0), (t7.id, 1), (t1.id, 2)]).await;
+    // T9: self(0)
+    common::assert_closure_rows(&conn, t9.id, &[(t9.id, 0)]).await;
+
+    // Add memberships: user R4 in T1, course R5 in B3, user R6 in D2
+    membership_svc
+        .add_membership(&ctx, t1.id, &user_type.code, "R4")
+        .await
+        .expect("add R4 user to T1");
+    membership_svc
+        .add_membership(&ctx, b3.id, &course_type.code, "R5")
+        .await
+        .expect("add R5 course to B3");
+    membership_svc
+        .add_membership(&ctx, d2.id, &user_type.code, "R6")
+        .await
+        .expect("add R6 user to D2");
+
+    // Total closure rows: 1 + 2 + 3 + 2 + 3 + 1 = 12
+    common::assert_closure_count(&conn, &[t1.id, d2.id, b3.id, t7.id, d8.id, t9.id], 12).await;
+}
+
+/// TC-ADR-02: Tenant allows self-nesting (T7 under T1).
+#[tokio::test]
+async fn adr_tenant_self_nesting() {
+    let db = common::test_db().await;
+    let type_svc = cf_resource_group::domain::type_service::TypeService::new(
+        db.clone(),
+        Arc::new(TypeRepository),
+    );
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let (tenant_type, _, _, _, _) = create_adr_types(&type_svc).await;
+
+    let t1 = common::create_root_group(&group_svc, &ctx, &tenant_type.code, "T1", tenant_id).await;
+    let t7 =
+        common::create_child_group(&group_svc, &ctx, &tenant_type.code, t1.id, "T7", tenant_id)
+            .await;
+    assert_eq!(t7.hierarchy.parent_id, Some(t1.id));
+}
+
+/// TC-ADR-03: Department cannot be root.
+#[tokio::test]
+async fn adr_department_cannot_be_root() {
+    let db = common::test_db().await;
+    let type_svc = cf_resource_group::domain::type_service::TypeService::new(
+        db.clone(),
+        Arc::new(TypeRepository),
+    );
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let (_, dept_type, _, _, _) = create_adr_types(&type_svc).await;
+
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: dept_type.code.clone(),
+                name: "RootDept".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, DomainError::InvalidParentType { .. }),
+        "Expected InvalidParentType, got {err:?}"
+    );
+}
+
+/// TC-ADR-04: Branch only under department -- fails under tenant.
+#[tokio::test]
+async fn adr_branch_only_under_department() {
+    let db = common::test_db().await;
+    let type_svc = cf_resource_group::domain::type_service::TypeService::new(
+        db.clone(),
+        Arc::new(TypeRepository),
+    );
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let (tenant_type, _, branch_type, _, _) = create_adr_types(&type_svc).await;
+
+    let t1 = common::create_root_group(&group_svc, &ctx, &tenant_type.code, "T1", tenant_id).await;
+
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: branch_type.code.clone(),
+                name: "BadBranch".to_owned(),
+                parent_id: Some(t1.id),
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            DomainError::InvalidParentType { .. } | DomainError::AllowedParentTypesViolation { .. }
+        ),
+        "Expected InvalidParentType or AllowedParentTypesViolation, got {err:?}"
+    );
+}
+
+/// TC-ADR-05: Branch allows users AND courses memberships.
+#[tokio::test]
+async fn adr_branch_allows_users_and_courses() {
+    let db = common::test_db().await;
+    let type_svc = cf_resource_group::domain::type_service::TypeService::new(
+        db.clone(),
+        Arc::new(TypeRepository),
+    );
+    let group_svc = common::make_group_service(db.clone());
+    let membership_svc = common::make_membership_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let (tenant_type, dept_type, branch_type, user_type, course_type) =
+        create_adr_types(&type_svc).await;
+
+    let t1 = common::create_root_group(&group_svc, &ctx, &tenant_type.code, "T1", tenant_id).await;
+    let d2 =
+        common::create_child_group(&group_svc, &ctx, &dept_type.code, t1.id, "D2", tenant_id).await;
+    let b3 =
+        common::create_child_group(&group_svc, &ctx, &branch_type.code, d2.id, "B3", tenant_id)
+            .await;
+
+    // Both should succeed
+    membership_svc
+        .add_membership(&ctx, b3.id, &user_type.code, "user-1")
+        .await
+        .expect("add user to branch");
+    membership_svc
+        .add_membership(&ctx, b3.id, &course_type.code, "course-1")
+        .await
+        .expect("add course to branch");
+}
+
+/// TC-ADR-06: Tenant allows only users (not courses).
+#[tokio::test]
+async fn adr_tenant_rejects_course_membership() {
+    let db = common::test_db().await;
+    let type_svc = cf_resource_group::domain::type_service::TypeService::new(
+        db.clone(),
+        Arc::new(TypeRepository),
+    );
+    let group_svc = common::make_group_service(db.clone());
+    let membership_svc = common::make_membership_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let (tenant_type, _, _, _, course_type) = create_adr_types(&type_svc).await;
+
+    let t1 = common::create_root_group(&group_svc, &ctx, &tenant_type.code, "T1", tenant_id).await;
+
+    let err = membership_svc
+        .add_membership(&ctx, t1.id, &course_type.code, "course-bad")
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            &err,
+            DomainError::Validation { message } if message.contains("allowed_membership_types")
+        ),
+        "Expected DomainError::Validation mentioning allowed_membership_types, got: {err:?}"
+    );
+}
+
+/// TC-ADR-07: Same user in multiple groups (D8 + T7).
+#[tokio::test]
+async fn adr_same_user_in_multiple_groups() {
+    let db = common::test_db().await;
+    let type_svc = cf_resource_group::domain::type_service::TypeService::new(
+        db.clone(),
+        Arc::new(TypeRepository),
+    );
+    let group_svc = common::make_group_service(db.clone());
+    let membership_svc = common::make_membership_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let (tenant_type, dept_type, _, user_type, _) = create_adr_types(&type_svc).await;
+
+    let t1 = common::create_root_group(&group_svc, &ctx, &tenant_type.code, "T1", tenant_id).await;
+    let t7 =
+        common::create_child_group(&group_svc, &ctx, &tenant_type.code, t1.id, "T7", tenant_id)
+            .await;
+    let d8 =
+        common::create_child_group(&group_svc, &ctx, &dept_type.code, t7.id, "D8", tenant_id).await;
+
+    // Same user in both groups
+    membership_svc
+        .add_membership(&ctx, t7.id, &user_type.code, "shared-user")
+        .await
+        .expect("add user to T7");
+    membership_svc
+        .add_membership(&ctx, d8.id, &user_type.code, "shared-user")
+        .await
+        .expect("add same user to D8");
+}
+
+/// TC-ADR-08: Same resource different types (R4 as course in B3 + user in T1).
+#[tokio::test]
+async fn adr_same_resource_different_types() {
+    let db = common::test_db().await;
+    let type_svc = cf_resource_group::domain::type_service::TypeService::new(
+        db.clone(),
+        Arc::new(TypeRepository),
+    );
+    let group_svc = common::make_group_service(db.clone());
+    let membership_svc = common::make_membership_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let (tenant_type, dept_type, branch_type, user_type, course_type) =
+        create_adr_types(&type_svc).await;
+
+    let t1 = common::create_root_group(&group_svc, &ctx, &tenant_type.code, "T1", tenant_id).await;
+    let d2 =
+        common::create_child_group(&group_svc, &ctx, &dept_type.code, t1.id, "D2", tenant_id).await;
+    let b3 =
+        common::create_child_group(&group_svc, &ctx, &branch_type.code, d2.id, "B3", tenant_id)
+            .await;
+
+    // R4 as course in B3
+    membership_svc
+        .add_membership(&ctx, b3.id, &course_type.code, "R4")
+        .await
+        .expect("add R4 as course to B3");
+    // R4 as user in T1
+    membership_svc
+        .add_membership(&ctx, t1.id, &user_type.code, "R4")
+        .await
+        .expect("add R4 as user to T1");
+}
+
+// =========================================================================
+// Security/Attack Tests for Group Metadata (TC-META-ATK-08, 09)
+// =========================================================================
+
+/// TC-META-ATK-08: SQL injection in group metadata is stored as-is, no injection.
+#[tokio::test]
+async fn security_group_metadata_sql_injection() {
+    let db = common::test_db().await;
+    let type_svc = cf_resource_group::domain::type_service::TypeService::new(
+        db.clone(),
+        Arc::new(TypeRepository),
+    );
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "sqlmeta").await;
+
+    let evil_meta = json!({
+        "name": "'; DROP TABLE resource_group; --",
+        "value": "1 OR 1=1",
+        "__internal": "attack"
+    });
+
+    let group = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: "SQLMetaGroup".to_owned(),
+                parent_id: None,
+                metadata: Some(evil_meta.clone()),
+            },
+            tenant_id,
+        )
+        .await
+        .expect("create group with SQL injection metadata");
+
+    // Verify metadata stored as-is
+    let loaded = group_svc
+        .get_group(&ctx, group.id)
+        .await
+        .expect("get group");
+    assert_eq!(loaded.metadata, Some(evil_meta));
+
+    // Verify DB still works (table not dropped)
+    let query = ODataQuery::default();
+    let page = group_svc.list_groups(&ctx, &query).await;
+    assert!(
+        page.is_ok(),
+        "DB should still work after SQL injection metadata"
+    );
+}
+
+/// TC-META-ATK-09: Large metadata payload (1MB). Document behavior.
+#[tokio::test]
+async fn security_group_metadata_large_payload() {
+    let db = common::test_db().await;
+    let type_svc = cf_resource_group::domain::type_service::TypeService::new(
+        db.clone(),
+        Arc::new(TypeRepository),
+    );
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let root_type = common::create_root_type(&type_svc, "bigmeta").await;
+
+    let big_value = "A".repeat(1_000_000);
+    let big_meta = json!({"payload": big_value});
+
+    // Document behavior: SQLite may accept or reject based on limits.
+    // The test verifies no panic occurs.
+    let result = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: "BigMetaGroup".to_owned(),
+                parent_id: None,
+                metadata: Some(big_meta.clone()),
+            },
+            tenant_id,
+        )
+        .await;
+
+    match result {
+        Ok(group) => {
+            // If accepted, verify roundtrip
+            let loaded = group_svc
+                .get_group(&ctx, group.id)
+                .await
+                .expect("get group");
+            assert_eq!(
+                loaded.metadata.as_ref().unwrap()["payload"]
+                    .as_str()
+                    .unwrap()
+                    .len(),
+                1_000_000,
+                "1MB payload should roundtrip"
+            );
+        }
+        // Deterministic deny classes are acceptable: validation rejects oversize
+        // payloads up-front, and the storage layer may reject through the DB
+        // (e.g. SQLite parameter-size limits). Any other error class indicates
+        // a regression.
+        Err(DomainError::Validation { .. } | DomainError::Database(_)) => {}
+        Err(e) => panic!("unexpected error class for large metadata payload: {e:?}"),
+    }
+}
+
+// =========================================================================
+// Tenant-root uniqueness (cpt-cf-resource-group-fr-enforce-tenant-root-uniqueness)
+// =========================================================================
+
+/// Build a unique tenant-type code: code starts with `TENANT_RG_TYPE_PATH` so
+/// `type_code.starts_with(TENANT_RG_TYPE_PATH)` classifies the group as a
+/// tenant-type group.
+fn unique_tenant_type_code() -> String {
+    format!(
+        "{}test{}.v1~",
+        resource_group_sdk::TENANT_RG_TYPE_PATH,
+        Uuid::now_v7().as_simple()
+    )
+}
+
+/// Create a tenant-type RG type (`can_be_root=true`, `allowed_parent_types=[self]`).
+async fn create_tenant_type(
+    svc: &TypeService<TypeRepository>,
+) -> resource_group_sdk::models::ResourceGroupType {
+    // `allowed_parent_types = []` because self-references aren't allowed at
+    // create time (the type is not yet in the registry). Suitable for testing
+    // the uniqueness invariant at root level.
+    svc.create_type(resource_group_sdk::CreateTypeRequest {
+        code: unique_tenant_type_code(),
+        can_be_root: true,
+        allowed_parent_types: vec![],
+        allowed_membership_types: vec![],
+        metadata_schema: None,
+    })
+    .await
+    .expect("create tenant type")
+}
+
+/// Create a tenant-type RG type that allows being placed under the given
+/// parent tenant-type (used to build a root→sub-tenant fixture).
+async fn create_tenant_sub_type(
+    svc: &TypeService<TypeRepository>,
+    parent_type_code: &str,
+) -> resource_group_sdk::models::ResourceGroupType {
+    svc.create_type(resource_group_sdk::CreateTypeRequest {
+        code: unique_tenant_type_code(),
+        can_be_root: true,
+        allowed_parent_types: vec![parent_type_code.to_owned()],
+        allowed_membership_types: vec![],
+        metadata_schema: None,
+    })
+    .await
+    .expect("create tenant sub-type")
+}
+
+/// TC-TRU-01: First tenant-type root is accepted.
+#[tokio::test]
+async fn tenant_root_first_create_allowed() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let tenant_type = create_tenant_type(&type_svc).await;
+    let root = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: tenant_type.code.clone(),
+                name: "MainTenant".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .expect("first tenant root should succeed");
+    assert!(root.hierarchy.parent_id.is_none());
+    // Effective tenant_id = group.id for tenant-type groups.
+    assert_eq!(root.hierarchy.tenant_id, root.id);
+}
+
+/// TC-TRU-02: Second tenant-type root is rejected with `TenantRootAlreadyExists`.
+#[tokio::test]
+async fn tenant_root_second_create_rejected() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    // Create the first tenant root.
+    let tenant_type = create_tenant_type(&type_svc).await;
+    group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: tenant_type.code.clone(),
+                name: "First".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .expect("first tenant root should succeed");
+
+    // Second tenant-type root must be rejected regardless of type identity
+    // (any tenant-type root collides with any other tenant-type root).
+    let second_type = create_tenant_type(&type_svc).await;
+    let err = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: second_type.code.clone(),
+                name: "Second".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            Uuid::now_v7(),
+        )
+        .await
+        .expect_err("second tenant root must be rejected");
+    assert!(
+        matches!(err, DomainError::TenantRootAlreadyExists { .. }),
+        "expected TenantRootAlreadyExists, got: {err:?}"
+    );
+}
+
+/// TC-TRU-03: Non-tenant root may coexist alongside a tenant root (RG is a forest).
+#[tokio::test]
+async fn non_tenant_root_alongside_tenant_root_allowed() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    // Tenant root.
+    let tenant_type = create_tenant_type(&type_svc).await;
+    let tenant_root = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: tenant_type.code.clone(),
+                name: "MainTenant".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .expect("tenant root");
+
+    // Non-tenant root (auxiliary forest, e.g. "workspace") — created with a
+    // regular can_be_root type whose code does NOT start with TENANT_RG_TYPE_PATH.
+    let workspace_type = common::create_root_type(&type_svc, "workspace").await;
+    let workspace = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: workspace_type.code.clone(),
+                name: "Workspaces".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_root.hierarchy.tenant_id,
+        )
+        .await
+        .expect("non-tenant root must be allowed alongside tenant root");
+    assert!(workspace.hierarchy.parent_id.is_none());
+}
+
+/// TC-TRU-04: `update_group` that would turn a group into a second tenant root
+/// (set `parent_id = NULL` while type is tenant-type) is rejected.
+#[tokio::test]
+async fn tenant_root_update_to_second_root_rejected() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    // Tenant root #1 (root type — no parents allowed at root level).
+    let root_type = create_tenant_type(&type_svc).await;
+    let root = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: root_type.code.clone(),
+                name: "Root".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .expect("tenant root");
+
+    // Sub-tenant type: another tenant-type group placed under root_type.
+    let sub_type = create_tenant_sub_type(&type_svc, &root_type.code).await;
+    let child = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: sub_type.code.clone(),
+                name: "SubTenant".to_owned(),
+                parent_id: Some(root.id),
+                metadata: None,
+            },
+            root.hierarchy.tenant_id,
+        )
+        .await
+        .expect("sub-tenant under root");
+
+    // Attempt to promote child to a root (parent_id = None) — must deny,
+    // the tenant root already exists. For a tenant-type sub-tenant the
+    // effective tenant_id equals its own id (derived by code-prefix), so the
+    // caller's scope must target that tenant to pass the AuthZ pre-check.
+    let child_ctx = common::make_ctx(child.hierarchy.tenant_id);
+    let err = group_svc
+        .update_group(
+            &child_ctx,
+            child.id,
+            UpdateGroupRequest {
+                name: child.name.clone(),
+                parent_id: None,
+                metadata: None,
+            },
+        )
+        .await
+        .expect_err("promoting sub-tenant to a second root must fail");
+    assert!(
+        matches!(err, DomainError::TenantRootAlreadyExists { .. }),
+        "expected TenantRootAlreadyExists, got: {err:?}"
+    );
+}
+
+/// TC-TRU-05: Idempotent update of the existing tenant root (no parent change,
+/// no type change) does not spuriously trip the uniqueness check.
+#[tokio::test]
+async fn tenant_root_self_update_allowed() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let tenant_type = create_tenant_type(&type_svc).await;
+    let root = group_svc
+        .create_group(
+            &ctx,
+            CreateGroupRequest {
+                id: None,
+                code: tenant_type.code.clone(),
+                name: "RootA".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant_id,
+        )
+        .await
+        .expect("tenant root");
+
+    // Rename only — still tenant-type, still root; existing_root_id == group_id,
+    // so the check must NOT raise TenantRootAlreadyExists. Target the root's
+    // own tenant scope so the AuthZ pre-check finds it.
+    let root_ctx = common::make_ctx(root.hierarchy.tenant_id);
+    let updated = group_svc
+        .update_group(
+            &root_ctx,
+            root.id,
+            UpdateGroupRequest {
+                name: "RootB".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+        )
+        .await
+        .expect("self-update of the only tenant root must succeed");
+    assert_eq!(updated.name, "RootB");
+}

--- a/modules/system/resource-group/resource-group/tests/tenant_filtering_db_test.rs
+++ b/modules/system/resource-group/resource-group/tests/tenant_filtering_db_test.rs
@@ -1,0 +1,609 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-testing-rest-api:p1
+#![allow(clippy::expect_used)]
+//! Full-chain integration test with a real (`SQLite` in-memory) database.
+//!
+//! Verifies the complete `AuthZ` -> `PolicyEnforcer` -> `GroupService` -> `AccessScope`
+//! -> `SecureORM` -> SQL WHERE `tenant_id` IN (...) -> filtered results path.
+//!
+//! Two tenants each create groups; listing groups through the `AuthZ`-scoped
+//! `GroupService` returns only the requesting tenant's data.
+
+mod common;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use authz_resolver_sdk::{
+    AuthZResolverClient, AuthZResolverError, EvaluationRequest, EvaluationResponse,
+    EvaluationResponseContext, PolicyEnforcer,
+    constraints::{Constraint, InGroupPredicate, InPredicate, Predicate},
+};
+use modkit_db::{DBProvider, DbError};
+use modkit_odata::ODataQuery;
+use modkit_security::pep_properties;
+
+use cf_resource_group::domain::group_service::{GroupService, QueryProfile};
+use cf_resource_group::domain::type_service::TypeService;
+use cf_resource_group::infra::storage::group_repo::GroupRepository;
+use cf_resource_group::infra::storage::membership_repo::MembershipRepository;
+use cf_resource_group::infra::storage::type_repo::TypeRepository;
+
+use common::{make_ctx, test_db};
+
+// ── Mock AuthZ: tenant-scoping (like static-authz-plugin) ───────────────
+
+struct TenantScopingAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for TenantScopingAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let tenant_id = request
+            .subject
+            .properties
+            .get("tenant_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+            .expect("subject must have tenant_id");
+
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext {
+                constraints: vec![Constraint {
+                    predicates: vec![Predicate::In(InPredicate::new(
+                        pep_properties::OWNER_TENANT_ID,
+                        [tenant_id],
+                    ))],
+                }],
+                deny_reason: None,
+            },
+        })
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Build a `GroupService` with the file-local `TenantScopingAuthZ` mock.
+///
+/// Differs from `common::make_group_service` only by the `AuthZ` implementation:
+/// `common` uses `AllowAllAuthZ`, while these tests need explicit tenant
+/// scoping via `In(OWNER_TENANT_ID)` to exercise the `AccessScope` path.
+fn make_group_service(
+    db: Arc<DBProvider<DbError>>,
+) -> GroupService<GroupRepository, TypeRepository> {
+    let authz: Arc<dyn AuthZResolverClient> = Arc::new(TenantScopingAuthZ);
+    let enforcer = PolicyEnforcer::new(authz);
+    GroupService::new(
+        db,
+        QueryProfile::default(),
+        enforcer,
+        Arc::new(GroupRepository),
+        Arc::new(TypeRepository),
+        common::make_types_registry(),
+    )
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+/// Full chain: two tenants create groups, each tenant sees only its own.
+///
+/// Flow per tenant:
+///   `SecurityContext{tenant=T}` -> `GroupService.list_groups(&ctx, &query)`
+///     -> `PolicyEnforcer.access_scope()` -> `AccessScope{owner_tenant_id IN (T)}`
+///     -> `GroupRepository.list_groups(&conn, &scope, &query)`
+///       -> `SecureORM` `.scope_with(&scope)` -> SQL WHERE `tenant_id` IN ('T')
+///     -> only T's groups returned
+// Scenario: L2-Tenant-01 - Tenant isolation for list_groups
+#[tokio::test]
+async fn tenant_isolation_list_groups() {
+    let db = test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = make_group_service(db.clone());
+
+    let tenant_a = Uuid::now_v7();
+    let tenant_b = Uuid::now_v7();
+    let ctx_a = make_ctx(tenant_a);
+    let ctx_b = make_ctx(tenant_b);
+
+    // Create a type (types are not tenant-scoped)
+    let type_code = common::create_root_type(&type_svc, "dbiso").await.code;
+
+    // Tenant A creates 2 groups
+    let ga1 = common::create_root_group(
+        &group_svc,
+        &ctx_a,
+        &type_code,
+        "Tenant A - Group 1",
+        tenant_a,
+    )
+    .await;
+    let ga2 = common::create_root_group(
+        &group_svc,
+        &ctx_a,
+        &type_code,
+        "Tenant A - Group 2",
+        tenant_a,
+    )
+    .await;
+
+    // Tenant B creates 1 group
+    let gb1 = common::create_root_group(
+        &group_svc,
+        &ctx_b,
+        &type_code,
+        "Tenant B - Group 1",
+        tenant_b,
+    )
+    .await;
+
+    let query = ODataQuery::default();
+
+    // ── Tenant A lists groups: should see only A's groups ──
+    let page_a = group_svc
+        .list_groups(&ctx_a, &query)
+        .await
+        .expect("list groups for tenant A");
+
+    let ids_a: Vec<Uuid> = page_a.items.iter().map(|g| g.id).collect();
+    assert!(ids_a.contains(&ga1.id), "Tenant A should see group A1");
+    assert!(ids_a.contains(&ga2.id), "Tenant A should see group A2");
+    assert!(!ids_a.contains(&gb1.id), "Tenant A must NOT see group B1");
+    assert_eq!(
+        ids_a.len(),
+        2,
+        "Tenant A should see exactly 2 groups, got: {ids_a:?}"
+    );
+
+    // ── Tenant B lists groups: should see only B's groups ──
+    let page_b = group_svc
+        .list_groups(&ctx_b, &query)
+        .await
+        .expect("list groups for tenant B");
+
+    let ids_b: Vec<Uuid> = page_b.items.iter().map(|g| g.id).collect();
+    assert!(ids_b.contains(&gb1.id), "Tenant B should see group B1");
+    assert!(!ids_b.contains(&ga1.id), "Tenant B must NOT see group A1");
+    assert!(!ids_b.contains(&ga2.id), "Tenant B must NOT see group A2");
+    assert_eq!(
+        ids_b.len(),
+        1,
+        "Tenant B should see exactly 1 group, got: {ids_b:?}"
+    );
+}
+
+/// Full chain: `get_group` with wrong tenant returns not-found.
+// Scenario: L2-Tenant-02 - Cross-tenant get_group invisible
+#[tokio::test]
+async fn tenant_isolation_get_group_cross_tenant_invisible() {
+    let db = test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = make_group_service(db.clone());
+
+    let tenant_a = Uuid::now_v7();
+    let tenant_b = Uuid::now_v7();
+    let ctx_a = make_ctx(tenant_a);
+    let ctx_b = make_ctx(tenant_b);
+
+    // Create type
+    let type_code = common::create_root_type(&type_svc, "xget").await.code;
+
+    // Tenant A creates a group
+    let ga =
+        common::create_root_group(&group_svc, &ctx_a, &type_code, "A's secret group", tenant_a)
+            .await;
+
+    // Tenant B tries to get tenant A's group → should fail
+    let result = group_svc.get_group(&ctx_b, ga.id).await;
+    assert!(
+        result.is_err(),
+        "Tenant B should not be able to get tenant A's group"
+    );
+}
+
+/// Full chain: `get_group_descendants` respects tenant scope.
+// Scenario: L2-Tenant-03 - Hierarchy queries are tenant-scoped
+#[tokio::test]
+async fn tenant_isolation_hierarchy_scoped() {
+    let db = test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = make_group_service(db.clone());
+
+    let tenant_a = Uuid::now_v7();
+    let tenant_b = Uuid::now_v7();
+    let ctx_a = make_ctx(tenant_a);
+    let ctx_b = make_ctx(tenant_b);
+
+    // Create parent and child types
+    let parent_type = common::create_root_type(&type_svc, "hierp").await.code;
+    let child_type = common::create_child_type(&type_svc, "hierc", &[&parent_type], &[])
+        .await
+        .code;
+
+    // Tenant A: parent + child
+    let parent =
+        common::create_root_group(&group_svc, &ctx_a, &parent_type, "A Parent", tenant_a).await;
+    let _child = common::create_child_group(
+        &group_svc,
+        &ctx_a,
+        &child_type,
+        parent.id,
+        "A Child",
+        tenant_a,
+    )
+    .await;
+
+    // Tenant B: unrelated group (same parent type, different tenant)
+    let _b_group =
+        common::create_root_group(&group_svc, &ctx_b, &parent_type, "B Unrelated", tenant_b).await;
+
+    // Tenant A lists hierarchy from parent — should NOT include B's group
+    let query = ODataQuery::default();
+    let hier = group_svc
+        .get_group_descendants(&ctx_a, parent.id, &query)
+        .await
+        .expect("list hierarchy for tenant A");
+
+    let hier_names: Vec<&str> = hier.items.iter().map(|g| g.name.as_str()).collect();
+    assert!(
+        hier_names.contains(&"A Parent"),
+        "hierarchy should contain parent"
+    );
+    assert!(
+        hier_names.contains(&"A Child"),
+        "hierarchy should contain child"
+    );
+    assert!(
+        !hier_names.iter().any(|n| n.contains("B Unrelated")),
+        "hierarchy must NOT contain tenant B's group, got: {hier_names:?}"
+    );
+
+    // Reverse direction: tenant B must not be able to peek into tenant A's
+    // subtree. The access-scope layer enforces isolation by returning an
+    // empty result rather than leaking rows (so existence of the parent is
+    // not disclosed). Either an explicit error or an empty page is an
+    // acceptable form of denial; leakage of A's groups is not.
+    let cross_tenant = group_svc
+        .get_group_descendants(&ctx_b, parent.id, &query)
+        .await;
+    if let Ok(page) = cross_tenant {
+        // The success path of cross-tenant hierarchy reads is access-scope's
+        // "deny via empty page" pattern (existence is not disclosed). Anything
+        // else -- including B's own groups bleeding through because the service
+        // ignored the requested root -- is a regression. Asserting strict
+        // emptiness is stronger than the previous "no A names leaked" check.
+        assert!(
+            page.items.is_empty(),
+            "cross-tenant hierarchy lookup must return an empty page, got: {:?}",
+            page.items
+                .iter()
+                .map(|g| (g.id, g.name.clone()))
+                .collect::<Vec<_>>(),
+        );
+    }
+    // Err path: explicit denial is equally acceptable.
+}
+
+/// Full chain: `update_group` with wrong tenant returns not-found.
+// Scenario: L2-Tenant-04 - Cross-tenant update blocked
+#[tokio::test]
+async fn tenant_isolation_update_cross_tenant_blocked() {
+    let db = test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = make_group_service(db.clone());
+
+    let tenant_a = Uuid::now_v7();
+    let tenant_b = Uuid::now_v7();
+    let ctx_a = make_ctx(tenant_a);
+    let ctx_b = make_ctx(tenant_b);
+
+    let type_code = common::create_root_type(&type_svc, "xupd").await.code;
+
+    // Tenant A creates a group
+    let ga = common::create_root_group(&group_svc, &ctx_a, &type_code, "A's group", tenant_a).await;
+
+    // Tenant B tries to update tenant A's group → should fail
+    let result = group_svc
+        .update_group(
+            &ctx_b,
+            ga.id,
+            resource_group_sdk::UpdateGroupRequest {
+                name: "Hijacked!".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "Tenant B should not be able to update tenant A's group"
+    );
+
+    // `is_err()` alone does not catch a partial write followed by an error —
+    // re-read the row as tenant A and verify the original state is untouched.
+    let after = group_svc
+        .get_group(&ctx_a, ga.id)
+        .await
+        .expect("tenant A must still see the original group");
+    assert_eq!(after.name, "A's group", "name must not have been hijacked");
+    assert_eq!(after.metadata, None, "metadata must remain None");
+    assert_eq!(
+        after.hierarchy.parent_id, None,
+        "parent_id must remain None"
+    );
+}
+
+/// Full chain: `delete_group` with wrong tenant returns not-found.
+// Scenario: L2-Tenant-05 - Cross-tenant delete blocked
+#[tokio::test]
+async fn tenant_isolation_delete_cross_tenant_blocked() {
+    let db = test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = make_group_service(db.clone());
+
+    let tenant_a = Uuid::now_v7();
+    let tenant_b = Uuid::now_v7();
+    let ctx_a = make_ctx(tenant_a);
+    let ctx_b = make_ctx(tenant_b);
+
+    let type_code = common::create_root_type(&type_svc, "xdel").await.code;
+
+    // Tenant A creates a group
+    let ga = common::create_root_group(
+        &group_svc,
+        &ctx_a,
+        &type_code,
+        "A's group to delete",
+        tenant_a,
+    )
+    .await;
+
+    // Tenant B tries to delete tenant A's group → should fail
+    let result = group_svc.delete_group(&ctx_b, ga.id, false).await;
+    assert!(
+        result.is_err(),
+        "Tenant B should not be able to delete tenant A's group"
+    );
+
+    // Tenant A can still see and delete their own group
+    let own = group_svc.get_group(&ctx_a, ga.id).await;
+    assert!(own.is_ok(), "Tenant A should still see their group");
+
+    let del = group_svc.delete_group(&ctx_a, ga.id, false).await;
+    assert!(
+        del.is_ok(),
+        "Tenant A should be able to delete their own group"
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 2: Group-based predicate tests (InGroup / InGroupSubtree)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Mock `AuthZ` that returns tenant scoping + `InGroup` predicate.
+/// Simulates S14 scenario: user has access to specific group IDs.
+struct GroupScopingAuthZ {
+    /// Groups the subject has access to (injected per test).
+    allowed_group_ids: Vec<Uuid>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for GroupScopingAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let tenant_id = request
+            .subject
+            .properties
+            .get("tenant_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok())
+            .expect("subject must have tenant_id");
+
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext {
+                constraints: vec![Constraint {
+                    predicates: vec![
+                        // Tenant scoping (always present)
+                        Predicate::In(InPredicate::new(
+                            pep_properties::OWNER_TENANT_ID,
+                            [tenant_id],
+                        )),
+                        // Group membership scoping
+                        Predicate::InGroup(InGroupPredicate::new(
+                            pep_properties::RESOURCE_ID,
+                            self.allowed_group_ids.clone(),
+                        )),
+                    ],
+                }],
+                deny_reason: None,
+            },
+        })
+    }
+}
+
+/// Phase 2 test: `InGroup` predicate compiles to correct `AccessScope`
+/// containing both tenant filter AND group membership filter.
+// Scenario: L2-Tenant-06 - InGroup predicate produces combined scope (S14)
+#[tokio::test]
+async fn group_based_in_group_predicate_produces_combined_scope() {
+    let group_a = Uuid::now_v7();
+    let group_b = Uuid::now_v7();
+    let tenant_id = Uuid::now_v7();
+
+    let authz: Arc<dyn AuthZResolverClient> = Arc::new(GroupScopingAuthZ {
+        allowed_group_ids: vec![group_a, group_b],
+    });
+    let enforcer = PolicyEnforcer::new(authz);
+    let ctx = make_ctx(tenant_id);
+
+    let scope = enforcer
+        .access_scope(
+            &ctx,
+            &cf_resource_group::domain::group_service::RG_GROUP_RESOURCE,
+            "list",
+            None,
+        )
+        .await
+        .expect("should succeed");
+
+    // Scope has 1 constraint with 2 filters: In(tenant) AND InGroup(groups)
+    assert_eq!(scope.constraints().len(), 1);
+    assert_eq!(scope.constraints()[0].filters().len(), 2);
+
+    // Tenant filter must be present (order-independent).
+    assert!(scope.contains_uuid(pep_properties::OWNER_TENANT_ID, tenant_id));
+
+    // At least one InGroup filter must be present. We do not assume the
+    // ordering of filters within a constraint — predicate compilation may
+    // reorder them and the semantics are unaffected.
+    let filters = scope.constraints()[0].filters();
+    assert!(
+        filters
+            .iter()
+            .any(|f| matches!(f, modkit_security::ScopeFilter::InGroup(_))),
+        "expected at least one InGroup filter, got: {filters:?}"
+    );
+}
+
+/// Phase 2 test: memberships seeded into DB, verify that group-based
+/// membership data is correctly stored and accessible.
+///
+/// This verifies the data layer works with the membership table that
+/// `InGroup` subqueries reference. The actual subquery SQL execution
+/// is validated by the `SecureORM` cond.rs unit tests.
+// Scenario: L2-Membership-01 - Membership data correctly stored
+#[tokio::test]
+async fn group_based_membership_data_correctly_stored() {
+    let db = test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = make_group_service(db.clone());
+
+    let tenant = Uuid::now_v7();
+    let ctx = make_ctx(tenant);
+
+    // Create types: project (root, allows "task" members) and task
+    let project_type = format!(
+        "gts.cf.core.rg.type.v1~x.test.proj{}.v1~",
+        Uuid::now_v7().as_simple()
+    );
+    let task_type = format!(
+        "gts.cf.core.rg.type.v1~x.test.task{}.v1~",
+        Uuid::now_v7().as_simple()
+    );
+
+    // Create task type first (project references it in allowed_membership_types)
+    type_svc
+        .create_type(resource_group_sdk::CreateTypeRequest {
+            code: task_type.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create task type");
+
+    type_svc
+        .create_type(resource_group_sdk::CreateTypeRequest {
+            code: project_type.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![task_type.clone()],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create project type");
+
+    // Create ProjectA and ProjectB
+    let project_a = group_svc
+        .create_group(
+            &ctx,
+            resource_group_sdk::CreateGroupRequest {
+                id: None,
+                code: project_type.clone(),
+                name: "ProjectA".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant,
+        )
+        .await
+        .expect("create ProjectA");
+
+    let project_b = group_svc
+        .create_group(
+            &ctx,
+            resource_group_sdk::CreateGroupRequest {
+                id: None,
+                code: project_type,
+                name: "ProjectB".to_owned(),
+                parent_id: None,
+                metadata: None,
+            },
+            tenant,
+        )
+        .await
+        .expect("create ProjectB");
+
+    // Add memberships via MembershipService (with PolicyEnforcer)
+    let authz: Arc<dyn AuthZResolverClient> = Arc::new(TenantScopingAuthZ);
+    let enforcer = PolicyEnforcer::new(authz);
+    let membership_svc = cf_resource_group::domain::membership_service::MembershipService::new(
+        db.clone(),
+        enforcer,
+        Arc::new(GroupRepository),
+        Arc::new(TypeRepository),
+        Arc::new(MembershipRepository),
+    );
+
+    // task-001, task-002 → ProjectA
+    membership_svc
+        .add_membership(&ctx, project_a.id, &task_type, "task-001")
+        .await
+        .expect("add task-001 to ProjectA");
+    membership_svc
+        .add_membership(&ctx, project_a.id, &task_type, "task-002")
+        .await
+        .expect("add task-002 to ProjectA");
+
+    // task-003 → ProjectB
+    membership_svc
+        .add_membership(&ctx, project_b.id, &task_type, "task-003")
+        .await
+        .expect("add task-003 to ProjectB");
+
+    // List memberships for ProjectA
+    let query = ODataQuery::default();
+    let all = membership_svc
+        .list_memberships(&ctx, &query)
+        .await
+        .expect("list memberships");
+
+    let project_a_members: Vec<&str> = all
+        .items
+        .iter()
+        .filter(|m| m.group_id == project_a.id)
+        .map(|m| m.resource_id.as_str())
+        .collect();
+
+    assert!(project_a_members.contains(&"task-001"));
+    assert!(project_a_members.contains(&"task-002"));
+    assert!(!project_a_members.contains(&"task-003"));
+
+    let members_of_b: Vec<&str> = all
+        .items
+        .iter()
+        .filter(|m| m.group_id == project_b.id)
+        .map(|m| m.resource_id.as_str())
+        .collect();
+
+    assert!(members_of_b.contains(&"task-003"));
+    assert!(!members_of_b.contains(&"task-001"));
+}

--- a/modules/system/resource-group/resource-group/tests/tenant_scoping_test.rs
+++ b/modules/system/resource-group/resource-group/tests/tenant_scoping_test.rs
@@ -1,0 +1,139 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-testing-rest-api:p1
+//! Integration tests: `AccessScope` tenant scoping for resource-group queries.
+//!
+//! Verifies that `AccessScope` constructed from `AuthZ` decisions correctly
+//! represents tenant isolation -- the building block for `SecureORM` filtering.
+//! These tests validate the scope shape without a database; the full
+//! `SecureORM` -> SQL path is covered by E2E tests.
+
+use uuid::Uuid;
+
+use modkit_security::{AccessScope, pep_properties};
+
+// ── AccessScope construction from tenant context ────────────────────────
+
+// Scenario: L1-Scope-01 - for_tenant contains tenant_id
+/// `AccessScope::for_tenant()` produces a scope that contains exactly
+/// the given `tenant_id` under `owner_tenant_id`.
+#[test]
+fn for_tenant_contains_tenant_id() {
+    let tid = Uuid::now_v7();
+    let scope = AccessScope::for_tenant(tid);
+
+    assert!(!scope.is_unconstrained());
+    assert!(scope.contains_uuid(pep_properties::OWNER_TENANT_ID, tid));
+}
+
+// Scenario: L1-Scope-02 - for_tenant excludes other tenants
+/// `AccessScope::for_tenant()` does NOT contain a different tenant.
+#[test]
+fn for_tenant_excludes_other_tenants() {
+    let tid = Uuid::now_v7();
+    let other = Uuid::now_v7();
+    let scope = AccessScope::for_tenant(tid);
+
+    assert!(!scope.contains_uuid(pep_properties::OWNER_TENANT_ID, other));
+}
+
+// Scenario: L1-Scope-03 - for_tenants contains all given IDs
+/// `AccessScope::for_tenants()` with multiple IDs contains all of them.
+#[test]
+fn for_tenants_contains_all_given_ids() {
+    let t1 = Uuid::now_v7();
+    let t2 = Uuid::now_v7();
+    let t3 = Uuid::now_v7();
+    let scope = AccessScope::for_tenants(vec![t1, t2, t3]);
+
+    assert!(scope.contains_uuid(pep_properties::OWNER_TENANT_ID, t1));
+    assert!(scope.contains_uuid(pep_properties::OWNER_TENANT_ID, t2));
+    assert!(scope.contains_uuid(pep_properties::OWNER_TENANT_ID, t3));
+}
+
+// Scenario: L1-Scope-04 - all_uuid_values_for extracts tenant IDs
+/// `all_uuid_values_for()` extracts all tenant IDs from a scope.
+#[test]
+fn all_uuid_values_extracts_tenant_ids() {
+    let t1 = Uuid::now_v7();
+    let t2 = Uuid::now_v7();
+    let scope = AccessScope::for_tenants(vec![t1, t2]);
+
+    let ids = scope.all_uuid_values_for(pep_properties::OWNER_TENANT_ID);
+    assert_eq!(ids.len(), 2);
+    assert!(ids.contains(&t1));
+    assert!(ids.contains(&t2));
+}
+
+// Scenario: L1-Scope-05 - allow_all is unconstrained
+/// `allow_all()` scope is unconstrained — no tenant filtering.
+#[test]
+fn allow_all_is_unconstrained() {
+    let scope = AccessScope::allow_all();
+    assert!(scope.is_unconstrained());
+}
+
+// Scenario: L1-Scope-06 - deny_all has no values
+/// `deny_all()` scope is not unconstrained and contains no values.
+#[test]
+fn deny_all_has_no_values() {
+    let scope = AccessScope::deny_all();
+    assert!(!scope.is_unconstrained());
+    assert!(
+        scope
+            .all_uuid_values_for(pep_properties::OWNER_TENANT_ID)
+            .is_empty()
+    );
+}
+
+// ── tenant_only() helper ────────────────────────────────────────────────
+
+// Scenario: L1-Scope-07 - tenant_only preserves tenant filter
+/// `tenant_only()` on a tenant scope keeps the tenant filter.
+#[test]
+fn tenant_only_preserves_tenant_filter() {
+    let tid = Uuid::now_v7();
+    let scope = AccessScope::for_tenant(tid).tenant_only();
+
+    assert!(scope.contains_uuid(pep_properties::OWNER_TENANT_ID, tid));
+}
+
+// Scenario: L1-Scope-08 - tenant_only on allow_all becomes deny_all
+/// `tenant_only()` on an `allow_all` scope becomes `deny_all` (fail-closed).
+/// This is by design: unconstrained scopes have no tenant filters to retain.
+#[test]
+fn tenant_only_on_allow_all_becomes_deny_all() {
+    let scope = AccessScope::allow_all().tenant_only();
+    assert!(scope.is_deny_all());
+}
+
+// ── Scope combination scenarios ─────────────────────────────────────────
+
+// Scenario: L1-Scope-09 - Separate tenant scopes are isolated
+/// Two scopes for different tenants are distinct (no cross-contamination).
+#[test]
+fn separate_tenant_scopes_are_isolated() {
+    let tid_a = Uuid::now_v7();
+    let tid_b = Uuid::now_v7();
+
+    let scope_a = AccessScope::for_tenant(tid_a);
+    let scope_b = AccessScope::for_tenant(tid_b);
+
+    // A sees only A
+    assert!(scope_a.contains_uuid(pep_properties::OWNER_TENANT_ID, tid_a));
+    assert!(!scope_a.contains_uuid(pep_properties::OWNER_TENANT_ID, tid_b));
+
+    // B sees only B
+    assert!(scope_b.contains_uuid(pep_properties::OWNER_TENANT_ID, tid_b));
+    assert!(!scope_b.contains_uuid(pep_properties::OWNER_TENANT_ID, tid_a));
+}
+
+// Scenario: L1-Scope-10 - for_resource scopes by id, not tenant
+/// `for_resource` creates a scope on the `id` property, not `owner_tenant_id`.
+#[test]
+fn for_resource_scopes_by_id_not_tenant() {
+    let resource_id = Uuid::now_v7();
+    let scope = AccessScope::for_resource(resource_id);
+
+    assert!(scope.contains_uuid(pep_properties::RESOURCE_ID, resource_id));
+    assert!(!scope.contains_uuid(pep_properties::OWNER_TENANT_ID, resource_id));
+}

--- a/modules/system/resource-group/resource-group/tests/type_service_test.rs
+++ b/modules/system/resource-group/resource-group/tests/type_service_test.rs
@@ -1,0 +1,1751 @@
+// Created: 2026-04-16 by Constructor Tech
+// @cpt-dod:cpt-cf-resource-group-dod-testing-type-mgmt:p1
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::doc_markdown)]
+//! Phase 2 tests: Type management CRUD, metadata_schema internal storage logic,
+//! and GTS path <-> ID resolution.
+//!
+//! Covers TC-TYP-01..16, TC-META-01..11, TC-GTS-01..15.
+//! Overlapping TC-META/TC-GTS cases are implemented once with a comment noting both IDs.
+
+mod common;
+
+use std::sync::Arc;
+
+use serde_json::json;
+use uuid::Uuid;
+
+use cf_resource_group::domain::error::DomainError;
+use cf_resource_group::domain::repo::TypeRepositoryTrait;
+use cf_resource_group::domain::type_service::TypeService;
+use cf_resource_group::infra::storage::entity::{
+    gts_type::{self, Entity as GtsTypeEntity},
+    gts_type_allowed_membership::{self, Entity as AllowedMembershipEntity},
+    gts_type_allowed_parent::{self, Entity as AllowedParentEntity},
+};
+use cf_resource_group::infra::storage::type_repo::TypeRepository;
+use modkit_db::secure::{SecureEntityExt, secure_insert};
+use modkit_security::AccessScope;
+use resource_group_sdk::{CreateTypeRequest, UpdateTypeRequest};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set};
+
+/// Generate a unique GTS type code with the given suffix.
+fn type_code(suffix: &str) -> String {
+    format!(
+        "gts.cf.core.rg.type.v1~x.test.{}{}.v1~",
+        suffix,
+        Uuid::now_v7().as_simple()
+    )
+}
+
+/// System-level scope for direct DB assertions (no tenant filtering).
+fn system_scope() -> AccessScope {
+    AccessScope::allow_all()
+}
+
+// =========================================================================
+// Type CRUD tests (TC-TYP-01..16)
+// =========================================================================
+
+/// TC-TYP-01: Create type with valid allowed_parent_types.
+/// Child type created; allowed_parent_types contains parent code;
+/// junction rows COUNT = len(allowed_parent_types).
+#[tokio::test]
+async fn type_create_with_valid_parents() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    // Create parent type first
+    let parent = common::create_root_type(&type_svc, "parent").await;
+
+    // Create child type with parent in allowed_parent_types
+    let child_code = type_code("child");
+    let child = type_svc
+        .create_type(CreateTypeRequest {
+            code: child_code.clone(),
+            can_be_root: false,
+            allowed_parent_types: vec![parent.code.clone()],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create child type");
+
+    assert_eq!(child.allowed_parent_types, vec![parent.code.clone()]);
+    assert!(!child.can_be_root);
+
+    // DB assertion: junction rows count matches
+    let conn = db.conn().expect("get conn");
+    let scope = system_scope();
+
+    let child_model = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&child_code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query child type")
+        .expect("child type exists");
+
+    let junction_rows = AllowedParentEntity::find()
+        .filter(gts_type_allowed_parent::Column::TypeId.eq(child_model.id))
+        .secure()
+        .scope_with(&scope)
+        .all(&conn)
+        .await
+        .expect("query junction");
+
+    assert_eq!(junction_rows.len(), 1, "Expected 1 junction row");
+
+    // Verify parent_type_id is resolved from GTS path to SMALLINT
+    let parent_model = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&parent.code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query parent")
+        .expect("parent type exists");
+    assert_eq!(junction_rows[0].parent_type_id, parent_model.id);
+}
+
+/// TC-TYP-02: Create type with non-existent allowed_parent_types -> Validation error.
+#[tokio::test]
+async fn type_create_nonexistent_parents() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("orphan");
+    let nonexistent_parent = type_code("ghost");
+    let err = type_svc
+        .create_type(CreateTypeRequest {
+            code,
+            can_be_root: false,
+            allowed_parent_types: vec![nonexistent_parent],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        matches!(err, DomainError::Validation { .. }),
+        "Expected Validation error: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("not found"),
+        "Error should mention 'not found': {err:?}"
+    );
+}
+
+/// TC-TYP-03: Create type with non-existent allowed_membership_types -> error.
+#[tokio::test]
+async fn type_create_nonexistent_memberships() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("membfail");
+    let nonexistent_membership = type_code("nomemb");
+    let err = type_svc
+        .create_type(CreateTypeRequest {
+            code,
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![nonexistent_membership],
+            metadata_schema: None,
+        })
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        matches!(err, DomainError::Validation { .. }),
+        "Expected Validation error for missing membership: {err:?}"
+    );
+}
+
+/// TC-TYP-04: Placement invariant: can_be_root=false, allowed_parent_types=[] -> Validation error.
+#[tokio::test]
+async fn type_create_placement_invariant_violation() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("noplacement");
+    let err = type_svc
+        .create_type(CreateTypeRequest {
+            code,
+            can_be_root: false,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        matches!(err, DomainError::Validation { .. }),
+        "Expected Validation error: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("root placement or"),
+        "Error should mention placement invariant: {err:?}"
+    );
+}
+
+/// TC-TYP-05: Update type happy path -- new allowed_parent_types replace old ones.
+/// DB assertion: old junction rows deleted, new rows match new list.
+#[tokio::test]
+async fn type_update_replaces_parents() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let parent_a = common::create_root_type(&type_svc, "pa").await;
+    let parent_b = common::create_root_type(&type_svc, "pb").await;
+
+    // Create child with parent_a
+    let child_code = type_code("updchild");
+    type_svc
+        .create_type(CreateTypeRequest {
+            code: child_code.clone(),
+            can_be_root: false,
+            allowed_parent_types: vec![parent_a.code.clone()],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create child");
+
+    // Update child to have parent_b instead of parent_a
+    let updated = type_svc
+        .update_type(
+            &child_code,
+            UpdateTypeRequest {
+                can_be_root: false,
+                allowed_parent_types: vec![parent_b.code.clone()],
+                allowed_membership_types: vec![],
+                metadata_schema: None,
+            },
+        )
+        .await
+        .expect("update child");
+
+    assert_eq!(updated.allowed_parent_types, vec![parent_b.code.clone()]);
+
+    // DB assertion: junction rows now only contain parent_b
+    let conn = db.conn().expect("get conn");
+    let scope = system_scope();
+
+    let child_model = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&child_code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("exists");
+
+    let junction_rows = AllowedParentEntity::find()
+        .filter(gts_type_allowed_parent::Column::TypeId.eq(child_model.id))
+        .secure()
+        .scope_with(&scope)
+        .all(&conn)
+        .await
+        .expect("query junction");
+
+    assert_eq!(
+        junction_rows.len(),
+        1,
+        "Expected exactly 1 junction row after update"
+    );
+
+    let parent_b_model = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&parent_b.code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("exists");
+    assert_eq!(junction_rows[0].parent_type_id, parent_b_model.id);
+}
+
+/// TC-TYP-06: Update type -- remove allowed_parent in use by groups.
+/// -> AllowedParentTypesViolation with violating group names.
+#[tokio::test]
+async fn type_update_remove_parent_in_use() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    // Create parent and child types
+    let parent_type = common::create_root_type(&type_svc, "usedpar").await;
+    let child_type =
+        common::create_child_type(&type_svc, "usedchild", &[&parent_type.code], &[]).await;
+
+    // Create a parent group and a child group under it
+    let parent_group =
+        common::create_root_group(&group_svc, &ctx, &parent_type.code, "ParentGrp", tenant_id)
+            .await;
+    common::create_child_group(
+        &group_svc,
+        &ctx,
+        &child_type.code,
+        parent_group.id,
+        "ChildGrp",
+        tenant_id,
+    )
+    .await;
+
+    // Try to remove parent_type from child_type's allowed_parent_types
+    let err = type_svc
+        .update_type(
+            &child_type.code,
+            UpdateTypeRequest {
+                can_be_root: true,
+                allowed_parent_types: vec![],
+                allowed_membership_types: vec![],
+                metadata_schema: None,
+            },
+        )
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        matches!(err, DomainError::AllowedParentTypesViolation { .. }),
+        "Expected AllowedParentTypesViolation: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("ChildGrp"),
+        "Error should mention violating group name: {err:?}"
+    );
+}
+
+/// TC-TYP-07: Update type -- set can_be_root=false with root groups existing.
+/// -> AllowedParentTypesViolation with root group names.
+#[tokio::test]
+async fn type_update_disable_root_with_root_groups() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    // Create another type for parents
+    let alt_parent_type = common::create_root_type(&type_svc, "altpar").await;
+
+    // Create root type and a root group
+    let root_type = common::create_root_type(&type_svc, "roottp").await;
+    common::create_root_group(&group_svc, &ctx, &root_type.code, "RootGrp", tenant_id).await;
+
+    // Try to set can_be_root=false (must provide a parent to satisfy placement invariant)
+    let err = type_svc
+        .update_type(
+            &root_type.code,
+            UpdateTypeRequest {
+                can_be_root: false,
+                allowed_parent_types: vec![alt_parent_type.code.clone()],
+                allowed_membership_types: vec![],
+                metadata_schema: None,
+            },
+        )
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        matches!(err, DomainError::AllowedParentTypesViolation { .. }),
+        "Expected AllowedParentTypesViolation: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("RootGrp"),
+        "Error should mention root group name: {err:?}"
+    );
+}
+
+/// TC-TYP-08: Update type -- not found.
+#[tokio::test]
+async fn type_update_not_found() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("notfound");
+    let err = type_svc
+        .update_type(
+            &code,
+            UpdateTypeRequest {
+                can_be_root: true,
+                allowed_parent_types: vec![],
+                allowed_membership_types: vec![],
+                metadata_schema: None,
+            },
+        )
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        matches!(err, DomainError::TypeNotFound { .. }),
+        "Expected TypeNotFound: {err:?}"
+    );
+}
+
+/// TC-TYP-09: Delete type with existing groups -> ConflictActiveReferences.
+#[tokio::test]
+async fn type_delete_with_active_groups() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+    let group_svc = common::make_group_service(db.clone());
+    let tenant_id = Uuid::now_v7();
+    let ctx = common::make_ctx(tenant_id);
+
+    let rt = common::create_root_type(&type_svc, "delwg").await;
+    common::create_root_group(&group_svc, &ctx, &rt.code, "BusyGrp", tenant_id).await;
+
+    let err = type_svc
+        .delete_type(&rt.code)
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        matches!(err, DomainError::ConflictActiveReferences { .. }),
+        "Expected ConflictActiveReferences: {err:?}"
+    );
+}
+
+/// TC-TYP-10: Update type -- placement invariant on new values.
+#[tokio::test]
+async fn type_update_placement_invariant_violation() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let rt = common::create_root_type(&type_svc, "updinv").await;
+
+    let err = type_svc
+        .update_type(
+            &rt.code,
+            UpdateTypeRequest {
+                can_be_root: false,
+                allowed_parent_types: vec![],
+                allowed_membership_types: vec![],
+                metadata_schema: None,
+            },
+        )
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        matches!(err, DomainError::Validation { .. }),
+        "Expected Validation error: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("root placement or"),
+        "Error should mention placement invariant: {err:?}"
+    );
+}
+
+/// TC-TYP-11: Create type with self-reference in allowed_parent_types -> error (not found
+/// because the type doesn't exist yet at resolve time).
+#[tokio::test]
+async fn type_create_self_reference_parent() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("selfref");
+    let err = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: false,
+            allowed_parent_types: vec![code],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect_err("should fail");
+
+    // Self-reference fails because the type doesn't exist yet when resolving
+    assert!(
+        matches!(err, DomainError::Validation { .. }),
+        "Expected error for self-reference: {err:?}"
+    );
+}
+
+/// TC-TYP-12: Create type with invalid format in allowed_parent_types -> Validation.
+#[tokio::test]
+async fn type_create_invalid_parent_format() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("badfmt");
+    let err = type_svc
+        .create_type(CreateTypeRequest {
+            code,
+            can_be_root: false,
+            allowed_parent_types: vec!["invalid-no-prefix".to_owned()],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        matches!(err, DomainError::Validation { .. }),
+        "Expected Validation error: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("prefix"),
+        "Error should mention prefix: {err:?}"
+    );
+}
+
+/// TC-TYP-13: Delete nonexistent type -> TypeNotFound.
+#[tokio::test]
+async fn type_delete_not_found() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("delnf");
+    let err = type_svc.delete_type(&code).await.expect_err("should fail");
+
+    assert!(
+        matches!(err, DomainError::TypeNotFound { .. }),
+        "Expected TypeNotFound: {err:?}"
+    );
+}
+
+/// TC-TYP-14: Create type with metadata_schema -> returned type has matching metadata_schema.
+#[tokio::test]
+async fn type_create_with_metadata_schema() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("withmeta");
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" }
+        }
+    });
+
+    let rg_type = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema.clone()),
+        })
+        .await
+        .expect("create type with schema");
+
+    assert_eq!(rg_type.metadata_schema, Some(schema));
+}
+
+/// TC-TYP-15: Update type replaces allowed_membership_types [A, B] -> [B, C].
+/// DB assertion: gts_type_allowed_membership contains only new entries.
+#[tokio::test]
+async fn type_update_replaces_memberships() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let ma = common::create_root_type(&type_svc, "memba").await;
+    let mb = common::create_root_type(&type_svc, "membb").await;
+    let mc = common::create_root_type(&type_svc, "membc").await;
+
+    let code = type_code("membupd");
+    type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![ma.code.clone(), mb.code.clone()],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create type");
+
+    // Update memberships to [B, C]
+    let updated = type_svc
+        .update_type(
+            &code,
+            UpdateTypeRequest {
+                can_be_root: true,
+                allowed_parent_types: vec![],
+                allowed_membership_types: vec![mb.code.clone(), mc.code.clone()],
+                metadata_schema: None,
+            },
+        )
+        .await
+        .expect("update type");
+
+    let mut actual_memberships = updated.allowed_membership_types.clone();
+    actual_memberships.sort();
+    let mut expected = vec![mb.code.clone(), mc.code.clone()];
+    expected.sort();
+    assert_eq!(actual_memberships, expected);
+
+    // DB assertion: junction table contains only B and C
+    let conn = db.conn().expect("get conn");
+    let scope = system_scope();
+
+    let type_model = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("exists");
+
+    let membership_rows = AllowedMembershipEntity::find()
+        .filter(gts_type_allowed_membership::Column::TypeId.eq(type_model.id))
+        .secure()
+        .scope_with(&scope)
+        .all(&conn)
+        .await
+        .expect("query");
+
+    assert_eq!(
+        membership_rows.len(),
+        2,
+        "Expected exactly 2 membership junction rows"
+    );
+}
+
+/// TC-TYP-16: Update type -- hierarchy check skips deleted parent type -> no error.
+/// If the previously allowed parent type was deleted, removing it from allowed_parent_types
+/// should succeed because there can be no groups using a deleted type.
+#[tokio::test]
+async fn type_update_hierarchy_check_skips_deleted_parent() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let parent = common::create_root_type(&type_svc, "delpar").await;
+    let child_code = type_code("skipchild");
+    type_svc
+        .create_type(CreateTypeRequest {
+            code: child_code.clone(),
+            can_be_root: false,
+            allowed_parent_types: vec![parent.code.clone()],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create child");
+
+    // Delete the parent type (no groups use it)
+    type_svc
+        .delete_type(&parent.code)
+        .await
+        .expect("delete parent");
+
+    // Now update child to remove the (deleted) parent -- should succeed
+    // because resolve_id returns None for deleted parent, so no violation check occurs.
+    // We must provide can_be_root=true since we are removing the only parent.
+    let updated = type_svc
+        .update_type(
+            &child_code,
+            UpdateTypeRequest {
+                can_be_root: true,
+                allowed_parent_types: vec![],
+                allowed_membership_types: vec![],
+                metadata_schema: None,
+            },
+        )
+        .await
+        .expect("update should succeed");
+
+    assert!(updated.allowed_parent_types.is_empty());
+    assert!(updated.can_be_root);
+}
+
+// =========================================================================
+// Metadata schema internal logic tests (TC-META-01..11 / TC-GTS-10..15)
+// =========================================================================
+
+/// TC-META-01 / TC-GTS-12: Type with metadata_schema Object round-trip.
+/// Returned schema matches input. DB stored JSONB has `__can_be_root`.
+/// API response has NO `__can_be_root`.
+#[tokio::test]
+async fn meta_object_schema_roundtrip() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("metaobj");
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "label": { "type": "string" }
+        }
+    });
+
+    let rg_type = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema.clone()),
+        })
+        .await
+        .expect("create type");
+
+    // Service layer returns clean schema (no __ keys)
+    assert_eq!(rg_type.metadata_schema, Some(schema));
+
+    // DB stored JSONB has __can_be_root
+    let conn = db.conn().expect("get conn");
+    let scope = system_scope();
+
+    let model = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("exists");
+
+    let stored = model.metadata_schema.expect("stored schema present");
+    assert_eq!(
+        stored.get("__can_be_root"),
+        Some(&json!(true)),
+        "DB should contain __can_be_root"
+    );
+    // User keys preserved in DB
+    assert!(stored.get("type").is_some(), "User 'type' key in DB");
+    assert!(
+        stored.get("properties").is_some(),
+        "User 'properties' key in DB"
+    );
+
+    // API response (loaded via service) has no __can_be_root
+    let loaded = type_svc.get_type(&code).await.expect("get type");
+    if let Some(ref ms) = loaded.metadata_schema {
+        assert!(
+            ms.get("__can_be_root").is_none(),
+            "API response should not contain __can_be_root"
+        );
+    }
+}
+
+/// TC-META-02: Type `metadata_schema` with a non-Object (array) shape.
+/// Behavior asserted: the schema fails JSON-Schema validation up-front, so
+/// the create call returns a `Validation`-class error mentioning
+/// "not a valid JSON Schema". (No round-trip ever happens — the schema is
+/// rejected at the API boundary; the legacy "wrap/unwrap" comment was stale.)
+#[tokio::test]
+async fn meta_non_object_array_roundtrip() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("metaarr");
+    let schema = json!(["string", "number"]);
+
+    let result = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema.clone()),
+        })
+        .await;
+
+    // Array is not valid JSON Schema (must be object or boolean) -> rejected
+    assert!(result.is_err(), "Array schema should be rejected");
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("not a valid JSON Schema"),
+        "Error should mention invalid JSON Schema"
+    );
+}
+
+/// TC-META-03: Type `metadata_schema` with a non-Object (string) shape.
+/// Behavior asserted: same as TC-META-02 — early validation rejection with
+/// "not a valid JSON Schema". The previous "wrap and lose data" comment was
+/// stale; nothing is wrapped, the schema is rejected before storage.
+#[tokio::test]
+async fn meta_non_object_string_roundtrip() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("metastr");
+    let schema = json!("just a string");
+
+    let result = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema),
+        })
+        .await;
+
+    // String is not valid JSON Schema (must be object or boolean) -> rejected
+    assert!(result.is_err(), "String schema should be rejected");
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("not a valid JSON Schema"),
+        "Error should mention invalid JSON Schema"
+    );
+}
+
+/// TC-META-04: Type `metadata_schema` with a non-Object (number) shape.
+/// Behavior asserted: same as TC-META-02/03 — early validation rejection
+/// with "not a valid JSON Schema". Together with TC-META-11
+/// (`meta_any_object_schema_accepted`) the suite documents the actual
+/// contract: `metadata_schema` must be a JSON Schema, which means an
+/// **object** (or boolean) at the root; non-object roots are rejected,
+/// while *any* object — even with arbitrary user-defined keys — is
+/// accepted without keyword-level validation.
+#[tokio::test]
+async fn meta_non_object_number_roundtrip() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("metanum");
+    let schema = json!(42);
+
+    let result = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema),
+        })
+        .await;
+
+    // Number is not valid JSON Schema (must be object or boolean) -> rejected
+    assert!(result.is_err(), "Number schema should be rejected");
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("not a valid JSON Schema"),
+        "Error should mention invalid JSON Schema"
+    );
+}
+
+/// TC-META-05: User sends __can_be_root in metadata_schema.
+/// System's can_be_root wins; user's __can_be_root is overwritten.
+#[tokio::test]
+async fn meta_user_can_be_root_overwritten() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("metacbr");
+    // User sends __can_be_root=false but the request says can_be_root=true
+    let schema = json!({
+        "__can_be_root": false,
+        "user_field": "hello"
+    });
+
+    let rg_type = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema),
+        })
+        .await
+        .expect("create type");
+
+    // Service layer derives can_be_root from stored __can_be_root which should be true
+    assert!(rg_type.can_be_root, "System's can_be_root=true should win");
+
+    // Returned metadata_schema should not contain __can_be_root
+    let ms = rg_type.metadata_schema.expect("has schema");
+    assert!(
+        ms.get("__can_be_root").is_none(),
+        "API should not expose __can_be_root"
+    );
+    assert_eq!(ms.get("user_field"), Some(&json!("hello")));
+
+    // Verify DB stored the system value (true), not user value (false)
+    let conn = db.conn().expect("get conn");
+    let scope = system_scope();
+
+    let model = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("exists");
+    let stored = model.metadata_schema.expect("stored");
+    assert_eq!(
+        stored.get("__can_be_root"),
+        Some(&json!(true)),
+        "DB should store system can_be_root=true, overwriting user's false"
+    );
+}
+
+/// TC-META-06 / TC-GTS-13: User sends __other_internal key.
+/// Stripped on read; returned metadata has only non-__ keys.
+#[tokio::test]
+async fn meta_internal_keys_stripped() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("metaint");
+    let schema = json!({
+        "__custom_internal": "should be stripped",
+        "visible_field": 42
+    });
+
+    let rg_type = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema),
+        })
+        .await
+        .expect("create type");
+
+    let ms = rg_type.metadata_schema.expect("has schema");
+    assert!(
+        ms.get("__custom_internal").is_none(),
+        "__ prefixed keys should be stripped"
+    );
+    assert_eq!(ms.get("visible_field"), Some(&json!(42)));
+}
+
+/// TC-META-07 / TC-GTS-14: Single underscore key _myField preserved.
+#[tokio::test]
+async fn meta_single_underscore_key_preserved() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("metasingle");
+    let schema = json!({
+        "_myField": "should survive"
+    });
+
+    let rg_type = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema),
+        })
+        .await
+        .expect("create type");
+
+    let ms = rg_type.metadata_schema.expect("has schema");
+    assert_eq!(
+        ms.get("_myField"),
+        Some(&json!("should survive")),
+        "Single underscore keys should be preserved"
+    );
+}
+
+/// TC-META-08 / TC-GTS-15: metadata_schema=None -> stored with __can_be_root.
+/// DB has {"__can_be_root": true/false}; API returns None.
+#[tokio::test]
+async fn meta_none_stored_with_can_be_root() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("metanone");
+    let rg_type = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create type");
+
+    // API returns None (only internal keys, stripped to empty -> None)
+    assert_eq!(rg_type.metadata_schema, None);
+
+    // DB stores {"__can_be_root": true}
+    let conn = db.conn().expect("get conn");
+    let scope = system_scope();
+
+    let model = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("exists");
+    let stored = model.metadata_schema.expect("stored schema present");
+    assert_eq!(
+        stored,
+        json!({"__can_be_root": true}),
+        "DB should store __can_be_root even with None schema"
+    );
+}
+
+/// TC-META-09 / TC-GTS-10: can_be_root derived from stored __can_be_root.
+/// true -> true, false -> false.
+#[tokio::test]
+async fn meta_can_be_root_derived_from_stored_key() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    // Test can_be_root=true
+    let root_type = common::create_root_type(&type_svc, "cbrtrue").await;
+    assert!(
+        root_type.can_be_root,
+        "Root type should have can_be_root=true"
+    );
+
+    // Test can_be_root=false (with allowed_parent_types)
+    let child_type =
+        common::create_child_type(&type_svc, "cbrfalse", &[&root_type.code], &[]).await;
+    assert!(
+        !child_type.can_be_root,
+        "Child type should have can_be_root=false"
+    );
+
+    // Verify via DB: __can_be_root values
+    let conn = db.conn().expect("get conn");
+    let scope = system_scope();
+
+    let root_model = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&root_type.code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("exists");
+    let root_stored = root_model.metadata_schema.expect("stored");
+    assert_eq!(root_stored.get("__can_be_root"), Some(&json!(true)));
+
+    let child_model = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&child_type.code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("exists");
+    let child_stored = child_model.metadata_schema.expect("stored");
+    assert_eq!(child_stored.get("__can_be_root"), Some(&json!(false)));
+}
+
+/// TC-META-10 / TC-GTS-11: can_be_root fallback when __can_be_root missing.
+/// Uses allowed_parent_types.is_empty() as fallback.
+/// Requires direct DB insert to create a type row without __can_be_root in JSONB.
+#[tokio::test]
+async fn meta_can_be_root_fallback_no_stored_key() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("nocbrkey");
+
+    // Insert directly into DB without __can_be_root using secure insert
+    let conn = db.conn().expect("get conn");
+    let scope = system_scope();
+
+    let model = gts_type::ActiveModel {
+        schema_id: Set(code.clone()),
+        metadata_schema: Set(Some(json!({"user_field": "test"}))),
+        ..Default::default()
+    };
+    secure_insert::<GtsTypeEntity>(model, &scope, &conn)
+        .await
+        .expect("direct insert");
+
+    // Load via service -- no allowed_parent_types so fallback = true
+    let loaded = type_svc.get_type(&code).await.expect("get type");
+    assert!(
+        loaded.can_be_root,
+        "Fallback: no __can_be_root + no parents -> can_be_root=true"
+    );
+
+    // Now create a type with parents and no __can_be_root
+    let parent_code = type_code("fallbackpar");
+    let parent_model = gts_type::ActiveModel {
+        schema_id: Set(parent_code.clone()),
+        metadata_schema: Set(Some(json!({"__can_be_root": true}))),
+        ..Default::default()
+    };
+    secure_insert::<GtsTypeEntity>(parent_model, &scope, &conn)
+        .await
+        .expect("insert parent");
+
+    let child_code = type_code("fallbackchild");
+    let child_model = gts_type::ActiveModel {
+        schema_id: Set(child_code.clone()),
+        metadata_schema: Set(Some(json!({"only_user": true}))),
+        ..Default::default()
+    };
+    secure_insert::<GtsTypeEntity>(child_model, &scope, &conn)
+        .await
+        .expect("insert child");
+
+    // Manually insert allowed_parent junction row
+    let parent_row = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&parent_code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("exists");
+
+    let child_row = GtsTypeEntity::find()
+        .filter(gts_type::Column::SchemaId.eq(&child_code))
+        .secure()
+        .scope_with(&scope)
+        .one(&conn)
+        .await
+        .expect("query")
+        .expect("exists");
+
+    let junction = gts_type_allowed_parent::ActiveModel {
+        type_id: Set(child_row.id),
+        parent_type_id: Set(parent_row.id),
+    };
+    secure_insert::<AllowedParentEntity>(junction, &scope, &conn)
+        .await
+        .expect("insert junction");
+
+    // Load via service -- has allowed_parent_types so fallback = false
+    let loaded_child = type_svc.get_type(&child_code).await.expect("get type");
+    assert!(
+        !loaded_child.can_be_root,
+        "Fallback: no __can_be_root + has parents -> can_be_root=false"
+    );
+}
+
+/// TC-META-11: `metadata_schema` keyword-validation — any **object**
+/// (regardless of which JSON-Schema keywords it does or does not use) is
+/// accepted at the API boundary. The root-shape constraint is still
+/// enforced (see TC-META-02/03/04 for non-object rejection); this test
+/// covers the complementary "no keyword whitelist" guarantee.
+#[tokio::test]
+async fn meta_any_object_schema_accepted() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    // The root is an object — required by the schema shape rule. Inside,
+    // arbitrary keys are tolerated (no keyword-level validation).
+    let code = type_code("anyjson");
+    let schema = json!({
+        "banana": true,
+        "count": 999,
+        "nested": { "deep": [1, 2, 3] }
+    });
+
+    let rg_type = type_svc
+        .create_type(CreateTypeRequest {
+            code,
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema.clone()),
+        })
+        .await
+        .expect("any object schema should be accepted");
+
+    assert_eq!(rg_type.metadata_schema, Some(schema));
+}
+
+// =========================================================================
+// GTS Resolution tests (TC-GTS-01..09)
+// =========================================================================
+
+/// TC-GTS-01: resolve_id for existing type -> Some(id) where id is i16.
+#[tokio::test]
+async fn gts_resolve_id_existing() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let rt = common::create_root_type(&type_svc, "resid").await;
+
+    let conn = db.conn().expect("get conn");
+    let id = TypeRepository
+        .resolve_id(&conn, &rt.code)
+        .await
+        .expect("resolve_id");
+    assert!(
+        id.is_some(),
+        "resolve_id should return Some for existing type"
+    );
+    let id_val = id.unwrap();
+    // Verify the id is a positive SMALLINT
+    assert!(id_val > 0, "Type id should be positive");
+}
+
+/// TC-GTS-02: resolve_id for nonexistent path -> None.
+#[tokio::test]
+async fn gts_resolve_id_nonexistent() {
+    let db = common::test_db().await;
+
+    let conn = db.conn().expect("get conn");
+    let code = type_code("noexist");
+    let id = TypeRepository
+        .resolve_id(&conn, &code)
+        .await
+        .expect("resolve_id");
+    assert!(
+        id.is_none(),
+        "resolve_id should return None for nonexistent type"
+    );
+}
+
+/// TC-GTS-03: resolve_ids batch -- all found -> Ok(vec![id1, id2, id3]).
+#[tokio::test]
+async fn gts_resolve_ids_all_found() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let t1 = common::create_root_type(&type_svc, "batch1").await;
+    let t2 = common::create_root_type(&type_svc, "batch2").await;
+    let t3 = common::create_root_type(&type_svc, "batch3").await;
+
+    let conn = db.conn().expect("get conn");
+    let codes = vec![t1.code.clone(), t2.code.clone(), t3.code.clone()];
+    let ids = TypeRepository
+        .resolve_ids(&conn, &codes)
+        .await
+        .expect("resolve_ids");
+
+    assert_eq!(ids.len(), 3, "Should resolve all 3 types");
+    // All IDs should be distinct
+    let mut unique = ids;
+    unique.sort_unstable();
+    unique.dedup();
+    assert_eq!(unique.len(), 3, "All IDs should be distinct");
+}
+
+/// TC-GTS-04: resolve_ids batch -- some missing -> Err(Validation("Referenced types not found: ...")).
+#[tokio::test]
+async fn gts_resolve_ids_some_missing() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let t1 = common::create_root_type(&type_svc, "partfound").await;
+    let missing_code = type_code("missing");
+
+    let conn = db.conn().expect("get conn");
+    let codes = vec![t1.code.clone(), missing_code.clone()];
+    let err = TypeRepository
+        .resolve_ids(&conn, &codes)
+        .await
+        .expect_err("should fail");
+
+    assert!(
+        matches!(err, DomainError::Validation { .. }),
+        "Expected Validation error: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("not found"),
+        "Error should mention 'not found': {err:?}"
+    );
+}
+
+/// TC-GTS-05: resolve_ids -- multiple missing -> error lists both.
+#[tokio::test]
+async fn gts_resolve_ids_multiple_missing() {
+    let db = common::test_db().await;
+
+    let missing1 = type_code("miss1");
+    let missing2 = type_code("miss2");
+
+    let conn = db.conn().expect("get conn");
+    let codes = vec![missing1.clone(), missing2.clone()];
+    let err = TypeRepository
+        .resolve_ids(&conn, &codes)
+        .await
+        .expect_err("should fail");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not found"),
+        "Error should mention 'not found': {msg}"
+    );
+    // Both missing codes should be mentioned
+    assert!(
+        msg.contains("miss1") && msg.contains("miss2"),
+        "Error should list both missing codes: {msg}"
+    );
+}
+
+/// TC-GTS-06: resolve_ids empty list -> Ok(vec![]).
+#[tokio::test]
+async fn gts_resolve_ids_empty_list() {
+    let db = common::test_db().await;
+
+    let conn = db.conn().expect("get conn");
+    let codes: Vec<String> = vec![];
+    let ids = TypeRepository
+        .resolve_ids(&conn, &codes)
+        .await
+        .expect("resolve_ids");
+    assert!(ids.is_empty(), "Empty input should return empty result");
+}
+
+/// TC-GTS-07: Full roundtrip: create -> resolve_id -> load_full_type_by_id -> path matches.
+#[tokio::test]
+async fn gts_full_roundtrip_create_resolve_load() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let rt = common::create_root_type(&type_svc, "roundtrip").await;
+
+    let conn = db.conn().expect("get conn");
+
+    // resolve_id
+    let id = TypeRepository
+        .resolve_id(&conn, &rt.code)
+        .await
+        .expect("resolve_id")
+        .expect("type exists");
+
+    // load_full_type_by_id
+    let loaded = TypeRepository
+        .load_full_type_by_id(&conn, id)
+        .await
+        .expect("load_full_type_by_id");
+
+    assert_eq!(loaded.code, rt.code, "Path should match after roundtrip");
+    assert_eq!(loaded.can_be_root, rt.can_be_root);
+}
+
+/// TC-GTS-08: load_allowed_parent_types junction -> IDs -> paths. Returns parent code.
+#[tokio::test]
+async fn gts_load_allowed_parent_types_returns_paths() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let parent = common::create_root_type(&type_svc, "gtspar").await;
+    let child = common::create_child_type(&type_svc, "gtschild", &[&parent.code], &[]).await;
+
+    assert_eq!(
+        child.allowed_parent_types,
+        vec![parent.code.clone()],
+        "allowed_parent_types should contain the parent's GTS path"
+    );
+
+    // Also verify via direct get_type (which goes through load_full_type)
+    let loaded = type_svc.get_type(&child.code).await.expect("get type");
+    assert_eq!(loaded.allowed_parent_types, vec![parent.code]);
+}
+
+/// TC-GTS-09: load_allowed_membership_types junction -> IDs -> paths. Returns membership code.
+#[tokio::test]
+async fn gts_load_allowed_membership_types_returns_paths() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let membership_type = common::create_root_type(&type_svc, "gtsmemb").await;
+    let code = type_code("gtswithmemb");
+    let rg_type = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![membership_type.code.clone()],
+            metadata_schema: None,
+        })
+        .await
+        .expect("create type");
+
+    assert_eq!(
+        rg_type.allowed_membership_types,
+        vec![membership_type.code.clone()],
+        "allowed_membership_types should contain the membership type's GTS path"
+    );
+
+    // Verify via get_type
+    let loaded = type_svc.get_type(&code).await.expect("get type");
+    assert_eq!(loaded.allowed_membership_types, vec![membership_type.code]);
+}
+
+// =========================================================================
+// Security/Attack Tests for Type metadata_schema (TC-META-ATK-01..07, 10, 11)
+// =========================================================================
+
+/// TC-META-ATK-01: Overwrite __can_be_root via metadata_schema -- system field wins.
+#[tokio::test]
+async fn security_metadata_schema_cannot_overwrite_can_be_root() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    // Create a parent type first so we can set can_be_root=false
+    let parent = common::create_root_type(&type_svc, "atk01par").await;
+
+    let code = type_code("atk01");
+    let rg_type = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: false,
+            allowed_parent_types: vec![parent.code.clone()],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(json!({
+                "__can_be_root": true,
+                "custom_field": "value"
+            })),
+        })
+        .await
+        .expect("create type with __can_be_root in metadata");
+
+    // System field should remain false regardless of metadata
+    assert!(
+        !rg_type.can_be_root,
+        "System can_be_root must not be overridden by metadata_schema"
+    );
+}
+
+/// TC-META-ATK-02: __can_be_root non-boolean value -- no panic, fallback works.
+#[tokio::test]
+async fn security_metadata_schema_can_be_root_non_boolean() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("atk02");
+    let rg_type = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(json!({
+                "__can_be_root": "not-a-bool",
+                "__allowed_parent_types": [1, 2, 3]
+            })),
+        })
+        .await
+        .expect("create type with non-bool __ keys");
+
+    assert!(rg_type.can_be_root, "System can_be_root must remain true");
+}
+
+/// TC-META-ATK-03: Multiple __ keys -- no accumulation, only non-__ keys returned.
+#[tokio::test]
+async fn security_metadata_schema_double_underscore_keys_filtered() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("atk03");
+    let schema = json!({
+        "__internal": "hidden",
+        "__secret": 42,
+        "visible": true
+    });
+
+    type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema),
+        })
+        .await
+        .expect("create type with __ keys");
+
+    // Retrieval must strip all `__*` keys — both the caller-supplied ones
+    // (`__internal`, `__secret`) and the module-internal ones added during
+    // storage (`__can_be_root`). Only non-underscore keys should remain.
+    // A slip in the filter (e.g. `starts_with('_')` vs `starts_with("__")`,
+    // or dropping the filter entirely) would let caller data leak back out,
+    // so the assertions below check each case.
+    let loaded = type_svc.get_type(&code).await.expect("get type");
+    assert!(loaded.can_be_root, "System fields unaffected by __ keys");
+
+    let schema = loaded
+        .metadata_schema
+        .expect("non-underscore keys must survive; schema must not be None");
+    let obj = schema
+        .as_object()
+        .expect("schema must be a JSON object after filtering");
+
+    assert!(
+        obj.get("__internal").is_none(),
+        "caller-supplied __internal must not leak back, got: {obj:?}",
+    );
+    assert!(
+        obj.get("__secret").is_none(),
+        "caller-supplied __secret must not leak back, got: {obj:?}",
+    );
+    assert!(
+        obj.get("__can_be_root").is_none(),
+        "module-internal __can_be_root must not leak back, got: {obj:?}",
+    );
+    assert_eq!(
+        obj.get("visible"),
+        Some(&json!(true)),
+        "non-underscore key must survive the filter",
+    );
+    assert_eq!(
+        obj.len(),
+        1,
+        "only the single non-__ key should remain, got: {obj:?}",
+    );
+}
+
+/// TC-META-ATK-04: Huge metadata_schema (1MB). Document behavior -- no panic.
+#[tokio::test]
+async fn security_metadata_schema_huge_payload() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("atk04");
+    let big_value = "A".repeat(1_000_000);
+    let schema = json!({"huge": big_value});
+
+    let result = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema),
+        })
+        .await;
+
+    match result {
+        Ok(rg_type) => {
+            // If accepted, verify roundtrip
+            let loaded = type_svc.get_type(&code).await.expect("get type");
+            let schema = loaded.metadata_schema.unwrap();
+            assert_eq!(
+                schema["huge"].as_str().unwrap().len(),
+                1_000_000,
+                "1MB schema should roundtrip"
+            );
+            assert!(rg_type.can_be_root);
+        }
+        // Deterministic deny classes are acceptable: validation rejects
+        // oversize payloads up-front, and the storage layer may reject
+        // through the DB (e.g. SQLite TEXT/JSON limits). Any other error
+        // class indicates a regression.
+        Err(DomainError::Validation { .. } | DomainError::Database(_)) => {}
+        Err(e) => panic!("unexpected error class for large metadata schema: {e:?}"),
+    }
+}
+
+/// TC-META-ATK-05: Deeply nested metadata_schema (100+ levels) -- no panic.
+#[tokio::test]
+async fn security_metadata_schema_deep_nesting() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("atk05");
+
+    // Build 100-level nested JSON
+    let mut nested: serde_json::Value = json!("leaf");
+    for _ in 0..100 {
+        nested = json!({"child": nested});
+    }
+
+    let result = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(nested),
+        })
+        .await;
+
+    // Should not panic regardless of outcome; tightened to accept only the
+    // deterministic deny classes. A deep-nesting payload may legitimately
+    // be rejected by validation (depth/size limits) or by the DB layer.
+    match result {
+        Ok(_) => {
+            let loaded = type_svc.get_type(&code).await.expect("get type");
+            assert!(loaded.metadata_schema.is_some());
+        }
+        Err(DomainError::Validation { .. } | DomainError::Database(_)) => {}
+        Err(e) => panic!("unexpected error class for deeply nested metadata: {e:?}"),
+    }
+}
+
+/// TC-META-ATK-06: Special JSON values (null, true) in metadata_schema -- handled gracefully.
+#[tokio::test]
+async fn security_metadata_schema_special_values() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    // Test with null value
+    let code1 = type_code("atk06a");
+    let t1 = type_svc
+        .create_type(CreateTypeRequest {
+            code: code1.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(json!(null)),
+        })
+        .await;
+    // null schema is accepted or rejected with a deterministic deny class.
+    if let Err(e) = t1 {
+        assert!(
+            matches!(e, DomainError::Validation { .. } | DomainError::Database(_)),
+            "unexpected error class for null metadata_schema: {e:?}"
+        );
+    }
+
+    // Test with bare true
+    let code2 = type_code("atk06b");
+    let t2 = type_svc
+        .create_type(CreateTypeRequest {
+            code: code2.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(json!(true)),
+        })
+        .await;
+    if let Err(e) = t2 {
+        assert!(
+            matches!(e, DomainError::Validation { .. } | DomainError::Database(_)),
+            "unexpected error class for `true` metadata_schema: {e:?}"
+        );
+    }
+}
+
+/// TC-META-ATK-07: SQL column name keys in metadata -- no collision.
+#[tokio::test]
+async fn security_metadata_schema_sql_column_names() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("atk07");
+    let schema = json!({
+        "code": "fake-code",
+        "can_be_root": "fake-bool",
+        "gts_type_id": 999,
+        "id": "fake-id",
+        "SELECT": "* FROM gts_type"
+    });
+
+    let rg_type = type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(schema),
+        })
+        .await
+        .expect("create type with SQL column name keys");
+
+    // System fields must be unaffected
+    assert!(rg_type.can_be_root);
+    assert_eq!(rg_type.code, code);
+
+    let loaded = type_svc.get_type(&code).await.expect("get type");
+    assert_eq!(
+        loaded.code, code,
+        "code field must not be overwritten by metadata"
+    );
+}
+
+/// TC-META-ATK-10: Update metadata_schema -- old keys do not leak. Full replacement.
+#[tokio::test]
+async fn security_metadata_schema_update_full_replacement() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("atk10");
+    type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(json!({"old_key": "old_value", "shared": 1})),
+        })
+        .await
+        .expect("create type");
+
+    // Update with completely different schema
+    let updated = type_svc
+        .update_type(
+            &code,
+            UpdateTypeRequest {
+                can_be_root: true,
+                allowed_parent_types: vec![],
+                allowed_membership_types: vec![],
+                metadata_schema: Some(json!({"new_key": "new_value"})),
+            },
+        )
+        .await
+        .expect("update type");
+
+    let schema = updated.metadata_schema.unwrap();
+    assert!(
+        schema.get("old_key").is_none(),
+        "Old key should not leak after full replacement: {schema}"
+    );
+    assert!(
+        schema.get("shared").is_none(),
+        "Shared key should not persist after full replacement: {schema}"
+    );
+    assert_eq!(schema["new_key"], "new_value");
+}
+
+/// TC-META-ATK-11: Concurrent updates do not merge -- last write wins.
+#[tokio::test]
+async fn security_metadata_schema_last_write_wins() {
+    let db = common::test_db().await;
+    let type_svc = TypeService::new(db.clone(), Arc::new(TypeRepository));
+
+    let code = type_code("atk11");
+    type_svc
+        .create_type(CreateTypeRequest {
+            code: code.clone(),
+            can_be_root: true,
+            allowed_parent_types: vec![],
+            allowed_membership_types: vec![],
+            metadata_schema: Some(json!({"version": 1})),
+        })
+        .await
+        .expect("create type");
+
+    // Simulate sequential updates (no real concurrency needed to verify no-merge)
+    type_svc
+        .update_type(
+            &code,
+            UpdateTypeRequest {
+                can_be_root: true,
+                allowed_parent_types: vec![],
+                allowed_membership_types: vec![],
+                metadata_schema: Some(json!({"version": 2, "extra": "a"})),
+            },
+        )
+        .await
+        .expect("update v2");
+
+    type_svc
+        .update_type(
+            &code,
+            UpdateTypeRequest {
+                can_be_root: true,
+                allowed_parent_types: vec![],
+                allowed_membership_types: vec![],
+                metadata_schema: Some(json!({"version": 3})),
+            },
+        )
+        .await
+        .expect("update v3");
+
+    let loaded = type_svc.get_type(&code).await.expect("get type");
+    let schema = loaded.metadata_schema.unwrap();
+    assert_eq!(schema["version"], 3);
+    assert!(
+        schema.get("extra").is_none(),
+        "Previous update keys must not merge: {schema}"
+    );
+}

--- a/modules/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/client.rs
+++ b/modules/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/client.rs
@@ -1,3 +1,6 @@
+// Created: 2026-04-23 by Constructor Tech
+// Updated: 2026-04-29 by Constructor Tech
+
 //! Client implementation for the RG tenant resolver plugin.
 //!
 //! Implements `TenantResolverPluginClient` using the domain service.
@@ -118,3 +121,8 @@ impl TenantResolverPluginClient for Service {
             .await
     }
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "client_tests.rs"]
+mod client_tests;

--- a/modules/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/client_tests.rs
+++ b/modules/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/client_tests.rs
@@ -1,0 +1,6 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-29 by Constructor Tech
+
+// Client trait implementation tests are covered by service_tests.rs
+// since client.rs delegates directly to service methods.
+// This file exists for structural consistency with other plugins.

--- a/modules/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/service.rs
+++ b/modules/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/service.rs
@@ -1,3 +1,6 @@
+// Created: 2026-04-23 by Constructor Tech
+// Updated: 2026-04-29 by Constructor Tech
+
 //! Domain service for the RG tenant resolver plugin.
 //!
 //! Maps Resource Group hierarchy data to tenant resolver models.
@@ -522,3 +525,8 @@ fn filter_descendants_by_barrier(
 
     result
 }
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "service_tests.rs"]
+mod service_tests;

--- a/modules/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/service_tests.rs
+++ b/modules/system/tenant-resolver/plugins/rg-tr-plugin/src/domain/service_tests.rs
@@ -1,0 +1,1128 @@
+// Created: 2026-04-16 by Constructor Tech
+// Updated: 2026-04-29 by Constructor Tech
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit_odata::ast::{CompareOperator, Expr, Value};
+use modkit_odata::{ODataQuery, Page, PageInfo};
+use modkit_security::SecurityContext;
+use resource_group_sdk::TENANT_RG_TYPE_PATH;
+use resource_group_sdk::api::ResourceGroupReadHierarchy;
+use resource_group_sdk::error::ResourceGroupError;
+use resource_group_sdk::models::{
+    GroupHierarchy, GroupHierarchyWithDepth, ResourceGroup, ResourceGroupWithDepth,
+};
+use tenant_resolver_sdk::{
+    BarrierMode, GetAncestorsOptions, GetDescendantsOptions, GetTenantsOptions, IsAncestorOptions,
+    TenantId, TenantResolverError, TenantResolverPluginClient, TenantStatus,
+};
+use uuid::Uuid;
+
+use crate::domain::service::Service;
+
+// -- Mock RG hierarchy --
+
+struct MockRgHierarchy {
+    /// Default items returned for any `get_group_ancestors` call (legacy).
+    ancestors: Vec<ResourceGroupWithDepth>,
+    /// Default items returned for any `get_group_descendants` call (legacy).
+    descendants: Vec<ResourceGroupWithDepth>,
+    /// Optional per-`group_id` dispatch for `get_group_ancestors`.
+    ancestors_by_id: std::collections::HashMap<Uuid, Vec<ResourceGroupWithDepth>>,
+    /// Optional per-`group_id` dispatch for `get_group_descendants`.
+    descendants_by_id: std::collections::HashMap<Uuid, Vec<ResourceGroupWithDepth>>,
+}
+
+impl MockRgHierarchy {
+    fn descendants_only(descendants: Vec<ResourceGroupWithDepth>) -> Self {
+        Self {
+            ancestors: vec![],
+            descendants,
+            ancestors_by_id: std::collections::HashMap::new(),
+            descendants_by_id: std::collections::HashMap::new(),
+        }
+    }
+
+    fn ancestors_only(ancestors: Vec<ResourceGroupWithDepth>) -> Self {
+        Self {
+            ancestors,
+            descendants: vec![],
+            ancestors_by_id: std::collections::HashMap::new(),
+            descendants_by_id: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Build a mock whose `get_group_ancestors` dispatches by `group_id`.
+    /// Use this when a test exercises multiple distinct queries that need
+    /// to return different ancestor chains — prevents existence checks from
+    /// passing by accident when the mock would otherwise return the same
+    /// list regardless of which `group_id` was asked for.
+    fn ancestors_by_id(map: std::collections::HashMap<Uuid, Vec<ResourceGroupWithDepth>>) -> Self {
+        Self {
+            ancestors: vec![],
+            descendants: vec![],
+            ancestors_by_id: map,
+            descendants_by_id: std::collections::HashMap::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl ResourceGroupReadHierarchy for MockRgHierarchy {
+    async fn get_group_descendants(
+        &self,
+        _ctx: &SecurityContext,
+        group_id: Uuid,
+        _query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+        // Precedence: if per-id dispatch is configured, honor it strictly —
+        // unknown ids return an empty page (simulates "group not found").
+        // Otherwise fall back to the flat list. Real RG returns the subtree
+        // anchored at `group_id`, so depth=0 is the group itself.
+        let items = if self.descendants_by_id.is_empty() {
+            self.descendants.clone()
+        } else {
+            self.descendants_by_id
+                .get(&group_id)
+                .cloned()
+                .unwrap_or_default()
+        };
+        Ok(Page {
+            items,
+            page_info: PageInfo {
+                next_cursor: None,
+                prev_cursor: None,
+                limit: 100,
+            },
+        })
+    }
+
+    async fn get_group_ancestors(
+        &self,
+        _ctx: &SecurityContext,
+        group_id: Uuid,
+        _query: &ODataQuery,
+    ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+        // See `get_group_descendants` for precedence rules.
+        let items = if self.ancestors_by_id.is_empty() {
+            self.ancestors.clone()
+        } else {
+            self.ancestors_by_id
+                .get(&group_id)
+                .cloned()
+                .unwrap_or_default()
+        };
+        Ok(Page {
+            items,
+            page_info: PageInfo {
+                next_cursor: None,
+                prev_cursor: None,
+                limit: 100,
+            },
+        })
+    }
+
+    async fn list_groups(
+        &self,
+        _ctx: &SecurityContext,
+        query: &ODataQuery,
+    ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
+        // Flatten every `ResourceGroupWithDepth` known to the mock (ancestors
+        // + descendants + per-id dispatches) into `ResourceGroup` entries,
+        // deduplicated by id, then apply the `OData $filter` predicate so
+        // tests cannot pass merely because the mock returned everything.
+        // See `group_matches_filter` for the predicate subset honoured.
+        let mut seen = std::collections::HashSet::new();
+        let mut items: Vec<ResourceGroup> = Vec::new();
+        let filter_expr = query.filter();
+        let flatten = |src: &[ResourceGroupWithDepth],
+                       seen: &mut std::collections::HashSet<Uuid>,
+                       items: &mut Vec<ResourceGroup>| {
+            for g in src {
+                if filter_expr.is_some_and(|e| !group_matches_filter(g, e)) {
+                    continue;
+                }
+                if seen.insert(g.id) {
+                    items.push(ResourceGroup {
+                        id: g.id,
+                        code: g.code.clone(),
+                        name: g.name.clone(),
+                        hierarchy: GroupHierarchy {
+                            parent_id: g.hierarchy.parent_id,
+                            tenant_id: g.hierarchy.tenant_id,
+                        },
+                        metadata: g.metadata.clone(),
+                    });
+                }
+            }
+        };
+        flatten(&self.ancestors, &mut seen, &mut items);
+        flatten(&self.descendants, &mut seen, &mut items);
+        for v in self.ancestors_by_id.values() {
+            flatten(v, &mut seen, &mut items);
+        }
+        for v in self.descendants_by_id.values() {
+            flatten(v, &mut seen, &mut items);
+        }
+        Ok(Page {
+            items,
+            page_info: PageInfo {
+                next_cursor: None,
+                prev_cursor: None,
+                limit: 100,
+            },
+        })
+    }
+}
+
+/// Lightweight `OData $filter` evaluator for the mock `list_groups`.
+///
+/// Honours the predicate subset the rg-tr-plugin service actually emits *or*
+/// that downstream callers (e.g. account-management's soft-delete precondition
+/// from PR #1746) may emit against `list_groups`:
+///
+///   * `id eq <uuid>` / `id ne <uuid>` / `id in (<uuid>, …)`
+///   * `hierarchy/parent_id eq <uuid>` / `... ne <uuid>` / `... in (…)`
+///   * `tenant_id eq <uuid>` / `... ne <uuid>` / `... in (…)`
+///   * `And` / `Or` / `Not` over the above
+///
+/// `tenant_id` is a `Uuid` field (never `None`) on every group, so its
+/// `eq`/`ne`/`in` semantics use the value directly rather than the
+/// `Option`-aware path used for `hierarchy/parent_id`.
+///
+/// Predicates on identifiers the mock does not understand (e.g. `type eq …`,
+/// `name eq …`) are treated as `true` — the mock has only one type-fixture
+/// per test, so type filtering would be a no-op anyway. This keeps the
+/// evaluator small while still catching regressions where the service stops
+/// passing the `id`-style predicates that batch reads depend on.
+fn group_matches_filter(g: &ResourceGroupWithDepth, expr: &Expr) -> bool {
+    match expr {
+        Expr::And(l, r) => group_matches_filter(g, l) && group_matches_filter(g, r),
+        Expr::Or(l, r) => group_matches_filter(g, l) || group_matches_filter(g, r),
+        Expr::Not(inner) => !group_matches_filter(g, inner),
+        Expr::Compare(lhs, op, rhs) => match (lhs.as_ref(), rhs.as_ref()) {
+            (Expr::Identifier(name), Expr::Value(Value::Uuid(u))) => {
+                let actual: Option<Uuid> = match name.as_str() {
+                    "id" => Some(g.id),
+                    "hierarchy/parent_id" => g.hierarchy.parent_id,
+                    "tenant_id" => Some(g.hierarchy.tenant_id),
+                    _ => return true, // unknown identifier — treat as no-op
+                };
+                match op {
+                    CompareOperator::Eq => actual == Some(*u),
+                    CompareOperator::Ne => actual != Some(*u),
+                    _ => true, // ordering ops are not used on UUIDs
+                }
+            }
+            _ => true,
+        },
+        Expr::In(lhs, values) => {
+            let Expr::Identifier(name) = lhs.as_ref() else {
+                return true;
+            };
+            let actual: Option<Uuid> = match name.as_str() {
+                "id" => Some(g.id),
+                "hierarchy/parent_id" => g.hierarchy.parent_id,
+                "tenant_id" => Some(g.hierarchy.tenant_id),
+                _ => return true,
+            };
+            let Some(actual) = actual else { return false };
+            values
+                .iter()
+                .any(|v| matches!(v, Expr::Value(Value::Uuid(u)) if *u == actual))
+        }
+        // Other AST shapes (Function, bare Identifier/Value) are not produced
+        // by the rg-tr-plugin service today; treat them as pass-through to
+        // keep the mock minimal but forward-compatible.
+        _ => true,
+    }
+}
+
+fn make_group(
+    id: Uuid,
+    name: &str,
+    parent_id: Option<Uuid>,
+    depth: i32,
+    metadata: Option<serde_json::Value>,
+) -> ResourceGroupWithDepth {
+    ResourceGroupWithDepth {
+        id,
+        code: TENANT_RG_TYPE_PATH.to_owned(),
+        name: name.to_owned(),
+        hierarchy: GroupHierarchyWithDepth {
+            parent_id,
+            tenant_id: id,
+            depth,
+        },
+        metadata,
+    }
+}
+
+fn service_with(mock: MockRgHierarchy) -> Service {
+    Service::new(Arc::new(mock))
+}
+
+fn ctx() -> SecurityContext {
+    SecurityContext::anonymous()
+}
+
+// -- get_tenant tests --
+
+#[tokio::test]
+async fn get_tenant_returns_info() {
+    let t1 = Uuid::now_v7();
+    let mock = MockRgHierarchy::ancestors_only(vec![make_group(t1, "Root", None, 0, None)]);
+    let svc = service_with(mock);
+
+    let tenant = svc.get_tenant(&ctx(), TenantId(t1)).await.unwrap();
+    assert_eq!(tenant.id, TenantId(t1));
+    assert_eq!(tenant.name, "Root");
+    assert_eq!(tenant.status, TenantStatus::Active);
+    assert!(!tenant.self_managed);
+    assert_eq!(tenant.tenant_type, Some(TENANT_RG_TYPE_PATH.to_owned()));
+}
+
+#[tokio::test]
+async fn get_tenant_with_metadata() {
+    let t1 = Uuid::now_v7();
+    let mock = MockRgHierarchy::ancestors_only(vec![make_group(
+        t1,
+        "Suspended",
+        None,
+        0,
+        Some(serde_json::json!({"status": "suspended", "self_managed": true})),
+    )]);
+    let svc = service_with(mock);
+
+    let tenant = svc.get_tenant(&ctx(), TenantId(t1)).await.unwrap();
+    assert_eq!(tenant.status, TenantStatus::Suspended);
+    assert!(tenant.self_managed);
+}
+
+#[tokio::test]
+async fn get_tenant_not_found() {
+    let mock = MockRgHierarchy::ancestors_only(vec![]);
+    let svc = service_with(mock);
+
+    let err = svc.get_tenant(&ctx(), TenantId(Uuid::now_v7())).await;
+    assert!(matches!(
+        err,
+        Err(TenantResolverError::TenantNotFound { .. })
+    ));
+}
+
+// -- get_tenants tests --
+
+#[tokio::test]
+async fn get_tenants_deduplicates_and_filters_status() {
+    // Three tenants in storage:
+    //   - `t_active`    — requested, Active    → must be in the result
+    //   - `t_suspended` — requested, Suspended → must be filtered by status
+    //   - `t_other`     — NOT requested, Active → must be filtered by ID
+    // The input list contains `t_active` twice to verify input-dedup.
+    //
+    // The mock's `list_groups` honours the OData `id in (...)` filter (see
+    // `group_matches_filter`), so `t_other` is excluded by the mock unless
+    // the service stops emitting that filter, and `t_suspended` is excluded
+    // by the service-side status filter on top.
+    let t_active = Uuid::now_v7();
+    let t_suspended = Uuid::now_v7();
+    let t_other = Uuid::now_v7();
+    let mock = MockRgHierarchy::ancestors_only(vec![
+        make_group(
+            t_active,
+            "Active",
+            None,
+            0,
+            Some(serde_json::json!({"status": "active"})),
+        ),
+        make_group(
+            t_suspended,
+            "Suspended",
+            None,
+            0,
+            Some(serde_json::json!({"status": "suspended"})),
+        ),
+        make_group(
+            t_other,
+            "Other",
+            None,
+            0,
+            Some(serde_json::json!({"status": "active"})),
+        ),
+    ]);
+    let svc = service_with(mock);
+
+    let result = svc
+        .get_tenants(
+            &ctx(),
+            &[
+                TenantId(t_active),
+                TenantId(t_active),
+                TenantId(t_suspended),
+            ],
+            &GetTenantsOptions {
+                status: vec![TenantStatus::Active],
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.len(),
+        1,
+        "expected exactly one tenant after status filter + dedup"
+    );
+    assert_eq!(result[0].id, TenantId(t_active));
+    assert_eq!(result[0].status, TenantStatus::Active);
+    assert!(
+        !result.iter().any(|t| t.id == TenantId(t_suspended)),
+        "Suspended tenant must be excluded by status filter"
+    );
+    assert!(
+        !result.iter().any(|t| t.id == TenantId(t_other)),
+        "Tenant not present in the request must not leak through, even when stored"
+    );
+}
+
+#[tokio::test]
+async fn get_tenants_skips_not_found() {
+    let mock = MockRgHierarchy::ancestors_only(vec![]);
+    let svc = service_with(mock);
+
+    let result = svc
+        .get_tenants(
+            &ctx(),
+            &[TenantId(Uuid::now_v7())],
+            &GetTenantsOptions::default(),
+        )
+        .await
+        .unwrap();
+    assert!(result.is_empty());
+}
+
+// -- get_ancestors tests --
+
+#[tokio::test]
+async fn get_ancestors_returns_parent_chain() {
+    let root = Uuid::now_v7();
+    let child = Uuid::now_v7();
+    let mock = MockRgHierarchy::ancestors_only(vec![
+        make_group(child, "Child", Some(root), 0, None),
+        make_group(root, "Root", None, -1, None),
+    ]);
+    let svc = service_with(mock);
+
+    let resp = svc
+        .get_ancestors(&ctx(), TenantId(child), &GetAncestorsOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.tenant.id, TenantId(child));
+    assert_eq!(resp.ancestors.len(), 1);
+    assert_eq!(resp.ancestors[0].id, TenantId(root));
+}
+
+#[tokio::test]
+async fn get_ancestors_barrier_on_self_returns_empty() {
+    let root = Uuid::now_v7();
+    let barrier_child = Uuid::now_v7();
+    let mock = MockRgHierarchy::ancestors_only(vec![
+        make_group(
+            barrier_child,
+            "Barrier",
+            Some(root),
+            0,
+            Some(serde_json::json!({"self_managed": true})),
+        ),
+        make_group(root, "Root", None, -1, None),
+    ]);
+    let svc = service_with(mock);
+
+    let resp = svc
+        .get_ancestors(
+            &ctx(),
+            TenantId(barrier_child),
+            &GetAncestorsOptions {
+                barrier_mode: BarrierMode::Respect,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.tenant.id, TenantId(barrier_child));
+    assert!(
+        resp.ancestors.is_empty(),
+        "self_managed tenant should have no visible ancestors"
+    );
+}
+
+#[tokio::test]
+async fn get_ancestors_barrier_on_ancestor_stops_traversal() {
+    let root = Uuid::now_v7();
+    let barrier = Uuid::now_v7();
+    let child = Uuid::now_v7();
+    let mock = MockRgHierarchy::ancestors_only(vec![
+        make_group(child, "Child", Some(barrier), 0, None),
+        make_group(
+            barrier,
+            "Barrier",
+            Some(root),
+            -1,
+            Some(serde_json::json!({"self_managed": true})),
+        ),
+        make_group(root, "Root", None, -2, None),
+    ]);
+    let svc = service_with(mock);
+
+    let resp = svc
+        .get_ancestors(
+            &ctx(),
+            TenantId(child),
+            &GetAncestorsOptions {
+                barrier_mode: BarrierMode::Respect,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Should include barrier but not root (stopped at barrier)
+    assert_eq!(resp.ancestors.len(), 1);
+    assert_eq!(resp.ancestors[0].id, TenantId(barrier));
+}
+
+#[tokio::test]
+async fn get_ancestors_ignore_barrier_returns_all() {
+    let root = Uuid::now_v7();
+    let barrier = Uuid::now_v7();
+    let child = Uuid::now_v7();
+    let mock = MockRgHierarchy::ancestors_only(vec![
+        make_group(child, "Child", Some(barrier), 0, None),
+        make_group(
+            barrier,
+            "Barrier",
+            Some(root),
+            -1,
+            Some(serde_json::json!({"self_managed": true})),
+        ),
+        make_group(root, "Root", None, -2, None),
+    ]);
+    let svc = service_with(mock);
+
+    let resp = svc
+        .get_ancestors(
+            &ctx(),
+            TenantId(child),
+            &GetAncestorsOptions {
+                barrier_mode: BarrierMode::Ignore,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.ancestors.len(), 2);
+}
+
+// -- get_descendants tests --
+
+#[tokio::test]
+async fn get_descendants_returns_subtree() {
+    let root = Uuid::now_v7();
+    let c1 = Uuid::now_v7();
+    let c2 = Uuid::now_v7();
+    let mock = MockRgHierarchy::descendants_only(vec![
+        make_group(root, "Root", None, 0, None),
+        make_group(c1, "C1", Some(root), 1, None),
+        make_group(c2, "C2", Some(root), 1, None),
+    ]);
+    let svc = service_with(mock);
+
+    let resp = svc
+        .get_descendants(&ctx(), TenantId(root), &GetDescendantsOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.tenant.id, TenantId(root));
+    assert_eq!(resp.descendants.len(), 2);
+}
+
+#[tokio::test]
+async fn get_descendants_barrier_excludes_subtree() {
+    let root = Uuid::now_v7();
+    let normal = Uuid::now_v7();
+    let barrier = Uuid::now_v7();
+    let behind = Uuid::now_v7();
+    let mock = MockRgHierarchy::descendants_only(vec![
+        make_group(root, "Root", None, 0, None),
+        make_group(normal, "Normal", Some(root), 1, None),
+        make_group(
+            barrier,
+            "Barrier",
+            Some(root),
+            1,
+            Some(serde_json::json!({"self_managed": true})),
+        ),
+        make_group(behind, "Behind", Some(barrier), 2, None),
+    ]);
+    let svc = service_with(mock);
+
+    let resp = svc
+        .get_descendants(
+            &ctx(),
+            TenantId(root),
+            &GetDescendantsOptions {
+                barrier_mode: BarrierMode::Respect,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    // Only normal should be visible; barrier + behind excluded
+    assert_eq!(resp.descendants.len(), 1);
+    assert_eq!(resp.descendants[0].id, TenantId(normal));
+}
+
+#[tokio::test]
+async fn get_descendants_status_filter() {
+    let root = Uuid::now_v7();
+    let active = Uuid::now_v7();
+    let suspended = Uuid::now_v7();
+    let mock = MockRgHierarchy::descendants_only(vec![
+        make_group(root, "Root", None, 0, None),
+        make_group(
+            active,
+            "Active",
+            Some(root),
+            1,
+            Some(serde_json::json!({"status": "active"})),
+        ),
+        make_group(
+            suspended,
+            "Suspended",
+            Some(root),
+            1,
+            Some(serde_json::json!({"status": "suspended"})),
+        ),
+    ]);
+    let svc = service_with(mock);
+
+    let resp = svc
+        .get_descendants(
+            &ctx(),
+            TenantId(root),
+            &GetDescendantsOptions {
+                status: vec![TenantStatus::Active],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.descendants.len(), 1);
+    assert_eq!(resp.descendants[0].id, TenantId(active));
+}
+
+#[tokio::test]
+async fn get_descendants_max_depth() {
+    let root = Uuid::now_v7();
+    let child = Uuid::now_v7();
+    let grandchild = Uuid::now_v7();
+    let mock = MockRgHierarchy::descendants_only(vec![
+        make_group(root, "Root", None, 0, None),
+        make_group(child, "Child", Some(root), 1, None),
+        make_group(grandchild, "Grandchild", Some(child), 2, None),
+    ]);
+    let svc = service_with(mock);
+
+    let resp = svc
+        .get_descendants(
+            &ctx(),
+            TenantId(root),
+            &GetDescendantsOptions {
+                max_depth: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    // Only direct children (depth=1), not grandchild (depth=2)
+    assert_eq!(resp.descendants.len(), 1);
+    assert_eq!(resp.descendants[0].id, TenantId(child));
+}
+
+// -- is_ancestor tests --
+
+#[tokio::test]
+async fn is_ancestor_self_returns_false() {
+    let t1 = Uuid::now_v7();
+    let mock = MockRgHierarchy::ancestors_only(vec![make_group(t1, "T1", None, 0, None)]);
+    let svc = service_with(mock);
+
+    let result = svc
+        .is_ancestor(
+            &ctx(),
+            TenantId(t1),
+            TenantId(t1),
+            &IsAncestorOptions::default(),
+        )
+        .await
+        .unwrap();
+    assert!(!result, "self is not an ancestor of self");
+}
+
+#[tokio::test]
+async fn is_ancestor_true_for_parent() {
+    let root = Uuid::now_v7();
+    let child = Uuid::now_v7();
+    // `is_ancestor` calls `resolve_tenant(root)` first, then
+    // `resolve_ancestors(child)`. Each query must see its own distinct
+    // ancestor chain — otherwise the first call would pass by returning
+    // child's depth=0 row as if it were root's. Dispatch by group_id.
+    let mock = MockRgHierarchy::ancestors_by_id(std::collections::HashMap::from([
+        (root, vec![make_group(root, "Root", None, 0, None)]),
+        (
+            child,
+            vec![
+                make_group(child, "Child", Some(root), 0, None),
+                make_group(root, "Root", None, -1, None),
+            ],
+        ),
+    ]));
+    let svc = service_with(mock);
+
+    let result = svc
+        .is_ancestor(
+            &ctx(),
+            TenantId(root),
+            TenantId(child),
+            &IsAncestorOptions::default(),
+        )
+        .await
+        .unwrap();
+    assert!(result);
+}
+
+#[tokio::test]
+async fn is_ancestor_barrier_descendant_returns_false() {
+    let root = Uuid::now_v7();
+    let barrier_child = Uuid::now_v7();
+    // Same dispatch requirement as `is_ancestor_true_for_parent`: the
+    // existence check for `root` must resolve against root's own ancestor
+    // chain, not the barrier child's.
+    let mock = MockRgHierarchy::ancestors_by_id(std::collections::HashMap::from([
+        (root, vec![make_group(root, "Root", None, 0, None)]),
+        (
+            barrier_child,
+            vec![
+                make_group(
+                    barrier_child,
+                    "Barrier",
+                    Some(root),
+                    0,
+                    Some(serde_json::json!({"self_managed": true})),
+                ),
+                make_group(root, "Root", None, -1, None),
+            ],
+        ),
+    ]));
+    let svc = service_with(mock);
+
+    let result = svc
+        .is_ancestor(
+            &ctx(),
+            TenantId(root),
+            TenantId(barrier_child),
+            &IsAncestorOptions {
+                barrier_mode: BarrierMode::Respect,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!result, "barrier descendant blocks ancestor claim");
+}
+
+// -- RG error handling --
+
+#[tokio::test]
+async fn rg_error_propagates() {
+    struct FailingRg;
+
+    #[async_trait]
+    impl ResourceGroupReadHierarchy for FailingRg {
+        async fn get_group_descendants(
+            &self,
+            _ctx: &SecurityContext,
+            _group_id: Uuid,
+            _query: &ODataQuery,
+        ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+            Err(ResourceGroupError::internal())
+        }
+
+        async fn get_group_ancestors(
+            &self,
+            _ctx: &SecurityContext,
+            _group_id: Uuid,
+            _query: &ODataQuery,
+        ) -> Result<Page<ResourceGroupWithDepth>, ResourceGroupError> {
+            Err(ResourceGroupError::internal())
+        }
+
+        async fn list_groups(
+            &self,
+            _ctx: &SecurityContext,
+            _query: &ODataQuery,
+        ) -> Result<Page<ResourceGroup>, ResourceGroupError> {
+            Err(ResourceGroupError::internal())
+        }
+    }
+
+    let svc = Service::new(Arc::new(FailingRg));
+    let err = svc.get_tenant(&ctx(), TenantId(Uuid::now_v7())).await;
+    assert!(
+        matches!(err, Err(TenantResolverError::Internal(_))),
+        "RG error should map to Internal"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Unit tests for `group_matches_filter` — the predicate evaluator the
+// mock `list_groups` uses to honour OData filters. Pure logic, sync.
+// ─────────────────────────────────────────────────────────────────────
+
+mod group_matches_filter_tests {
+    use super::*;
+
+    /// Convenience: build the canonical group with explicit `id`, `parent_id`,
+    /// `tenant_id` so each test case can assert which axis matched.
+    fn g(id: Uuid, parent_id: Option<Uuid>, tenant_id: Uuid) -> ResourceGroupWithDepth {
+        ResourceGroupWithDepth {
+            id,
+            code: TENANT_RG_TYPE_PATH.to_owned(),
+            name: "g".to_owned(),
+            hierarchy: GroupHierarchyWithDepth {
+                parent_id,
+                tenant_id,
+                depth: 0,
+            },
+            metadata: None,
+        }
+    }
+
+    fn id_expr(name: &str) -> Expr {
+        Expr::Identifier(name.to_owned())
+    }
+
+    fn uuid_value(u: Uuid) -> Expr {
+        Expr::Value(Value::Uuid(u))
+    }
+
+    fn cmp(lhs: Expr, op: CompareOperator, rhs: Expr) -> Expr {
+        Expr::Compare(Box::new(lhs), op, Box::new(rhs))
+    }
+
+    fn in_(lhs: Expr, vs: Vec<Expr>) -> Expr {
+        Expr::In(Box::new(lhs), vs)
+    }
+
+    // ── tenant_id ─────────────────────────────────────────────────────
+
+    #[test]
+    fn tenant_id_eq_matches_owning_tenant() {
+        let t = Uuid::now_v7();
+        let other = Uuid::now_v7();
+        let group = g(Uuid::now_v7(), None, t);
+        assert!(group_matches_filter(
+            &group,
+            &cmp(id_expr("tenant_id"), CompareOperator::Eq, uuid_value(t))
+        ));
+        assert!(!group_matches_filter(
+            &group,
+            &cmp(id_expr("tenant_id"), CompareOperator::Eq, uuid_value(other))
+        ));
+    }
+
+    #[test]
+    fn tenant_id_ne_excludes_owning_tenant() {
+        let t = Uuid::now_v7();
+        let other = Uuid::now_v7();
+        let group = g(Uuid::now_v7(), None, t);
+        assert!(!group_matches_filter(
+            &group,
+            &cmp(id_expr("tenant_id"), CompareOperator::Ne, uuid_value(t))
+        ));
+        assert!(group_matches_filter(
+            &group,
+            &cmp(id_expr("tenant_id"), CompareOperator::Ne, uuid_value(other))
+        ));
+    }
+
+    #[test]
+    fn tenant_id_in_matches_when_owning_tenant_is_listed() {
+        let t = Uuid::now_v7();
+        let a = Uuid::now_v7();
+        let b = Uuid::now_v7();
+        let group = g(Uuid::now_v7(), None, t);
+        assert!(group_matches_filter(
+            &group,
+            &in_(id_expr("tenant_id"), vec![uuid_value(t), uuid_value(a)])
+        ));
+        assert!(!group_matches_filter(
+            &group,
+            &in_(id_expr("tenant_id"), vec![uuid_value(a), uuid_value(b)])
+        ));
+    }
+
+    // ── id ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn id_eq_matches_self_only() {
+        let id = Uuid::now_v7();
+        let other = Uuid::now_v7();
+        let group = g(id, None, Uuid::now_v7());
+        assert!(group_matches_filter(
+            &group,
+            &cmp(id_expr("id"), CompareOperator::Eq, uuid_value(id))
+        ));
+        assert!(!group_matches_filter(
+            &group,
+            &cmp(id_expr("id"), CompareOperator::Eq, uuid_value(other))
+        ));
+    }
+
+    #[test]
+    fn id_in_matches_when_self_is_listed() {
+        let id = Uuid::now_v7();
+        let other = Uuid::now_v7();
+        let group = g(id, None, Uuid::now_v7());
+        assert!(group_matches_filter(
+            &group,
+            &in_(id_expr("id"), vec![uuid_value(id), uuid_value(other)])
+        ));
+        assert!(!group_matches_filter(
+            &group,
+            &in_(id_expr("id"), vec![uuid_value(other)])
+        ));
+    }
+
+    // ── hierarchy/parent_id ───────────────────────────────────────────
+
+    #[test]
+    fn parent_id_eq_matches_set_parent() {
+        let p = Uuid::now_v7();
+        let other = Uuid::now_v7();
+        let group = g(Uuid::now_v7(), Some(p), Uuid::now_v7());
+        assert!(group_matches_filter(
+            &group,
+            &cmp(
+                id_expr("hierarchy/parent_id"),
+                CompareOperator::Eq,
+                uuid_value(p)
+            )
+        ));
+        assert!(!group_matches_filter(
+            &group,
+            &cmp(
+                id_expr("hierarchy/parent_id"),
+                CompareOperator::Eq,
+                uuid_value(other)
+            )
+        ));
+    }
+
+    #[test]
+    fn parent_id_in_excludes_root_group_with_none_parent() {
+        // Root groups have parent_id = None; any non-empty `parent_id in (...)`
+        // should not match — the `in` arm short-circuits to `false` when the
+        // resolved Option is `None`.
+        let p = Uuid::now_v7();
+        let root = g(Uuid::now_v7(), None, Uuid::now_v7());
+        assert!(!group_matches_filter(
+            &root,
+            &in_(id_expr("hierarchy/parent_id"), vec![uuid_value(p)])
+        ));
+    }
+
+    // ── unknown identifier (pass-through) ─────────────────────────────
+
+    #[test]
+    fn unknown_identifier_eq_passes_through() {
+        // The mock has only one type fixture per test, so `type eq …` and
+        // `name eq …` are intentionally treated as no-ops (return true).
+        let group = g(Uuid::now_v7(), None, Uuid::now_v7());
+        assert!(group_matches_filter(
+            &group,
+            &cmp(
+                id_expr("name"),
+                CompareOperator::Eq,
+                Expr::Value(Value::String("any".to_owned()))
+            )
+        ));
+        assert!(group_matches_filter(
+            &group,
+            &cmp(
+                id_expr("type"),
+                CompareOperator::Eq,
+                Expr::Value(Value::String("anything".to_owned()))
+            )
+        ));
+    }
+
+    // ── combinators: And / Or / Not ───────────────────────────────────
+
+    #[test]
+    fn and_combines_tenant_id_and_id() {
+        let t = Uuid::now_v7();
+        let id = Uuid::now_v7();
+        let other_t = Uuid::now_v7();
+        let group = g(id, None, t);
+
+        // (tenant_id eq t) AND (id eq id) → match
+        let both_match = Expr::And(
+            Box::new(cmp(
+                id_expr("tenant_id"),
+                CompareOperator::Eq,
+                uuid_value(t),
+            )),
+            Box::new(cmp(id_expr("id"), CompareOperator::Eq, uuid_value(id))),
+        );
+        assert!(group_matches_filter(&group, &both_match));
+
+        // (tenant_id eq other_t) AND (id eq id) → no match (tenant_id fails)
+        let one_fails = Expr::And(
+            Box::new(cmp(
+                id_expr("tenant_id"),
+                CompareOperator::Eq,
+                uuid_value(other_t),
+            )),
+            Box::new(cmp(id_expr("id"), CompareOperator::Eq, uuid_value(id))),
+        );
+        assert!(!group_matches_filter(&group, &one_fails));
+    }
+
+    #[test]
+    fn or_matches_when_either_branch_matches() {
+        let t = Uuid::now_v7();
+        let id = Uuid::now_v7();
+        let unrelated = Uuid::now_v7();
+        let group = g(id, None, t);
+
+        // (tenant_id eq unrelated) OR (id eq id) → match (id arm)
+        let or_expr = Expr::Or(
+            Box::new(cmp(
+                id_expr("tenant_id"),
+                CompareOperator::Eq,
+                uuid_value(unrelated),
+            )),
+            Box::new(cmp(id_expr("id"), CompareOperator::Eq, uuid_value(id))),
+        );
+        assert!(group_matches_filter(&group, &or_expr));
+
+        // (tenant_id eq unrelated) OR (id eq unrelated) → no match
+        let neither = Expr::Or(
+            Box::new(cmp(
+                id_expr("tenant_id"),
+                CompareOperator::Eq,
+                uuid_value(unrelated),
+            )),
+            Box::new(cmp(
+                id_expr("id"),
+                CompareOperator::Eq,
+                uuid_value(unrelated),
+            )),
+        );
+        assert!(!group_matches_filter(&group, &neither));
+    }
+
+    #[test]
+    fn not_inverts_the_inner_predicate() {
+        let t = Uuid::now_v7();
+        let group = g(Uuid::now_v7(), None, t);
+
+        let not_match = Expr::Not(Box::new(cmp(
+            id_expr("tenant_id"),
+            CompareOperator::Eq,
+            uuid_value(t),
+        )));
+        assert!(!group_matches_filter(&group, &not_match));
+
+        let not_other = Expr::Not(Box::new(cmp(
+            id_expr("tenant_id"),
+            CompareOperator::Eq,
+            uuid_value(Uuid::now_v7()),
+        )));
+        assert!(group_matches_filter(&group, &not_other));
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Integration test for tenant_id filter through the trait surface.
+// Verifies the mock `list_groups` actually scopes results when callers
+// (e.g. account-management's soft-delete precondition from PR #1746)
+// build `ODataQuery::with_filter(tenant_id eq <uuid>)`.
+// ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_groups_honours_tenant_id_eq_filter() {
+    use modkit_security::SecurityContext;
+    use resource_group_sdk::api::ResourceGroupReadHierarchy;
+
+    let tenant_a = Uuid::now_v7();
+    let tenant_b = Uuid::now_v7();
+    let group_a = ResourceGroupWithDepth {
+        hierarchy: GroupHierarchyWithDepth {
+            parent_id: None,
+            tenant_id: tenant_a,
+            depth: 0,
+        },
+        ..make_group(Uuid::now_v7(), "InA", None, 0, None)
+    };
+    let group_b = ResourceGroupWithDepth {
+        hierarchy: GroupHierarchyWithDepth {
+            parent_id: None,
+            tenant_id: tenant_b,
+            depth: 0,
+        },
+        ..make_group(Uuid::now_v7(), "InB", None, 0, None)
+    };
+    let mock = MockRgHierarchy::ancestors_only(vec![group_a.clone(), group_b.clone()]);
+
+    // tenant_id eq tenant_a → only group_a is returned.
+    let query = ODataQuery::default().with_filter(Expr::Compare(
+        Box::new(Expr::Identifier("tenant_id".to_owned())),
+        CompareOperator::Eq,
+        Box::new(Expr::Value(Value::Uuid(tenant_a))),
+    ));
+    let page = mock
+        .list_groups(&SecurityContext::anonymous(), &query)
+        .await
+        .unwrap();
+    assert_eq!(
+        page.items.len(),
+        1,
+        "only one group should match tenant_id eq tenant_a"
+    );
+    assert_eq!(page.items[0].id, group_a.id);
+
+    // tenant_id in (tenant_b) → only group_b.
+    let query_in = ODataQuery::default().with_filter(Expr::In(
+        Box::new(Expr::Identifier("tenant_id".to_owned())),
+        vec![Expr::Value(Value::Uuid(tenant_b))],
+    ));
+    let page = mock
+        .list_groups(&SecurityContext::anonymous(), &query_in)
+        .await
+        .unwrap();
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].id, group_b.id);
+
+    // No filter → both groups (sanity check, ensures the new arm is the
+    // only thing gating results).
+    let page = mock
+        .list_groups(&SecurityContext::anonymous(), &ODataQuery::default())
+        .await
+        .unwrap();
+    assert_eq!(page.items.len(), 2);
+}


### PR DESCRIPTION
## Summary

PR **5/6**. Test coverage for the service and plugin layers delivered in #1550 and #1553. Real end-to-end / REST / Python e2e tests land in #1556.

### Plugin unit tests (`#[cfg(test)]` inline via `#[path]`)

- **rg-authz-plugin**: `client_tests.rs` (subtree drain / empty / partial), `service_tests.rs` (barrier filtering, in-memory `self_managed` handling, predicate shape)
- **tr-authz-plugin**: `service_tests.rs` (TR-driven resolution, predicate emission from request properties, barrier delegated to TR)
- **rg-tr-plugin**: `client_tests.rs`, `service_tests.rs` (TENANT_RG_TYPE_PATH filtering, hierarchy shape, barrier metadata)

### REST unit tests (resource-group module)

- `auth_tests.rs` — mTLS + JWT path, anonymous rejection
- `dto_tests.rs` — camelCase / `type` rename round-trips, OpenAPI contract
- `odata_mapper_tests.rs` — FilterNode → SeaORM Column translation

### SQLite-backed integration tests (`tests/`)

- `common/mod.rs` — shared fixtures: in-memory DB, allow-all AuthZ mock, `SecurityContext` helpers, type / group factories
- `group_service_test.rs` (~2.6k lines) — create / get / list / update / delete across CRUD, hierarchy moves, cascade rules, edge cases
- `type_service_test.rs` (~1.7k lines) — type lifecycle, allowed-parents / allowed-memberships mutation, closure-table invariants
- `tenant_scoping_test.rs` — `AccessScope` construction and isolation
- `tenant_filtering_db_test.rs` — full chain tenant isolation on a real DB: list, get, hierarchy, update, delete cross-tenant rejected

## PR Train

| # | PR | Branch | Base | Lines |
|---|------|--------|------|-------|
| 1 | #1552 | pr/rg-1-sdk | main | ~1000 |
| 2 | #1550 | pr/rg-2-plugins | pr/rg-1-sdk | ~2000 |
| 3 | #1553 | pr/rg-3-backend | pr/rg-2-plugins | ~5600 |
| 4 | #1554 | pr/rg-4-rest | pr/rg-3-backend | ~4000 |
| 5 | **this** — #1555 | pr/rg-5-tests-svc | pr/rg-4-rest | ~7300 |
| 6 | #1556 | pr/rg-6-tests-rest | pr/rg-5-tests-svc | ~6000 |

Stacked linearly. Merge order: 1 → 2 → 3 → 4 → 5 → 6.

## Test plan

- [x] `cargo nextest run --workspace --exclude cf-modkit-macros-tests --exclude cf-modkit-db-macros` — 3983 tests pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf` green
- [x] `cpt validate` — all checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authorization resolution, resource group hierarchy operations, and tenant filtering with new integration test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->