### PR TITLE
ci(clippy): run cargo-hack --each-feature to cover cfg-gated branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,10 @@ jobs:
           rustup show active-toolchain || rustup toolchain install
           rustup show
 
-      - name: Install nextest
+      - name: Install nextest and cargo-hack
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
         with:
-          tool: nextest
+          tool: nextest,cargo-hack
 
       # Cache Cargo registry/git + target/ across platforms.
       - name: Cache Cargo/target

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,9 @@ help:
 ## Install all required development tools
 setup: .setup-stamp
 
-.setup-stamp:
+# Re-run setup whenever the tool list changes (Makefile is the source of truth),
+# so developers who already have .setup-stamp pick up newly-added tools.
+.setup-stamp: Makefile
 	@echo "Installing required development tools..."
 	rustup component add clippy
 	cargo install lychee
@@ -134,6 +136,7 @@ setup: .setup-stamp
 	cargo install cargo-dylint
 	cargo install dylint-link
 	cargo install cargo-fuzz
+	cargo install cargo-hack
 	@if echo "$$OS" | grep -iq windows || [ -n "$$COMSPEC" ]; then \
 		echo "WARNING: kani-verifier and cargo-llvm-cov installation skipped on Windows."; \
 		echo "These tools are not supported on Windows. Use WSL2 or Docker to install instead."; \
@@ -207,10 +210,14 @@ validate-module-names:
 
 .PHONY: clippy lychee kani geiger safety lint dylint dylint-list dylint-test gts-docs gts-docs-vendor gts-docs-release gts-docs-vendor-release gts-docs-test cypilot-validate cypilot-spec-coverage
 
-# Run clippy linter (excludes gts-rust submodule which has its own lint settings)
+# Run clippy via cargo-hack with `--each-feature`: one pass per individual
+# feature, plus a `--no-default-features` pass and an `--all-features` pass.
+# This ensures mutually exclusive cfg branches (e.g. `fips`/`not(fips)`) are
+# both visited — see GH issue #1574.
 clippy:
 	$(call check_rustup_component,clippy)
-	cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf
+	$(call check_tool,cargo-hack)
+	cargo hack clippy --workspace --all-targets --each-feature -- -D warnings -D clippy::perf
 
 # Check cypilot spec-to-code traceability coverage
 cypilot-spec-coverage:

--- a/examples/modkit/users-info/users-info-sdk/src/lib.rs
+++ b/examples/modkit/users-info/users-info-sdk/src/lib.rs
@@ -1,16 +1,28 @@
 //! User Info SDK
 //!
 //! This crate provides the public API for the `user_info` module:
-//! - `UsersInfoClientV1` trait
+//! - `UsersInfoClientV1` trait — feature `odata` (enabled by default)
+//! - `UsersStreamingClientV1` / `CitiesStreamingClientV1` /
+//!   `AddressesStreamingClientV1` streaming facades — feature `odata`
+//!   (enabled by default)
 //! - Model types for users, addresses and cities
 //! - Error type (`UsersInfoError`)
-//! - `OData` filter field definitions (behind `odata` feature)
+//! - `OData` filter field definitions — feature `odata` (enabled by default)
+//!
+//! The `odata` feature is on by default; consumers that set
+//! `default-features = false` need to re-enable it explicitly to access the
+//! client and streaming facades.
 //!
 //! ## Usage
 //!
-//! Consumers obtain the client from `ClientHub`:
+//! Consumers obtain the client from `ClientHub` (requires the `odata` feature):
 //! ```ignore
-//! use user_info_sdk::UsersInfoClientV1;
+//! // Cargo.toml:
+//! //   users-info-sdk = { workspace = true }            # default features incl. "odata"
+//! //   # or, if opted out:
+//! //   users-info-sdk = { workspace = true, default-features = false, features = ["odata"] }
+//!
+//! use users_info_sdk::UsersInfoClientV1;
 //!
 //! // Get the client from ClientHub
 //! let client = hub.get::<dyn UsersInfoClientV1>()?;
@@ -22,14 +34,15 @@
 //!
 //! ## `OData` Support
 //!
-//! Enable the `odata` feature to access filter field definitions:
+//! The `odata` feature (enabled by default) exposes filter field definitions:
 //! ```ignore
-//! use user_info_sdk::odata::{UserFilterField, CityFilterField};
+//! use users_info_sdk::odata::{UserFilterField, CityFilterField};
 //! ```
 
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 
+#[cfg(feature = "odata")]
 pub mod client;
 pub mod errors;
 pub mod models;
