### PR TITLE
chore: bump the Rust version to 1.95.0

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install latest nightly toolchain (project requires Rust 1.92+)
+# Install latest nightly toolchain (project requires Rust 1.95+)
 # rust-src is required for sanitizer builds
 RUN rustup toolchain install nightly --force && \
     rustup default nightly && \

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -2,7 +2,7 @@
 # Copyright 2026 HyperSpot Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# Update Rust toolchain to latest nightly (project requires Rust 1.92+)
+# Update Rust toolchain to latest nightly (project requires Rust 1.95+)
 # ClusterFuzzLite sets RUSTUP_TOOLCHAIN=nightly-2025-09-05 which is too old
 # We must override it to use latest nightly
 unset RUSTUP_TOOLCHAIN

--- a/.github/workflows/api_contracts.yml
+++ b/.github/workflows/api_contracts.yml
@@ -81,7 +81,7 @@ jobs:
           cache: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       # Cache Cargo registry/git + target/ across platforms.
       - name: Cache Cargo/target
@@ -89,7 +89,7 @@ jobs:
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-${{ runner.os }}-stable-1.92
+          shared-key: pr-${{ runner.os }}-stable-1.95
 
       # Install sccache (cross-platform)
       - name: Install sccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           cache: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - name: Install nextest
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
@@ -74,7 +74,7 @@ jobs:
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-${{ runner.os }}-stable-1.92
+          shared-key: pr-${{ runner.os }}-stable-1.95
 
       # Install sccache (cross-platform)
       - name: Install sccache
@@ -112,7 +112,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - name: Install nextest
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
@@ -124,7 +124,7 @@ jobs:
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-${{ runner.os }}-integration-stable-1.92
+          shared-key: pr-${{ runner.os }}-integration-stable-1.95
 
       # Install sccache (cross-platform)
       - name: Install sccache
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       # Install tools via prebuilt binaries for speed.
       - name: Install cargo-deny
@@ -187,7 +187,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      RUSTUP_TOOLCHAIN: nightly-2026-01-20
+      RUSTUP_TOOLCHAIN: nightly-2026-01-22
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -198,7 +198,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain (with llvm-tools)
-        uses: dtolnay/rust-toolchain@881ba7bf39a41cda34ac9e123fb41b44ed08232f # nightly
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
           toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
           components: llvm-tools-preview
@@ -237,13 +237,13 @@ jobs:
     name: Dylint Tests
     runs-on: ubuntu-latest
     env:
-      RUSTUP_TOOLCHAIN: nightly-2025-09-18
+      RUSTUP_TOOLCHAIN: nightly-2026-01-22
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust nightly toolchain
-        uses: dtolnay/rust-toolchain@881ba7bf39a41cda34ac9e123fb41b44ed08232f # nightly
+        uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
         with:
           toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
           components: llvm-tools-preview,rustc-dev

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -24,14 +24,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-fmt-stable-1.92
+          shared-key: pr-fmt-stable-1.95
 
       - name: cargo fmt (check)
         run: make fmt

--- a/.github/workflows/gts-validation.yml
+++ b/.github/workflows/gts-validation.yml
@@ -28,14 +28,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
         with:
           cache-bin: false
           cache-targets: false
-          shared-key: pr-Linux-stable-1.92
+          shared-key: pr-Linux-stable-1.95
 
       - name: Validate GTS identifiers
         run: make gts-docs

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - name: release-plz release-pr
         uses: release-plz/action@52440b50d383aa252927de395c8b2c1e0a9cf8e9 # v0.3.155
@@ -176,7 +176,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@9bc92bc5598b4f3bec5d910d352094982cb0c3b9 # 1.92.0
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
 
       - name: Install nextest
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We welcome contributions in:
 
 ### 1.1 Prerequisites
 
-- **Rust stable** with Cargo (Edition 2024, Rust MSRV 1.92.0)
+- **Rust stable** with Cargo (Edition 2024, Rust MSRV 1.95.0)
 - **Protocol Buffers compiler** (`protoc`) (see `README.md`)
 - **Git** for version control
 - **Your favorite editor** (VS Code with rust-analyzer recommended)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 authors = ["Cyber Fabric"]
 repository = "https://github.com/cyberfabric/cyberfabric-core"
 description = "HyperSpot Server"
