### PR TITLE
fix(serverless-runtime): add ADR entries for workflow DSL and temporal workflow engine

### DIFF
--- a/modules/serverless-runtime/docs/DESIGN.md
+++ b/modules/serverless-runtime/docs/DESIGN.md
@@ -134,6 +134,8 @@ Requirements that significantly influence architecture decisions.
 |--------|-----------------|
 | `cpt-cf-serverless-runtime-adr-callable-type-hierarchy` | Unified callable type hierarchy: Function as base type, Workflow as derived specialization |
 | `cpt-cf-serverless-runtime-adr-jsonrpc-mcp-protocol-surfaces` | JSON-RPC 2.0 and MCP protocol surfaces for direct function invocation and AI agent tool integration |
+| `cpt-cf-serverless-runtime-adr-workflow-dsl` | CNCF Serverless Workflow Specification v1.0.0 adopted as the vendor-neutral, declarative JSON/YAML workflow DSL — decoupled from the execution engine |
+| `cpt-cf-serverless-runtime-adr-temporal-workflow-engine` | Temporal chosen as the durable execution backend for the workflow engine adapter, interpreting the Serverless Workflow DSL atop Temporal primitives |
 
 ### 1.3 Architecture Layers
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design documentation to reference architectural decisions regarding workflow specification and execution engine selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->