### PR TITLE
doc(tenant-resolver-plugin) PRD + DESIGN

### DIFF
--- a/.cypilot/config/artifacts.toml
+++ b/.cypilot/config/artifacts.toml
@@ -204,7 +204,21 @@ required = false
 [systems.autodetect.validation]
 require_kind_registered_in_kit = true
 require_md_extension = true
-fail_on_unmatched_markdown = true
+# fail_on_unmatched_markdown is disabled at this scope because children autodetect rules
+# (e.g. account-management/docs/tr-plugin) do not carve their paths out of the parent's
+# unmatched-markdown walk, so tightening this would flag legitimate sub-plugin artifacts
+# as unmatched.
+#
+# Known trade-off: because this autodetect block matches every modules/system/$system
+# (oagw, resource-group, account-management, and any future sibling), setting this flag
+# to `false` here also disables unmatched-markdown detection across every other
+# modules/system/* subtree — not only account-management. Strictness is retained on each
+# child scope (see the tr-plugin child below, which keeps fail_on_unmatched_markdown = true).
+#
+# Do NOT tighten this flag without first introducing a per-path carve-out mechanism for
+# the tr-plugin-style sub-plugin case; otherwise the legitimate sub-plugin artifacts will
+# re-surface as unmatched-markdown failures for every module that ships nested artifacts.
+fail_on_unmatched_markdown = false
 
 [[systems.autodetect.codebase]]
 name = "Modules"
@@ -230,6 +244,35 @@ extensions = [".rs"]
 name = "Nested SDK"
 path = "{system_root}/{system}-sdk/src"
 extensions = [".rs"]
+
+# Nested sub-plugin scope: account-management/docs/tr-plugin/ carries its own PRD/DESIGN/ADR.
+# Declared as a child of the `modules/system/$system` autodetect rule so the sub-plugin
+# artifacts are detected as belonging to tr-plugin, not to account-management.
+[[systems.autodetect.children]]
+kit = "sdlc"
+system_root = "{project_root}/modules/system/account-management/docs/tr-plugin"
+artifacts_root = "{system_root}"
+
+[systems.autodetect.children.artifacts]
+[systems.autodetect.children.artifacts.PRD]
+pattern = "PRD.md"
+traceability = "DOCS-ONLY"
+required = false
+
+[systems.autodetect.children.artifacts.DESIGN]
+pattern = "DESIGN.md"
+traceability = "DOCS-ONLY"
+required = false
+
+[systems.autodetect.children.artifacts.ADR]
+pattern = "ADR/*.md"
+traceability = "DOCS-ONLY"
+required = false
+
+[systems.autodetect.children.validation]
+require_kind_registered_in_kit = true
+require_md_extension = true
+fail_on_unmatched_markdown = true
 
 [[systems]]
 name = "examples"

