### PR TITLE
feat(tracing): deepen instrumentation across host, handlers, auth, DB, and retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-appender",
+ "tracing-error",
  "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1542,7 +1543,6 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "tracing",
  "utoipa",
 ]
 
@@ -8335,6 +8335,16 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/docs/TRACING_SETUP.md
+++ b/docs/TRACING_SETUP.md
@@ -1,124 +1,105 @@
-````markdown
 # Distributed Tracing Setup
 
-This guide walks you through setting up **OpenTelemetry distributed tracing** with **Jaeger** or **Uptrace** for the
-CyberFabric framework for testing purposes.
+How to wire the CyberFabric framework to an OpenTelemetry collector (Jaeger,
+Uptrace, Tempo, etc.) and what spans you get out of the box.
 
-## Overview
+## What the framework gives you
 
-The CyberFabric framework includes first-class support for distributed tracing with:
+Without writing any instrumentation code:
 
-- **Automatic trace context extraction** from incoming HTTP requests (W3C Trace Context)
-- **Automatic trace context injection** for outgoing HTTP requests
-- **Centralized configuration** via YAML
-- **HttpClient with OTEL layer** for instrumented HTTP calls
-- **Integration with existing logging**
+- **W3C Trace Context propagation** — incoming `traceparent` header is honored
+  as parent; outgoing HTTP calls made through `modkit_http::HttpClientBuilder`
+  with `.with_otel()` inject it automatically.
+- **Span hierarchy for every REST request:**
+  `http_request` (TraceLayer) → `handler` (route template from `MatchedPath`)
+  → `auth` (jwt validation, principal) → module handler code → `db.insert` /
+  `db.update` / `db.delete` / `db.txn` (SecureConn) and
+  `outgoing_http` → `http.retry` (per attempt) for downstream calls.
+- **Startup and shutdown spans** — `HostRuntime`'s `run_*_phase` methods each
+  get a method-level span (`phase="init" | "db" | "rest" | ...`) with per-module
+  child spans (`module.init`, `module.start`, `db.migrate`, `rest.register`, …).
+- **Real graceful shutdown** — `SdkTracerProvider` and `SdkMeterProvider` are
+  force-flushed and shut down on exit, so the final batch of buffered spans
+  actually reaches the collector.
+- **`tracing_error::ErrorLayer` installed** — error types that opt in via
+  `tracing_error::SpanTrace::capture()` get the current span context for free.
+- **Unified trace-ID extraction** — `modkit::telemetry::current_trace_id()`
+  returns the real W3C trace ID of the active OTEL span (or `None`); use it in
+  `From<DomainError> for Problem` impls and any other place that needs a
+  `trace_id` string.
 
-## Quick Start with Jaeger
+## Quick start with Jaeger
 
-### 1. Start Jaeger (Local Development)
+### 1. Start Jaeger
 
 ```bash
-# Start Jaeger All-in-One with OTLP support
 docker run -d --name jaeger \
-  -p 16686:16686 \    # UI: http://localhost:16686
-  -p 4317:4317 \      # OTLP gRPC
-  -p 4318:4318 \      # OTLP HTTP
+  -p 16686:16686 \
+  -p 4317:4317 \
+  -p 4318:4318 \
   -e COLLECTOR_OTLP_ENABLED=true \
   jaegertracing/all-in-one:latest
-````
+```
 
-### 2. Configure Tracing
+Ports: `16686` = UI, `4317` = OTLP gRPC, `4318` = OTLP HTTP.
 
-Create a configuration file (e.g., `config/with-tracing.yaml`):
+### 2. Configure tracing
+
+The real schema nests everything under `opentelemetry`. Match the shape in
+`libs/modkit/src/telemetry/config.rs` — top-level `tracing:` is not recognized.
 
 ```yaml
-server:
-  home_dir: "~/.hyperspot"
-  host: "127.0.0.1"
-  port: 8087
+opentelemetry:
+  resource:
+    service_name: "hyperspot-api"
+    attributes:
+      service.version: "1.0.0"
+      deployment.environment: "dev"
 
-# Enable OpenTelemetry tracing
-tracing:
-  enabled: true
-  service_name: "hyperspot-api"
-
+  # Shared exporter for both tracing and metrics.
+  # Per-signal `exporter` overrides this when present.
   exporter:
-    kind: "otlp_grpc"
+    kind: "otlp_grpc"                # or "otlp_http"
     endpoint: "http://127.0.0.1:4317"
     timeout_ms: 5000
 
-  sampler:
-    parent_based_ratio:
-      ratio: 0.1  # Sample 10% of traces
+  tracing:
+    enabled: true
+    sampler:
+      parent_based_ratio:
+        ratio: 0.1                   # 10% sampling
+    propagation:
+      w3c_trace_context: true
 
-  propagation:
-    w3c_trace_context: true
-
-  resource:
-    service.version: "1.0.0"
-    deployment.environment: "dev"
-
-logging:
-  default:
-    console_level: "info"
-    file: "logs/hyperspot.log"
+  metrics:
+    enabled: true
 ```
 
-### 3. Run the Server
+### 3. Run
 
 ```bash
 cargo run --bin hyperspot-server -- --config config/with-tracing.yaml
 ```
 
-### 4. View Traces
+### 4. View traces
 