-rust-version = "1.92.0"
+rust-version = "1.95.0"
 readme = "README.md"
 
 [profile.dev]

--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ dylint-test: install-tools
 dylint:
 	$(call check_tool,cargo-dylint)
 	$(call check_tool,dylint-link)
-	cargo +nightly-2025-09-18 dylint --all --workspace
+	cargo +nightly-2026-01-22 dylint --all --workspace
 
 # Run all code safety checks
 safety: clippy kani lint dylint # geiger

--- a/docs/arch/authorization/INTEGRATION_TEST_PLAN.md
+++ b/docs/arch/authorization/INTEGRATION_TEST_PLAN.md
@@ -44,7 +44,7 @@ Follows existing project conventions: `testing/e2e/modules/{module}/` for HTTP-l
 
 ## Prerequisites
 
-- Rust stable (MSRV 1.92.0)
+- Rust stable (MSRV 1.95.0)
 - Docker (for PostgreSQL)
 - `protoc` installed (`brew install protobuf` on macOS)
 

--- a/libs/modkit-canonical-errors/tests/ui/missing_field_violation_on_invalid_argument.stderr
+++ b/libs/modkit-canonical-errors/tests/ui/missing_field_violation_on_invalid_argument.stderr
@@ -1,4 +1,4 @@
-error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<ResourceOptional, NeedsFieldViolation>`, but its trait bounds were not satisfied
+error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<modkit_canonical_errors::builder::ResourceOptional, modkit_canonical_errors::builder::NeedsFieldViolation>`, but its trait bounds were not satisfied
   --> tests/ui/missing_field_violation_on_invalid_argument.rs:10:54
    |
 10 |     let _err = UserResourceError::invalid_argument().create();
@@ -7,7 +7,7 @@ error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<Resour
   ::: src/builder.rs
    |
    | pub struct NeedsFieldViolation;
-   | ------------------------------ doesn't satisfy `NeedsFieldViolation: ContextResolved`
+   | ------------------------------ doesn't satisfy `_: ContextResolved`
    |
    = note: the following trait bounds were not satisfied:
-           `NeedsFieldViolation: ContextResolved`
+           `modkit_canonical_errors::builder::NeedsFieldViolation: modkit_canonical_errors::builder::ContextResolved`

--- a/libs/modkit-canonical-errors/tests/ui/missing_precondition_violation_on_failed_precondition.stderr
+++ b/libs/modkit-canonical-errors/tests/ui/missing_precondition_violation_on_failed_precondition.stderr
@@ -1,4 +1,4 @@
-error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<ResourceOptional, NeedsPreconditionViolation>`, but its trait bounds were not satisfied
+error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<modkit_canonical_errors::builder::ResourceOptional, modkit_canonical_errors::builder::NeedsPreconditionViolation>`, but its trait bounds were not satisfied
   --> tests/ui/missing_precondition_violation_on_failed_precondition.rs:10:57
    |
 10 |     let _err = UserResourceError::failed_precondition().create();
@@ -7,7 +7,7 @@ error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<Resour
   ::: src/builder.rs
    |
    | pub struct NeedsPreconditionViolation;
-   | ------------------------------------- doesn't satisfy `NeedsPreconditionViolation: ContextResolved`
+   | ------------------------------------- doesn't satisfy `_: ContextResolved`
    |
    = note: the following trait bounds were not satisfied:
-           `NeedsPreconditionViolation: ContextResolved`
+           `modkit_canonical_errors::builder::NeedsPreconditionViolation: modkit_canonical_errors::builder::ContextResolved`

--- a/libs/modkit-canonical-errors/tests/ui/missing_quota_violation_on_resource_exhausted.stderr
+++ b/libs/modkit-canonical-errors/tests/ui/missing_quota_violation_on_resource_exhausted.stderr
@@ -1,4 +1,4 @@
-error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<ResourceOptional, NeedsQuotaViolation>`, but its trait bounds were not satisfied
+error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<modkit_canonical_errors::builder::ResourceOptional, modkit_canonical_errors::builder::NeedsQuotaViolation>`, but its trait bounds were not satisfied
   --> tests/ui/missing_quota_violation_on_resource_exhausted.rs:10:72
    |
 10 |     let _err = UserResourceError::resource_exhausted("Quota exceeded").create();
