### PR TITLE
fix: update Rust version in E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Update Rust
+        run: rustup update
+
       - name: Install Python dependencies
         run: pip install -r testing/e2e/requirements.txt
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to ensure the Rust toolchain is kept current during automated testing, improving build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->