-Open [http://localhost:16686](http://localhost:16686) and search for service `hyperspot-api`.
+[http://localhost:16686](http://localhost:16686) → service `hyperspot-api`.
 
 ---
 
-## Quick Start with Uptrace
+## Quick start with Uptrace
 
-[Uptrace](https://uptrace.dev) is a modern tracing UI that works with OpenTelemetry and ClickHouse/Postgres.
-
-### 1. Start Uptrace (Docker Compose)
-
-```yaml
-services:
-  uptrace:
-    image: uptrace/uptrace:2.0.1
-    ports:
-      - "14318:80"     # Web UI: http://localhost:14318
-      - "14317:4317"   # OTLP gRPC
-      - "14319:4318"   # OTLP HTTP
-    volumes:
-      - ./uptrace.yml:/etc/uptrace/config.yml
-    depends_on:
-      - clickhouse
-      - postgres
-      - redis
-
-  clickhouse:
-    image: clickhouse/clickhouse-server:25.8
-    ports: [ "9000:9000" ]
-
-  postgres:
-    image: postgres:16
-    environment:
-      POSTGRES_DB: uptrace
-      POSTGRES_USER: uptrace
-      POSTGRES_PASSWORD: uptrace
-
-  redis:
-    image: redis:8.2
-```
-
-### 2. Configure Tracing with Uptrace DSN
+[Uptrace](https://uptrace.dev) is a ClickHouse-backed OTEL UI. The Rust side
+is identical — only the exporter endpoint + DSN header differ.
 
 ```yaml
-tracing:
-  enabled: true
-  service_name: "hyperspot-api"
+opentelemetry:
+  resource:
+    service_name: "hyperspot-api"
+    attributes:
+      service.version: "1.3.7"
+      deployment.environment: "dev"
+      service.namespace: "hyperspot"
 
   exporter:
     kind: "otlp_grpc"
@@ -127,299 +108,231 @@ tracing:
     headers:
       uptrace-dsn: "http://project1_secret@localhost:14318?grpc=14317"
 
-  sampler:
-    always_on: { }
-
-  resource:
-    service.version: "1.3.7"
-    deployment.environment: "dev"
-    service.namespace: "hyperspot"
+  tracing:
+    enabled: true
+    sampler:
+      always_on: {}
 ```
 
-### 3. Run the Server
+Minimal Docker Compose for the backend is in the previous revision of this doc
+and the Uptrace README; it hasn't changed.
+
+---
+
+## Configuration reference
+
+### Exporter
+
+| Key | Type | Notes |
+|---|---|---|
+| `opentelemetry.exporter.kind` | `otlp_grpc` \| `otlp_http` | Default `otlp_grpc`. |
+| `opentelemetry.exporter.endpoint` | string | Defaults: `http://127.0.0.1:4317` (gRPC), `http://127.0.0.1:4318` (HTTP). |
+| `opentelemetry.exporter.headers` | map<string,string> | Auth / routing headers (e.g. `authorization: Bearer …`, `uptrace-dsn: …`). Merged with `OTEL_EXPORTER_OTLP_HEADERS` env. |
+| `opentelemetry.exporter.timeout_ms` | u64 | Per-export timeout. |
+| `opentelemetry.tracing.exporter` | same shape | Per-signal override; fully replaces the shared exporter when set. |
+| `opentelemetry.metrics.exporter` | same shape | Same, for metrics. |
+
+### Sampler
+
+Pick exactly one variant under `sampler`:
+
+```yaml
+opentelemetry:
+  tracing:
+    sampler:
+      parent_based_ratio: { ratio: 0.1 }
+      # or: parent_based_always_on: {}   (honor parent decision, else on)
+      # or: always_on: {}
+      # or: always_off: {}
+```
+
+### Propagation and HTTP options
+
+```yaml
+opentelemetry:
+  tracing:
+    propagation:
+      w3c_trace_context: true
+    http:
+      inject_request_id_header: "x-request-id"
+      record_headers:
+        - "user-agent"
+        - "x-forwarded-for"
+```
+
+`record_headers` values with sensitive content (`authorization`, cookies) are
+not redacted at export time — add them at your own risk.
+
+### Environment overrides
+
+Any config value has an equivalent env var using the `APP__` prefix and double
+underscores as separators:
 
 ```bash
-cargo run --bin hyperspot-server -- --config config/with-tracing.yaml
-```
-
-### 4. View Traces
-
-Open [http://localhost:14318](http://localhost:14318) and search for service `hyperspot-api`.
-
----
-
-## Configuration Reference
-
-### Basic Configuration
-
-```yaml
-tracing:
-  enabled: true                    # Enable/disable tracing
-  service_name: "my-service"       # Service name in traces
-```
-
-### Exporter Configuration
-
-#### OTLP gRPC (Default)
-
-```yaml
-tracing:
-  exporter:
-    kind: "otlp_grpc"
-    endpoint: "http://127.0.0.1:4317"
-    timeout_ms: 5000
-    headers: # Optional auth headers
-      authorization: "Bearer token"
-```
-
-#### OTLP HTTP
-
-```yaml
-tracing:
-  exporter:
-    kind: "otlp_http"
-    endpoint: "http://127.0.0.1:4318/v1/traces"
-    timeout_ms: 5000
+export APP__OPENTELEMETRY__TRACING__ENABLED=true
+export APP__OPENTELEMETRY__RESOURCE__SERVICE_NAME=hyperspot-prod
+export APP__OPENTELEMETRY__EXPORTER__ENDPOINT=http://jaeger:4317
+export APP__OPENTELEMETRY__TRACING__SAMPLER__PARENT_BASED_RATIO__RATIO=0.01
 ```
 
 ---
 
-(rest of your original doc unchanged below)
+## Span reference
 
-### Sampling Strategies
+What the framework emits, by subsystem. Field names follow the
+[OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/).
 
-#### Always Sample
+| Span | Parent | Level | Key fields |
+|---|---|---|---|
+| `http_request` | (root) | info | `method`, `uri`, `status`, `http.method`, `http.target`, `http.status_code`, `latency_ms`, `trace_id`, `request_id` |
+| `handler` | `http_request` | info | `otel.name`, `http.method`, `http.route`, `http.status_code` |
+| `auth` | `handler` | info | `otel.kind="internal"`, `auth.method`, `auth.requirement`, `auth.principal`, `auth.tenant`, `auth.result` |
+| `db.insert` / `db.update` / `db.delete` | caller | debug | `db.system`, `db.operation`, `entity`, `err` on error |
+| `db.txn` | caller | debug | `db.system`, `otel.kind="client"` |
+| `outgoing_http` | caller | info | `http.method`, `http.url`, `http.status_code`, `otel.kind="client"`, `error` on failure |
+| `http.retry` | `outgoing_http` | debug | `attempt`, `http.method`, `http.url`, `http.status_code`, `error` |
+| `grpc_call` | caller | debug | `op`, `attempt` (gRPC client retry) |
+| `phase` (`run_*_phase`) | (root at startup) | info | `phase="init"/"db"/"rest"/"start"/...`, `err` on failure |
+| `module.init` / `module.start` / `module.stop` / `db.migrate` / `rest.register` / `grpc.register` / `module.post_init` / `oop.spawn` | `phase` | info | `module` |
 
-```yaml
-tracing:
-  sampler:
-    always_on: { }
+`handler` is produced by `modkit::api::handler_span_middleware`, wired between
+the api-gateway's `TraceLayer` and the business middlewares. It requires routes
+to be registered before the layer is attached (which is the case in
+`rest_finalize` — the production path).
+
+---
+
+## Using `HttpClient` with OpenTelemetry
+
+The `.with_otel()` builder method requires the `otel` feature:
+
+```toml
+[dependencies]
+modkit-http = { workspace = true, features = ["otel"] }
 ```
-
-#### Never Sample
-
-```yaml
-tracing:
-  sampler:
-    always_off: { }
-```
-
-#### Ratio-Based Sampling
-
-```yaml
-tracing:
-  sampler:
-    parent_based_ratio:
-      ratio: 0.1  # Sample 10% of traces
-```
-
-### Resource Attributes
-
-Add metadata to all spans:
-
-```yaml
-tracing:
-  resource:
-    service.version: "1.2.3"
-    deployment.environment: "production"
-    service.namespace: "hyperspot"
-    k8s.cluster.name: "prod-cluster"
-    k8s.namespace.name: "hyperspot-ns"
-```
-
-### HTTP Options
-
-```yaml
-tracing:
-  http:
-    inject_request_id_header: "x-request-id"
-    record_headers:
-      - "user-agent"
-      - "x-forwarded-for"
-      - "authorization"  # Be careful with sensitive headers
-```
-
-## Using HttpClient with OpenTelemetry
-
-> **Important: Feature Gate Required**
->
-> The `.with_otel()` method on `HttpClientBuilder` requires the `otel` feature to be enabled.
-> Add this to your `Cargo.toml`:
->
-> ```toml
-> [dependencies]
-> modkit-http = { workspace = true, features = ["otel"] }
-> ```
->
-> Without this feature, the `with_otel()` method will not be available, and you'll get
-> a compile error.
-
-### In Your Module
-
-```rust,ignore
-use modkit_http::{HttpClient, HttpClientBuilder};
-
-#[async_trait]
-impl MyModule {
-    async fn call_external_api(&self) -> Result<String> {
-        // Build client with OTEL tracing enabled
-        let client = HttpClientBuilder::new()
-            .with_otel()  // Enable OpenTelemetry tracing
-            .build()?;
-
-        // Trace context is automatically injected via W3C traceparent header
-        // RequestBuilder API: chain methods then send
-        let data = client
-            .get("https://api.example.com/data")
-            .send()
-            .await?
-            .checked_bytes()
-            .await?;
-
-        Ok(String::from_utf8_lossy(&data).into_owned())
-    }
-}
-```
-
-### Configuring the modkit_http::HttpClient
-
-```rust,ignore
-use modkit_http::{HttpClient, HttpClientBuilder};
-use std::time::Duration;
-
-// Full configuration example
-let client = HttpClientBuilder::new()
-    .with_otel()                          // Enable OpenTelemetry tracing
-    .timeout(Duration::from_secs(30))     // Request timeout
-    .user_agent("my-service/1.0")         // Custom User-Agent
-    .max_body_size(10 * 1024 * 1024)      // 10MB body limit
-    .build()?;
-```
-
-## Manual Span Creation
-
-Create custom spans for business logic:
 
 ```rust,ignore
 use modkit_http::HttpClientBuilder;
-use tracing::{info_span, Instrument, info};
 
-async fn process_user_data(user_id: u64) -> Result<()> {
-    // Create a span for this operation
-    let span = info_span!("process_user", user.id = user_id);
+let client = HttpClientBuilder::new()
+    .with_otel()                                   // injects traceparent on every request
+    .timeout(std::time::Duration::from_secs(30))
+    .user_agent("my-service/1.0")
+    .build()?;
 
+let bytes = client
+    .get("https://api.example.com/data")
+    .send()
+    .await?
+    .checked_bytes()
+    .await?;
+```
+
+`with_otel()` adds the `OtelLayer` (produces the `outgoing_http` span) and the
+retry middleware layer (produces per-attempt `http.retry` spans). Both sit
+between your code and the underlying `reqwest` call.
+
+## Manual spans
+
+For business-logic spans around work the framework doesn't see:
+
+```rust,ignore
+use tracing::{info_span, Instrument};
+
+async fn process_user(user_id: u64) -> anyhow::Result<()> {
     async {
-        // Your business logic here
-        info!("Processing user {}", user_id);
-
-        // Child operations will be traced automatically with OTEL-enabled client
-        let client = HttpClientBuilder::new()
-            .with_otel()
-            .build()?;
-
-        let url = format!("https://api.example.com/users/{}", user_id);
-        let user_data = client.get(&url).send().await?.checked_bytes().await?;
-
+        // work here — any instrumented call (DB, HTTP) nests under this span.
         Ok(())
-    }.instrument(span).await
+    }
+    .instrument(info_span!("process_user", user.id = user_id))
+    .await
 }
 ```
 
-## Production Deployment
+Use `#[tracing::instrument(skip_all, fields(...))]` when the whole function
+body is the span. Avoid `.entered()` across `.await` — it pins a thread-local
+and can interleave spans under a multithreaded runtime.
+
+---
+
+## Field naming convention
+
+We standardize on the OpenTelemetry semantic conventions so that spans exported
+to Jaeger / Tempo / Uptrace light up the upstream UI features (service maps,
+DB latency panels, error filtering) without per-service configuration.
+
+| Concept | Legacy (still emitted) | Canonical |
+|---|---|---|
+| HTTP method | `method` | `http.method` |
+| HTTP route (templated) | — (was `endpoint`, removed) | `http.route` |
+| HTTP target (actual path) | `uri` | `http.target` |
+| HTTP status | `status` | `http.status_code` |
+| DB system | — | `db.system` |
+| DB operation | — | `db.operation` |
+| Error flag | `err` | `error` (bool) + `exception.*` on errors |
+| Authenticated principal | `user_id` (ad-hoc) | `enduser.id` or `auth.principal` |
+| Trace id for log correlation | `trace_id` | `trace_id` (kept — matches log pipelines) |
+
+**New code** uses the canonical names. **Existing code** keeps legacy fields
+because log pipelines, dashboards, and the `access_log` integration tests key
+on those names; migrate opportunistically when a file is touched for another
+reason, and record the canonical field alongside the legacy one when you do.
+
+Two surfaces are exempt from migration in both directions:
+
+- `modules/system/api-gateway/src/middleware/access_log.rs` — the access-log
+  event is a stable pipeline contract. Do not rename its fields.
+- `endpoint = …` fields on gRPC-hub / directory spans refer to a gRPC service
+  address, not an HTTP route — OTEL has no semantic convention for this. Leave
+  them as-is.
+
+---
+
+## Production
+
+### Sampling
+
+Default to `parent_based_ratio` in production (`ratio: 0.01` for 1% on a busy
+service). Never `always_on` in prod — a chatty service will saturate the
+collector ingress.
 
 ### Docker Compose with Jaeger
 
 ```yaml
-  services:
-    jaeger:
-      image: ${REGISTRY:-}jaegertracing/jaeger:${JAEGER_VERSION:-latest}
-      ports:
-        - "16686:16686"
-        - "4317:4317"
-        - "4318:4318"
-      environment:
-        - LOG_LEVEL=debug
-        - COLLECTOR_OTLP_ENABLED=true
-      networks:
-        - jaeger-example
-
-  networks:
-    jaeger-example:
-```
-
-### Environment Variable Overrides
-
-You can override any config via environment variables:
-
-```bash
-# Enable tracing
-export APP__TRACING__ENABLED=true
-export APP__TRACING__SERVICE_NAME=hyperspot-prod
-
-# Configure exporter
-export APP__TRACING__EXPORTER__KIND=otlp_grpc
-export APP__TRACING__EXPORTER__ENDPOINT=http://jaeger:4317
-
-# Configure sampling
-export APP__TRACING__SAMPLER__STRATEGY=parentbased_ratio
-export APP__TRACING__SAMPLER__RATIO=0.01  # 1% sampling in prod
+services:
+  jaeger:
+    image: ${REGISTRY:-}jaegertracing/jaeger:${JAEGER_VERSION:-latest}
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
 ```
 
 ## Troubleshooting
 
-### No Traces Appearing
+### No traces appearing
 
-1. **Check Jaeger is running**: Visit http://localhost:16686
-2. **Verify endpoint**: Ensure `exporter.endpoint` matches Jaeger's OTLP port
-3. **Check sampling**: Set `sampler.strategy: {always_on: {}}` for testing
-4. **View logs**: Look for "OpenTelemetry tracing initialized" message
+1. Confirm Jaeger/Uptrace is up and reachable on the configured endpoint.
+2. `opentelemetry.tracing.enabled: true` — disabled by default.
+3. For smoke tests use `sampler: { always_on: {} }` so nothing gets sampled out.
+4. Look for `OpenTelemetry tracing initialized` at startup. If you don't see
+   it, the config is being parsed into a different shape than you expect —
+   check that your YAML keys actually nest under `opentelemetry`, not
+   top-level `tracing`.
 
-### Performance Impact
+### Trace context not propagating
 
-1. **Use sampling in production**: Set appropriate `ratio` (0.01 = 1%)
-2. **Monitor resource usage**: Tracing adds some CPU/memory overhead
-3. **Batch export**: The framework uses batched export by default
+- Incoming: client must send `traceparent`; `propagation.w3c_trace_context`
+  must be `true` (default).
+- Outgoing: HTTP client must be built with `.with_otel()`. Plain `reqwest`
+  calls won't inject.
 
-### Trace Context Not Propagating
+### Final spans missing at shutdown
 
-1. **Check headers**: Ensure upstream sends `traceparent` header
-2. **Verify propagation**: Set `propagation.w3c_trace_context: true`
-3. **Use HttpClient with OTEL**: Ensure outgoing calls use `HttpClientBuilder::new().with_otel()`
-
-## Observability Best Practices
-
-### Structured Attributes
-
-Use consistent attribute names:
-
-```rust,ignore
-tracing::info_span!(
-    "user_operation",
-    user.id = user_id,
-    user.email = %user_email,
-    operation.type = "create",
-    operation.result = "success"
-)
-```
-
-### Error Handling
-
-Mark spans with errors:
-
-```rust,ignore
-let span = tracing::info_span!("risky_operation");
-let _guard = span.enter();
-
-match risky_operation().await {
-Ok(result) => {
-span.record("operation.result", "success");
-Ok(result)
-}
-Err(e) => {
-span.record("error", true);
-span.record("error.message", % e);
-span.record("operation.result", "error");
-Err(e)
-}
-}
-```
+Since the tracer provider shutdown rewrite in #817, `shutdown_tracing()` does
+force-flush + shutdown, and `bootstrap::run_server` / `bootstrap::run_migrate`
+both call it on exit. If you still see truncated traces, the process is
+probably not going through those entry points — a panic or
+`std::process::exit()` skips destructors and drops the batch.

--- a/examples/modkit/users-info/users-info/src/api/rest/error.rs
+++ b/examples/modkit/users-info/users-info/src/api/rest/error.rs
@@ -119,9 +119,9 @@ fn canonical_to_problem(ce: &CanonicalError) -> Problem {
         problem = problem.with_errors(errors);
     }
 
-    // Enrich trace_id from current span
-    if let Some(span_id) = tracing::Span::current().id() {
-        problem = problem.with_trace_id(span_id.into_u64().to_string());
+    // Enrich trace_id from current OTEL span (falls back to None without OTEL).
+    if let Some(trace_id) = modkit::telemetry::current_trace_id() {
+        problem = problem.with_trace_id(trace_id);
     }
 
     problem

--- a/libs/modkit-db/src/lib.rs
+++ b/libs/modkit-db/src/lib.rs
@@ -347,6 +347,9 @@ impl DbHandle {
             DbEngine::Postgres => {
                 let o = PgPoolOptions::new().apply(&opts);
                 let pool = o.connect(dsn).await?;
+                // TODO(tracing follow-up): switch to `sea_orm::Database::connect(ConnectOptions)` to enable
+                // SeaORM's built-in sqlx_logging for DB statement tracing. Current path takes a
+                // pre-built sqlx pool which bypasses SeaORM's ConnectOptions.
                 let sea = SqlxPostgresConnector::from_sqlx_postgres_pool(pool);
                 Ok(Self {
                     engine,
@@ -360,6 +363,9 @@ impl DbHandle {
             DbEngine::MySql => {
                 let o = MySqlPoolOptions::new().apply(&opts);
                 let pool = o.connect(dsn).await?;
+                // TODO(tracing follow-up): switch to `sea_orm::Database::connect(ConnectOptions)` to enable
+                // SeaORM's built-in sqlx_logging for DB statement tracing. Current path takes a
+                // pre-built sqlx pool which bypasses SeaORM's ConnectOptions.
                 let sea = SqlxMySqlConnector::from_sqlx_mysql_pool(pool);
                 Ok(Self {
                     engine,
@@ -438,6 +444,9 @@ impl DbHandle {
                 }
 
                 let pool = o.connect_with(conn_opts).await?;
+                // TODO(tracing follow-up): switch to `sea_orm::Database::connect(ConnectOptions)` to enable
+                // SeaORM's built-in sqlx_logging for DB statement tracing. Current path takes a
+                // pre-built sqlx pool which bypasses SeaORM's ConnectOptions.
                 let sea = SqlxSqliteConnector::from_sqlx_sqlite_pool(pool);
 
                 Ok(Self {

--- a/libs/modkit-db/src/options.rs
+++ b/libs/modkit-db/src/options.rs
@@ -85,6 +85,9 @@ impl DbConnectOptions {
 
                 let sqlx_pool = pool_opts.connect_with(opts.clone()).await?;
 
+                // TODO(tracing follow-up): switch to `sea_orm::Database::connect(ConnectOptions)` to enable
+                // SeaORM's built-in sqlx_logging for DB statement tracing. Current path takes a
+                // pre-built sqlx pool which bypasses SeaORM's ConnectOptions.
                 let sea = sea_orm::SqlxSqliteConnector::from_sqlx_sqlite_pool(sqlx_pool);
 
                 let filename = opts.get_filename().display().to_string();
@@ -102,6 +105,9 @@ impl DbConnectOptions {
 
                 let sqlx_pool = pool_opts.connect_with(opts.clone()).await?;
 
+                // TODO(tracing follow-up): switch to `sea_orm::Database::connect(ConnectOptions)` to enable
+                // SeaORM's built-in sqlx_logging for DB statement tracing. Current path takes a
+                // pre-built sqlx pool which bypasses SeaORM's ConnectOptions.
                 let sea = sea_orm::SqlxPostgresConnector::from_sqlx_postgres_pool(sqlx_pool);
 
                 let handle = DbHandle {
@@ -123,6 +129,9 @@ impl DbConnectOptions {
 
                 let sqlx_pool = pool_opts.connect_with(opts.clone()).await?;
 
+                // TODO(tracing follow-up): switch to `sea_orm::Database::connect(ConnectOptions)` to enable
+                // SeaORM's built-in sqlx_logging for DB statement tracing. Current path takes a
+                // pre-built sqlx pool which bypasses SeaORM's ConnectOptions.
                 let sea = sea_orm::SqlxMySqlConnector::from_sqlx_mysql_pool(sqlx_pool);
 
                 let handle = DbHandle {

--- a/libs/modkit-db/src/secure/secure_conn.rs
+++ b/libs/modkit-db/src/secure/secure_conn.rs
@@ -3,6 +3,16 @@
 //! This module provides `SecureConn`, a wrapper around a private `SeaORM` connection
 //! that enforces access control policies on all operations.
 //!
+//! # Tracing
+//!
+//! Public async query entry points (`insert`, `update_with_ctx`, `delete_by_id`) and
+//! transaction boundaries (`transaction`, `transaction_with`, `transaction_with_config`,
+//! `in_transaction`, `in_transaction_mapped`) emit `#[tracing::instrument]` spans at
+//! `DEBUG` level with OTEL semantic-convention fields (`db.system`, `db.operation`,
+//! `entity`). These spans capture timing and error signals but intentionally do NOT
+//! record individual SQL statement text — enabling `SeaORM`'s `sqlx_logging(true)` is
+//! tracked as a follow-up (see `TODO(tracing follow-up)` in `lib.rs` / `options.rs`).
+//!
 //! Plugin/module developers should never handle raw `DatabaseConnection` or manually
 //! apply scopes. Instead, they receive a `SecureConn` instance that guarantees:
 //!
@@ -317,6 +327,17 @@ impl SecureConn {
     ///
     /// - `ScopeError::Invalid` if entity requires tenant but scope has none
     /// - `ScopeError::Db` if database insert fails
+    #[tracing::instrument(
+        level = "debug",
+        name = "db.insert",
+        skip_all,
+        fields(
+            db.system = self.db_engine(),
+            db.operation = "INSERT",
+            entity = std::any::type_name::<E>(),
+        ),
+        err,
+    )]
     pub async fn insert<E>(
         &self,
         scope: &AccessScope,
@@ -366,6 +387,17 @@ impl SecureConn {
     ///
     /// - `ScopeError::Denied` if the entity is not accessible in the current scope
     /// - `ScopeError::Db` if the database operation fails
+    #[tracing::instrument(
+        level = "debug",
+        name = "db.update",
+        skip_all,
+        fields(
+            db.system = self.db_engine(),
+            db.operation = "UPDATE",
+            entity = std::any::type_name::<E>(),
+        ),
+        err,
+    )]
     pub async fn update_with_ctx<E>(
         &self,
         scope: &AccessScope,
@@ -400,6 +432,17 @@ impl SecureConn {
     /// # Errors
     ///
     /// Returns `ScopeError::Invalid` if the entity does not have a `resource_col` defined.
+    #[tracing::instrument(
+        level = "debug",
+        name = "db.delete",
+        skip_all,
+        fields(
+            db.system = self.db_engine(),
+            db.operation = "DELETE",
+            entity = std::any::type_name::<E>(),
+        ),
+        err,
+    )]
     pub async fn delete_by_id<E>(&self, scope: &AccessScope, id: Uuid) -> Result<bool, ScopeError>
     where
         E: ScopableEntity + EntityTrait,
@@ -488,6 +531,15 @@ impl SecureConn {
     /// - The transaction cannot be started
     /// - A database operation fails (transaction is rolled back)
     /// - The commit fails
+    #[tracing::instrument(
+        level = "debug",
+        name = "db.txn",
+        skip_all,
+        fields(
+            db.system = self.db_engine(),
+            otel.kind = "client",
+        ),
+    )]
     pub async fn transaction<F>(self, f: F) -> (Self, anyhow::Result<()>)
     where
         F: for<'a> FnOnce(
@@ -552,6 +604,15 @@ impl SecureConn {
     /// - The transaction cannot be started
     /// - A database operation fails (transaction is rolled back)
     /// - The commit fails
+    #[tracing::instrument(
+        level = "debug",
+        name = "db.txn",
+        skip_all,
+        fields(
+            db.system = self.db_engine(),
+            otel.kind = "client",
+        ),
+    )]
     pub async fn transaction_with<T, F>(self, f: F) -> (Self, anyhow::Result<T>)
     where
         T: Send + 'static,
@@ -646,6 +707,15 @@ impl SecureConn {
     /// - The transaction cannot be started with the specified configuration
     /// - A database operation fails (transaction is rolled back)
     /// - The commit fails
+    #[tracing::instrument(
+        level = "debug",
+        name = "db.txn",
+        skip_all,
+        fields(
+            db.system = self.db_engine(),
+            otel.kind = "client",
+        ),
+    )]
     pub async fn transaction_with_config<T, F>(
         self,
         cfg: TxConfig,
@@ -732,6 +802,15 @@ impl SecureConn {
     /// The `Result` component is `Err(TxError<E>)` if:
     /// - The callback returns a domain error (`TxError::Domain(E)`).
     /// - The transaction fails due to a database/infrastructure error (`TxError::Infra(InfraError)`).
+    #[tracing::instrument(
+        level = "debug",
+        name = "db.txn",
+        skip_all,
+        fields(
+            db.system = self.db_engine(),
+            otel.kind = "client",
+        ),
+    )]
     pub async fn in_transaction<T, E, F>(self, f: F) -> (Self, Result<T, TxError<E>>)
     where
         T: Send + 'static,
@@ -798,6 +877,10 @@ impl SecureConn {
     /// The `Result` component is `Err(E)` if:
     /// - The callback returns a domain error (`E`).
     /// - The transaction fails due to a database/infrastructure error, mapped via `map_infra`.
+    //
+    // Intentionally not `#[tracing::instrument]`: this delegates to
+    // `in_transaction`, which already emits the `db.txn` span. Annotating both
+    // would produce a duplicate nested span for the same transaction boundary.
     pub async fn in_transaction_mapped<T, E, F, M>(self, map_infra: M, f: F) -> (Self, Result<T, E>)
     where
         T: Send + 'static,

--- a/libs/modkit-errors/Cargo.toml
+++ b/libs/modkit-errors/Cargo.toml
@@ -20,12 +20,11 @@ workspace = true
 [features]
 default = []
 utoipa = ["dep:utoipa"]
-axum = ["dep:axum", "dep:tracing"]
+axum = ["dep:axum"]
 
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
 utoipa = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
-tracing = { workspace = true, optional = true }
 http = { workspace = true }

--- a/libs/modkit-errors/src/problem.rs
+++ b/libs/modkit-errors/src/problem.rs
@@ -158,25 +158,16 @@ impl Problem {
 
 /// Axum integration: make Problem directly usable as a response.
 ///
-/// Automatically enriches the Problem with `trace_id` from the current
-/// tracing span if not already set.
+/// Setting `trace_id` is the caller's responsibility (via
+/// [`Problem::with_trace_id`] or `WithTraceContext` in `modkit`) — this
+/// impl intentionally does not auto-enrich, because the only correct
+/// source (OTEL span context) lives in a higher-level crate.
 #[cfg(feature = "axum")]
 impl axum::response::IntoResponse for Problem {
     fn into_response(self) -> axum::response::Response {
         use axum::http::HeaderValue;
-
-        // Enrich with trace_id from current span if not already set
-        let problem = if self.trace_id.is_none() {
-            match tracing::Span::current().id() {
-                Some(span_id) => self.with_trace_id(span_id.into_u64().to_string()),
-                _ => self,
-            }
-        } else {
-            self
-        };
-
-        let status = problem.status;
-        let mut resp = axum::Json(problem).into_response();
+        let status = self.status;
+        let mut resp = axum::Json(self).into_response();
         *resp.status_mut() = status;
         resp.headers_mut().insert(
             axum::http::header::CONTENT_TYPE,

--- a/libs/modkit-http/src/layers/otel.rs
+++ b/libs/modkit-http/src/layers/otel.rs
@@ -61,13 +61,20 @@ where
         let method = req.method().clone();
         let uri = req.uri().clone();
 
-        // Sanitize URL for tracing: remove query string to avoid leaking sensitive params
-        let url_str = format!(
-            "{}://{}{}",
-            uri.scheme_str().unwrap_or("https"),
-            uri.authority().map_or("", http::uri::Authority::as_str),
-            uri.path()
-        );
+        // Sanitize URL for tracing: drop the query string AND userinfo.
+        // `Authority::as_str()` includes any `user:pass@` segment, so we
+        // rebuild from `host()` + `port()` to keep credentials out of span
+        // fields and log output.
+        let url_str = {
+            let scheme = uri.scheme_str().unwrap_or("https");
+            let host_port = uri.authority().map_or(String::new(), |a| {
+                a.port_u16().map_or_else(
+                    || a.host().to_owned(),
+                    |port| format!("{}:{}", a.host(), port),
+                )
+            });
+            format!("{}://{}{}", scheme, host_port, uri.path())
+        };
 
         // Create span before injection so that inject_current_span propagates
         // this span's context (not the parent's) into the outgoing request headers.

--- a/libs/modkit-http/src/layers/retry.rs
+++ b/libs/modkit-http/src/layers/retry.rs
@@ -10,6 +10,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use tower::{Layer, Service, ServiceExt};
+use tracing::{Instrument, debug_span, field::Empty};
 
 /// Header name for retry attempt number (1-indexed).
 /// Added to retried requests to indicate which retry attempt this is.
@@ -124,6 +125,24 @@ where
         Box::pin(async move {
             let method = parts.method.clone();
 
+            // Sanitized URL for per-attempt spans — scheme://host[:port]/path
+            // (no query, no userinfo). `Authority::as_str()` includes any
+            // `user:pass@` segment, so we rebuild from `host()` + `port()` to
+            // make sure credentials never end up in span fields or logs.
+            // Mirrors the form used by `OtelLayer` so the parent
+            // `outgoing_http` span and its `http.retry` children agree on the
+            // value of `http.url`.
+            let url_sanitized = {
+                let scheme = parts.uri.scheme_str().unwrap_or("https");
+                let host_port = parts.uri.authority().map_or(String::new(), |a| {
+                    a.port_u16().map_or_else(
+                        || a.host().to_owned(),
+                        |port| format!("{}:{}", a.host(), port),
+                    )
+                });
+                format!("{}://{}{}", scheme, host_port, parts.uri.path())
+            };
+
             // Extract request identity for logging (host + optional request-id)
             // Use authority() for full host:port, falling back to host() or "unknown"
             let url_host = parts
@@ -173,8 +192,33 @@ where
                 let mut svc = inner.clone();
                 svc.ready().await?;
 
-                match svc.call(req).await {
+                // Per-attempt child span, mirroring the gRPC retry pattern in
+                // `modkit-transport-grpc::rpc_retry::call_with_retry`.
+                // The parent is the `outgoing_http` span from `OtelLayer`, so a 3-attempt
+                // retry sequence yields three timed `http.retry` children (attempt=0,1,2),
+                // not three adjacent untimed events.
+                //
+                // `attempt` is 0-indexed: 0 = first call, 1 = first retry, etc.
+                // This matches the `attempt` counter used everywhere else in this loop
+                // and keeps the debug output self-consistent with the `x-retry-attempt`
+                // header (which is only added when `attempt > 0`, i.e. from retry #1 on).
+                let attempt_span = debug_span!(
+                    "http.retry",
+                    attempt,
+                    http.method = %method,
+                    http.url = %url_sanitized,
+                    http.status_code = Empty,
+                    error = Empty,
+                );
+
+                let call_result = async { svc.call(req).await }
+                    .instrument(attempt_span.clone())
+                    .await;
+
+                match call_result {
                     Ok(resp) => {
+                        attempt_span.record("http.status_code", resp.status().as_u16());
+
                         // Check if we should retry based on HTTP status code
                         let status_code = resp.status().as_u16();
                         let trigger = RetryTrigger::Status(status_code);
@@ -247,7 +291,11 @@ where
                                     backoff_duration
                                 };
 
-                            tracing::debug!(
+                            // Span already carries attempt / method / url / status_code; this
+                            // event is demoted to TRACE because it additionally records the
+                            // retry-decision context (trigger, backoff duration, whether
+                            // Retry-After was honored) that is not on the span fields.
+                            tracing::trace!(
                                 retry = attempt + 1,
                                 max_retries = config.max_retries,
                                 status = status_code,
@@ -268,6 +316,8 @@ where
                         return Ok(resp);
                     }
                     Err(err) => {
+                        attempt_span.record("error", true);
+
                         if config.max_retries == 0 || attempt >= config.max_retries {
                             return Err(err);
                         }
@@ -293,7 +343,11 @@ where
                                 backoff_duration
                             };
 
-                        tracing::debug!(
+                        // Span already carries attempt / method / url / error=true; this
+                        // event is demoted to TRACE because it additionally records the
+                        // retry-decision context (trigger, backoff duration, error message)
+                        // that is not on the span fields.
+                        tracing::trace!(
                             retry = attempt + 1,
                             max_retries = config.max_retries,
                             error = %err,

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -68,6 +68,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 inventory = { workspace = true }
 tracing = { workspace = true }
+tracing-error = { workspace = true }
 figment = { workspace = true }
 file-rotate = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }

--- a/libs/modkit/src/api/error_layer.rs
+++ b/libs/modkit/src/api/error_layer.rs
@@ -43,21 +43,14 @@ fn is_problem_response(response: &Response) -> bool {
         .is_some_and(|ct| ct.contains("application/problem+json"))
 }
 
-/// Extract trace ID from headers or generate one
+/// Extract trace ID from the current OTEL span or from request headers.
+///
+/// Delegates to [`crate::telemetry::trace_id_from_request`] so that all
+/// callers share a single, correct implementation (OTEL context → W3C
+/// `traceparent` → `x-request-id` / `x-trace-id`).
+#[must_use]
 pub fn extract_trace_id(headers: &HeaderMap) -> Option<String> {
-    // Try to get trace ID from various common headers
-    headers
-        .get("x-trace-id")
-        .or_else(|| headers.get("x-request-id"))
-        .or_else(|| headers.get("traceparent"))
-        .and_then(|v| v.to_str().ok())
-        .map(str::to_owned)
-        .or_else(|| {
-            // Try to get from current tracing span
-            tracing::Span::current()
-                .id()
-                .map(|id| id.into_u64().to_string())
-        })
+    crate::telemetry::trace_id_from_request(headers)
 }
 
 /// Centralized error mapping function

--- a/libs/modkit/src/api/handler_span.rs
+++ b/libs/modkit/src/api/handler_span.rs
@@ -1,0 +1,136 @@
+//! Automatic handler-level span for every REST request.
+//!
+//! Sits inside the api-gateway `TraceLayer` (so `http_request` is the parent)
+//! and records `http.route` from Axum's [`MatchedPath`] extension. Handlers can
+//! still stack their own `#[tracing::instrument]` on top for more granularity.
+//!
+//! Field naming follows OpenTelemetry semantic conventions (`http.method`,
+//! `http.route`, `http.status_code`, plus the `otel.name` override so the span
+//! shows up in collectors as e.g. `GET /users/{id}`).
+//!
+//! ## Placement requirement
+//!
+//! `MatchedPath` is populated by Axum's routing layer. For this middleware to
+//! observe a templated route, it must run **after** routes have been matched.
+//! In practice that means it should be installed via `Router::layer(...)` on a
+//! router that already has its routes registered (for example in
+//! `rest_finalize` rather than `rest_prepare`). If `MatchedPath` is absent the
+//! middleware falls back to the raw request path, which is still useful for
+//! debugging but has unbounded cardinality.
+//!
+//! [`MatchedPath`]: axum::extract::MatchedPath
+
+use axum::{
+    extract::{MatchedPath, Request},
+    middleware::Next,
+    response::Response,
+};
+use tracing::{Instrument, field::Empty};
+
+/// Middleware that wraps the downstream handler in an `info`-level `handler`
+/// span.
+///
+/// Records `http.route` (templated path when available) plus `http.method`,
+/// and fills in `http.status_code` from the outgoing response. The `otel.name`
+/// override gives collectors a compact `"{METHOD} {route}"` name.
+pub async fn handler_span_middleware(request: Request, next: Next) -> Response {
+    let route = request.extensions().get::<MatchedPath>().map_or_else(
+        || request.uri().path().to_owned(),
+        |mp| mp.as_str().to_owned(),
+    );
+
+    let method = request.method().clone();
+
+    let span = tracing::info_span!(
+        "handler",
+        otel.name = %format!("{method} {route}"),
+        http.method = %method,
+        http.route = %route,
+        http.status_code = Empty,
+    );
+
+    let response = next.run(request).instrument(span.clone()).await;
+    span.record("http.status_code", response.status().as_u16());
+    response
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+    use axum::{
+        Router,
+        body::Body,
+        http::{Request as HttpRequest, StatusCode},
+        middleware::from_fn,
+        routing::get,
+    };
+    use tower::ServiceExt;
+
+    async fn ok_handler() -> &'static str {
+        "hello"
+    }
+
+    async fn error_handler() -> (StatusCode, &'static str) {
+        (StatusCode::IM_A_TEAPOT, "nope")
+    }
+
+    #[tokio::test]
+    async fn forwards_successful_response() {
+        let app = Router::new()
+            .route("/items/{id}", get(ok_handler))
+            .layer(from_fn(handler_span_middleware));
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/items/42")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn preserves_downstream_status_codes() {
+        let app = Router::new()
+            .route("/teapot", get(error_handler))
+            .layer(from_fn(handler_span_middleware));
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/teapot")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::IM_A_TEAPOT);
+    }
+
+    #[tokio::test]
+    async fn handles_unmatched_path_without_panicking() {
+        // Exercises the `MatchedPath`-absent fallback: when no route matches,
+        // axum returns 404 and the middleware uses the raw request path.
+        let app = Router::new()
+            .route("/known", get(ok_handler))
+            .layer(from_fn(handler_span_middleware));
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/unknown")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/libs/modkit/src/api/mod.rs
+++ b/libs/modkit/src/api/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod api_dto;
 pub mod error_layer;
+pub mod handler_span;
 pub mod odata;
 pub mod openapi_registry;
 pub mod operation_builder;
@@ -21,6 +22,7 @@ mod odata_policy_tests;
 pub use error_layer::{
     IntoProblem, error_mapping_middleware, extract_trace_id, map_error_to_problem,
 };
+pub use handler_span::handler_span_middleware;
 pub use openapi_registry::{OpenApiInfo, OpenApiRegistry, OpenApiRegistryImpl, ensure_schema};
 pub use operation_builder::{
     Missing, OperationBuilder, OperationSpec, ParamLocation, ParamSpec, Present, RateLimitSpec,

--- a/libs/modkit/src/api/trace_layer.rs
+++ b/libs/modkit/src/api/trace_layer.rs
@@ -2,19 +2,15 @@
 //!
 //! This module provides helper traits and functions to automatically enrich
 //! `Problem` with trace context:
-//! - `trace_id`: extracted from the current tracing span
-//! - `instance`: extracted from the request URI
+//! - `trace_id`: real W3C trace ID of the active OpenTelemetry span context,
+//!   via `modkit::telemetry::current_trace_id()`. May be `None` when OTEL is
+//!   disabled or no span context is active — in that case the field is left
+//!   unset on the response rather than populated with a placeholder.
+//! - `instance`: extracted from the request URI.
 //!
 //! This eliminates per-callsite boilerplate and ensures consistent error reporting.
 
 use crate::api::problem::Problem;
-
-/// Extract `trace_id` from the current tracing span
-fn extract_trace_id() -> Option<String> {
-    // Try to extract from the current span's trace_id field
-    // This requires coordination with the tracing subscriber
-    tracing::Span::current().id().map(|id| format!("{id:?}"))
-}
 
 /// Helper trait for enriching Problem with trace context
 pub trait WithTraceContext {
@@ -26,7 +22,7 @@ pub trait WithTraceContext {
 impl WithTraceContext for Problem {
     fn with_trace_context(mut self, instance: impl Into<String>) -> Self {
         self = self.with_instance(instance);
-        if let Some(tid) = extract_trace_id() {
+        if let Some(tid) = crate::telemetry::current_trace_id() {
             self = self.with_trace_id(tid);
         }
         self

--- a/libs/modkit/src/bootstrap/host/logging.rs
+++ b/libs/modkit/src/bootstrap/host/logging.rs
@@ -466,6 +466,10 @@ fn install_subscriber(
         let base = base;
 
         let base = base.with(env);
+        // Install tracing_error::ErrorLayer above the fmt layers so that error
+        // types opting in to `tracing_error::SpanTrace::capture()` see the
+        // current span context. Zero cost when unused.
+        let base = base.with(tracing_error::ErrorLayer::default());
         base.with(console_text)
             .with(console_json)
             .with(file_layer_opt)
@@ -505,7 +509,9 @@ fn init_minimal(
         #[cfg(not(feature = "otel"))]
         let base = base;
 
-        base.with(env).with(fmt_layer)
+        base.with(env)
+            .with(tracing_error::ErrorLayer::default())
+            .with(fmt_layer)
     };
 
     // LogTracer is already initialized by the caller (init_logging_unified),

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -18,6 +18,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 use uuid::Uuid;
 
 use crate::backends::OopSpawnConfig;
@@ -158,9 +159,8 @@ impl HostRuntime {
     ///
     /// # Errors
     /// Returns `RegistryError` if system wiring fails.
+    #[tracing::instrument(level = "info", skip_all, fields(phase = "pre_init"), err)]
     pub fn run_pre_init_phase(&self) -> Result<(), RegistryError> {
-        tracing::info!("Phase: pre_init");
-
         let sys_ctx = SystemContext::new(
             self.instance_id,
             Arc::clone(&self.module_manager),
@@ -175,13 +175,16 @@ impl HostRuntime {
             }
 
             if let Some(sys_mod) = entry.caps.query::<SystemCap>() {
-                tracing::debug!(module = entry.name, "Running system pre_init");
-                sys_mod
-                    .pre_init(&sys_ctx)
-                    .map_err(|e| RegistryError::PreInit {
-                        module: entry.name,
-                        source: e,
-                    })?;
+                let span = tracing::info_span!("module.pre_init", module = %entry.name);
+                span.in_scope(|| {
+                    tracing::debug!(module = entry.name, "Running system pre_init");
+                    sys_mod
+                        .pre_init(&sys_ctx)
+                        .map_err(|e| RegistryError::PreInit {
+                            module: entry.name,
+                            source: e,
+                        })
+                })?;
             }
         }
 
@@ -287,9 +290,8 @@ impl HostRuntime {
     /// never receive directly. Each module gets a separate migration history
     /// table, preventing cross-module interference.
     #[cfg(feature = "db")]
+    #[tracing::instrument(level = "info", skip_all, fields(phase = "db"), err)]
     async fn run_db_phase(&self) -> Result<(), RegistryError> {
-        tracing::info!("Phase: db (before init)");
-
         for entry in self.registry.modules_by_system_priority() {
             // Check for cancellation before processing each module
             if self.cancel.is_cancelled() {
@@ -297,24 +299,30 @@ impl HostRuntime {
                 return Err(RegistryError::Cancelled);
             }
 
-            let ctx = self.module_context(entry.name).await?;
-            let db_module = entry.caps.query::<DatabaseCap>();
+            let span = tracing::info_span!("db.migrate", module = %entry.name);
+            async {
+                let ctx = self.module_context(entry.name).await?;
+                let db_module = entry.caps.query::<DatabaseCap>();
 
-            match self
-                .db_migration_target(entry.name, &ctx, db_module.clone())
-                .await?
-            {
-                Some((db, dbm)) => {
-                    Self::migrate_module(entry.name, &db, dbm).await?;
+                match self
+                    .db_migration_target(entry.name, &ctx, db_module.clone())
+                    .await?
+                {
+                    Some((db, dbm)) => {
+                        Self::migrate_module(entry.name, &db, dbm).await?;
+                    }
+                    None if db_module.is_some() => {
+                        tracing::debug!(
+                            module = entry.name,
+                            "Module has DbModule trait but no DB handle (no config)"
+                        );
+                    }
+                    None => {}
                 }
-                None if db_module.is_some() => {
-                    tracing::debug!(
-                        module = entry.name,
-                        "Module has DbModule trait but no DB handle (no config)"
-                    );
-                }
-                None => {}
+                Ok::<_, RegistryError>(())
             }
+            .instrument(span)
+            .await?;
         }
 
         Ok(())
@@ -323,28 +331,31 @@ impl HostRuntime {
     /// INIT phase: initialize all modules in topological order.
     ///
     /// System modules initialize first, followed by user modules.
+    #[tracing::instrument(level = "info", skip_all, fields(phase = "init"), err)]
     async fn run_init_phase(&self) -> Result<(), RegistryError> {
-        tracing::info!("Phase: init");
-
         for entry in self.registry.modules_by_system_priority() {
-            let ctx =
-                self.ctx_builder
-                    .for_module(entry.name)
+            let span = tracing::info_span!("module.init", module = %entry.name);
+            async {
+                let ctx = self.ctx_builder.for_module(entry.name).await.map_err(|e| {
+                    RegistryError::Init {
+                        module: entry.name,
+                        source: e,
+                    }
+                })?;
+                tracing::debug!(module = entry.name, "Initializing a module...");
+                entry
+                    .core
+                    .init(&ctx)
                     .await
                     .map_err(|e| RegistryError::Init {
                         module: entry.name,
                         source: e,
                     })?;
-            tracing::info!(module = entry.name, "Initializing a module...");
-            entry
-                .core
-                .init(&ctx)
-                .await
-                .map_err(|e| RegistryError::Init {
-                    module: entry.name,
-                    source: e,
-                })?;
-            tracing::info!(module = entry.name, "Initialized a module.");
+                tracing::debug!(module = entry.name, "Initialized a module.");
+                Ok::<_, RegistryError>(())
+            }
+            .instrument(span)
+            .await?;
         }
 
         Ok(())
@@ -356,9 +367,8 @@ impl HostRuntime {
     /// and subsequent phases that may rely on a fully-populated runtime registry.
     ///
     /// System modules run first, followed by user modules, preserving topo order.
+    #[tracing::instrument(level = "info", skip_all, fields(phase = "post_init"), err)]
     async fn run_post_init_phase(&self) -> Result<(), RegistryError> {
-        tracing::info!("Phase: post_init");
-
         let sys_ctx = SystemContext::new(
             self.instance_id,
             Arc::clone(&self.module_manager),
@@ -367,13 +377,18 @@ impl HostRuntime {
 
         for entry in self.registry.modules_by_system_priority() {
             if let Some(sys_mod) = entry.caps.query::<SystemCap>() {
-                sys_mod
-                    .post_init(&sys_ctx)
-                    .await
-                    .map_err(|e| RegistryError::PostInit {
-                        module: entry.name,
-                        source: e,
-                    })?;
+                let span = tracing::info_span!("module.post_init", module = %entry.name);
+                async {
+                    sys_mod
+                        .post_init(&sys_ctx)
+                        .await
+                        .map_err(|e| RegistryError::PostInit {
+                            module: entry.name,
+                            source: e,
+                        })
+                }
+                .instrument(span)
+                .await?;
             }
         }
 
@@ -386,9 +401,8 @@ impl HostRuntime {
     /// 1. Preparing the host module
     /// 2. Registering all REST providers
     /// 3. Finalizing with `OpenAPI` endpoints
+    #[tracing::instrument(level = "info", skip_all, fields(phase = "rest"), err)]
     async fn run_rest_phase(&self) -> Result<Router, RegistryError> {
-        tracing::info!("Phase: rest (sync)");
-
         let mut router = Router::new();
 
         // Find host(s) and whether any rest modules exist
@@ -440,29 +454,36 @@ impl HostRuntime {
         let registry: &dyn crate::contracts::OpenApiRegistry = host.as_registry();
 
         // 1) Host prepare: base Router / global middlewares / basic OAS meta
-        router =
+        router = {
+            let prepare_span = tracing::info_span!("rest.prepare", module = %host_entry.name);
+            let _enter = prepare_span.enter();
             host.rest_prepare(&host_ctx, router)
                 .map_err(|source| RegistryError::RestPrepare {
                     module: host_entry.name,
                     source,
-                })?;
+                })?
+        };
 
         // 2) Register all REST providers (in the current discovery order)
         for e in self.registry.modules() {
             if let Some(rest) = e.caps.query::<RestApiCap>() {
-                let ctx = self.ctx_builder.for_module(e.name).await.map_err(|err| {
-                    RegistryError::RestRegister {
-                        module: e.name,
-                        source: err,
-                    }
-                })?;
-
-                router = rest
-                    .register_rest(&ctx, router, registry)
-                    .map_err(|source| RegistryError::RestRegister {
-                        module: e.name,
-                        source,
+                let span = tracing::info_span!("rest.register", module = %e.name);
+                router = async {
+                    let ctx = self.ctx_builder.for_module(e.name).await.map_err(|err| {
+                        RegistryError::RestRegister {
+                            module: e.name,
+                            source: err,
+                        }
                     })?;
+
+                    rest.register_rest(&ctx, router, registry)
+                        .map_err(|source| RegistryError::RestRegister {
+                            module: e.name,
+                            source,
+                        })
+                }
+                .instrument(span)
+                .await?;
             }
         }
 
@@ -480,9 +501,8 @@ impl HostRuntime {
     /// gRPC registration phase: collect services from all grpc modules.
     ///
     /// Services are stored in the installer store for the `grpc-hub` to consume during start.
+    #[tracing::instrument(level = "info", skip_all, fields(phase = "grpc"), err)]
     async fn run_grpc_phase(&self) -> Result<(), RegistryError> {
-        tracing::info!("Phase: grpc (registration)");
-
         // If no grpc_hub and no grpc_services, skip the phase
         if self.registry.grpc_hub.is_none() && self.registry.grpc_services.is_empty() {
             return Ok(());
@@ -500,23 +520,27 @@ impl HostRuntime {
 
             // Collect services from all grpc modules
             for (module_name, service_module) in &self.registry.grpc_services {
-                let ctx = self
-                    .ctx_builder
-                    .for_module(module_name)
-                    .await
-                    .map_err(|err| RegistryError::GrpcRegister {
-                        module: module_name.clone(),
-                        source: err,
-                    })?;
+                let span = tracing::info_span!("grpc.register", module = %module_name);
+                let installers = async {
+                    let ctx = self
+                        .ctx_builder
+                        .for_module(module_name)
+                        .await
+                        .map_err(|err| RegistryError::GrpcRegister {
+                            module: module_name.clone(),
+                            source: err,
+                        })?;
 
-                let installers =
                     service_module
                         .get_grpc_services(&ctx)
                         .await
                         .map_err(|source| RegistryError::GrpcRegister {
                             module: module_name.clone(),
                             source,
-                        })?;
+                        })
+                }
+                .instrument(span)
+                .await?;
 
                 for reg in &installers {
                     if !seen.insert(reg.service_name) {
@@ -552,23 +576,28 @@ impl HostRuntime {
     /// START phase: start all stateful modules.
     ///
     /// System modules start first, followed by user modules.
+    #[tracing::instrument(level = "info", skip_all, fields(phase = "start"), err)]
     async fn run_start_phase(&self) -> Result<(), RegistryError> {
-        tracing::info!("Phase: start");
-
         for e in self.registry.modules_by_system_priority() {
             if let Some(s) = e.caps.query::<RunnableCap>() {
-                tracing::debug!(
-                    module = e.name,
-                    is_system = e.caps.has::<SystemCap>(),
-                    "Starting stateful module"
-                );
-                s.start(self.cancel.clone())
-                    .await
-                    .map_err(|source| RegistryError::Start {
-                        module: e.name,
-                        source,
-                    })?;
-                tracing::info!(module = e.name, "Started module");
+                let span = tracing::info_span!("module.start", module = %e.name);
+                async {
+                    tracing::debug!(
+                        module = e.name,
+                        is_system = e.caps.has::<SystemCap>(),
+                        "Starting stateful module"
+                    );
+                    s.start(self.cancel.clone())
+                        .await
+                        .map_err(|source| RegistryError::Start {
+                            module: e.name,
+                            source,
+                        })?;
+                    tracing::debug!(module = e.name, "Started module");
+                    Ok::<_, RegistryError>(())
+                }
+                .instrument(span)
+                .await?;
             }
         }
 
@@ -583,7 +612,7 @@ impl HostRuntime {
                     tracing::warn!(module = entry.name, error = %err, "Failed to stop module");
                 }
                 _ => {
-                    tracing::info!(module = entry.name, "Stopped module");
+                    tracing::debug!(module = entry.name, "Stopped module");
                 }
             }
         }
@@ -613,39 +642,42 @@ impl HostRuntime {
     /// Errors are logged but do not fail the shutdown process.
     /// Note: `OoP` modules are stopped automatically by the backend when the
     /// cancellation token is triggered.
+    #[tracing::instrument(level = "info", skip_all, fields(phase = "stop"), err)]
     async fn run_stop_phase(&self) -> Result<(), RegistryError> {
-        tracing::info!("Phase: stop");
-
         let deadline = self.shutdown_deadline;
 
         // Stop all modules in reverse order, each with its own independent deadline
         for e in self.registry.modules().iter().rev() {
             let module_name = e.name;
+            let span = tracing::info_span!("module.stop", module = %module_name);
+            async {
+                // Create a fresh deadline token for THIS module
+                // Each module gets the full shutdown_deadline independently
+                let deadline_token = CancellationToken::new();
+                let deadline_token_for_timeout = deadline_token.clone();
 
-            // Create a fresh deadline token for THIS module
-            // Each module gets the full shutdown_deadline independently
-            let deadline_token = CancellationToken::new();
-            let deadline_token_for_timeout = deadline_token.clone();
+                // Spawn a task to cancel this module's deadline token after shutdown_deadline
+                let deadline_task = tokio::spawn(async move {
+                    tokio::time::sleep(deadline).await;
+                    tracing::warn!(
+                        module = module_name,
+                        deadline_secs = deadline.as_secs(),
+                        "Module shutdown deadline reached, sending hard-stop signal"
+                    );
+                    deadline_token_for_timeout.cancel();
+                });
 
-            // Spawn a task to cancel this module's deadline token after shutdown_deadline
-            let deadline_task = tokio::spawn(async move {
-                tokio::time::sleep(deadline).await;
-                tracing::warn!(
-                    module = module_name,
-                    deadline_secs = deadline.as_secs(),
-                    "Module shutdown deadline reached, sending hard-stop signal"
-                );
-                deadline_token_for_timeout.cancel();
-            });
+                // Stop this module with its own deadline token
+                // The module can observe the token transition from uncancelled→cancelled
+                Self::stop_one_module(e, deadline_token).await;
 
-            // Stop this module with its own deadline token
-            // The module can observe the token transition from uncancelled→cancelled
-            Self::stop_one_module(e, deadline_token).await;
-
-            // Cancel the deadline task and await it to ensure full cleanup
-            deadline_task.abort();
-            #[allow(clippy::let_underscore_must_use)]
-            let _ = deadline_task.await;
+                // Cancel the deadline task and await it to ensure full cleanup
+                deadline_task.abort();
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = deadline_task.await;
+            }
+            .instrument(span)
+            .await;
         }
 
         Ok(())
@@ -655,54 +687,57 @@ impl HostRuntime {
     ///
     /// This phase runs after `grpc-hub` is already listening, so we can pass
     /// the real directory endpoint to `OoP` modules.
+    #[tracing::instrument(level = "info", skip_all, fields(phase = "oop_spawn"), err)]
     async fn run_oop_spawn_phase(&self) -> Result<(), RegistryError> {
         let oop_opts = match &self.oop_options {
             Some(opts) if !opts.modules.is_empty() => opts,
             _ => return Ok(()),
         };
 
-        tracing::info!("Phase: oop_spawn");
-
         // Wait for grpc_hub to publish its endpoint (it runs async in start phase)
         let directory_endpoint = self.wait_for_grpc_hub_endpoint().await;
 
         for module_cfg in &oop_opts.modules {
-            // Build environment with directory endpoint and rendered config
-            // Note: User controls --config via execution.args in master config
-            let mut env = module_cfg.env.clone();
-            env.insert(
-                MODKIT_MODULE_CONFIG_ENV.to_owned(),
-                module_cfg.rendered_config_json.clone(),
-            );
-            if let Some(ref endpoint) = directory_endpoint {
-                env.insert(MODKIT_DIRECTORY_ENDPOINT_ENV.to_owned(), endpoint.clone());
-            }
+            let span = tracing::info_span!("oop.spawn", module = %module_cfg.module_name);
+            async {
+                // Build environment with directory endpoint and rendered config
+                // Note: User controls --config via execution.args in master config
+                let mut env = module_cfg.env.clone();
+                env.insert(
+                    MODKIT_MODULE_CONFIG_ENV.to_owned(),
+                    module_cfg.rendered_config_json.clone(),
+                );
+                if let Some(ref endpoint) = directory_endpoint {
+                    env.insert(MODKIT_DIRECTORY_ENDPOINT_ENV.to_owned(), endpoint.clone());
+                }
 
-            // Use args from execution config as-is (user controls --config via args)
-            let args = module_cfg.args.clone();
+                // Use args from execution config as-is (user controls --config via args)
+                let args = module_cfg.args.clone();
 
-            let spawn_config = OopSpawnConfig {
-                module_name: module_cfg.module_name.clone(),
-                binary: module_cfg.binary.clone(),
-                args,
-                env,
-                working_directory: module_cfg.working_directory.clone(),
-            };
+                let spawn_config = OopSpawnConfig {
+                    module_name: module_cfg.module_name.clone(),
+                    binary: module_cfg.binary.clone(),
+                    args,
+                    env,
+                    working_directory: module_cfg.working_directory.clone(),
+                };
 
-            oop_opts
-                .backend
-                .spawn(spawn_config)
-                .await
-                .map_err(|e| RegistryError::OopSpawn {
-                    module: module_cfg.module_name.clone(),
-                    source: e,
+                oop_opts.backend.spawn(spawn_config).await.map_err(|e| {
+                    RegistryError::OopSpawn {
+                        module: module_cfg.module_name.clone(),
+                        source: e,
+                    }
                 })?;
 
-            tracing::info!(
-                module = %module_cfg.module_name,
-                directory_endpoint = ?directory_endpoint,
-                "Spawned OoP module via backend"
-            );
+                tracing::debug!(
+                    module = %module_cfg.module_name,
+                    directory_endpoint = ?directory_endpoint,
+                    "Spawned OoP module via backend"
+                );
+                Ok::<_, RegistryError>(())
+            }
+            .instrument(span)
+            .await?;
         }
 
         Ok(())

--- a/libs/modkit/src/telemetry/init.rs
+++ b/libs/modkit/src/telemetry/init.rs
@@ -7,7 +7,6 @@
 use anyhow::Context;
 #[cfg(feature = "otel")]
 use opentelemetry::{KeyValue, global, trace::TracerProvider as _};
-use std::sync::Once;
 
 #[cfg(feature = "otel")]
 use opentelemetry_otlp::{Protocol, WithExportConfig};
@@ -130,7 +129,12 @@ fn build_grpc_exporter(
     b.build().context("build OTLP gRPC exporter")
 }
 
-static INIT_TRACING: Once = Once::new();
+#[cfg(feature = "otel")]
+static TRACER_PROVIDER: std::sync::OnceLock<SdkTracerProvider> = std::sync::OnceLock::new();
+
+#[cfg(feature = "otel")]
+static METER_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::metrics::SdkMeterProvider> =
+    std::sync::OnceLock::new();
 
 /// Initialize OpenTelemetry tracing from configuration and return a layer
 /// to be attached to `tracing_subscriber`.
@@ -181,10 +185,19 @@ pub fn init_tracing(
     let tracer = provider.tracer(service_name);
     let otel_layer = tracing_opentelemetry::OpenTelemetryLayer::new(tracer);
 
-    // Make it global
-    INIT_TRACING.call_once(|| {
-        global::set_tracer_provider(provider);
-    });
+    // `OnceLock::set` is the atomic singleton guard. If another thread won the
+    // race we must not return a layer backed by an untracked provider — that
+    // provider would never be flushed at shutdown. Shut it down and surface
+    // the error to the caller instead.
+    if let Err(unused_provider) = TRACER_PROVIDER.set(provider.clone()) {
+        if let Err(e) = unused_provider.shutdown() {
+            tracing::warn!(error = %e, "shutdown of duplicate provider failed");
+        }
+        return Err(anyhow::anyhow!(
+            "OpenTelemetry tracing is already initialized"
+        ));
+    }
+    global::set_tracer_provider(provider);
 
     tracing::info!("OpenTelemetry layer created successfully");
     Ok(otel_layer)
@@ -276,12 +289,24 @@ pub(crate) fn build_metadata_from_cfg_and_env(
 // ===== shutdown_tracing =======================================================
 
 /// Gracefully shut down OpenTelemetry tracing.
-/// In opentelemetry 0.31 there is no global `shutdown_tracer_provider()`.
-/// Keep a handle to `SdkTracerProvider` in your app state and call `shutdown()`
-/// during graceful shutdown. This function remains a no-op for compatibility.
+///
+/// Force-flushes and shuts down the globally-installed [`SdkTracerProvider`]
+/// captured during [`init_tracing`]. Safe to call even when tracing was never
+/// initialized: in that case this is a no-op.
 #[cfg(feature = "otel")]
 pub fn shutdown_tracing() {
-    tracing::info!("Tracing shutdown: no-op (keep a provider handle to call `shutdown()`).");
+    if let Some(provider) = TRACER_PROVIDER.get() {
+        if let Err(e) = provider.force_flush() {
+            tracing::warn!(error = %e, "OTEL tracer force_flush failed during shutdown");
+        }
+        if let Err(e) = provider.shutdown() {
+            tracing::warn!(error = %e, "OTEL tracer provider shutdown failed");
+        } else {
+            tracing::info!("OTEL tracer provider shut down cleanly");
+        }
+    } else {
+        tracing::debug!("shutdown_tracing: provider was never initialized");
+    }
 }
 
 #[cfg(not(feature = "otel"))]
@@ -290,12 +315,25 @@ pub fn shutdown_tracing() {
 }
 
 /// Gracefully shut down OpenTelemetry metrics.
-/// In opentelemetry 0.31 there is no global `shutdown_meter_provider()`.
-/// Keep a handle to `SdkMeterProvider` in your app state and call `shutdown()`
-/// during graceful shutdown. This function remains a no-op for compatibility.
+///
+/// Force-flushes and shuts down the globally-installed
+/// [`opentelemetry_sdk::metrics::SdkMeterProvider`] captured during
+/// [`init_metrics_provider`]. Safe to call even when metrics were never
+/// initialized: in that case this is a no-op.
 #[cfg(feature = "otel")]
 pub fn shutdown_metrics() {
-    tracing::info!("Metrics shutdown: no-op (keep a provider handle to call `shutdown()`).");
+    if let Some(provider) = METER_PROVIDER.get() {
+        if let Err(e) = provider.force_flush() {
+            tracing::warn!(error = %e, "OTEL meter force_flush failed during shutdown");
+        }
+        if let Err(e) = provider.shutdown() {
+            tracing::warn!(error = %e, "OTEL meter provider shutdown failed");
+        } else {
+            tracing::info!("OTEL meter provider shut down cleanly");
+        }
+    } else {
+        tracing::debug!("shutdown_metrics: provider was never initialized");
+    }
 }
 
 #[cfg(not(feature = "otel"))]
@@ -306,7 +344,8 @@ pub fn shutdown_metrics() {
 // ===== init_metrics_provider ==================================================
 
 #[cfg(feature = "otel")]
-static METRICS_INIT: std::sync::OnceLock<Result<(), String>> = std::sync::OnceLock::new();
+static METRICS_INIT: std::sync::OnceLock<Result<(), std::sync::Arc<str>>> =
+    std::sync::OnceLock::new();
 
 /// Build a [`SdkMeterProvider`] from the resolved metrics exporter settings and
 /// register it as the global meter provider.
@@ -337,7 +376,10 @@ pub fn init_metrics_provider(otel_cfg: &OpenTelemetryConfig) -> anyhow::Result<(
     }
 
     METRICS_INIT
-        .get_or_init(|| do_init_metrics_provider(otel_cfg).map_err(|e| e.to_string()))
+        .get_or_init(|| {
+            do_init_metrics_provider(otel_cfg)
+                .map_err(|e| std::sync::Arc::<str>::from(e.to_string()))
+        })
         .clone()
         .map_err(|e| anyhow::anyhow!("{e}"))
 }
@@ -394,6 +436,11 @@ fn do_init_metrics_provider(otel_cfg: &OpenTelemetryConfig) -> anyhow::Result<()
 
     let provider = builder.build();
 
+    // `set` only fails on a second initialization, which `METRICS_INIT` already
+    // guards against; swallowing the error is safe.
+    if METER_PROVIDER.set(provider.clone()).is_err() {
+        tracing::debug!("METER_PROVIDER OnceLock was already set");
+    }
     global::set_meter_provider(provider);
     tracing::info!("OpenTelemetry metrics initialized successfully");
 
@@ -519,6 +566,24 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Accept either a fresh successful init or the singleton-guard "already
+    /// initialized" error. `init_tracing` stores its provider in a
+    /// process-global `OnceLock`; only the first call in any test binary
+    /// actually builds a provider, while later calls deliberately return Err.
+    /// The point of the per-config tests is that the configuration itself is
+    /// accepted by the builder, not that the provider re-initializes.
+    #[cfg(feature = "otel")]
+    fn assert_init_accepts_config<T>(result: anyhow::Result<T>, ctx: &str) {
+        if let Err(e) = result {
+            let msg = e.to_string();
+            assert!(
+                msg.contains("already initialized"),
+                "{ctx}: init_tracing should succeed or report \
+                 already-initialized; got: {msg}"
+            );
+        }
+    }
+
     #[tokio::test]
     #[cfg(feature = "otel")]
     async fn test_init_tracing_enabled() {
@@ -528,7 +593,7 @@ mod tests {
         });
 
         let result = init_tracing(&otel);
-        assert!(result.is_ok());
+        assert_init_accepts_config(result, "enabled");
     }
 
     #[test]
@@ -554,7 +619,7 @@ mod tests {
         };
 
         let result = init_tracing(&otel);
-        assert!(result.is_ok());
+        assert_init_accepts_config(result, "resource_attributes");
     }
 
     #[test]
@@ -570,7 +635,7 @@ mod tests {
         });
 
         let result = init_tracing(&otel);
-        assert!(result.is_ok());
+        assert_init_accepts_config(result, "always_on_sampler");
     }
 
     #[test]
@@ -586,7 +651,7 @@ mod tests {
         });
 
         let result = init_tracing(&otel);
-        assert!(result.is_ok());
+        assert_init_accepts_config(result, "always_off_sampler");
     }
 
     #[test]
@@ -602,7 +667,7 @@ mod tests {
         });
 
         let result = init_tracing(&otel);
-        assert!(result.is_ok());
+        assert_init_accepts_config(result, "ratio_sampler");
     }
 
     #[test]
@@ -622,7 +687,7 @@ mod tests {
         });
 
         let result = init_tracing(&otel);
-        assert!(result.is_ok());
+        assert_init_accepts_config(result, "http_exporter");
     }
 
     #[test]
@@ -643,7 +708,7 @@ mod tests {
         });
 
         let result = init_tracing(&otel);
-        assert!(result.is_ok());
+        assert_init_accepts_config(result, "grpc_exporter");
     }
 
     #[test]

--- a/libs/modkit/src/telemetry/mod.rs
+++ b/libs/modkit/src/telemetry/mod.rs
@@ -6,6 +6,7 @@
 pub mod config;
 pub mod init;
 pub mod throttled_log;
+pub mod trace_id;
 
 pub use config::{
     Exporter, HttpOpts, LogsCorrelation, MetricsConfig, OpenTelemetryConfig, OpenTelemetryResource,
@@ -15,3 +16,4 @@ pub use config::{
 pub use init::init_tracing;
 pub use init::{init_metrics_provider, shutdown_tracing};
 pub use throttled_log::ThrottledLog;
+pub use trace_id::{current_trace_id, trace_id_from_request};

--- a/libs/modkit/src/telemetry/trace_id.rs
+++ b/libs/modkit/src/telemetry/trace_id.rs
@@ -1,0 +1,146 @@
+//! Unified trace-ID extraction.
+//!
+//! When the `otel` feature is enabled, `current_trace_id()` returns the real
+//! W3C trace ID of the active OpenTelemetry span. Without the feature it
+//! returns `None`. Never use `tracing::Span::current().id()` for trace IDs —
+//! that is a subscriber-local numeric span id, not a trace id.
+
+use http::HeaderMap;
+
+/// Real W3C trace ID of the active OTEL span, if any.
+#[cfg(feature = "otel")]
+#[must_use]
+pub fn current_trace_id() -> Option<String> {
+    use opentelemetry::trace::TraceContextExt;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+    let ctx = tracing::Span::current().context();
+    let span = ctx.span();
+    let sc = span.span_context();
+    sc.is_valid().then(|| sc.trace_id().to_string())
+}
+
+#[cfg(not(feature = "otel"))]
+#[must_use]
+pub fn current_trace_id() -> Option<String> {
+    None
+}
+
+/// Parse the trace-id portion of a W3C `traceparent` header
+/// (format: `00-<trace_id>-<span_id>-<flags>`). Per the W3C spec, `trace_id`
+/// must be 32 lowercase hex characters and not all zeros; we reject anything
+/// else so callers never propagate a malformed id into `Problem.trace_id` or
+/// log-correlation fields.
+fn parse_traceparent_trace_id(traceparent: &str) -> Option<String> {
+    let parts: Vec<&str> = traceparent.split('-').collect();
+    if parts.len() < 4 || parts[0] != "00" {
+        return None;
+    }
+    let tid = parts[1];
+    if tid.len() != 32
+        || !tid
+            .bytes()
+            .all(|b| b.is_ascii_digit() || matches!(b, b'a'..=b'f'))
+        || tid.bytes().all(|b| b == b'0')
+    {
+        return None;
+    }
+    Some(tid.to_owned())
+}
+
+/// Best-effort trace ID: OTEL context first, then `traceparent`, then `x-request-id`.
+#[must_use]
+pub fn trace_id_from_request(headers: &HeaderMap) -> Option<String> {
+    if let Some(id) = current_trace_id() {
+        return Some(id);
+    }
+    if let Some(tp) = headers.get("traceparent").and_then(|v| v.to_str().ok())
+        && let Some(id) = parse_traceparent_trace_id(tp)
+    {
+        return Some(id);
+    }
+    headers
+        .get("x-request-id")
+        .or_else(|| headers.get("x-trace-id"))
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_traceparent() {
+        let tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        assert_eq!(
+            parse_traceparent_trace_id(tp),
+            Some("4bf92f3577b34da6a3ce929d0e0e4736".to_owned())
+        );
+    }
+
+    #[test]
+    fn rejects_non_v00_traceparent() {
+        let tp = "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        assert_eq!(parse_traceparent_trace_id(tp), None);
+    }
+
+    #[test]
+    fn rejects_short_traceparent() {
+        assert_eq!(parse_traceparent_trace_id("00-abc-def"), None);
+    }
+
+    #[test]
+    fn rejects_empty_trace_id() {
+        assert_eq!(parse_traceparent_trace_id("00--00f067aa0ba902b7-01"), None);
+    }
+
+    #[test]
+    fn rejects_short_trace_id() {
+        assert_eq!(
+            parse_traceparent_trace_id("00-abc123-00f067aa0ba902b7-01"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_uppercase_trace_id() {
+        assert_eq!(
+            parse_traceparent_trace_id("00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_all_zero_trace_id() {
+        assert_eq!(
+            parse_traceparent_trace_id("00-00000000000000000000000000000000-00f067aa0ba902b7-01"),
+            None
+        );
+    }
+
+    #[test]
+    fn trace_id_from_headers_prefers_traceparent_over_x_request_id() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "traceparent",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+                .parse()
+                .unwrap(),
+        );
+        headers.insert("x-request-id", "req-123".parse().unwrap());
+
+        // Without an active OTEL span, falls back to traceparent.
+        let id = trace_id_from_request(&headers);
+        assert_eq!(id, Some("4bf92f3577b34da6a3ce929d0e0e4736".to_owned()));
+    }
+
+    #[test]
+    fn trace_id_from_headers_uses_x_request_id_when_no_traceparent() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", "req-abc".parse().unwrap());
+        let id = trace_id_from_request(&headers);
+        assert_eq!(id, Some("req-abc".to_owned()));
+    }
+}

--- a/modules/mini-chat/mini-chat/src/api/rest/error.rs
+++ b/modules/mini-chat/mini-chat/src/api/rest/error.rs
@@ -5,69 +5,57 @@ use crate::domain::error::DomainError;
 
 impl From<DomainError> for Problem {
     fn from(e: DomainError) -> Self {
-        let trace_id = tracing::Span::current()
-            .id()
-            .map(|id| id.into_u64().to_string());
-        match &e {
+        let problem = match &e {
             DomainError::ChatNotFound { id } => Problem::new(
                 StatusCode::NOT_FOUND,
                 "Chat Not Found",
                 format!("Chat with id {id} was not found"),
-            )
-            .with_trace_id(trace_id.unwrap_or_default()),
+            ),
 
             DomainError::InvalidModel { model } => Problem::new(
                 StatusCode::BAD_REQUEST,
                 "Invalid Model",
                 format!("Model '{model}' is not available in the catalog"),
-            )
-            .with_trace_id(trace_id.unwrap_or_default()),
+            ),
 
             DomainError::Validation { message } => {
                 Problem::new(StatusCode::BAD_REQUEST, "Validation Error", message.clone())
-                    .with_trace_id(trace_id.unwrap_or_default())
             }
 
             DomainError::Forbidden => Problem::new(
                 StatusCode::FORBIDDEN,
                 "Access denied",
                 "You do not have permission to perform this action",
-            )
-            .with_trace_id(trace_id.unwrap_or_default()),
+            ),
 
             DomainError::Conflict { code, message } => {
                 Problem::new(StatusCode::CONFLICT, "Conflict", message.clone())
                     .with_code(code.clone())
-                    .with_trace_id(trace_id.unwrap_or_default())
             }
 
             DomainError::NotFound { entity, id } => Problem::new(
                 StatusCode::NOT_FOUND,
                 format!("{entity} not found"),
                 format!("{entity} with id {id} was not found"),
-            )
-            .with_trace_id(trace_id.unwrap_or_default()),
+            ),
 
             DomainError::MessageNotFound { id } => Problem::new(
                 StatusCode::NOT_FOUND,
                 "Message Not Found",
                 format!("Message with id {id} was not found"),
-            )
-            .with_trace_id(trace_id.unwrap_or_default()),
+            ),
 
             DomainError::InvalidReactionTarget { id } => Problem::new(
                 StatusCode::BAD_REQUEST,
                 "Invalid Reaction Target",
                 format!("Message {id} is not an assistant message"),
-            )
-            .with_trace_id(trace_id.unwrap_or_default()),
+            ),
 
             DomainError::ModelNotFound { model_id } => Problem::new(
                 StatusCode::NOT_FOUND,
                 "model_not_found",
                 format!("Model '{model_id}' was not found"),
-            )
-            .with_trace_id(trace_id.unwrap_or_default()),
+            ),
 
             DomainError::Database { message } | DomainError::InternalError { message } => {
                 tracing::error!(error_message = %message, "internal error occurred");
@@ -76,62 +64,54 @@ impl From<DomainError> for Problem {
                     "Internal Error",
                     "An internal error occurred",
                 )
-                .with_trace_id(trace_id.unwrap_or_default())
             }
 
             DomainError::WebSearchDisabled => Problem::new(
                 StatusCode::BAD_REQUEST,
                 "web_search_disabled",
                 "Web search is currently disabled",
-            )
-            .with_trace_id(trace_id.unwrap_or_default()),
+            ),
 
             DomainError::WebSearchCallsExceeded => Problem::new(
                 StatusCode::BAD_REQUEST,
                 "web_search_calls_exceeded",
                 "Web search calls exceeded for this message",
-            )
-            .with_trace_id(trace_id.unwrap_or_default()),
+            ),
 
             DomainError::UnsupportedFileType { mime } => Problem::new(
                 StatusCode::UNSUPPORTED_MEDIA_TYPE,
                 "unsupported_file_type",
                 format!("Unsupported file type: {mime}"),
             )
-            .with_code("unsupported_file_type".to_owned())
-            .with_trace_id(trace_id.unwrap_or_default()),
+            .with_code("unsupported_file_type".to_owned()),
 
             DomainError::FileTooLarge { message } => Problem::new(
                 StatusCode::PAYLOAD_TOO_LARGE,
                 "file_too_large",
                 message.clone(),
             )
-            .with_code("file_too_large".to_owned())
-            .with_trace_id(trace_id.unwrap_or_default()),
+            .with_code("file_too_large".to_owned()),
 
             DomainError::DocumentLimitExceeded { message } => Problem::new(
                 StatusCode::BAD_REQUEST,
                 "document_limit_exceeded",
                 message.clone(),
             )
-            .with_code("document_limit_exceeded".to_owned())
-            .with_trace_id(trace_id.unwrap_or_default()),
+            .with_code("document_limit_exceeded".to_owned()),
 
             DomainError::StorageLimitExceeded { message } => Problem::new(
                 StatusCode::BAD_REQUEST,
                 "storage_limit_exceeded",
                 message.clone(),
             )
-            .with_code("storage_limit_exceeded".to_owned())
-            .with_trace_id(trace_id.unwrap_or_default()),
+            .with_code("storage_limit_exceeded".to_owned()),
 
             DomainError::ServiceUnavailable { message } => Problem::new(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "service_unavailable",
                 message.clone(),
             )
-            .with_code("service_unavailable".to_owned())
-            .with_trace_id(trace_id.unwrap_or_default()),
+            .with_code("service_unavailable".to_owned()),
 
             DomainError::ProviderError {
                 code,
@@ -140,8 +120,12 @@ impl From<DomainError> for Problem {
                 tracing::error!(code = %code, message = %sanitized_message, "provider error");
                 Problem::new(StatusCode::BAD_GATEWAY, code, sanitized_message)
                     .with_code(code.clone())
-                    .with_trace_id(trace_id.unwrap_or_default())
             }
+        };
+
+        match modkit::telemetry::current_trace_id() {
+            Some(tid) => problem.with_trace_id(tid),
+            None => problem,
         }
     }
 }

--- a/modules/simple-user-settings/simple-user-settings/src/api/rest/error.rs
+++ b/modules/simple-user-settings/simple-user-settings/src/api/rest/error.rs
@@ -5,9 +5,7 @@ use crate::errors::ErrorCode;
 
 /// Map domain error to RFC9457 Problem using the GTS error catalog
 pub fn domain_error_to_problem(e: &DomainError, instance: &str) -> Problem {
-    let trace_id = tracing::Span::current()
-        .id()
-        .map(|id| id.into_u64().to_string());
+    let trace_id = modkit::telemetry::current_trace_id();
 
     match e {
         DomainError::NotFound => build_not_found_problem(instance, trace_id),

--- a/modules/system/api-gateway/src/middleware/auth.rs
+++ b/modules/system/api-gateway/src/middleware/auth.rs
@@ -1,6 +1,7 @@
 use axum::http::Method;
 use axum::response::IntoResponse;
 use std::{collections::HashMap, sync::Arc};
+use tracing::{Instrument, field::Empty, info_span};
 
 use crate::middleware::common;
 
@@ -201,45 +202,94 @@ pub async fn authn_middleware(
     mut req: axum::extract::Request,
     next: axum::middleware::Next,
 ) -> axum::response::Response {
-    // Skip CORS preflight — insert anonymous SecurityContext so downstream
-    // handlers that extract Extension<SecurityContext> don't panic.
-    if is_preflight_request(req.method(), req.headers()) {
-        req.extensions_mut().insert(SecurityContext::anonymous());
-        return next.run(req).await;
-    }
+    let span = info_span!(
+        "auth",
+        otel.kind = "internal",
+        auth.method = Empty,
+        auth.requirement = Empty,
+        auth.principal = Empty,
+        auth.tenant = Empty,
+        auth.result = Empty,
+    );
 
-    let path = req
-        .extensions()
-        .get::<axum::extract::MatchedPath>()
-        .map_or_else(|| req.uri().path().to_owned(), |p| p.as_str().to_owned());
-
-    let path = common::resolve_path(&req, path.as_str());
-
-    let requirement = state.route_policy.resolve(req.method(), path.as_str());
-
-    match requirement {
-        AuthRequirement::None => {
+    async move {
+        // Skip CORS preflight — insert anonymous SecurityContext so downstream
+        // handlers that extract Extension<SecurityContext> don't panic.
+        if is_preflight_request(req.method(), req.headers()) {
+            let current = tracing::Span::current();
+            current.record("auth.method", "preflight");
+            current.record("auth.result", "skipped");
             req.extensions_mut().insert(SecurityContext::anonymous());
-            next.run(req).await
+            return next.run(req).await;
         }
-        AuthRequirement::Required => {
-            let Some(token) = extract_bearer_token(req.headers()) else {
-                return Problem::new(
-                    axum::http::StatusCode::UNAUTHORIZED,
-                    "Unauthorized",
-                    "Missing or invalid Authorization header",
-                )
-                .into_response();
-            };
 
-            match state.authn_client.authenticate(token).await {
-                Ok(result) => {
-                    req.extensions_mut().insert(result.security_context);
-                    next.run(req).await
+        let path = req
+            .extensions()
+            .get::<axum::extract::MatchedPath>()
+            .map_or_else(|| req.uri().path().to_owned(), |p| p.as_str().to_owned());
+
+        let path = common::resolve_path(&req, path.as_str());
+
+        let requirement = state.route_policy.resolve(req.method(), path.as_str());
+        let current = tracing::Span::current();
+        match requirement {
+            AuthRequirement::None => {
+                current.record("auth.requirement", "public");
+                current.record("auth.method", "anonymous");
+                current.record("auth.result", "ok");
+                req.extensions_mut().insert(SecurityContext::anonymous());
+                next.run(req).await
+            }
+            AuthRequirement::Required => {
+                current.record("auth.requirement", "required");
+                current.record("auth.method", "bearer");
+                let Some(token) = extract_bearer_token(req.headers()) else {
+                    current.record("auth.result", "no_credentials");
+                    return with_trace_id(Problem::new(
+                        axum::http::StatusCode::UNAUTHORIZED,
+                        "Unauthorized",
+                        "Missing or invalid Authorization header",
+                    ))
+                    .into_response();
+                };
+
+                match state.authn_client.authenticate(token).await {
+                    Ok(result) => {
+                        current.record(
+                            "auth.principal",
+                            tracing::field::display(result.security_context.subject_id()),
+                        );
+                        current.record(
+                            "auth.tenant",
+                            tracing::field::display(result.security_context.subject_tenant_id()),
+                        );
+                        current.record("auth.result", "ok");
+                        req.extensions_mut().insert(result.security_context);
+                        next.run(req).await
+                    }
+                    Err(err) => {
+                        current.record("auth.result", authn_error_result_label(&err));
+                        authn_error_to_response(&err)
+                    }
                 }
-                Err(err) => authn_error_to_response(&err),
             }
         }
+    }
+    .instrument(span)
+    .await
+}
+
+/// Stable, low-cardinality label describing why authentication failed.
+///
+/// These strings are used for the `auth.result` span field and must stay in
+/// sync with the arms of `authn_error_to_response`.
+fn authn_error_result_label(err: &AuthNResolverError) -> &'static str {
+    match err {
+        AuthNResolverError::Unauthorized(_) => "unauthorized",
+        AuthNResolverError::NoPluginAvailable => "no_plugin",
+        AuthNResolverError::ServiceUnavailable(_) => "service_unavailable",
+        AuthNResolverError::TokenAcquisitionFailed(_) => "token_acquisition_failed",
+        AuthNResolverError::Internal(_) => "internal",
     }
 }
 
@@ -263,7 +313,18 @@ fn authn_error_to_response(err: &AuthNResolverError) -> axum::response::Response
             "Internal authentication error",
         ),
     };
-    Problem::new(status, title, detail).into_response()
+    with_trace_id(Problem::new(status, title, detail)).into_response()
+}
+
+/// Attach the active OTEL span's W3C trace ID to a `Problem`, when one is
+/// available. After dropping the auto-enrich in `Problem::into_response`
+/// (PR #1570), error responses must do this explicitly so that clients can
+/// correlate the failure with collected traces.
+fn with_trace_id(p: Problem) -> Problem {
+    match modkit::telemetry::current_trace_id() {
+        Some(tid) => p.with_trace_id(tid),
+        None => p,
+    }
 }
 
 /// Log authentication errors at appropriate levels.

--- a/modules/system/api-gateway/src/module.rs
+++ b/modules/system/api-gateway/src/module.rs
@@ -366,7 +366,15 @@ impl ApiGateway {
         // 3.5) Structured access log (runs after push_req_id populates XRequestId extension)
         router = router.layer(from_fn(middleware::access_log::access_log_middleware));
 
-        // 3) Record request_id into span + extensions (requires span to exist first => must be inner to Trace)
+        // 3) Handler span (child of TraceLayer's http_request; parent of biz middlewares).
+        // Records http.route from Axum's MatchedPath; falls back to the raw path
+        // when MatchedPath is absent (e.g. 404s that never reach a route).
+        // Must be INSIDE push_req_id_to_extensions so the latter records request_id
+        // onto the http_request span, not onto handler.
+        router = router.layer(from_fn(modkit::api::handler_span_middleware));
+
+        // 2.5) Record request_id into the http_request span + extensions.
+        // Must be OUTSIDE handler_span so Span::current() resolves to http_request.
         router = router.layer(from_fn(middleware::request_id::push_req_id_to_extensions));
 
         // 2) Trace (outer to push_req_id_to_extensions)
@@ -384,19 +392,24 @@ impl ApiGateway {
                         .and_then(|v| v.to_str().ok())
                         .unwrap_or("n/a");
 
+                    // Legacy fields (`method`, `uri`, `status`) are kept for
+                    // log-based dashboards that already key on them. OTEL
+                    // semantic-convention fields (`http.method`, `http.target`,
+                    // `http.status_code`, …) are recorded alongside for new
+                    // consumers. See `docs/TRACING_SETUP.md` §Field naming.
                     let span = tracing::info_span!(
                         "http_request",
                         method = %req.method(),
                         uri = %req.uri().path(),
                         version = ?req.version(),
                         module = "api_gateway",
-                        endpoint = %req.uri().path(),
                         request_id = %rid,
                         status = Empty,
                         latency_ms = Empty,
                         // OpenTelemetry semantic conventions
                         "http.method" = %req.method(),
                         "http.target" = %req.uri().path(),
+                        "http.status_code" = Empty,
                         "http.scheme" = req.uri().scheme_str().unwrap_or("http"),
                         "http.host" = req.headers().get("host")
                             .and_then(|h| h.to_str().ok())
@@ -420,7 +433,9 @@ impl ApiGateway {
                      latency: std::time::Duration,
                      span: &tracing::Span| {
                         let ms = latency.as_millis();
-                        span.record("status", res.status().as_u16());
+                        let code = res.status().as_u16();
+                        span.record("status", code);
+                        span.record("http.status_code", code);
                         span.record("latency_ms", ms);
                     },
                 )

--- a/modules/system/nodes-registry/nodes-registry/src/api/rest/error.rs
+++ b/modules/system/nodes-registry/nodes-registry/src/api/rest/error.rs
@@ -4,9 +4,7 @@ use modkit::api::problem::Problem;
 
 /// Map domain errors to HTTP problem responses
 pub fn domain_error_to_problem(err: DomainError, instance: &str) -> Problem {
-    let trace_id = tracing::Span::current()
-        .id()
-        .map(|id| id.into_u64().to_string());
+    let trace_id = modkit::telemetry::current_trace_id();
 
     let mut problem = match err {
         DomainError::NodeNotFound(id) => Problem::new(

--- a/modules/system/types-registry/types-registry/src/api/rest/error.rs
+++ b/modules/system/types-registry/types-registry/src/api/rest/error.rs
@@ -7,9 +7,7 @@ use crate::domain::error::DomainError;
 
 impl From<DomainError> for Problem {
     fn from(e: DomainError) -> Self {
-        let trace_id = tracing::Span::current()
-            .id()
-            .map(|id| id.into_u64().to_string());
+        let trace_id = modkit::telemetry::current_trace_id();
 
         let (status, code, title, detail) = match &e {
             DomainError::InvalidGtsId(msg) => (


### PR DESCRIPTION
- Replace three broken `Span::current().id()`-based trace-ID extractors (plus five per-module copies) with `modkit::telemetry::current_trace_id()`, which reads the real W3C trace ID via `OpenTelemetrySpanExt`. Removes the `Problem::into_response` auto-enrich that manufactured fake trace IDs; callers set `trace_id` explicitly or via `WithTraceContext`.
- Store `SdkTracerProvider` and `SdkMeterProvider` in `OnceLock` so `shutdown_tracing` / `shutdown_metrics` actually force-flush and shut down. Previously documented no-ops — the final batch of spans was dropped on every process exit.
- Install `tracing_error::ErrorLayer` (already a workspace dep, never wired in).
- Span-instrument `HostRuntime::run_*_phase` methods (`phase="init"/"db"/...` + per-module child spans), the Axum handler layer (new `handler_span_middleware` populating `http.route` from `MatchedPath`), `authn_middleware` (`auth` span with late-bound `auth.method` / `auth.principal` / `auth.result`), `SecureConn`'s async DB ops and transaction boundaries (`db.system`, `db.operation`, `entity`), and `modkit-http`'s retry loop (per-attempt `http.retry` spans, parity with the gRPC retry path).
- Document the OTEL semantic-convention field naming in `docs/TRACING_SETUP.md`. Mass rename of existing fields is not done — log pipelines depend on the legacy names.

Note: `Problem.trace_id` is now `null` when the caller didn't set one, rather than the fake `"42"` the old auto-enrich produced. All in-tree callers set it explicitly, so in-tree behavior is unchanged; worth a line in release notes for external consumers.

Closes #817.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Handler-level HTTP request tracing (route, method, status) and new telemetry APIs for canonical trace-id extraction
  * Database spans for inserts/updates/deletes and transaction boundaries
  * Per-attempt HTTP retry spans and enhanced auth tracing (method/result/principal)
  * Improved tracer/metrics init and conditional force-flush/shutdown; tracing-error layer added

* **Bug Fixes**
  * Trace ID extraction/propagation aligned with OpenTelemetry; error responses no longer auto-enrich trace IDs

* **Documentation**
  * Full rewrite of tracing setup: OpenTelemetry wiring, YAML schema, span reference, and troubleshooting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->