### PR TITLE
ci: switch Rust toolchain to `stable` channel so MSRV bumps stop breaking e2e

### DIFF
--- a/.github/workflows/api_contracts.yml
+++ b/.github/workflows/api_contracts.yml
@@ -81,7 +81,7 @@ jobs:
           cache: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@stable
 
       # Cache Cargo registry/git + target/ across platforms.
       - name: Cache Cargo/target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           cache: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install nextest
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
@@ -112,7 +112,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install nextest
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@stable
 
       # Install tools via prebuilt binaries for speed.
       - name: Install cargo-deny

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Set up Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.1
         with:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2

--- a/.github/workflows/gts-validation.yml
+++ b/.github/workflows/gts-validation.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -42,7 +42,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@stable
 
       - name: release-plz release-pr
         uses: release-plz/action@52440b50d383aa252927de395c8b2c1e0a9cf8e9 # v0.3.155
@@ -176,7 +176,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install nextest
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3

--- a/Makefile
+++ b/Makefile
@@ -698,9 +698,13 @@ ci_docs: lychee
 # Run CI pipeline locally, requires docker
 ci: fmt clippy test-no-macros test-macros test-db deny test-users-info-pg lychee dylint dylint-test
 
-# Build the hyperspot-server release binary using the stable toolchain.
+# Build the hyperspot-server release binary.
+# Toolchain is pinned by rust-toolchain.toml at the repo root — do NOT
+# pass `cargo +stable`, that overrides the pin and picks up whatever
+# rustup's `stable` channel currently resolves to (which on a stale
+# runner image can be a version older than the workspace MSRV).
 cargo-build:
-	cargo +stable build --release --bin hyperspot-server $(E2E_ARGS)
+	cargo build --release --bin hyperspot-server $(E2E_ARGS)
 
 # Split debug symbols into separate artifact(s) and strip the binary.
 # Requires platform tools: objcopy (Linux), dsymutil+strip (macOS).

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 ﻿[toolchain]
-channel = "1.95.0"
+channel = "stable"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## TL;DR

After PR #1586 ("chore: bump the Rust version to 1.95.0") was merged on 2026-04-24 10:27 UTC, the `e2e` job started failing on **every** subsequent PR (first on dependabot #rand-0.10.1 at 10:30 UTC, then on pr/rg-2-plugins #1550, and so on). The error is always the same:

```
error: rustc 1.94.1 is not supported by the following packages:
  cf-api-gateway@0.2.1 requires rustc 1.95.0
  cf-credstore@0.1.16 requires rustc 1.95.0
  …
```

This PR closes two gaps PR #1586 left behind **and** switches the whole toolchain policy to `stable` so future Rust releases stop introducing this class of failure.

## Why it broke

Two independent gaps combined:

1. **`.github/workflows/e2e.yml` was the only workflow PR #1586 did not update.** It never installed Rust at all; it relied on whatever rustc the `ubuntu-latest` runner image happened to ship preinstalled. The other five workflows (`api_contracts.yml`, `ci.yml`, `fmt.yml`, `gts-validation.yml`, `release-plz.yml`) did get `dtolnay/rust-toolchain@…1.95.0`.

2. **`Makefile::cargo-build` passed `cargo +stable build …`**, which explicitly tells rustup *"ignore any `rust-toolchain.toml` pin, use the stable channel"*. On the GitHub runner, rustup's `stable` is whatever version was current **when that runner image was baked**; today's image maps `stable` → 1.94.1.

Either alone would have caught the MSRV bump; together they masked the problem.

## Why PR #1586 was green at merge

Worth calling out explicitly so this isn't repeated:

- #1586's last `e2e` run executed **the day before** merge (2026-04-23 10:35 UTC) against runner image `ubuntu24/20260420.95`. That image preinstalled a newer rustc that happened to satisfy 1.95.0, so `cargo +stable build` worked **by coincidence** — the pin itself was never validated.
- GitHub does **not** re-run required checks at merge time; it trusts the last green from the PR. So the image-roll that landed overnight was never retested against #1586's changes before merge.

Subsequent PRs landed on `ubuntu24/20260413.86` (preinstalled rustc 1.94.1, rustup `stable` → 1.94.1), and the real gap surfaced.

Evidence:

```
Install Rust toolchain: info: note that the toolchain '1.95.0-x86_64-unknown-linux-gnu'
                              is currently in use (overridden by rust-toolchain.toml)
Run E2E tests:          cargo +stable build --release --bin hyperspot-server …
                        error: rustc 1.94.1 is not supported …
```

Even after installing 1.95.0 via `dtolnay/rust-toolchain`, the Makefile's `+stable` override drags the build back to whatever `stable` means in rustup — which on that runner is 1.94.1.

## What this PR changes

### 1. `rust-toolchain.toml` → `channel = "stable"`