--- a/docs/arch/authorization/AUTHZ_USAGE_SCENARIOS.md
+++ b/docs/arch/authorization/AUTHZ_USAGE_SCENARIOS.md
@@ -678,7 +678,7 @@ WHERE owner_tenant_id IN (
 
 When querying from T1 with `barrier_mode=all`, only rows where `barrier = 0` match → T1, T4.
 
-**Key insight:** T2 → T2 and T2 → T3 have `barrier = 0` because barriers are tracked **strictly between** ancestor and descendant, not including the ancestor itself. When T2 is the query root, its self_managed status doesn't block access to its own subtree.
+**Key insight:** T2 → T2 and T2 → T3 have `barrier = 0` because the `barrier` column is defined over the interval **`(ancestor, descendant]`** — the ancestor endpoint is excluded (canonical definition in [TENANT_MODEL.md §Closure Table](./TENANT_MODEL.md#closure-table)). When T2 is the query root, its self_managed status doesn't block access to its own subtree.
 
 ---
 

--- a/docs/arch/authorization/DESIGN.md
+++ b/docs/arch/authorization/DESIGN.md
@@ -1139,7 +1139,7 @@ Filters resources by tenant subtree using the closure table. The `resource_prope
 | `"all"` | `AND barrier = 0` | (default) Respect all barriers. Stops traversal at `self_managed` tenants. |
 | `"none"` | (omit clause) | Ignore barriers. Use for billing, tenant metadata, or other cross-barrier operations. |
 
-**Future extensibility:** The `barrier` column is INT to allow future use as a bitmask for multiple barrier types. Future modes (e.g., `"data_sovereignty_only"`) can be added with selective checks like `(barrier & mask) = 0` without breaking existing consumers.
+**Future extensibility:** The `barrier` column is SMALLINT to allow future use as a bitmask for multiple barrier types (16 bits of headroom; portable across PostgreSQL and MySQL). Future modes (e.g., `"data_sovereignty_only"`) can be added with selective checks like `(barrier & mask) = 0` without breaking existing consumers.
 
 **Relationship to request `tenant_context`:** The PDP uses `context.tenant_context` from the request to determine the tenant context, then generates `in_tenant_subtree` predicates in the response. The predicate's `root_tenant_id` comes from either the request's `tenant_context.root_id` or PDP's resolution from token/subject. The `barrier_mode` and `tenant_status` parameters flow through from request to predicate.
 
@@ -1309,16 +1309,17 @@ Denormalized closure table for tenant hierarchy. Enables efficient subtree queri
 |--------|------|----------|-------------|
 | `ancestor_id` | UUID | No | Parent tenant in the hierarchy |
 | `descendant_id` | UUID | No | Child tenant (the one we check ownership against) |
-| `barrier` | INT | No | 0 = no barrier on path, 1 = barrier exists between ancestor and descendant (default 0) |
-| `descendant_status` | TEXT | No | Status of descendant tenant (`active`, `suspended`, `deleted`) |
+| `barrier` | SMALLINT | No | 0 = no barrier on path, 1 = barrier exists between ancestor and descendant (default 0) |
+| `descendant_status` | SMALLINT | No | Status of descendant tenant, encoded as a small integer. Domain is **`{1=active, 2=suspended, 3=deleted}`** only — the internal `0=provisioning` code is **absent** from `tenant_closure` by construction (see the provisioning-exclusion note below). Int↔name translation is owned by the application layer. |
 
 **Notes:**
 - Status is denormalized into closure for query simplicity (avoids JOIN). When a tenant's status changes, all rows where it is `descendant_id` are updated.
-- **Barrier semantics:** The `barrier` column stores barriers **strictly between** ancestor and descendant, **not including the ancestor itself**. This means when T2 is self_managed, rows with `ancestor_id = T2` have `barrier = 0`, while rows with T2 on the path from another ancestor have `barrier = 1`.
+- **Provisioning exclusion:** `tenant_closure` never contains a row for a tenant in `provisioning` state. Closure rows are inserted on the `provisioning → active` transition (end of the tenant-create saga) and removed on hard-deletion; the `0=provisioning` code is therefore not a legal value for `tenant_closure.descendant_status` even though it is legal for `tenants.status`. The database-level enforcement point is `CHECK (descendant_status IN (1, 2, 3))` on the `tenant_closure` table — see [`modules/system/account-management/docs/migration.sql`](../../../modules/system/account-management/docs/migration.sql) for the constraint and column COMMENT, and [AM ADR-0007 — Exclude Provisioning Tenants from `tenant_closure`](../../../modules/system/account-management/docs/ADR/0007-cpt-cf-account-management-adr-provisioning-excluded-from-closure.md) for the decision rationale. Consumers of `tenant_closure` (Tenant Resolver Plugin today, business-module replicas later) therefore do **not** need a provisioning-specific filter — the invisibility is structural.
+- **Barrier semantics:** The `barrier` column is defined over the interval **`(ancestor, descendant]`** — the ancestor endpoint is excluded, the descendant endpoint is included (canonical definition in [TENANT_MODEL.md §Closure Table](./TENANT_MODEL.md#closure-table)). This means when T2 is self_managed, rows with `ancestor_id = T2` have `barrier = 0`, while rows with T2 on the path from another ancestor have `barrier = 1`.
 - The `barrier` column enables simple filtering: `barrier_mode: "all"` adds `AND barrier = 0`, `barrier_mode: "none"` omits the clause.
 - Self-referential rows exist: each tenant has a row where `ancestor_id = descendant_id`.
 - **Predicate mapping:** `in_tenant_subtree` predicate compiles to SQL using this closure table.
-- **Future extensibility:** The `barrier` column is INT to allow future use as a bitmask for multiple barrier types (e.g., `(barrier & mask) = 0` for selective enforcement).
+- **Future extensibility:** The `barrier` column is SMALLINT to allow future use as a bitmask for multiple barrier types (16 bits of headroom, portable across PostgreSQL and MySQL; e.g., `(barrier & mask) = 0` for selective enforcement).
 
 **Example query (in_tenant_subtree):**
 ```sql

--- a/docs/arch/authorization/TENANT_MODEL.md
+++ b/docs/arch/authorization/TENANT_MODEL.md
@@ -216,12 +216,15 @@ The `tenant_closure` table is a denormalized representation of the tenant hierar
 |--------|------|-------------|
 | `ancestor_id` | UUID | Ancestor tenant |
 | `descendant_id` | UUID | Descendant tenant |
-| `barrier` | INT NOT NULL DEFAULT 0 | 0 = no barrier on path, 1 = barrier exists between ancestor and descendant |
+| `barrier` | SMALLINT NOT NULL DEFAULT 0 | 0 = no respected barrier on path `(ancestor, descendant]`, 1 = at least one `self_managed` tenant exists on that path |
 | `descendant_status` | enum | Status of descendant tenant (denormalized for query efficiency) |
 
-**Barrier semantics:** The `barrier` column stores whether a barrier exists **strictly between** ancestor and descendant, **not including the ancestor itself**. This means:
-- When querying from T2 (a self_managed tenant), rows with `ancestor_id = T2` have `barrier = 0` because T2 is the ancestor, not "between" itself and its descendants
-- When querying from T1 (parent of T2), rows with `ancestor_id = T1` and `descendant_id` in T2's subtree have `barrier = 1` because T2 is between T1 and its descendants
+**Barrier semantics:** The `barrier` column is defined over the path `(ancestor, descendant]`: the ancestor endpoint is excluded, the descendant endpoint is included. Formally, `barrier = 1` iff any tenant on that path has `self_managed = true`. Self-rows `(id, id)` are a special case and always carry `barrier = 0`.
+
+This endpoint rule is what makes a plain `AND barrier = 0` predicate satisfy the SDK contract:
+- `get_ancestors(T, Respect)` returns empty if `T` itself is self-managed, because every strict-ancestor row ending at `T` has `barrier = 1`
+- `get_descendants(T, Respect)` excludes a self-managed child `C` and its subtree, because rows starting at `T` and ending at `C` or below have `barrier = 1`
+- `is_ancestor(A, D, Respect)` returns `false` when `D` itself is self-managed or when another self-managed tenant lies on `(A, D]`
 
 **Example data for the hierarchy:**
 
@@ -244,9 +247,10 @@ T1
 | T4 | T4 | 0 | active |
 
 **Key observations:**
-- `T1 → T2`: barrier = 1 because T2 (self_managed) is on the path
-- `T1 → T3`: barrier = 1 because T2 is on the path from T1 to T3
-- `T2 → T2` and `T2 → T3`: barrier = 0 because T2 is the **ancestor**, not between T2 and its descendants
+- `T1 → T2`: barrier = 1 because the descendant endpoint `T2` is self-managed and the descendant endpoint is included in `(ancestor, descendant]`
+- `T1 → T3`: barrier = 1 because `T2` is on `(T1, T3]`
+- `T2 → T2`: barrier = 0 because self-rows always carry `barrier = 0`
+- `T2 → T3`: barrier = 0 because ancestor `T2` is excluded from `(T2, T3]`
 - Because the hierarchy has a single root, that root appears as `ancestor_id` of every tenant in the table (subject to the barrier rules above).
 
 **Query: "All tenants in T1's subtree, with `barrier_mode: "all"`"**
@@ -267,9 +271,9 @@ Result: T1, T4 (T2 and T3 excluded due to barrier = 1)
 SELECT descendant_id FROM tenant_closure WHERE ancestor_id = 'T2' AND barrier = 0
 ```
 
-Result: T2, T3 (barrier = 0 for both rows because T2 is the ancestor, not between T2 and its descendants)
+Result: T2, T3 (`T2 → T2` is the self-row; `T2 → T3` has `barrier = 0` because ancestor `T2` is excluded from `(T2, T3]`)
 
-**Future extensibility:** The `barrier` column is INT to allow future use as a bitmask for multiple barrier types (e.g., bit 0 for self_managed, bit 1 for data_sovereignty). SQL would change from `barrier = 0` to `(barrier & mask) = 0` for selective enforcement.
+**Future extensibility:** The `barrier` column is SMALLINT to allow future use as a bitmask for multiple barrier types (e.g., bit 0 for self_managed, bit 1 for data_sovereignty). 16 bits of bitmask headroom is ample for any realistic number of barrier dimensions, and the type is portable across PostgreSQL and MySQL. Selective enforcement changes from `barrier = 0` to a `(barrier & mask) = 0` check without touching the schema.
 
 **Synchronization:** How projection tables are synchronized with vendor systems, consistency guarantees, and conflict resolution are out of scope for this document. See Tenant Resolver design documentation (TBD).
 

--- a/modules/system/account-management/docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md
+++ b/modules/system/account-management/docs/ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md
@@ -107,6 +107,7 @@ PRD Section 3.4 (User Data Ownership) defines the ownership boundaries that this
 
 - **PRD**: [PRD.md](../PRD.md)
 - **DESIGN**: [DESIGN.md](../DESIGN.md)
+- **Related**: [ADR-0006](0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md) — ADR-0005 establishes that AM maintains no local user table; ADR-0006 decides where the user-tenant binding lives within that constraint. Decided together on the same date.
 
 This decision directly addresses the following requirements and design elements:
 

--- a/modules/system/account-management/docs/ADR/0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md
+++ b/modules/system/account-management/docs/ADR/0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md
@@ -112,6 +112,7 @@ PRD Section 3.4 (User Data Ownership) explicitly states: "IdP is the single sour
 
 - **PRD**: [PRD.md](../PRD.md)
 - **DESIGN**: [DESIGN.md](../DESIGN.md)
+- **Related**: [ADR-0005](0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md) — ADR-0005 establishes IdP as the sole source of truth for user identity; this ADR specifies the user-tenant binding storage within that constraint. Decided together on the same date.
 
 This decision directly addresses the following requirements and design elements:
 

--- a/modules/system/account-management/docs/ADR/0007-cpt-cf-account-management-adr-provisioning-excluded-from-closure.md
+++ b/modules/system/account-management/docs/ADR/0007-cpt-cf-account-management-adr-provisioning-excluded-from-closure.md
@@ -1,0 +1,133 @@
+---
+status: accepted
+date: 2026-04-23
+decision-makers: Virtuozzo
+---
+
+# ADR-0007: Exclude Provisioning Tenants from `tenant_closure`
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Option A — Closure contains only SDK-visible tenants (drop `descendant_status` entirely)](#option-a--closure-contains-only-sdk-visible-tenants-drop-descendant_status-entirely)
+  - [Option B — Closure contains only SDK-visible tenants (keep `descendant_status` for visible states)](#option-b--closure-contains-only-sdk-visible-tenants-keep-descendant_status-for-visible-states)
+  - [Option C — Keep the original design: provisioning rows live in closure, plugin filters them](#option-c--keep-the-original-design-provisioning-rows-live-in-closure-plugin-filters-them)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+**ID**: `cpt-cf-account-management-adr-provisioning-excluded-from-closure`
+
+## Context and Problem Statement
+
+`tenant_closure` is AM's canonical transitive-ancestry table, read today by the Tenant Resolver Plugin and planned for future replication to business modules that need subtree/barrier awareness without cross-module calls to AM.
+
+The original design wrote a closure row for every `tenants` row from the moment it was inserted during the tenant-create saga, including the transient `provisioning` state. `descendant_status` carried the `provisioning` value on those rows, and the Tenant Resolver Plugin applied an unconditional `descendant_status <> 'provisioning'` predicate on every closure-driven read to hide them from SDK responses.
+
+This works for a single-reader model but creates two problems once the closure becomes a publication contract:
+
+1. **Replication surface leak.** Every replica consumer must know about `provisioning` and filter it out. Internal AM saga state flows across the replication boundary even though only SDK-visible tenants are consumed.
+2. **Burden on every future reader.** Business modules integrating against a replicated `tenant_closure` inherit the provisioning-exclusion obligation. Missing the filter yields silently wrong subtree queries.
+
+Review feedback (external) raised this explicitly: *"Did you consider an option to don't store provisioning records in the tenant_closure table? In the future we will use the same tenant_closure table in the business modules and implement replication mechanism for it. We will have to handle those records with the provisioning state separately."*
+
+## Decision Drivers
+
+- The closure must be a **clean publication contract** — consumers should receive only SDK-visible state.
+- AM must remain the sole authority for tenant lifecycle, including the transient `provisioning` window.
+- Hot-path query performance for `get_descendants` with caller-supplied status filtering must be preserved (this was the reason `descendant_status` was denormalized into the closure in the first place).
+- Transactional consistency between `tenants` and `tenant_closure` must be preserved — readers never observe divergent state.
+- Change scope should be small enough to apply without rewriting the tenant-create saga.
+
+## Considered Options
+
+- **Option A** — Closure contains only SDK-visible tenants; drop `descendant_status` entirely (force JOIN to `tenants` for status filtering).
+- **Option B** — Closure contains only SDK-visible tenants; keep `descendant_status` but restrict its domain to `{active, suspended, deleted}`.
+- **Option C** — Keep the original design (provisioning rows live in closure; plugin filters them on every read).
+
+## Decision Outcome
+
+Chosen option: **Option B** — provisioning tenants are absent from `tenant_closure` entirely; `descendant_status` remains but with a restricted 3-value domain.
+
+Closure rows are inserted in a single transaction with the `provisioning → active` transition at the end of the tenant-create saga (saga step 3), and removed in a single transaction with hard-deletion. During provisioning, the tenant row exists in `tenants` with `status = 'provisioning'` and nothing in `tenant_closure`. Compensation (provisioning reaper rolling back a stuck provisioning row) deletes the `tenants` row only; no closure cleanup is needed because nothing was ever written.
+
+### Consequences
+
+- **Good**: The closure becomes a clean publication contract. Any future consumer — the Tenant Resolver Plugin today, business-module replicas tomorrow — never observes provisioning state and carries no provisioning-specific filtering obligation.
+- **Good**: `tenant_closure.descendant_status` CHECK tightens to `{active, suspended, deleted}`, eliminating one internal-state value from the schema surface.
+- **Good**: The Tenant Resolver Plugin's unconditional `descendant_status <> 'provisioning'` filter goes away. Provisioning invisibility becomes structural — closure-driven reads cannot surface provisioning tenants by construction. Plugin-side provisioning filtering remains only as defense-in-depth on direct `tenants` reads (existence probes, bulk-by-ids, ancestor hydration JOINs).
+- **Good**: Hot-path performance is preserved — `descendant_status` remains denormalized for fast status-filtered subtree reads; no JOIN regression on `get_descendants`.
+- **Neutral**: The tenant-create saga shifts closure insertion from step 1 to step 3. Step 1 becomes purely a `tenants` insert; step 3 inserts the `tenants` status update plus all closure rows in one transaction. The transactional shape is unchanged (both saga steps are short transactions bracketing the IdP call), only the row allocation between them shifts.
+- **Neutral**: Any existing AM internal code that needed to resolve hierarchy for a `provisioning` tenant via `tenant_closure` must fall back to walking `tenants.parent_id` instead. Audit needed before implementation; in v1 the saga itself does not need hierarchy for provisioning tenants beyond the direct `parent_id` already stored on the row.
+- **Bad**: One more invariant to enforce — "no provisioning rows in closure" — joining the existing list of closure invariants. Integrity checks must verify the absence, not just presence.
+
+### Confirmation
+
+Verified by integration tests covering:
+
+1. Tenant created and left in `provisioning` → no closure rows exist for it; Tenant Resolver Plugin returns `TenantNotFound` for every SDK method targeting the id.
+2. Provisioning reaper compensating a stuck row → `tenants` row removed; no closure cleanup needed; no orphan rows left behind.
+3. Successful activation (`provisioning → active`) → closure rows appear atomically with the status transition; visible to Tenant Resolver Plugin immediately.
+4. Schema CHECK rejects `descendant_status = 0` (provisioning code) in `tenant_closure`.
+5. `TenantService` activation path is the only code path that inserts self-row + strict-ancestor rows.
+
+## Pros and Cons of the Options
+
+### Option A — Closure contains only SDK-visible tenants (drop `descendant_status` entirely)
+
+The cleanest shape: if a row exists in `tenant_closure`, the tenant is SDK-visible; if not, it is provisioning or hard-deleted. No denormalization at all; every status-filtered subtree read JOINs `tenants`.
+
+- Good, because the closure becomes a pure structural projection with no denormalized state.
+- Good, because status updates on `tenants` no longer require closure writes.
+- Bad, because every `get_descendants` call with a status filter needs a JOIN to `tenants` — write-amplification trade-off flips direction and the hot path pays for every read.
+- Bad, because index coverage needs to change: `tenant_closure(ancestor_id, barrier, descendant_status)` → something like `tenant_closure(ancestor_id, barrier)` with `tenants(id, status)` covering status filtering on the JOIN side.
+
+### Option B — Closure contains only SDK-visible tenants (keep `descendant_status` for visible states)
+
+Same provisioning-absence guarantee as Option A, but `descendant_status` stays as a denormalized column carrying only `{active, suspended, deleted}`.
+
+- Good, because it satisfies the replication hygiene goal (no provisioning in closure) with minimum churn.
+- Good, because hot-path status-filtered subtree reads keep the single-index path they have today — no JOIN regression.
+- Good, because the Tenant Resolver Plugin's unconditional provisioning filter becomes a no-op and can be removed, simplifying the query builder.
+- Bad, because there is still a denormalized column to maintain transactionally on status transitions (but only between 3 states, not 4).
+
+### Option C — Keep the original design: provisioning rows live in closure, plugin filters them
+
+The status quo before this ADR.
+
+- Good, because it is the smallest change (none).
+- Good, because the "every tenant has a self-row + strict-ancestor rows" invariant is simple and universal.
+- Bad, because it cannot satisfy the replication use case without duplicating the provisioning-filter obligation to every future consumer.
+- Bad, because it exposes internal AM saga state on a storage contract that is intended to become a publication boundary.
+- Bad, because the plugin must carry an unconditional filter on every SDK read that exists solely to hide saga state from consumers — a cross-cutting concern that fights the "closure = canonical hierarchy" framing.
+
+## More Information
+
+This ADR affects:
+
+- [AM PRD §5.2 `cpt-cf-account-management-fr-tenant-closure`](../PRD.md) — closure-maintenance contract rewritten to specify "insert on `provisioning → active`, remove on hard-delete", and `descendant_status` domain tightened to SDK-visible states only.
+- [AM DESIGN §2 `cpt-cf-account-management-principle-barrier-as-data`](../DESIGN.md) + §3 closure invariants table + §3.6 tenant-create saga diagram + §3.7 `Table: tenant_closure` — all updated to reflect the new allocation.
+- [migration.sql](../migration.sql) — `tenant_closure.descendant_status` CHECK tightened from `IN (0,1,2,3)` to `IN (1,2,3)`; column COMMENT updated.
+- [tr-plugin PRD `cpt-cf-tr-plugin-fr-provisioning-invisibility`](../tr-plugin/PRD.md) — split into structural (AM closure contract) + defense-in-depth (plugin `tenants` reads) layers.
+- [tr-plugin DESIGN](../tr-plugin/DESIGN.md) — unconditional `descendant_status <> 'provisioning'` filter removed from query-builder descriptions; provisioning invisibility now described as structural on closure-driven reads.
+
+Related ADRs:
+
+- [ADR-0003 — Conversion Approval](./0003-cpt-cf-account-management-adr-conversion-approval.md) — sibling dual-consent state machine; closure barrier updates live in the same transaction as `self_managed` flips, separate from the provisioning/activation allocation this ADR addresses.
+- [ADR-0004 — Reject RG as Canonical Tenant Hierarchy Store](./0004-cpt-cf-account-management-adr-resource-group-tenant-hierarchy-source.md) — establishes AM as the sole owner of `tenants` and `tenant_closure`; this ADR tightens what lives in the latter.
+
+## Traceability
+
+| Traces to | Type | Notes |
+|-----------|------|-------|
+| `cpt-cf-account-management-fr-tenant-closure` | PRD FR | Closure-maintenance contract rewritten per this decision |
+| `cpt-cf-account-management-principle-barrier-as-data` | DESIGN principle | Principle paragraph updated to call out closure exclusion of provisioning |
+| `cpt-cf-tr-plugin-fr-provisioning-invisibility` | Plugin PRD FR | Split into structural + defense-in-depth layers |
+| `cpt-cf-tr-plugin-fr-get-descendants` | Plugin PRD FR | Filter predicate on `descendant_status` for provisioning no longer needed |

--- a/modules/system/account-management/docs/DESIGN.md
+++ b/modules/system/account-management/docs/DESIGN.md
@@ -54,19 +54,19 @@ User group management is handled by the [Resource Group](../../resource-group/do
 
 ```mermaid
 graph LR
-    Admin["Platform / Tenant<br>Administrator"] -->|REST API| AM["Account<br>Management"]
-    AM -->|provision/deprovision<br>users & tenants| IdP["IdP Provider<br>Plugin"]
-    AM -->|type validation<br>& schema queries| GTS["GTS Types<br>Registry"]
-    AM -->|user-group type<br>registration & cleanup| RG["Resource<br>Group"]
-    AM ---|source-of-truth<br>tenant data| DB[("PostgreSQL")]
-    TR["Tenant Resolver"] -.->|reads tenant<br>source-of-truth| DB
-    AuthZ["AuthZ Resolver<br>(PDP plugin)"] -.->|tenant hierarchy<br>& barrier queries| TR
-    Billing["Billing System"] -.->|reads tenant<br>metadata| AM
+    Admin["Platform / Tenant<br/>Administrator"] -->|REST API| AM["Account<br/>Management"]
+    AM -->|provision/deprovision<br/>users & tenants| IdP["IdP Provider<br/>Plugin"]
+    AM -->|type validation<br/>& schema queries| GTS["GTS Types<br/>Registry"]
+    AM -->|user-group type<br/>registration & cleanup| RG["Resource<br/>Group"]
+    AM ---|"tenants + tenant_closure<br/>(source of truth)"| DB[(PostgreSQL)]
+    TR["Tenant Resolver<br/>(query facade)"] -.->|"tenants + tenant_closure<br/>via read-only DB role"| DB
+    AuthZ["AuthZ Resolver<br/>(PDP plugin)"] -.->|"tenant hierarchy<br/>& barrier queries"| TR
+    Billing["Billing System"] -.->|"reads tenant<br/>metadata"| AM
 ```
 
 **System actors by PRD ID**
 
-- `cpt-cf-account-management-actor-tenant-resolver` consumes AM source-of-truth tenant hierarchy and barrier state through the tenant data contract.
+- `cpt-cf-account-management-actor-tenant-resolver` reads AM-owned `tenants` and `tenant_closure` directly via a read-only database role and serves the SDK-facing query facade over that data.
 - `cpt-cf-account-management-actor-authz-resolver` consumes tenant context, barrier inputs, and metadata authorization attributes for access decisions.
 - `cpt-cf-account-management-actor-billing` consumes read-only hierarchy and billing-relevant metadata views under platform-authorized barrier-bypass policy.
 
@@ -90,13 +90,14 @@ graph LR
 | `cpt-cf-account-management-fr-tenant-type-enforcement` | `TenantService` queries `TypesRegistryClient` for type constraints at child creation time. |
 | `cpt-cf-account-management-fr-tenant-type-nesting` | Same-type nesting permitted when GTS type definition allows it; acyclicity guaranteed by tree structure. |
 | `cpt-cf-account-management-fr-managed-tenant-creation` | Tenant created with `self_managed=false`; no barrier flag set. |
-| `cpt-cf-account-management-fr-self-managed-tenant-creation` | Tenant created with `self_managed=true`; barrier flag stored for downstream resolver consumption. |
+| `cpt-cf-account-management-fr-self-managed-tenant-creation` | Tenant created with `self_managed=true`; the barrier flag is stored on the tenant row and materialized into `tenant_closure.barrier` on the same transaction for every `(ancestor, descendant)` pair whose path `(ancestor, descendant]` contains the new tenant. |
+| `cpt-cf-account-management-fr-tenant-closure` | AM owns `tenant_closure` with the platform-canonical shape `(ancestor_id, descendant_id, barrier, descendant_status)`. `TenantService` and `ConversionService::approve` maintain closure rows transactionally with every hierarchy or lifecycle mutation so downstream readers observe tree and closure as one consistent state. |
 | `cpt-cf-account-management-fr-mode-conversion-approval` | `ConversionService` owns the dual-consent lifecycle for any post-creation toggle of `tenants.self_managed`. Each side acts from its own authorized scope and root tenants are excluded from the flow. |
 | `cpt-cf-account-management-fr-mode-conversion-expiry` | A background expiry task closes unresolved conversion requests after the configured approval window without changing tenant mode. |
 | `cpt-cf-account-management-fr-mode-conversion-single-pending` | A partial unique invariant on the conversion store plus service-level conflict handling ensure at most one pending conversion request per tenant. |
 | `cpt-cf-account-management-fr-mode-conversion-consistent-apply` | Approval updates both conversion status and tenant barrier state as one consistent transaction outcome. |
 | `cpt-cf-account-management-fr-conversion-creation-time-self-managed` | `TenantService::create_tenant` accepts `self_managed=true` directly at creation time and stores the flag without a `ConversionRequest`; the parent's explicit creation call is the consent. Only post-creation toggles are routed through `ConversionService`. |
-| `cpt-cf-account-management-fr-child-conversions-query` | `ConversionService::list_inbound_for_parent` joins `conversion_requests` with `tenants` on `parent_id`. Operates within parent tenant AuthZ scope; no barrier bypass required. Exposes only conversion-request metadata (child `id`, child `name`, `initiator_side`, `target_mode`, `status`, timestamps), not full child tenant data. |
+| `cpt-cf-account-management-fr-child-conversions-query` | `ConversionService::list_inbound_for_parent` joins `conversion_requests` with `tenants` on `parent_id`. Operates within parent tenant AuthZ scope; no barrier bypass required. Exposes only conversion-request metadata (conversion `id`, `child_tenant_id`, `child_tenant_name`, `initiator_side`, `target_mode`, `status`, `requested_by`, terminal-actor fields as applicable, timestamps), not full child tenant data. |
 | `cpt-cf-account-management-fr-conversion-cancel` | `ConversionService::cancel` transitions a pending `ConversionRequest` to `cancelled` only when `caller_side == initiator_side`. Exposed via `PATCH .../conversions/{r}` (child scope) and `PATCH .../child-conversions/{r}` (parent scope) with body `{"status": "cancelled"}`. Role-check failures return `409 conflict` with sub-code `invalid_actor_for_transition`. |
 | `cpt-cf-account-management-fr-conversion-reject` | `ConversionService::reject` transitions a pending `ConversionRequest` to `rejected` only when `caller_side != initiator_side`. Exposed via the same `PATCH` endpoints with body `{"status": "rejected"}`. Role-check failures return `409 conflict` with sub-code `invalid_actor_for_transition`. |
 | `cpt-cf-account-management-fr-conversion-retention` | Background job `ConversionService::soft_delete_resolved` stamps `deleted_at` on resolved rows older than `resolved_retention` (default 30d); default queries filter `deleted_at IS NULL`. Hard-delete follows AM's existing retention cadence. |
@@ -116,16 +117,16 @@ graph LR
 | `cpt-cf-account-management-fr-tenant-metadata-list` | `MetadataService::list_for_tenant` returns paginated own-entries for a tenant; REST endpoint `GET /api/account-management/v1/tenants/{id}/metadata` is tenant-scope-filtered by the platform layer, so self-managed barriers apply without AM-specific logic. |
 | `cpt-cf-account-management-fr-tenant-metadata-permissions` | REST handlers pass `schema_id` into `PolicyEnforcer::enforce` as a resource attribute (`SCHEMA_ID`) on `Metadata.read`, `Metadata.write`, `Metadata.delete`, and `Metadata.list` actions, so external AuthZ policy can express per-`schema_id` grants without AM evaluating policy itself. |
 | `cpt-cf-account-management-fr-deterministic-errors` | Unified error mapper translates domain and infrastructure failures to stable public categories; the authoritative HTTP/sub-code mapping is published in the OpenAPI contract. |
-| `cpt-cf-account-management-fr-observability-metrics` | OpenTelemetry metrics for domain-internal latencies (IdP calls, GTS validation, metadata resolution, bootstrap), background job throughput, error rates, and security counters. Per-endpoint CRUD counts and children-query latency are captured by platform HTTP middleware; capacity gauges (active tenants) are derivable from DB queries. Projection freshness is a Tenant Resolver concern. |
+| `cpt-cf-account-management-fr-observability-metrics` | OpenTelemetry metrics for domain-internal latencies (IdP calls, GTS validation, metadata resolution, bootstrap), background job throughput, error rates, closure-maintenance counters, and security counters. Per-endpoint CRUD counts and children-query latency are captured by platform HTTP middleware; capacity gauges (active tenants) are derivable from DB queries. |
 
 #### NFR Allocation
 
 | NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
 |--------|-------------|--------------|-----------------|----------------------|
-| `cpt-cf-account-management-nfr-context-validation-latency` | End-to-end tenant-context validation p95 ≤ 5ms | Schema design + indexes on `tenants` table (AM contribution); Tenant Resolver caching (resolver contribution) | Composite indexes on `(parent_id, status)`, `(id, status)`, and `(tenant_type_uuid)`; denormalized `depth` column avoids recursive queries. AM provides the indexed source-of-truth schema; the end-to-end p95 ≤ 5ms target requires Tenant Resolver's caching layer on top. | AM: integration tests verify indexed query baseline with seeded dataset. Platform: pre-GA load test benchmark (end-to-end through Tenant Resolver + caching) against approved deployment profile. |
+| `cpt-cf-account-management-nfr-context-validation-latency` | End-to-end tenant-context validation p95 ≤ 5ms | Schema design + indexes on `tenants` / `tenant_closure` + bounded reverse-hydration caches for UUID-backed public GTS identifiers | Composite indexes on `(parent_id, status)`, the single-root invariant backing `parent_id IS NULL`, `(tenant_type_uuid)`, `tenant_closure(ancestor_id, barrier, descendant_status)`, and `tenant_closure(descendant_id)`; denormalized `depth` avoids recursive checks on write paths. AM provides the indexed source-of-truth schema; the end-to-end p95 ≤ 5ms target assumes indexed resolver reads and warm reverse-hydration mappings for `tenant_type_uuid` / `schema_uuid`, not hierarchy caching. | AM: integration tests verify indexed query baselines and deterministic reverse-hydration miss behavior. Platform: pre-GA load test benchmark (end-to-end through Tenant Resolver) against approved deployment profile. |
 | `cpt-cf-account-management-nfr-tenant-isolation` | Zero cross-tenant data leaks | SecureConn + PolicyEnforcer on all API endpoints | All database access through `SecureConn` with tenant-scoped queries; `PolicyEnforcer` PEP pattern on every REST handler. | Automated security test suite with cross-tenant access attempts |
 | `cpt-cf-account-management-nfr-audit-completeness` | 100% tenant config changes audited | Platform append-only audit infrastructure | AM relies on the platform append-only audit infrastructure as the single audit sink. Request handlers emit audit records via the platform request pipeline; AM-owned non-request flows emit into the same sink with `actor=system` (bootstrap completion, conversion expiry, provisioning-reaper compensation, hard-delete / tenant-deprovision cleanup). Database-level `created_at`/`updated_at` timestamps provide additional chronology but are not the audit system. | Verify platform audit entries exist for state-changing API operations and for AM-owned system-actor lifecycle events in integration tests |
-| `cpt-cf-account-management-nfr-barrier-enforcement` | Barrier state sufficient for downstream enforcement; AM-owned barrier-state changes audited | `self_managed` column + tenant hierarchy in `tenants` table | AM exposes `self_managed` flag and parent-child relationships; Tenant Resolver and AuthZ Resolver consume this data for barrier traversal and access decisions. AM commits the flag synchronously within the conversion transaction; enforcement latency depends on how quickly Tenant Resolver's projection reflects the change (sync interval is a Tenant Resolver concern, not an AM guarantee). Platform request audit logging captures all barrier-state-changing operations (mode conversions) per `cpt-cf-account-management-nfr-audit-completeness`; cross-tenant access auditing is a platform AuthZ concern. | Integration tests validating barrier data completeness for resolver consumption; verify platform audit log entries exist for mode conversion operations |
+| `cpt-cf-account-management-nfr-barrier-enforcement` | Barrier state sufficient for downstream enforcement; AM-owned barrier-state changes audited | `self_managed` column on `tenants` + `barrier` column on `tenant_closure` | AM exposes `self_managed` on tenant rows and the materialized `barrier` column on `tenant_closure`; Tenant Resolver and AuthZ Resolver consume both directly for barrier traversal and access decisions. AM commits `self_managed` on the tenant row and the affected `tenant_closure.barrier` rows inside the same conversion transaction, so barrier-aware queries reflect the new state as soon as the transaction commits. Platform request audit logging captures all barrier-state-changing operations (mode conversions) per `cpt-cf-account-management-nfr-audit-completeness`; cross-tenant access auditing is a platform AuthZ concern. | Integration tests validating barrier data completeness across `tenants` and `tenant_closure`; verify platform audit log entries exist for mode conversion operations |
 | `cpt-cf-account-management-nfr-tenant-model-versatility` | Both managed and self-managed in same tree | `self_managed` boolean per tenant, independent of siblings | Sibling tenants under the same parent can have different `self_managed` values; mode conversion is a per-tenant operation. | Integration tests with mixed-mode hierarchies |
 | `cpt-cf-account-management-nfr-compatibility` | No breaking changes within minor release | Path-based API versioning + stable SDK trait contract | REST API uses `/api/account-management/v1/` prefix; SDK trait changes require new major version with migration path. | Contract tests on SDK trait + API schema regression tests |
 | `cpt-cf-account-management-nfr-production-scale` | Approved deployment profile before DESIGN sign-off | Schema design + index strategy | Approved deployment profile: 100K tenants, depth 5 (advisory threshold 10), 300K users (IdP-stored), 30K user groups / 300K memberships (RG-stored), 1K rps peak. All targets within planning envelope. Schema impact assessment confirms existing indexes and B-tree depths are sufficient for that profile; no partitioning is required. | Capacity test against approved profile (100K tenants, 300K users, 1K rps) |
@@ -133,7 +134,7 @@ graph LR
 | `cpt-cf-account-management-nfr-reliability` | Reads stay available during IdP outages; retry contract is explicit | Saga-based tenant creation + degraded-mode reads + reaper compensation | Non-IdP-dependent reads and admin operations continue during IdP outages. Tenant creation uses the three-step provisioning saga; clean step-2 compensation returns `idp_unavailable` and is retryable, while transport failure, timeout, or finalization failure after IdP-side success leave `POST /tenants` in an ambiguous, non-idempotent state that callers must reconcile before retry. | Integration tests for clean compensation, ambiguous finalization failure, provisioning reaper cleanup, and degraded reads during IdP outage |
 | `cpt-cf-account-management-nfr-data-lifecycle` | Tenant deprovisioning cascades cleanup | `TenantService::delete_tenant` + background hard-delete job | Soft delete transitions to `deleted` status; background job hard-deletes after retention period; cascade triggers IdP `deprovision_tenant` (with retry on failure), Resource Group cleanup for tenant-scoped user groups (via `ResourceGroupClient`), and metadata entry deletion. | Integration tests verifying cascaded cleanup |
 | `cpt-cf-account-management-nfr-authentication-context` | Authenticated requests via platform SecurityContext; MFA for admin ops deferred to platform AuthN policy | `SecurityContext` requirement on all REST handlers via framework middleware | AM does not validate tokens or enforce MFA directly. All REST endpoints require a valid `SecurityContext` provided by the framework AuthN pipeline. MFA enforcement for administrative operations such as tenant creation and mode conversion is a platform AuthN policy concern — AM relies on the framework to reject requests that do not meet the configured authentication strength. | API tests: every endpoint returns 401 without valid `SecurityContext`; E2E: admin operations succeed only with authenticated requests |
-| `cpt-cf-account-management-nfr-data-quality` | Transactional commit visibility for Tenant Resolver sync; hierarchy integrity checks | Transactional DB writes + diagnostic integrity query | AM commits hierarchy changes transactionally, making them immediately visible in the `tenants` table for Tenant Resolver consumption. Schema stability per `cpt-cf-account-management-nfr-compatibility` ensures the database-level data contract remains intact. AM provides a hierarchy integrity check (orphaned children, broken parent references, depth mismatches) as a diagnostic capability. The end-to-end 30s freshness SLO is a platform-level target requiring Tenant Resolver's sync mechanism; AM's contribution is transactional commit visibility. | Integration: hierarchy integrity check detects seeded anomalies (orphaned child, depth mismatch); Integration: committed writes are immediately visible via direct table query |
+| `cpt-cf-account-management-nfr-data-quality` | Transactional consistency across `tenants` and `tenant_closure`; hierarchy integrity checks | Transactional DB writes spanning `tenants` and `tenant_closure` + diagnostic integrity query | AM commits hierarchy changes and the corresponding `tenant_closure` updates in a single transaction, so a committed write is observable as one consistent `(tenants, tenant_closure)` state across every reader. Schema stability per `cpt-cf-account-management-nfr-compatibility` ensures the database-level data contract remains intact. AM provides a hierarchy integrity check (orphaned children, broken parent references, depth mismatches, missing or stale closure rows, `descendant_status` divergence) as a diagnostic capability. | Integration: hierarchy integrity check detects seeded anomalies (orphaned child, depth mismatch, missing closure row); Integration: committed writes are immediately visible across both tables via direct query |
 | `cpt-cf-account-management-nfr-data-integrity-diagnostics` | Diagnostic checks for observable hierarchy anomalies | `TenantService::check_hierarchy_integrity()` + observability surface | AM exposes explicit integrity diagnostics for orphaned children, broken parent links, root-count anomalies, and depth mismatches. | Integration tests seed anomalies and verify diagnostic output plus metric surfacing |
 | `cpt-cf-account-management-nfr-data-remediation` | Operator-visible remediation path for AM-owned integrity anomalies | Observability + runbook-owned lifecycle handling | Compensation failures and integrity anomalies emit telemetry quickly, remain visible until addressed, and map to runbook-driven triage owned by platform operations. | Alert simulation and operational review |
 | `cpt-cf-account-management-nfr-ops-metrics-treatment` | Minimum operational treatment for AM domain metrics | Shared dashboards + alert routing | AM publishes the minimum metric set required for operator treatment: IdP failures, bootstrap not-ready, provisioning reaper activity, integrity violations, and cleanup failures. | Dashboard/alert review plus smoke checks in staging |
@@ -149,6 +150,8 @@ The following architecture decisions are adopted in this DESIGN:
 | Conversion approval | Stateful `ConversionRequest` entity with a configurable approval window (default 72h), partial unique index for at-most-one pending row per tenant, background expiry and soft-delete retention jobs. Symmetric collection-based REST API (`/conversions` child-scope, `/child-conversions` parent-scope, each with `{request_id}`) lets each side initiate via `POST` and resolve via `PATCH` from its own AuthZ scope. Lifecycle enum is five-valued (`pending`/`approved`/`cancelled`/`rejected`/`expired`) with explicit actor-per-status semantics. | `cpt-cf-account-management-adr-conversion-approval` — [ADR-0003](ADR/0003-cpt-cf-account-management-adr-conversion-approval.md) |
 | User identity source of truth | IdP is the single source of truth for user identity data (credentials, profile, authentication state, user existence). AM does not maintain a local user table, projection, or cache. | `cpt-cf-account-management-adr-idp-user-identity-source-of-truth` — [ADR-0005](ADR/0005-cpt-cf-account-management-adr-idp-user-identity-source-of-truth.md) |
 | User-tenant binding | IdP stores the user-tenant binding as a tenant identity attribute on the user record. AM coordinates binding via the IdP contract but does not independently store or cache the relationship. | `cpt-cf-account-management-adr-idp-user-tenant-binding` — [ADR-0006](ADR/0006-cpt-cf-account-management-adr-idp-user-tenant-binding.md) |
+| Tenant hierarchy closure ownership | AM owns both the canonical tenant tree and the platform-canonical `tenant_closure` table `(ancestor_id, descendant_id, barrier, descendant_status)`. Closure maintenance is transactional with tenant writes in `TenantService` and `ConversionService::approve`. AM does not expose a sync capability (canonical enumeration or revision/change token); Tenant Resolver reads AM-owned storage directly via a **dedicated SecureConn connection pool** bound to a read-only database role — distinct from AM's writer pool, so plugin hot-path reads and AM writer traffic are isolated at the pool layer and cannot starve each other. | `cpt-cf-tr-plugin-adr-p1-tenant-hierarchy-closure-ownership` — [ADR-001](tr-plugin/ADR/ADR-001-tenant-hierarchy-closure-ownership.md) |
+| Provisioning tenants excluded from `tenant_closure` | Closure rows are inserted transactionally with the `provisioning → active` transition (saga step 3) and removed with hard-deletion. Provisioning tenants never appear in `tenant_closure`; `descendant_status` domain tightens to `{active, suspended, deleted}`. The Tenant Resolver Plugin's unconditional `descendant_status <> 'provisioning'` filter goes away — provisioning invisibility becomes structural on closure-driven reads. | `cpt-cf-account-management-adr-provisioning-excluded-from-closure` — [ADR-0007](ADR/0007-cpt-cf-account-management-adr-provisioning-excluded-from-closure.md) |
 
 Rejected prospective direction: `cpt-cf-account-management-adr-resource-group-tenant-hierarchy-source` — [ADR-0004](ADR/0004-cpt-cf-account-management-adr-resource-group-tenant-hierarchy-source.md) considered moving canonical tenant hierarchy storage from the AM `tenants` table to Resource Group, but rejected it because it splits tenant structure and tenant lifecycle ownership across modules. This DESIGN intentionally retains the dedicated `tenants` table as the AM source of truth.
 
@@ -201,7 +204,7 @@ Every tenant write validates that the resulting hierarchy remains a valid tree: 
 
 - [ ] `p2` - **ID**: `cpt-cf-account-management-principle-barrier-as-data`
 
-AM does not enforce access-control barriers. It stores the `self_managed` flag, returns it in API responses, and includes it in the source-of-truth dataset consumed by Tenant Resolver. AM domain logic does not filter or restrict API results based on barrier values — barrier enforcement is applied at the platform AuthZ layer: all AM REST API endpoints pass through `PolicyEnforcer` → AuthZ Resolver → Tenant Resolver, which excludes self-managed tenants and their subtrees from the caller's access scope before AM domain logic executes. AM's domain services do read hierarchy data that may include barrier-hidden tenants for two internal purposes: (1) **metadata inheritance boundary** — the ancestor walk stops at self-managed boundaries so that a self-managed tenant never inherits metadata from ancestors above its barrier (see `cpt-cf-account-management-fr-tenant-metadata-api`); (2) **structural invariant validation** — hierarchy-owner operations (parent-child type validation during creation, child-count pre-checks during deletion, child-state validation for the parent-scoped conversion endpoint) require full hierarchy visibility regardless of barrier state. Neither purpose constitutes access-control filtering — the results are used for internal precondition checks and are not exposed to API callers. These reads are performed via unscoped hierarchy lookups on the `tenants` table (see Security Architecture, Data Protection), distinct from the platform's `BarrierMode::Ignore` concept which AM does not use. When a tenant converts to self-managed, AM commits `self_managed=true` synchronously within the conversion transaction. Enforcement takes effect once Tenant Resolver's denormalized projection reflects the updated flag; the propagation interval is owned by Tenant Resolver, not AM.
+AM does not enforce access-control barriers. It stores the `self_managed` flag on `tenants` rows, materializes the same barrier state into `tenant_closure.barrier` for every affected `(ancestor, descendant)` pair, returns both in reads consumed by downstream modules, and exposes `self_managed` in API responses. Barrier enforcement is resource-type dependent and applied at the platform AuthZ layer rather than inside AM domain logic: barrier-enforced subtree/resource reads use Tenant Resolver / AuthZ semantics, while parent-side tenant metadata visibility remains policy-defined per the platform tenant model. AM domain logic does not implement module-specific barrier filtering, but its services do read hierarchy data that may include barrier-hidden tenants for two internal purposes: (1) **metadata inheritance boundary** — the ancestor walk stops at self-managed boundaries so that a self-managed tenant never inherits metadata from ancestors above its barrier (see `cpt-cf-account-management-fr-tenant-metadata-api`); (2) **structural invariant validation** — hierarchy-owner operations (parent-child type validation during creation, child-count pre-checks during deletion, child-state validation for the parent-scoped conversion endpoint) require full hierarchy visibility regardless of barrier state. Neither purpose constitutes access-control filtering — the results are used for internal precondition checks and are not exposed to API callers. These reads are performed via unscoped hierarchy lookups on the `tenants` table (see Security Architecture, Data Protection), distinct from the platform's `BarrierMode::Ignore` concept which AM does not use. AM's storage contract defines `tenant_closure.barrier = 1` iff some tenant on `(ancestor, descendant]` is self-managed (ancestor excluded, descendant included), with self-rows fixed to `barrier = 0` (the `barrier` column is `SMALLINT` per TENANT_MODEL.md — 16 bits of bitmask headroom for future multi-dimensional barriers, portable across PostgreSQL and MySQL; v1 uses bit 0 for self_managed). `tenant_closure` contains rows only for SDK-visible tenants (`active`, `suspended`, `deleted`); provisioning tenants are absent from the closure entirely and their barrier materialization happens at the `provisioning → active` transition, inserted in the same transaction as the status update. When a tenant converts to self-managed, AM commits `self_managed=true` on the tenant row and flips the `barrier` column on every affected non-self `(ancestor, descendant)` row of `tenant_closure` inside the same conversion transaction, so barrier-aware queries observe the new state as soon as the transaction commits.
 
 **Drivers**: `cpt-cf-account-management-fr-self-managed-tenant-creation`, `cpt-cf-account-management-fr-mode-conversion-approval`, `cpt-cf-account-management-fr-mode-conversion-expiry`, `cpt-cf-account-management-fr-child-conversions-query`, `cpt-cf-account-management-nfr-barrier-enforcement`
 
@@ -302,11 +305,13 @@ Legacy system integration is handled through the pluggable IdP provider contract
 | Entity | Description | Schema |
 |--------|-------------|--------|
 | Tenant | Core tenant node in the hierarchy tree. Holds identity, parent reference, status, mode, type, and depth. | `account-management-sdk` models |
+| TenantClosureEntry | Row of the AM-owned `tenant_closure` table capturing an `(ancestor_id, descendant_id)` pair together with the materialized `barrier` value (`SMALLINT`, v1 uses bit 0 for self_managed — `barrier = 1` when any tenant on `(ancestor, descendant]` is self-managed; self-rows are always `0`) and the denormalized `descendant_status` copied from the descendant's `tenants.status`. Closure rows exist only for SDK-visible tenants (`active`, `suspended`, `deleted`) — provisioning tenants are absent from the closure entirely. Every SDK-visible tenant owns a self-row `(id, id)` in addition to strict-ancestor rows. Closure entries are an internal storage projection for Tenant Resolver query paths; they are not exposed through the public AM REST API. | AM-owned table; internal entity (not part of the public SDK surface) |
 | TenantMetadata | Extensible metadata entry scoped to a tenant, validated against a GTS-registered schema. | `account-management-sdk` models |
 | ConversionRequest | Durable record of a dual-consent mode conversion for a single tenant. Captures `target_mode`, `initiator_side`, the five-valued status (`pending` / `approved` / `cancelled` / `rejected` / `expired`), approval window, resolver identities, and soft-delete tombstone. At most one `pending` row per tenant (partial unique index). | `account-management-sdk` models |
 
 **Relationships**:
 - Tenant → Tenant: Self-referential parent-child (via `parent_id`). A tenant has zero or one parent and zero or more children. The root tenant has `parent_id = NULL`.
+- Tenant → TenantClosureEntry: Each SDK-visible tenant participates in closure rows as both ancestor and descendant; every SDK-visible tenant has a self-row `(id, id)`. Closure rows are lifecycle-bound to the descendant — the self-row and strict-ancestor rows are inserted on the `provisioning → active` transition (one row per step up the `parent_id` chain), and all rows where the tenant appears as descendant are removed on hard-delete. Provisioning tenants have no closure rows at all.
 - Tenant → TenantMetadata: One-to-many. A tenant can have multiple metadata entries, at most one per `schema_id`.
 - Tenant → ConversionRequest: One-to-many overall, at most one **pending** request per tenant at any time (enforced by partial unique index). A conversion request references the target tenant; `initiator_side` records which side (`child` or `parent`) issued the `POST`. Resolved rows remain attached to the tenant until the soft-delete retention window elapses and the cleanup job hard-deletes them.
 - Tenant → GTS Type: Many-to-one (via internal `tenant_type_uuid`, projected publicly as chained `tenant_type`). Each tenant references a GTS-registered type that defines parent-child constraints.
@@ -327,6 +332,11 @@ Legacy system integration is handled through the pluggable IdP provider contract
 | `ConversionRequestStatus` | `pending`, `approved`, `cancelled`, `rejected`, `expired`, plus tombstoned historical state via `deleted_at`. | Conversion service + storage constraint |
 | Single root invariant | Exactly one tenant has `parent_id = NULL`; root is undeletable. | Bootstrap + domain validation + partial unique index |
 | Tree invariant | Each tenant has at most one parent and no cycles. | Domain service + FK structure |
+| Closure provisioning exclusion invariant | `tenant_closure` contains rows **only** for tenants whose `tenants.status` is SDK-visible (`active`, `suspended`, `deleted`). Tenants in the transient `provisioning` state have no closure rows. Rows are inserted in a single transaction with the `provisioning → active` transition and removed in a single transaction with hard-deletion. Rationale: the closure is a publication contract (future replication to business modules), and provisioning is internal AM saga state that must not leak across that boundary. | `TenantService::activate_tenant` (insert) + hard-deletion flow (remove) |
+| Closure self-row invariant | Every tenant with SDK-visible status has a `(id, id)` row in `tenant_closure`, with `barrier = 0` and `descendant_status = tenants.status`. | `TenantService::activate_tenant` + integrity check |
+| Closure coverage invariant | For every tenant row with SDK-visible status, `tenant_closure` contains one row per strict ancestor along the `parent_id` chain in addition to the self-row. | `TenantService::activate_tenant` + integrity check |
+| Closure barrier materialization invariant | `tenant_closure.barrier` is `1` on `(A, D)` when any tenant on the strict `A → D` path (excluding A, including D) has `self_managed = true`; otherwise `0`. The column is `SMALLINT` (bit 0 = self_managed in v1). | `TenantService::create_child_tenant` + `ConversionService::approve` |
+| Closure status denormalization invariant | `tenant_closure.descendant_status` tracks `tenants.status` for the row identified by `descendant_id`. Domain is `{active, suspended, deleted}` only — the `provisioning` value is never written because those tenants have no closure rows. | `TenantService::update_status` + hard-deletion flow |
 | Pending conversion invariant | At most one pending conversion request exists per tenant. | Conversion service + partial unique index |
 | Metadata uniqueness invariant | At most one direct metadata entry exists per `(tenant_id, schema_id)`. | Metadata service + unique constraint |
 | User identity ownership invariant | AM never becomes the system of record for credentials or user profiles. | IdP contract boundary + no local user table |
@@ -367,7 +377,7 @@ Derived type schemas resolve their behavioral traits via `x-gts-traits` (per [GT
 3. Validate the requested parent-child type relationship against the GTS `allowed_parent_types` rules — reject with `type_not_allowed` (409) if not permitted
 4. Call `IdpProviderPluginClient::provision_tenant`; provider implementations create tenant-scoped resources or reuse shared ones based on deployment-specific behavior and tenant traits such as `idp_provisioning`. Providers **MUST NOT** silently no-op — unsupported operations **MUST** fail with `idp_unsupported_operation`
 
-**User-group Resource Group type schema:** AM registers the chained RG type `gts.x.core.rg.type.v1~x.core.am.user_group.v1~` — [user_group.v1.schema.json](./schemas/user_group.v1.schema.json). It lives in the flat AM docs schema list, reuses the RG base contract, and defines no AM-specific `metadata` fields in v1.
+**User-group Resource Group type schema:** AM registers the chained RG type `gts.x.core.rg.type.v1~x.core.am.user_group.v1~` — [user_group.v1.schema.json](./schemas/user_group.v1.schema.json). It lives in the flat AM docs schema list, reuses the RG base contract, and defines no AM-specific `metadata` fields in v1. The `user_group` schema uses a chained GTS `$id` (`gts://gts.x.core.rg.type.v1~x.core.am.user_group.v1~`) because user groups are delegated to Resource Group per the Delegation-to-RG principle; the chain expresses that AM's user-group type extends the RG base resource-group type.
 
 **Referenced user resource schema:** The user-group type's `allowed_memberships` points at the platform user resource type `gts.x.core.am.user.v1~` — [user.v1.schema.json](./schemas/user.v1.schema.json).
 
@@ -434,6 +444,7 @@ graph TD
 
         subgraph INFRA["Infrastructure"]
             REPO[TenantRepository]
+            CLOSURE_REPO[ClosureRepository]
             META_REPO[MetadataRepository]
             CONV_REPO[ConversionRepository]
         end
@@ -441,19 +452,20 @@ graph TD
 
     subgraph EXTERNAL["External Dependencies"]
         IDP[IdP Provider]
-        DB[(Database)]
+        DB[("Database<br>tenants + tenant_closure<br>+ tenant_metadata<br>+ conversion_requests")]
     end
 
     subgraph PLATFORM["Platform Modules"]
         GTS[GTS Types Registry]
         RG[Resource Group]
-        TR[Tenant Resolver]
+        TR["Tenant Resolver<br>(query facade)"]
     end
 
     TH --> TS
     MH --> MS
     UH --> TS
     TS --> REPO
+    TS --> CLOSURE_REPO
     TS --> CONV_REPO
     TS --> GTS
     TS --> IDP
@@ -462,9 +474,10 @@ graph TD
     BS --> TS
     BS --> IDP
     REPO --> DB
+    CLOSURE_REPO --> DB
     META_REPO --> DB
     CONV_REPO --> DB
-    TR -.->|consumes| DB
+    TR -.->|tenants + tenant_closure<br>via read-only DB role| DB
     AM --> BS
     AM --> AC
 ```
@@ -507,6 +520,7 @@ TenantService owns tenant lifecycle orchestration, tenant-related IdP operations
 - Tenant creation saga: insert the tenant in `provisioning`, call `IdpProviderPluginClient::provision_tenant` outside the transaction, then persist provider-returned metadata and finalize the tenant as `active`. If provisioning fails, a compensating transaction removes the `provisioning` row so neither system keeps an orphan.
 - Provisioning recovery: if finalization fails after the IdP step succeeds, the tenant remains in internal `provisioning` state. A background provisioning reaper always compensates by calling `deprovision_tenant` and deleting the row; it does not retry finalization. `provisioning` tenants are hidden from API queries and rejected for all normal operations.
 - Hierarchy and lifecycle rules: validate depth against advisory and strict thresholds, allow only `active` ↔ `suspended` status changes on PATCH, and require the `DELETE` flow for deletion so child and resource-ownership preconditions are enforced.
+- Closure maintenance: every write path that changes tenant SDK-visibility also mutates `tenant_closure` in the same transaction as the owning `tenants` write, and `tenant_closure` never contains rows for tenants in the internal `provisioning` state. **Activation** (the `provisioning → active` transition at the end of the tenant-create saga) inserts the descendant's self-row with `barrier = 0` plus one strict-ancestor row per step up the `parent_id` chain, materializing `barrier` as `1` iff some tenant on `(ancestor, descendant]` is self-managed, and setting `descendant_status = active`. **Compensation** (provisioning reaper rolling back a stuck `provisioning` row) removes the `tenants` row only; no closure work is needed because no closure rows were ever written. **Status change** (between SDK-visible states `active` / `suspended` / `deleted`) rewrites `descendant_status` on every row where `descendant_id = X`. **Hard-deletion** (leaves only) removes every row where the hard-deleted tenant appears as descendant. Soft-delete flips both `tenants.status` and the matching `tenant_closure.descendant_status` rows; no closure row is inserted or removed. Subtree moves are not supported in v1 (`update_tenant` mutates only `name` and `status`), so no subtree-wide closure rebuild is needed.
 - Mode conversion delegation: post-creation toggles of `self_managed` are not applied directly by `TenantService`; they are routed to `ConversionService` (see below), which owns the `ConversionRequest` state machine, role-per-transition validation, and the atomic toggle-at-approval step. `TenantService::create_tenant` still accepts `self_managed=true` at creation time without a `ConversionRequest` — the parent's explicit creation call is the consent.
 - IdP integration: execute tenant deprovisioning during hard deletion and provide IdP user operations (provision, deprovision, query) through `IdpProviderPluginClient`. Providers **MUST NOT** silently no-op on mutating operations; failures are retried rather than skipped.
 - Tenant-facing queries: provide paginated children queries with status filtering. Conversion-request listing endpoints are implemented by `ConversionService` (see below) and do not bypass the self-managed barrier.
@@ -524,7 +538,22 @@ Does not evaluate authorization policies — relies on `PolicyEnforcer` PEP in t
 
 ##### Diagnostic Capabilities
 
-**Hierarchy integrity check mechanism**: Exposed as an internal SDK method `TenantService::check_hierarchy_integrity()`. Implementation uses a recursive CTE to detect orphaned children (nodes whose `parent_id` references a non-existent tenant), broken parent references, depth mismatches (where the stored `depth` column disagrees with the computed depth from the root), and root-count anomalies (zero or multiple rows with `parent_id IS NULL`). Results are surfaced as structured diagnostic output and as the `am_hierarchy_integrity_violations` gauge metric.
+**Hierarchy integrity check mechanism**: Exposed as an internal SDK method `TenantService::check_hierarchy_integrity()`. Implementation uses a recursive CTE over `tenants` plus a set of `tenants ⋈ tenant_closure` joining queries, and returns a structured report grouped by category. The closure-shape categories are what enforce the **Closure self-row invariant** and **Closure coverage invariant** recorded in the `TenantService` invariants table earlier in this DESIGN; provisioning exclusion (`tenant_closure` never contains rows for tenants in `provisioning` status) is enforced per [AM ADR-0007](ADR/0007-cpt-cf-account-management-adr-provisioning-excluded-from-closure.md) and the DB-level guard `CHECK (descendant_status IN (1, 2, 3))` in [migration.sql](migration.sql), so stale/provisioning rows in `tenant_closure` are a check target rather than a normal state.
+
+*Tree-shape anomalies* (over `tenants` alone):
+- **Orphaned child** — `parent_id` references a non-existent tenant row. Offending fields: `tenant_id`, `parent_id`.
+- **Broken parent reference** — dangling `parent_id` surfaced separately when the target is a hard-deleted row visible to a concurrent read.
+- **Depth mismatch** — stored `tenants.depth` disagrees with the depth computed by walking `parent_id` to the root. Offending fields: `tenant_id`, `stored_depth`, `computed_depth`.
+- **Root-count anomaly** — zero or multiple rows with `parent_id IS NULL`. Offending fields: `root_count`, `root_tenant_ids[]`.
+
+*Closure-shape anomalies* (join `tenants` ⋈ `tenant_closure`):
+- **Missing closure self-row** — a tenant with SDK-visible status (`active` / `suspended` / `deleted`) has no `(id, id)` row in `tenant_closure`, or the self-row carries `barrier ≠ 0`. Offending fields: `tenant_id`, `observed_self_row_present`, `observed_barrier`.
+- **Coverage gap (missing strict-ancestor row)** — a tenant with SDK-visible status is missing one or more `(ancestor_id, descendant_id = tenant_id)` rows along its `parent_id` chain. Offending fields: `descendant_tenant_id`, `missing_ancestor_tenant_ids[]`.
+- **Stale closure row** — `tenant_closure` contains a row whose `descendant_id` references a `tenants` row in `provisioning` status or that is absent from `tenants`. Offending fields: `ancestor_id`, `descendant_id`, `closure_descendant_status`, `tenants_status` (or `"missing"`).
+- **Barrier-column divergence** — the materialized `tenant_closure.barrier` disagrees with the canonical rule "`barrier = 1` iff some tenant on `(ancestor, descendant]` has `self_managed = true`" (self-rows always `barrier = 0`). Offending fields: `ancestor_id`, `descendant_id`, `observed_barrier`, `expected_barrier`, `self_managed_tenants_on_path[]`.
+- **`descendant_status` denormalization divergence** — `tenant_closure.descendant_status` disagrees with the mapped `tenants.status` for the same `descendant_id` (domain `{1=active, 2=suspended, 3=deleted}`). Offending fields: `ancestor_id`, `descendant_id`, `closure_descendant_status`, `tenants_status`.
+
+Results are returned as structured diagnostic output — per-category arrays carrying the offending-row fields listed above — and aggregated into the `am_hierarchy_integrity_violations` gauge metric with a `category` label (`orphaned_child`, `broken_parent_reference`, `depth_mismatch`, `root_count_anomaly`, `missing_closure_self_row`, `closure_coverage_gap`, `stale_closure_row`, `barrier_column_divergence`, `descendant_status_divergence`) so closure anomalies can be alerted and dashboarded distinctly from tree-shape anomalies.
 
 #### ConversionService
 
@@ -539,11 +568,11 @@ Owns the `ConversionRequest` state machine for post-creation toggles of `tenants
 The ConversionService owns everything about pending and resolved conversion requests, while `TenantService` continues to own `tenants` CRUD.
 
 - `initiate(caller_side, tenant_id, actor)`: validates preconditions (tenant is non-root, is `active`, caller's side has a valid scope for `tenant_id`, no pending row exists), derives `target_mode = NOT tenants.self_managed`, inserts a `pending` row with `initiator_side = caller_side` and `expires_at = now() + approval_ttl`. Partial unique index `UNIQUE (tenant_id) WHERE status='pending' AND deleted_at IS NULL` guarantees the at-most-one invariant at the DB level; service layer translates the conflict into `409 conflict` with sub-code `pending_exists` and the existing `request_id`.
-- `approve(caller_side, request_id, actor)`: valid only when `status = pending` and `caller_side != initiator_side`. In a single transaction: sets `status = approved`, `approved_by = actor`, toggles `tenants.self_managed` to `target_mode`, and writes the audit entry. Atomicity between the status transition and the flag toggle is what removes the "crash between approval and barrier removal" hazard.
+- `approve(caller_side, request_id, actor)`: valid only when `status = pending` and `caller_side != initiator_side`. In a single transaction: sets `status = approved`, `approved_by = actor`, toggles `tenants.self_managed` to `target_mode`, recomputes `tenant_closure.barrier` for every `(ancestor_id, descendant_id)` pair where the converted tenant lies on the strict `ancestor → descendant` path (excluding the ancestor itself, including the converted tenant as descendant) — the new barrier is derived from the canonical invariant (`barrier = 1` iff any tenant on `(ancestor, descendant]` *still* has `self_managed = true` after the flip), not copied from the converted tenant's flag, so nested self-managed boundaries on the same path remain correctly enforced when one of them converts back — and writes the audit entry. Atomicity across the request status, the tenant flag, and the closure barrier columns is what removes the "crash between approval and barrier removal" hazard. Write amplification is bounded by `O(strict_ancestors × (1 + descendants))` on the converted tenant, which is the ADR-001 envelope.
 - `cancel(caller_side, request_id, actor)`: valid only when `status = pending` and `caller_side == initiator_side`. Sets `status = cancelled`, `cancelled_by = actor`. Does **not** touch `tenants.self_managed`.
 - `reject(caller_side, request_id, actor)`: valid only when `status = pending` and `caller_side != initiator_side`. Sets `status = rejected`, `rejected_by = actor`. Does **not** touch `tenants.self_managed`.
 - `list_own_for_tenant(tenant_id, status_filter, pagination)`: tenant-scoped list for the child-scope collection. Default `status_filter = pending`; `any` returns all non-soft-deleted rows.
-- `list_inbound_for_parent(parent_id, status_filter, pagination)`: joins `conversion_requests` with `tenants` on `parent_id`. Exposes only the metadata fields allowed behind the barrier (`request_id`, `tenant_id`, `child_name`, `initiator_side`, `target_mode`, `status`, timestamps).
+- `list_inbound_for_parent(parent_id, status_filter, pagination)`: joins `conversion_requests` with `tenants` on `parent_id`. Projects the conversion-request row — `request_id`, `tenant_id`, `child_name`, `initiator_side`, `target_mode`, `status`, the actor uuids (`requested_by`, `approved_by`, `cancelled_by`, `rejected_by`), and timestamps — and nothing from the child's tenant record beyond its name. **Trade-off — dual-consent vs. barrier purity:** the actor uuids cross the self-managed barrier deliberately, because the parent admin has to know which counterparty in the child tenant initiated the request and who later cancelled / rejected / approved it in order to act on it within the dual-consent workflow. The fields exposed are opaque IdP uuids with no profile data attached — AM stores none per `cpt-cf-account-management-nfr-data-classification` — and resolving any uuid to a human identity still requires separate authorization against IdP, governed by platform AuthZ. The child's full tenant record, its metadata, and its subtree remain behind the barrier. "Minimal conversion-request metadata" elsewhere in this DESIGN and in the PRD means *"only the conversion-request row, not the child tenant record"*; it does not mean stripping the request's own audit-actor fields.
 - `expire` (background): scans `status = 'pending' AND expires_at < now() AND deleted_at IS NULL`, transitions matching rows to `expired`, emits an audit record with `system` actor and the `am_conversion_expired_total` counter.
 - `soft_delete_resolved` (background): scans resolved rows (`status IN ('approved','cancelled','rejected','expired')`) whose `updated_at + resolved_retention < now() AND deleted_at IS NULL`, stamps `deleted_at = now()`, and emits the `am_conversion_soft_deleted_total` counter. Hard deletion follows AM's existing retention cadence on `deleted_at`-tombstoned rows.
 
@@ -612,7 +641,9 @@ Metadata CRUD (create, read, update, delete), per-tenant listing, and hierarchy-
 
 ##### Responsibility boundaries
 
-Does not define metadata schemas — schemas are registered in GTS. Does not interpret metadata content — treats values as opaque GTS-validated payloads. Does not maintain a local inheritance-policy table — the policy is always resolved from the registered schema's `x-gts-traits`. Reads the `self_managed` flag during inheritance resolution to stop the ancestor walk at self-managed boundaries — a self-managed tenant's resolved value never includes ancestors above its barrier.
+Does not define metadata schemas — schemas are registered in GTS. Does not interpret metadata content — treats values as opaque GTS-validated payloads. Does not maintain a local inheritance-policy table — the policy is always resolved from the registered schema's `x-gts-traits`. Reads the `self_managed` flag during inheritance resolution to stop the ancestor walk at self-managed boundaries — a self-managed tenant's resolved value never includes ancestors above its barrier. Metadata inheritance walks skip tenants whose status is `suspended` and continue to their ancestors (suspension is a lifecycle state, not a barrier). The walk stops only at self-managed barriers or the root.
+
+**Enforcement layer — application-only, by design.** Per ADR-0002 `cpt-cf-account-management-adr-metadata-inheritance`, inheritance semantics are enforced exclusively inside `MetadataService::resolve` at read time. There is no DB-level CHECK, trigger, or materialized-inheritance column on `tenant_metadata` — the `tenant_metadata` table stores only values written directly on `tenant_id`, and ancestor walk-up lives entirely in application code. This is deliberate (walk-up resolution has no write amplification and is always consistent with the current `parent_id` chain), and the storage comment in `migration.sql` documents the consequence: any SQL reader that bypasses `MetadataService` will see only directly-written values, not the inherited view. Consumers requiring inherited values **MUST** use the `/resolved` API boundary or the `MetadataService::resolve` entry point; direct `SELECT ... FROM tenant_metadata` is the direct-write view only. No reconciliation job is needed — inheritance is derived on every read rather than materialized.
 
 ##### Related components (by ID)
 
@@ -780,7 +811,7 @@ IdP provider plugin credentials are managed by the plugin implementation and the
 | **Protocol / Driver** | `TypesRegistryClient` via ClientHub |
 | **Data Format** | GTS type definitions, schema bodies, and traits |
 | **Compatibility** | Registered schema identifiers remain the stable external contract key for tenant types and metadata kinds across AM and OpenAPI; tenant rows and metadata rows derive deterministic UUIDv5 storage surrogates from those identifiers for compact indexing without changing the public contract |
-| **Availability / Fallback** | GTS-backed writes validate against current registry data. Tenant and metadata projections that must reverse-hydrate chained identifiers from stored UUID keys depend on Types Registry (or a bounded AM cache fed from it) and fail deterministically rather than returning opaque UUIDs. |
+| **Availability / Fallback** | GTS-backed writes validate against current registry data. Reads that do not require fresh schema/type projection can continue during a registry outage, but tenant and metadata projections that must reverse-hydrate chained identifiers from stored UUID keys depend on Types Registry (or a bounded AM cache fed from it) and fail deterministically on cache miss rather than returning opaque UUIDs. |
 
 #### Tenant Resolver
 
@@ -788,12 +819,12 @@ IdP provider plugin credentials are managed by the plugin implementation and the
 
 | Aspect | Detail |
 |--------|--------|
-| **Type** | Downstream platform consumer |
-| **Direction** | AM provides source-of-truth data |
-| **Protocol / Driver** | Database-level data contract over AM-owned tenant tables |
-| **Data Format** | Tenant identifiers, parent-child relationships, depth, status, and barrier state |
-| **Compatibility** | Schema changes to the AM source tables must remain coordinated with resolver projection logic and rolling-upgrade compatibility constraints |
-| **Availability / Fallback** | AM commits source-of-truth state transactionally. Projection freshness, cache policy, and resync behavior are Tenant Resolver responsibilities. |
+| **Type** | Downstream platform consumer (query facade) |
+| **Direction** | Tenant Resolver reads AM-owned storage |
+| **Protocol / Driver** | Read-only PostgreSQL role provisioned by AM with `SELECT`-only grants scoped to `tenants` and `tenant_closure` |
+| **Data Format** | Rows from `tenants` (`id`, `parent_id`, `name`, `tenant_type_uuid`, `status`, `self_managed`, `depth`, timestamps, and any resolver-mapped metadata fields) and `tenant_closure` (`ancestor_id`, `descendant_id`, `barrier`, `descendant_status`) — the platform-canonical closure shape defined in [TENANT_MODEL.md](../../../../docs/arch/authorization/TENANT_MODEL.md). Public chained `tenant_type` identifiers are re-hydrated by Tenant Resolver from `tenant_type_uuid` via Types Registry. |
+| **Compatibility** | Schema changes to `tenants` and `tenant_closure` are coordinated contract changes between AM and Tenant Resolver; rolling-upgrade compatibility constraints apply to both modules simultaneously |
+| **Availability / Fallback** | Tenant Resolver query availability tracks AM database availability. AM commits tree and closure updates as one transaction, so Tenant Resolver observes every committed non-`provisioning` hierarchy change the moment it becomes visible in the database — there is no projection, no sync job, no drift-detection loop, and no revision or change token. Internal `provisioning` rows may exist transiently during bootstrap and tenant-create sagas, but they are outside the resolver-facing contract and remain non-visible until finalized to `active` or compensated away. |
 
 #### AuthZ Resolver
 
@@ -867,7 +898,8 @@ sequenceDiagram
         TS->>TS: Resolve root_tenant_type from config
         rect rgb(230, 245, 255)
             Note over TS,DB: Saga step 1 — short TX
-            TS->>DB: INSERT tenant (root, type=root_tenant_type, status='provisioning')
+            TS->>DB: INSERT tenant (root, type=root_tenant_type, status='provisioning', self_managed)
+            Note over TS,DB: No tenant_closure rows written yet —<br/>provisioning tenants are absent from the closure by contract
             TS->>DB: COMMIT
         end
         Note over TS,IDP: Saga step 2 — IdP call (no open TX)
@@ -879,6 +911,7 @@ sequenceDiagram
                 Note over TS,DB: Saga step 3 — finalize (short TX)
                 TS->>DB: INSERT tenant_metadata (provider entries, if any)
                 TS->>DB: UPDATE tenant SET status = 'active'
+                TS->>DB: INSERT tenant_closure (root_id, root_id, barrier=0, descendant_status='active')
                 TS->>DB: COMMIT
             end
             TS-->>BS: Root tenant created
@@ -886,7 +919,7 @@ sequenceDiagram
             BS-->>AM: Bootstrap complete
         else Finalization fails
             DB-->>TS: Finalization error
-            TS-->>BS: Bootstrap failed; root remains in provisioning
+            TS-->>BS: Bootstrap failed, root remains in provisioning
             BS->>BS: Do not create a second root while stale row exists
             BS->>BS: Release lock
             BS-->>AM: Bootstrap not complete
@@ -913,7 +946,7 @@ sequenceDiagram
 | `idp_retry_backoff_max` | duration | No (default: 30s) | Maximum backoff for IdP availability retry. |
 | `idp_retry_timeout` | duration | No (default: 5min) | Total timeout for IdP availability wait. Bootstrap fails if exceeded. |
 
-**Description**: On first platform start, AM acquires a distributed lock to prevent concurrent bootstrap from parallel service starts, then creates the initial root tenant using the configured `root_tenant_type` (validated against GTS — must be a registered type). Tenant creation follows the same saga pattern as API-created tenants: (1) a short transaction inserts the tenant with `status=provisioning`; (2) `provision_tenant` is called outside any transaction with the deployer-configured `root_tenant_metadata`; (3) a second short transaction persists any provider-returned metadata and transitions the tenant to visible `active` status. The metadata is opaque to AM — it flows through to the IdP provider plugin, which uses it to determine deployment-specific behavior (e.g., a Keycloak provider receiving `{ "adopt_realm": "master" }` may adopt an existing realm, while other metadata may trigger fresh resource creation). If the provider returns no metadata (binding established through external configuration or convention), bootstrap proceeds normally. On subsequent starts, bootstrap detects the existing root (in `active` status) and is a no-op. A root tenant stuck in `provisioning` status from a prior failed bootstrap attempt is left for provisioning-reaper compensation; bootstrap does not create a second root while that stale row exists. Successful bootstrap emits a platform audit event with `actor=system`. If IdP is unavailable, bootstrap retries with backoff until timeout. The lock ensures that even with multiple replicas starting simultaneously, only one performs the bootstrap sequence. The lock implementation is infrastructure-specific (e.g., database advisory lock, distributed lock service) and not prescribed by this design.
+**Description**: On first platform start, AM acquires a distributed lock to prevent concurrent bootstrap from parallel service starts, then creates the initial root tenant using the configured `root_tenant_type` (validated against GTS — must be a registered type). Tenant creation follows the same saga pattern as API-created tenants: (1) a short transaction inserts the `tenants` row with `status=provisioning` — no `tenant_closure` rows are written yet, because provisioning tenants are absent from the closure by contract; (2) `provision_tenant` is called outside any transaction with the deployer-configured `root_tenant_metadata`; (3) a second short transaction persists any provider-returned metadata, transitions the tenant to visible `active` status, and inserts the root's self-row into `tenant_closure` (`ancestor_id = descendant_id = root_id`, `barrier = 0`, `descendant_status = active`) — the root has no strict ancestors, so only the self-row is created. The metadata is opaque to AM — it flows through to the IdP provider plugin, which uses it to determine deployment-specific behavior (e.g., a Keycloak provider receiving `{ "adopt_realm": "master" }` may adopt an existing realm, while other metadata may trigger fresh resource creation). If the provider returns no metadata (binding established through external configuration or convention), bootstrap proceeds normally. On subsequent starts, bootstrap detects the existing root (in `active` status) and is a no-op. A root tenant stuck in `provisioning` status from a prior failed bootstrap attempt is left for provisioning-reaper compensation; bootstrap does not create a second root while that stale row exists. Successful bootstrap emits a platform audit event with `actor=system`. If IdP is unavailable, bootstrap retries with backoff until timeout. The lock ensures that even with multiple replicas starting simultaneously, only one performs the bootstrap sequence. The lock implementation is infrastructure-specific (e.g., database advisory lock, distributed lock service) and not prescribed by this design.
 
 #### Create Child Tenant with Type Validation
 
@@ -949,7 +982,8 @@ sequenceDiagram
 
     rect rgb(230, 245, 255)
         Note over TS,DB: Saga step 1 — short TX
-        TS->>DB: INSERT tenant (status = 'provisioning')
+        TS->>DB: INSERT tenant (status = 'provisioning', self_managed)
+        Note over TS,DB: No tenant_closure rows written yet —<br/>provisioning tenants are absent from the closure by contract
         TS->>DB: COMMIT
     end
 
@@ -961,6 +995,7 @@ sequenceDiagram
         rect rgb(255, 230, 230)
             Note over TS,DB: Compensate — short TX
             TS->>DB: DELETE tenant WHERE id = child_id AND status = 'provisioning'
+            Note over TS,DB: No tenant_closure cleanup needed — no rows were written
             TS->>DB: COMMIT
         end
         TS-->>API: Error: idp_unavailable
@@ -974,6 +1009,7 @@ sequenceDiagram
                     TS->>DB: INSERT tenant_metadata (provider-produced entries)
                 end
                 TS->>DB: UPDATE tenant SET status = 'active'
+                TS->>DB: INSERT tenant_closure (self-row with barrier=0 + one row per strict ancestor along parent chain,<br/>barrier materialized from self_managed on (ancestor, descendant],<br/>descendant_status = 'active')
                 TS->>DB: COMMIT
             end
             TS-->>API: Tenant response
@@ -987,13 +1023,14 @@ sequenceDiagram
             PR->>IDP: deprovision_tenant(child_id, ...)
             IDP-->>PR: OK / already absent
             PR->>DB: DELETE tenant WHERE id = child_id AND status = 'provisioning'
+            Note over PR,DB: No tenant_closure cleanup needed — provisioning rows never enter the closure
             PR->>DB: COMMIT
-            Note over TS,PR: Step 3 failure always compensates; AM does not retry finalization
+            Note over TS,PR: Step 3 failure always compensates, and AM does not retry finalization
         end
     end
 ```
 
-**Description**: Tenant creation validates parent status, type constraints via GTS, and hierarchy depth. The creation itself follows a three-step saga to avoid holding a DB transaction open during the external IdP call: (1) a short transaction inserts the tenant row with `status=provisioning`; (2) `IdpProviderPluginClient::provision_tenant` is called outside any transaction to set up IdP-side resources (e.g., a Keycloak realm); (3) a second short transaction persists any provider-returned metadata entries (e.g., effective realm name) and transitions the tenant to visible `active` status. If the IdP call fails at step 2, a compensating transaction deletes the `provisioning` row — neither system retains an orphan, and the caller receives `idp_unavailable`. If the finalization transaction at step 3 fails, the tenant remains in `provisioning` status; a background provisioning reaper compensates by calling `deprovision_tenant` (idempotent), emitting a platform audit event with `actor=system`, and deleting the row. AM does not retry the finalization step (see Reliability Architecture). `POST /tenants` is intentionally non-idempotent: only the clean compensated `idp_unavailable` path is retry-safe; transport failure, timeout, or generic `5xx` require reconciliation before retry. If the advisory threshold is exceeded, AM emits the v1 advisory warning signal (metric increment plus structured warning log entry) and creation proceeds. In strict mode, creation is rejected when the hard limit is exceeded.
+**Description**: Tenant creation validates parent status, type constraints via GTS, and hierarchy depth. The creation itself follows a three-step saga to avoid holding a DB transaction open during the external IdP call: (1) a short transaction inserts the tenant row with `status=provisioning` — no `tenant_closure` rows are written yet, because the closure contract excludes provisioning tenants entirely (`cpt-cf-account-management-fr-tenant-closure`); (2) `IdpProviderPluginClient::provision_tenant` is called outside any transaction to set up IdP-side resources (e.g., a Keycloak realm); (3) a second short transaction persists any provider-returned metadata entries (e.g., effective realm name), transitions the tenant to visible `active` status, and atomically inserts the matching `tenant_closure` rows (self-row with `barrier=0` plus one row per strict ancestor along the `parent_id` chain, with `barrier` set to `1` iff some tenant on `(ancestor, descendant]` is self-managed, and `descendant_status=active`). If the IdP call fails at step 2, a compensating transaction deletes the `provisioning` row — no closure cleanup is needed because nothing was ever written there — and the caller receives `idp_unavailable`. If the finalization transaction at step 3 fails, the tenant remains in `provisioning` status with no closure rows; a background provisioning reaper compensates by calling `deprovision_tenant` (idempotent), emitting a platform audit event with `actor=system`, and deleting the `tenants` row. AM does not retry the finalization step (see Reliability Architecture). `POST /tenants` is intentionally non-idempotent: only the clean compensated `idp_unavailable` path is retry-safe; transport failure, timeout, or generic `5xx` require reconciliation before retry. If the advisory threshold is exceeded, AM emits the v1 advisory warning signal (metric increment plus structured warning log entry) and creation proceeds. In strict mode, creation is rejected when the hard limit is exceeded.
 
 #### Resolve Inherited Metadata
 
@@ -1071,10 +1108,10 @@ sequenceDiagram
     Note over C: Within approval_ttl...
     C->>API: PATCH /tenants/{scope}/{conversions|child-conversions}/{request_id} {"status":"approved"}
     API->>CS: approve(caller_side, request_id, actor)
-    CS->>DB: Transactional: status=approved, approved_by=actor, tenants.self_managed := target_mode
+    CS->>DB: Transactional: status=approved, approved_by=actor, tenants.self_managed := target_mode, recompute tenant_closure.barrier for affected (ancestor, descendant) rows
     DB-->>CS: committed
     CS-->>API: 200 OK
-    Note over API,C: PATCH responses use the caller-scope projection. Child scope may include actor identity fields; parent scope omits them.
+    Note over API,C: PATCH responses use the caller-scope projection. Child scope may include actor identity fields, while parent scope omits them.
     API-->>C: 200 OK {status=approved, ...scope-specific projection...}
 ```
 
@@ -1151,7 +1188,7 @@ The sequences above are the canonical interaction views. The table below closes 
 | `cpt-cf-account-management-usecase-soft-delete-leaf` | `cpt-cf-account-management-interface-tenant-mgmt-rest`, Section 4.3 Reliability and Operations | Leaf soft delete is the public lifecycle boundary; hard deletion remains a background concern. |
 | `cpt-cf-account-management-usecase-reject-delete-root` | `cpt-cf-account-management-interface-tenant-mgmt-rest`, `cpt-cf-account-management-component-bootstrap-service` | The single-root invariant is protected across bootstrap, CRUD, and retention cleanup. |
 | `cpt-cf-account-management-usecase-reject-depth-exceeded` | `cpt-cf-account-management-seq-create-child`, `cpt-cf-account-management-component-tenant-service` | Strict-mode depth enforcement is part of the child creation path. |
-| `cpt-cf-account-management-usecase-discover-child-conversions` | `cpt-cf-account-management-seq-convert-dual-consent`, `cpt-cf-account-management-interface-conversions-api` | Parent-scope conversion discovery is the only barrier-aware structural-read carve-out exposed directly by AM. |
+| `cpt-cf-account-management-usecase-discover-child-conversions` | `cpt-cf-account-management-seq-convert-dual-consent`, `cpt-cf-account-management-interface-conversions-api` | Parent-scope conversion discovery is the only additional AM-owned structural-read carve-out beyond the platform's generic tenant-metadata visibility rules. |
 | `cpt-cf-account-management-usecase-retention-of-resolved-conversion` | `cpt-cf-account-management-component-conversion-service`, Section 4.3 Reliability and Operations | Resolved conversion rows remain queryable only for their configured retention window. |
 | `cpt-cf-account-management-usecase-write-tenant-metadata` | `cpt-cf-account-management-interface-metadata-rest`, `cpt-cf-account-management-component-metadata-service` | Metadata writes remain schema-driven and tenant-scoped. |
 | `cpt-cf-account-management-usecase-list-tenant-metadata` | `cpt-cf-account-management-interface-metadata-rest`, `cpt-cf-account-management-component-metadata-service` | Listing returns direct entries only; inherited resolution is a separate boundary. |
@@ -1169,12 +1206,33 @@ The reference DDL and index definitions live in [migration.sql](./migration.sql)
 
 **ID**: `cpt-cf-account-management-dbtable-tenants`
 
-`tenants` is the AM source-of-truth table for hierarchy structure, tenant type assignment, lifecycle state, and the v1 binary barrier flag. Tenant rows store internal `tenant_type_uuid`; the public chained `tenant_type` identifier is re-hydrated from Types Registry when AM projects tenant data through the API. It exists to support:
+`tenants` is the AM source-of-truth table for hierarchy structure, tenant type assignment, lifecycle state, and the `self_managed` boolean barrier flag. Tenant rows store internal `tenant_type_uuid`; the public chained `tenant_type` identifier is re-hydrated from Types Registry when AM projects tenant data through the API. It exists to support:
 
 - direct-child reads and lifecycle mutations without recursive recomputation on every request
-- source-table synchronization by `cpt-cf-account-management-contract-tenant-resolver`
+- direct reads by `cpt-cf-account-management-contract-tenant-resolver` over a read-only database role with `SELECT`-only grants scoped to `tenants` and `tenant_closure`
 - background retention cleanup in leaf-first order
-- durable storage of the barrier bit consumed by `cpt-cf-account-management-actor-tenant-resolver` and `cpt-cf-account-management-actor-authz-resolver`
+- durable storage of the `self_managed` boolean consumed by `cpt-cf-account-management-actor-tenant-resolver` and `cpt-cf-account-management-actor-authz-resolver` (materialized into the `tenant_closure.barrier` `SMALLINT` column as bit 0 — see [TENANT_MODEL.md §Closure Table](../../../../docs/arch/authorization/TENANT_MODEL.md#closure-table))
+
+#### Table: tenant_closure
+
+**ID**: `cpt-cf-account-management-dbtable-tenant-closure`
+
+`tenant_closure` is the AM-owned transitive-ancestry table with the platform-canonical shape `(ancestor_id, descendant_id, barrier, descendant_status)` defined in [TENANT_MODEL.md](../../../../docs/arch/authorization/TENANT_MODEL.md). Closure rows exist **only** for tenants whose `tenants.status` is SDK-visible (`active`, `suspended`, `deleted`); tenants in the internal `provisioning` state are absent from the closure entirely. Every SDK-visible tenant owns a self-row `(id, id)` in addition to one strict-ancestor row per step up the `parent_id` chain. The `barrier` column is `SMALLINT` (v1 encodes bit 0 = self_managed per TENANT_MODEL.md §Closure Table; 16 bits of bitmask headroom is retained for future multi-dimensional barriers, and the type is portable across PostgreSQL and MySQL without dialect-specific type mapping); `barrier = 1` materializes whether any tenant on the strict `ancestor → descendant` path (excluding the ancestor, including the descendant) has `self_managed = true`, and `barrier = 0` otherwise. The `descendant_status` column denormalizes `tenants.status` for the row identified by `descendant_id`; its domain is `{active, suspended, deleted}` only, since provisioning tenants never enter the closure. Rows are inserted in one transaction with the `provisioning → active` transition and removed in one transaction with hard-deletion — see [`cpt-cf-account-management-fr-tenant-closure`](PRD.md#transitive-ancestry-storage). The table exists to support:
+
+- direct barrier-aware subtree and ancestor queries by `cpt-cf-account-management-contract-tenant-resolver` over the same read-only database role used for `tenants`
+- one-step evaluation of `BarrierMode::Respect` / `BarrierMode::Ignore` semantics without walking the tree at query time
+- transactional co-maintenance with `tenants` writes in `TenantService` and `ConversionService::approve`, so barrier changes and hierarchy changes become visible together
+
+Closure maintenance write amplification is bounded per ADR-001:
+
+| Operation | Amplification |
+|-----------|---------------|
+| Create child | O(depth) inserts: self-row plus one row per strict ancestor |
+| Soft delete | O(depth) updates on `descendant_status`; no row insert or delete |
+| Hard delete (leaves only) | O(depth) deletes where the target appears as descendant |
+| Status change | O(depth) updates on `descendant_status` |
+| Convert (toggle `self_managed`) | O(strict_ancestors × (1 + descendants)) barrier updates along every path through the converted tenant |
+| Subtree move | Not supported in v1 |
 
 #### Table: tenant_metadata
 
@@ -1208,15 +1266,21 @@ The physical schema in [migration.sql](./migration.sql) must preserve these inva
 - a tenant may have at most one metadata value per public `schema_id` (enforced physically through the derived `schema_uuid`)
 - a tenant may have at most one pending conversion request visible to normal API queries
 - resolved conversion rows cannot outlive their owning tenant and are eventually tombstoned and purged
-- metadata and conversion rows are lifecycle-bound to the owning tenant so retention cleanup cannot leave AM-owned orphan rows behind
+- metadata, conversion, and closure rows are lifecycle-bound to the owning tenant so retention cleanup cannot leave AM-owned orphan rows behind
+- every tenant whose `tenants.status` is SDK-visible (`active`, `suspended`, `deleted`) has exactly one `(id, id)` self-row in `tenant_closure` with `barrier = 0` and `descendant_status = tenants.status`
+- tenants in the internal `provisioning` state have **no** rows in `tenant_closure` — neither as ancestor nor as descendant
+- for every SDK-visible tenant, `tenant_closure` contains one row per strict ancestor along the `parent_id` chain in addition to the self-row, with no gaps and no extra rows
+- `tenant_closure.barrier` is `1` on `(A, D)` when and only when any tenant on the strict `A → D` path (excluding A, including D) has `self_managed = true`
+- `tenant_closure.descendant_status` equals `tenants.status` for the row identified by `descendant_id` at every committed point in time (by construction, the value is never `provisioning`)
+- closure rows are inserted in the same transaction as the `provisioning → active` status transition and removed in the same transaction as hard-deletion, so external readers never observe divergent `(tenants, tenant_closure)` state and never observe `provisioning` rows in the closure
 
 #### Why This Storage Model Supports the Design
 
-- The tenant tree stays normalized enough for integrity and downstream resolver sync, while the stored `depth` value keeps hierarchy-mutating checks and retention ordering cheap at the approved scale.
+- The tenant tree stays normalized enough for integrity checks and stored `depth` keeps hierarchy-mutating validations and retention ordering cheap at the approved scale, while the co-located `tenant_closure` table provides the transitive query shape `cpt-cf-account-management-contract-tenant-resolver` needs without any projection, sync job, or external derived store.
 - Metadata is separated from tenant core fields so schema-extensible payloads do not destabilize the tenant data contract or require schema churn for every new metadata kind.
 - Metadata persistence uses fixed-width `schema_uuid` keys for compact indexes and predictable joins while keeping the public API/AuthZ contract anchored on the human-readable chained `schema_id`.
 - Conversion lifecycle state is separated from `tenants` so dual-consent history, expiry, and retention can evolve independently of core tenant CRUD.
-- The public contract depends on stable resource projections, not on direct storage exposure; downstream readers such as Billing and Tenant Resolver consume versioned views or coordinated source-table contracts rather than ad hoc schema knowledge.
+- The public contract depends on stable resource projections for administrative reads — Billing and other integrators consume versioned AM APIs rather than the underlying storage. Tenant Resolver is the single platform consumer that reads AM-owned storage directly, and does so over a read-only database role scoped to `tenants` and `tenant_closure`; the canonical closure shape is the contract.
 
 ### 3.8 Error Codes Reference
 
@@ -1369,8 +1433,8 @@ AM is the foundational multi-tenancy module handling tenant hierarchy, barrier s
 
 #### Recovery Architecture
 
-- Backup, PITR, and replica recovery are inherited from the platform database layer.
-- After database restore, AM is authoritative again immediately, and downstream consumers such as Tenant Resolver must resynchronize from AM-owned state.
+- Backup, PITR, and replica recovery are inherited from the platform database layer. `tenant_closure` is backed up and restored as part of the same database snapshot as `tenants`, so restore produces a self-consistent `(tenants, tenant_closure)` pair by construction.
+- After database restore, AM is authoritative again immediately. `cpt-cf-account-management-actor-tenant-resolver` begins serving reads over the restored `(tenants, tenant_closure)` tables with no intermediate resync step because it holds no derived state of its own.
 - IdP-side resources created after the restore point may require manual reconciliation because AM does not yet implement automated reverse-discovery of provider state.
 - Platform RPO / RTO targets apply to AM. No AM-specific disaster-recovery topology is required beyond the platform baseline.
 
@@ -1406,7 +1470,7 @@ Error-budget interpretation:
 
 | Data set | System of record | Consumer boundary |
 |----------|------------------|-------------------|
-| Tenant hierarchy, tenant type, status, barrier mode | AM | Tenant Resolver, AuthZ Resolver, Billing, and AM public/API consumers |
+| Tenant hierarchy, tenant type, status, barrier mode, `tenant_closure` | AM | Tenant Resolver (reads `tenants` + `tenant_closure` directly via a read-only database role), AuthZ Resolver (via Tenant Resolver), Billing (AM public/API reads), and AM public/API consumers |
 | Tenant metadata | AM | AM metadata APIs, IdP provider context resolution, Billing schema-driven reads |
 | Conversion requests | AM | Child-side and parent-side conversion workflows |
 | User identity and tenant binding | IdP | AM orchestrates lifecycle calls but does not become the canonical store |
@@ -1493,9 +1557,9 @@ The main design pitfalls are:
 
 - pending `ConversionRequest` rows become ambiguous after a move because the counterparty side is derived from the current parent-child relationship; the conservative first rule should therefore reject subtree moves while any tenant in the moved subtree has a pending conversion request, rather than silently re-binding review rights
 - moves that would cross an effective IdP provisioning boundary are unsafe until the IdP contract defines tenant rebind / migration semantics; the first supported version should reject moves when source and target imply different dedicated provider-side tenant contexts
-- direct tenant metadata rows remain valid, but any schema with `inheritance_policy=inherit` may resolve differently after the move because the ancestor chain changes; this is an intended consequence that must be reflected immediately in AM reads and downstream resolver sync
+- direct tenant metadata rows remain valid, but any schema with `inheritance_policy=inherit` may resolve differently after the move because the ancestor chain changes; this is an intended consequence that must be reflected immediately in AM reads and in the co-maintained `tenant_closure` rows for the moved subtree
 - self-managed barrier effects may change for the moved subtree because ancestor visibility and inherited metadata resolution are evaluated along the new hierarchy
-- Tenant Resolver, AuthZ Resolver, and Billing must observe the move as one coherent hierarchy change for the whole subtree; the future contract therefore needs an explicit downstream resync / invalidation model rather than relying on ad hoc polling behavior
+- Tenant Resolver, AuthZ Resolver, and Billing must observe the move as one coherent hierarchy change for the whole subtree; the future contract therefore needs a single-transaction closure-rewrite model that replaces the affected `tenant_closure` rows together with the `parent_id` change, rather than any separate invalidation or polling step
 
 ## 5. Traceability
 

--- a/modules/system/account-management/docs/PRD.md
+++ b/modules/system/account-management/docs/PRD.md
@@ -22,6 +22,7 @@ Created:  2026-03-30 by Virtuozzo
 - [4. Scope](#4-scope)
   - [4.1 In Scope](#41-in-scope)
   - [4.2 Out of Scope](#42-out-of-scope)
+  - [4.3 Deferred Detailed Coverage](#43-deferred-detailed-coverage)
 - [5. Functional Requirements](#5-functional-requirements)
   - [5.1 Platform Bootstrap](#51-platform-bootstrap)
   - [5.2 Tenant Hierarchy Management](#52-tenant-hierarchy-management)
@@ -109,11 +110,11 @@ The platform needs a tenant model with unlimited hierarchy depth (configurable a
 
 | Metric | Baseline | Target | Timeframe |
 |--------|----------|--------|-----------|
-| Tenant onboarding effort | 5+ API calls and manual IdP configuration per tenant | Single API call — tenant create with type and mode | Module GA |
+| Tenant onboarding effort | 5+ API calls and manual IdP configuration per tenant (*baseline estimate from the current pre-AM workflow: create tenant record, provision IdP realm/org, bind admin identity, create root user-group, set barrier/policy flags; no production measurement exists because AM itself replaces this workflow, so the baseline is a design-time estimate used for GA pass/fail rather than a measured SLO*) | Single API call — tenant create with type and mode | Module GA |
 | Separate deployments per tenant model | 2 separate deployment configurations required today (one per managed/self-managed pattern) | Both modes in one tenant tree — zero per-model deployments (pass/fail) | Module GA |
 | End-to-end tenant context validation latency (p95) | 0 approved AM-backed benchmarks against the target | ≥ 1 approved pre-GA benchmark on the deployment profile with p95 ≤ 5ms through the resolver path | Pre-GA load test gate |
 | Cross-tenant data leaks | 0 AM-specific automated isolation scenarios wired into the gate today | Zero leaks observed; 100% of the planned AM isolation scenarios pass | Pre-GA security gate |
-| Hierarchy depth coverage | Fixed shallow hierarchies (2–3 levels) | No hard AM structural depth cap; configurable advisory threshold (default: 10); benchmark-backed validation of at least 3 distinct type topologies including hierarchies beyond the default threshold on the approved deployment profile | Pre-GA performance + integration gate |
+| Hierarchy depth coverage | Fixed shallow hierarchies (2–3 levels) | No hard AM structural depth cap; configurable advisory threshold (default: 10); benchmark-backed validation of at least 3 distinct type topologies, at least one of which reaches **≥ 15 levels** (50% above the default advisory threshold) on the approved deployment profile defined in §13 | Pre-GA performance + integration gate |
 | Conforming IdP provider implementations | 0 provider implementations validated against the AM contract suite | ≥ 2 provider implementations pass the AM tenant/user lifecycle contract suite without breaking the public API contract | Pre-GA integration gate |
 
 ### 1.4 Non-goals
@@ -139,9 +140,9 @@ The platform needs a tenant model with unlimited hierarchy depth (configurable a
 | Subject Tenant | Tenant the subject (user or API client) belongs to. Used for authorization context. |
 | Context Tenant | Tenant scope root for an operation. May differ from Subject Tenant in platform-authorized cross-tenant administrative scenarios. |
 | Resource Tenant | Actual tenant owning a specific resource. |
-| Self-Managed Tenant | Child tenant that creates a visibility barrier. The parent cannot see or access resources below this tenant through normal hierarchy and resource APIs. The only v1 exception is the dedicated conversion-request discovery surface (`/child-conversions`), which exposes minimal request metadata required for the dual-consent workflow. |
+| Self-Managed Tenant | Child tenant that creates a visibility barrier for barrier-enforced subtree/resource reads. Barrier handling is resource-type dependent per the platform tenant model: parent-side reads of child tenant metadata may still be policy-authorized, while barrier-respecting subtree/resource traversal stops at the self-managed boundary. AM's only module-specific v1 carve-out is the dedicated conversion-request discovery surface (`/child-conversions`), which exposes minimal request metadata required for the dual-consent workflow. |
 | Managed Tenant | Child tenant where the parent is eligible for controlled access to child tenant APIs and resources per policy. No visibility barrier exists. |
-| Tenant Barrier | Visibility and access boundary created by self-managed tenants. When a tenant is self-managed, it blocks ancestor visibility into the subtree below it except for the narrow v1 conversion-request metadata carve-out described for `/child-conversions`. |
+| Tenant Barrier | Visibility and access boundary created by self-managed tenants for barrier-enforced reads and subtree traversal. Whether the barrier applies is resource-type dependent per the platform tenant model; AM itself adds no module-specific bypass beyond the narrow conversion-request metadata carve-out described for `/child-conversions`. |
 | Barrier Mode | Authorization parameter controlling barrier handling: `Respect` (default) stops traversal at self-managed boundaries; `Ignore` traverses through barriers for operations like billing queries. Values align with the `BarrierMode` SDK enum. Tenant metadata resolution does not use `BarrierMode::Ignore` — inheritance stops at self-managed boundaries instead (see §5.7). |
 | Tenant Tree | Single rooted hierarchy of tenants. Has exactly one root tenant (`parent_id = NULL`) created at platform bootstrap. |
 | Root Tenant | Top-level tenant in the tree (`parent_id = NULL`). Exactly one root tenant exists per deployment, created automatically during platform bootstrap. |
@@ -180,13 +181,13 @@ The platform needs a tenant model with unlimited hierarchy depth (configurable a
 
 **ID**: `cpt-cf-account-management-actor-tenant-resolver`
 
-- **Role**: Maintains a denormalized projection of the tenant hierarchy for efficient subtree queries on the authorization hot path. Periodically synchronizes with the Account Service source of truth.
+- **Role**: Query facade over the AM-owned tenant hierarchy. Reads `tenants` and `tenant_closure` directly from the AM database over a read-only role provisioned by AM with `SELECT`-only grants, and serves barrier-aware subtree, ancestor, and existence queries on the authorization hot path. Holds no derived state of its own — every query reflects AM's currently committed state.
 
 #### AuthZ Resolver Plugin
 
 **ID**: `cpt-cf-account-management-actor-authz-resolver`
 
-- **Role**: Evaluates authorization decisions using tenant context, barrier semantics, and subtree scoping constraints. Consumes the tenant hierarchy projection via [Tenant Resolver](../../tenant-resolver) for query-level tenant isolation.
+- **Role**: Evaluates authorization decisions using tenant context, barrier semantics, and subtree scoping constraints. Consumes the barrier-aware query facade exposed by [Tenant Resolver](../../tenant-resolver/) for query-level tenant isolation.
 
 #### IdP Provider
 
@@ -206,7 +207,17 @@ The platform needs a tenant model with unlimited hierarchy depth (configurable a
 
 - **Role**: Provides runtime-extensible type definitions for tenant types, enabling new tenant classifications without code changes. Validates parent-child type constraints at tenant creation time.
 
-**Downstream consumer resilience**: Billing System and AuthZ Resolver Plugin are downstream consumers of AM data. Their resilience to AM unavailability is their own concern, consistent with the Tenant Resolver pattern where projection staleness is a Tenant Resolver responsibility.
+**Downstream consumer resilience**: Billing System and AuthZ Resolver Plugin are downstream consumers of AM data. Their resilience to AM unavailability is their own concern. Tenant Resolver Plugin reads AM-owned storage directly via a read-only database role, so its availability tracks AM database availability and it holds no independent derived state to reconcile.
+
+**Downstream SLA contract model**: AM does **not** issue per-consumer SLA contracts (availability, freshness, or convergence windows) to its downstream consumers. The architecture makes those guarantees unnecessary rather than negotiated:
+
+| Consumer | Freshness / availability model | Basis |
+|----------|-------------------------------|-------|
+| Tenant Resolver Plugin | Atomic: every AM commit is immediately visible. Query latency tracks AM database read latency and is bounded by the tenant-context-validation target in §6.1 / §9 (p95 ≤ 5ms). Availability tracks AM database availability. | Stateless DB facade; no derived state, no projection window. |
+| AuthZ Resolver Plugin | Consumer-owned: AuthZ decides its own cache-invalidation and convergence strategy over the AM-owned hierarchy and barrier state exposed by the Tenant Resolver. AM neither commits to a propagation deadline nor maintains an AM-side cache. | Downstream consumer; responsible for its own resilience (see above). |
+| Billing System | Consumer-owned, batch-friendly: Billing aggregates tenant hierarchy on its own cadence using `BarrierMode::Ignore`. AM commits no tight convergence window; hours-scale lag is architecturally acceptable. | Downstream consumer; responsible for its own resilience (see above). |
+
+The absence of AM-side SLA contracts is a deliberate architectural choice, not an omission: AM is an administrative source-of-truth module (see §3), and any per-consumer freshness guarantee would either require AM-owned caching/replication (rejected in [ADR-0004](ADR/0004-cpt-cf-account-management-adr-resource-group-tenant-hierarchy-source.md)) or shift AM into the request-path enforcement role it explicitly refuses (see §3).
 
 ## 3. Operational Concept & Environment
 
@@ -241,7 +252,7 @@ AM stores the tenant mode (`managed` or `self-managed`) and the hierarchy state 
 - nested self-managed boundaries are allowed;
 - authorized platform-owned consumers such as Billing System may use platform-level barrier-bypass modes outside AM itself.
 
-AM may still perform internal hierarchy-owner reads for two non-policy purposes: validating structure-changing operations against the full tenant tree, and stopping metadata inheritance at self-managed boundaries. The only product-level visibility exception that AM exposes directly is parent-side discovery of child conversion requests, and that exception returns only minimal request metadata needed for the dual-consent workflow.
+AM may still perform internal hierarchy-owner reads for two non-policy purposes: validating structure-changing operations against the full tenant tree, and stopping metadata inheritance at self-managed boundaries. Parent-side visibility of child tenant metadata follows the platform tenant model and platform AuthZ policy rather than an AM-specific bypass. The only additional AM-owned structural-read carve-out is parent-side discovery of child conversion requests, and that exception returns only minimal request metadata needed for the dual-consent workflow.
 
 ### 3.4 User Data Ownership
 
@@ -268,6 +279,7 @@ AM coordinates user lifecycle operations but **does not own user identity data**
 - Platform bootstrap: initial root tenant auto-creation during install, idempotent (p1).
 - Tenant type classification via GTS registry with configurable parent-child constraints (p1).
 - Tenant hierarchy: single rooted tree with parent-child relationships and unlimited depth with a configurable advisory threshold (p1).
+- Canonical transitive-ancestry storage: AM owns the `tenant_closure` table in the platform-canonical shape `(ancestor_id, descendant_id, barrier, descendant_status)` defined in TENANT_MODEL.md, maintains it transactionally with tenant writes, and exposes it to the Tenant Resolver Plugin through a read-only database role (p1).
 - Managed tenant model: parent eligible for delegated child administration with no barrier, subject to platform authorization policy (p1).
 - Self-managed tenant model: strict isolation via barrier; metadata inheritance stops at self-managed boundaries (p1).
 - Tenant CRUD operations: create, read, update, soft-delete with configurable retention (p1).
@@ -282,10 +294,29 @@ AM coordinates user lifecycle operations but **does not own user identity data**
 - User self-registration: users are provisioned via API within tenant security context (invite model only).
 - User authentication flows: covered by IAM PRD.
 - Tenant context propagation (SecurityContext population, cross-tenant rejection, service-to-service forwarding): framework and AuthZ Resolver responsibility.
-- Barrier-aware tenant tree traversal (ancestor chains, descendant queries with `BarrierMode`): Tenant Resolver Plugin responsibility. AM provides source-of-truth data and direct children queries.
+- Barrier-aware tenant tree traversal (ancestor chains, descendant queries with `BarrierMode`): Tenant Resolver Plugin responsibility. AM owns the underlying `tenants` + `tenant_closure` storage and the canonical closure shape, and exposes it to the Plugin via a read-only database role; barrier-aware SDK queries are served by the Plugin over that shared storage. AM's own public API exposes tenant CRUD and direct-children discovery, not barrier-aware subtree traversal.
 - AuthZ Resolver (PDP) implementation: covered by Cyber Fabric DESIGN; this module covers the tenant model consumed by PDP.
 - Resource provisioning and lifecycle for non-identity platform resources: outside AM scope. AM provides tenant context and ownership boundaries but does not manage downstream resource CRUD or provisioning workflows.
 - Tenant lifecycle events (CloudEvents): deferred until EVT (Events and Audit Bus) is introduced.
+
+### 4.3 Deferred Detailed Coverage
+
+Sections 1–5 scope the product and enumerate functional requirements at contract granularity. The following topics are intentionally treated in later sections of this PRD rather than inlined above, so reviewers can distinguish deliberate deferral from accidental omission:
+
+| Topic | Covered in | Rationale for deferral |
+|-------|-----------|------------------------|
+| Non-functional thresholds (latency, audit completeness, data classification, reliability, data lifecycle, production scale) | §6 | Contract obligations separated from functional scope so they can be reviewed as a coherent NFR set. |
+| Public library and integration interfaces (SDK surface, IdP contract, downstream consumer interfaces) | §7 | Interface shape depends on FRs + NFRs together; kept downstream of both. |
+| Use-case walkthroughs (bootstrap, tenant lifecycle, mode conversion, user groups, IdP ops, metadata) | §8 | FRs define *what*, use cases illustrate *how the actors compose them*; kept separate to avoid FR-level narrative drift. |
+| Acceptance criteria (review-ready GA gates) | §9 | Aggregated from FR + NFR + use-case claims; lives after all three. |
+| External dependencies and consumer matrix | §10 | Enumerated once, after actors and FRs are settled. |
+| Assumptions (IdP bootstrap, GTS availability, RG ownership graph) | §11 | Global to the PRD; not scoped per FR. |
+| Risks and mitigations | §12 | Cross-cutting; scored against the whole scope rather than per section. |
+| Review baseline decisions (approved deployment profile, barrier taxonomy, authoritative artifacts) | §13 | Point-in-time freeze for the v1 review; intentionally isolated so review baseline edits are auditable. |
+| Open questions requiring follow-up resolution | §14 | Unresolved items with owner/disposition; not FRs or NFRs. |
+| Traceability links (upstream requirements, downstream artifacts, canonical platform references) | §15 | Structural index; lives at the tail by convention. |
+
+Integration test strategy, per-endpoint SLA tables, implementation-level DECOMPOSITION/FEATURE traceability, and CloudEvents for metadata/lifecycle mutations are **not** in this PRD at all — they are explicitly out of scope for this review-ready baseline (see §1.4 Non-goals and §15 Traceability).
 
 ## 5. Functional Requirements
 
@@ -415,6 +446,16 @@ The system **MUST** return tenant details for a requested tenant identifier when
 The system **MUST** allow an authorized administrator to update only mutable tenant attributes through the general update operation: `name` and `status` (limited to `active` ↔ `suspended` transitions; `deleted` is handled exclusively by the soft-delete operation). The system **MUST** reject attempts to modify immutable hierarchy-defining fields such as `id`, `parent_id`, `tenant_type`, `self_managed`, and `depth`; mode changes remain handled by the dedicated conversion flow.
 
 - **Rationale**: Administrative workflows require controlled edits to tenant presentation and lifecycle state without allowing accidental hierarchy or mode mutations through a generic update path. Restricting the update path to non-terminal status transitions ensures deletion guards (child/resource checks) cannot be bypassed.
+
+#### Transitive Ancestry Storage
+
+- [ ] `p1` - **ID**: `cpt-cf-account-management-fr-tenant-closure`
+
+**Actors**: `cpt-cf-account-management-actor-tenant-admin`, `cpt-cf-account-management-actor-tenant-resolver`, `cpt-cf-account-management-actor-authz-resolver`
+
+The system **MUST** own a `tenant_closure` table with the platform-canonical shape `(ancestor_id, descendant_id, barrier, descendant_status)` defined in TENANT_MODEL.md. Closure rows **MUST** exist only for tenants whose `tenants.status` is SDK-visible (`active`, `suspended`, `deleted`): each such tenant has a self-row `(id, id)` plus one row per strict ancestor along the `parent_id` chain. Tenants in the transient `provisioning` state **MUST NOT** have any closure rows — they are inserted in a single transaction with the `provisioning → active` status transition, and removed in a single transaction with hard-deletion. Every status transition between SDK-visible states **MUST** update `descendant_status` transactionally for all rows where that tenant is `descendant_id`. The `barrier` column (`SMALLINT`, v1 uses bit 0 for self_managed per TENANT_MODEL.md) reflects whether any tenant on the path `(ancestor, descendant]` is `self_managed` (ancestor excluded, descendant included); self-rows `(id, id)` **MUST** carry `barrier = 0`. The `descendant_status` column domain is `{active, suspended, deleted}` only — the internal `provisioning` state is excluded by construction. The system **MUST** expose this storage to the Tenant Resolver Plugin through a read-only database role scoped to `tenants` and `tenant_closure`, and **MUST NOT** provide any sync, projection, revision-token, or change-feed capability on top of that storage.
+
+- **Rationale**: Barrier-aware subtree, ancestor, and existence queries on the authorization hot path need a transitive representation of the tenant tree. Co-owning the canonical closure table inside AM, and co-maintaining it transactionally with tenant writes, is what allows the Tenant Resolver Plugin to be a stateless query facade with no sync pipeline, no projection freshness budget, and no drift-detection loop — barrier changes and hierarchy changes become visible to the Plugin atomically the moment AM commits them. Keeping `provisioning` tenants out of `tenant_closure` entirely (rather than carrying them as a filtered state) makes the closure a clean publication contract for future replication to business modules — replica consumers never observe transient AM saga state and have no `provisioning`-specific filtering obligation.
 
 ### 5.3 Tenant Type Enforcement
 
@@ -558,6 +599,8 @@ The system **MUST** allow only the counterparty of a pending conversion request 
 Resolved conversion requests (`approved`, `cancelled`, `rejected`, `expired`) **MUST** remain queryable for a configurable review window and then leave the default API surface while remaining available to retained audit/history flows.
 
 - **Rationale**: Historical resolutions carry audit and UX value — "my last conversion attempt was rejected two weeks ago" must remain answerable without forcing unbounded storage growth. A configurable retention window gives operators a single knob to balance audit needs, operational clarity, and storage cost.
+
+Pending `ConversionRequest` rows transition to `expired` by an AM background reaper that scans for rows whose `expires_at` has passed. The reaper runs on a `cleanup_interval` cadence (default 60s). Expired rows remain queryable for `resolved_retention` (default 30 days) before the retention job stamps `deleted_at` and default API reads exclude them. Hard-delete follows AM's platform retention cadence. See `cpt-cf-account-management-fr-mode-conversion-expiry` and `cpt-cf-account-management-fr-conversion-retention`.
 
 ### 5.5 IdP Tenant & User Operations Contract
 
@@ -762,7 +805,7 @@ The module **MUST** export domain-specific metrics for dependency health, metada
 
 - [ ] `p1` - **ID**: `cpt-cf-account-management-nfr-context-validation-latency`
 
-AM data access and source-of-truth lookups **MUST** enable end-to-end tenant-context validation to complete in p95 ≤ 5ms under normal load when resolver-side caching is enabled.
+AM data access and source-of-truth lookups **MUST** enable end-to-end tenant-context validation — including the Tenant Resolver Plugin's indexed read path over `tenants` + `tenant_closure` via the read-only database role and steady-state reverse-hydration of UUID-backed public GTS identifiers — to complete in p95 ≤ 5ms under normal load on the approved deployment profile.
 
 - **Threshold**: 5ms at p95 across the full tenant-context validation path under the approved deployment profile.
 - **Rationale**: AM is not the request-path enforcement point, but its source-of-truth query model must not block the platform SLO.
@@ -824,23 +867,22 @@ Published REST APIs **MUST** follow path-based versioning. SDK client and IdP in
 
 - [ ] `p1` - **ID**: `cpt-cf-account-management-nfr-production-scale`
 
-The platform team **MUST** define and approve a canonical AM deployment profile before DESIGN sign-off. At minimum, the profile **MUST** specify target values for the following dimensions and keep them within, or explicitly revise, the current planning envelope. The approved profile **MUST** include benchmark evidence for the hierarchy depth and volume envelope claimed for production, including dependent resolver paths that consume AM hierarchy data.
+The AM deployment profile is defined authoritatively in §13 *Review Baseline Decisions* and frozen for the v1 review. The dimensions below are the **design targets** the architecture is validated against — not measured production workloads (AM is a new module; no production AM traffic exists yet). Each bound is anchored to a specific architectural decision in the companion DESIGN, so enlarging any bound requires revisiting that decision rather than a documentation change.
 
-| Dimension | Current Planning Envelope |
-|-----------|---------------------------|
-| Tenants (hierarchy nodes) | 1K–100K |
-| Typical hierarchy depth | 3–10 levels (AM model has no hard depth cap; advisory threshold default: 10; deeper production support is benchmark-gated) |
-| Users (across all tenants) | 10K–1M |
-| User groups (Resource Group entities) | 1K–50K (stored in Resource Group) |
-| Group memberships (Resource Group membership links) | 10K–500K (stored in Resource Group) |
-| Concurrent API requests (peak) | 100–10K rps |
+| Dimension | v1 Design Target (from §13) | Anchored architectural decision |
+|-----------|-----------------------------|--------------------------------|
+| Tenants (hierarchy nodes) | 100K | Closure-table sizing and B-tree index layout on `tenant_closure (ancestor_id, barrier, descendant_status)` (DESIGN §3.1 *Domain Model* / §3.7 *Database schemas & tables*) |
+| Typical hierarchy depth | 3–10 levels, with no hard cap; advisory threshold default 10; benchmark-gated validation up to ≥ 15 levels per §1.3 | Closure row count per tenant ≈ depth; recursive structural-validation cost (DESIGN §3.2 `TenantService`) |
+| Users (across all tenants) | 300K (IdP-stored) | Out of AM's storage; affects only audit-trail identity references |
+| User groups / memberships | 30K user groups, 300K memberships (Resource Group-stored) | Out of AM's storage; sets RG integration expectations only |
+| Concurrent API requests (peak) | 1K rps | Per-endpoint latency table in §9 (Acceptance Criteria) and the Tenant Resolver p95 ≤ 5ms hot-path budget |
 
-- **Threshold**: 100% of the listed dimensions have an approved target before DESIGN sign-off.
-- **Additional throughput targets**:
-  - Lifecycle reads must support the approved 1K rps peak without violating NFR 6.1.
-  - Administrative mutations must sustain at least 25 writes/second for a 15-minute window under the approved profile.
-  - Background expiry and retention work must be able to clear a backlog of 10K due rows within 60 minutes under the approved profile.
-- **Rationale**: AM indexing, job cadence, and consumer freshness expectations depend on explicit scale and throughput inputs rather than implicit assumptions.
+- **Threshold**: all dimensions locked to §13; changes require an amendment to §13 *and* the anchored architectural decision.
+- **Additional throughput targets** (design targets, validated pre-GA):
+  - Lifecycle reads sustain the 1K rps peak without violating NFR 6.1.
+  - Administrative mutations sustain ≥ 25 writes/second for a 15-minute window under the profile.
+  - Background expiry and retention work clear a backlog of 10K due rows within 60 minutes under the profile.
+- **Rationale**: stating these as design targets anchored to concrete architectural decisions prevents the envelope from drifting independently of the architecture it was sized against. The wider planning ranges previously shown here (up to 1M users, 10K rps) were not architecture-validated and are removed to avoid implying production-supported limits that were never designed for. Evidence becomes measured only after GA load-test gates (§1.3 success criteria).
 
 ### 6.9 Data Classification
 
@@ -873,7 +915,7 @@ Tenant deprovisioning **MUST** remove tenant-scoped metadata, trigger Resource G
 
 - [ ] `p2` - **ID**: `cpt-cf-account-management-nfr-data-quality`
 
-AM hierarchy changes **MUST** be committed transactionally and become immediately visible in the source-of-truth tenant tables. Mandatory fields **MUST** be validated before persistence. The downstream 30-second projection freshness target remains a platform-level objective that depends on Tenant Resolver's sync behavior.
+AM hierarchy changes **MUST** be committed transactionally across `tenants` and `tenant_closure` together and become immediately visible in the source-of-truth tenant tables. Mandatory fields **MUST** be validated before persistence. The Tenant Resolver Plugin reads those tables directly over a read-only database role and therefore observes every committed change the moment the transaction commits — there is no projection freshness window, no sync interval, and no barrier-propagation latency between AM and the Plugin.
 
 #### Data Integrity Diagnostics
 
@@ -958,18 +1000,18 @@ IdP implementations may align with standards such as SCIM 2.0 and OIDC where app
 - **Direction**: required from client (schema/type resolution consumed by AM)
 - **Protocol/Format**: SDK trait or equivalent registry API
 - **Consumed / Provided Data**: tenant type definitions, allowed-parent rules, metadata-schema validation material, and metadata inheritance traits.
-- **Availability / Fallback**: Existing AM reads remain available if GTS is unavailable. Type-validating writes and metadata writes that require fresh schema lookup fail with `service_unavailable`; AM does not invent or cache unverified schema changes locally.
+- **Availability / Fallback**: Existing AM reads that do not require fresh schema/type projection remain available if GTS is unavailable. Reads that must reverse-hydrate public chained identifiers from stored `tenant_type_uuid` / `schema_uuid` keys depend on Types Registry availability or a bounded local cache and fail deterministically on cache miss rather than returning opaque UUIDs. Type-validating writes and metadata writes that require fresh schema lookup fail with `service_unavailable`; AM does not invent or cache unverified schema changes locally.
 - **Compatibility**: Registered schema identifiers remain the stable keys by which AM references tenant types and metadata kinds.
 
 #### Tenant Resolver Plugin Data Contract
 
 - [ ] `p1` - **ID**: `cpt-cf-account-management-contract-tenant-resolver`
 
-- **Direction**: provided by library (tenant hierarchy data for Resolver consumption)
-- **Protocol/Format**: Database-level data contract (source-of-truth tenant tables consumed by Resolver sync)
-- **Consumed / Provided Data**: tenant identifiers, parent-child relationships, status, depth, type, and barrier state.
-- **Availability / Fallback**: AM provides immediate transactional visibility in source tables. Projection lag and cache freshness are Tenant Resolver responsibilities.
-- **Compatibility**: Schema changes to source-of-truth tenant tables require coordinated update with Tenant Resolver Plugin. Schema migrations to source-of-truth tenant tables MUST be backward-compatible within a minor release to support rolling upgrades where AM and Tenant Resolver may temporarily run different versions.
+- **Direction**: provided (AM exposes its own storage to the Tenant Resolver Plugin for direct reads)
+- **Protocol/Format**: Read-only PostgreSQL role provisioned by AM with `SELECT`-only grants scoped to `tenants` and `tenant_closure`. The canonical closure shape `(ancestor_id, descendant_id, barrier, descendant_status)` defined in TENANT_MODEL.md is the on-the-wire contract. AM does not expose any sync, projection, revision-token, or change-feed surface.
+- **Consumed / Provided Data**: rows of `tenants` (`id`, `parent_id`, `name`, `tenant_type_uuid`, `status`, `self_managed`, `depth`, timestamps, and any additional resolver-mapped metadata fields) and rows of `tenant_closure` (`ancestor_id`, `descendant_id`, `barrier`, `descendant_status`). Public chained `tenant_type` values are re-hydrated by the Tenant Resolver side through Types Registry; raw UUID keys are not the public contract.
+- **Availability / Fallback**: AM commits tree and closure updates as one transaction, so the Tenant Resolver Plugin observes every committed hierarchy change the moment it becomes visible in the database — there is no projection lag and no cache freshness window for hierarchy state. AM persists internal `provisioning` rows on `tenants` during bootstrap/tenant-create sagas, but the `tenant_closure` contract excludes those rows entirely: closure entries are inserted atomically with the `provisioning → active` transition, so Tenant Resolver reads against the closure never observe provisioning tenants, by construction. Plugin read availability tracks AM database availability.
+- **Compatibility**: Schema changes to `tenants` and `tenant_closure` are a coordinated contract change between AM and the Tenant Resolver Plugin. Migrations **MUST** be backward-compatible within a minor release so that rolling upgrades where AM and the Plugin temporarily run different versions remain safe against the shared storage.
 
 #### AuthZ Resolver Integration
 
@@ -1078,12 +1120,12 @@ IdP implementations may align with standards such as SCIM 2.0 and OIDC where app
 **Main Flow**:
 1. Tenant admin of `T1` submits a child tenant create request with type `division`, name `"East Division"`, and mode `self_managed=false`.
 2. System validates parent status, type constraints, and current hierarchy depth.
-3. System completes tenant creation; the new child becomes visible under parent `T1` in status `active` and managed mode.
-4. Hierarchy projection converges on the next sync cycle.
+3. System completes tenant creation; the new child becomes visible under parent `T1` in status `active` and managed mode. The `tenants` row and the matching `tenant_closure` entries (self-row plus one row per strict ancestor along the `parent_id` chain) are committed in the same transaction.
+4. The Tenant Resolver Plugin's next barrier-aware query observes the new child immediately because it reads the same database.
 
 **Postconditions**:
 - Child tenant exists under `T1`
-- Hierarchy projection reflects the new child after synchronization
+- Closure rows for the new child are committed and immediately queryable by the Tenant Resolver Plugin
 
 **Alternative Flows**:
 - **Type not allowed under parent**: See `cpt-cf-account-management-usecase-reject-type-not-allowed`
@@ -1354,7 +1396,7 @@ IdP implementations may align with standards such as SCIM 2.0 and OIDC where app
 **Postconditions**:
 - `tenants.self_managed` on `T2` reflects `target_mode`
 - Conversion history shows both the initiating and approving sides with their respective identities
-- Downstream barrier state converges once Tenant Resolver's projection picks up the new value (propagation latency is a platform concern, not AM's)
+- `tenant_closure.barrier` is updated in the same transaction across every `(ancestor, descendant)` pair whose path `(ancestor, descendant]` contains `T2`, so barrier-aware queries served by the Tenant Resolver Plugin observe the new state the moment the approval commits
 
 **Alternative Flows**:
 - **Counterparty does not approve within the window**: See `cpt-cf-account-management-usecase-conversion-expires`
@@ -1818,7 +1860,19 @@ IdP implementations may align with standards such as SCIM 2.0 and OIDC where app
 - [ ] Authorization policy can restrict `read`, `write`, `delete`, and `list` actions on resource type `Metadata` at `schema_id` granularity; `PolicyEnforcer` receives `schema_id` as a resource attribute on every metadata operation.
 - [ ] `not_found` errors on metadata endpoints carry the stable sub-codes `metadata_schema_not_registered` and `metadata_entry_not_found`.
 - [ ] Tenant isolation is verified by automated security tests: Tenant A cannot access Tenant B data through any path.
-- [ ] Tenant context validation completes in p95 ≤ 5ms.
+- [ ] Tenant context validation completes in p95 ≤ 5ms (hot path, served by Tenant Resolver Plugin over AM-owned storage).
+- [ ] Control-plane (administrative) endpoints meet the following latency targets on the §13 approved deployment profile (1K rps peak). These are admin-plane targets, not request-path enforcement; the hot-path budget above is the binding p95 for read-path tenant context:
+
+    | Endpoint class | p95 | p99 |
+    |----------------|-----|-----|
+    | `GET` single tenant / `GET` single metadata entry | ≤ 50 ms | ≤ 150 ms |
+    | `GET` list (direct children, metadata listing, conversion-request discovery) | ≤ 150 ms | ≤ 400 ms |
+    | `POST` create tenant (includes IdP provisioning saga) | ≤ 300 ms | ≤ 1000 ms |
+    | `PATCH` / `PUT` update (tenant mutable fields, metadata full-replace) | ≤ 200 ms | ≤ 500 ms |
+    | `DELETE` (soft-delete, with child/resource precondition checks) | ≤ 150 ms | ≤ 500 ms |
+    | Mode conversion request create / resolve | ≤ 200 ms | ≤ 500 ms |
+
+    IdP-dependent endpoints (tenant create, user provisioning, user deprovisioning) inherit IdP latency and may exceed these p99 bounds when the IdP itself is slow; in that case the AM-side error contract (`idp_unavailable`) applies rather than a latency-violation SLO.
 - [ ] All tenant configuration changes are recorded in the platform append-only audit infrastructure with actor and tenant identity, including `actor=system` events for AM-owned background transitions.
 - [ ] All failures map to deterministic error categories.
 - [ ] AM exports the documented domain-specific metrics for dependency health, metadata resolution, bootstrap lifecycle, tenant-retention work, conversion lifecycle, hierarchy-depth threshold exceedance, and cross-tenant denials.
@@ -1846,7 +1900,7 @@ IdP implementations may align with standards such as SCIM 2.0 and OIDC where app
 
 | Consumer | What it consumes |
 |----------|-----------------|
-| Tenant Resolver Plugin | Syncs denormalized hierarchy projection from AM source-of-truth tenant tables. |
+| Tenant Resolver Plugin | Reads AM-owned `tenants` and `tenant_closure` directly via a read-only database role and serves barrier-aware query APIs over that data. |
 | AuthZ Resolver Plugin | Consumes tenant hierarchy and barrier state for authorization decisions. |
 | RBAC Engine | Consumes user group structure and membership data from Resource Group for group-to-role binding; uses AM tenant hierarchy and barrier context separately where needed. |
 | Billing System | Consumes tenant hierarchy metadata with barrier bypass for billing aggregation. |
@@ -1860,14 +1914,14 @@ IdP implementations may align with standards such as SCIM 2.0 and OIDC where app
 - The v1 tenant-mode contract is binary: `managed` and `self-managed`. Richer barrier taxonomies are explicitly out of scope for this review baseline.
 - RBAC Engine handles role definitions, role assignments, and group-to-role binding; Resource Group provides group structure and membership data, while AM provides tenant hierarchy, barrier context, and IdP-backed user lookup when needed.
 - Resource ownership is represented in the Resource Group ownership graph; tenant deletion validation relies on the absence of resource associations under the tenant's ownership scope.
-- Authorization enforcement (AuthZ Resolver) and barrier-aware traversal (Tenant Resolver) are external consumers of AM source-of-truth data; their projection consistency and query performance are their own responsibility.
+- Authorization enforcement (AuthZ Resolver) and barrier-aware traversal (Tenant Resolver Plugin) are downstream consumers of AM data. The Tenant Resolver Plugin is a stateless query facade over the same database that AM owns, consuming `tenants` and `tenant_closure` directly through a read-only database role; the Plugin holds no derived state of its own, so consistency with AM follows from transactional co-maintenance of those tables inside AM.
 
 ## 12. Risks
 
 | Risk | Likelihood | Severity | Impact | Mitigation |
 |------|-----------|----------|--------|------------|
 | Cross-tenant data leak due to query-level isolation bypass | Low | High | Tenant data exposure, contractual and legal liability | Automated security test suite with cross-tenant access attempts; barrier enforcement at query level; continuous monitoring |
-| Tenant hierarchy depth exceeding practical limits at scale | Low | Medium | Performance degradation of hierarchy queries and projections | Configurable advisory threshold (default: 10) with opt-in strict mode; monitoring of hierarchy depth distribution; design for scalability beyond 10,000 tenants |
+| Tenant hierarchy depth exceeding practical limits at scale | Low | Medium | Performance degradation of hierarchy queries and projections | Configurable advisory threshold (default: 10) with opt-in strict mode; monitoring of hierarchy depth distribution; closure-table sizing and indexing anchored to the §13 approved deployment profile (100K tenants, 1K rps) per §6.8 |
 | Circular nesting in user groups | Low | Low | Infinite loops in permission resolution | Enforced by Resource Group forest invariants — cycle detection at group move/create time; consumers receive `CycleDetected` directly from Resource Group before persistence. AM is not in the call path. |
 | IdP provider unavailability during operations | Medium | High | Tenant creation and user lifecycle operations become temporarily unavailable | Clear deterministic error mapping (`idp_unavailable`), bootstrap retry/backoff, and operator alerting via observability metrics |
 | Ambiguous retry after tenant-create timeout or generic platform fault | Medium | Medium | Blind retry of tenant creation can trigger duplicate tenant or IdP-side provisioning attempts because the initial outcome may already have crossed the IdP boundary | Document tenant creation as intentionally non-idempotent; require reconciliation before retry; use platform audit records, compensation metrics, and reaper cleanup for investigation |
@@ -1883,7 +1937,11 @@ The following decisions are fixed for the review-ready v1 baseline:
 
 ## 14. Open Questions
 
-- **Do we need managed-tenant impersonation in v1?** The current review-ready baseline does not commit AM to issuing impersonation tokens or exposing a stable impersonation endpoint. If v1 requires that capability, PRD, DESIGN, OpenAPI, AuthZ vocabulary, IdP contract, and security/test scope must be updated together as one coordinated contract change.
+_None open for the v1 baseline._
+
+**Resolved for v1:**
+
+- **Managed-tenant impersonation — out of scope for v1.** AM does not issue impersonation tokens and exposes no impersonation endpoint. Delegated parent administration of managed children is handled exclusively through platform AuthZ policy evaluation over normal `SecurityContext`, not through a separate impersonation flow. If future versions require impersonation, the change is coordinated across PRD, DESIGN, OpenAPI, AuthZ vocabulary, IdP contract, and security/test scope and will be tracked under a new ADR at that time; it is **not** a deferred v1 commitment.
 
 ## 15. Traceability
 

--- a/modules/system/account-management/docs/account-management-v1.yaml
+++ b/modules/system/account-management/docs/account-management-v1.yaml
@@ -14,6 +14,11 @@ info:
     PRD and DESIGN intentionally summarize behavior and refer here for wire
     shapes, field semantics, and HTTP-level error mapping.
 
+    Versioning: breaking changes increment the major version embedded in the URL
+    path (`/api/account-management/v1/` → `/v2/`) and are coordinated with a
+    migration window per the Compatibility NFR in DESIGN.md. Additive changes
+    within v1 do not rev the path.
+
 servers:
   - url: https://api.example.com
 
@@ -488,6 +493,9 @@ components:
       name: status
       in: query
       required: false
+      description: |
+        Optional tenant-status filter. One of: `active`, `suspended`, `deleted`.
+        Omit to include all statuses.
       schema:
         $ref: '#/components/schemas/TenantStatus'
     ConversionStatusFilter:
@@ -642,6 +650,7 @@ components:
         - target_mode
         - initiator_side
         - status
+        - requested_by
         - created_at
         - expires_at
         - updated_at
@@ -662,7 +671,6 @@ components:
         requested_by:
           type: string
           format: uuid
-          nullable: true
         approved_by:
           type: string
           format: uuid
@@ -690,11 +698,12 @@ components:
       additionalProperties: false
       required:
         - id
-        - tenant_id
+        - child_tenant_id
         - child_tenant_name
         - target_mode
         - initiator_side
         - status
+        - requested_by
         - created_at
         - expires_at
         - updated_at
@@ -702,7 +711,7 @@ components:
         id:
           type: string
           format: uuid
-        tenant_id:
+        child_tenant_id:
           type: string
           format: uuid
         child_tenant_name:
@@ -714,6 +723,21 @@ components:
           enum: [child, parent]
         status:
           $ref: '#/components/schemas/ConversionStatus'
+        requested_by:
+          type: string
+          format: uuid
+        approved_by:
+          type: string
+          format: uuid
+          nullable: true
+        cancelled_by:
+          type: string
+          format: uuid
+          nullable: true
+        rejected_by:
+          type: string
+          format: uuid
+          nullable: true
         created_at:
           type: string
           format: date-time

--- a/modules/system/account-management/docs/migration.sql
+++ b/modules/system/account-management/docs/migration.sql
@@ -5,6 +5,15 @@
 -- This file is intentionally documentation-first: implementation migrations may
 -- express the same logical schema through ModKit/SeaORM migration code.
 -- Dialect: PostgreSQL reference DDL.
+-- Retention policy overview:
+--   conversion_requests: soft-deleted (`deleted_at` stamped) by the AM retention
+--     job after `resolved_retention` (default 30d) elapses past the terminal
+--     status transition; hard-deleted on AM's platform retention cadence.
+--   tenants: soft-deleted via `tenants.deleted_at`; hard-deleted by the
+--     background tenant-hard-delete job after the tenant retention window and
+--     precondition checks (no non-deleted children, no RG ownership references).
+--   tenant_closure: rows for a tenant are removed only on tenant hard-delete.
+--     Provisioning tenants are never present (see comment on descendant_status).
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
@@ -14,7 +23,14 @@ CREATE TABLE tenants (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     parent_id UUID NULL,
     name TEXT NOT NULL CHECK (length(name) BETWEEN 1 AND 255),
-    status TEXT NOT NULL CHECK (status IN ('provisioning', 'active', 'suspended', 'deleted')),
+    -- status domain is the FULL internal domain {0=provisioning, 1=active, 2=suspended, 3=deleted}.
+    -- Code 0 (provisioning) is an AM-internal saga state that intentionally never appears in
+    -- `tenant_closure.descendant_status` — closure rows are inserted in the provisioning→active
+    -- transaction, so the closure contract exposes only the SDK-visible subset {1,2,3}
+    -- (see ADR-0007 and the comment on tenant_closure.descendant_status below).
+    -- Any reader that expects status=0 to be present in `tenant_closure` is querying the wrong
+    -- table; use `tenants` for full-domain reads and `tenant_closure` for publication-contract reads.
+    status SMALLINT NOT NULL CHECK (status IN (0, 1, 2, 3)),
     self_managed BOOLEAN NOT NULL DEFAULT FALSE,
     tenant_type_uuid UUID NOT NULL,
     depth INTEGER NOT NULL CHECK (depth >= 0),
@@ -55,6 +71,46 @@ COMMENT ON COLUMN tenants.tenant_type_uuid
     IS 'Deterministic UUIDv5 derived from the public chained tenant_type GTS identifier using the GTS namespace constant; compact storage/index key for tenant type assignment.';
 COMMENT ON COLUMN tenants.depth
     IS 'Denormalized hierarchy depth used for advisory threshold checks and leaf-first retention cleanup ordering.';
+COMMENT ON COLUMN tenants.status
+    IS 'Tenant lifecycle state, encoded as SMALLINT for MySQL/PostgreSQL parity. Mapping: 0=provisioning, 1=active, 2=suspended, 3=deleted. Int↔name translation is owned by the application layer; SQL authored outside the ORM MUST reference these codes, never string literals.';
+
+-- ── Tenant closure ───────────────────────────────────────────────────────────
+
+CREATE TABLE tenant_closure (
+    ancestor_id UUID NOT NULL,
+    descendant_id UUID NOT NULL,
+    barrier SMALLINT NOT NULL DEFAULT 0,
+    descendant_status SMALLINT NOT NULL CHECK (descendant_status IN (1, 2, 3)),
+    CONSTRAINT pk_tenant_closure
+        PRIMARY KEY (ancestor_id, descendant_id),
+    CONSTRAINT fk_tenant_closure_ancestor
+        FOREIGN KEY (ancestor_id)
+        REFERENCES tenants(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT fk_tenant_closure_descendant
+        FOREIGN KEY (descendant_id)
+        REFERENCES tenants(id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE,
+    CONSTRAINT ck_tenant_closure_self_row_barrier
+        CHECK (ancestor_id <> descendant_id OR barrier = 0),
+    CONSTRAINT ck_tenant_closure_barrier_nonnegative
+        CHECK (barrier >= 0)
+);
+
+CREATE INDEX idx_tenant_closure_ancestor_barrier_status
+    ON tenant_closure (ancestor_id, barrier, descendant_status);
+
+CREATE INDEX idx_tenant_closure_descendant
+    ON tenant_closure (descendant_id);
+
+COMMENT ON TABLE tenant_closure
+    IS 'AM-owned transitive ancestry table used by Tenant Resolver for barrier-aware hierarchy reads over source-of-truth storage.';
+COMMENT ON COLUMN tenant_closure.barrier
+    IS 'Bit-encoded barrier flags on path (ancestor, descendant] (ancestor excluded, descendant included). v1 uses bit 0 for self_managed; barrier = 0 means no respected barrier on the path, barrier != 0 means at least one is set. The column is SMALLINT (signed 2-byte int, -32768..32767 on both PostgreSQL and MySQL) and ck_tenant_closure_barrier_nonnegative enforces CHECK (barrier >= 0), so the usable non-negative domain is 0..32767. That yields 15 usable flag bits (bits 0..14); the sign bit (bit 15) is unavailable because a value with bit 15 set overflows the signed positive range and/or trips the CHECK. 15 flag bits remain ample for the multi-dimensional barrier types contemplated in TENANT_MODEL.md, and SMALLINT stays portable across PostgreSQL and MySQL without dialect-specific type mapping. Self-rows must remain 0.';
+COMMENT ON COLUMN tenant_closure.descendant_status
+    IS 'Denormalized SDK-visible lifecycle state for descendant_id. Domain is {1=active, 2=suspended, 3=deleted} — the internal provisioning state (tenants.status = 0) is excluded by construction: closure rows are inserted on the provisioning→active transition and removed on hard-delete, so tenant_closure never contains provisioning rows. This keeps the closure a clean publication contract for replication to business modules — consumers do not need provisioning-specific filtering.';
 
 -- ── Tenant metadata ──────────────────────────────────────────────────────────
 
@@ -78,7 +134,7 @@ CREATE INDEX idx_tenant_metadata_schema_uuid
     ON tenant_metadata (schema_uuid);
 
 COMMENT ON TABLE tenant_metadata
-    IS 'Extensible tenant-scoped metadata entries validated against GTS-registered schemas.';
+    IS 'Extensible tenant-scoped metadata entries validated against GTS-registered schemas. Per-schema inheritance policy (ADR-0002 `cpt-cf-account-management-adr-metadata-inheritance`) is NOT enforced at the storage layer: each row stores only the value written directly on `tenant_id`. Inherited resolution is performed at READ time by the application-layer `MetadataService::resolve` (DESIGN §3.2 MetadataService), which walks the `parent_id` ancestor chain and stops at self-managed barriers for `inherit` schemas. Direct SQL readers that bypass `MetadataService` will therefore see only directly-written values — this is deliberate (ADR-0002: walk-up read resolution, no write amplification) and is the reason there is no CHECK/trigger/materialized inheritance on this table.';
 COMMENT ON COLUMN tenant_metadata.schema_uuid
     IS 'Deterministic UUIDv5 derived from schema_id using the GTS namespace constant; primary storage and index key for metadata lookups.';
 COMMENT ON COLUMN tenant_metadata.value
@@ -136,4 +192,4 @@ COMMENT ON TABLE conversion_requests
 COMMENT ON COLUMN conversion_requests.requested_by
     IS 'Canonical platform subject UUID from SecurityContext. Raw provider user identifiers are not stored here.';
 COMMENT ON COLUMN conversion_requests.deleted_at
-    IS 'Soft-delete tombstone for resolved-history retention. Default API reads exclude tombstoned rows.';
+    IS 'Soft-delete tombstone. Stamped by the AM retention job when `resolved_retention` (default 30d) elapses past the row reaching a terminal status (`approved`, `cancelled`, `rejected`, `expired`). Default API reads filter `deleted_at IS NULL`. Hard-delete occurs on AM''s platform retention cadence.';

--- a/modules/system/account-management/docs/tr-plugin/ADR/ADR-001-tenant-hierarchy-closure-ownership.md
+++ b/modules/system/account-management/docs/tr-plugin/ADR/ADR-001-tenant-hierarchy-closure-ownership.md
@@ -1,0 +1,166 @@
+---
+status: accepted
+date: 2026-04-21
+decision-makers: Cyber Fabric Platform team
+---
+
+# ADR-001: Tenant Hierarchy Closure Ownership
+
+**ID**: `cpt-cf-tr-plugin-adr-p1-tenant-hierarchy-closure-ownership`
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Comparative Table](#comparative-table)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [AM tree plus Tenant Resolver closure](#am-tree-plus-tenant-resolver-closure)
+  - [AM tree plus AM generic closure](#am-tree-plus-am-generic-closure)
+  - [AM tree plus AM canonical closure](#am-tree-plus-am-canonical-closure)
+  - [AM implements full Tenant Resolver trait logic](#am-implements-full-tenant-resolver-trait-logic)
+- [More Information](#more-information)
+
+<!-- /toc -->
+
+## Context and Problem Statement
+
+The platform needs a fast transitive hierarchy read model for tenant traversal, barrier-aware enforcement, and subtree membership checks. Account Management (AM) is the canonical owner of tenant hierarchy state (`id`, `parent_id`, `status`, `self_managed`, tenant type), while Tenant Resolver (TR) is being designed as the hot-path query module consumed by AuthZ and other policy-facing flows.
+
+Two platform-level facts frame the problem:
+
+1. The `tenant_closure` table is standardized at the platform level in [TENANT_MODEL.md](../../../../../../docs/arch/authorization/TENANT_MODEL.md) with the canonical schema `(ancestor_id, descendant_id, barrier, descendant_status)`. The `barrier` column and denormalized `descendant_status` are part of the platform-canonical closure shape — they are not resolver-specific extensions.
+2. AM already owns barrier state as data (`self_managed` boolean on the `tenants` row) under the `cpt-cf-account-management-principle-barrier-as-data` principle, and AM already performs barrier-aware ancestor walks on the hot path for metadata inheritance (see `cpt-cf-account-management-adr-metadata-inheritance` and `cpt-cf-account-management-fr-tenant-metadata-api`). Barrier semantics are already part of AM's internal domain, not an imported resolver concern.
+
+The architectural question is whether to keep a split where TR owns a separate closure projection synchronized from AM, or to consolidate closure ownership into AM alongside the canonical tree, following the pattern already used by Resource Group (which owns both `resource_group` and `resource_group_closure`).
+
+## Decision Drivers
+
+- Preserve clear ownership of canonical tenant data (`cpt-cf-tr-plugin-principle-query-facade`)
+- Avoid cross-module synchronization boundaries when the underlying data has a single writer
+- Align with the platform-canonical `tenant_closure` schema defined in `TENANT_MODEL.md`
+- Meet hot-path traversal/query NFRs without introducing projection freshness windows
+- Keep barrier traversal semantics aligned with the Tenant Resolver SDK source of truth
+- Avoid coupling AM to resolver-specific query semantics that do not already belong to AM's domain
+- Follow the ownership pattern established by Resource Group (canonical tree and canonical closure co-located)
+
+## Considered Options
+
+- **Option 1: AM tree + Tenant Resolver closure** — AM owns canonical tenant hierarchy; Tenant Resolver owns and rebuilds the closure projection from AM's sync-oriented contract.
+- **Option 2: AM tree + AM generic closure** — AM owns canonical hierarchy and a generic closure table (`ancestor_id`, `descendant_id`, `depth`), while Tenant Resolver remains a facade for barrier/status/query semantics.
+- **Option 3: AM tree + AM canonical closure** — AM owns canonical hierarchy and the platform-canonical `tenant_closure` including `barrier` and `descendant_status` as defined in `TENANT_MODEL.md`. Tenant Resolver becomes a query facade over AM-owned canonical storage.
+- **Option 4: AM implements full Tenant Resolver trait logic** — AM owns canonical hierarchy and directly implements the full `TenantResolverPluginClient` behavior, making Tenant Resolver a facade-free or nearly facade-free compatibility layer.
+
+## Decision Outcome
+
+Chosen option: **Option 3 — AM tree + AM canonical closure**.
+
+AM owns both the canonical tenant tree and the platform-canonical `tenant_closure` table `(ancestor_id, descendant_id, barrier, descendant_status)`. Closure maintenance occurs transactionally alongside tenant writes in AM. Tenant Resolver remains a distinct module but is scoped to query facade responsibilities — `BarrierMode` application, ordering guarantees, pagination, and the SDK surface consumed by AuthZ and other clients. Tenant Resolver does not own a derived projection, does not run a `SyncEngine`/`ClosureWriter`, and does not consume a sync-oriented AM capability.
+
+Two facts support consolidating closure ownership in AM:
+
+1. The `tenant_closure` schema in `TENANT_MODEL.md` already includes `barrier` and `descendant_status` as canonical columns. The closure shape is platform-canonical; AM adopting it does not import resolver-specific concerns.
+2. AM already encodes barrier semantics natively — `self_managed` is a tenant-row flag and AM already walks the hierarchy with barrier awareness for metadata inheritance. Maintaining the barrier flag in `tenant_closure` is a performance materialization of logic AM already runs.
+
+The AM tenant write model is favorable to in-AM closure maintenance:
+
+- **Create** — O(depth) inserts per new tenant.
+- **Soft delete** — flips `tenants.status` to `'deleted'` and, because `tenant_closure.descendant_status` is denormalized from `tenants.status` (closure-status denormalization invariant), also performs O(depth) updates on `tenant_closure.descendant_status` for every row where `descendant_id = X`; no closure row is inserted or removed. This is the same shape as the generic Status change entry below — it is called out separately here so maintainers know the soft-delete path still carries the O(depth) closure-denormalization cost.
+- **Hard delete** — restricted to leaves by `cpt-cf-account-management-fr-tenant-soft-delete`; O(depth) deletes.
+- **Status change** — O(depth) updates to denormalized `tenant_closure.descendant_status` on rows where `descendant_id = X` (same mechanism as Soft delete; covers `active ↔ suspended` and the soft-delete flip to `deleted`).
+- **Convert (self_managed toggle)** — O(strict_ancestors(X) × (1 + descendants(X))) updates to the `barrier` column. Bounded by depth and subtree size; convert is a rare dual-consent operation (`cpt-cf-account-management-fr-mode-conversion-approval`).
+- **Subtree move** — not supported in AM; `update_tenant` mutates only `name` and `status` (`cpt-cf-account-management-fr-tenant-update`).
+
+Consolidating closure ownership in AM removes the operational complexity that a split ownership model would require — drift detection, revision tokens, rebuild loops, projection freshness windows, and dual representation of hierarchy state across two modules.
+
+### Consequences
+
+- Hierarchy state exists in exactly one module and one database. No cross-module projection, no freshness window between commit and enforcement.
+- AM owns closure maintenance transactionally with tenant writes. Write amplification is bounded: linear in depth for create/delete/status, bounded by ancestors × subtree size for convert.
+- Tenant Resolver's role narrows to a query facade: `BarrierMode` application, ordering, pagination, SDK contract. It no longer owns a derived projection or a sync loop.
+- Resource Group's co-located tree-plus-closure pattern becomes the uniform platform pattern for hierarchical domains.
+- No AM-exposed sync capability (canonical enumeration + revision/change token) is required. AM's public contract remains request-oriented rather than sync-oriented.
+- Tenant Resolver DESIGN and PRD must be updated: removal of `SyncEngine`, `ClosureWriter`, `tenant_closure` ownership, drift-detection contract, and associated NFRs. AM DESIGN must be updated to introduce the `tenant_closure` table and closure-maintenance responsibilities in `TenantService` and the conversion flow.
+- A future event-driven design (VHP-460) can still be revisited, but its motivation shrinks because the primary driver — cross-module projection lag — no longer exists.
+
+### Confirmation
+
+- AM DESIGN introduces `tenant_closure` with the platform-canonical schema `(ancestor_id, descendant_id, barrier, descendant_status)` and allocates closure maintenance to `TenantService` write paths and `ConversionService::approve`.
+- Tenant Resolver DESIGN removes `SyncEngine`, `ClosureWriter`, `tenant_closure` ownership, revision-token contract, drift-detection FRs, and projection-availability NFR scoped to a derived model.
+- Tenant Resolver DESIGN retains the SDK surface (`TenantResolverPluginClient`) and adds a direct data dependency on AM-owned storage (via a read-only database contract or a read-oriented client).
+- Tenant Resolver connects to AM-owned storage through its own **dedicated SecureConn connection pool** bound to the read-only role — physically separate from AM's writer pool — so plugin hot-path read traffic and AM writer traffic are isolated at the pool layer and cannot starve one another. Pool sizing, saturation alerts (`tenant_resolver_db_pool_waiters` / `tenant_resolver_db_pool_utilization`), and per-statement `query_timeout` are owned by the plugin, not AM.
+- AM does not expose a sync capability (canonical enumeration + revision/change token).
+- No parallel projection of tenant hierarchy state exists outside AM.
+- Integration tests verify closure invariants on create/delete/status/convert without an intervening sync step.
+
+## Comparative Table
+
+| Option | Ownership clarity | Write-path complexity | Read-path performance fit | Coupling to resolver semantics | Freshness model | Impact on Tenant Resolver role | Fit |
+|--------|-------------------|-----------------------|----------------------------|-------------------------------|----------------|-------------------------------|--------|
+| **AM tree + Tenant Resolver closure** | Dual ownership: AM owns source tree, TR owns derived read model | Medium in TR, low in AM, plus revision-token writes in AM | Strong once projection is fresh | Low-to-medium: AM exposes sync contract only | Poll-driven, bounded by revision-token check + rebuild | TR owns a derived projection and sync loop | Viable, but pays permanent sync overhead |
+| **AM tree + AM generic closure** | AM owns tree and a generic transitive model; TR owns barrier/status/order semantics at query time | Low-medium in AM (closure only, no barrier materialization) | Good, but barrier filtering requires path-joins at query time | Low | Transactional with source writes; no sync lag | TR filters and shapes queries over AM's generic closure | Clean, but diverges from platform-canonical `tenant_closure` schema |
+| **AM tree + AM canonical closure** | Single owner for tree and canonical closure | Bounded: O(depth) for create/delete/status; O(ancestors × subtree) for rare convert; no subtree moves | Strong: platform-canonical barrier-aware closure enables O(1)-JOIN filtering | Low: `barrier` and `status` are canonical tenant data, not resolver-imported concepts | Transactional with source writes; no sync lag | TR becomes a query facade over AM-owned canonical storage | **Best fit** |
+| **AM implements full Tenant Resolver trait logic** | Single owner for tree, closure, and resolver behavior | Highest: AM owns write model, closure, and full resolver semantics | Potentially strong, but pushes hot-path concerns into AM | Very high: AM is directly coupled to the Tenant Resolver SDK contract | Transactional with source writes; no sync lag | TR becomes a compatibility shim or is eliminated | Overreach; collapses useful module boundary |
+
+## Pros and Cons of the Options
+
+### AM tree plus Tenant Resolver closure
+
+- Good, because canonical data ownership and hot-path read-model ownership are explicitly separated.
+- Good, because Tenant Resolver can evolve projection internals independently of AM storage.
+- Bad, because it introduces a permanent synchronization surface — revision tokens, poll loops, rebuild orchestration, drift detection — that has no corresponding business requirement.
+- Bad, because hierarchy state is materialized twice across two modules, doubling the failure surface (projection staleness, rebuild failure, drift).
+- Bad, because AM still pays write-side cost (revision-token maintenance on every hierarchy mutation) without gaining a simpler contract.
+- Bad, because the closure projection shape TR would maintain is the platform-canonical shape; splitting its ownership from the source tree is structural duplication rather than separation of concerns.
+
+### AM tree plus AM generic closure
+
+- Good, because a generic closure is the minimal addition to AM and can be maintained transactionally with source writes.
+- Good, because Tenant Resolver retains clear query-semantics ownership without consuming a derived projection.
+- Bad, because it diverges from the platform-canonical `tenant_closure` schema in `TENANT_MODEL.md`, which already includes `barrier` and `descendant_status`.
+- Bad, because barrier-aware queries require per-query path joins to check barriers along the path, pushing read-time cost back onto every caller.
+- Bad, because `descendant_status` denormalization is already standard in the platform closure schema; omitting it forces TR or callers to re-derive what the platform already defines.
+
+### AM tree plus AM canonical closure
+
+- Good, because AM owns one coherent aggregate — tree, barrier, closure — with transactional consistency and no cross-module sync.
+- Good, because the closure shape matches `TENANT_MODEL.md` directly; there is no new or resolver-specific schema to define.
+- Good, because barrier is already an AM-native concept (`cpt-cf-account-management-principle-barrier-as-data`) and AM already runs barrier-aware hierarchy walks on the hot path for metadata inheritance.
+- Good, because the AM write surface is favorable: create/delete/status are O(depth), convert is rare and bounded, subtree moves are not supported.
+- Good, because it aligns with the Resource Group pattern of co-located tree and closure ownership, making hierarchy ownership uniform across the platform.
+- Good, because Tenant Resolver's role narrows to a query facade — a simpler, more cohesive responsibility — without becoming a compatibility shim.
+- Bad, because AM takes on closure maintenance on hierarchy mutations, including non-trivial amplification on the rare convert operation.
+- Bad, because Tenant Resolver DESIGN and PRD require non-trivial updates — removal of `SyncEngine`, `ClosureWriter`, drift-detection contract, and related NFRs.
+- Bad, because TR depends directly on AM-owned storage (read-only), which narrows the AM/TR contract surface but requires explicit agreement on the shared schema and its evolution.
+
+### AM implements full Tenant Resolver trait logic
+
+- Good, because a single module owns canonical state and traversal behavior with no intermediate abstraction.
+- Bad, because AM becomes directly responsible for `TenantResolverPluginClient` semantics — `BarrierMode`, ordering, pagination, hot-path latency — which are genuinely resolver concerns unrelated to administrative correctness.
+- Bad, because it collapses a useful module boundary; AM starts absorbing responsibilities that do not belong to administrative source-of-truth ownership.
+- Bad, because Tenant Resolver becomes a redundant abstraction or a legacy compatibility wrapper with no clear independent purpose.
+- Bad, because it is the largest redesign and provides no incremental value over Option 3, where TR retains a meaningful query-facade role.
+
+## More Information
+
+- Impacted artifacts (updates applied as of 2026-04-22):
+  - [PRD](../PRD.md) — rescoped to query-facade semantics; sync contract assumptions, drift detection, and projection ownership removed.
+  - [DESIGN](../DESIGN.md) — `SyncEngine` / `ClosureWriter` / `tenant_closure` ownership removed; direct read dependency on AM storage documented; SDK surface retained.
+  - [AM DESIGN](../../../docs/DESIGN.md) — `tenant_closure` introduced with platform-canonical schema; closure maintenance allocated to `TenantService` and `ConversionService::approve`; no sync-oriented capability introduced — see the **Barrier as Data** principle under §2.1 *Design Principles* and FR `cpt-cf-account-management-fr-tenant-closure` referenced from §1.2 *Architecture Drivers* (Functional Drivers mapping) for the integrated prose.
+  - [AM PRD](../../../docs/PRD.md) — canonical closure ownership added to AM scope via FR `cpt-cf-account-management-fr-tenant-closure` under §4.1 *In Scope* and §5.2 *Tenant Hierarchy Management*. References use FR slugs (which are stable) rather than line numbers (which drift on reflow).
+- Removed / rescoped requirements (retained for historical audit; these slugs carried the live `cpt-cf-tr-plugin-*` prefix in the pre-ADR draft PRD and are no longer definitions anywhere):
+  - ~~fr-full-sync~~ — removed; no sync path exists.
+  - ~~fr-drift-detection~~ — removed; transactional consistency replaces drift detection.
+  - ~~nfr-sync-integrity~~ — removed.
+  - ~~nfr-projection-availability~~ — rescoped or removed; availability now tracks AM storage availability.
+- Platform references:
+  - [TENANT_MODEL.md](../../../../../../docs/arch/authorization/TENANT_MODEL.md) — canonical `tenant_closure` schema with `barrier` and `descendant_status`.
+  - [RESOURCE_GROUP_MODEL.md](../../../../../../docs/arch/authorization/RESOURCE_GROUP_MODEL.md) — precedent for co-located tree plus closure ownership (`resource_group` + `resource_group_closure`).
+  - `cpt-cf-account-management-principle-barrier-as-data` — barrier as AM-native data.
+  - `cpt-cf-account-management-adr-metadata-inheritance` — AM already performs barrier-aware ancestor walks on the hot path.
+- Future reconsideration:
+  - Revisit if AM hierarchy write rates or convert frequency change materially and make in-AM closure maintenance a measured bottleneck.
+  - Revisit if VHP-460 event-driven sync introduces an independent reason to externalize projection ownership beyond current motivations.

--- a/modules/system/account-management/docs/tr-plugin/DESIGN.md
+++ b/modules/system/account-management/docs/tr-plugin/DESIGN.md
@@ -1,0 +1,753 @@
+Created: 2026-04-21 by Diffora
+
+# Technical Design — Tenant Resolver Plugin (AM-backed)
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-design-tr-plugin`
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database schemas & tables](#37-database-schemas--tables)
+  - [3.8 Error Codes Reference](#38-error-codes-reference)
+- [4. Additional Context](#4-additional-context)
+  - [4.1 Applicability and Delegations](#41-applicability-and-delegations)
+  - [4.2 Security Architecture](#42-security-architecture)
+  - [Threat Modeling](#threat-modeling)
+  - [4.3 Reliability and Operations](#43-reliability-and-operations)
+  - [Data Governance](#data-governance)
+  - [Testing Architecture](#testing-architecture)
+  - [Open Questions](#open-questions)
+  - [Documentation Strategy](#documentation-strategy)
+  - [Known Limitations & Technical Debt](#known-limitations--technical-debt)
+  - [4.4 Scope Exclusions](#44-scope-exclusions)
+- [5. Traceability](#5-traceability)
+
+<!-- /toc -->
+
+> **Abbreviations**: Account Management = **AM**; Tenant Resolver Plugin = **TRP**; Global Type System = **GTS**. Used throughout this document.
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+The Tenant Resolver Plugin is a **query facade** over the tenant hierarchy owned by [Account Management](../DESIGN.md). It implements the CyberFabric [`TenantResolverPluginClient`](../../../tenant-resolver/tenant-resolver-sdk/src/plugin_api.rs) trait (`get_tenant`, `get_root_tenant`, `get_tenants`, `get_ancestors`, `get_descendants`, `is_ancestor`) by reading AM-owned `tenants` and `tenant_closure` tables directly through a dedicated read-only database role. The plugin owns no data, no schema, and no sync loop. Every SDK call is a single indexed read against AM-owned storage for hierarchy state; the only process-local state is a bounded lazy cache that reverse-resolves `tenant_type_uuid` to the public chained `tenant_type` string.
+
+Hierarchy state lives in exactly one place and in exactly one transaction scope. AM maintains `tenant_closure` transactionally with tenant writes ([`cpt-cf-account-management-fr-tenant-closure`](../PRD.md)), so the plugin never observes partial, lagged, or drifting hierarchy state. Barrier and status enforcement reduce to filter predicates on the canonical closure shape `(ancestor_id, descendant_id, barrier, descendant_status)` from [TENANT_MODEL.md](../../../../../docs/arch/authorization/TENANT_MODEL.md); the plugin applies `BarrierMode`, status filters, and SDK ordering guarantees at query time over those columns.
+
+The plugin is **not** a standalone replaceable component. It is Account Management's internal adapter to the Tenant Resolver SDK contract and ships as a module inside the `account-management` crate at `modules/system/account-management/src/tr_plugin/`. Co-location is deliberate: the plugin's correctness relies on AM-writer invariants (transactional `(tenants, tenant_closure)` maintenance, self-row existence, barrier materialization over `(ancestor, descendant]`, provisioning-lifecycle semantics) that the table shape alone does not express. Shipping the plugin as a standalone crate would implicitly advertise reusability against any "compatible" two-table schema that the plugin cannot validate at runtime; keeping it inside the AM crate binds it to the one writer whose invariants it trusts. The hosting [Tenant Resolver](../../../tenant-resolver/) gateway discovers the plugin via GTS types-registry and resolves it through `ClientHub`. The plugin does not call `AccountManagementClient` for SDK traffic; it connects to AM-owned storage through the SecureConn pool assigned to a read-only database role scoped to `tenants` + `tenant_closure`.
+
+#### System Context
+
+```mermaid
+graph LR
+    AuthZ["AuthZ Resolver<br>Plugin"] -->|hierarchy & barrier<br>queries| GW["Tenant Resolver<br>Gateway"]
+    GW -->|delegates<br>in-process| TRP["Tenant Resolver<br>Plugin (this module)"]
+    TRP -->|"read-only role<br>over tenants + tenant_closure"| AMDB[("AM storage")]
+    AM["Account<br>Management"] ---|"transactional writer<br>(tree + closure)"| AMDB
+```
+
+**System actors by PRD ID**
+
+- [`cpt-cf-tr-plugin-actor-tenant-resolver-gateway`](PRD.md#tenant-resolver-gateway) delegates plugin calls from the Tenant Resolver gateway.
+- [`cpt-cf-tr-plugin-actor-authz-resolver`](PRD.md#authz-resolver-plugin) drives the hot-path read traffic via the gateway.
+- [`cpt-cf-tr-plugin-actor-account-management`](PRD.md#account-management) owns the tenant tree and canonical `tenant_closure`.
+- [`cpt-cf-tr-plugin-actor-operator`](PRD.md#platform-operator) owns the read-only role provisioning and consumes observability.
+
+### 1.2 Architecture Drivers
+
+#### Functional Drivers
+
+| Requirement | Design Response |
+|-------------|-----------------|
+| `cpt-cf-tr-plugin-fr-plugin-api` | `PluginImpl` implements the SDK trait and registers with the gateway through `ClientHub` using the plugin's GTS instance identifier as scope. |
+| `cpt-cf-tr-plugin-fr-get-tenant` | `PluginImpl::get_tenant` reads a single `tenants` row by id, excluding provisioning rows, and projects it to `TenantInfo`. Returns `TenantNotFound` for unknown IDs or provisioning rows, regardless of SDK-visible status. |
+| `cpt-cf-tr-plugin-fr-get-root-tenant` | `PluginImpl::get_root_tenant` reads the unique `tenants` row that has no parent and a non-provisioning status, and returns `Internal` if AM storage does not currently satisfy the single-root invariant (including the bootstrap window when the sole root is still provisioning). |
+| `cpt-cf-tr-plugin-fr-get-tenants` | `PluginImpl::get_tenants` issues a single bulk-by-ids read against `tenants`, excluding provisioning rows, then applies `GetTenantsOptions.status` as an additional filter. Input IDs are deduplicated and missing or provisioning rows are silently dropped. |
+| `cpt-cf-tr-plugin-fr-get-ancestors` | `PluginImpl::get_ancestors` validates the starting tenant exists and is not provisioning, uses its AM row to populate `response.tenant`, then reads AM's `tenant_closure` for strict-ancestor rows (descendant = starting id, ancestor ≠ descendant) joined to `tenants` for hydration (excluding provisioning), ordered by `tenants.depth` descending with `tenants.id` as a deterministic tie-break (direct parent first, root last). Under `BarrierMode::Respect` the strict-ancestor rows are further restricted to those with `barrier` clear. No application-layer hierarchy traversal is performed. Because AM defines `barrier` over `(ancestor, descendant]`, this yields the SDK behavior exactly: a self-managed starting tenant returns empty ancestors, while the nearest self-managed ancestor is included and traversal stops above it. |
+| `cpt-cf-tr-plugin-fr-get-descendants` | `PluginImpl::get_descendants` validates the starting tenant exists and is not provisioning, uses its AM row to populate `response.tenant`, then issues a single bounded recursive read that walks `tenants.parent_id` rooted at the starting tenant (bounded by `max_depth`, siblings ordered by `id`) and joins `tenant_closure` on `(ancestor = starting_tenant, descendant)` to apply caller-supplied status and barrier mode. Provisioning exclusion is structural — the closure has no provisioning rows by contract — and does not require a plugin-side predicate on `descendant_status`. The recursive walk is ordering work — it is how the SDK's pre-order contract is satisfied without an AM-materialized pre-order key — and does not re-evaluate barrier or status semantics, which remain predicates on the canonical closure row. Because AM defines `barrier` over `(ancestor, descendant]`, `Respect` excludes self-managed children and their subtrees while still allowing traversal from inside a self-managed tenant's own subtree. Status filter does not apply to the starting tenant (per SDK contract). |
+| `cpt-cf-tr-plugin-fr-is-ancestor` | `PluginImpl::is_ancestor` returns `false` for self-reference, validates both tenant IDs exist and are not provisioning, and then checks `tenant_closure` for a strict-ancestor row with the requested barrier filter applied. Under `BarrierMode::Respect`, the same `(ancestor, descendant]` encoding makes a self-managed descendant endpoint return `false` without any extra endpoint-specific branch. |
+| `cpt-cf-tr-plugin-fr-barrier-semantics` | AM populates `tenant_closure.barrier` (integer bitmask, v1 uses bit 0 for self_managed) under [`cpt-cf-account-management-fr-tenant-closure`](../PRD.md) so that the barrier bit is set iff some tenant on `(ancestor, descendant]` is self-managed, with self-rows fixed to clear; every SDK operation with `BarrierMode::Respect` therefore reduces to a single predicate on this column. Descendant ordering via the plugin-computed recursive walk does not replicate or override this predicate. |
+| `cpt-cf-tr-plugin-fr-status-filtering` | AM populates `tenant_closure.descendant_status` denormalized on every tenant status transition between SDK-visible states (`active`, `suspended`, `deleted`). Because provisioning tenants are not in the closure by contract, `descendant_status` never carries a provisioning value; the plugin filters caller-supplied status directly on this column with no additional provisioning predicate. |
+| `cpt-cf-tr-plugin-fr-provisioning-invisibility` | Provisioning invisibility is enforced primarily by AM's schema contract: `tenant_closure` contains no rows for tenants in `provisioning` state (see [`cpt-cf-account-management-fr-tenant-closure`](../PRD.md)), so closure-driven reads (`get_descendants`, `is_ancestor`, `get_ancestors`) cannot surface provisioning tenants even before plugin-side filtering. Defense-in-depth: reads of `tenants` (existence probes, bulk-by-ids, ancestor hydration JOINs) still drop provisioning rows in the query-builder, so a provisioning row can never appear in an SDK response regardless of which table the plugin hits. The rule is not opt-in and is exercised on every SDK method. |
+| `cpt-cf-tr-plugin-fr-observability` | OpenTelemetry telemetry (see §4.3) covers query latency histograms, query-shape distribution, barrier enforcement rate, barrier-bypass audit signal, and tenant-not-found rate. |
+
+#### NFR Allocation
+
+| NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
+|--------|-------------|--------------|-----------------|----------------------|
+| `cpt-cf-tr-plugin-nfr-query-latency` | `get_tenant` / `get_root_tenant` / `get_ancestors` / `is_ancestor` p95 ≤ 5ms on indexed read; `get_tenants` p95 ≤ 10ms at batch size ≤ 128 | SecureConn pool + AM closure indexes + bounded `tenant_type` cache | `get_tenant` / `get_root_tenant` are a single indexed read with the provisioning exclusion applied on the row; `get_tenants` is a single bulk-by-ids lookup bounded by batch size; `get_ancestors` / `is_ancestor` are at most two indexed reads per call (existence probe on `tenants` by id + closure read by descendant or by ancestor/descendant pair). Ancestor ordering is driven by AM's stable `tenants.depth` column, direct parent first and root last with `tenants.id` as tie-break — no application-layer walk. Connection pool sized against the gateway's concurrency profile; AM owns the index coverage documented in [§3.7 Database schemas & tables](#37-database-schemas--tables). | Microbenchmarks on 10K and 200K tenant fixtures with warm connection pool and warm `tenant_type` cache; separate cold-start/cache-miss verification; batch microbenchmarks at sizes 1, 16, 128. |
+| `cpt-cf-tr-plugin-nfr-subtree-latency` | `get_descendants` p99 ≤ 20ms for result sets ≤ 1 000 rows | AM closure indexes + `tenants(parent_id, status)` + `max_depth` + existence probe | Two-step plan: an existence probe on `tenants` by id, then a single bounded recursive read rooted at the starting tenant that walks `tenants.parent_id` (leveraging `idx_tenants_parent_status`) and joins `tenant_closure` on `(ancestor = starting_tenant, descendant)` (leveraging the closure primary key) to apply `barrier` and `descendant_status` as filter predicates. Provisioning exclusion is structural (closure contains no provisioning rows), so no additional filter predicate is needed on the join. `max_depth` is applied as the recursion bound; for an N-row result set the walk does O(N) work on `tenants(parent_id, status)` plus O(N) primary-key lookups on `tenant_closure`. Unbounded subtrees (`max_depth = None` on a large ancestor) are outside this NFR — governed by `query_timeout` and gateway rate limiting. | Load test with representative subtree shapes at the 1 000-row boundary. |
+| `cpt-cf-tr-plugin-nfr-closure-consistency` | Every SDK read observes a transactionally consistent `(tenants, tenant_closure)` pair | AM transactional closure maintenance | AM commits tree and closure mutations in one transaction (see [`cpt-cf-account-management-fr-tenant-closure`](../PRD.md)); the plugin performs no caching or replication. | Integration test: concurrent tenant writes and plugin reads verify no partial-state window. |
+| `cpt-cf-tr-plugin-nfr-tenant-isolation` | Queries never cross a respected barrier | Closure `barrier` column (integer bitmask) + SDK options | Every operation with `BarrierMode::Respect` applies the barrier-clear filter against AM's `(ancestor, descendant]` barrier encoding (v1 single-bit form of the wider bitmask); `BarrierMode::Ignore` is reserved for operator/billing flows authorized by the caller. | Barrier matrix integration tests covering every operation × mode combination, including self-managed starting-tenant and descendant-endpoint cases. |
+| `cpt-cf-tr-plugin-nfr-audit-trail` | Every plugin read is observable | Structured logs + OpenTelemetry telemetry | `trace_id` from the active OpenTelemetry context is propagated into logs, traces, and metric attributes; `request_id` is included when the gateway provides one. | Log assertion in integration test; ensure trace context propagates to DB spans and `request_id` appears in logs when present. |
+| `cpt-cf-tr-plugin-nfr-observability` | Operator dashboards cover Performance, Reliability, Security, Versatility | OpenTelemetry telemetry set (§4.3) | Minimum 3 telemetry instruments per applicable quality vector exported via the platform telemetry pipeline. | Dashboard/alert review in staging. |
+
+#### Key ADRs
+
+- [`cpt-cf-tr-plugin-adr-p1-tenant-hierarchy-closure-ownership`](ADR/ADR-001-tenant-hierarchy-closure-ownership.md) — AM owns canonical `tenants` + `tenant_closure`; the plugin is a pure query facade that reads AM-owned storage via a read-only database role.
+
+### 1.3 Architecture Layers
+
+- [ ] `p3` - **ID**: `cpt-cf-tr-plugin-tech-modkit-stack`
+
+| Layer | Responsibility | Technology |
+|-------|---------------|------------|
+| SDK | Public plugin trait and transport-agnostic models consumed from `tenant-resolver-sdk`; not redefined here | Rust SDK crate + ClientHub-compatible trait surface |
+| Plugin API | SDK method handling, gateway integration, option/result translation | Rust services + ModKit `ClientHub` registration |
+| Domain | Barrier-mode application, SDK ordering, status filtering, `max_depth` bounds | Rust domain services |
+| Infrastructure | Read-only database access to AM-owned storage | SecureConn pool bound to the plugin's read-only role |
+
+**Technology stack alignment.** The stack (Rust + ModKit + SecureConn + AM-owned relational storage) is the platform standard used by every sibling CyberFabric module (Account Management, OAGW, Resource Group), so team-capability alignment is a platform property rather than a plugin-local one. Long-term maintainability is anchored by the SDK contract's stability zone (see [§2.2 Platform Versioning Policy](#platform-versioning-policy)) — no plugin-local technology risk is introduced beyond what the platform already carries. Plugin-visible technology risks are surfaced in [§4.3 Known Limitations & Technical Debt](#known-limitations--technical-debt).
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Query Facade over AM-owned Storage
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-principle-query-facade`
+
+The plugin owns no data and no schema. Every SDK call resolves to a read against AM's `tenants` and `tenant_closure` tables under the plugin's read-only database role. There is no derived projection and no sync path; hierarchy state is authoritative at the moment of the read. The plugin may maintain a bounded in-process cache only for `tenant_type_uuid -> tenant_type` reverse lookups backed by Types Registry.
+
+#### SDK Is the Public Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-principle-sdk-source-of-truth`
+
+Public types (`TenantInfo`, `TenantRef`, `TenantStatus`, `BarrierMode`, `GetAncestorsOptions`, `GetTenantsOptions`, `GetDescendantsOptions`, `IsAncestorOptions`, `GetAncestorsResponse`, `GetDescendantsResponse`) are owned by `tenant-resolver-sdk`. This DESIGN references them by name and does not restate the definitions. Column-to-field projection is applied at the API boundary; SDK types are the wire contract with the gateway.
+
+#### Barrier as Data, Not as Policy
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-principle-barrier-as-data`
+
+Barrier state is an integer bitmask column on each closure row (v1 uses bit 0 for self_managed — see [TENANT_MODEL.md §Closure Table](../../../../../docs/arch/authorization/TENANT_MODEL.md#closure-table)), populated by AM on every tenant write under [`cpt-cf-account-management-principle-barrier-as-data`](../DESIGN.md#barrier-as-data). AM defines it over `(ancestor, descendant]` with self-rows fixed to clear, so query-time enforcement reduces to a single barrier-clear filter without any extra endpoint-specific barrier logic in the plugin. The plugin does not interpret organizational policy or make authorization decisions — those remain with the AuthZ Resolver.
+
+#### Single-Store Hierarchy
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-principle-single-store`
+
+Tenant hierarchy state is never materialized outside AM. The plugin reads it; other platform modules read it through the SDK. There is no second copy, no rebuild, no drift, no freshness window — consistency is the default, not a target.
+
+### 2.2 Constraints
+
+#### AM-owned Storage Is the Only Backend
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-constraint-am-storage-only`
+
+The plugin connects to the same physical database that AM writes to, under a read-only database role scoped to `tenants` and `tenant_closure`. It does not peer with other tenant sources, federated identity providers, or external CMDBs, and it does not hold any other database credentials.
+
+#### Read-Only Database Role
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-constraint-read-only-role`
+
+The plugin's SecureConn pool is provisioned with read-only grants on `tenants` and `tenant_closure` and no other privilege. Any attempt to mutate AM-owned storage through the plugin role is rejected by the database, not by plugin code. Role provisioning is an operator concern (see [§4.2 Least-Privilege Guidance](#least-privilege-guidance)).
+
+#### No In-Process AM Client for SDK Traffic
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-constraint-no-am-client`
+
+The plugin does not call `AccountManagementClient` on the SDK path. AM's public request-oriented surface is for administrative traffic; hierarchy reads bypass it in favor of the read-only database role, which is cheaper and transactionally consistent with AM writes by construction.
+
+#### SecurityContext Propagation
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-constraint-security-context-passthrough`
+
+Every plugin method receives `SecurityContext` from the gateway and must preserve it through the SDK call path. Observability identifiers are separate from `SecurityContext`: `trace_id` / `span_id` come from the active OpenTelemetry context, and `request_id` may be attached by gateway middleware. The plugin does not enforce authorization itself (that is an AuthZ Resolver concern) but it must not strip or forge `SecurityContext`.
+
+#### No Public Wire API
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-constraint-no-wire-api`
+
+The plugin exposes no REST/gRPC endpoints. All observability is via OpenTelemetry signals and structured logs; all functional surface is the SDK trait. This keeps the plugin replaceable behind the gateway.
+
+#### Platform Versioning Policy
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-constraint-versioning-policy`
+
+The plugin follows the same compatibility policy as the rest of the platform: no breaking SDK changes within a minor release. The shared schema with AM evolves under AM's migration policy; the plugin depends on AM-owned column names and types listed in [§3.5 External Dependencies — Account Management Storage](#account-management-storage) and coordinates any rename/removal with AM in the same release.
+
+#### Scope Exclusions (constraints out of scope at the plugin layer)
+
+- [ ] `p3` - **ID**: `cpt-cf-tr-plugin-constraint-scope-exclusions`
+
+The following constraint classes are Not applicable at the plugin layer because the plugin is an in-process backend module holding no user data, no third-party vendor dependency, no regulated payload, and no independent team/budget surface:
+
+- **Regulatory constraints** — Not applicable: the plugin stores no credentials, no user PII, and no tokens; regulated-data controls (GDPR / HIPAA / PCI DSS / SOX) are inherited from the platform posture and AM's data-governance stance.
+- **Vendor / licensing constraints** — Not applicable: the plugin's technology choices (Rust + ModKit + SecureConn + AM-owned relational storage) are platform-standard; no plugin-local vendor or licensing dependency exists beyond AM's.
+- **Legacy-system integration constraints** — Not applicable: the plugin is a greenfield Tenant Resolver surface. There is no legacy tenant-hierarchy consumer the plugin must stay compatible with.
+- **Data-residency constraints** — Not applicable at the plugin level: the plugin holds no state; residency is inherited from AM's deployment (single-region for v1, per §1.4 Non-goals in the PRD).
+- **Resource constraints (budget / team / time)** — Not applicable as plugin-local commitments: resourcing follows the platform's shared roadmap and SRE-owned capacity; plugin-level timeline is gated on the pre-GA targets in [PRD §1.3 Success criteria](PRD.md#13-goals-business-outcomes).
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+The plugin reuses SDK types (see [`models.rs`](../../../tenant-resolver/tenant-resolver-sdk/src/models.rs)) as its public domain. It introduces no plugin-specific persisted types; every read is a projection of AM-owned rows onto SDK types at the API boundary.
+
+| Type | ID | Role | Source |
+|------|----|------|--------|
+| `TenantInfo` | *SDK* | Full tenant view returned by `get_tenant`/`get_tenants` | `tenant-resolver-sdk` |
+| `TenantRef` | *SDK* | Lightweight reference returned by `get_ancestors`/`get_descendants` | `tenant-resolver-sdk` |
+| `TenantStatus` | *SDK* | `Active` / `Suspended` / `Deleted` | `tenant-resolver-sdk` |
+| `BarrierMode` | *SDK* | `Respect` (default) / `Ignore` | `tenant-resolver-sdk` |
+
+At the SDK boundary, the plugin exposes `tenant_type` as an opaque public chained GTS schema identifier (for example, `gts.x.core.am.tenant_type.v1~x.core.am.customer.v1~`). Internally, AM stores the `tenant_type_uuid` UUIDv5 surrogate on `tenants`; the plugin reads that UUID, reverse-resolves the public `tenant_type` through Types Registry, and keeps the mapping in a bounded lazy process-local cache. The plugin does not parse or interpret tenant-type traits.
+
+AM's physical `tenants.status` domain includes an internal provisioning value used during bootstrap and the tenant-create saga. Provisioning tenants are kept out of the SDK surface by construction: they are absent from `tenant_closure` entirely (AM inserts closure rows only on the `provisioning → active` transition per [`cpt-cf-account-management-fr-tenant-closure`](../PRD.md)), so `tenant_closure.descendant_status` domain is `{active, suspended, deleted}` and closure-driven reads cannot surface provisioning tenants at all. Direct reads of `tenants` (existence probes, bulk-by-ids, ancestor hydration JOINs) additionally drop provisioning rows as a defense-in-depth filter, so the SDK-visible `TenantStatus` domain is strictly `Active` / `Suspended` / `Deleted` (see [`cpt-cf-tr-plugin-fr-provisioning-invisibility`](PRD.md#provisioning-row-invisibility)).
+
+The plugin does not define its own closure record type. The shape read from AM's `tenant_closure` — `(ancestor_id, descendant_id, barrier, descendant_status)` as specified in [TENANT_MODEL.md](../../../../../docs/arch/authorization/TENANT_MODEL.md) — is the only closure shape in the system, and it is projected directly to SDK `TenantRef` with barrier and status applied as filter predicates at the storage layer.
+
+### 3.2 Component Model
+
+```mermaid
+graph TD
+    GW["Tenant Resolver<br>Gateway"] -->|TenantResolverPluginClient| PI[PluginImpl]
+    PI -->|reads via<br>read-only role| DB[("AM storage<br>tenants + tenant_closure")]
+    AM["Account Management<br>(writer)"] -->|transactional tree +<br>closure mutations| DB
+```
+
+#### PluginImpl
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-component-plugin-impl`
+
+**Why this component exists**
+
+`PluginImpl` is the sole component of the plugin. It exposes the SDK trait to the Tenant Resolver gateway and translates SDK calls into parameterized read queries against AM-owned storage over the plugin's read-only database role.
+
+**Responsibility scope**
+
+- Implements every `TenantResolverPluginClient` method (`get_tenant`, `get_root_tenant`, `get_tenants`, `get_ancestors`, `get_descendants`, `is_ancestor`).
+- Builds the read query for each SDK call against AM's `tenants` + `tenant_closure` (see [§3.6 Interactions & Sequences](#36-interactions--sequences)).
+- Validates tenant existence where the SDK requires `TenantNotFound` instead of an empty result (`get_ancestors`, `get_descendants`, `is_ancestor`).
+- Translates SDK options (`BarrierMode`, status filter, `max_depth`) into filter predicates on the closure row.
+- Normalizes result ordering: ancestors by `tenants.depth` descending with `tenants.id` as tie-break (direct parent first, root last, given AM's root-depth-0 convention); descendants by a deterministic pre-order traversal derived from the joined `tenants` rows.
+- Applies the SDK's barrier semantics per method: `get_ancestors` includes the nearest self-managed ancestor and stops there under `BarrierMode::Respect`; `get_descendants` excludes self-managed children and their subtrees under `Respect`; `is_ancestor` returns `false` when a respected barrier lies on the path.
+- Reverse-resolves `tenant_type_uuid` to the public chained `tenant_type` identifier via Types Registry.
+- Maintains a bounded lazy cache for `tenant_type_uuid -> tenant_type` mappings so repeated reads do not require a Types Registry lookup on every call.
+- Projects AM column values onto SDK types (`TenantInfo`, `TenantRef`) at the API boundary.
+- Preserves `SecurityContext` and emits database spans / structured logs with OpenTelemetry `trace_id` / `span_id`, plus `request_id` when the gateway provides one.
+
+**Responsibility boundaries**
+
+Does not cache hierarchy rows, ancestor chains, descendant sets, or closure state. Does not write to storage. Does not validate `SecurityContext` (the SDK contract delegates that to the plugin, but the plugin trusts the gateway's AuthN projection; any authorization enforcement the gateway needs is added at the gateway layer). Does not interpret closure semantics beyond applying SDK-documented filter predicates. The sole cacheable surface is the bounded `tenant_type_uuid -> tenant_type` reverse lookup; barrier materialization, status denormalization, and pre-order stability remain AM's contract on the shared schema.
+
+**Configuration**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `db_url` | operator-provided | SecureConn target for the read-only database role. |
+| `pool_max_connections` | implementation-defined | Connection-pool upper bound; sized against the gateway's concurrency profile. |
+| `query_timeout` | `5s` | Per-statement timeout enforced at the DB driver level. |
+| `tenant_type_cache_max_entries` | implementation-defined bounded default | Maximum number of cached `tenant_type_uuid -> tenant_type` mappings retained in process. |
+
+### 3.3 API Contracts
+
+#### TenantResolverPluginClient (SDK trait)
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-interface-plugin-client`
+
+- **Technology**: Rust trait + ClientHub
+- **Location**: [`modules/system/tenant-resolver/tenant-resolver-sdk/src/plugin_api.rs`](../../../tenant-resolver/tenant-resolver-sdk/src/plugin_api.rs)
+
+The plugin implements the unmodified SDK trait. The OpenAPI/REST surface exposed by the Tenant Resolver gateway is owned by the gateway, not by this plugin. Method-level semantics (barrier behavior, SDK-contract ordering, status filtering) are described in [§3.2 PluginImpl](#pluginimpl) and the [Drivers table](#functional-drivers). Consumers should always treat the SDK trait doc comments as authoritative.
+
+#### AM-owned schema (consumed, not defined)
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-interface-am-schema`
+
+- **Technology**: Relational tables, owned by AM (dialect-neutral contract; physical DDL lives in AM's migration layer)
+- **Location**: AM-owned — see [`cpt-cf-account-management-dbtable-tenants`](../DESIGN.md#table-tenants) and [`cpt-cf-account-management-dbtable-tenant-closure`](../DESIGN.md#table-tenant_closure)
+
+The plugin depends on AM exposing the following columns under stable names:
+
+| Table | Columns consumed | Purpose |
+|-------|------------------|---------|
+| `tenants` | `id`, `parent_id`, `name`, `tenant_type_uuid` (non-null), `status` (SDK-facing reads drop provisioning rows), `self_managed`, `depth`, `created_at`, `updated_at` | Hydrate `TenantInfo` for `get_tenant` / `get_root_tenant` / `get_tenants`; hydrate `TenantRef` for ancestor/descendant results; reverse-resolve the public `tenant_type` string through Types Registry. `depth` (AM's denormalized absolute depth from the root) supplies the ancestor-depth ordering used by `get_ancestors` and the recursion bound for `get_descendants` `max_depth`. The plugin does **not** read `deleted_at` or any other AM-owned tenant column on the SDK path. |
+| `tenant_closure` | `ancestor_id`, `descendant_id`, `barrier`, `descendant_status` | Answer `get_ancestors`, `get_descendants`, `is_ancestor` with barrier and status filtering applied as filter predicates on the AM-canonical row. AM does **not** expose a pre-order ordering column or a depth-from-ancestor column on this table; descendant pre-order is computed by the plugin at query time via a recursive walk of `tenants.parent_id`. |
+
+Any rename, removal, or type change to these columns requires a coordinated AM + plugin release. The plugin never calls a mutation on AM-owned storage; the read-only database role forbids it at the privilege layer.
+
+### 3.4 Internal Dependencies
+
+| Dependency Module | Interface Used | Purpose |
+|-------------------|----------------|---------|
+| [Tenant Resolver SDK](../../../tenant-resolver/tenant-resolver-sdk/) | `TenantResolverPluginClient` trait + models | Public contract implemented by the plugin. |
+| [Tenant Resolver (gateway)](../../../tenant-resolver/) | Plugin registration via `ClientHub` under the plugin's GTS instance scope | Delegation target for the gateway. |
+| [Types Registry](../../../types-registry/) | Reverse lookup of `tenant_type_uuid` to chained `tenant_type` identifier | Public tenant type hydration for SDK responses. |
+
+**Dependency rules** (per project conventions)
+
+- No circular dependencies.
+- SDK types are referenced by name; they are not redefined in the plugin crate.
+- `SecurityContext` MUST propagate across in-process calls and into database spans.
+
+### 3.5 External Dependencies
+
+#### Account Management Storage
+
+- **Contract**: `cpt-cf-tr-plugin-contract-am-read-only-role`
+
+| Aspect | Detail |
+|--------|--------|
+| Direction | Plugin → AM-owned database, read-only. |
+| Transport | SecureConn pool bound to a dedicated read-only database role; no network boundary with AM itself (AM writes are transactional to the same database). |
+| Tables consumed | `tenants`, `tenant_closure` (AM-owned; see [§3.3 API Contracts](#am-owned-schema-consumed-not-defined)). |
+| Privileges | Read-only grants on `tenants` and `tenant_closure`; no write, truncate, or schema-change privilege of any kind. |
+| Visibility contract | AM's saga flows persist transient provisioning rows on `tenants` during bootstrap and tenant-create, but the `tenant_closure` contract excludes them by construction — closure rows are inserted only on the `provisioning → active` transition. Closure-driven reads therefore cannot surface provisioning tenants. The plugin additionally drops provisioning rows on direct reads of `tenants` (existence probes, bulk-by-ids, ancestor hydration JOINs) as defense-in-depth, regardless of caller-supplied status filters (see [`cpt-cf-tr-plugin-fr-provisioning-invisibility`](PRD.md#provisioning-row-invisibility)). |
+| Failure handling | Transient connection errors surface as `TenantResolverError::Internal` to the caller. There is no retry loop inside the plugin — the gateway decides retry semantics. |
+| Audit | Every SDK call emits a database span with OpenTelemetry trace/span context and structured logs carrying `trace_id`; `request_id` is included when provided by the gateway. AM-side write audit is governed by [`cpt-cf-account-management-nfr-audit-completeness`](../PRD.md#64-audit-trail-completeness). |
+
+#### Types Registry Reverse Lookup
+
+- **Contract**: `cpt-cf-tr-plugin-contract-types-registry-reverse-lookup`
+
+| Aspect | Detail |
+|--------|--------|
+| Direction | Plugin → Types Registry, read-only. |
+| Transport | In-process ClientHub client or equivalent module boundary used for schema/type lookup. |
+| Purpose | Resolve `tenant_type_uuid` from AM storage back to the public chained `tenant_type` identifier required by SDK responses. |
+| Cache behavior | The plugin uses a bounded lazy process-local cache keyed by `tenant_type_uuid`; cache miss triggers a Types Registry lookup and successful results are memoized until evicted. |
+| Failure handling | If the mapping cannot be resolved, the plugin fails the request deterministically with `TenantResolverError::Internal`; it must not return raw UUIDs in place of public `tenant_type`. |
+
+#### Account Management (in-process module)
+
+The plugin does not consume `AccountManagementClient` on the SDK path. AM is a peer module in the same process and the same database; the plugin's only dependency on AM is the shared schema.
+
+### 3.6 Interactions & Sequences
+
+#### Get Tenant
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-seq-get-tenant`
+
+```mermaid
+sequenceDiagram
+    participant GW as Gateway
+    participant PI as PluginImpl
+    participant DB as AM storage
+    participant TR as Types Registry
+
+    GW->>PI: get_tenant(ctx, id)
+    PI->>DB: read tenants by id (non-provisioning)
+    DB-->>PI: row | ∅
+    alt row returned
+        opt tenant_type_uuid cache miss
+            PI->>TR: resolve(tenant_type_uuid)
+            TR-->>PI: chained tenant_type | error
+        end
+        PI-->>GW: TenantInfo
+    else no row (absent or provisioning)
+        PI-->>GW: TenantResolverError::TenantNotFound
+    end
+```
+
+#### Get Root Tenant
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-seq-get-root-tenant`
+
+```mermaid
+sequenceDiagram
+    participant GW as Gateway
+    participant PI as PluginImpl
+    participant DB as AM storage
+    participant TR as Types Registry
+
+    GW->>PI: get_root_tenant(ctx)
+    PI->>DB: read root tenant (no parent, non-provisioning)
+    DB-->>PI: unique row | none | multiple
+    alt unique row returned
+        opt tenant_type_uuid cache miss
+            PI->>TR: resolve(tenant_type_uuid)
+            TR-->>PI: chained tenant_type | error
+        end
+        PI-->>GW: TenantInfo
+    else no row (incl. bootstrap provisioning) or multiple rows
+        PI-->>GW: TenantResolverError::Internal
+    end
+```
+
+#### Ancestor Query (hot path)
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-seq-ancestor-query`
+
+```mermaid
+sequenceDiagram
+    participant GW as Gateway
+    participant PI as PluginImpl
+    participant DB as AM storage
+    participant TR as Types Registry
+
+    GW->>PI: get_ancestors(ctx, id, options)
+    PI->>DB: existence probe by id (non-provisioning)
+    DB-->>PI: tenant row | ∅
+    alt tenant exists (non-provisioning)
+        PI->>DB: read strict ancestors via closure (barrier applied), ordered by depth descending
+        DB-->>PI: rows
+        opt any uncached tenant_type_uuid values
+            PI->>TR: resolve_many(tenant_type_uuid[])
+            TR-->>PI: chained tenant_type mappings | error
+        end
+        PI-->>GW: GetAncestorsResponse { tenant, ancestors }
+    else tenant missing or provisioning
+        PI-->>GW: TenantResolverError::TenantNotFound
+    end
+```
+
+Because `tenant_closure.barrier` is defined over `(ancestor, descendant]`, applying the barrier filter under `Respect` is sufficient for the SDK edge cases: a self-managed starting tenant produces no ancestor rows, while the nearest self-managed ancestor itself remains visible and stops traversal above it.
+
+Ordering is driven by AM's stable `tenants.depth` column (absolute distance from the root): descending depth with `tenants.id` as tie-break yields direct-parent-first, root-last, and full determinism. The plugin does not compute ancestor ordering via any application-layer walk — the ancestor path is served by two indexed reads (existence probe on `tenants` by id + closure read on `(descendant_id)` joined to `tenants` by id).
+
+#### Descendant Query (barrier-aware)
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-seq-descendant-query`
+
+```mermaid
+sequenceDiagram
+    participant GW as Gateway
+    participant PI as PluginImpl
+    participant DB as AM storage
+    participant TR as Types Registry
+
+    GW->>PI: get_descendants(ctx, id, options)
+    PI->>DB: existence probe by id (non-provisioning)
+    DB-->>PI: tenant row | ∅
+    alt tenant exists (non-provisioning)
+        PI->>DB: recursive subtree CTE (barrier/status/max_depth applied)
+        DB-->>PI: rows (pre-order)
+        opt any uncached tenant_type_uuid values
+            PI->>TR: resolve_many(tenant_type_uuid[])
+            TR-->>PI: chained tenant_type mappings | error
+        end
+        PI-->>GW: GetDescendantsResponse { tenant, descendants }
+    else tenant missing or provisioning
+        PI-->>GW: TenantResolverError::TenantNotFound
+    end
+```
+
+The plugin first probes `tenants` by id, skipping provisioning rows. If no row is returned, the call surfaces as `TenantNotFound`.
+
+When the starting tenant exists, the plugin issues a single subtree read rooted at that id, joining `tenants` with `tenant_closure`. Three caller-driven filters are applied:
+
+- **`max_depth`** bounds how far the walk descends from the starting tenant (unbounded when not set).
+- **`status`** narrows the returned descendants to a caller-supplied subset (e.g. `active`).
+- **Barrier mode**, when `Respect`, excludes any descendant whose path from the starting tenant crosses a self-managed tenant (including the self-managed endpoints themselves). Under `Ignore` the barrier filter is dropped.
+
+Provisioning invisibility is structural: `tenant_closure` contains no rows for provisioning tenants by AM's closure contract, so the descendant side of the join can never surface a provisioning row regardless of the caller-supplied `status` filter. The existence probe on the starting tenant additionally excludes provisioning rows on the `tenants` table, so a provisioning starting tenant returns `TenantNotFound` before any closure read.
+
+Results are returned in pre-order (parent before children, siblings in `tenants.id` order) so the SDK contract is deterministic. The starting tenant itself is returned separately as `response.tenant` and never appears in `descendants`. Any uncached `tenant_type_uuid` values observed in the returned rows are resolved in a single batch call to Types Registry before the response is assembled.
+
+Because `tenant_closure.barrier` is defined over `(ancestor, descendant]`, a `Respect` query that starts from within a self-managed tenant's own subtree is not blocked — the barrier predicate only fires on paths that cross a self-managed boundary between the starting tenant and the descendant.
+
+#### Is Ancestor
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-seq-is-ancestor`
+
+```mermaid
+sequenceDiagram
+    participant GW as Gateway
+    participant PI as PluginImpl
+    participant DB as AM storage
+
+    GW->>PI: is_ancestor(ctx, ancestor_id, descendant_id, options)
+    alt ancestor_id == descendant_id
+        PI-->>GW: false
+    else
+        PI->>DB: existence probe for both tenant ids (non-provisioning)
+        DB-->>PI: 2 rows | fewer than 2
+        alt both tenants exist (non-provisioning)
+            PI->>DB: strict-ancestor existence check on closure (barrier applied)
+            DB-->>PI: bool
+            PI-->>GW: bool
+        else either tenant missing or provisioning
+            PI-->>GW: TenantResolverError::TenantNotFound
+        end
+    end
+```
+
+Because `tenant_closure.barrier` is defined over `(ancestor, descendant]`, applying the barrier filter under `Respect` makes `is_ancestor(..., Respect)` return `false` both when the descendant endpoint is self-managed and when some other self-managed tenant lies on the path.
+
+#### Use-Case Coverage Map
+
+| PRD Use Case | Sequence(s) covering it |
+|--------------|-------------------------|
+| `cpt-cf-tr-plugin-usecase-get-root-tenant` | Get Root Tenant |
+| `cpt-cf-tr-plugin-usecase-get-tenant` | Get Tenant |
+| `cpt-cf-tr-plugin-usecase-ancestor-query` | Ancestor Query |
+| `cpt-cf-tr-plugin-usecase-descendant-query` | Descendant Query |
+| `cpt-cf-tr-plugin-usecase-is-ancestor` | Is Ancestor |
+| `cpt-cf-tr-plugin-usecase-barrier-respect` | Ancestor Query + Descendant Query with `BarrierMode::Respect` |
+
+### 3.7 Database schemas & tables
+
+- [ ] `p3` - **ID**: `cpt-cf-tr-plugin-db-schema`
+
+The plugin owns no tables, no indexes, and no migrations. All storage is AM-owned; schemas, indexes, and DDL live in [AM DESIGN §3.7](../DESIGN.md#37-database-schemas--tables). The plugin depends on the read-only columns listed in [§3.3 API Contracts](#am-owned-schema-consumed-not-defined) and on the following index coverage maintained by AM:
+
+| Index | Purpose for the plugin |
+|-------|-----------------------|
+| `tenants(id)` primary key | `get_tenant` / `get_tenants` / existence probes on every SDK method; provisioning filter evaluated on the row. |
+| Uniqueness on the single root (`parent_id` null) | `get_root_tenant` deterministic root lookup and integrity validation; provisioning filter applied on top of the unique hit. AM's migration layer chooses the physical representation (partial unique index on PostgreSQL, generated-column unique index or equivalent on dialects without partial indexes). |
+| `tenants(parent_id, status)` | Covers the recursive walk of `tenants.parent_id` used by `get_descendants` for pre-order and `max_depth`; also lets the provisioning exclusion be evaluated during the index scan. |
+| `tenant_closure(ancestor_id, barrier, descendant_status)` | `get_descendants` join predicate with barrier and caller-supplied status filters. Provisioning exclusion is structural (closure never contains provisioning rows), so this index carries only the SDK-visible `descendant_status` domain. |
+| `tenant_closure(descendant_id)` | `get_ancestors` lookup; joined to `tenants` by id for `depth`-based ordering. |
+| `tenant_closure(ancestor_id, descendant_id)` primary key | `is_ancestor` existence probe. |
+
+AM does **not** publish a pre-order column on `tenant_closure` or a depth-from-ancestor column. Descendant pre-order is computed by the plugin at query time using the recursive walk described in [§3.6 Descendant Query](#descendant-query-barrier-aware); ancestor ordering uses `tenants.depth` directly. The plugin contract is satisfied as long as AM's schema preserves the column shape documented in [§3.3](#am-owned-schema-consumed-not-defined) and the index coverage above. Physical representation (partitioning, index types, clustering) is an AM choice that the plugin treats as opaque.
+
+### 3.8 Error Codes Reference
+
+The plugin returns SDK errors through `Result<_, TenantResolverError>`. Error surface is SDK-owned; the plugin uses the existing SDK variants rather than introducing plugin-specific error codes.
+
+| Error (SDK) | When returned | Notes |
+|-------------|---------------|-------|
+| `TenantResolverError::TenantNotFound` | `get_tenant` / `get_ancestors` / `get_descendants` / `is_ancestor` asked about a tenant that is not present in `tenants` | Not retried — absence is authoritative at the moment of the read. |
+| `TenantResolverError::Internal` (or the SDK's equivalent catch-all) | Database connection failure, query timeout, root-tenant invariant violation in `get_root_tenant`, or tenant-type reverse-hydration failure | Callers should retry at the gateway level unless the underlying cause is a persistent data-integrity issue. |
+
+## 4. Additional Context
+
+### 4.1 Applicability and Delegations
+
+| Concern | Owned by plugin? | Owner / Reason |
+|---------|------------------|----------------|
+| Tenant CRUD, mode change, status change | No | AM — see [`cpt-cf-account-management-component-tenant-service`](../DESIGN.md#tenantservice). |
+| Tenant hierarchy closure maintenance | No | AM — see [`cpt-cf-account-management-fr-tenant-closure`](../PRD.md). |
+| Tenant type validation | No | GTS Types Registry via AM. |
+| Tenant type reverse hydration | Yes | Plugin resolves `tenant_type_uuid` through Types Registry and caches successful mappings lazily. |
+| Authorization decisions | No | AuthZ Resolver Plugin. |
+| Subtree-membership integration for consuming policy modules | No | Deployment-specific integration owned by the consuming stack; AM's `tenant_closure` is the canonical surface. |
+| Resource Group / User Group hierarchy | No | Resource Group module. |
+| Token validation, session revocation | No | Platform AuthN + IdP. |
+
+### 4.2 Security Architecture
+
+#### Trust Model
+
+| Aspect | Trust Level | Notes |
+|--------|-------------|-------|
+| Gateway → Plugin | Implicit | Same process; same memory space; same SecurityContext. |
+| `SecurityContext` content | Trusted input | Plugin trusts the gateway's AuthN projection; does not re-validate tokens. |
+| Plugin → AM storage | Privilege-enforced | SecureConn pool over a read-only database role; read-only grants on `tenants` and `tenant_closure`. |
+
+#### Authorization Model
+
+The plugin does not evaluate authorization. It returns data shaped by two orthogonal knobs that consumers supply:
+
+1. **Barrier mode** (`BarrierMode::Respect` / `Ignore`) — `Respect` is the default and is expected for almost all authorization queries. `Ignore` is reserved for platform-authorized operator flows (billing rollups, support tooling). The plugin does not verify the caller is entitled to `Ignore`; that is the gateway/consumer concern. Every `Ignore` call is counted on a dedicated telemetry instrument so operators can audit bypass usage.
+2. **Status filter** — consumers decide whether to include `suspended`/`deleted` tenants.
+
+#### Least-Privilege Guidance
+
+The plugin process holds only the credentials for its read-only database role. It does not hold AM's writer credentials, IdP credentials, or signing keys. The role's grants are read-only on `tenants` and `tenant_closure` only, with no privileges on any other AM-owned schema object.
+
+#### Audit
+
+Per-query observability is emitted via structured logs and OpenTelemetry spans carrying `trace_id`; `request_id` is included when the gateway provides one. These identifiers come from tracing/request context rather than `SecurityContext`. There is no per-query audit-to-AM signal — AM's audit-completeness NFR covers tenant writes, not plugin reads. Barrier-state changes are audited on the AM side (see [`cpt-cf-account-management-nfr-barrier-enforcement`](../PRD.md#65-barrier-enforcement)).
+
+**Log retention, tamper-proofing, and incident response** are inherited from platform controls rather than duplicated at the plugin layer:
+
+- *Log retention*: the plugin emits OpenTelemetry signals and structured log lines with no retention override; retention follows the platform telemetry pipeline's policy.
+- *Tamper-proof logging*: the plugin does not implement signed or append-only logging itself; tamper-proofing is a property of the platform telemetry transport + backend (immutable OpenTelemetry span store) rather than a plugin-local concern.
+- *Incident response hooks*: plugin alerts (`tenant_resolver_query_errors_total{op,kind}`, `tenant_resolver_db_pool_waiters`, barrier-bypass rate) route through the platform SRE on-call chain via the alerting thresholds defined in [§4.3 Feature Telemetry](#feature-telemetry). The plugin exposes no `/healthz` endpoint or independent escalation surface — operator-facing health is observable via the telemetry signals above.
+- *Non-repudiation*: the plugin issues no writes, so write-level non-repudiation is Not applicable at the plugin layer. Read-level attribution via the gateway-supplied `request_id` and OpenTelemetry trace context is sufficient for forensic review of plugin-observed events.
+
+### Threat Modeling
+
+#### Threat Catalog
+
+| Threat | Vector | Mitigation |
+|--------|--------|------------|
+| Plugin writes to AM-owned storage | Bug, supply-chain attack, or misconfiguration | Read-only database role rejects every mutation at the privilege layer; CI verifies role grants pre-deployment. |
+| Stale barrier allows cross-tenant visibility after mode flip | Not applicable under single-store ownership | Closure `barrier` column is updated inside the same AM transaction as the `self_managed` flip; the next plugin read observes the new value. |
+| DoS via `get_descendants` on a large subtree | Caller requests unbounded subtree | `max_depth` option supported; gateway-level rate limiting expected; `tenant_resolver_query_duration_seconds` alerts on p99 regressions. |
+| Query-timeout exhaustion under load | Long-running subtree query holds a DB connection | Per-statement `query_timeout` (default 5 s) enforced at the driver; connection pool upper bound prevents unbounded concurrency. |
+| Information leak via tenant probing | Adversary enumerates tenant IDs | Per-query `tenant_not_found_total` surface lets operators detect scanning; authorization is enforced upstream. |
+| Credential leak of the plugin's DB role | Misconfiguration or breach | Role is read-only and scoped to two tables; secret rotation follows the platform secret-management policy. |
+
+#### Security Assumptions
+
+- The process hosting the plugin is trusted (same process as the gateway).
+- `SecurityContext` projection by the gateway/AuthN Resolver is correct for the fields defined by the current platform contract.
+- The AM-owned database enforces TLS and credential hygiene; the plugin's read-only role is provisioned under the platform's standard role-management workflow.
+
+### 4.3 Reliability and Operations
+
+#### Fault Domains and Redundancy
+
+| Fault | Behaviour |
+|-------|-----------|
+| AM-owned database unavailable for reads | Plugin returns a transient error on every SDK call; gateway decides retry semantics. No independent degraded mode — without the database the plugin has no state to serve from. |
+| Plugin process restart | Cold-start requires no hierarchy rebuild and no projection repopulation. The plugin pre-warms the `tenant_type_uuid → tenant_type` cache at readiness by enumerating registered tenant-type schemas from Types Registry (a small, bounded set), so Types Registry sits off the hot path once readiness succeeds. New tenant-type registrations arriving after readiness are filled lazily on cache miss. |
+| Types Registry unavailable on cache miss | Calls that need public `tenant_type` hydration fail with `TenantResolverError::Internal`; hierarchy reads remain DB-backed, but the plugin must not substitute raw UUIDs for public chained identifiers. |
+| AM writer unavailable while reads continue | Plugin remains fully available — reads are against the committed database state and are not coupled to AM's writer health. |
+| Connection-pool exhaustion under burst | New calls queue up to the pool's backpressure limit; queued waiters beyond the limit receive `TenantResolverError::Internal`. `tenant_resolver_db_pool_waiters` alerts when sustained. |
+
+#### Recovery Architecture
+
+- **No plugin-owned state to recover.** Consistency is a property of AM's transactional writes; there is no anti-entropy step.
+- **Database-level recovery** is AM's responsibility. The plugin resumes serving the moment the database is reachable.
+
+#### Performance and Cost Budget
+
+| Metric | Target |
+|--------|--------|
+| `tenant_resolver_query_duration_seconds{op=~"get_tenant\|get_root_tenant"}` p95 | ≤ 5 ms |
+| `tenant_resolver_query_duration_seconds{op=~"get_ancestors\|is_ancestor"}` p95 | ≤ 5 ms |
+| `tenant_resolver_query_duration_seconds{op="get_descendants"}` p99 | ≤ 20 ms |
+| `tenant_resolver_db_pool_utilization` | ≤ 80% sustained |
+| Plugin steady-state memory | Pool buffers + per-call working set only; no tenant-count-dependent allocations |
+
+#### Cost and Budget Allocation
+
+- **Per-call cost**: hot-path SDK calls resolve to 1–2 indexed reads (existence probe on AM's tenant primary key + optional closure lookup) plus, for `get_descendants`, a bounded recursive walk whose cost scales with the returned subtree rather than with the total tenant count. The plugin adds no storage, no egress, and no process-local state beyond the pool and per-call working set ([§4.3 Performance and Cost Budget](#performance-and-cost-budget)), so incremental infra cost over AM's baseline is IOPS + CPU on the AM-owned database.
+- **Types Registry amortization**: the `tenant_type_uuid → tenant_type` cache is pre-warmed at plugin readiness from the small enumerable set of registered tenant-type schemas ([§4.3 Fault Domains](#fault-domains-and-redundancy) — plugin-process-restart row), so steady-state reads do not pull Types Registry into the response path. Cache-miss bursts are observed via `tenant_resolver_tenant_type_cache_miss_total` ([§4.3 Feature Telemetry](#feature-telemetry)).
+- **Budget delegation**: infrastructure and database cost are owned by AM's capacity budget under `cpt-cf-account-management-nfr-production-scale`. The plugin's local cost surface is the SecureConn pool size, which is tuned against the gateway's concurrency profile rather than owned as an independent budget line.
+- **Cost-optimization patterns**: Not applicable as plugin-local patterns — the plugin holds no storage, no caches for hierarchy data, and no egress surface. The deliberate absence of a plugin-side hierarchy cache (see [§4.3 Known Limitations & Technical Debt](#known-limitations--technical-debt)) is an architectural choice anchored in `cpt-cf-tr-plugin-principle-single-store`; caching would be introduced only if measured DB load forced it and an invalidation contract from AM were available.
+- **Time-to-market**: the plugin is pre-GA; go-live is gated on the PRD's Success criteria table ([PRD §1.3](PRD.md#13-goals-business-outcomes) — Module GA + Pre-GA soak / security / scale gates), not on an independent delivery timeline.
+
+#### Feature Telemetry
+
+| Vector | Metric | Purpose | Threshold |
+|--------|--------|---------|-----------|
+| Performance | `tenant_resolver_query_duration_seconds{op}` | Hot-path latency per operation | p95 ≤ 5 ms; p99 ≤ 20 ms for `get_descendants` |
+| Performance | `tenant_resolver_closure_query_duration_seconds` | DB read latency on `tenant_closure` | p95 ≤ 10 ms |
+| Performance | `tenant_resolver_tenant_type_cache_miss_total` | Visibility into cache-miss bursts that pull Types Registry into the response path | — |
+| Performance | `tenant_resolver_db_pool_utilization` | Connection-pool saturation | ≤ 80% sustained |
+| Reliability | `tenant_resolver_query_errors_total{op,kind}` | Error budget by operation and cause | alert on sustained non-zero |
+| Reliability | `tenant_resolver_db_pool_waiters` | Connection-pool contention | alert on sustained queueing |
+| Reliability | `tenant_resolver_tenant_not_found_total` | Absence rate (scanning + genuine misses) | — |
+| Security | `tenant_resolver_barrier_enforced_total` | How often `Respect` excludes rows | — |
+| Security | `tenant_resolver_barrier_bypass_total{op}` | Dedicated audit signal for `BarrierMode::Ignore` usage | — |
+| Security | `tenant_resolver_tenant_not_found_total` | Probing signal | — |
+| Versatility | `tenant_resolver_query_types_total{op}` | API usage distribution | — |
+| Versatility | `tenant_resolver_query_barrier_mode_total{op,mode}` | Barrier-mode mix across operations | — |
+| Versatility | `tenant_resolver_result_status_distribution_total{op,status}` | Status-class mix observed on `get_tenants` / `get_descendants` responses — attribution of hot-path traffic across active / suspended / deleted, derived from rows the plugin returns. No standalone scan. | — |
+
+### Data Governance
+
+- **Data class**: tenant hierarchy metadata — commercially sensitive, not PII.
+- **Retention**: the plugin holds no data; retention is an AM concern governed by the AM schema.
+- **Cross-border/residency**: inherited from the AM deployment; the plugin adds no cross-border movement.
+- **Regulatory**: no credentials, no user PII, no tokens are stored by the plugin.
+
+### Testing Architecture
+
+| Layer | Tests |
+|-------|-------|
+| Unit / domain | SDK-contract ordering in `PluginImpl`; query-builder semantics for barrier mode, status filter, and `max_depth`. |
+| Integration | Plugin ↔ AM co-hosted fixture: seed tenants through AM, read through the plugin, verify barrier matrix across every operation × mode without any intervening sync step. |
+| Contract | Validate that every SDK method's documented semantics are exercised (self-reference handling, empty-batch handling, `max_depth` boundary, status filter scope). |
+| Privilege | Static check that the plugin's database role has only read grants on `tenants` and `tenant_closure`; runtime assertion on startup that a write attempt is rejected. |
+| Scale | 200K-tenant fixture for `get_descendants` p99 on a representative subtree size. |
+| Chaos | Kill the database mid-query; saturate the connection pool; concurrent AM tenant writes during read load. |
+
+### Open Questions
+
+| Question | Owner | Target resolution |
+|----------|-------|-------------------|
+| Read-replica routing for the plugin's role | Platform SRE | Deferred; v1 reads from the primary. |
+| Cross-region reads | Platform SRE | Deferred; v1 is single-region. |
+
+### Documentation Strategy
+
+The plugin's public contract is the SDK; the SDK's rustdoc is authoritative for every method. This DESIGN documents the query shapes, the read-only role contract, and the operational dependencies on AM-owned storage; the PRD captures the WHAT/WHY. No standalone OpenAPI file is published.
+
+### Known Limitations & Technical Debt
+
+| Item | Reason / Path forward |
+|------|-----------------------|
+| No plugin-side caching | By design — hierarchy consistency is a property of AM transactional writes. Introduce caching only if measured DB load forces it, and only paired with an invalidation contract from AM. |
+| Shared-database coupling to AM | By design — the read-only role is the decoupling boundary. A future split (for example, dedicated replica) requires re-evaluating consistency semantics with AM. |
+| No multi-region reads | Single-region only; revisit when the platform grows multi-region deployments. |
+
+### 4.4 Scope Exclusions
+
+Every bullet below is an explicit "Not applicable because…" statement; it binds the plugin's scope at the DESIGN layer so reviewers can distinguish "author considered and excluded" from "author forgot". Many of these delegations are also reflected in [PRD §6 NFR Exclusions](PRD.md#nfr-exclusions) and in [§4.1 Applicability and Delegations](#41-applicability-and-delegations); this section consolidates them at the DESIGN layer so semantic checklists (SEC / REL / DATA / INT / OPS / MAINT / TEST / UX / PERF / BIZ / DOC) can be answered explicitly per bullet.
+
+**Security architecture (SEC)**
+
+- *Multi-factor authentication, SSO / federation, user session management, user-credential policies, session timeout / renewal* — Not applicable at the plugin layer because user authentication and session lifecycle are owned by the Tenant Resolver gateway's upstream chain; the plugin authenticates only its own read-only database role via SecureConn and has no user sessions or tokens of its own.
+- *Role definitions, permission matrix, API-endpoint authorization, privilege-escalation prevention* — Not applicable because the plugin has no user-facing authorization surface; the only authorization boundary is the DB privilege layer, enforced by the database against the plugin's read-only role (`cpt-cf-tr-plugin-constraint-read-only-role`).
+- *Encryption at rest, encryption key management, data masking / anonymization, secure data disposal* — Not applicable at the plugin layer because the plugin holds no state; all storage (including encryption at rest, key management, and disposal procedures) is owned by AM under its Data Governance stance. Encryption in transit between plugin and AM storage is provided by SecureConn + the AM-owned database's TLS enforcement.
+- *Network segmentation, DMZ architecture, firewall rules, output encoding, CORS policy* — Not applicable because the plugin exposes no network surface; it runs in-process behind the Tenant Resolver gateway and communicates with AM storage only via SecureConn.
+
+**Performance architecture (PERF)**
+
+- *Horizontal scaling approach, vertical scaling limits, load balancing, queue/broker strategy, user session management* — Not applicable as plugin-local concerns: horizontal scaling tracks Tenant Resolver gateway replicas (each replica carries one plugin instance with its own SecureConn pool); vertical scaling is bounded by `pool_max_connections` and database connection limits; load balancing is upstream at the gateway; there is no async / queue surface; there are no user sessions.
+- *CDN strategy, edge computing* — Not applicable because the plugin is an in-process backend module with no external network surface.
+- *CPU efficiency, storage efficiency, network-bandwidth efficiency* — Not applicable beyond the DB round-trip and SerDe cost that already dominate the latency budget: the plugin holds no storage, emits only OpenTelemetry signals + per-call log lines, and performs no plugin-local computation beyond filter-predicate application and SDK projection.
+
+**Reliability architecture (REL)**
+
+- *Plugin-layer redundancy, failover, circuit breakers, bulkheads* — Not applicable as plugin-local patterns: `pool_max_connections` + per-statement `query_timeout` act as the bulkhead; circuit-breaking is the gateway's concern and is observable via `tenant_resolver_query_errors_total{op,kind}`; plugin-level failover is a no-op because hierarchy state has exactly one authoritative source (AM-owned storage), and redundancy is owned by AM's DB HA posture.
+- *Dead-letter queues, poison-message handling, compensating transactions, multi-step error recovery* — Not applicable because the plugin is synchronous, read-only, and holds no queues or multi-step workflows. Transient errors surface immediately to the gateway, which owns retry and escalation.
+- *Backup, point-in-time recovery, disaster recovery, business continuity, data replication* — Not applicable at the plugin layer because the plugin holds no state. Recovery mechanisms are owned by AM; the plugin resumes serving the moment the AM-owned database is reachable.
+- *Spec-flag architecture, canary / blue-green deployment, rollback procedures, health-check endpoints* — Inherited from the Tenant Resolver gateway's release strategy rather than owned at the plugin layer. Health is observable via the `tenant_resolver_query_errors_total{op,kind}` + `tenant_resolver_db_pool_waiters` metrics in [§4.3 Feature Telemetry](#feature-telemetry); the plugin does not expose a `/healthz` endpoint because it has no external network surface.
+
+**Data architecture (DATA)**
+
+- *Data partitioning, replication, sharding, hot/warm/cold tiering, data archival* — Not applicable at the plugin layer because the plugin owns no storage. All such strategies are AM-owned and operate on AM-owned tables under AM's data-governance stance (see [AM DESIGN §3.7](../DESIGN.md#37-database-schemas--tables)).
+- *Referential integrity, constraint enforcement, concurrent-modification semantics, orphan-data prevention* — AM-owned and enforced at the database layer under AM's schema authority; the plugin reads the committed state only. Plugin-level validation is limited to existence checks prior to closure queries ([§3.2 PluginImpl](#pluginimpl)).
+- *Data lineage, data catalog integration, master-data management, data-quality monitoring, data dictionary / glossary* — Lineage flows from AM writes (authoritative) through the plugin's read-only role into consumer SDK responses; data catalog and MDM are AM-owned; quality monitoring is covered by `tenant_resolver_tenant_not_found_total` and closure-consistency integration tests ([§4.3 Testing Architecture](#testing-architecture)). The data dictionary lives in [AM DESIGN §3.7](../DESIGN.md#37-database-schemas--tables) and [TENANT_MODEL.md](../../../../../docs/arch/authorization/TENANT_MODEL.md).
+
+**Integration architecture (INT)**
+
+- *Per-dependency SLA, circuit-breaker implementations* — SLA is inherited from AM's database availability posture and Types Registry's availability SLO; the plugin does not buffer calls or operate in a half-open / closed-circuit mode. Transient errors from either dependency surface immediately to the gateway.
+- *Event-driven architecture, event catalog, event schemas, event sourcing / replay, event ordering, DLQ handling* — Not applicable because the plugin emits no domain events; the only emissions are OpenTelemetry signals (metrics, traces, logs) documented in [§4.3 Feature Telemetry](#feature-telemetry).
+
+**Operations architecture (OPS)**
+
+- *Container / VM strategy, orchestration, environment-promotion strategy, secret management* — Container/VM strategy and orchestration are inherited from the Tenant Resolver gateway's deployment (plugin is in-process, not independently deployed). Environment promotion rides the platform release pipeline. The plugin's DB-role credentials are provisioned via the platform secret-management policy (see [§4.2 Threat Catalog — credential-leak mitigation](#threat-modeling)); the plugin never logs, echoes, or serializes credentials.
+- *Infrastructure-as-code, environment parity, immutable infrastructure, auto-scaling configuration, resource tagging* — Not applicable at the plugin scope: the plugin ships as an in-process module; IaC + environment parity + immutable-infra posture are inherited from the Tenant Resolver gateway's deployment and the platform's central IaC repository.
+
+**Maintainability architecture (MAINT)**
+
+- *Package / namespace conventions, dependency-injection approach* — The plugin is a module inside the `account-management` crate under `src/tr_plugin/`, not a standalone crate (see [§1.1](#11-architectural-vision) for the co-location rationale). Dependency injection is provided by ModKit's `ClientHub`, which resolves the plugin's SDK-trait binding and external dependencies (Types Registry, AM storage role) by configuration.
+- *Runbooks, knowledge base* — Runbooks for on-call (pool-saturation, Types-Registry-unavailable, DB-unreachable) are owned by platform SRE and referenced from the telemetry alert routes in [§4.3 Feature Telemetry](#feature-telemetry). Plugin-specific knowledge-base entries live in the platform wiki under Tenant Resolver > TR-Plugin.
+
+**Testing architecture (TEST)**
+
+- *Testability seams*: `PluginImpl` takes its DB connection pool and Types Registry client through `ClientHub`, enabling substitution with in-memory fakes in unit tests. The mock/stub boundary is the SecureConn + Types Registry client trait objects.
+- *Test data management*: seeded via AM's normal tenant-create path in integration fixtures; no hand-rolled DDL in the plugin.
+- *Test environment*: plugin ↔ AM co-hosted database fixture per the Integration row of [§4.3 Testing Architecture](#testing-architecture).
+- *Test isolation*: per-test-case database schema reset via fixture tear-down.
+
+**User-facing architecture (UX)**
+
+- *Frontend architecture, state management, responsive design, progressive enhancement, offline support* — Not applicable because the plugin is an in-process backend module with no end-user UI. User-facing surfaces (if any) are owned by consumers of the Tenant Resolver gateway, not by this plugin.
+
+**Compliance (COMPL)**
+
+- *Compliance requirements mapping, control implementations, evidence collection, compliance monitoring, consent management, data-subject rights, cross-border transfer controls, privacy impact assessment* — Not applicable at the plugin scope: the plugin stores no credentials, no user PII, and no tokens (see [§4.3 Data Governance](#data-governance)). Compliance is inherited from the platform posture and AM's data-governance controls.
+
+## 5. Traceability
+
+| PRD ID | DESIGN Element(s) |
+|--------|-------------------|
+| `cpt-cf-tr-plugin-fr-plugin-api` | `cpt-cf-tr-plugin-component-plugin-impl`, `cpt-cf-tr-plugin-interface-plugin-client` |
+| `cpt-cf-tr-plugin-fr-get-tenant` | `cpt-cf-tr-plugin-component-plugin-impl`, `cpt-cf-tr-plugin-seq-get-tenant` |
+| `cpt-cf-tr-plugin-fr-get-root-tenant` | `cpt-cf-tr-plugin-component-plugin-impl`, `cpt-cf-tr-plugin-seq-get-root-tenant` |
+| `cpt-cf-tr-plugin-fr-get-tenants` | `cpt-cf-tr-plugin-component-plugin-impl` |
+| `cpt-cf-tr-plugin-fr-get-ancestors` | `cpt-cf-tr-plugin-component-plugin-impl`, `cpt-cf-tr-plugin-seq-ancestor-query` |
+| `cpt-cf-tr-plugin-fr-get-descendants` | `cpt-cf-tr-plugin-component-plugin-impl`, `cpt-cf-tr-plugin-seq-descendant-query` |
+| `cpt-cf-tr-plugin-fr-is-ancestor` | `cpt-cf-tr-plugin-component-plugin-impl`, `cpt-cf-tr-plugin-seq-is-ancestor` |
+| `cpt-cf-tr-plugin-fr-barrier-semantics` | `cpt-cf-tr-plugin-principle-barrier-as-data`, `cpt-cf-tr-plugin-interface-am-schema` |
+| `cpt-cf-tr-plugin-fr-status-filtering` | `cpt-cf-tr-plugin-component-plugin-impl`, `cpt-cf-tr-plugin-interface-am-schema` |
+| `cpt-cf-tr-plugin-fr-provisioning-invisibility` | `cpt-cf-tr-plugin-component-plugin-impl`, `cpt-cf-tr-plugin-interface-am-schema`, `cpt-cf-tr-plugin-contract-am-read-only-role` |
+| `cpt-cf-tr-plugin-fr-observability` | §4.3 Feature Telemetry |
+| `cpt-cf-tr-plugin-nfr-query-latency` | `cpt-cf-tr-plugin-component-plugin-impl`, §3.7 index coverage |
+| `cpt-cf-tr-plugin-nfr-subtree-latency` | `cpt-cf-tr-plugin-component-plugin-impl`, §3.7 index coverage |
+| `cpt-cf-tr-plugin-nfr-closure-consistency` | `cpt-cf-tr-plugin-principle-single-store`, `cpt-cf-tr-plugin-contract-am-read-only-role` |
+| `cpt-cf-tr-plugin-nfr-tenant-isolation` | `cpt-cf-tr-plugin-principle-barrier-as-data`, `cpt-cf-tr-plugin-interface-am-schema` |
+| `cpt-cf-tr-plugin-nfr-audit-trail` | §4.2 Audit, §4.3 Feature Telemetry |
+| `cpt-cf-tr-plugin-nfr-observability` | §4.3 Feature Telemetry |

--- a/modules/system/account-management/docs/tr-plugin/PRD.md
+++ b/modules/system/account-management/docs/tr-plugin/PRD.md
@@ -1,0 +1,695 @@
+Created: 2026-04-21 by Diffora
+
+# PRD — Tenant Resolver Plugin (AM-backed)
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Non-goals](#14-non-goals)
+  - [1.5 Glossary](#15-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Core Boundary](#31-core-boundary)
+  - [3.2 Deployment Context](#32-deployment-context)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope](#41-in-scope)
+  - [4.2 Out of Scope](#42-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 SDK Contract Implementation](#51-sdk-contract-implementation)
+  - [5.2 Barrier and Status Semantics](#52-barrier-and-status-semantics)
+  - [5.3 Observability](#53-observability)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 Query Latency](#61-query-latency)
+  - [6.2 Subtree Query Latency](#62-subtree-query-latency)
+  - [6.3 Closure Consistency](#63-closure-consistency)
+  - [6.4 Tenant Isolation](#64-tenant-isolation)
+  - [6.5 Audit Trail](#65-audit-trail)
+  - [6.6 Observability Coverage](#66-observability-coverage)
+  - [NFR Exclusions](#nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+  - [8.1 Get Root Tenant](#81-get-root-tenant)
+  - [8.2 Get Tenant](#82-get-tenant)
+  - [8.3 Ancestor Query](#83-ancestor-query)
+  - [8.4 Descendant Query](#84-descendant-query)
+  - [8.5 Is Ancestor](#85-is-ancestor)
+  - [8.6 Barrier-Respecting Query](#86-barrier-respecting-query)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+- [13. Open Questions](#13-open-questions)
+- [14. Traceability](#14-traceability)
+
+<!-- /toc -->
+
+> **Abbreviations**: Account Management = **AM**; Tenant Resolver Plugin = **TRP**; Global Type System = **GTS**; Policy Enforcement Point = **PEP**. Used throughout this document.
+
+## 1. Overview
+
+### 1.1 Purpose
+
+The Tenant Resolver Plugin (TRP) is the default implementation of the Cyber Fabric [Tenant Resolver](../../../tenant-resolver/) plugin contract. It answers hierarchy and barrier questions on the authorization hot path — `get_tenant`, `get_root_tenant`, `get_tenants`, `get_ancestors`, `get_descendants`, `is_ancestor` — as a **query facade** over the tenant hierarchy owned by [Account Management (AM)](../PRD.md).
+
+TRP exists so that every authorization decision that needs subtree scoping or barrier enforcement can be answered in single-digit milliseconds against AM's transactionally consistent `(tenants, tenant_closure)` pair, without introducing a second copy of hierarchy state or a synchronization window between AM writes and policy enforcement. The plugin owns the SDK surface; AM owns the data.
+
+**Packaging.** TRP is not a standalone, swappable plugin — it ships as a module inside the `account-management` crate at `modules/system/account-management/src/tr_plugin/`. Co-location is deliberate: the plugin's correctness relies on AM-writer invariants (transactional `(tenants, tenant_closure)` maintenance, self-row existence, barrier materialization over `(ancestor, descendant]`, provisioning-lifecycle semantics) that the two-table schema alone does not express. A standalone crate would implicitly advertise reusability against any schema-compatible storage the plugin cannot validate at runtime; keeping TRP inside the AM crate binds it to the one writer whose invariants it trusts.
+
+### 1.2 Background / Problem Statement
+
+[Account Management](../DESIGN.md) is the platform's source of truth for tenant hierarchy, tenant mode (`self_managed`), and tenant status. Its administrative public APIs (`get_tenant`, `get_children`) are designed for correctness, not for per-request authorization latency. On the hot path, policy evaluation needs ancestor chains, subtree membership, and barrier enforcement answered in a single indexed read rather than by traversing the `parent_id` chain on every call.
+
+AM maintains a canonical `tenant_closure` table with the platform-canonical schema `(ancestor_id, descendant_id, barrier, descendant_status)` from [TENANT_MODEL.md](../../../../../docs/arch/authorization/TENANT_MODEL.md), updated transactionally with every tenant write under [`cpt-cf-account-management-fr-tenant-closure`](../PRD.md). This PRD specifies the default plugin that uses that closure to serve the Tenant Resolver SDK contract.
+
+Representative consumers this plugin serves:
+
+| Consumer | Call pattern | Latency sensitivity |
+|----------|--------------|---------------------|
+| AuthZ Resolver — policy evaluation | 1–N `get_ancestors` / `is_ancestor` calls per decision | p95 ≤ 5 ms per call on the indexed closure path |
+| PEP `in_tenant_subtree` predicate compilation | subtree-membership reads against `tenant_closure` | sub-millisecond indexed read on the AM-owned closure |
+| Billing and operator tooling | `get_descendants` with `BarrierMode::Ignore` across whole tenant subtree | seconds-scale batch; correctness over latency |
+| Operator dashboards | `get_tenant` + `get_descendants` | interactive, direct-read |
+
+Barrier enforcement is a **security** property: a parent must not see into a subtree that has been flipped to self-managed. Consolidating hierarchy ownership in AM — tree and closure in the same transaction — removes the freshness window that a separate projection would impose. The plugin's correctness reduces to applying SDK-documented predicates and ordering over AM's canonical closure.
+
+### 1.3 Goals (Business Outcomes)
+
+- Answer hot-path reads within budget on the approved deployment profile: `get_tenant`, `get_root_tenant`, `get_ancestors`, and `is_ancestor` at p95 ≤ 5 ms; `get_descendants` at p99 ≤ 20 ms, so that subtree-aware authorization can be evaluated on the request path without widening the platform latency budget.
+- Guarantee that every SDK call observes a transactionally consistent pair of `tenants` + `tenant_closure` — no projection lag, no freshness window, no drift — so that barrier enforcement is correct by construction rather than by a polling contract.
+- Keep plugin steady-state memory flat with tenant count for hierarchy state (no projections, no in-memory hierarchy state, no hierarchy-result cache). A bounded lazy cache for `tenant_type_uuid -> tenant_type` reverse lookup is allowed so repeated public response hydration does not require a Types Registry read on every call.
+- Keep the plugin's privilege surface minimal: a read-only database role scoped to `tenants` + `tenant_closure`, with no ability to mutate AM-owned data, so that a plugin compromise cannot corrupt canonical hierarchy state.
+- Export the minimum telemetry set needed for Performance, Reliability, Security, and Versatility dashboards, so that query latency, connection-pool health, and barrier-enforcement rate are observable without bespoke instrumentation.
+
+**Success criteria:**
+
+| Metric | Baseline | Target | Timeframe |
+|--------|----------|--------|-----------|
+| Hot-path query latency (p95) | No AM-backed plugin exists against the target today | p95 ≤ 5 ms on the approved deployment profile for `get_tenant`, `get_root_tenant`, `get_ancestors`, `is_ancestor` | Module GA |
+| Subtree query latency (p99) | — | p99 ≤ 20 ms on the approved deployment profile for `get_descendants` | Module GA |
+| Closure/tree consistency | — | Zero partial-state windows observed under concurrent AM writes + plugin reads across 24 h of load | Pre-GA soak test |
+| Cross-tenant leakage via stale barrier | — | Zero leaks observed across the barrier-matrix test suite (all operations × both `BarrierMode` values) | Pre-GA security gate |
+| Plugin write attempts on AM storage | — | Zero — verified by privilege assertion at startup and by CI on role grants | Pre-GA security gate |
+| Observability coverage | — | ≥ 3 telemetry instruments per applicable quality vector exported | Module GA |
+
+### 1.4 Non-goals
+
+- **Source-of-truth tenant data.** The plugin never authors tenant records. Tenant CRUD, mode change, status change, and type validation are owned by AM.
+- **Hierarchy closure maintenance.** `tenant_closure` is owned and maintained by AM under [`cpt-cf-account-management-fr-tenant-closure`](../PRD.md). The plugin reads it; it never writes it.
+- **Authorization decisions.** The plugin returns hierarchy data and enforces barrier semantics at the data layer. Whether a caller is entitled to call `BarrierMode::Ignore` or to observe `suspended`/`deleted` tenants is an AuthZ Resolver / gateway concern.
+- **Process-local caching of hierarchy data.** The plugin holds no in-process cache of tenants, ancestors, descendants, or closure rows. Consistency is a property of AM transactional writes, not of a plugin cache-invalidation scheme. A bounded lazy cache for `tenant_type_uuid -> tenant_type` reverse lookup is allowed because it does not cache hierarchy visibility decisions.
+- **REST / gRPC wire API.** The plugin is in-process behind the Tenant Resolver gateway and exposes no external endpoint. The gateway owns all network-facing contracts.
+- **Multi-region reads.** v1 is single-region; cross-region routing is an SRE-level decision tied to the platform's multi-region posture.
+- **Read-replica routing.** v1 reads from the primary. Replica routing is revisited per deployment profile.
+
+### 1.5 Glossary
+
+> **Canonical source**: platform-wide terms (Tenant, Barrier, Barrier Mode, Self-Managed Tenant, Tenant Barrier, Tenant Status, `tenant_closure`, GTS) are defined authoritatively in [Account Management PRD §1.5](../PRD.md#15-glossary) and [TENANT_MODEL.md](../../../../../docs/arch/authorization/TENANT_MODEL.md). This glossary does **not** redefine them — updates to those terms happen in the canonical source and are inherited here by reference. The table below covers tr-plugin-specific terms only.
+
+| Term | Definition |
+|------|------------|
+| Query Facade | Architectural role of the plugin — it exposes the SDK trait and translates each call into a parameterized SQL read against AM-owned storage, with no intermediate state. |
+| Read-only Database Role | Dedicated database role provisioned for the plugin with `SELECT`-only grants on `tenants` and `tenant_closure` and no other privileges. |
+| Barrier Flag | Platform-canonical column on `tenant_closure` noting whether `BarrierMode::Respect` must stop traversal for a given `(ancestor_id, descendant_id)` pair. AM defines it over the path `(ancestor, descendant]` (ancestor excluded, descendant included), with self-rows fixed to `false`, and maintains it transactionally with tenant writes. |
+| Denormalized Status | Platform-canonical `descendant_status` column on `tenant_closure`, maintained by AM so status filtering does not require joining `tenants` on every hot-path read. |
+| Provisioning Row | Transient internal tenant state (`tenants.status = 'provisioning'`) written by AM during bootstrap and the tenant-create saga and compensated away or finalized to `active`. Provisioning tenants have **no** rows in `tenant_closure` — closure entries are inserted atomically with the `provisioning → active` transition, so the closure contract never exposes provisioning state to downstream consumers. The SDK `TenantStatus` enum has no provisioning variant. The plugin additionally filters these rows out of direct `tenants` reads as defense-in-depth (see [`cpt-cf-tr-plugin-fr-provisioning-invisibility`](#provisioning-row-invisibility)). |
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Platform Operator
+
+**ID**: `cpt-cf-tr-plugin-actor-operator`
+
+- **Role**: Operates the Cyber Fabric control plane; owns the plugin's connection-pool configuration, the read-only database role provisioning, and the plugin's observability thresholds and alerts.
+- **Needs**: Size and tune the connection pool against gateway concurrency; provision and rotate the plugin's read-only database role; observe query latency, pool saturation, error rates, barrier-enforcement metrics, and tenant-not-found rates.
+
+### 2.2 System Actors
+
+#### Tenant Resolver Gateway
+
+**ID**: `cpt-cf-tr-plugin-actor-tenant-resolver-gateway`
+
+- **Role**: In-process delegator that receives every platform call on the [Tenant Resolver](../../../tenant-resolver/) SDK and resolves the configured plugin through `ClientHub`. This plugin is one such implementation; the gateway does not evaluate hierarchy logic itself.
+
+#### AuthZ Resolver Plugin
+
+**ID**: `cpt-cf-tr-plugin-actor-authz-resolver`
+
+- **Role**: Issues `get_ancestors`, `is_ancestor`, and `get_descendants` calls through the gateway during policy evaluation. Drives the hot-path read traffic that the plugin's connection pool and AM's closure indexes are sized for.
+
+#### Policy Enforcement Point (PEP)
+
+**ID**: `cpt-cf-tr-plugin-actor-pep`
+
+- **Role**: Domain-module query compiler that reads subtree-membership information. In SQL-backed deployments PEP reads AM's canonical `tenant_closure` directly at query compilation time; the plugin exposes the same data through the SDK for non-SQL consumers.
+
+#### Account Management
+
+**ID**: `cpt-cf-tr-plugin-actor-account-management`
+
+- **Role**: Source-of-truth tenant service. Owns `tenants` and `tenant_closure` and maintains them transactionally on every tenant write. See [AM PRD — Tenant Hierarchy](../PRD.md#52-tenant-hierarchy-management) and [AM DESIGN — Tenant Service](../DESIGN.md#tenantservice).
+
+#### Platform Telemetry
+
+**ID**: `cpt-cf-tr-plugin-actor-platform-telemetry`
+
+- **Role**: Collects OpenTelemetry metrics, traces, and structured logs emitted by the plugin; surfaces them to operator dashboards and alert routes. Consumes only output; does not call the plugin.
+
+## 3. Operational Concept & Environment
+
+The plugin is a Cyber Fabric module hosted inside the Tenant Resolver gateway process. It participates in the platform module lifecycle (start → ready → stop) and uses the shared `ClientHub` for gateway registration. This section records only module-specific deviations from project defaults.
+
+### 3.1 Core Boundary
+
+The plugin:
+
+- Implements the [`TenantResolverPluginClient`](../../../tenant-resolver/tenant-resolver-sdk/src/plugin_api.rs) SDK trait and registers with the gateway through `ClientHub` under the plugin's GTS instance scope.
+- Connects to the AM-owned database through a dedicated SecureConn pool bound to a read-only database role (`SELECT` on `tenants` and `tenant_closure`).
+- Translates SDK calls to parameterized SQL reads, applies `BarrierMode` / status filter / `max_depth` as SQL predicates, and hydrates SDK types from the result rows.
+
+The plugin does not:
+
+- Own any schema, table, index, migration, or persisted state.
+- Cache tenants, ancestors, descendants, closure rows, or any derived hierarchy state in memory.
+- Run a sync loop, rebuild a projection, or consume a change-token from AM.
+- Evaluate authorization decisions, issue SQL predicates beyond the SDK contract, or apply `SecurityContext` enforcement.
+- Write to AM-owned storage — the database role forbids it.
+- Expose any REST, gRPC, or external wire API; all observability is via OpenTelemetry signals and structured logs.
+- Participate in user, group, or resource lifecycle flows.
+
+### 3.2 Deployment Context
+
+- **Process:** In-process module hosted by the Tenant Resolver gateway. Gateway registration traverses `ClientHub`.
+- **Storage access:** SecureConn connection pool to the AM-owned database over a read-only database role. No network boundary with AM's writer process; consistency is enforced at the database level by AM's transactional closure maintenance.
+- **Config surface:** `db_url` (read-only role endpoint), `pool_max_connections`, `query_timeout` (default 5 s).
+- **Isolation:** The plugin process holds only the credentials for the read-only role. It holds no AM writer credentials, no IdP credentials, and no signing keys.
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Full implementation of the [`TenantResolverPluginClient`](../../../tenant-resolver/tenant-resolver-sdk/src/plugin_api.rs) trait (`get_tenant`, `get_root_tenant`, `get_tenants`, `get_ancestors`, `get_descendants`, `is_ancestor`) with SDK-contract ordering, null/barrier/status semantics, and `BarrierMode` handling (p1).
+- Parameterized SQL reads against AM-owned `tenants` and `tenant_closure`, applying barrier, status, and `max_depth` as SQL predicates on the AM-canonical closure columns (p1).
+- Full implementation of root-tenant discovery (`get_root_tenant`) with the SDK's single-root invariant and deterministic failure semantics when AM storage is inconsistent (p1).
+- Reverse hydration of public `tenant_type` values from AM's stored `tenant_type_uuid` through Types Registry, backed by a bounded lazy process-local cache (p1).
+- SecureConn connection pool bound to a dedicated read-only database role, with privilege assertion at plugin startup and in CI (p1).
+- Per-statement query timeout and connection-pool backpressure (p2).
+- OpenTelemetry telemetry set covering Performance, Reliability, Security, and Versatility vectors (p1).
+- Structured logs carrying `trace_id` on every SDK call, plus `request_id` when the gateway provides one (p1).
+
+### 4.2 Out of Scope
+
+- Hierarchy closure maintenance — owned by AM under [`cpt-cf-account-management-fr-tenant-closure`](../PRD.md).
+- Process-local caching of tenants, ancestors, descendants, or closure rows — by design; consistency is transactional at the database.
+- Any synchronization loop, projection rebuild, drift detection, revision/change-token contract with AM, or staging-swap mechanism — AM owns closure transactionally.
+- Multi-region reads and cross-region routing.
+- Read-replica routing and topology tuning.
+- Public REST / gRPC API surface or external SDK — callers interact with the gateway, not the plugin.
+- Authorization decision logic, `SecurityContext` validation, or tenant-type trait interpretation.
+- Tenant data mutations — the plugin never writes to AM; the database role forbids it.
+
+## 5. Functional Requirements
+
+> **Testing strategy**: All requirements verified via automated tests (unit, integration, e2e) targeting 90%+ code coverage unless otherwise specified. Document verification method only for non-test approaches.
+
+### 5.1 SDK Contract Implementation
+
+#### Plugin Client Registration
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-fr-plugin-api`
+
+**Actors**: `cpt-cf-tr-plugin-actor-tenant-resolver-gateway`
+
+The plugin **MUST** implement the [`TenantResolverPluginClient`](../../../tenant-resolver/tenant-resolver-sdk/src/plugin_api.rs) SDK trait in full and register itself with the Tenant Resolver gateway through `ClientHub` under the plugin's configured GTS instance identifier. All SDK-defined semantics (nullability, ordering, barrier handling, error variants) **MUST** be preserved unchanged.
+
+- **Rationale**: The gateway is the only consumer. Any deviation from the SDK contract would either fail at the gateway's trait-bound or silently break every downstream AuthZ decision that depends on hierarchy ordering and barrier enforcement.
+
+#### Get Tenant
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-fr-get-tenant`
+
+**Actors**: `cpt-cf-tr-plugin-actor-authz-resolver`, `cpt-cf-tr-plugin-actor-tenant-resolver-gateway`
+
+The plugin **MUST** return a `TenantInfo` for any tenant present in `tenants` in `active`, `suspended`, or `deleted` status, and **MUST** return `TenantResolverError::TenantNotFound` for identifiers not present or whose row is in internal `provisioning` status (per [`cpt-cf-tr-plugin-fr-provisioning-invisibility`](#provisioning-row-invisibility)). The lookup **MUST** be served by a single indexed `SELECT` against `tenants` carrying the provisioning-exclusion predicate.
+
+- **Rationale**: Callers depend on status-agnostic identity resolution across the three SDK-visible statuses; filtering on `active`/`suspended`/`deleted` is the caller's responsibility and happens at the AuthZ layer, not the data layer. The `provisioning` state is a different kind of invariant — it is internal to AM and has no SDK representation, so the plugin treats it as absence by construction.
+
+#### Get Root Tenant
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-fr-get-root-tenant`
+
+**Actors**: `cpt-cf-tr-plugin-actor-authz-resolver`, `cpt-cf-tr-plugin-actor-tenant-resolver-gateway`
+
+The plugin **MUST** return the unique root tenant as `TenantInfo`, where the root is the single tenant with `parent_id = NULL` and `status <> 'provisioning'`. The lookup **MUST** be served from AM-owned `tenants`. If storage does not currently contain exactly one non-provisioning root tenant — including the bootstrap window when the root is still `provisioning` — the plugin **MUST** fail deterministically with `TenantResolverError::Internal` rather than synthesizing a value or returning a provisioning row (per [`cpt-cf-tr-plugin-fr-provisioning-invisibility`](#provisioning-row-invisibility)).
+
+- **Rationale**: The SDK treats the single-root invariant as part of the tenant model contract. If AM storage violates that invariant — or if bootstrap has not yet finalized the root — returning an arbitrary row would hide a structural data-integrity fault on the authorization path.
+
+#### Get Tenants (Batch)
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-fr-get-tenants`
+
+**Actors**: `cpt-cf-tr-plugin-actor-authz-resolver`
+
+The plugin **MUST** accept a batch of identifiers, deduplicate them, apply the caller-supplied `GetTenantsOptions.status` filter as a SQL predicate (`status = []` means all SDK-visible statuses), return a `TenantInfo` for each identifier found that matches the filter, and silently drop identifiers not present in `tenants` or whose row is in internal `provisioning` status (per [`cpt-cf-tr-plugin-fr-provisioning-invisibility`](#provisioning-row-invisibility)). Order of the response is **not** required to match input order (matches the SDK doc comment on `get_tenants`).
+
+- **Rationale**: Bulk lookups are common in authorization evaluation; silent-drop semantics match the SDK contract and let callers treat absence as authoritative at the moment of the read. Provisioning rows are silently dropped for the same reason — they are never visible to SDK callers.
+
+#### Get Ancestors
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-fr-get-ancestors`
+
+**Actors**: `cpt-cf-tr-plugin-actor-authz-resolver`, `cpt-cf-tr-plugin-actor-tenant-resolver-gateway`
+
+The plugin **MUST** return `GetAncestorsResponse`, where `tenant` is the requested tenant as `TenantRef` and `ancestors` is the strict-ancestor chain in deterministic direct-parent-first order (root last), with a stable tie-breaker across tenants at the same hierarchy level. The starting tenant **MUST** exist and **MUST NOT** be invisible per [`cpt-cf-tr-plugin-fr-provisioning-invisibility`](#provisioning-row-invisibility) — otherwise the plugin returns `TenantResolverError::TenantNotFound`. Ancestors that are themselves invisible per provisioning invisibility **MUST** be excluded. When `BarrierMode::Respect` is requested, barrier enforcement **MUST** follow [`cpt-cf-tr-plugin-fr-barrier-semantics`](#barrier-enforcement-at-the-data-layer): a self-managed starting tenant returns an empty ancestor chain; a self-managed ancestor is itself included and traversal stops above it. When `BarrierMode::Ignore` is requested, the full strict-ancestor chain **MUST** be returned. Ancestor ordering **MUST NOT** require any application-layer hierarchy walk — see [DESIGN §3.2 PluginImpl](DESIGN.md#pluginimpl) and [DESIGN §3.6 Ancestor Query](DESIGN.md#ancestor-query-hot-path) for the allocation.
+
+- **Rationale**: AuthZ traverses ancestor chains to evaluate inherited policy and resource-scope eligibility; deterministic direct-parent-first ordering is required so that callers can short-circuit at the nearest-ancestor match. Ancestor ordering is derived from AM's denormalized hierarchy depth (`cpt-cf-account-management-nfr-context-validation-latency` index strategy) and is served by indexed reads; the concrete mechanism is an allocation decision recorded in DESIGN.
+
+#### Get Descendants
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-fr-get-descendants`
+
+**Actors**: `cpt-cf-tr-plugin-actor-authz-resolver`, `cpt-cf-tr-plugin-actor-tenant-resolver-gateway`
+
+The plugin **MUST** return `GetDescendantsResponse`, where `tenant` is the requested tenant as `TenantRef` and `descendants` is the descendant subtree in the SDK's deterministic pre-order traversal (parent before descendants of that parent; stable sibling ordering), honouring the caller-supplied `BarrierMode`, `max_depth`, and `status_filter`. The starting tenant **MUST** exist and **MUST NOT** be invisible per [`cpt-cf-tr-plugin-fr-provisioning-invisibility`](#provisioning-row-invisibility) — otherwise the plugin returns `TenantResolverError::TenantNotFound`. `max_depth` **MUST** be enforced as a bound on traversal depth from the starting tenant. Barrier enforcement under `BarrierMode::Respect` **MUST** follow [`cpt-cf-tr-plugin-fr-barrier-semantics`](#barrier-enforcement-at-the-data-layer): self-managed children and their subtrees are excluded, while queries that start from inside a self-managed tenant's own subtree are allowed. Descendants invisible per provisioning invisibility **MUST** be unconditionally excluded regardless of caller-supplied `status_filter`. The `status_filter` **MUST** apply only to `descendants`, not to the starting `tenant` (per SDK contract). Results **MUST** exclude the starting tenant from `descendants`. The concrete ordering mechanism and `max_depth` bounding are allocation decisions recorded in [DESIGN §3.2 PluginImpl](DESIGN.md#pluginimpl) and [DESIGN §3.6 Descendant Query](DESIGN.md#descendant-query-barrier-aware).
+
+- **Rationale**: Subtree queries are the second most frequent call from AuthZ; bounding depth and filtering by `descendant_status` as a SQL predicate on the closure row avoids transporting rows the caller would discard. Pre-order is computed at query time because AM exposes neither a materialized pre-order key nor a per-closure-row depth; the cost of the bounded recursive walk scales with the returned subtree rather than with total tenant count. Barrier enforcement remains a single SQL predicate on the closure — the recursive walk is *ordering* work, not *barrier* work.
+
+#### Is Ancestor
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-fr-is-ancestor`
+
+**Actors**: `cpt-cf-tr-plugin-actor-authz-resolver`
+
+The plugin **MUST** answer `is_ancestor(ancestor_id, descendant_id)` with `true` iff `descendant_id` is a strict descendant of `ancestor_id` under the supplied `BarrierMode`, using AM-owned `tenant_closure` after validating that both tenant identifiers exist and are not in `provisioning` status. Under `BarrierMode::Respect`, the existence probe **MUST** apply the canonical no-barrier predicate on the closure row (v1: `AND barrier = 0`); because AM defines `barrier` over `(ancestor, descendant]`, this also enforces the SDK's endpoint case that a self-managed `descendant_id` is not considered reachable from any ancestor. Self-reference (`ancestor_id == descendant_id`) **MUST** return `false`. If either tenant identifier is absent from `tenants` or its row is in `provisioning` status (per [`cpt-cf-tr-plugin-fr-provisioning-invisibility`](#provisioning-row-invisibility)), the plugin **MUST** return `TenantResolverError::TenantNotFound`.
+
+- **Rationale**: `is_ancestor` is the lightest-weight decision primitive for policy evaluation; strict-descendant semantics match the authorization model (a tenant is not its own ancestor).
+
+### 5.2 Barrier and Status Semantics
+
+#### Barrier Enforcement at the Data Layer
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-fr-barrier-semantics`
+
+**Actors**: `cpt-cf-tr-plugin-actor-authz-resolver`, `cpt-cf-tr-plugin-actor-pep`
+
+Every SDK operation invoked with `BarrierMode::Respect` **MUST** enforce the per-pair barrier against AM's canonical barrier state as the sole barrier-evaluation step — no application-layer path walking, no per-row policy evaluation, and no plugin-local recomputation of barrier state from tenant mode. Barrier enforcement **MUST** reduce to a single-point lookup per ancestor-descendant pair so that the three SDK edge cases are all satisfied by the same check: self-managed starting tenants return empty ancestors; self-managed children are excluded from descendants (`Respect`); `is_ancestor` returns `false` when the descendant endpoint is self-managed or another barrier lies on the path. `BarrierMode::Ignore` **MUST** return rows regardless of barrier state and **MUST** be observable on a dedicated metric so operators can audit bypass usage. Alignment with AM's canonical barrier semantics — defined over the interval `(ancestor, descendant]` per [`cpt-cf-account-management-principle-barrier-as-data`](../DESIGN.md#barrier-as-data) and [TENANT_MODEL.md §Closure Table](../../../../../docs/arch/authorization/TENANT_MODEL.md#closure-table) — is a correctness precondition.
+
+Ordering and `max_depth` bounding for `get_descendants` (see [`cpt-cf-tr-plugin-fr-get-descendants`](#get-descendants)) **MUST NOT** re-evaluate, replicate, or override the barrier check — barrier enforcement remains a single lookup per pair. The concrete mechanism (schema, predicates, CTE shape) is an allocation recorded in [DESIGN §3.2 PluginImpl](DESIGN.md#pluginimpl) and [DESIGN §3.6 Descendant Query](DESIGN.md#descendant-query-barrier-aware).
+
+- **Rationale**: Barrier enforcement must be answered in hot-path time per authorization decision; AM maintains the canonical barrier state transactionally with tenant mutations — see [`cpt-cf-account-management-principle-barrier-as-data`](../DESIGN.md#barrier-as-data). Keeping query-time traversal strictly out of barrier evaluation preserves auditability: whether a row crosses a respected barrier is always a property of one canonical data point, never of a code path.
+
+#### Status Filtering at the Data Layer
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-fr-status-filtering`
+
+**Actors**: `cpt-cf-tr-plugin-actor-authz-resolver`
+
+The plugin **MUST** apply caller-supplied status filters against AM's canonical tenant-status state without any application-layer hierarchy walk for status filtering. For `get_descendants`, caller-supplied status filtering **MUST NOT** apply to the starting tenant — the caller observes the starting tenant regardless of its status. Provisioning exclusion is enforced structurally by AM's closure contract (provisioning tenants have no closure rows, so closure-driven reads cannot surface them) and by the plugin's defense-in-depth filter on direct `tenants` reads (per [`cpt-cf-tr-plugin-fr-provisioning-invisibility`](#provisioning-row-invisibility)); the caller cannot opt in to provisioning rows. The concrete mechanism (use of AM's denormalized closure-status column vs. per-row join) is an allocation recorded in [DESIGN §3.2 PluginImpl](DESIGN.md#pluginimpl).
+
+- **Rationale**: Subtree-scoped authorization frequently excludes `Suspended`/`Deleted` tenants; leveraging AM's denormalized descendant-status column avoids amplifying read cost per descendant, and the SDK contract requires the starting tenant not to be filtered out. The provisioning exclusion is orthogonal — it is a plugin-boundary invariant, not an authorization choice, so caller intent cannot override it.
+
+#### Provisioning Row Invisibility
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-fr-provisioning-invisibility`
+
+**Actors**: `cpt-cf-tr-plugin-actor-tenant-resolver-gateway`, `cpt-cf-tr-plugin-actor-authz-resolver`
+
+The plugin **MUST** treat AM rows carrying the internal `provisioning` status as non-existent from the SDK perspective. Provisioning invisibility is enforced in two layers:
+
+1. **Structural (primary)** — AM's closure contract ([`cpt-cf-account-management-fr-tenant-closure`](../PRD.md)) guarantees `tenant_closure` contains no rows for provisioning tenants. Closure-driven reads (`get_descendants`, `is_ancestor`, strict-ancestor side of `get_ancestors`) therefore cannot surface provisioning tenants at all, by construction.
+2. **Defense-in-depth (plugin-side)** — direct reads of `tenants` (existence probes for every SDK method, bulk-by-ids for `get_tenants`, ancestor hydration JOINs for `get_ancestors`) **MUST** carry a provisioning-exclusion predicate so that a corrupted or transitional `tenants` row cannot leak into an SDK response.
+
+Concretely:
+
+- `get_tenant` and `is_ancestor` **MUST** return `TenantResolverError::TenantNotFound` when the matched `tenants` row is provisioning.
+- `get_tenants` **MUST** silently drop provisioning rows from the response.
+- `get_root_tenant` **MUST** apply the provisioning filter before evaluating the single-root invariant; if the sole root-candidate is still provisioning (e.g. bootstrap in progress), the plugin **MUST** fail with `TenantResolverError::Internal`.
+- `get_ancestors` and `get_descendants` **MUST** treat a provisioning starting tenant as absent (`TenantNotFound`).
+- The exclusion **MUST** be enforced uniformly across every SDK method.
+
+The exclusion applies regardless of caller-supplied `GetTenantsOptions.status` / `GetDescendantsOptions.status_filter` — provisioning is not a caller-selectable status. The concrete enforcement point (query-builder boundary in `PluginImpl`, uniform across every SDK method) is an allocation recorded in [DESIGN §3.2 PluginImpl](DESIGN.md#pluginimpl) and [DESIGN §1.2 Functional Drivers row for `cpt-cf-tr-plugin-fr-provisioning-invisibility`](DESIGN.md#12-architecture-drivers).
+
+- **Rationale**: AM's tenant-create saga and bootstrap flow persist transient `provisioning` rows in the `tenants` table **only** — `tenant_closure` rows are not written during the provisioning window. Closure rows are inserted in a single transaction with the `provisioning → active` transition at saga step 3, and removed in a single transaction on hard-deletion (see [AM ADR-0007 — Exclude Provisioning Tenants from `tenant_closure`](../ADR/0007-cpt-cf-account-management-adr-provisioning-excluded-from-closure.md) and the DB-level guard `CHECK (descendant_status IN (1, 2, 3))` on `tenant_closure` in [migration.sql](../migration.sql)). Compensation of a stuck provisioning tenant deletes only the `tenants` row; no closure cleanup is needed because nothing was ever written. Provisioning invisibility on closure-driven reads is therefore structural — by construction, not by filtering. The plugin-side provisioning-exclusion predicate on direct `tenants` reads (existence probes, bulk-by-ids, ancestor hydration JOINs) is defense-in-depth against a stray `tenants`-row leak: the SDK `TenantStatus` enum defines only `Active` / `Suspended` / `Deleted`, so surfacing a `provisioning` row — as a raw DB value or by synthesizing a fake status — would be both a contract violation and a pre-activation visibility leak. Centralizing the filter at the plugin boundary makes correctness verifiable by construction and keeps the rest of the SDK path oblivious to AM's internal saga states.
+
+### 5.3 Observability
+
+#### Metric and Log Surface
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-fr-observability`
+
+**Actors**: `cpt-cf-tr-plugin-actor-operator`, `cpt-cf-tr-plugin-actor-platform-telemetry`
+
+The plugin **MUST** export OpenTelemetry telemetry covering query latency per operation, database query duration, connection-pool utilization and waiters, query error rates by cause, barrier-enforcement rate, barrier-bypass usage (distinguishable on a dedicated metric), barrier-mode / query-shape mix, and tenant-not-found rate. Every SDK call **MUST** produce a database span carrying OpenTelemetry trace/span context so that logs, traces, and metric points can be joined in the platform telemetry backend. Structured logs **MUST** include `trace_id` and, when the gateway provides one, `request_id`.
+
+- **Rationale**: Query latency, pool saturation, and barrier-enforcement rate are the operational signals that distinguish healthy traffic from a stuck pool, a scanning adversary, or a regression. Without the defined telemetry set operators cannot diagnose hot-path behavior.
+
+## 6. Non-Functional Requirements
+
+> **Global baselines**: Project-wide NFRs (reliability, security posture, observability conventions) are inherited from the root PRD and from AM. This section enumerates only module-specific NFRs with measurable thresholds.
+>
+> **Testing strategy**: NFRs verified via automated benchmarks, load tests, chaos tests, and production telemetry on the approved deployment profile (see AM §13 Review Baseline Decisions — 100K tenants, plus the plugin's 200K-tenant scaling target).
+
+### 6.1 Query Latency
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-nfr-query-latency`
+
+The plugin **MUST** answer `get_tenant`, `get_root_tenant`, `get_ancestors`, and `is_ancestor` within **p95 ≤ 5 ms** on the approved deployment profile. `get_tenants` **MUST** answer within **p95 ≤ 10 ms** for batches of up to 128 identifiers; larger batches scale linearly with batch size and are explicitly out of the per-call budget.
+
+- **Threshold**: p95 ≤ 5 ms for single-tenant and ancestor operations; p95 ≤ 10 ms for `get_tenants` at batch size ≤ 128. Measured from SDK call entry to SDK response return under nominal load with warm connection pool and warm `tenant_type` cache.
+- **Rationale**: Every authorization decision may issue one or more of these calls; staying inside a 5 ms budget per call keeps authorization latency within the platform's overall request-path budget. `get_tenant` / `get_root_tenant` are one indexed `SELECT` (primary key or partial index on `parent_id IS NULL`), both carrying the `status <> 'provisioning'` predicate; `is_ancestor` is at most two indexed reads (existence probe on `tenants` PK + `EXISTS` on `tenant_closure` PK); `get_ancestors` is two indexed reads (existence probe on `tenants` PK + `tenant_closure` index on `descendant_id` joined to `tenants` PK, ordered by `tenants.depth` DESC). Batch lookups amortize connection-pool overhead across multiple identifiers but remain bounded so bulk calls do not swamp the hot-path connection pool.
+- **Architecture Allocation**: See [DESIGN §3.2 `PluginImpl`](DESIGN.md#pluginimpl) and [§3.7 index coverage](DESIGN.md#37-database-schemas--tables).
+
+### 6.2 Subtree Query Latency
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-nfr-subtree-latency`
+
+`get_descendants` **MUST** complete at **p99 ≤ 20 ms** on the approved deployment profile when the result set is bounded to **≤ 1 000 rows** (typically by the caller supplying `max_depth` or operating on a subtree of that size). Unbounded calls (`max_depth = None` on a large subtree) are explicitly outside this NFR; they are governed by per-statement `query_timeout` and gateway-level rate limiting.
+
+- **Threshold**: p99 ≤ 20 ms when `|descendants| ≤ 1 000`, measured end-to-end from SDK call to SDK response with warm connection pool and warm `tenant_type` cache.
+- **Rationale**: Subtree queries are broader than ancestor queries and scale with the caller-controlled depth / subtree size. The plugin issues a starting-tenant existence probe plus a single recursive-CTE query that walks the `tenants.parent_id` tree rooted at the starting tenant (bounded by `max_depth`) and joins into `tenant_closure` on `(ancestor_id = starting_tenant, descendant_id)` to apply `barrier` and `descendant_status` predicates. For an N-row result set the walk does O(N) work on `tenants(parent_id, status)` plus O(N) primary-key lookups on `tenant_closure`. Bounding the NFR to the 1 000-row cut-off matches typical PEP compilation shapes and keeps the hot-path connection pool protected from unbounded scans; unbounded calls (e.g., operator rollups) are a separate regime owned by `query_timeout` and gateway-level rate limiting, not by the latency budget.
+- **Architecture Allocation**: See [DESIGN §3.2 `PluginImpl`](DESIGN.md#pluginimpl) and [§3.7 index coverage](DESIGN.md#37-database-schemas--tables).
+
+### 6.3 Closure Consistency
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-nfr-closure-consistency`
+
+Every SDK call **MUST** observe a transactionally consistent `(tenants, tenant_closure)` pair. No configuration, load, or failure condition may produce a response in which tenant-hierarchy state disagrees between the two tables.
+
+- **Threshold**: Zero partial-state windows observed under concurrent AM writes + plugin reads across 24 h of soak test; integration tests verify closure invariants on create/delete/status/convert without any intervening sync step.
+- **Rationale**: Consistency here is a security property — a stale barrier or a stale denormalized status is a visibility bug. By binding closure maintenance to AM's write transactions (see [`cpt-cf-account-management-fr-tenant-closure`](../PRD.md)) and forbidding caches for hierarchy or closure data, the platform removes the failure mode entirely rather than bounding it. The only allowed cache is a bounded reverse-lookup cache for `tenant_type_uuid -> tenant_type`, which does not affect barrier or status semantics.
+- **Architecture Allocation**: See [DESIGN §2.1 Single-Store Hierarchy](DESIGN.md#single-store-hierarchy) and [§3.5 Account Management Storage](DESIGN.md#account-management-storage).
+
+### 6.4 Tenant Isolation
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-nfr-tenant-isolation`
+
+Queries with `BarrierMode::Respect` **MUST NOT** return any row that lies across a respected barrier. Zero barrier-crossing leaks **MUST** be observed on the full barrier matrix test suite (every SDK operation × both `BarrierMode` values) during pre-GA and at every release.
+
+- **Threshold**: Zero observed leaks.
+- **Rationale**: A single leak is a security incident. Keeping barrier enforcement as a single SQL predicate on the AM-canonical `barrier` column makes isolation verifiable by construction.
+- **Architecture Allocation**: See [DESIGN §2.1 Barrier as Data, Not as Policy](DESIGN.md#barrier-as-data-not-as-policy) and [§3.3 AM-owned schema](DESIGN.md#api-contracts-am-owned-schema-consumed-not-defined).
+
+### 6.5 Audit Trail
+
+- [ ] `p2` - **ID**: `cpt-cf-tr-plugin-nfr-audit-trail`
+
+Every SDK call (success or failure) **MUST** produce a structured log carrying `trace_id` and OpenTelemetry trace/span context that identify the same call in logs, traces, and metrics. When the gateway provides a `request_id`, that identifier **MUST** be included in the same log record. Every use of `BarrierMode::Ignore` **MUST** be recorded on a dedicated telemetry instrument distinguishable from `Respect`.
+
+- **Threshold**: 100% of SDK calls have matching log + trace context; `BarrierMode::Ignore` uses are separately countable in telemetry.
+- **Rationale**: Correlating a failed call or a barrier-bypass with the corresponding trace requires shared trace context, and `request_id` improves log-level debugging when the call originates from an HTTP gateway. Without those identifiers, operators cannot diagnose a bypass or a regression from telemetry alone.
+- **Architecture Allocation**: See [DESIGN §4.2 Audit](DESIGN.md#audit) and [§4.3 Feature Telemetry](DESIGN.md#feature-telemetry).
+
+### 6.6 Observability Coverage
+
+- [ ] `p2` - **ID**: `cpt-cf-tr-plugin-nfr-observability`
+
+The plugin **MUST** export at least **3 telemetry instruments** per applicable quality vector: Performance, Reliability, Security, and Versatility. Efficiency is not a plugin-owned vector because the plugin holds no state.
+
+- **Threshold**: ≥ 3 telemetry instruments × 4 vectors (Performance, Reliability, Security, Versatility); dashboards and alerts wired before GA.
+- **Rationale**: Without per-vector coverage, operators cannot distinguish "slow but correct" from "fast but leaking" from "healthy but degrading"; alert fatigue and misdiagnosis follow.
+- **Architecture Allocation**: See [DESIGN §4.3 Feature Telemetry](DESIGN.md#feature-telemetry).
+
+### NFR Exclusions
+
+- **Multi-region availability / cross-region RPO**: Not applicable — v1 is single-region. Revisit when the platform grows multi-region deployments.
+- **End-user PII protection**: Not applicable — the plugin stores no state; AM is the data custodian.
+- **Offline / disconnected operation**: Not applicable — the plugin is in-process behind the gateway and reads from AM-owned storage; "offline" means the database is unreachable.
+- **Freshness / staleness bounds**: Not applicable — consistency is transactional at the database, not bounded by a sync interval.
+- **Plugin-level uptime SLO**: Not applicable as a standalone target — plugin availability tracks the AM-owned database availability governed by AM's reliability posture; there is no independent degraded mode and no projection to fall back to. Operator-facing availability is observed via `tenant_resolver_query_errors_total{op,kind}` and `tenant_resolver_db_pool_waiters`.
+- **Safety (operational safety / fail-safe / hazard warnings / emergency shutdown / human override)**: Not applicable — the plugin is a pure information system with no physical-world interaction, no actuators, no medical-device or industrial-control coupling. Safety-class requirements (ISO/IEC 25010:2023 §4.2.9) do not apply.
+- **User experience (UX) / accessibility / internationalization / device-platform / inclusivity**: Not applicable — the plugin is an in-process Rust module with no user-facing interface. Callers interact with the Tenant Resolver gateway, not with this plugin; UX / WCAG / i18n / offline-device / cognitive-accessibility concerns are out of scope at the plugin layer.
+- **Plugin-level user authentication (MFA, SSO / federation, session management, credential policies)**: Not applicable — user authentication and session lifecycle are owned by the Tenant Resolver gateway's upstream chain; the plugin authenticates only its own read-only database role via SecureConn and has no user sessions or tokens of its own.
+- **Write-level non-repudiation**: Not applicable — the plugin issues no writes; read-level attribution via the gateway-supplied `request_id` and OpenTelemetry trace context (see §6.5 Audit Trail) is sufficient for forensic review of plugin-observed events.
+- **Plugin-level recovery (RPO / RTO / backup / DR / BC / data replication)**: Not applicable — the plugin holds no state; recovery is entirely AM-owned and operates on AM-owned tables under AM's data-governance stance.
+- **Release cadence / rollback / blue-green / canary / environment parity**: Not applicable at the plugin level — the plugin ships as an in-process module co-deployed with the Tenant Resolver gateway and inherits the platform release pipeline; rollback is "redeploy previous plugin binary" with no data migration.
+- **Plugin-level log retention / incident response hooks**: Not applicable — log retention is inherited from the platform telemetry pipeline; incident alerts route through platform SRE on-call via the metrics defined in [DESIGN §4.3 Feature Telemetry](DESIGN.md#feature-telemetry).
+- **Regulatory compliance / industry-standard certifications / OWASP-ASVS / NIST-800-53 plugin-specific controls**: Not applicable at the plugin scope — the plugin stores no credentials, no user PII, no tokens; compliance is inherited from the platform security posture and AM's data-governance controls.
+- **OpenAPI / Swagger API documentation**: Not applicable — the plugin's contract is a Rust trait (`TenantResolverPluginClient`); the SDK trait's rustdoc is authoritative. No HTTP wire API exists at the plugin boundary.
+- **End-user documentation, admin guides, training material, help system, support tier, self-service support, third-party data processors (GDPR Art. 28), user-generated content ownership, data cleansing/validation/catalog/lineage/MDM, seasonal / historical growth patterns, report-generation latency**: Not applicable — the plugin is an internal platform module with no end-user UI, no third-party data processors, no user-generated content surface, and no report-generation path; developer documentation is the SDK trait's rustdoc plus this PRD and DESIGN.
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+#### TenantResolverPluginClient (SDK trait, consumed)
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-interface-plugin-client-contract`
+
+- **Type**: Rust trait
+- **Stability**: stable — version-bounded by the Tenant Resolver SDK
+- **Description**: The public read contract the plugin implements. Defined by [`tenant-resolver-sdk`](../../../tenant-resolver/tenant-resolver-sdk/src/plugin_api.rs); this plugin does not extend or shadow the trait.
+- **Breaking Change Policy**: SDK-owned. Any breaking change to the trait requires an SDK major version bump and a coordinated plugin update.
+
+### 7.2 External Integration Contracts
+
+#### AM Read-Only Storage Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-contract-am-read-only-role`
+
+- **Direction**: required from AM (plugin consumes)
+- **Protocol/Format**: SecureConn pool over a dedicated read-only database role.
+- **Consumed state** (AM-owned; the plugin is a read-only consumer): the AM tenant row data and the platform-canonical closure shape defined in [TENANT_MODEL.md §Closure Table](../../../../../docs/arch/authorization/TENANT_MODEL.md#closure-table) — including AM's denormalized hierarchy-depth attribute used for ancestor ordering and descendant depth bounding, AM's canonical barrier state over the interval `(ancestor, descendant]`, and AM's denormalized descendant status. The canonical schema (column names, types, constraints, indexes) and the allocation of plugin-visible fields to the SDK projection are recorded in [DESIGN §3.3 API Contracts — AM-owned schema (consumed, not defined)](DESIGN.md#api-contracts-am-owned-schema-consumed-not-defined), [DESIGN §3.5 External Dependencies — Account Management Storage](DESIGN.md#account-management-storage), and [AM DESIGN §3.7 `tenants` + `tenant_closure`](../DESIGN.md#37-database-schemas--tables). The plugin reads only the subset of AM columns required for SDK projection; it does not read AM administrative columns (e.g., soft-delete timestamps) on the SDK path.
+- **Public `tenant_type` hydration**: `tenant_type_uuid` values returned from AM are reverse-resolved through Types Registry; the plugin may keep successful mappings in a bounded lazy process-local cache.
+- **Privileges**: read-only on AM's canonical tenant tables; no mutation privileges on any AM-owned object. The role's grant set is asserted at plugin startup and in CI (see [`cpt-cf-tr-plugin-nfr-tenant-isolation`](#64-tenant-isolation)).
+- **Compatibility**: any rename, removal, or type change to the consumed columns requires a coordinated AM + plugin release. AM is the sole writer; the plugin never invokes any mutation. Closure maintenance on every tenant write is AM's responsibility under [`cpt-cf-account-management-fr-tenant-closure`](../PRD.md).
+
+#### Types Registry Reverse Lookup Contract
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-contract-types-registry-reverse-lookup`
+
+- **Direction**: required from Types Registry (plugin consumes)
+- **Protocol/Format**: In-process module call through the platform module boundary used for GTS type lookup.
+- **Consumed / Provided Data**: `tenant_type_uuid -> chained tenant_type` reverse lookup for the UUIDs returned from AM-owned `tenants` rows.
+- **Caching**: The plugin may memoize successful mappings in a bounded lazy process-local cache keyed by `tenant_type_uuid`.
+- **Failure semantics**: If a public `tenant_type` cannot be resolved for a tenant row, the plugin **MUST** fail the call deterministically with `TenantResolverError::Internal`; it **MUST NOT** return raw UUIDs in place of the SDK's public `tenant_type` field.
+- **Compatibility**: Mapping semantics must remain stable for AM-stored `tenant_type_uuid` values produced from the shared UUIDv5 convention.
+
+## 8. Use Cases
+
+### 8.1 Get Root Tenant
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-usecase-get-root-tenant`
+
+**Actor**: `cpt-cf-tr-plugin-actor-authz-resolver` (via `cpt-cf-tr-plugin-actor-tenant-resolver-gateway`)
+
+**Preconditions**:
+- Plugin is ready; connection pool is warm.
+- AM storage satisfies the single-root invariant (`parent_id = NULL` on exactly one tenant row) and the root is in a non-provisioning status (bootstrap has completed).
+
+**Main Flow**:
+1. Gateway calls `get_root_tenant(ctx)` on the plugin.
+2. The plugin issues a `SELECT` against AM's `tenants` for the unique row with `parent_id IS NULL AND status <> 'provisioning'`.
+3. On hit, the plugin reverse-resolves `tenant_type_uuid` to the public chained `tenant_type` identifier through Types Registry; successful lookups are memoized in a bounded lazy cache.
+4. The plugin projects the row onto `TenantInfo` and returns it.
+
+**Postconditions**:
+- Caller receives the unique root `TenantInfo`.
+- `tenant_resolver_query_duration_seconds{op="get_root_tenant"}` recorded.
+
+**Alternative Flows**:
+- **No root or multiple roots present, or sole root is still `provisioning`**: `TenantResolverError::Internal` returned; the inconsistency (or the bootstrap-incomplete state) is surfaced to operators.
+- **Database unreachable / query timeout**: `TenantResolverError::Internal` returned; `tenant_resolver_query_errors_total{op="get_root_tenant",kind}` increments.
+
+### 8.2 Get Tenant
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-usecase-get-tenant`
+
+**Actor**: `cpt-cf-tr-plugin-actor-authz-resolver` (via `cpt-cf-tr-plugin-actor-tenant-resolver-gateway`)
+
+**Preconditions**:
+- Plugin is ready; connection pool is warm.
+
+**Main Flow**:
+1. Gateway calls `get_tenant(ctx, id)` on the plugin.
+2. The plugin issues a single indexed `SELECT` against AM's `tenants` with `id = $1 AND status <> 'provisioning'`.
+3. On hit, the plugin reverse-resolves `tenant_type_uuid` to the public chained `tenant_type` identifier through Types Registry; successful lookups are memoized in a bounded lazy cache.
+4. The plugin projects the row onto `TenantInfo` and returns it.
+
+**Postconditions**:
+- Caller receives `TenantInfo`.
+- `tenant_resolver_query_duration_seconds{op="get_tenant"}` recorded.
+
+**Alternative Flows**:
+- **Tenant not found or in `provisioning` status**: `TenantResolverError::TenantNotFound` returned; `tenant_resolver_tenant_not_found_total` increments. The plugin does not distinguish "absent" from "provisioning" in the public error.
+- **Database unreachable / query timeout**: `TenantResolverError::Internal` returned; `tenant_resolver_query_errors_total{op="get_tenant",kind}` increments; gateway decides retry.
+
+### 8.3 Ancestor Query
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-usecase-ancestor-query`
+
+**Actor**: `cpt-cf-tr-plugin-actor-authz-resolver` (via `cpt-cf-tr-plugin-actor-tenant-resolver-gateway`)
+
+**Preconditions**:
+- Tenant `T` exists in `tenants`.
+
+**Main Flow**:
+1. AuthZ calls `get_ancestors(ctx, T, options)` through the gateway.
+2. The plugin validates that tenant `T` exists in `tenants` with `status <> 'provisioning'` and uses the AM-owned tenant row to populate `response.tenant`.
+3. The plugin reads AM's `tenant_closure` with `descendant_id = T AND ancestor_id <> descendant_id`, joining `tenants` on the ancestor side with `status <> 'provisioning'`, applying the caller-supplied barrier mode, and ordering by `tenants.depth DESC, tenants.id`.
+4. If any returned rows carry uncached `tenant_type_uuid` values, the plugin reverse-resolves them through Types Registry and memoizes successful mappings.
+5. Results are returned as `GetAncestorsResponse { tenant, ancestors }`, with `ancestors` ordered from the tenant outward (direct parent first, root last).
+
+**Postconditions**:
+- Caller receives the ancestor chain in documented order.
+- `tenant_resolver_query_duration_seconds{op="get_ancestors"}` and `tenant_resolver_barrier_enforced_total` increment as applicable.
+
+**Alternative Flows**:
+- **Starting tenant not found**: `TenantResolverError::TenantNotFound` returned; `tenant_resolver_tenant_not_found_total` increments.
+- **Ignore mode**: Full chain returned regardless of barrier flag; `tenant_resolver_barrier_bypass_total{op="get_ancestors"}` increments for operator audit.
+
+### 8.4 Descendant Query
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-usecase-descendant-query`
+
+**Actor**: `cpt-cf-tr-plugin-actor-authz-resolver` (via `cpt-cf-tr-plugin-actor-tenant-resolver-gateway`)
+
+**Preconditions**:
+- Tenant `T` exists in `tenants`.
+
+**Main Flow**:
+1. AuthZ calls `get_descendants(ctx, T, options{barrier_mode, status_filter, max_depth})` through the gateway.
+2. The plugin validates that tenant `T` exists in `tenants` with `status <> 'provisioning'` and uses the AM-owned tenant row to populate `response.tenant`.
+3. The plugin issues a single bounded recursive read rooted at `T` that walks the `tenants.parent_id` tree (with siblings ordered by `id`), bounded by `max_depth`. The walk is joined to `tenant_closure` on `(ancestor_id = T, descendant_id)` to apply the caller-supplied barrier mode (barrier-clear filter under `Respect`) and the caller-supplied `descendant_status` filter. Provisioning exclusion is structural — `tenant_closure` contains no provisioning rows by AM's closure contract ([`cpt-cf-account-management-fr-tenant-closure`](../PRD.md)) — so no additional predicate is needed on the join.
+4. If any returned rows carry uncached `tenant_type_uuid` values, the plugin reverse-resolves them through Types Registry and memoizes successful mappings.
+5. Results are returned as `GetDescendantsResponse { tenant, descendants }`, with `descendants` in the SDK's documented pre-order traversal (parent before descendants of that parent) — ordering is produced by the CTE, not by a materialized AM column.
+
+**Postconditions**:
+- Caller receives the bounded subtree.
+- `tenant_resolver_query_duration_seconds{op="get_descendants"}` recorded.
+
+**Alternative Flows**:
+- **`max_depth` = 1**: Returns direct children only.
+- **Empty subtree**: Empty vector returned; not an error.
+- **Status filter excludes everything**: Empty vector; `tenant_resolver_query_types_total{op="get_descendants"}` still increments.
+
+### 8.5 Is Ancestor
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-usecase-is-ancestor`
+
+**Actor**: `cpt-cf-tr-plugin-actor-authz-resolver`
+
+**Preconditions**:
+- Both `ancestor_id` and `descendant_id` are syntactically valid identifiers.
+
+**Main Flow**:
+1. AuthZ calls `is_ancestor(ctx, ancestor_id, descendant_id, options)`.
+2. The plugin validates that both tenant identifiers resolve to rows in `tenants` with `status <> 'provisioning'`. If either row is missing or in `provisioning` status, the plugin returns `TenantResolverError::TenantNotFound` — this check **MUST** occur before any early return, consistent with `cpt-cf-tr-plugin-fr-provisioning-invisibility` and the §8.5 Alternative Flow below.
+3. If `ancestor_id == descendant_id`, the plugin returns `false` without querying `tenant_closure` (a tenant is never a strict ancestor of itself; this optimization runs only after step 2 has already confirmed the id exists and is non-provisioning).
+4. Otherwise the plugin issues an `EXISTS` probe on `tenant_closure` with `ancestor_id <> descendant_id` and the supplied barrier mode.
+
+**Postconditions**:
+- Caller receives a `bool`.
+- `tenant_resolver_query_duration_seconds{op="is_ancestor"}` recorded.
+
+**Alternative Flows**:
+- **Either identifier absent from `tenants` or in `provisioning` status**: `TenantResolverError::TenantNotFound` returned.
+
+### 8.6 Barrier-Respecting Query
+
+- [ ] `p1` - **ID**: `cpt-cf-tr-plugin-usecase-barrier-respect`
+
+**Actor**: `cpt-cf-tr-plugin-actor-authz-resolver`
+
+**Preconditions**:
+- Hierarchy: `Root → A → B (self-managed) → C`.
+- AM has committed the tenant tree and the corresponding `tenant_closure` rows in the same transaction.
+
+**Main Flow**:
+1. AuthZ calls `get_descendants(Root, BarrierMode::Respect)` through the gateway.
+2. Plugin returns `{A}` only; the subtree beyond the self-managed boundary at `B` is excluded by `AND barrier = 0`.
+3. AuthZ calls `get_ancestors(C, BarrierMode::Respect)`; plugin returns `{B}` (ancestors beyond the barrier are excluded).
+4. AuthZ calls `is_ancestor(Root, B, BarrierMode::Respect)`; plugin returns `false` because the descendant endpoint `B` itself is self-managed and `barrier = 1` on `(Root, B]`.
+5. AuthZ separately calls `get_descendants(Root, BarrierMode::Ignore)` on the billing-rollup path; plugin returns `{A, B, C}`.
+
+**Postconditions**:
+- Barrier enforcement is observed at the data layer; `tenant_resolver_barrier_enforced_total` increments for steps 1–3.
+- `BarrierMode::Ignore` usage is distinguishable on `tenant_resolver_barrier_bypass_total` for operator review.
+
+**Alternative Flows**:
+- **Nested barriers**: Hierarchy `Root → A (self-managed) → B → C (self-managed) → D`. `get_descendants(Root, Respect)` returns `{}` (the direct child `A` is self-managed, so `A` and its subtree are excluded); `get_descendants(A, Respect)` returns `{B}` (`B` is a plain descendant; `C` is self-managed so it and `D` are excluded); `get_descendants(C, Respect)` returns `{D}` (starting tenant `C` is self-managed but the SDK contract excludes only self-managed *descendants*; `D` is a plain descendant with `(C, D] = {D}` and `barrier = 0`, so it is included). Traversal never continues *past* a self-managed descendant, but a self-managed tenant's own subtree remains visible when queried directly.
+
+## 9. Acceptance Criteria
+
+- [ ] Plugin registers with the Tenant Resolver gateway via `ClientHub` under its configured GTS instance identifier and passes the gateway's SDK-conformance probe.
+- [ ] Every SDK operation (`get_tenant`, `get_root_tenant`, `get_tenants`, `get_ancestors`, `get_descendants`, `is_ancestor`) passes the SDK-contract test suite, including empty-batch handling, self-reference semantics, root-tenant invariants, null/absent handling, and documented ordering guarantees.
+- [ ] `BarrierMode::Respect` excludes barrier-crossing rows and `BarrierMode::Ignore` returns them, verified by the barrier-matrix test suite covering every operation × mode combination; zero leaks observed. Barrier enforcement is a single SQL predicate on `tenant_closure.barrier`; the descendant pre-order walk does not replicate or override it.
+- [ ] `get_descendants` returns descendants in the SDK's deterministic pre-order with siblings ordered by `id`, produced at query time by a bounded recursive walk of `tenants.parent_id` rooted at the starting tenant; `max_depth` is enforced as the walk's recursion bound. `get_ancestors` returns ancestors in `tenants.depth DESC, tenants.id` order, expressed as an `ORDER BY` on the joined `tenants` row. Verified by ordering tests on mixed-shape fixtures.
+- [ ] Status filtering on `get_tenants` and `get_descendants` is applied as a SQL predicate on the canonical column (`tenants.status` or `tenant_closure.descendant_status`); `get_descendants` does not filter the starting tenant.
+- [ ] Every SDK call observes a transactionally consistent `(tenants, tenant_closure)` pair under concurrent AM writes, verified by an integration test that seeds tenant mutations through AM and reads through the plugin without any intervening step.
+- [ ] `get_tenant`, `get_root_tenant`, `get_ancestors`, and `is_ancestor` stay within p95 ≤ 5 ms on the approved deployment profile; `get_descendants` stays within p99 ≤ 20 ms.
+- [ ] The plugin's database role exposes only `SELECT` on `tenants` and `tenant_closure`; a startup assertion and a CI check both confirm the grant set. Any mutation attempted through the role is rejected by the database.
+- [ ] Connection pool waits and errors surface on `tenant_resolver_db_pool_waiters` and `tenant_resolver_query_errors_total{op,kind}`; dashboards and alert routes exist pre-GA.
+- [ ] Telemetry set exports ≥ 3 instruments per applicable quality vector (Performance, Reliability, Security, Versatility); dashboards and alert routes exist pre-GA.
+- [ ] Every SDK call emits a structured log with `trace_id` and OpenTelemetry trace/span context, plus `request_id` when provided by the gateway, so that the same execution is joinable across `tenant_resolver_query_duration_seconds`, logs, and traces; every use of `BarrierMode::Ignore` is countable on a dedicated bypass metric.
+- [ ] No plugin-owned REST / gRPC endpoint exists; the gateway is the sole external surface.
+- [ ] `TenantResolverError::TenantNotFound` is returned (not a synthesized value) for identifiers absent from `tenants`, or for identifiers whose row is in internal `provisioning` status, on the SDK operations that require existence (`get_tenant`, `get_ancestors`, `get_descendants`, `is_ancestor`); absence and provisioning both are authoritative at the moment of the read and are not distinguished in the public error.
+- [ ] Provisioning invisibility is enforced in two layers: (1) structurally, `tenant_closure` contains no rows for provisioning tenants (AM's closure contract) so closure-driven reads cannot surface them; (2) every direct read the plugin issues against `tenants` that participates in an SDK response carries the provisioning-exclusion predicate as defense-in-depth. An integration test seeds a `provisioning` tenant via AM's saga path and asserts it is invisible on every SDK method (`get_tenant`, `get_root_tenant`, `get_tenants`, `get_ancestors`, `get_descendants`, `is_ancestor`) under both `BarrierMode` values and all `status` filter choices.
+- [ ] Public `tenant_type` values are returned as chained GTS schema identifiers or the call fails deterministically; raw `tenant_type_uuid` values never leak through the SDK.
+
+## 10. Dependencies
+
+**Plugin depends on:**
+
+| Dependency | Description | Criticality |
+|------------|-------------|-------------|
+| [Account Management](../PRD.md) | Source-of-truth tenant hierarchy; owns `tenants` and `tenant_closure` and maintains them transactionally on every tenant write. Provisions the read-only database role consumed by this plugin. | p1 |
+| [Tenant Resolver gateway](../../../tenant-resolver/) | Delegation target that resolves the plugin through `ClientHub` under the plugin's GTS instance scope. | p1 |
+| [Tenant Resolver SDK](../../../tenant-resolver/tenant-resolver-sdk/) | `TenantResolverPluginClient` trait and models. Changes to the trait require a coordinated plugin update. | p1 |
+| AM-owned database | Physical PostgreSQL instance that hosts `tenants` and `tenant_closure`; reached via SecureConn under the plugin's read-only role. | p1 |
+| [Types Registry](../../../types-registry/) | Reverse-resolves `tenant_type_uuid` values from AM storage into public chained `tenant_type` identifiers for SDK responses. | p1 |
+| Platform telemetry | OpenTelemetry metrics/traces pipeline and structured-log pipeline for operator dashboards and alerts. | p2 |
+
+**Depend on this plugin (consumers):**
+
+| Consumer | What it consumes |
+|----------|------------------|
+| Tenant Resolver gateway | SDK trait methods on every tenant-hierarchy call from the platform. |
+| AuthZ Resolver Plugin | Hot-path hierarchy queries via the gateway. |
+| Domain-module PEPs | Non-SQL consumers that need subtree membership through the SDK; SQL-backed PEPs read AM's `tenant_closure` directly at compilation time. |
+
+## 11. Assumptions
+
+- **AM transactional closure maintenance is available at implementation time.** The plugin's correctness assumes AM updates `tenant_closure` in the same transaction as every tenant write (see [`cpt-cf-account-management-fr-tenant-closure`](../PRD.md)).
+- **AM-owned read-only role is provisioned.** Operator provisioning grants `SELECT` on `tenants` and `tenant_closure` to the plugin's role before plugin startup. The plugin asserts the grant set at boot.
+- **AM and the plugin share a database.** v1 assumes co-located tenant storage; cross-region or dedicated-replica routing is out of scope.
+- **Types Registry is reachable for cache misses.** Public `tenant_type` hydration depends on Types Registry whenever the local `tenant_type_uuid` cache is cold or misses.
+- **`SecurityContext` propagation is gateway-owned.** The plugin trusts the `SecurityContext` it receives from the gateway and does not re-validate tokens or re-authenticate callers.
+- **Approved deployment profile matches AM's.** Scale targets inherit AM's profile (100K tenants, 300K users, 1K rps peak — see AM PRD §13), plus the plugin's 200K-tenant scaling target.
+- **Plugin computes descendant ordering and `max_depth` at query time.** AM does not materialize a pre-order key on `tenant_closure` or a depth-from-ancestor column. The plugin emits the SDK's deterministic pre-order for `get_descendants` by walking the `tenants.parent_id` tree rooted at the starting tenant in a bounded recursive CTE, with siblings ordered by `id`, and applies `max_depth` as the recursion bound. Ancestor ordering for `get_ancestors` is expressed at the SQL layer using AM's stable `tenants.depth` column (absolute depth from the root) — no recursive walk is needed on the ancestor path. Barrier and status enforcement remain single SQL predicates on the AM-canonical closure row and are not affected by the walk.
+- **Hot-path latency budgets are evaluated in steady state.** The stated p95/p99 targets assume a warm connection pool and a warm bounded `tenant_type` cache; cold-start and cache-miss behavior remain observable and must fail deterministically if Types Registry is unavailable.
+
+## 12. Risks
+
+| Risk | Likelihood | Severity | Impact | Mitigation |
+|------|-----------|----------|--------|------------|
+| AM's `tenant_closure` shape or index coverage diverges from the plugin's read expectations. | Low | High | Hot-path reads regress or fail under load. | Shared schema is versioned as part of AM; renames / removals require coordinated AM + plugin releases. Integration tests pin column names and index coverage. |
+| Plugin role is provisioned with broader privileges than `SELECT` on the two tables. | Low | High | A plugin compromise could corrupt canonical hierarchy state. | Startup assertion on the role's grant set; CI check against role definitions; operator-run provisioning playbook reviewed as part of deployment. |
+| Connection-pool saturation under burst load stalls hot-path reads. | Medium | Medium | Elevated latency and queueing errors at the gateway. | Pool sized against the gateway's concurrency profile; `tenant_resolver_db_pool_waiters` alert; per-statement `query_timeout`. |
+| Types Registry is slow or unavailable on a `tenant_type` cache miss. | Medium | Medium | Calls that need public `tenant_type` hydration fail with `Internal` or exceed hot-path latency targets during cold-start / miss bursts. | Pre-warm the `tenant_type_uuid → tenant_type` cache at plugin readiness from the small, enumerable set of registered tenant-type schemas; bounded lazy cache covers later type additions. Monitor cache-miss and request latency; fail deterministically rather than returning raw UUIDs; validate steady-state budgets with warm cache and exercise cold-start separately. |
+| Long-running `get_descendants` on a very large subtree monopolizes connections. | Low | Medium | Shared pool contention degrades other operations. | `max_depth` supported at the SDK; per-statement timeout enforced; gateway-level rate limiting is the primary control. |
+| Database unavailability while AM writer is healthy. | Low | High | Plugin fails all reads; no independent degraded mode. | By design — the plugin has no projection to fall back to. The database is the unit of availability; HA is an AM-level concern. |
+| Scaling beyond 200K tenants changes the cost profile of subtree reads. | Low | Medium | `get_descendants` latency regresses beyond documented NFR. | 200K-tenant scale fixture exercised pre-GA; AM's `tenant_closure` index design is the scaling lever, not an application-level change in the plugin. |
+
+## 13. Open Questions
+
+- **Read-replica routing for the plugin's role.** Owner: Platform SRE. Target resolution: deferred — v1 reads from the primary. Revisiting requires defining plugin-visible consistency semantics on the chosen replica topology.
+- **Cross-region reads.** Owner: Platform SRE. Target resolution: deferred — v1 is single-region.
+
+## 14. Traceability
+
+- **Upstream requirements**: No UPSTREAM_REQS document exists for this plugin. Requirements are derived directly from the in-repo [AM PRD](../PRD.md), [AM DESIGN](../DESIGN.md), the [Tenant Resolver SDK trait](../../../tenant-resolver/tenant-resolver-sdk/src/plugin_api.rs), and [TENANT_MODEL.md](../../../../../docs/arch/authorization/TENANT_MODEL.md).
+- **Downstream artifacts**: [DESIGN.md](DESIGN.md) maps every FR and NFR ID in this PRD to DESIGN components, principles, interfaces, and contracts — see [DESIGN §5 Traceability](DESIGN.md#5-traceability). [ADR-001](ADR/ADR-001-tenant-hierarchy-closure-ownership.md) captures the closure-ownership decision that shapes this PRD. [`schemas/tr_plugin.v1.schema.json`](schemas/tr_plugin.v1.schema.json) publishes the chained Modkit plugin instance type registered with types-registry at module startup; ordering contracts are owned by the SDK trait docs, not by the instance schema. `DECOMPOSITION` and `FEATURE` artifacts are intentionally deferred; they will be created once implementation begins against AM's committed closure contract.
+- **Canonical platform references**:
+  - [Account Management PRD](../PRD.md) — source-of-truth tenant model, closure ownership, barrier semantics.
+  - [Account Management DESIGN](../DESIGN.md) — `tenants` + `tenant_closure` schema, barrier-as-data principle, transactional closure maintenance.
+  - [TENANT_MODEL.md](../../../../../docs/arch/authorization/TENANT_MODEL.md) — platform-canonical `tenant_closure` schema.
+  - [Tenant Resolver SDK — `TenantResolverPluginClient`](../../../tenant-resolver/tenant-resolver-sdk/src/plugin_api.rs) — authoritative trait surface.
+  - [Tenant Resolver SDK — models](../../../tenant-resolver/tenant-resolver-sdk/src/models.rs) — authoritative public types reused by this plugin.

--- a/modules/system/account-management/docs/tr-plugin/schemas/tr_plugin.v1.schema.json
+++ b/modules/system/account-management/docs/tr-plugin/schemas/tr_plugin.v1.schema.json
@@ -1,0 +1,22 @@
+{
+  "$id": "gts://gts.x.core.modkit.plugin.v1~x.core.tenant_resolver.plugin.v1~",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Tenant Resolver Plugin (AM-backed)",
+  "description": "Chained Modkit plugin type implemented by the AM-backed Tenant Resolver Plugin. Concrete plugin instances append a vendor-qualified suffix (for example, gts.x.core.modkit.plugin.v1~x.core.tenant_resolver.plugin.v1~<vendor>.<package>.tenant_resolver.plugin.v1) and are registered with types-registry at module startup so the Tenant Resolver gateway can discover and resolve them through ClientHub.",
+  "allOf": [
+    {
+      "$ref": "gts://gts.x.core.modkit.plugin.v1~"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {},
+          "description": "No tr-plugin-specific properties in v1. The plugin contract is carried by the SDK TenantResolverPluginClient trait, not by the registered instance payload."
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
About TENANT_MODEL.md changes:

The old wording said "strictly between ancestor and descendant, not including the ancestor itself" without pinning the descendant endpoint. Under a literal reading of "strictly between" the interior (T1, T2) is empty, so T1 → T2 should be barrier = 0 — but
   the same section's example table showed T1 → T2: barrier = 1. So the doc contradicted itself.    

  The new wording makes the endpoint rule explicit:                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                 
  - (ancestor, descendant] — ancestor excluded, descendant included                                                                                                                                                                                                              
  - Self-rows (id, id) fixed to barrier = 0 as a special case


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified tenant authorization barrier semantics with updated interval notation.
  * Restructured Account Management and Tenant Resolver Plugin architecture documentation to reflect closure-table ownership and query-facade design patterns.
  * Added comprehensive Tenant Resolver Plugin specification covering query execution, barrier enforcement, and performance guarantees.
  * Updated API contracts for conversion requests with new actor fields and required metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->