### PR TITLE
chore: use proper rust toolchain version from rust-toolchain.toml in Makefile and CI

### DIFF
--- a/.github/workflows/api_contracts.yml
+++ b/.github/workflows/api_contracts.yml
@@ -80,8 +80,10 @@ jobs:
           go-version: 'stable'
           cache: false
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       # Cache Cargo registry/git + target/ across platforms.
       - name: Cache Cargo/target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,10 @@ jobs:
           go-version: 'stable'
           cache: false
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       - name: Install nextest
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
@@ -111,8 +113,10 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       - name: Install nextest
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3
@@ -167,8 +171,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       # Install tools via prebuilt binaries for speed.
       - name: Install cargo-deny

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,8 +51,10 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Update Rust
-        run: rustup update
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       - name: Install Python dependencies
         run: pip install -r testing/e2e/requirements.txt

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -23,8 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2

--- a/.github/workflows/gts-validation.yml
+++ b/.github/workflows/gts-validation.yml
@@ -27,8 +27,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       - name: Cache Cargo/target
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -41,8 +41,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       - name: release-plz release-pr
         uses: release-plz/action@52440b50d383aa252927de395c8b2c1e0a9cf8e9 # v0.3.155
@@ -175,8 +177,10 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - name: Install Rust toolchain from rust-toolchain.toml
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup show
 
       - name: Install nextest
         uses: taiki-e/install-action@6ef672efc2b5aabc787a9e94baf4989aa02a97df # v2.70.3

--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ dylint-test: install-tools
 dylint:
 	$(call check_tool,cargo-dylint)
 	$(call check_tool,dylint-link)
-	cargo +nightly-2026-01-22 dylint --all --workspace
+	cargo dylint --all --workspace
 
 # Run all code safety checks
 safety: clippy kani lint dylint # geiger

--- a/Makefile
+++ b/Makefile
@@ -700,7 +700,7 @@ ci: fmt clippy test-no-macros test-macros test-db deny test-users-info-pg lychee
 
 # Build the hyperspot-server release binary using the stable toolchain.
 cargo-build:
-	cargo +stable build --release --bin hyperspot-server $(E2E_ARGS)
+	cargo build --release --bin hyperspot-server $(E2E_ARGS)
 
 # Split debug symbols into separate artifact(s) and strip the binary.
 # Requires platform tools: objcopy (Linux), dsymutil+strip (macOS).

--- a/Makefile
+++ b/Makefile
@@ -698,7 +698,7 @@ ci_docs: lychee
 # Run CI pipeline locally, requires docker
 ci: fmt clippy test-no-macros test-macros test-db deny test-users-info-pg lychee dylint dylint-test
 
-# Build the hyperspot-server release binary using the stable toolchain.
+# Build the hyperspot-server release binary using a toolchain from the rust-toolchain.toml
 cargo-build:
 	cargo build --release --bin hyperspot-server $(E2E_ARGS)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all CI/CD workflows to use centralized Rust toolchain configuration
  * Consolidated toolchain management across build pipelines
  * Simplified build infrastructure by removing external action dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->