Single source of truth. Local dev and CI both follow the latest stable release automatically; no hardcoded `1.X.Y` string in any workspace config file. Rust's 6-week stable cycle is now a no-op for this workspace — no manual bump needed when a new stable ships.

### 2. Eight CI workflow references `dtolnay/rust-toolchain@…1.95.0` → `@stable`

`.github/workflows/api_contracts.yml`, `ci.yml`, `fmt.yml`, `gts-validation.yml`, `release-plz.yml`, and (newly added) `e2e.yml` all now say `dtolnay/rust-toolchain@stable`. The action refreshes rustup's `stable` channel on every run, so stale runner images no longer trap us with an older preinstalled rustc.

Two `@…nightly` uses in `ci.yml` are **left alone** (intentional — they support nightly-gated jobs).

### 3. `.github/workflows/e2e.yml` gets the missing `Install Rust toolchain` step

The identical pattern as the other five workflows.

### 4. `Makefile::cargo-build` drops `cargo +stable`

A bare `cargo build` now reads `rust-toolchain.toml` — exactly what #1586's pin intended to happen. An inline comment explains the pitfall so a future contributor does not re-introduce `+stable` thinking *"it's just stable"*.

### 5. `tools/dylint_lints/rust-toolchain.toml` left unchanged

Dylint's lint crate legitimately pins `nightly-2026-01-22` (it depends on rustc internals). Not touched.

## Why this prevents recurrence on future Rust upgrades

The original failure was a classic *"N out of N+1 places updated"* bug — PR #1586 had to touch **six** files (`rust-toolchain.toml`, workspace `Cargo.toml::rust-version`, plus five workflows) and missed one, plus the Makefile silently overrode the pin. The prevention strategy here has four layers:

1. **No version string in workflow files.** Every workflow pin now says `@stable`, not `@e0818162…# 1.95.0`. The next Rust release will *not* require editing any of these workflows. Nothing to forget.

2. **No version string in `rust-toolchain.toml`.** `channel = "stable"` means cargo-reads-this-file picks up the new stable automatically.

3. **Makefile delegates to `rust-toolchain.toml`.** No more `+stable` override anywhere in the tree. A future local-dev or CI contributor invoking `cargo build` sees identical behaviour.

4. **Inline documentation at the ex-pitfall.** The Makefile now carries a comment explaining *why* `+stable` was wrong. If someone re-adds it in the future, a review should catch it.

### Reduced checklist for future MSRV bumps

Before this PR (6 file types to update per release):
- [ ] `rust-toolchain.toml`
- [ ] `tools/dylint_lints/rust-toolchain.toml` *(nightly — separate cadence anyway)*
- [ ] `Cargo.toml::workspace.rust-version`
- [ ] 5 stable-pinned workflows
- [ ] (and don't forget `e2e.yml`, which was missed last time)

After this PR (only the MSRV floor, if any):
- [ ] `Cargo.toml::workspace.rust-version` — **only if** you deliberately want to advertise a higher MSRV to downstream consumers. Independent of the `stable` channel policy.

Everything else (toolchain version, what cargo actually invokes) auto-follows stable.

### Trade-off we accept

Switching to `@stable` means CI auto-follows rustc releases. A new stable with stricter clippy / compiler lints can break a PR that was green yesterday — not because of the PR, but because of the toolchain bump. This is the price for removing the manual-update footgun.

If the team later decides deterministic pinning matters more than auto-follow, the pattern is easy to reverse: pin a specific `dtolnay/rust-toolchain@…1.X.Y` in the workflows and set `rust-toolchain.toml::channel = "1.X.Y"`. The Makefile fix (drop `+stable`) remains correct either way.

A natural follow-up (out of scope here): add a lightweight CI lint that asserts every `dtolnay/rust-toolchain@<tag>` in the repo matches the channel in `rust-toolchain.toml`, so any attempt to diverge again gets caught at PR review rather than after merge.

## Test plan

- [x] Local: `rustup update stable` → `stable` = 1.95.0; `cargo check --release --bin hyperspot-server` succeeds; cargo invocation chooses 1.95.0 purely via `rust-toolchain.toml` (no `+stable` hint anywhere).
- [x] Local: `grep -rn 'cargo +stable' Makefile` returns nothing.
- [x] Local: `grep -rn 'dtolnay/rust-toolchain@' .github/workflows/` — only `@stable` and intentional `@nightly` references remain.
- [ ] CI: this PR's `e2e` check passes on the current (broken) runner image pool.
- [ ] CI: the next dependabot / feature PR that merges after this lands should not hit the MSRV-mismatch failure.

## Out of scope

- Backporting the fix into the active RG PR train branches (`pr/rg-2-plugins`, …, `pr/rg-6-tests-rest`). Each will pick this up on rebase.
- Adding a CI lint that cross-validates workflow pins against `rust-toolchain.toml` — deserves its own PR.