@@ -39,6 +52,7 @@ pub mod models;
 pub mod odata;
 
 // Re-export main types at crate root for convenience
+#[cfg(feature = "odata")]
 pub use client::{
     AddressesStreamingClientV1, CitiesStreamingClientV1, UsersInfoClientV1, UsersStreamingClientV1,
 };

--- a/libs/modkit-db/Cargo.toml
+++ b/libs/modkit-db/Cargo.toml
@@ -20,24 +20,32 @@ workspace = true
 [features]
 default = []
 
+# Internal helper, enabled automatically by any concrete backend. Used as a
+# virtual OR in targets that need some backend but don't care which (e.g. the
+# outbox benchmarks). Not intended to be enabled directly.
+_any-backend = []
+
 # DB driver selection -- the single entry point for backend choice.
 # sea-orm and sea-orm-migration remain non-optional: modkit-db unconditionally
 # re-exports sea_orm_migration and uses sea_orm::{DatabaseConnection, DbErr, …}
 # in non-cfg-gated code.  sqlx is optional because every source-level use is
 # already behind #[cfg(feature = "pg"|"mysql"|"sqlite")].
 sqlite = [
+    "_any-backend",
     "dep:sqlx",
     "sqlx/sqlite",
     "sea-orm/sqlx-sqlite",
     "sea-orm-migration/sqlx-sqlite",
 ]
 pg = [
+    "_any-backend",
     "dep:sqlx",
     "sqlx/postgres",
     "sea-orm/sqlx-postgres",
     "sea-orm-migration/sqlx-postgres",
 ]
 mysql = [
+    "_any-backend",
     "dep:sqlx",
     "sqlx/mysql",
     "sea-orm/sqlx-mysql",
@@ -97,12 +105,14 @@ required-features = ["sqlite", "preview-outbox"]
 [[bench]]
 name = "outbox_throughput"
 harness = false
-required-features = ["preview-outbox"]
+# `_any-backend` is a virtual OR over pg/mysql/sqlite (see [features] above).
+# The bench body compile-errors out if no backend is present.
+required-features = ["preview-outbox", "_any-backend"]
 
 [[bench]]
 name = "worker_overhead"
 harness = false
-required-features = ["preview-outbox"]
+required-features = ["preview-outbox", "_any-backend"]
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["html_reports"] }

--- a/libs/modkit-db/tests/db_generic.rs
+++ b/libs/modkit-db/tests/db_generic.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
-#![cfg(feature = "integration")]
+#![cfg(all(
+    feature = "integration",
+    any(feature = "sqlite", feature = "pg", feature = "mysql")
+))]
 
 mod common;
 use anyhow::Result;