@@ -7,7 +7,7 @@ error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<Resour
   ::: src/builder.rs
    |
    | pub struct NeedsQuotaViolation;
-   | ------------------------------ doesn't satisfy `NeedsQuotaViolation: ContextResolved`
+   | ------------------------------ doesn't satisfy `_: ContextResolved`
    |
    = note: the following trait bounds were not satisfied:
-           `NeedsQuotaViolation: ContextResolved`
+           `modkit_canonical_errors::builder::NeedsQuotaViolation: modkit_canonical_errors::builder::ContextResolved`

--- a/libs/modkit-canonical-errors/tests/ui/missing_reason_on_aborted.stderr
+++ b/libs/modkit-canonical-errors/tests/ui/missing_reason_on_aborted.stderr
@@ -1,4 +1,4 @@
-error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<ResourceOptional, NeedsReason>`, but its trait bounds were not satisfied
+error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<modkit_canonical_errors::builder::ResourceOptional, modkit_canonical_errors::builder::NeedsReason>`, but its trait bounds were not satisfied
   --> tests/ui/missing_reason_on_aborted.rs:10:92
    |
 10 |     let _err = UserResourceError::aborted("Operation aborted due to concurrency conflict").create();
@@ -7,7 +7,7 @@ error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<Resour
   ::: src/builder.rs
    |
    | pub struct NeedsReason;
-   | ---------------------- doesn't satisfy `NeedsReason: ContextResolved`
+   | ---------------------- doesn't satisfy `_: ContextResolved`
    |
    = note: the following trait bounds were not satisfied:
-           `NeedsReason: ContextResolved`
+           `modkit_canonical_errors::builder::NeedsReason: modkit_canonical_errors::builder::ContextResolved`

--- a/libs/modkit-canonical-errors/tests/ui/missing_reason_on_out_of_range.stderr
+++ b/libs/modkit-canonical-errors/tests/ui/missing_reason_on_out_of_range.stderr
@@ -1,4 +1,4 @@
-error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<ResourceOptional, NeedsFieldViolation>`, but its trait bounds were not satisfied
+error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<modkit_canonical_errors::builder::ResourceOptional, modkit_canonical_errors::builder::NeedsFieldViolation>`, but its trait bounds were not satisfied
   --> tests/ui/missing_reason_on_out_of_range.rs:10:69
    |
 10 |     let _err = UserResourceError::out_of_range("Page out of range").create();
@@ -7,7 +7,7 @@ error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<Resour
   ::: src/builder.rs
    |
    | pub struct NeedsFieldViolation;
-   | ------------------------------ doesn't satisfy `NeedsFieldViolation: ContextResolved`
+   | ------------------------------ doesn't satisfy `_: ContextResolved`
    |
    = note: the following trait bounds were not satisfied:
-           `NeedsFieldViolation: ContextResolved`
+           `modkit_canonical_errors::builder::NeedsFieldViolation: modkit_canonical_errors::builder::ContextResolved`

--- a/libs/modkit-canonical-errors/tests/ui/missing_reason_on_permission_denied.stderr
+++ b/libs/modkit-canonical-errors/tests/ui/missing_reason_on_permission_denied.stderr
@@ -1,13 +1,13 @@
-error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<ResourceAbsent, NeedsReason>`, but its trait bounds were not satisfied
+error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<modkit_canonical_errors::builder::ResourceAbsent, modkit_canonical_errors::builder::NeedsReason>`, but its trait bounds were not satisfied
   --> tests/ui/missing_reason_on_permission_denied.rs:10:55
    |
 10 |     let _err = UserResourceError::permission_denied().create();
-   |                                                       ^^^^^^ method cannot be called on `ResourceErrorBuilder<ResourceAbsent, NeedsReason>` due to unsatisfied trait bounds
+   |                                                       ^^^^^^ method cannot be called due to unsatisfied trait bounds
    |
   ::: src/builder.rs
    |
    | pub struct NeedsReason;
