### PR TITLE
feat(oagw): types-registry static entities config and oagw read-only management API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,6 +2288,7 @@ dependencies = [
  "axum",
  "cf-modkit",
  "cf-modkit-macros",
+ "cf-modkit-security",
  "cf-types-registry-sdk",
  "gts",
  "inventory",

--- a/modules/system/oagw/oagw/src/api/rest/dto.rs
+++ b/modules/system/oagw/oagw/src/api/rest/dto.rs
@@ -1019,6 +1019,7 @@ impl From<domain::MatchRules> for MatchRules {
 impl From<CreateUpstreamRequest> for domain::CreateUpstreamRequest {
     fn from(r: CreateUpstreamRequest) -> Self {
         Self {
+            id: None,
             server: r.server.into(),
             protocol: r.protocol,
             alias: r.alias,
@@ -1053,6 +1054,7 @@ impl From<UpdateUpstreamRequest> for domain::UpdateUpstreamRequest {
 impl From<(Uuid, CreateRouteRequest)> for domain::CreateRouteRequest {
     fn from((upstream_id, r): (Uuid, CreateRouteRequest)) -> Self {
         Self {
+            id: None,
             upstream_id,
             match_rules: r.match_rules.into(),
             plugins: r.plugins.map(Into::into),

--- a/modules/system/oagw/oagw/src/api/rest/routes/mod.rs
+++ b/modules/system/oagw/oagw/src/api/rest/routes/mod.rs
@@ -19,13 +19,18 @@ impl AsRef<str> for License {
 impl LicenseFeature for License {}
 
 /// Register all OAGW REST routes with OpenAPI metadata.
+///
+/// When `state.config.management_api_enabled` is `false`, only read-only
+/// endpoints (list / get) and the proxy catch-all are registered. Write
+/// operations (create / update / delete) are omitted.
 pub fn register_routes(
     mut router: Router,
     openapi: &dyn OpenApiRegistry,
     state: AppState,
 ) -> Router {
-    router = upstream::register(router, openapi);
-    router = route::register(router, openapi);
+    let writable = state.config.management_api_enabled;
+    router = upstream::register(router, openapi, writable);
+    router = route::register(router, openapi, writable);
     router = proxy::register(router);
     router.layer(axum::Extension(state))
 }

--- a/modules/system/oagw/oagw/src/api/rest/routes/route.rs
+++ b/modules/system/oagw/oagw/src/api/rest/routes/route.rs
@@ -8,24 +8,30 @@ use super::License;
 
 const API_TAG: &str = "OAGW Routes";
 
-pub(super) fn register(mut router: Router, openapi: &dyn OpenApiRegistry) -> Router {
+pub(super) fn register(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    writable: bool,
+) -> Router {
     // POST /oagw/v1/routes — Create route
-    router = OperationBuilder::post("/oagw/v1/routes")
-        .operation_id("oagw.create_route")
-        .summary("Create route")
-        .description("Create a new route mapping for an upstream service")
-        .tag(API_TAG)
-        .authenticated()
-        .require_license_features::<License>([])
-        .json_request::<dto::CreateRouteRequest>(openapi, "Route configuration")
-        .handler(handlers::route::create_route)
-        .json_response_with_schema::<dto::RouteResponse>(
-            openapi,
-            http::StatusCode::CREATED,
-            "Created route",
-        )
-        .standard_errors(openapi)
-        .register(router, openapi);
+    if writable {
+        router = OperationBuilder::post("/oagw/v1/routes")
+            .operation_id("oagw.create_route")
+            .summary("Create route")
+            .description("Create a new route mapping for an upstream service")
+            .tag(API_TAG)
+            .authenticated()
+            .require_license_features::<License>([])
+            .json_request::<dto::CreateRouteRequest>(openapi, "Route configuration")
+            .handler(handlers::route::create_route)
+            .json_response_with_schema::<dto::RouteResponse>(
+                openapi,
+                http::StatusCode::CREATED,
+                "Created route",
+            )
+            .standard_errors(openapi)
+            .register(router, openapi);
+    }
 
     // GET /oagw/v1/routes/{id} — Get route
     router = OperationBuilder::get("/oagw/v1/routes/{id}")
@@ -45,38 +51,40 @@ pub(super) fn register(mut router: Router, openapi: &dyn OpenApiRegistry) -> Rou
         .standard_errors(openapi)
         .register(router, openapi);
 
-    // PUT /oagw/v1/routes/{id} — Update route
-    router = OperationBuilder::put("/oagw/v1/routes/{id}")
-        .operation_id("oagw.update_route")
-        .summary("Update route")
-        .description("Replace an existing route configuration")
-        .tag(API_TAG)
-        .path_param("id", "Route GTS identifier")
-        .authenticated()
-        .require_license_features::<License>([])
-        .json_request::<dto::UpdateRouteRequest>(openapi, "Route update data")
-        .handler(handlers::route::update_route)
-        .json_response_with_schema::<dto::RouteResponse>(
-            openapi,
-            http::StatusCode::OK,
-            "Updated route",
-        )
-        .standard_errors(openapi)
-        .register(router, openapi);
+    if writable {
+        // PUT /oagw/v1/routes/{id} — Update route
+        router = OperationBuilder::put("/oagw/v1/routes/{id}")
+            .operation_id("oagw.update_route")
+            .summary("Update route")
+            .description("Replace an existing route configuration")
+            .tag(API_TAG)
+            .path_param("id", "Route GTS identifier")
+            .authenticated()
+            .require_license_features::<License>([])
+            .json_request::<dto::UpdateRouteRequest>(openapi, "Route update data")
+            .handler(handlers::route::update_route)
+            .json_response_with_schema::<dto::RouteResponse>(
+                openapi,
+                http::StatusCode::OK,
+                "Updated route",
+            )
+            .standard_errors(openapi)
+            .register(router, openapi);
 
-    // DELETE /oagw/v1/routes/{id} — Delete route
-    router = OperationBuilder::delete("/oagw/v1/routes/{id}")
-        .operation_id("oagw.delete_route")
-        .summary("Delete route")
-        .description("Delete a route by its GTS identifier")
-        .tag(API_TAG)
-        .path_param("id", "Route GTS identifier")
-        .authenticated()
-        .require_license_features::<License>([])
-        .handler(handlers::route::delete_route)
-        .json_response(http::StatusCode::NO_CONTENT, "Route deleted")
-        .standard_errors(openapi)
-        .register(router, openapi);
+        // DELETE /oagw/v1/routes/{id} — Delete route
+        router = OperationBuilder::delete("/oagw/v1/routes/{id}")
+            .operation_id("oagw.delete_route")
+            .summary("Delete route")
+            .description("Delete a route by its GTS identifier")
+            .tag(API_TAG)
+            .path_param("id", "Route GTS identifier")
+            .authenticated()
+            .require_license_features::<License>([])
+            .handler(handlers::route::delete_route)
+            .json_response(http::StatusCode::NO_CONTENT, "Route deleted")
+            .standard_errors(openapi)
+            .register(router, openapi);
+    }
 
     // GET /oagw/v1/routes — List routes (optional upstream_id filter)
     router = OperationBuilder::get("/oagw/v1/routes")

--- a/modules/system/oagw/oagw/src/api/rest/routes/upstream.rs
+++ b/modules/system/oagw/oagw/src/api/rest/routes/upstream.rs
@@ -8,24 +8,30 @@ use super::License;
 
 const API_TAG: &str = "OAGW Upstreams";
 
-pub(super) fn register(mut router: Router, openapi: &dyn OpenApiRegistry) -> Router {
+pub(super) fn register(
+    mut router: Router,
+    openapi: &dyn OpenApiRegistry,
+    writable: bool,
+) -> Router {
     // POST /oagw/v1/upstreams — Create upstream
-    router = OperationBuilder::post("/oagw/v1/upstreams")
-        .operation_id("oagw.create_upstream")
-        .summary("Create upstream")
-        .description("Create a new upstream service configuration")
-        .tag(API_TAG)
-        .authenticated()
-        .require_license_features::<License>([])
-        .json_request::<dto::CreateUpstreamRequest>(openapi, "Upstream configuration")
-        .handler(handlers::upstream::create_upstream)
-        .json_response_with_schema::<dto::UpstreamResponse>(
-            openapi,
-            http::StatusCode::CREATED,
-            "Created upstream",
-        )
-        .standard_errors(openapi)
-        .register(router, openapi);
+    if writable {
+        router = OperationBuilder::post("/oagw/v1/upstreams")
+            .operation_id("oagw.create_upstream")
+            .summary("Create upstream")
+            .description("Create a new upstream service configuration")
+            .tag(API_TAG)
+            .authenticated()
+            .require_license_features::<License>([])
+            .json_request::<dto::CreateUpstreamRequest>(openapi, "Upstream configuration")
+            .handler(handlers::upstream::create_upstream)
+            .json_response_with_schema::<dto::UpstreamResponse>(
+                openapi,
+                http::StatusCode::CREATED,
+                "Created upstream",
+            )
+            .standard_errors(openapi)
+            .register(router, openapi);
+    }
 
     // GET /oagw/v1/upstreams — List upstreams
     router = OperationBuilder::get("/oagw/v1/upstreams")
@@ -69,38 +75,40 @@ pub(super) fn register(mut router: Router, openapi: &dyn OpenApiRegistry) -> Rou
         .standard_errors(openapi)
         .register(router, openapi);
 
-    // PUT /oagw/v1/upstreams/{id} — Update upstream
-    router = OperationBuilder::put("/oagw/v1/upstreams/{id}")
-        .operation_id("oagw.update_upstream")
-        .summary("Update upstream")
-        .description("Replace an existing upstream service configuration")
-        .tag(API_TAG)
-        .path_param("id", "Upstream GTS identifier")
-        .authenticated()
-        .require_license_features::<License>([])
-        .json_request::<dto::UpdateUpstreamRequest>(openapi, "Upstream update data")
-        .handler(handlers::upstream::update_upstream)
-        .json_response_with_schema::<dto::UpstreamResponse>(
-            openapi,
-            http::StatusCode::OK,
-            "Updated upstream",
-        )
-        .standard_errors(openapi)
-        .register(router, openapi);
+    if writable {
+        // PUT /oagw/v1/upstreams/{id} — Update upstream
+        router = OperationBuilder::put("/oagw/v1/upstreams/{id}")
+            .operation_id("oagw.update_upstream")
+            .summary("Update upstream")
+            .description("Replace an existing upstream service configuration")
+            .tag(API_TAG)
+            .path_param("id", "Upstream GTS identifier")
+            .authenticated()
+            .require_license_features::<License>([])
+            .json_request::<dto::UpdateUpstreamRequest>(openapi, "Upstream update data")
+            .handler(handlers::upstream::update_upstream)
+            .json_response_with_schema::<dto::UpstreamResponse>(
+                openapi,
+                http::StatusCode::OK,
+                "Updated upstream",
+            )
+            .standard_errors(openapi)
+            .register(router, openapi);
 
-    // DELETE /oagw/v1/upstreams/{id} — Delete upstream
-    router = OperationBuilder::delete("/oagw/v1/upstreams/{id}")
-        .operation_id("oagw.delete_upstream")
-        .summary("Delete upstream")
-        .description("Delete an upstream and cascade-delete its routes")
-        .tag(API_TAG)
-        .path_param("id", "Upstream GTS identifier")
-        .authenticated()
-        .require_license_features::<License>([])
-        .handler(handlers::upstream::delete_upstream)
-        .json_response(http::StatusCode::NO_CONTENT, "Upstream deleted")
-        .standard_errors(openapi)
-        .register(router, openapi);
+        // DELETE /oagw/v1/upstreams/{id} — Delete upstream
+        router = OperationBuilder::delete("/oagw/v1/upstreams/{id}")
+            .operation_id("oagw.delete_upstream")
+            .summary("Delete upstream")
+            .description("Delete an upstream and cascade-delete its routes")
+            .tag(API_TAG)
+            .path_param("id", "Upstream GTS identifier")
+            .authenticated()
+            .require_license_features::<License>([])
+            .handler(handlers::upstream::delete_upstream)
+            .json_response(http::StatusCode::NO_CONTENT, "Upstream deleted")
+            .standard_errors(openapi)
+            .register(router, openapi);
+    }
 
     router
 }

--- a/modules/system/oagw/oagw/src/config.rs
+++ b/modules/system/oagw/oagw/src/config.rs
@@ -48,6 +48,12 @@ pub struct OagwConfig {
     /// will use ALPN H2H1 negotiation). Default: 3600 (1 hour).
     #[serde(default = "default_protocol_cache_ttl_secs")]
     pub protocol_cache_ttl_secs: u64,
+    /// Whether the upstream/route management REST APIs are enabled.
+    /// When `true`, all CRUD endpoints are registered. When `false`, only
+    /// read-only endpoints (list / get) are available — write operations
+    /// (create / update / delete) are omitted. Default: `true`.
+    #[serde(default = "default_true")]
+    pub management_api_enabled: bool,
 }
 
 impl Default for OagwConfig {
@@ -63,8 +69,13 @@ impl Default for OagwConfig {
             websocket_max_frame_size_bytes: None,
             streaming_idle_timeout_secs: default_streaming_idle_timeout_secs(),
             protocol_cache_ttl_secs: default_protocol_cache_ttl_secs(),
+            management_api_enabled: true,
         }
     }
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_proxy_timeout_secs() -> u64 {
@@ -126,6 +137,7 @@ pub struct RuntimeConfig {
     pub websocket_close_timeout_secs: u64,
     pub websocket_max_frame_size_bytes: Option<usize>,
     pub streaming_idle_timeout_secs: u64,
+    pub management_api_enabled: bool,
 }
 
 impl From<&OagwConfig> for RuntimeConfig {
@@ -136,6 +148,7 @@ impl From<&OagwConfig> for RuntimeConfig {
             websocket_close_timeout_secs: cfg.websocket_close_timeout_secs,
             websocket_max_frame_size_bytes: cfg.websocket_max_frame_size_bytes,
             streaming_idle_timeout_secs: cfg.streaming_idle_timeout_secs,
+            management_api_enabled: cfg.management_api_enabled,
         }
     }
 }
@@ -190,6 +203,7 @@ impl fmt::Debug for OagwConfig {
                 &self.streaming_idle_timeout_secs,
             )
             .field("protocol_cache_ttl_secs", &self.protocol_cache_ttl_secs)
+            .field("management_api_enabled", &self.management_api_enabled)
             .finish()
     }
 }

--- a/modules/system/oagw/oagw/src/domain/model.rs
+++ b/modules/system/oagw/oagw/src/domain/model.rs
@@ -383,6 +383,10 @@ impl Default for ListQuery {
 #[domain_model]
 #[derive(Debug, Clone, PartialEq)]
 pub struct CreateUpstreamRequest {
+    /// Optional pre-assigned ID. When `Some`, the service uses this UUID
+    /// instead of generating a random one. Used by type-provisioning to
+    /// preserve GTS instance UUIDs.
+    pub id: Option<Uuid>,
     pub server: Server,
     pub protocol: String,
     pub alias: Option<String>,
@@ -413,6 +417,10 @@ pub struct UpdateUpstreamRequest {
 #[domain_model]
 #[derive(Debug, Clone, PartialEq)]
 pub struct CreateRouteRequest {
+    /// Optional pre-assigned ID. When `Some`, the service uses this UUID
+    /// instead of generating a random one. Used by type-provisioning to
+    /// preserve GTS instance UUIDs.
+    pub id: Option<Uuid>,
     pub upstream_id: Uuid,
     pub match_rules: MatchRules,
     pub plugins: Option<PluginsConfig>,

--- a/modules/system/oagw/oagw/src/domain/services/client.rs
+++ b/modules/system/oagw/oagw/src/domain/services/client.rs
@@ -297,6 +297,7 @@ fn sdk_create_upstream_to_domain(
     req: oagw_sdk::CreateUpstreamRequest,
 ) -> model::CreateUpstreamRequest {
     model::CreateUpstreamRequest {
+        id: None,
         server: server_to_domain(req.server().clone()),
         protocol: req.protocol().to_string(),
         alias: req.alias().map(|s| s.to_string()),
@@ -329,6 +330,7 @@ fn sdk_update_upstream_to_domain(
 
 fn sdk_create_route_to_domain(req: oagw_sdk::CreateRouteRequest) -> model::CreateRouteRequest {
     model::CreateRouteRequest {
+        id: None,
         upstream_id: req.upstream_id(),
         match_rules: match_rules_to_domain(req.match_rules().clone()),
         plugins: req.plugins().cloned().map(plugins_config_to_domain),

--- a/modules/system/oagw/oagw/src/domain/services/management.rs
+++ b/modules/system/oagw/oagw/src/domain/services/management.rs
@@ -88,7 +88,7 @@ impl ControlPlaneService for ControlPlaneServiceImpl {
         let alias = enforce_alias_create(req.alias.as_deref(), &req.server.endpoints)?;
 
         let tenant_id = ctx.subject_tenant_id();
-        let id = Uuid::new_v4();
+        let id = req.id.unwrap_or_else(Uuid::new_v4);
         let tenant_chain = self.build_tenant_chain(ctx).await?;
 
         // Check if an ancestor tenant has an upstream with this alias.
@@ -310,7 +310,7 @@ impl ControlPlaneService for ControlPlaneServiceImpl {
             })?;
 
         let route = Route {
-            id: Uuid::new_v4(),
+            id: req.id.unwrap_or_else(Uuid::new_v4),
             tenant_id,
             upstream_id: req.upstream_id,
             match_rules: req.match_rules,
@@ -1958,6 +1958,7 @@ mod tests {
     /// Hostname-based upstream — alias is auto-derived as `api.openai.com`.
     fn make_create_upstream_hostname() -> CreateUpstreamRequest {
         CreateUpstreamRequest {
+            id: None,
             server: Server {
                 endpoints: vec![Endpoint {
                     scheme: Scheme::Https,
@@ -1980,6 +1981,7 @@ mod tests {
     /// IP-based upstream — requires an explicit alias.
     fn make_create_upstream_ip(alias: &str) -> CreateUpstreamRequest {
         CreateUpstreamRequest {
+            id: None,
             server: Server {
                 endpoints: vec![Endpoint {
                     scheme: Scheme::Https,
@@ -2030,6 +2032,7 @@ mod tests {
 
     fn make_create_route(upstream_id: Uuid) -> CreateRouteRequest {
         CreateRouteRequest {
+            id: None,
             upstream_id,
             match_rules: MatchRules {
                 http: Some(HttpMatch {
@@ -2100,6 +2103,7 @@ mod tests {
 
         // Non-standard port — port included.
         let req = CreateUpstreamRequest {
+            id: None,
             server: Server {
                 endpoints: vec![Endpoint {
                     scheme: Scheme::Https,
@@ -3940,6 +3944,7 @@ mod tests {
 
         // Root creates a route on that upstream.
         let route_req = CreateRouteRequest {
+            id: None,
             upstream_id: root_upstream.id,
             match_rules: MatchRules {
                 http: Some(HttpMatch {
@@ -3999,6 +4004,7 @@ mod tests {
 
         // Root creates a route.
         let root_route_req = CreateRouteRequest {
+            id: None,
             upstream_id: root_upstream.id,
             match_rules: MatchRules {
                 http: Some(HttpMatch {
@@ -4027,6 +4033,7 @@ mod tests {
 
         // Child creates its own route on its own upstream.
         let child_route_req = CreateRouteRequest {
+            id: None,
             upstream_id: child_upstream.id,
             match_rules: MatchRules {
                 http: Some(HttpMatch {
@@ -4572,6 +4579,7 @@ mod tests {
         let ctx = test_ctx(tenant);
 
         let req = CreateUpstreamRequest {
+            id: None,
             server: Server {
                 endpoints: vec![Endpoint {
                     scheme: Scheme::Https,
@@ -4722,6 +4730,7 @@ mod tests {
         let ctx = test_ctx(tenant);
 
         let req = CreateUpstreamRequest {
+            id: None,
             server: Server {
                 endpoints: vec![
                     Endpoint {
@@ -4758,6 +4767,7 @@ mod tests {
 
         // Pool A: non-standard port 8443.
         let req_a = CreateUpstreamRequest {
+            id: None,
             server: Server {
                 endpoints: vec![
                     Endpoint {
@@ -4787,6 +4797,7 @@ mod tests {
 
         // Pool B: non-standard port 9443 — same hosts, different port.
         let req_b = CreateUpstreamRequest {
+            id: None,
             server: Server {
                 endpoints: vec![
                     Endpoint {
@@ -4827,6 +4838,7 @@ mod tests {
         // Endpoints share only a public suffix ("co.uk"), not a registrable domain.
         // The system must NOT derive an alias from a bare public suffix.
         let req = CreateUpstreamRequest {
+            id: None,
             server: Server {
                 endpoints: vec![
                     Endpoint {
@@ -4868,6 +4880,7 @@ mod tests {
 
         // Same public-suffix-only endpoints, but an explicit alias is provided.
         let req = CreateUpstreamRequest {
+            id: None,
             server: Server {
                 endpoints: vec![
                     Endpoint {
@@ -4944,6 +4957,7 @@ mod tests {
 
         // GET route on same path and priority — no overlap.
         let get_route_req = CreateRouteRequest {
+            id: None,
             upstream_id: u.id,
             match_rules: MatchRules {
                 http: Some(HttpMatch {
@@ -5087,6 +5101,7 @@ mod tests {
 
         // Route with [Post, Put].
         let req1 = CreateRouteRequest {
+            id: None,
             upstream_id: u.id,
             match_rules: MatchRules {
                 http: Some(HttpMatch {
@@ -5108,6 +5123,7 @@ mod tests {
 
         // Route with [Put, Delete] — overlaps on Put.
         let req2 = CreateRouteRequest {
+            id: None,
             upstream_id: u.id,
             match_rules: MatchRules {
                 http: Some(HttpMatch {

--- a/modules/system/oagw/oagw/src/domain/test_support.rs
+++ b/modules/system/oagw/oagw/src/domain/test_support.rs
@@ -750,6 +750,7 @@ pub fn build_test_app_state(
                 websocket_close_timeout_secs: 5,
                 websocket_max_frame_size_bytes: None,
                 streaming_idle_timeout_secs: 300,
+                management_api_enabled: true,
             },
         },
         facade,

--- a/modules/system/oagw/oagw/src/domain/type_provisioning.rs
+++ b/modules/system/oagw/oagw/src/domain/type_provisioning.rs
@@ -12,19 +12,19 @@ use uuid::Uuid;
 
 /// An upstream definition read from the types-registry.
 ///
-/// `gts_instance_id` is the UUID parsed from the GTS entity identifier
-/// (e.g. the `<uuid>` part of `gts.x.core.oagw.upstream.v1~<uuid>`).
-/// Used by `post_init()` to map GTS-level references in route entities
-/// to OAGW-assigned upstream UUIDs.
+/// The GTS instance UUID is carried inside `request.id` so that OAGW
+/// uses the config-provided ID directly instead of generating a random one.
 #[domain_model]
 #[derive(Debug, Clone)]
 pub struct ProvisionedUpstream {
     pub tenant_id: Uuid,
     pub request: CreateUpstreamRequest,
-    pub gts_instance_id: Option<Uuid>,
 }
 
 /// A route definition read from the types-registry.
+///
+/// The GTS instance UUID is carried inside `request.id` so that OAGW
+/// uses the config-provided ID directly instead of generating a random one.
 #[domain_model]
 #[derive(Debug, Clone)]
 pub struct ProvisionedRoute {

--- a/modules/system/oagw/oagw/src/infra/type_provisioning.rs
+++ b/modules/system/oagw/oagw/src/infra/type_provisioning.rs
@@ -326,7 +326,7 @@ struct UpstreamPayload {
 #[derive(Deserialize)]
 struct RoutePayload {
     tenant_id: Uuid,
-    upstream_id: Uuid,
+    upstream_id: String,
     #[serde(rename = "match")]
     match_rules: MatchRules,
     #[serde(default)]
@@ -634,6 +634,7 @@ impl UpstreamPayload {
         ProvisionedUpstream {
             tenant_id: self.tenant_id,
             request: domain::CreateUpstreamRequest {
+                id: gts_instance_id,
                 server: self.server.into(),
                 protocol: self.protocol,
                 alias: self.alias,
@@ -645,26 +646,39 @@ impl UpstreamPayload {
                 tags: self.tags,
                 enabled: self.enabled,
             },
-            gts_instance_id,
         }
     }
 }
 
-impl From<RoutePayload> for ProvisionedRoute {
-    fn from(p: RoutePayload) -> Self {
-        Self {
-            tenant_id: p.tenant_id,
+impl RoutePayload {
+    fn into_provisioned(
+        self,
+        gts_id: &str,
+        gts_instance_id: Uuid,
+    ) -> Result<ProvisionedRoute, DomainError> {
+        // Accept both full GTS identifier and bare UUID for upstream_id.
+        let upstream_id = extract_gts_instance_uuid(&self.upstream_id)
+            .or_else(|| Uuid::parse_str(&self.upstream_id).ok())
+            .ok_or_else(|| {
+                DomainError::validation(format!(
+                    "Route '{gts_id}': upstream_id '{}' is not a valid UUID or GTS identifier",
+                    self.upstream_id
+                ))
+            })?;
+        Ok(ProvisionedRoute {
+            tenant_id: self.tenant_id,
             request: domain::CreateRouteRequest {
-                upstream_id: p.upstream_id,
-                match_rules: p.match_rules.into(),
-                plugins: p.plugins.map(Into::into),
-                rate_limit: p.rate_limit.map(Into::into),
-                cors: p.cors.map(Into::into),
-                tags: p.tags,
-                priority: p.priority,
-                enabled: p.enabled,
+                id: Some(gts_instance_id),
+                upstream_id,
+                match_rules: self.match_rules.into(),
+                plugins: self.plugins.map(Into::into),
+                rate_limit: self.rate_limit.map(Into::into),
+                cors: self.cors.map(Into::into),
+                tags: self.tags,
+                priority: self.priority,
+                enabled: self.enabled,
             },
-        }
+        })
     }
 }
 
@@ -674,6 +688,18 @@ impl From<RoutePayload> for ProvisionedRoute {
 fn extract_gts_instance_uuid(gts_id: &str) -> Option<Uuid> {
     let instance = gts_id.rsplit('~').next()?;
     Uuid::parse_str(instance).ok()
+}
+
+/// Like `extract_gts_instance_uuid` but returns an error suitable for
+/// failing startup when the instance segment is not a valid UUID.
+fn require_gts_instance_uuid(gts_id: &str) -> Result<Uuid, DomainError> {
+    extract_gts_instance_uuid(gts_id).ok_or_else(|| {
+        DomainError::validation(format!(
+            "GTS entity '{gts_id}' has a non-UUID instance segment; \
+             OAGW requires upstream and route $id values to end with a UUID \
+             (e.g. gts.x.core.oagw.upstream.v1~<uuid>)"
+        ))
+    })
 }
 
 /// `TypeProvisioningService` implementation that delegates to `TypesRegistryClient`.
@@ -702,17 +728,16 @@ impl TypeProvisioningService for TypeProvisioningServiceImpl {
 
         let mut result = Vec::with_capacity(entities.len());
         for entity in entities {
+            let gts_instance_id = require_gts_instance_uuid(&entity.gts_id)?;
             match serde_json::from_value::<UpstreamPayload>(entity.content.clone()) {
                 Ok(payload) => {
-                    let gts_instance_id = extract_gts_instance_uuid(&entity.gts_id);
-                    result.push(payload.into_provisioned(gts_instance_id));
+                    result.push(payload.into_provisioned(Some(gts_instance_id)));
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        gts_id = %entity.gts_id,
-                        error = %e,
-                        "Skipping upstream: failed to deserialize GTS entity content"
-                    );
+                    return Err(DomainError::validation(format!(
+                        "Upstream '{}': failed to deserialize GTS entity content: {e}",
+                        entity.gts_id
+                    )));
                 }
             }
         }
@@ -733,16 +758,16 @@ impl TypeProvisioningService for TypeProvisioningServiceImpl {
 
         let mut result = Vec::with_capacity(entities.len());
         for entity in entities {
+            let gts_instance_id = require_gts_instance_uuid(&entity.gts_id)?;
             match serde_json::from_value::<RoutePayload>(entity.content.clone()) {
                 Ok(payload) => {
-                    result.push(payload.into());
+                    result.push(payload.into_provisioned(&entity.gts_id, gts_instance_id)?);
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        gts_id = %entity.gts_id,
-                        error = %e,
-                        "Skipping route: failed to deserialize GTS entity content"
-                    );
+                    return Err(DomainError::validation(format!(
+                        "Route '{}': failed to deserialize GTS entity content: {e}",
+                        entity.gts_id
+                    )));
                 }
             }
         }
@@ -822,38 +847,62 @@ mod tests {
     #[tokio::test]
     async fn list_upstreams_returns_parsed_entities() {
         let tenant = Uuid::new_v4();
+        let instance_id = Uuid::new_v4();
         let content = upstream_content(tenant);
+        let gts_id = format!("gts.x.core.oagw.upstream.v1~{instance_id}");
 
         let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(move |_| {
-                Ok(vec![make_upstream_entity(
-                    "gts.x.core.oagw.upstream.v1~abc123",
-                    content.clone(),
-                )])
-            }),
+            list_fn: Box::new(move |_| Ok(vec![make_upstream_entity(&gts_id, content.clone())])),
         });
         let svc = TypeProvisioningServiceImpl::new(registry);
 
         let upstreams = svc.list_upstreams().await.unwrap();
         assert_eq!(upstreams.len(), 1);
         assert_eq!(upstreams[0].tenant_id, tenant);
+        assert_eq!(upstreams[0].request.id, Some(instance_id));
         assert!(upstreams[0].request.enabled);
     }
 
     #[tokio::test]
-    async fn list_upstreams_skips_invalid_content() {
+    async fn list_upstreams_rejects_non_uuid_instance_id() {
         let registry = Arc::new(MockRegistry {
             list_fn: Box::new(|_| {
                 Ok(vec![make_upstream_entity(
-                    "gts.x.core.oagw.upstream.v1~bad",
+                    "gts.x.core.oagw.upstream.v1~x.core.oagw.test.v1",
+                    upstream_content(Uuid::new_v4()),
+                )])
+            }),
+        });
+        let svc = TypeProvisioningServiceImpl::new(registry);
+
+        let err = svc.list_upstreams().await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("non-UUID instance segment"),
+            "expected non-UUID error, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_upstreams_rejects_invalid_content() {
+        let instance_id = Uuid::new_v4();
+        let gts_id = format!("gts.x.core.oagw.upstream.v1~{instance_id}");
+        let registry = Arc::new(MockRegistry {
+            list_fn: Box::new(move |_| {
+                Ok(vec![make_upstream_entity(
+                    &gts_id,
                     serde_json::json!({"invalid": true}),
                 )])
             }),
         });
         let svc = TypeProvisioningServiceImpl::new(registry);
 
-        let upstreams = svc.list_upstreams().await.unwrap();
-        assert!(upstreams.is_empty());
+        let err = svc.list_upstreams().await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to deserialize"),
+            "expected deserialization error, got: {msg}"
+        );
     }
 
     #[tokio::test]
@@ -882,39 +931,63 @@ mod tests {
     async fn list_routes_returns_parsed_entities() {
         let tenant = Uuid::new_v4();
         let upstream_id = Uuid::new_v4();
+        let route_instance_id = Uuid::new_v4();
         let content = route_content(tenant, upstream_id);
+        let gts_id = format!("gts.x.core.oagw.route.v1~{route_instance_id}");
 
         let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(move |_| {
-                Ok(vec![make_route_entity(
-                    "gts.x.core.oagw.route.v1~abc123",
-                    content.clone(),
-                )])
-            }),
+            list_fn: Box::new(move |_| Ok(vec![make_route_entity(&gts_id, content.clone())])),
         });
         let svc = TypeProvisioningServiceImpl::new(registry);
 
         let routes = svc.list_routes().await.unwrap();
         assert_eq!(routes.len(), 1);
         assert_eq!(routes[0].tenant_id, tenant);
+        assert_eq!(routes[0].request.id, Some(route_instance_id));
         assert_eq!(routes[0].request.upstream_id, upstream_id);
         assert!(routes[0].request.enabled);
     }
 
     #[tokio::test]
-    async fn list_routes_skips_invalid_content() {
+    async fn list_routes_rejects_non_uuid_instance_id() {
         let registry = Arc::new(MockRegistry {
             list_fn: Box::new(|_| {
                 Ok(vec![make_route_entity(
-                    "gts.x.core.oagw.route.v1~bad",
+                    "gts.x.core.oagw.route.v1~x.core.oagw.test.v1",
+                    route_content(Uuid::new_v4(), Uuid::new_v4()),
+                )])
+            }),
+        });
+        let svc = TypeProvisioningServiceImpl::new(registry);
+
+        let err = svc.list_routes().await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("non-UUID instance segment"),
+            "expected non-UUID error, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_routes_rejects_invalid_content() {
+        let instance_id = Uuid::new_v4();
+        let gts_id = format!("gts.x.core.oagw.route.v1~{instance_id}");
+        let registry = Arc::new(MockRegistry {
+            list_fn: Box::new(move |_| {
+                Ok(vec![make_route_entity(
+                    &gts_id,
                     serde_json::json!({"garbage": true}),
                 )])
             }),
         });
         let svc = TypeProvisioningServiceImpl::new(registry);
 
-        let routes = svc.list_routes().await.unwrap();
-        assert!(routes.is_empty());
+        let err = svc.list_routes().await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to deserialize"),
+            "expected deserialization error, got: {msg}"
+        );
     }
 
     #[tokio::test]
@@ -1054,7 +1127,10 @@ mod tests {
         });
 
         let payload: RoutePayload = serde_json::from_value(json).unwrap();
-        let provisioned: ProvisionedRoute = payload.into();
+        let route_uuid = Uuid::new_v4();
+        let provisioned = payload
+            .into_provisioned("gts.x.core.oagw.route.v1~x.core.oagw.test.v1", route_uuid)
+            .expect("upstream_id should parse");
 
         assert_eq!(provisioned.tenant_id, tenant);
         let req = &provisioned.request;

--- a/modules/system/oagw/oagw/src/module.rs
+++ b/modules/system/oagw/oagw/src/module.rs
@@ -179,6 +179,7 @@ impl Module for OutboundApiGatewayModule {
         };
 
         self.state.store(Some(Arc::new(app_state)));
+
         Ok(())
     }
 }
@@ -204,13 +205,12 @@ impl SystemCapability for OutboundApiGatewayModule {
             .as_ref()
             .clone();
 
-        // -- Materialise upstreams, building a GTS-instance-UUID -> OAGW-UUID map --
-        // Routes registered via types-registry reference upstreams by the
-        // deterministic GTS instance UUID. OAGW assigns random UUIDs, so we
-        // need to rewrite route upstream_ids before creating them.
+        // -- Materialise upstreams and routes from types-registry --
+        // GTS instance UUIDs are passed through as `CreateUpstreamRequest.id`
+        // and `CreateRouteRequest.id`, so OAGW uses the config-provided IDs
+        // directly. Route `upstream_id` already references the upstream's GTS
+        // instance UUID, so no remapping is needed.
         let upstreams = provisioning.list_upstreams().await?;
-        let mut gts_to_oagw: std::collections::HashMap<uuid::Uuid, uuid::Uuid> =
-            std::collections::HashMap::new();
         for u in &upstreams {
             let ctx = SecurityContext::builder()
                 .subject_tenant_id(u.tenant_id)
@@ -223,9 +223,6 @@ impl SystemCapability for OutboundApiGatewayModule {
                 .map_err(|e| {
                     anyhow::anyhow!("Failed to provision upstream (tenant={}): {e}", u.tenant_id)
                 })?;
-            if let Some(gts_id) = u.gts_instance_id {
-                gts_to_oagw.insert(gts_id, created.id);
-            }
             info!(
                 id = %created.id,
                 tenant_id = %u.tenant_id,
@@ -240,14 +237,13 @@ impl SystemCapability for OutboundApiGatewayModule {
                 .subject_tenant_id(r.tenant_id)
                 .subject_id(modkit_security::constants::DEFAULT_SUBJECT_ID)
                 .build()?;
-            // Rewrite upstream_id if it references a GTS instance UUID.
-            let mut req = r.request.clone();
-            if let Some(&oagw_id) = gts_to_oagw.get(&req.upstream_id) {
-                req.upstream_id = oagw_id;
-            }
-            let created = app_state.cp.create_route(&ctx, req).await.map_err(|e| {
-                anyhow::anyhow!("Failed to provision route (tenant={}): {e}", r.tenant_id)
-            })?;
+            let created = app_state
+                .cp
+                .create_route(&ctx, r.request.clone())
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("Failed to provision route (tenant={}): {e}", r.tenant_id)
+                })?;
             info!(
                 id = %created.id,
                 tenant_id = %r.tenant_id,
@@ -276,8 +272,6 @@ impl RestApiCapability for OutboundApiGatewayModule {
         router: axum::Router,
         openapi: &dyn OpenApiRegistry,
     ) -> anyhow::Result<axum::Router> {
-        info!("Registering OAGW REST routes");
-
         let state = self
             .state
             .load()
@@ -285,6 +279,12 @@ impl RestApiCapability for OutboundApiGatewayModule {
             .ok_or_else(|| anyhow::anyhow!("OAGW module not initialized — call init() first"))?
             .as_ref()
             .clone();
+
+        let mgmt_enabled = state.config.management_api_enabled;
+        info!(
+            management_api_enabled = mgmt_enabled,
+            "Registering OAGW REST routes"
+        );
 
         let router = routes::register_routes(router, openapi, state);
         Ok(router)

--- a/modules/system/types-registry/types-registry/Cargo.toml
+++ b/modules/system/types-registry/types-registry/Cargo.toml
@@ -41,6 +41,7 @@ parking_lot = { workspace = true }
 # Local dependencies
 modkit = { workspace = true }
 modkit-macros = { workspace = true }
+modkit-security = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/modules/system/types-registry/types-registry/src/config.rs
+++ b/modules/system/types-registry/types-registry/src/config.rs
@@ -1,6 +1,7 @@
 //! Configuration for the Types Registry module.
 
 use serde::Deserialize;
+use uuid::Uuid;
 
 /// Configuration for the Types Registry module.
 #[derive(Debug, Clone, Deserialize)]
@@ -13,6 +14,25 @@ pub struct TypesRegistryConfig {
     /// Fields to check for schema ID reference (in order of priority).
     /// Default: `["$schema", "gtsTid", "type"]`
     pub schema_id_fields: Vec<String>,
+
+    /// Default tenant ID injected into static entities that don't specify one.
+    ///
+    /// When a static entity in `entities` has no `tenant_id` field, this value
+    /// is automatically inserted before registration. Defaults to
+    /// `modkit_security::constants::DEFAULT_TENANT_ID`.
+    #[serde(default = "default_tenant_id")]
+    pub default_tenant_id: Uuid,
+
+    /// Raw GTS entity JSON values to register at startup.
+    ///
+    /// Each entry must be a valid GTS entity with at least an `$id` (or
+    /// `gtsId`/`id`) field. Entities are registered in order.
+    #[serde(default)]
+    pub entities: Vec<serde_json::Value>,
+}
+
+fn default_tenant_id() -> Uuid {
+    modkit_security::constants::DEFAULT_TENANT_ID
 }
 
 impl Default for TypesRegistryConfig {
@@ -20,6 +40,8 @@ impl Default for TypesRegistryConfig {
         Self {
             entity_id_fields: vec!["$id".to_owned(), "gtsId".to_owned(), "id".to_owned()],
             schema_id_fields: vec!["$schema".to_owned(), "gtsTid".to_owned(), "type".to_owned()],
+            default_tenant_id: default_tenant_id(),
+            entities: Vec::new(),
         }
     }
 }
@@ -44,6 +66,11 @@ mod tests {
         let cfg = TypesRegistryConfig::default();
         assert_eq!(cfg.entity_id_fields, vec!["$id", "gtsId", "id"]);
         assert_eq!(cfg.schema_id_fields, vec!["$schema", "gtsTid", "type"]);
+        assert!(cfg.entities.is_empty());
+        assert_eq!(
+            cfg.default_tenant_id,
+            modkit_security::constants::DEFAULT_TENANT_ID
+        );
     }
 
     #[test]

--- a/modules/system/types-registry/types-registry/src/module.rs
+++ b/modules/system/types-registry/types-registry/src/module.rs
@@ -7,7 +7,7 @@ use modkit::api::OpenApiRegistry;
 use modkit::contracts::SystemCapability;
 use modkit::{Module, ModuleCtx, RestApiCapability};
 use tracing::{debug, info};
-use types_registry_sdk::TypesRegistryClient;
+use types_registry_sdk::{RegisterResult, RegisterSummary, TypesRegistryClient};
 
 use crate::config::TypesRegistryConfig;
 use crate::domain::local_client::TypesRegistryLocalClient;
@@ -54,8 +54,52 @@ impl Module for TypesRegistryModule {
         );
 
         let gts_config = cfg.to_gts_config();
+        let static_entities = cfg.entities.clone();
+        let default_tenant_id = cfg.default_tenant_id;
+
         let repo = Arc::new(InMemoryGtsRepository::new(gts_config));
         let service = Arc::new(TypesRegistryService::new(repo, cfg));
+
+        // Register static entities from config (before ready-mode validation)
+        if !static_entities.is_empty() {
+            let tenant_id_str = default_tenant_id.to_string();
+            let entities: Vec<serde_json::Value> = static_entities
+                .into_iter()
+                .map(|mut v| {
+                    if let Some(obj) = v.as_object_mut() {
+                        obj.entry("tenant_id")
+                            .or_insert_with(|| serde_json::Value::String(tenant_id_str.clone()));
+                    }
+                    v
+                })
+                .collect();
+
+            let entity_count = entities.len();
+            let results = service.register(entities);
+            let summary = RegisterSummary::from_results(&results);
+
+            if !summary.all_succeeded() {
+                for result in &results {
+                    if let RegisterResult::Err { gts_id, error } = result {
+                        tracing::error!(
+                            gts_id = gts_id.as_deref().unwrap_or("<unknown>"),
+                            error = %error,
+                            "Failed to register static GTS entity"
+                        );
+                    }
+                }
+                anyhow::bail!(
+                    "types-registry: {}/{} static entities failed to register",
+                    summary.failed,
+                    summary.total()
+                );
+            }
+
+            info!(
+                count = entity_count,
+                "Registered static GTS entities from config"
+            );
+        }
 
         self.service
             .set(service.clone())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAGW Management API can run in read-only mode (create/update/delete endpoints disabled).
  * Types Registry can pre-register configured static entities at startup and will surface failures.

* **Improvements**
  * Provisioning uses provided upstream IDs directly; startup logging includes management API state.
  * Payload parsing and validation tightened: invalid or malformed entities now return validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->