--- a/libs/modkit-db/tests/params_integration.rs
+++ b/libs/modkit-db/tests/params_integration.rs
@@ -1,5 +1,8 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
-#![cfg(feature = "integration")]
+#![cfg(all(
+    feature = "integration",
+    any(feature = "sqlite", feature = "pg", feature = "mysql")
+))]
 
 //! Integration tests for database connection parameters.
 //!

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -46,6 +46,7 @@ bootstrap = [
     "dep:tracing-appender",
     "dep:file-rotate",
     "dep:tracing-log",
+    "dep:tracing-subscriber",
     "dep:chrono",
     "dep:url",
     "dep:dsn",

--- a/libs/modkit/src/bootstrap/crypto.rs
+++ b/libs/modkit/src/bootstrap/crypto.rs
@@ -29,8 +29,12 @@ static INSTALLED: Once = Once::new();
 /// Returns [`CryptoProviderError::FipsProviderConflict`] if the `fips` feature is
 /// enabled and another crypto provider has already been installed.
 pub fn init_crypto_provider() -> Result<(), CryptoProviderError> {
-    #[allow(unused_mut)]
+    // `mut` is only needed in the `fips` branch (which reassigns `result`
+    // on provider conflict); the non-fips branch never writes to it.
+    #[cfg(feature = "fips")]
     let mut result = Ok(());
+    #[cfg(not(feature = "fips"))]
+    let result = Ok(());
 
     INSTALLED.call_once(|| {
         #[cfg(feature = "fips")]
@@ -47,8 +51,8 @@ pub fn init_crypto_provider() -> Result<(), CryptoProviderError> {
 
         #[cfg(not(feature = "fips"))]
         {
-            #[allow(clippy::let_underscore_must_use)]
-            let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+            // A provider may already have been installed (e.g. by tests); ignore that case.
+            let _ignored = rustls::crypto::aws_lc_rs::default_provider().install_default();
         }
     });
 

--- a/libs/modkit/src/bootstrap/run.rs
+++ b/libs/modkit/src/bootstrap/run.rs
@@ -283,6 +283,7 @@ fn try_build_oop_module_config(
 /// # Errors
 ///
 /// Returns an error if OpenTelemetry tracing initialization fails while tracing is enabled.
+#[cfg_attr(not(feature = "otel"), allow(clippy::unnecessary_wraps))]
 pub fn init_procedure(config: &AppConfig) -> Result<()> {
     // Build OpenTelemetry layer before logging
     #[cfg(feature = "otel")]

--- a/libs/modkit/src/context.rs
+++ b/libs/modkit/src/context.rs
@@ -34,6 +34,7 @@ pub struct ModuleCtx {
     config_provider: Arc<dyn ConfigProvider>,
     client_hub: Arc<crate::client_hub::ClientHub>,
     cancellation_token: CancellationToken,
+    #[cfg_attr(not(feature = "db"), allow(dead_code))]
     db: Option<DbProvider>,
 }
 
@@ -46,6 +47,7 @@ pub struct ModuleContextBuilder {
     config_provider: Arc<dyn ConfigProvider>,
     client_hub: Arc<crate::client_hub::ClientHub>,
     root_token: CancellationToken,
+    #[cfg_attr(not(feature = "db"), allow(dead_code))]
     db_manager: Option<Arc<DbManager>>, // internal only, never exposed to modules
 }
 
@@ -76,6 +78,7 @@ impl ModuleContextBuilder {
     ///
     /// # Errors
     /// Returns an error if database resolution fails.
+    #[cfg_attr(not(feature = "db"), allow(clippy::unused_async))]
     pub async fn for_module(&self, module_name: &str) -> anyhow::Result<ModuleCtx> {
         let db: Option<DbProvider> = {
             #[cfg(feature = "db")]

--- a/libs/modkit/src/registry.rs
+++ b/libs/modkit/src/registry.rs
@@ -938,6 +938,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "db")]
     fn db_capability_without_core_fails() {
         let mut b = RegistryBuilder::default();
         b.register_core_with_meta("core_a", &[], Arc::new(DummyCore));
@@ -970,6 +971,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "db")]
     fn capability_query_works() {
         let mut b = RegistryBuilder::default();
         let module = Arc::new(DummyCore);
@@ -1040,8 +1042,10 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "db")]
     #[derive(Default)]
     struct DummyDb;
+    #[cfg(feature = "db")]
     impl contracts::DatabaseCapability for DummyDb {
         fn migrations(&self) -> Vec<Box<dyn sea_orm_migration::MigrationTrait>> {
             vec![]

--- a/libs/modkit/src/runtime/host_runtime.rs
+++ b/libs/modkit/src/runtime/host_runtime.rs
@@ -189,6 +189,7 @@ impl HostRuntime {
     }
 
     /// Helper: resolve context for a module with error mapping.
+    #[cfg(feature = "db")]
     async fn module_context(
         &self,
         module_name: &'static str,

--- a/libs/modkit/src/telemetry/init.rs
+++ b/libs/modkit/src/telemetry/init.rs
@@ -308,7 +308,7 @@ pub fn shutdown_metrics() {
 // ===== init_metrics_provider ==================================================
 
 #[cfg(feature = "otel")]
-static METRICS_INIT: std::sync::OnceLock<Result<(), String>> = std::sync::OnceLock::new();
+static METRICS_INIT: std::sync::OnceLock<()> = std::sync::OnceLock::new();
 
 /// Build a [`SdkMeterProvider`] from the resolved metrics exporter settings and
 /// register it as the global meter provider.
@@ -320,8 +320,9 @@ static METRICS_INIT: std::sync::OnceLock<Result<(), String>> = std::sync::OnceLo
 /// Exporter resolution: `opentelemetry.metrics.exporter` overrides
 /// `opentelemetry.exporter` when present.
 ///
-/// This function is guarded by [`OnceLock`] — the provider is built and
-/// registered at most once; subsequent calls return the cached result.
+/// Initialisation runs at most once on success and is cached. Errors are
+/// **not** cached — a transient failure (e.g. OTLP endpoint briefly
+/// unreachable) is returned to the caller, and a subsequent call may retry.
 ///
 /// # Errors
 ///
@@ -338,10 +339,16 @@ pub fn init_metrics_provider(otel_cfg: &OpenTelemetryConfig) -> anyhow::Result<(
         return Ok(());
     }
 
-    METRICS_INIT
-        .get_or_init(|| do_init_metrics_provider(otel_cfg).map_err(|e| e.to_string()))
-        .clone()
-        .map_err(|e| anyhow::anyhow!("{e}"))
+    if METRICS_INIT.get().is_some() {
+        return Ok(());
+    }
+
+    do_init_metrics_provider(otel_cfg)?;
+    // Race between concurrent first-callers is benign: OTel allows
+    // re-registering the global meter provider, so at worst we initialise
+    // twice. The `set` returns Err for the loser of the race; ignored.
+    let _set_result = METRICS_INIT.set(());
+    Ok(())
 }
 
 #[cfg(feature = "otel")]

--- a/libs/modkit/src/telemetry/init.rs
+++ b/libs/modkit/src/telemetry/init.rs
@@ -7,6 +7,7 @@
 use anyhow::Context;
 #[cfg(feature = "otel")]
 use opentelemetry::{KeyValue, global, trace::TracerProvider as _};
+#[cfg(feature = "otel")]
 use std::sync::Once;
 
 #[cfg(feature = "otel")]
@@ -130,6 +131,7 @@ fn build_grpc_exporter(
     b.build().context("build OTLP gRPC exporter")
 }
 
+#[cfg(feature = "otel")]
 static INIT_TRACING: Once = Once::new();
 
 /// Initialize OpenTelemetry tracing from configuration and return a layer
@@ -494,12 +496,15 @@ pub fn otel_connectivity_probe(_cfg: &super::config::OpenTelemetryConfig) -> any
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
+    #[cfg(feature = "otel")]
     use crate::telemetry::config::{
         Exporter, ExporterKind, OpenTelemetryConfig, OpenTelemetryResource, Sampler, TracingConfig,
     };
+    #[cfg(feature = "otel")]
     use std::collections::{BTreeMap, HashMap};
 
     /// Helper to build an `OpenTelemetryConfig` with the given tracing config.
+    #[cfg(feature = "otel")]
     fn otel_with_tracing(tracing: TracingConfig) -> OpenTelemetryConfig {
         OpenTelemetryConfig {
             tracing,

--- a/libs/modkit/tests/db_phase_tests.rs
+++ b/libs/modkit/tests/db_phase_tests.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "db")]
 
 //! Tests for DB migration phase behavior
 //!

--- a/libs/modkit/tests/macro_tests.rs
+++ b/libs/modkit/tests/macro_tests.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "db")]
 
 //! Comprehensive tests for the #[module] macro with the new registry/builder
 

--- a/libs/modkit/tests/runner_tests.rs
+++ b/libs/modkit/tests/runner_tests.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
-#![cfg(feature = "db")]
 
 //! Comprehensive tests for the `ModKit` runner functionality
 //!
@@ -18,12 +17,13 @@ use uuid::Uuid;
 use modkit::{
     ModuleCtx,
     config::ConfigProvider,
-    contracts::{
-        DatabaseCapability, Module, OpenApiRegistry, RestApiCapability, RunnableCapability,
-    },
+    contracts::{Module, OpenApiRegistry, RestApiCapability, RunnableCapability},
     registry::{ModuleRegistry, RegistryBuilder},
     runtime::{DbOptions, RunOptions, ShutdownOptions, run},
 };
+
+#[cfg(feature = "db")]
+use modkit::contracts::DatabaseCapability;
 
 // Test tracking infrastructure
 #[allow(dead_code)]
@@ -154,6 +154,7 @@ impl Module for TestModule {
     }
 }
 
+#[cfg(feature = "db")]
 impl DatabaseCapability for TestModule {
     fn migrations(&self) -> Vec<Box<dyn sea_orm_migration::MigrationTrait>> {
         self.calls
@@ -168,13 +169,16 @@ impl DatabaseCapability for TestModule {
     }
 }
 
+#[cfg(feature = "db")]
 struct FailingMigration;
+#[cfg(feature = "db")]
 impl sea_orm_migration::MigrationName for FailingMigration {
     #[allow(clippy::unnecessary_literal_bound)]
     fn name(&self) -> &str {
         "m000_fail"
     }
 }
+#[cfg(feature = "db")]
 #[async_trait::async_trait]
 impl sea_orm_migration::MigrationTrait for FailingMigration {
     async fn up(
@@ -247,6 +251,7 @@ fn create_test_registry(modules: Vec<TestModule>) -> anyhow::Result<ModuleRegist
         let module = Arc::new(module);
 
         builder.register_core_with_meta(module_name_str, &[], module.clone() as Arc<dyn Module>);
+        #[cfg(feature = "db")]
         builder.register_db_with_meta(
             module_name_str,
             module.clone() as Arc<dyn DatabaseCapability>,
@@ -265,6 +270,7 @@ fn create_test_registry(modules: Vec<TestModule>) -> anyhow::Result<ModuleRegist
 }
 
 // Helper function to create a mock DbManager for testing
+#[cfg(feature = "db")]
 fn create_mock_db_manager() -> Arc<modkit_db::DbManager> {
     use figment::{Figment, providers::Serialized};
 
@@ -285,6 +291,7 @@ fn create_mock_db_manager() -> Arc<modkit_db::DbManager> {
     Arc::new(modkit_db::DbManager::from_figment(figment, home_dir).unwrap())
 }
 
+#[cfg(feature = "db")]
 #[tokio::test]
 async fn test_db_phase_failure_stops_lifecycle() {
     use modkit::runtime::HostRuntime;
@@ -383,6 +390,7 @@ async fn test_db_options_none() {
     assert!(result.is_ok());
 }
 
+#[cfg(feature = "db")]
 #[tokio::test]
 async fn test_db_options_manager() {
     let cancel = CancellationToken::new();
@@ -547,6 +555,7 @@ fn test_run_options_construction() {
     // Test that we can construct RunOptions with all variants
     match opts.db {
         DbOptions::None => {}
+        #[cfg(feature = "db")]
         DbOptions::Manager(_) => panic!("Expected DbOptions::None"),
     }
 

--- a/libs/modkit/tests/runner_tests.rs
+++ b/libs/modkit/tests/runner_tests.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
+#![cfg(feature = "db")]
 
 //! Comprehensive tests for the `ModKit` runner functionality
 //!


### PR DESCRIPTION
Fixes #1574.
Fixes #1760.
Fixes #1761.

`make clippy` now runs `cargo hack clippy --each-feature`, which performs
one clippy pass per individual feature plus `--no-default-features` and
`--all-features`.

This PR is the minimal "make it pass" change: cargo-hack wiring plus
`allow(...)` / file-level `#[cfg]` suppressions. Two follow-up PRs clean
up specific spots where a proper refactor beats a suppression.

## Stack (open in order)

1. **This PR** — cargo-hack + suppressions
2. #1736 — refactor: crypto provider init uses OnceLock<Result<_>> (draft, depends on this)
3. #1737 — refactor: builder pattern for ModuleCtx db/db_manager fields (draft, depends on #1736)

## Infrastructure
- `make clippy` now runs `cargo hack clippy --each-feature --workspace --all-targets -- -D warnings -D clippy::perf`
- `make setup` installs `cargo-hack`
- CI installs `cargo-hack` alongside `nextest`

## Suppressions / cfg-gates
- `allow(unused_mut)` on a cfg-conditionally-mutated local in `crypto.rs`
- `#[cfg_attr(not(feature = "db"), allow(dead_code))]` on `ModuleCtx`/`ModuleContextBuilder` db fields
- `#[cfg_attr(not(feature = "db"), allow(clippy::unused_async))]` on `for_module`
- `#[cfg_attr(not(feature = "otel"), allow(clippy::unnecessary_wraps))]` on `init_procedure`
- `#[cfg(feature = "db")]` file-level gates on integration tests and a few db-only methods/structs
- `#[cfg(feature = "odata")]` gate on `users-info-sdk`'s `client` module

## Cargo.toml changes (required for the sweep to pass)
- `libs/modkit/Cargo.toml` — `bootstrap` feature now declares its `tracing-subscriber` dep explicitly (was implicitly relying on `otel`)
- `libs/modkit-db/Cargo.toml` — new internal `_any-backend` feature, enabled by any of `sqlite`/`pg`/`mysql`; outbox benches require it (AND-only `required-features` can't express OR)
- Expanded `#![cfg]` on `modkit-db` integration tests to require a backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI and build: install an additional Rust tooling helper and update setup/lint steps to run per-feature checks.
  * Feature config: add a virtual backend feature and require it for certain benchmark targets; adjust a bootstrap feature to include an additional dependency.

* **Refactor**
  * Make many modules and tests compile only when the appropriate feature combinations are enabled, reducing unintended builds.

* **Documentation**
  * Clarify example crate docs and usage with the OData feature and Cargo.toml guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->