-   | ---------------------- doesn't satisfy `NeedsReason: ContextResolved`
+   | ---------------------- doesn't satisfy `_: ContextResolved`
    |
    = note: the following trait bounds were not satisfied:
-           `NeedsReason: ContextResolved`
+           `modkit_canonical_errors::builder::NeedsReason: modkit_canonical_errors::builder::ContextResolved`

--- a/libs/modkit-canonical-errors/tests/ui/missing_reason_on_unauthenticated.stderr
+++ b/libs/modkit-canonical-errors/tests/ui/missing_reason_on_unauthenticated.stderr
@@ -1,13 +1,13 @@
-error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<ResourceAbsent, NeedsReason>`, but its trait bounds were not satisfied
+error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<modkit_canonical_errors::builder::ResourceAbsent, modkit_canonical_errors::builder::NeedsReason>`, but its trait bounds were not satisfied
  --> tests/ui/missing_reason_on_unauthenticated.rs:7:50
   |
 7 |     let _err = CanonicalError::unauthenticated().create();
-  |                                                  ^^^^^^ method cannot be called on `ResourceErrorBuilder<ResourceAbsent, NeedsReason>` due to unsatisfied trait bounds
+  |                                                  ^^^^^^ method cannot be called due to unsatisfied trait bounds
   |
  ::: src/builder.rs
   |
   | pub struct NeedsReason;
-  | ---------------------- doesn't satisfy `NeedsReason: ContextResolved`
+  | ---------------------- doesn't satisfy `_: ContextResolved`
   |
   = note: the following trait bounds were not satisfied:
-          `NeedsReason: ContextResolved`
+          `modkit_canonical_errors::builder::NeedsReason: modkit_canonical_errors::builder::ContextResolved`

--- a/libs/modkit-canonical-errors/tests/ui/missing_resource_on_not_found.stderr
+++ b/libs/modkit-canonical-errors/tests/ui/missing_resource_on_not_found.stderr
@@ -1,13 +1,13 @@
-error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<ResourceMissing, NoContext>`, but its trait bounds were not satisfied
+error[E0599]: the method `create` exists for struct `ResourceErrorBuilder<modkit_canonical_errors::builder::ResourceMissing, modkit_canonical_errors::builder::NoContext>`, but its trait bounds were not satisfied
   --> tests/ui/missing_resource_on_not_found.rs:10:63
    |
 10 |     let _err = UserResourceError::not_found("User not found").create();
-   |                                                               ^^^^^^ method cannot be called on `ResourceErrorBuilder<ResourceMissing, NoContext>` due to unsatisfied trait bounds
+   |                                                               ^^^^^^ method cannot be called due to unsatisfied trait bounds
    |
   ::: src/builder.rs
    |
    | pub struct ResourceMissing;
-   | -------------------------- doesn't satisfy `ResourceMissing: ResourceResolved`
+   | -------------------------- doesn't satisfy `_: ResourceResolved`
    |
    = note: the following trait bounds were not satisfied:
-           `ResourceMissing: ResourceResolved`
+           `modkit_canonical_errors::builder::ResourceMissing: modkit_canonical_errors::builder::ResourceResolved`

--- a/libs/modkit-canonical-errors/tests/ui/retry_after_only_on_service_unavailable.stderr
+++ b/libs/modkit-canonical-errors/tests/ui/retry_after_only_on_service_unavailable.stderr
@@ -4,6 +4,6 @@ error[E0599]: no method named `with_retry_after_seconds` found for struct `Resou
 7 |       let _err = CanonicalError::internal("bug")
   |  ________________-
 8 | |         .with_retry_after_seconds(5)
-  | |         -^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ResourceErrorBuilder<ResourceAbsent, NoContext>`
+  | |         -^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ResourceErrorBuilder<modkit_canonical_errors::builder::ResourceAbsent, modkit_canonical_errors::builder::NoContext>`
   | |_________|
   |

--- a/libs/modkit-macros-tests/tests/ui/fail/module_name_consecutive_hyphens.stderr
+++ b/libs/modkit-macros-tests/tests/ui/fail/module_name_consecutive_hyphens.stderr
@@ -3,9 +3,3 @@ error: module name must not contain consecutive hyphens
   |
 6 |     name = "file--parser",  // Should fail: consecutive hyphens
   |            ^^^^^^^^^^^^^^
-
-error[E0412]: cannot find type `TestModule` in this scope
-  --> tests/ui/fail/module_name_consecutive_hyphens.rs:11:17
-   |
-11 | impl Module for TestModule {
-   |                 ^^^^^^^^^^ not found in this scope

--- a/libs/modkit-macros-tests/tests/ui/fail/module_name_ends_hyphen.stderr
+++ b/libs/modkit-macros-tests/tests/ui/fail/module_name_ends_hyphen.stderr
@@ -3,9 +3,3 @@ error: module name must not end with a hyphen
   |
 6 |     name = "parser-",  // Should fail: ends with hyphen
   |            ^^^^^^^^^
-
-error[E0412]: cannot find type `TestModule` in this scope
-  --> tests/ui/fail/module_name_ends_hyphen.rs:11:17
-   |
-11 | impl Module for TestModule {
-   |                 ^^^^^^^^^^ not found in this scope

--- a/libs/modkit-macros-tests/tests/ui/fail/module_name_snake_case.stderr
+++ b/libs/modkit-macros-tests/tests/ui/fail/module_name_snake_case.stderr
@@ -4,9 +4,3 @@ error: module name must use kebab-case, not snake_case
   |
 6 |     name = "file_parser",  // Should fail: uses snake_case instead of kebab-case
   |            ^^^^^^^^^^^^^
-
-error[E0412]: cannot find type `TestModule` in this scope
-  --> tests/ui/fail/module_name_snake_case.rs:11:17
-   |
-11 | impl Module for TestModule {
-   |                 ^^^^^^^^^^ not found in this scope

--- a/libs/modkit-macros-tests/tests/ui/fail/module_name_starts_hyphen.stderr
+++ b/libs/modkit-macros-tests/tests/ui/fail/module_name_starts_hyphen.stderr
@@ -3,9 +3,3 @@ error: module name must start with a lowercase letter, found '-'
   |
 6 |     name = "-parser",  // Should fail: starts with hyphen
   |            ^^^^^^^^^
-
-error[E0412]: cannot find type `TestModule` in this scope
-  --> tests/ui/fail/module_name_starts_hyphen.rs:11:17
-   |
-11 | impl Module for TestModule {
-   |                 ^^^^^^^^^^ not found in this scope

--- a/libs/modkit-macros-tests/tests/ui/fail/module_name_uppercase.stderr
+++ b/libs/modkit-macros-tests/tests/ui/fail/module_name_uppercase.stderr
@@ -3,9 +3,3 @@ error: module name must start with a lowercase letter, found 'F'
   |
 6 |     name = "FileParser",  // Should fail: contains uppercase letters
   |            ^^^^^^^^^^^^
-
-error[E0412]: cannot find type `TestModule` in this scope
-  --> tests/ui/fail/module_name_uppercase.rs:11:17
-   |
-11 | impl Module for TestModule {
-   |                 ^^^^^^^^^^ not found in this scope

--- a/libs/modkit/src/bootstrap/crypto.rs
+++ b/libs/modkit/src/bootstrap/crypto.rs
@@ -29,6 +29,7 @@ static INSTALLED: Once = Once::new();
 /// Returns [`CryptoProviderError::FipsProviderConflict`] if the `fips` feature is
 /// enabled and another crypto provider has already been installed.
 pub fn init_crypto_provider() -> Result<(), CryptoProviderError> {
+    #[allow(unused_mut)]
     let mut result = Ok(());
 
     INSTALLED.call_once(|| {
@@ -46,6 +47,7 @@ pub fn init_crypto_provider() -> Result<(), CryptoProviderError> {
 
         #[cfg(not(feature = "fips"))]
         {
+            #[allow(clippy::let_underscore_must_use)]
             let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         }
     });

--- a/modules/mini-chat/deploy/docker/mini-chat.Dockerfile
+++ b/modules/mini-chat/deploy/docker/mini-chat.Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for hyperspot-server with mini-chat + k8s features
 # Stage 1: Builder
-FROM rust:1.92-bookworm@sha256:e90e846de4124376164ddfbaab4b0774c7bdeef5e738866295e5a90a34a307a2 AS builder
+FROM rust:1.95.0-bookworm@sha256:6bb82db0878825e157664188b319c875de4f1fff5d70f5917b3a3f1974b472e4 AS builder
 
 # Build arguments
 ARG CARGO_FEATURES=mini-chat,static-authn,static-authz,single-tenant,static-credstore,k8s

--- a/modules/system/oagw/oagw/src/api/rest/handlers/route.rs
+++ b/modules/system/oagw/oagw/src/api/rest/handlers/route.rs
@@ -82,7 +82,10 @@ pub async fn list_routes(
     let upstream_uuid = params
         .upstream_id
         .as_deref()
-        .map(|id| parse_gts_id(id, gts::UPSTREAM_SCHEMA, instance))
+        .map(
+            #[allow(clippy::result_large_err)]
+            |id| parse_gts_id(id, gts::UPSTREAM_SCHEMA, instance),
+        )
         .transpose()?;
     let query = crate::domain::model::ListQuery {
         top: params.limit.min(100),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 ﻿[toolchain]
-channel = "1.92.0"
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]

--- a/testing/docker/hyperspot.Dockerfile
+++ b/testing/docker/hyperspot.Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for hyperspot-server API backend
 # Stage 1: Builder
-FROM rust:1.92-bookworm@sha256:e90e846de4124376164ddfbaab4b0774c7bdeef5e738866295e5a90a34a307a2 AS builder
+FROM rust:1.95.0-bookworm@sha256:6bb82db0878825e157664188b319c875de4f1fff5d70f5917b3a3f1974b472e4 AS builder
 
 # Build arguments for cargo features
 ARG CARGO_FEATURES

--- a/tools/dylint_lints/Cargo.lock
+++ b/tools/dylint_lints/Cargo.lock
@@ -213,6 +213,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +567,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
+ "rustls",
  "schemars",
  "sea-orm-migration",
  "serde",
@@ -742,13 +765,22 @@ dependencies = [
 
 [[package]]
 name = "clippy_utils"
-version = "0.1.92"
-source = "git+https://github.com/rust-lang/rust-clippy?rev=20ce69b9a63bcd2756cd906fe0964d1e901e042a#20ce69b9a63bcd2756cd906fe0964d1e901e042a"
+version = "0.1.95"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=54482290b5f32e6c6b57cc9e0a17153f432b0036#54482290b5f32e6c6b57cc9e0a17153f432b0036"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",
  "rustc_apfloat",
  "serde",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1351,6 +1383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dylint"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1692,12 @@ dependencies = [
  "lazy_static",
  "num",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3504,6 +3548,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,6 +3669,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -4937,6 +5030,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"

--- a/tools/dylint_lints/Cargo.toml
+++ b/tools/dylint_lints/Cargo.toml
@@ -52,7 +52,7 @@ unsafe_code = "forbid"
 unused_extern_crates = "warn"
 
 [workspace.dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "20ce69b9a63bcd2756cd906fe0964d1e901e042a" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "54482290b5f32e6c6b57cc9e0a17153f432b0036" }
 dylint_linting = "=5.0.0"
 dylint_testing = "=5.0.0"
 lint_utils = { path = "lint_utils" }

--- a/tools/dylint_lints/de03_domain_layer/de0301_no_infra_in_domain/rust-toolchain
+++ b/tools/dylint_lints/de03_domain_layer/de0301_no_infra_in_domain/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-09-18"
+channel = "nightly-2026-01-22"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/tools/dylint_lints/de03_domain_layer/de0308_no_http_in_domain/rust-toolchain
+++ b/tools/dylint_lints/de03_domain_layer/de0308_no_http_in_domain/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-09-18"
+channel = "nightly-2026-01-22"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/tools/dylint_lints/de07_security/de0706_no_direct_sqlx/rust-toolchain
+++ b/tools/dylint_lints/de07_security/de0706_no_direct_sqlx/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-09-18"
+channel = "nightly-2026-01-22"
 components = ["llvm-tools-preview", "rustc-dev"]

--- a/tools/dylint_lints/de07_security/de0707_drop_zeroize/src/lib.rs
+++ b/tools/dylint_lints/de07_security/de0707_drop_zeroize/src/lib.rs
@@ -260,10 +260,7 @@ impl<'tcx> LateLintPass<'tcx> for De0707DropZeroize {
             return;
         };
         let impl_def_id = item.owner_id.def_id;
-        let Some(impl_trait_ref) = cx.tcx.impl_trait_ref(impl_def_id) else {
-            return;
-        };
-        let impl_trait_ref = impl_trait_ref.instantiate_identity();
+        let impl_trait_ref = cx.tcx.impl_trait_ref(impl_def_id).instantiate_identity();
         let Some(drop_trait_did) = cx.tcx.lang_items().drop_trait() else {
             return;
         };

--- a/tools/dylint_lints/de09_gts_layer/de0901_gts_string_pattern/src/lib.rs
+++ b/tools/dylint_lints/de09_gts_layer/de0901_gts_string_pattern/src/lib.rs
@@ -59,7 +59,7 @@ impl EarlyLintPass for De0901GtsStringPattern {
         // Extract both the item name and the initializer expression from const/static items.
         // Note: `Item` has no top-level `ident`; it lives inside `ConstItem` / `StaticItem`.
         let (item_name, init_expr): (&str, Option<&Expr>) = match &item.kind {
-            ItemKind::Const(ci) => (ci.ident.name.as_str(), ci.expr.as_deref()),
+            ItemKind::Const(ci) => (ci.ident.name.as_str(), ci.rhs.as_ref().map(|rhs| rhs.expr())),
             ItemKind::Static(si) => (si.ident.name.as_str(), si.expr.as_deref()),
             _ => return,
         };

--- a/tools/dylint_lints/lint_utils/Cargo.toml
+++ b/tools/dylint_lints/lint_utils/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 test = false
 
 [dependencies]
-clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "20ce69b9a63bcd2756cd906fe0964d1e901e042a" }
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "54482290b5f32e6c6b57cc9e0a17153f432b0036" }
 dylint_linting.workspace = true
 
 [package.metadata.rust-analyzer]

--- a/tools/dylint_lints/lint_utils/src/lib.rs
+++ b/tools/dylint_lints/lint_utils/src/lib.rs
@@ -12,7 +12,7 @@ use rustc_lint::LintContext;
 use rustc_ast::{UseTree, UseTreeKind};
 
 use rustc_span::source_map::SourceMap;
-use rustc_span::{FileName, RealFileName, Span};
+use rustc_span::{FileName, RemapPathScopeComponents, Span};
 use std::collections::HashSet;
 
 const ALLOWED_FLAGS: &[&str] = &["request", "response"];
@@ -54,10 +54,12 @@ pub fn filename_str(source_map: &SourceMap, span: Span) -> Option<String> {
         FileName::Real(real) => {
             if let Some(local) = real.local_path() {
                 Some(local.to_string_lossy().to_string())
-            } else if let RealFileName::Remapped { virtual_name, .. } = real {
-                Some(virtual_name.to_string_lossy().to_string())
             } else {
-                None
+                Some(
+                    real.path(RemapPathScopeComponents::DIAGNOSTICS)
+                        .to_string_lossy()
+                        .to_string(),
+                )
             }
         }
         _ => None,

--- a/tools/dylint_lints/rust-toolchain.toml
+++ b/tools/dylint_lints/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-09-18"
+channel = "nightly-2026-01-22"
 components = ["llvm-tools-preview", "rustc-dev"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the project Rust minimum/toolchain to 1.95.0 across CI, build configs, Docker images, and documentation.
* **Tests**
  * Updated UI/compile-test expectations to match revised compiler diagnostic formatting.
* **Chores**
  * Updated linting/nightly toolchain pins and related tooling dependency revisions to align with the new toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->