### PR TITLE
feat(usage-collector): add SDK crate and design documentation

### DIFF
--- a/.cypilot/config/artifacts.toml
+++ b/.cypilot/config/artifacts.toml
@@ -15,6 +15,17 @@ patterns = [
 ]
 
 [[ignore]]
+reason = "Ignore usage-collector codebase and features — code traceability markers added incrementally across PR train. Remove after all PRs merged."
+patterns = [
+  "modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/*",
+  "modules/system/usage-collector/usage-collector/src/*",
+  "modules/system/usage-collector/usage-collector-rest-client/src/*",
+  "modules/system/usage-collector/usage-collector-sdk/src/*",
+  "modules/system/usage-collector/usage-emitter/src/*",
+  "modules/system/usage-collector/docs/features/*",
+]
+
+[[ignore]]
 reason = "Ignore 'modules/system' parent directory — not a module, only a grouping for system submodules."
 patterns = ["modules/system"]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,6 +2313,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-usage-collector-sdk"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "cf-modkit",
+ "chrono",
+ "gts",
+ "gts-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
 name = "cff-parser"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ members = [
     "modules/system/oagw/oagw-sdk",
     "modules/mini-chat/mini-chat-sdk",
     "modules/mini-chat/mini-chat",
+    "modules/system/usage-collector/usage-collector-sdk",
 ]
 exclude = ["tools/fuzz"]
 resolver = "3"
@@ -252,6 +253,9 @@ credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.18", path = "modu
 
 # mini-chat
 mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.10.0", path = "modules/mini-chat/mini-chat-sdk" }
+
+# usage-collector
+usage-collector-sdk = { package = "cf-usage-collector-sdk", version = "0.1.0", path = "modules/system/usage-collector/usage-collector-sdk" }
 
 # system modules
 grpc_hub = { package = "cf-grpc-hub", version = "0.2.0", path = "modules/system/grpc-hub" }

--- a/modules/system/usage-collector/docs/ADR/0001-cpt-cf-usage-collector-adr-scoped-emit-source.md
+++ b/modules/system/usage-collector/docs/ADR/0001-cpt-cf-usage-collector-adr-scoped-emit-source.md
@@ -47,40 +47,40 @@ Chosen option: "`for_module()` scoped client bound once at module init", because
 
 ### Consequences
 
-* Good, because call sites remain clean — `emit(ctx, record)` carries no source boilerplate
+* Good, because call sites remain clean — `build_usage_record(...).enqueue()` carries no source boilerplate
 * Good, because the `for_module()` call in module init is the single, auditable point where source is declared, using the compile-time `MODULE_NAME` constant rather than a free-form string
-* Good, because the SDK can enforce metric prefix consistency at `emit()` time and fail fast in the source process before the outbox is written
+* Good, because the emitter validates the metric against the allowed-metrics list at `enqueue()` time and fails fast in the source process before the outbox is written
 * Good, because the module name used for attribution is the same authoritative name registered in the module orchestrator, not a separately maintained string
-* Bad, because consuming modules must store a `ScopedUsageCollectorClientV1` wrapper rather than the raw `UsageCollectorClientV1` trait object — a minor change to client storage conventions
+* Bad, because consuming modules must store a `ScopedUsageEmitter` wrapper rather than the raw `UsageCollectorClientV1` trait object — a minor change to client storage conventions
 * Bad, because source attribution remains self-asserted — a developer can deliberately pass any module name to `for_module()`; this is acceptable given the internal threat model but would not withstand adversarial bypass
 
 ### Confirmation
 
 * Code review: verify each consuming module calls `for_module()` with its own `MODULE_NAME` constant (e.g., `LlmGatewayModule::MODULE_NAME`), not another module's constant
-* SDK unit tests: verify `ScopedUsageCollectorClientV1::emit()` returns an error when the metric name does not start with the declared source module prefix
-* Integration test: verify that emitting a metric with a mismatched prefix (e.g., a file-storage scoped client emitting `llm-gateway.tokens.input`) is rejected at the SDK level before reaching the outbox
+* SDK unit tests: verify `ScopedUsageEmitter::authorize_for()` followed by `build_usage_record(...).enqueue()` returns `UsageEmitterError::MetricNotAllowed` when the metric name is not in the `allowed_metrics` list for the declared source module
+* Integration test: verify that emitting a metric not present in the module's `allowed_metrics` config (e.g., a file-storage scoped emitter attempting to emit `llm-gateway.tokens.input`) is rejected at the SDK level before reaching the outbox
 
 ## Pros and Cons of the Options
 
 ### Per-call source declaration on `emit()` or `UsageRecord`
 
-Pass `source_module` as an explicit parameter to `emit()` or as a required field on `UsageRecord` on every call.
+Pass `source_module` as an explicit parameter to `enqueue()` or as a required field on `UsageRecord` on every call.
 
 * Good, because source attribution is explicit and visible at every call site
 * Good, because no additional wrapper type is required
-* Bad, because every `emit()` call site carries a repetitive boilerplate parameter
-* Bad, because there is no single auditable binding point — the correct module name must be passed correctly across every emit call, increasing the risk of copy-paste errors
+* Bad, because every `enqueue()` call site carries a repetitive boilerplate parameter
+* Bad, because there is no single auditable binding point — the correct module name must be passed correctly across every enqueue call, increasing the risk of copy-paste errors
 * Bad, because there is no natural place to derive the value from `Self::MODULE_NAME`; the call site must supply it manually each time
 
 ### `for_module()` scoped client bound once at module init
 
-The SDK exposes `for_module(name: &str) -> ScopedUsageCollectorClientV1`. Each consuming module calls this once during initialization with `Self::MODULE_NAME` and stores the scoped client. The `ScopedUsageCollectorClientV1` stamps the declared source on every `emit()` and validates the metric prefix.
+The `UsageEmitterV1` trait exposes `for_module(name: &str) -> ScopedUsageEmitter`. Each consuming module calls this once during initialization with `Self::MODULE_NAME` and stores the scoped emitter. The `ScopedUsageEmitter` stamps the declared source on every `enqueue()` and validates the metric against the module's `allowed_metrics` list fetched from the gateway during `authorize_for()`.
 
 * Good, because source attribution is declared once, from the authoritative compile-time constant
-* Good, because call sites are clean — `emit(ctx, record)` with no source parameter
+* Good, because call sites are clean — `build_usage_record(...).enqueue()` with no source parameter
 * Good, because the binding is code-review-auditable in one location (module init)
-* Good, because metric prefix enforcement happens automatically on every emit without call-site involvement
-* Bad, because consuming modules store a `ScopedUsageCollectorClientV1` instead of the raw trait object
+* Good, because allowed-metrics validation happens automatically on every enqueue without call-site involvement
+* Bad, because consuming modules store a `ScopedUsageEmitter` instead of the raw `UsageEmitterV1` trait object
 
 ### Convention-only, no SDK-level source tracking
 
@@ -110,8 +110,8 @@ This decision is stable for the initial release. Revisit if:
 
 This decision directly addresses the following requirements or design elements:
 
-* `cpt-cf-usage-collector-component-sdk` — adds `for_module()` to the SDK component's responsibility scope, returning a `ScopedUsageCollectorClientV1` that binds source attribution and enforces metric prefix at emit time
-* `cpt-cf-usage-collector-interface-sdk-trait` — `for_module()` extends the SDK public interface, returning a `ScopedUsageCollectorClientV1`
-* `cpt-cf-usage-collector-interface-scoped-client` — `ScopedUsageCollectorClientV1` is the type consuming modules store and use for emission; it binds `MODULE_NAME` and validates metric prefix at `emit()` time
+* `cpt-cf-usage-collector-component-emitter` — adds `for_module()` to the emitter component's responsibility scope, returning a `ScopedUsageEmitter` that binds source attribution and validates metrics against the allowed-metrics list
+* `cpt-cf-usage-collector-interface-emitter-trait` — `for_module()` is the entry point on `UsageEmitterV1`, returning a `ScopedUsageEmitter`
+* `cpt-cf-usage-collector-interface-scoped-emitter` — `ScopedUsageEmitter` is the type consuming modules store and use for emission; it binds `MODULE_NAME` and validates the metric against the allowed-metrics list during `authorize_for()`
 * `cpt-cf-usage-collector-principle-fail-closed` — the SDK fails closed on metric prefix mismatch, rejecting the emit before the outbox is written
 * `cpt-cf-usage-collector-fr-ingestion` — source attribution is part of the ingestion record, enabling per-module metric auditing at the gateway and storage layers

--- a/modules/system/usage-collector/docs/ADR/0002-cpt-cf-usage-collector-adr-two-phase-emit-authz.md
+++ b/modules/system/usage-collector/docs/ADR/0002-cpt-cf-usage-collector-adr-two-phase-emit-authz.md
@@ -15,7 +15,7 @@
   - [PDP call synchronously at `emit()` time (inside or adjacent to DB transaction)](#pdp-call-synchronously-at-emit-time-inside-or-adjacent-to-db-transaction)
   - [Authorization deferred to gateway at delivery time (dispatcher → gateway)](#authorization-deferred-to-gateway-at-delivery-time-dispatcher--gateway)
   - [Pre-loaded static SDK policy (config-based metric allowlist, no PDP)](#pre-loaded-static-sdk-policy-config-based-metric-allowlist-no-pdp)
-  - [Two-phase PDP: `authorize_emit()` before transaction + in-memory constraint evaluation at `emit()`](#two-phase-pdp-authorize_emit-before-transaction--in-memory-constraint-evaluation-at-emit)
+  - [Two-phase PDP: `authorize_for()` before transaction + in-memory constraint evaluation at `enqueue()`](#two-phase-pdp-authorize_for-before-transaction--in-memory-constraint-evaluation-at-enqueue)
 - [More Information](#more-information)
   - [TOCTOU Window Analysis](#toctou-window-analysis)
   - [Performance Budget](#performance-budget)
@@ -36,7 +36,7 @@ The SDK's `emit()` call must persist usage records to the local outbox within th
 * Authorization checks MUST NOT be performed inside an open DB transaction — network calls holding DB locks violate platform conventions and degrade source service throughput
 * Authorization errors MUST be surfaced to the source service's caller at request time, before any domain operation is committed
 * The system MUST fail closed on authorization failure (`cpt-cf-usage-collector-principle-fail-closed`)
-* The `ScopedUsageCollectorClientV1` from ADR 0001 (`cpt-cf-usage-collector-adr-scoped-emit-source`) is already instantiated per source module and holds the source module identity — it is the natural owner of emit authorization logic
+* The `ScopedUsageEmitter` from ADR 0001 (`cpt-cf-usage-collector-adr-scoped-emit-source`) is already instantiated per source module and holds the source module identity — it is the natural owner of emit authorization logic
 * The existing `authz-resolver-sdk` `PolicyEnforcer` / `AuthZResolverClient` must be reused without introducing new authorization primitives
 
 ## Considered Options
@@ -44,42 +44,42 @@ The SDK's `emit()` call must persist usage records to the local outbox within th
 * PDP call synchronously at `emit()` time (inside or adjacent to DB transaction)
 * Authorization deferred to gateway at delivery time (dispatcher → gateway)
 * Pre-loaded static SDK policy (config-based metric allowlist, no PDP)
-* Two-phase PDP: `authorize_emit()` before transaction returns `EmitAuthorization`; `emit()` evaluates constraints in-memory
+* Two-phase PDP: `authorize_for()` before transaction returns `AuthorizedUsageEmitter`; `emit()` evaluates constraints in-memory
 
 ## Decision Outcome
 
-Chosen option: "Two-phase PDP: `authorize_emit()` before transaction + in-memory constraint evaluation at `emit()`", because it is the only option that satisfies all three constraints simultaneously: no network call inside a DB transaction, immediate failure feedback at request time, and reuse of the existing platform PDP infrastructure.
+Chosen option: "Two-phase PDP: `authorize_for()` before transaction + in-memory constraint evaluation at `enqueue()`", because it is the only option that satisfies all three constraints simultaneously: no network call inside a DB transaction, immediate failure feedback at request time, and reuse of the existing platform PDP infrastructure.
 
-`ScopedUsageCollectorClientV1` gains two responsibilities:
+`ScopedUsageEmitter` gains two responsibilities:
 
-1. `authorize_emit(ctx, metric_name: &str) -> Result<EmitAuthorization, EmitError>` — called before the DB transaction opens; contacts the PDP for the given metric, fetches the registered usage type schema for `metric_name` from types-registry, and returns an opaque `EmitAuthorization` token on success, or propagates a denial error immediately.
-2. `emit(ctx, record, &EmitAuthorization)` — called inside the DB transaction; evaluates the pre-fetched constraints against the record in-memory (no I/O), then inserts the outbox row.
+1. `authorize_for(ctx, tenant_id, resource_id, resource_type) -> Result<AuthorizedUsageEmitter, UsageEmitterError>` — called before the DB transaction opens; contacts the PDP for `USAGE_RECORD`/`CREATE`, fetches the allowed-metrics configuration for the module from the gateway; returns an `AuthorizedUsageEmitter` token on success, or propagates a denial error immediately.
+2. `build_usage_record(metric, value).enqueue()` — called inside the DB transaction; evaluates the pre-fetched constraints against the record in-memory (no I/O), then inserts the outbox row.
 
-The `EmitAuthorization` type wraps the PDP response constraints (`Vec<Constraint>` from `authz-resolver-sdk`) and is opaque to the calling module. A denial from the PDP is surfaced as an `Err` from `authorize_emit()`, so `EmitAuthorization` is only constructed on success. In-memory constraint evaluation uses the existing `Constraint` / `Predicate` types (`Eq`, `In`) from `authz-resolver-sdk`, evaluated against `UsageRecord` fields without SQL compilation.
+The `AuthorizedUsageEmitter` type carries the PDP permit result, the authorized `tenant_id`/`resource_id`/`resource_type`, and the allowed-metrics list fetched from the gateway; it is opaque to the calling module. A denial from the PDP is surfaced as an `Err` from `authorize_for()`, so `AuthorizedUsageEmitter` is only constructed on success. In-memory constraint evaluation uses the `allowed_metrics` list to validate metric names and kinds against the `UsageRecord` fields without any network I/O.
 
-`EmitAuthorization` includes `issued_at: Instant` (set at construction time) and `nonce: u64` (randomly generated per call). `emit()` calls `EmitAuthorization::validate_freshness()` as the first step before any constraint evaluation or outbox INSERT; if `issued_at.elapsed() > MAX_AUTH_AGE`, `emit()` returns `EmitError::AuthorizationExpired`. `MAX_AUTH_AGE` is a compile-time constant set to 30 seconds — well above any normal request handler duration and well below the minimum operationally meaningful policy propagation delay. This provides runtime enforcement of the single-use, single-request constraint without relying solely on code review.
+`AuthorizedUsageEmitter` includes `issued_at: Instant` (set at construction time). `enqueue()` calls `AuthorizedUsageEmitter::validate_authorization_freshness()` as the first step before any constraint evaluation or outbox INSERT; if `issued_at.elapsed() > authorization_max_age`, `enqueue()` returns `UsageEmitterError::AuthorizationExpired`. The `authorization_max_age` is a configurable field on `UsageEmitterConfig` (default 30 seconds) — well above any normal request handler duration and well below the minimum operationally meaningful policy propagation delay. This provides runtime enforcement of the single-request constraint without relying solely on code review.
 
 ### Consequences
 
 * Good, because the PDP call happens before any DB transaction opens — no network I/O holds DB locks
-* Good, because authorization errors are surfaced at request time via `authorize_emit()` failure — the source caller receives an immediate, meaningful error before any domain operation commits
-* Good, because `emit()` performs only in-memory constraint evaluation and an outbox INSERT — no external calls on the critical emission path
-* Good, because the implementation reuses `authz-resolver-sdk` constraint types and `PolicyEnforcer::build_request_with()` without introducing new authorization primitives
-* Good, because `ScopedUsageCollectorClientV1` (established in ADR 0001) is the natural and auditable owner of `authorize_emit()`, which already carries the source module identifier for PDP resource property attribution
-* Good, because `EmitAuthorization` is opaque to consuming modules — no authz concepts leak into business code at call sites
-* Bad, because source services must call `authorize_emit()` once per request that may emit usage — adds one PDP round-trip per request on the non-transaction path
-* Bad, because `emit()` gains a required `&EmitAuthorization` argument, changing the SDK API surface relative to a naive `emit(ctx, record)` signature
-* Bad, because in-memory constraint evaluation requires a new evaluator in the SDK (`EmitAuthorization::is_satisfied_by`) — the existing framework only compiles constraints to SQL via `AccessScope`
-* Bad, because when the platform PDP (`authz-resolver`) is unavailable, `authorize_emit()` returns an error and all usage emission from the source fails for the duration of the outage — this is an intentional fail-closed behavior per `cpt-cf-usage-collector-principle-fail-closed`, but it couples usage metering availability to PDP availability; PDP uptime must be treated as a hard dependency for usage sources
+* Good, because authorization errors are surfaced at request time via `authorize_for()` failure — the source caller receives an immediate, meaningful error before any domain operation commits
+* Good, because `enqueue()` performs only in-memory constraint evaluation and an outbox INSERT — no external calls on the critical emission path
+* Good, because the implementation reuses `authz-resolver-sdk` `PolicyEnforcer` for the PDP call without introducing new authorization primitives
+* Good, because `ScopedUsageEmitter` (established in ADR 0001) is the natural and auditable owner of `authorize_for()`, which already carries the source module identifier for PDP resource property attribution
+* Good, because `AuthorizedUsageEmitter` is opaque to consuming modules — no authz concepts leak into business code at call sites
+* Bad, because source services must call `authorize_for()` once per request that may emit usage — adds one PDP round-trip per request on the non-transaction path
+* Bad, because the emission call site changes from a simple `emit(ctx, record)` to `authorize_for()` → `build_usage_record(...).enqueue()`, changing the SDK API surface
+* Bad, because in-memory allowed-metrics validation requires per-metric list lookup added to the `AuthorizedUsageEmitter` — the existing framework only compiles PDP constraints to SQL via `AccessScope`
+* Bad, because when the platform PDP (`authz-resolver`) is unavailable, `authorize_for()` returns an error and all usage emission from the source fails for the duration of the outage — this is an intentional fail-closed behavior per `cpt-cf-usage-collector-principle-fail-closed`, but it couples usage metering availability to PDP availability; PDP uptime must be treated as a hard dependency for usage sources
 
 ### Confirmation
 
-* Unit tests: `authorize_emit()` propagates PDP denial (`decision: false`) as `EmitError::Denied` without inserting any outbox row
-* Unit tests: `emit()` with an `EmitAuthorization` whose constraints exclude the record's metric name returns `EmitError::ConstraintViolation` without inserting any outbox row
-* Unit tests: `emit()` with empty constraints (unconstrained `EmitAuthorization`) succeeds and inserts the outbox row
-* Unit tests: `emit()` with an `EmitAuthorization` whose `issued_at` is older than `MAX_AUTH_AGE` returns `EmitError::AuthorizationExpired` without inserting any outbox row
-* Unit tests: two successive calls to `emit()` with the same `EmitAuthorization` instance both succeed when within `MAX_AUTH_AGE`; the nonce field is present but freshness enforcement is time-based, not single-use (replay within the window is bounded to one request lifetime by construction)
-* Integration test: source service calls `authorize_emit()` before opening a DB transaction, then calls `emit()` inside the transaction — confirms no PDP or other network calls occur while the transaction is open
+* Unit tests: `authorize_for()` propagates PDP denial as `UsageEmitterError::AuthorizationFailed` without inserting any outbox row
+* Unit tests: `enqueue()` with an `AuthorizedUsageEmitter` whose allowed-metrics list excludes the record's metric name returns `UsageEmitterError::MetricNotAllowed` without inserting any outbox row
+* Unit tests: `enqueue()` with an allowed-metrics list that includes the record's metric succeeds and inserts the outbox row
+* Unit tests: `enqueue()` with an `AuthorizedUsageEmitter` whose `issued_at` is older than `authorization_max_age` returns `UsageEmitterError::AuthorizationExpired` without inserting any outbox row
+* Unit tests: two successive calls to `enqueue()` with the same `AuthorizedUsageEmitter` instance both succeed when within `authorization_max_age`; freshness enforcement is time-based, not single-use (replay within the window is bounded to one request lifetime by construction)
+* Integration test: source service calls `authorize_for()` before opening a DB transaction, then calls `build_usage_record(...).enqueue()` inside the transaction — confirms no PDP or other network calls occur while the transaction is open
 
 ## Pros and Cons of the Options
 
@@ -113,50 +113,50 @@ Encode the allowed metric names for each source service in SDK initialization co
 * Bad, because policy changes require redeploying source services to take effect — no dynamic policy enforcement
 * Bad, because deviates from the platform-wide PDP pattern used across all other CyberFabric modules
 
-### Two-phase PDP: `authorize_emit()` before transaction + in-memory constraint evaluation at `emit()`
+### Two-phase PDP: `authorize_for()` before transaction + in-memory constraint evaluation at `enqueue()`
 
 Separate the PDP call (network, async, before the transaction) from the constraint check (in-memory, synchronous, inside the transaction). See Decision Outcome for full description.
 
 * Good, because PDP call happens outside the DB transaction — no lock contention
-* Good, because `emit()` is fast — only in-memory evaluation and outbox INSERT
+* Good, because `enqueue()` is fast — only in-memory evaluation and outbox INSERT
 * Good, because authorization failures surface immediately at request time
 * Good, because reuses existing `authz-resolver-sdk` infrastructure and constraint types
 * Bad, because requires one PDP call per request that may emit usage
-* Bad, because `emit()` API changes to accept `&EmitAuthorization`
+* Bad, because the emission call site changes from a simple `emit(ctx, record)` to a two-step `authorize_for()` + `build_usage_record(...).enqueue()` API
 
 ## More Information
 
-The constraint evaluation logic uses `authz-resolver-sdk`'s existing `Constraint` / `Predicate` types. The PDP request sent by `authorize_emit()` uses `PolicyEnforcer::build_request_with()` directly — bypassing `access_scope_with()` — to obtain raw `Vec<Constraint>` without SQL compilation, since evaluation targets an in-memory `UsageRecord` struct rather than a database query. The `source_module` identifier (from ADR 0001) is included as a resource property in the PDP evaluation request, enabling metric-namespace-scoped policies in the PDP.
+The PDP request sent by `authorize_for()` uses `PolicyEnforcer::access_scope_with()` with `require_constraints(false)` — a permit/deny decision suffices; raw constraint evaluation was replaced by the allowed-metrics list fetched from the gateway via `get_module_config()`. The `tenant_id`, `resource_id`, and `resource_type` are included as resource properties in the PDP evaluation request. The `source_module` identifier (from ADR 0001) is baked into `ScopedUsageEmitter` and attached to every PDP request, enabling source-scoped policies in the PDP.
 
 Per-request PDP calls are chosen over request-level caching for simplicity and consistency with the platform pattern used in other modules (see `examples/modkit/users-info`). Caching can be introduced in a future ADR if PDP call volume proves to be a concern at scale.
 
 ### TOCTOU Window Analysis
 
-A time-of-check/time-of-use (TOCTOU) window exists between `authorize_emit()` (PDP call) and `emit()` (constraint evaluation). If an authorization policy is revoked or tightened in this window, `emit()` will evaluate constraints from the now-stale `EmitAuthorization` and may permit an emission that would be denied under the updated policy.
+A time-of-check/time-of-use (TOCTOU) window exists between `authorize_for()` (PDP call) and `enqueue()` (constraint evaluation). If an authorization policy is revoked or tightened in this window, `enqueue()` will evaluate constraints from the now-stale `AuthorizedUsageEmitter` and may permit an emission that would be denied under the updated policy.
 
 This window is accepted under the following rationale:
 
 - The window duration is bounded by the request handler execution time — typically well under 500ms in the absence of pathological application code — which is too short for routine policy changes to be operationally targeted at individual requests
 - PDP policy changes are administrative operations with propagation delays of their own; expecting sub-second policy revocation enforcement across all active request contexts is beyond the operational model of the platform PDP
-- The fail-closed principle applies to the next request: any subsequent `authorize_emit()` call will observe the updated policy and deny immediately
-- Reusing `EmitAuthorization` across request boundaries is explicitly prohibited (see Confirmation); each request obtains a fresh token, bounding maximum staleness to one request lifetime
+- The fail-closed principle applies to the next request: any subsequent `authorize_for()` call will observe the updated policy and deny immediately
+- Reusing `AuthorizedUsageEmitter` across request boundaries is explicitly prohibited (see Confirmation); each request obtains a fresh token, bounding maximum staleness to one request lifetime
 
-To minimize exposure, `EmitAuthorization` MUST NOT be cached or reused across request handlers. Runtime enforcement is provided by the freshness check in `emit()`: tokens older than `MAX_AUTH_AGE` (30 seconds) are rejected with `EmitError::AuthorizationExpired`. This bounds maximum staleness to `MAX_AUTH_AGE` regardless of call-site behavior, eliminating reliance on code review for TOCTOU window closure.
+To minimize exposure, `AuthorizedUsageEmitter` MUST NOT be cached or reused across request handlers. Runtime enforcement is provided by the freshness check in `enqueue()`: tokens older than `authorization_max_age` (default 30 seconds, configurable) are rejected with `UsageEmitterError::AuthorizationExpired`. This bounds maximum staleness to `MAX_AUTH_AGE` regardless of call-site behavior, eliminating reliance on code review for TOCTOU window closure.
 
 ### Performance Budget
 
-`authorize_emit()` introduces one synchronous PDP round-trip per request on the non-transaction path. To satisfy `cpt-cf-usage-collector-nfr-ingestion-latency` (p95 ≤ 200ms for the full emit path including the domain operation), the combined latency budget for `authorize_emit()` is bounded by the following heuristic:
+`authorize_for()` introduces one synchronous PDP round-trip per request on the non-transaction path. To satisfy `cpt-cf-usage-collector-nfr-ingestion-latency` (p95 ≤ 200ms for the full emit path including the domain operation), the combined latency budget for `authorize_for()` is bounded by the following heuristic:
 
-- Local DB insert (`emit()`) plus domain operation: ~50ms typical
+- Local DB insert (`enqueue()`) plus domain operation: ~50ms typical
 - PDP call budget: ≤ 100ms p95 to leave ≥ 50ms headroom against the 200ms threshold
 
-`authorize_emit()` MUST use a network timeout of ≤ 150ms to ensure a slow or unresponsive PDP does not breach the ingestion latency NFR. This timeout MUST be configurable and MUST default to 150ms or lower. If the PDP does not respond within the timeout, `authorize_emit()` MUST return `EmitError::Denied` (fail-closed).
+`authorize_for()` MUST use a network timeout of ≤ 150ms to ensure a slow or unresponsive PDP does not breach the ingestion latency NFR. This timeout MUST be configurable and MUST default to 150ms or lower. If the PDP does not respond within the timeout, `authorize_for()` MUST return `UsageEmitterError::AuthorizationFailed` (fail-closed).
 
 ## Review Cadence
 
 This decision is stable. Revisit if:
 
-- PDP round-trip volume at scale justifies introducing request-level caching of `EmitAuthorization` tokens — this would require a new ADR defining cache TTL, invalidation, and stale-token risk
+- PDP round-trip volume at scale justifies introducing request-level caching of `AuthorizedUsageEmitter` tokens — this would require a new ADR defining cache TTL, invalidation, and stale-token risk
 - The ingestion latency NFR tightens below 200ms such that the PDP latency budget must be re-evaluated
 - A platform-wide change to the PDP infrastructure (e.g., local sidecar PDP) materially changes the round-trip cost, potentially eliminating the TOCTOU concern and the "Bad" PDP-unavailability consequence
 
@@ -168,10 +168,10 @@ This decision is stable. Revisit if:
 This decision directly addresses the following requirements or design elements:
 
 * `cpt-cf-usage-collector-fr-ingestion` — preserves quick ingestion by keeping the outbox INSERT on the critical path and moving the PDP call off it
-* `cpt-cf-usage-collector-fr-tenant-attribution` — `authorize_emit()` passes the subject's tenant context to the PDP, ensuring tenant-aware authorization at the point of emission
-* `cpt-cf-usage-collector-fr-tenant-isolation` — PDP constraints returned by `authorize_emit()` can enforce tenant-scoped metric restrictions, evaluated before any record enters the outbox
-* `cpt-cf-usage-collector-principle-fail-closed` — denial from the PDP propagates as an `Err` from `authorize_emit()`; no record is enqueued on authorization failure
-* `cpt-cf-usage-collector-principle-source-side-persistence` — the outbox INSERT in `emit()` remains within the caller's DB transaction; only in-memory evaluation is added inside the transaction boundary
-* `cpt-cf-usage-collector-component-sdk` — `authorize_emit()` and `EmitAuthorization` extend the SDK component's responsibility scope
-* `cpt-cf-usage-collector-interface-scoped-client` — `ScopedUsageCollectorClientV1` gains `authorize_emit(ctx, metric_name: &str) -> Result<EmitAuthorization, EmitError>` and the `EmitAuthorization` type; `emit()` gains a required `&EmitAuthorization` parameter
-* `cpt-cf-usage-collector-adr-scoped-emit-source` — this decision builds on ADR 0001: `ScopedUsageCollectorClientV1` is the owner of `authorize_emit()`, using the `source_module` it already holds for PDP resource property attribution
+* `cpt-cf-usage-collector-fr-tenant-attribution` — `authorize_for()` passes the subject's tenant context to the PDP, ensuring tenant-aware authorization at the point of emission
+* `cpt-cf-usage-collector-fr-tenant-isolation` — PDP constraints returned by `authorize_for()` can enforce tenant-scoped metric restrictions, evaluated before any record enters the outbox
+* `cpt-cf-usage-collector-principle-fail-closed` — denial from the PDP propagates as an `Err` from `authorize_for()`; no record is enqueued on authorization failure
+* `cpt-cf-usage-collector-principle-source-side-persistence` — the outbox INSERT in `enqueue()` remains within the caller's DB transaction; only in-memory evaluation is added inside the transaction boundary
+* `cpt-cf-usage-collector-component-emitter` — `authorize_for()` and `AuthorizedUsageEmitter` extend the emitter component's responsibility scope
+* `cpt-cf-usage-collector-interface-scoped-emitter` — `ScopedUsageEmitter` gains `authorize_for(ctx, tenant_id, resource_id, resource_type) -> Result<AuthorizedUsageEmitter, UsageEmitterError>`; `build_usage_record(metric, value).enqueue()` performs in-memory validation within the caller's transaction
+* `cpt-cf-usage-collector-adr-scoped-emit-source` — this decision builds on ADR 0001: `ScopedUsageEmitter` is the owner of `authorize_for()`, using the `source_module` it already holds for PDP resource property attribution

--- a/modules/system/usage-collector/docs/DECOMPOSITION.md
+++ b/modules/system/usage-collector/docs/DECOMPOSITION.md
@@ -1,0 +1,599 @@
+# DECOMPOSITION — Usage Collector
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-status-overall`
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+- [2. Entries](#2-entries)
+  - [2.1 Core SDK, Emitter & In-Process Ingest ⏳ HIGH](#21-core-sdk-emitter--in-process-ingest--high)
+  - [2.2 REST Client & Remote Ingest Delivery ⏳ HIGH](#22-rest-client--remote-ingest-delivery--high)
+  - [2.3 Usage Query API ⏳ HIGH](#23-usage-query-api--high)
+  - [2.4 Production Storage Plugin ⏳ HIGH](#24-production-storage-plugin--high)
+  - [2.5 Usage Type System ⏳ HIGH](#25-usage-type-system--high)
+  - [2.6 Emission Rate Limiting ⏳ HIGH](#26-emission-rate-limiting--high)
+  - [2.7 Retention Policy Management ⏳ MEDIUM](#27-retention-policy-management--medium)
+  - [2.8 Operator Operations, Watermarks & Audit ⏳ MEDIUM](#28-operator-operations-watermarks--audit--medium)
+- [3. Feature Dependencies](#3-feature-dependencies)
+
+<!-- /toc -->
+
+## 1. Overview
+
+The Usage Collector DESIGN is decomposed into 8 features following a build-from-bottom-up strategy. The foundation layer (Feature 1) establishes the core SDK, emitter, in-process ingest pipeline, static metric configuration, and a no-op storage plugin that together enable end-to-end usage emission for in-process sources. The remote delivery layer (Feature 2) extends this to out-of-process sources via the REST client. Query capability (Feature 3) and the first production storage plugin (Feature 4) unlock real aggregation and raw query workflows. The type system (Feature 5) replaces static metric configuration with dynamic types-registry-backed validation. Rate limiting (Feature 6) adds per-source emission controls. Operator capabilities (Features 7–8) complete the system with retention management and the operator-initiated write operations (backfill, amendment, deactivation, watermarks, audit events).
+
+**Decomposition Strategy**:
+
+- Features grouped by functional cohesion (related capabilities together)
+- Dependencies follow the SDK → emitter → gateway → plugin layering from the DESIGN
+- Features 1–2 reflect the preliminary implementation already in progress; Features 3–8 are not yet started
+
+**Deliberate Omissions**: None. All DESIGN components, sequences, data entities, FRs, principles, and constraints are covered.
+
+## 2. Entries
+
+### 2.1 [Core SDK, Emitter & In-Process Ingest](features/sdk-and-ingest-core/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+<!-- STATUS: IN_PROGRESS — all p1 DoD items implemented; one p1 instruction gap (inst-authz-1: no-open-transaction assertion deferred — requires modkit-db framework API change). -->
+
+- **Type**: Service
+
+- **Purpose**: Establish the core data model, delivery traits, two-phase authorization emitter, transactional outbox pipeline, gateway ingest handler, static metric configuration, and no-op storage plugin. Delivers the complete in-process emission path from `authorize_for()` through the outbox background pipeline to the gateway and plugin. This is the prerequisite for all other features.
+
+- **Depends On**: None
+
+- **Scope**:
+  - `usage-collector-sdk` crate: client and plugin-client trait definitions, shared usage record model types, GTS schema for plugin registration, error types
+  - `usage-emitter` crate: scoped emitter with two-phase authorization flow (pre-authorization and per-record authorization), transactional outbox enqueue, background outbox delivery handler
+  - `usage-collector` gateway crate: plugin resolution via GTS with timeout enforcement, outbox queue registration and schema migrations, record ingest endpoint, module config fetch endpoint, static metric configuration
+  - `noop-usage-collector-storage-plugin` crate: no-op storage plugin implementation for tests and local development
+  - Owns authorization check on all inbound requests via `component-gateway`
+  <!-- Metrics Config Boundary: F1 owns collection config (what data to collect, sampling rates, collection intervals); F5 owns reporting/export config (exporters, dashboards, alerting thresholds) -->
+
+- **Out of scope**:
+  - Remote HTTP delivery (Feature 2)
+  - Query API (Feature 3)
+  - Real storage backend plugins (Feature 4)
+  - Types-registry type validation (Feature 5)
+  - Rate limiting enforcement (Feature 6)
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-ingestion`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-idempotency`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-delivery-guarantee`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-counter-semantics`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-gauge-semantics`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-tenant-attribution`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-resource-attribution`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-subject-attribution`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-tenant-isolation`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-ingestion-authorization`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-pluggable-storage`
+  - [ ] `p2` - `cpt-cf-usage-collector-fr-record-metadata`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-availability`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-ingestion-latency`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-authentication`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-authorization`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-scalability`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-fault-tolerance`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-recovery` (owner: F1)
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-graceful-degradation`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-rpo` (owner: F1)
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-source-side-persistence`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-pluggable-storage`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-tenant-from-ctx`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-scoped-source-attribution`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-two-phase-authz`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-outbox-infra`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-single-plugin`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-modkit`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-no-business-logic`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-encryption`
+
+- **Domain Model Entities**:
+  - `UsageRecord` — DEFINES: UsageRecord schema (canonical data model for usage events)
+  - `AuthorizedUsageEmitter`
+  - `ModuleConfig` / `AllowedMetric`
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-sdk`
+  - [ ] `p1` - `cpt-cf-usage-collector-component-emitter`
+    > **Owner**: F1 — initialises and configures the emitter
+    > **Used by**: F5 (type validation in authorize_for), F6 (SDK-side quota check in authorize_for)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-gateway`
+    > **Owner**: F1 — initialises and configures the gateway; owns authorization check on all inbound requests
+    > **Used by**: F2 (passes pre-authenticated requests through), F3 (query handlers), F5 (defense-in-depth validation + types endpoint), F6 (gateway-side rate limiting), F7 (retention policy CRUD), F8 (backfill, amendment, deactivation, watermarks, audit)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-storage-plugin` (noop only)
+    > **Owner**: F4 — implements the full production storage plugin trait
+    > **Used by**: F1 (noop implementation only), F3 (query operations), F7 (enforce_retention), F8 (backfill_ingest, amend_record, deactivate_record, get_watermarks)
+
+- **API**:
+  - POST /usage-collector/v1/records
+  - GET /usage-collector/v1/modules/{module_name}/config
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-emit`  <!-- Shared Sequence Participation: F1 role = initiator (triggers emission — authorizes and enqueues the record into the outbox) -->
+
+- **Data**:
+  - `usage-records` table (written by storage plugin on ingest)
+  - [ ] `cpt-cf-usage-collector-dbtable-outbox`
+
+- **Phases/Milestones**:
+  - Phase 1: SDK crate (`usage-collector-sdk`) — core traits, data model, error types
+  - Phase 2: Emitter crate (`usage-emitter`) — two-phase authorization, outbox enqueue, background delivery
+  - Phase 3: Gateway crate (`usage-collector`) — plugin resolution, ingest endpoint, config endpoint, static metric config
+  - Phase 4: No-op storage plugin (`noop-usage-collector-storage-plugin`) — test/local-dev plugin
+
+---
+
+### 2.2 [REST Client & Remote Ingest Delivery](features/rest-ingest/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-rest-ingest`
+
+- **Type**: Service
+
+- **Purpose**: Enable out-of-process usage sources to emit records using the same `UsageEmitterV1` API as in-process sources. The `usage-collector-rest-client` crate registers `UsageEmitterV1` in `ClientHub` backed by an HTTP client that acquires a bearer token from the AuthN resolver and POSTs records to the gateway ingest endpoint with identical authorization and validation semantics.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+
+- **Scope**:
+  - `usage-collector-rest-client` crate: `UsageCollectorRestClient` implementing `UsageCollectorClientV1`, bearer token acquisition via authn-resolver (client credentials flow), HTTP POST to `POST /usage-collector/v1/records`, outbox schema migrations registration, `HandlerResult` mapping (Retry on 5xx/429/network errors; Reject on permanent 4xx)
+  - Gateway two-level authorization model for REST ingestion: service-to-service bearer token authentication of the forwarder plus gateway-level PDP check against the forwarder's service identity
+
+- **Out of scope**:
+  - In-process emission pipeline (Feature 1)
+  - Query endpoints (Feature 3)
+  - Re-evaluation of the original caller's authorization context from F1 — the gateway performs service-to-service bearer token authentication of the forwarder and a gateway-level PDP check against the forwarder's service identity, but does NOT duplicate or re-check the authorization decisions already made upstream for the original caller
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-rest-ingestion`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-tenant-from-ctx`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+
+- **Domain Model Entities**:
+  - `UsageRecord` — USES: UsageRecord (defined in F1) — reads records for delivery
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-rest-client`
+
+- **API**:
+  - POST /usage-collector/v1/records (client-side outbox delivery)
+  - GET /usage-collector/v1/modules/{module_name}/config (client-side config fetch)
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-emit-remote`
+
+- **Data**:
+  - None (stateless delivery hop; records persisted in source's local outbox)
+
+- **Phases/Milestones**: none
+
+---
+
+### 2.3 [Usage Query API](features/query-api/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-query-api`
+
+- **Type**: REST API Layer
+
+- **Purpose**: Enable authorized consumers to retrieve aggregated and raw usage data from the gateway so tenants and operators can inspect, audit, and act on collected usage records.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+
+- **Scope**:
+  - `usage-collector-sdk` additions: `AggregationQuery`, `AggregationResult`, `RawQuery`, `PagedResult` types; `query_aggregated` and `query_raw` operations on `UsageCollectorPluginClientV1`
+  - `usage-collector` gateway: `GET /usage-collector/v1/aggregated` handler (tenant from SecurityContext, PDP authorization + constraint application, delegation to plugin), `GET /usage-collector/v1/raw` handler (same authorization pattern, cursor-based pagination)
+  - Plugin trait query operations: `query_aggregated` (aggregation functions SUM/COUNT/MIN/MAX/AVG, optional filters, GROUP BY dimensions pushed down to storage engine), `query_raw` (tenant-scoped, optional filters, cursor pagination)
+
+- **Out of scope**:
+  - Ingest pipeline (Feature 1)
+  - Production storage backend implementation (Feature 4)
+  - Watermark metadata query (Feature 8)
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-query-aggregation`
+  - [ ] `p2` - `cpt-cf-usage-collector-fr-query-raw`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-workload-isolation`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-tenant-from-ctx`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-no-business-logic`
+
+- **Domain Model Entities**:
+  - `AggregationQuery`
+  - `AggregationResult`
+  - `RawQuery`
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-gateway` (query handlers)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-storage-plugin` (query operations)
+
+- **API**:
+  - GET /usage-collector/v1/aggregated
+  - GET /usage-collector/v1/raw
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-query-aggregated`
+  - `cpt-cf-usage-collector-seq-query-raw`
+
+- **Data**:
+  - `usage-records` table (read by storage plugin for aggregation and raw queries)
+
+- **Phases/Milestones**: none
+
+---
+
+### 2.4 [Production Storage Plugin](features/production-storage-plugin/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-production-storage-plugin`
+
+- **Type**: Plugin Interface
+
+- **Purpose**: Provide durable, high-throughput storage for usage records so the system can meet its throughput, latency, and recovery objectives with a real storage backend instead of the no-op placeholder.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`, `cpt-cf-usage-collector-feature-query-api`
+
+- **Scope**:
+  - First production plugin crate implementing the full storage plugin trait
+  - Idempotent record ingest keyed on idempotency key; counter delta accumulation semantics
+  - Aggregation query pushdown to the storage engine with optional pre-aggregated acceleration; cursor-based raw query pagination with tenant and dimension filtering
+  - Operator write operations: backfill ingest, record amendment, record deactivation
+  - Retention enforcement and watermark retrieval operations
+  - GTS schema registration, database schema migrations, encrypted connections to the storage backend
+
+- **Out of scope**:
+  - No-op plugin (Feature 1)
+  - Second storage backend
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-pluggable-storage`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-query-latency`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-throughput`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-rpo` (applies-to: all — F4 must independently satisfy the RPO constraint via durable storage backend)
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-recovery` (applies-to: all — F4 must independently satisfy recovery via storage backend durability guarantees)
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-retention`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-pluggable-storage`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-single-plugin`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-types-registry` (GTS schema for plugin registration)
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-encryption`
+
+- **Domain Model Entities**:
+  - `UsageRecord` — USES: UsageRecord (defined in F1) — reads and persists records for storage
+  - `RetentionPolicy` (enforced by plugin)
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-storage-plugin` (production implementation)
+
+- **API**:
+  - None (internal plugin interface only)
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-emit` (storage write path)  <!-- Shared Sequence Participation: F4 role = buffer (persists the record durably via the production storage plugin) -->
+  - `cpt-cf-usage-collector-seq-query-aggregated` (storage read path)
+  - `cpt-cf-usage-collector-seq-query-raw` (storage read path)
+
+- **Data**:
+  - `usage-records` table (primary storage: idempotent upsert on ingest, read for aggregation and raw queries)
+  - [ ] `cpt-cf-usage-collector-dbtable-records`
+  - [ ] `cpt-cf-usage-collector-dbtable-counter-accumulation`
+
+- **Phases/Milestones**:
+  - Phase 1: Storage backend selection (ClickHouse or TimescaleDB) and schema design
+  - Phase 2: Ingest operations — idempotent upsert, counter delta accumulation, GTS schema registration, migrations
+  - Phase 3: Query operations — aggregation pushdown, cursor-based raw pagination
+  - Phase 4: Operator write operations — backfill ingest, record amendment, deactivation, watermarks, retention enforcement
+
+---
+
+### 2.5 [Usage Type System](features/type-system/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-type-system`
+
+- **Type**: Service
+
+- **Purpose**: Ensure every emitted record conforms to a registered usage type schema so invalid or unknown metric kinds are rejected before reaching the storage backend and operators can register custom measuring units.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+
+- **Scope**:
+  - `usage-emitter`: fetch registered usage type schema from types-registry during `authorize_for()` phase 1; validate the record against the schema in-memory before the outbox INSERT; surface validation failures as `UsageEmitterError` before any domain operation is committed
+  - `usage-collector` gateway: defense-in-depth schema validation on ingest before delegating to plugin; `POST /usage-collector/v1/types` endpoint delegating entirely to types-registry for custom usage type registration (name, metric kind, unit label)
+  - `UsageType` domain entity (owned by types-registry; fetched by emitter and gateway)
+
+- **Out of scope**:
+  - Static `metrics` config from Feature 1 (retained as the allowed-metrics list; type schemas are now sourced from types-registry)
+  - Storage plugin implementation (Feature 4)
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-type-validation`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-custom-units`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-two-phase-authz`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-types-registry`
+
+- **Domain Model Entities**:
+  - `UsageType`
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-emitter` (type validation in authorize_for)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-gateway` (defense-in-depth validation + types endpoint)
+
+- **API**:
+  - POST /usage-collector/v1/types
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-emit` (type validation in phase 1)  <!-- Shared Sequence Participation: F5 role = monitor (validates record schema before outbox INSERT; observes emission health via defense-in-depth gateway check) -->
+  <!-- Metrics Config Boundary: F5 owns reporting/export config (exporters, dashboards, alerting thresholds); F1 owns collection config (what data to collect, sampling rates, collection intervals) -->
+
+- **Data**:
+  - None (type schemas managed in types-registry, not locally)
+
+- **Phases/Milestones**:
+  - Phase 1: Emitter integration — types-registry fetch and in-memory schema validation in `authorize_for()` phase 1
+  - Phase 2: Gateway integration — defense-in-depth validation on ingest and `POST /usage-collector/v1/types` delegation endpoint
+
+---
+
+### 2.6 [Emission Rate Limiting](features/rate-limiting/) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-rate-limiting`
+
+- **Type**: Service
+
+- **Purpose**: Prevent outbox flooding by enforcing per-source emission quotas at SDK `authorize_for()` phase 1 before any transaction opens. Supplement with per-(source, tenant) rate limit enforcement at the gateway on ingest to protect the storage backend from quota-exhausting sources.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+
+- **Scope**:
+  - `usage-emitter` phase 1 extension: `authorize_for()` fetches the current source-level emission quota and window snapshot from the gateway; `enqueue()` evaluates the quota in-memory and rejects before the outbox INSERT if the source quota is exhausted
+  - `usage-collector` gateway ingest extension: per-(source, tenant) rate limit check on `POST /usage-collector/v1/records`
+  - Rate limit configuration: configurable window and quota per source module set via static deployment configuration (no public REST configuration endpoint in this feature)
+  - Observability: rejected emissions surfaced via pluggable metrics interface
+
+- **Out of scope**:
+  - Backfill rate limiting (separate independent rate limits, Feature 8)
+  - Type validation (Feature 5)
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-rate-limiting`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-two-phase-authz`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+
+- **Domain Model Entities**:
+  - None (quota window state managed by the gateway, not a named domain entity)
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-emitter` (SDK-side quota check in authorize_for)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-gateway` (gateway-side per-(source, tenant) rate limiting)
+
+- **API**:
+  - None (internal enforcement; no public configuration endpoint in this feature)
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-emit` (quota check in phase 1)  <!-- Shared Sequence Participation: F6 role = rate-gate (throttles emission rate — rejects at authorize_for phase 1 when source quota is exhausted before outbox INSERT) -->
+  <!-- Rate Limit vs Quota Boundary: F6 enforces short-window per-(source, tenant) rate limits on real-time ingest; F8 enforces long-window per-tenant quota limits via backfill and operator-controlled caps -->
+
+- **Data**:
+  - None (quota tracking is in-memory or in the gateway's local state)
+
+- **Phases/Milestones**:
+  - Phase 1: Emitter-side quota check — `authorize_for()` extension with quota fetch and in-memory evaluation
+  - Phase 2: Gateway-side rate limiting — per-(source, tenant) check on ingest endpoint and observability integration
+
+---
+
+### 2.7 [Retention Policy Management](features/retention-policies/) ⏳ MEDIUM
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-feature-retention-policies`
+
+- **Type**: Background Task
+
+- **Purpose**: Allow platform operators to configure data retention policies at global, per-tenant, and per-usage-type scopes. Enforce these policies via the storage plugin using storage-native TTL or scheduled deletion, with a mandatory global default that cannot be deleted.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`, `cpt-cf-usage-collector-feature-production-storage-plugin`
+
+- **Scope**:
+  - `RetentionPolicy` domain entity: scope (`global` / `tenant` / `usage-type`), target identifier, retention duration
+  - Gateway REST API: `GET /usage-collector/v1/retention` (list), `PUT /usage-collector/v1/retention/{scope}` (create/update), `DELETE /usage-collector/v1/retention/{scope}` (non-global only; global default deletion rejected)
+  - Precedence rule enforcement: per-usage-type > per-tenant > global
+  - Plugin `enforce_retention` operation: permanent hard delete of expired records via storage-native TTL or scheduled deletion; triggered by the gateway on a background schedule
+  - `inactive` status is reserved for operator amendment (Feature 8) and MUST NOT be used by retention enforcement
+
+- **Out of scope**:
+  - Amendment and deactivation (Feature 8)
+  - Rate limiting (Feature 6)
+
+- **Requirements Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-retention-policies`
+  - [ ] `p1` - `cpt-cf-usage-collector-nfr-retention`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-no-business-logic`
+
+- **Domain Model Entities**:
+  - `RetentionPolicy`
+
+- **Design Components**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-component-gateway` (retention policy CRUD)
+  - [ ] `p1` - `cpt-cf-usage-collector-component-storage-plugin` (enforce_retention)
+
+- **API**:
+  - GET /usage-collector/v1/retention
+  - PUT /usage-collector/v1/retention/{scope}
+  - DELETE /usage-collector/v1/retention/{scope}
+
+- **Sequences**:
+  - None (policy management is synchronous CRUD; enforcement runs as a background task)
+
+- **Data**:
+  - `retention-policies` table (retention policy CRUD and enforcement state)
+
+- **Phases/Milestones**:
+  - Phase 1: `RetentionPolicy` domain entity, gateway REST API (GET/PUT/DELETE), precedence rule enforcement
+  - Phase 2: Plugin `enforce_retention` operation — background schedule integration and storage-native TTL/deletion
+
+---
+
+### 2.8 [Operator Operations, Watermarks & Audit](features/operator-ops/) ⏳ MEDIUM
+
+- [ ] `p2` - **ID**: `cpt-cf-usage-collector-feature-operator-ops`
+
+- **Type**: Service
+
+- **Purpose**: Complete the operator-facing capability set: backfill for historical record ingestion with a gateway-local outbox pipeline and independent rate limits, individual record amendment and deactivation, watermark metadata exposure for external reconciliation, and structured `WriteAuditEvent` emission to `audit_service` for every operator-initiated write.
+
+- **Depends On**: `cpt-cf-usage-collector-feature-sdk-and-ingest-core`, `cpt-cf-usage-collector-feature-query-api`, `cpt-cf-usage-collector-feature-production-storage-plugin`
+
+- **Scope**:
+  - Backfill: `POST /usage-collector/v1/backfill`; PDP authorization for specified `tenant_id`; configurable time boundary enforcement (max window default 90 days, future tolerance default 5 min, elevated authz beyond max window); gateway-local backfill outbox (`Outbox::enqueue_batch` within handler transaction); internal `MessageHandler` calling `plugin.backfill_ingest()`; independent rate limits and lower processing priority relative to real-time ingest; `202 Accepted` response
+  - Amendment: `PATCH /usage-collector/v1/records/{id}`; PDP authorization; `plugin.amend_record()` with optimistic concurrency
+  - Deactivation: `POST /usage-collector/v1/records/{id}/deactivate`; PDP authorization; `plugin.deactivate_record()` (sets `status = inactive`, record retained for audit)
+  - Watermarks: `GET /usage-collector/v1/metadata/watermarks`; calls `plugin.get_watermarks()` returning per-source and per-tenant event counts and latest ingested timestamps
+  - Audit: `WriteAuditEvent` emitted to platform `audit_service` after each completed operator write (backfill on outbox commit, amendment, deactivation); best-effort with ≤2s timeout; emission failures logged and monitored but do not roll back or fail the primary operation
+
+- **Out of scope**:
+  - Retention policy management (Feature 7)
+  - Rate limiting for real-time ingest (Feature 6)
+  <!-- Rate Limit vs Quota Boundary: F8 enforces long-window per-tenant quota limits (backfill rate limits, operator-controlled write caps); F6 enforces short-window per-(source, tenant) rate limits on real-time ingest -->
+
+- **Requirements Covered**:
+
+  - [ ] `p2` - `cpt-cf-usage-collector-fr-backfill-api`
+  - [ ] `p2` - `cpt-cf-usage-collector-fr-event-amendment`
+  - [ ] `p3` - `cpt-cf-usage-collector-fr-backfill-boundaries`
+  - [ ] `p3` - `cpt-cf-usage-collector-fr-metadata-exposure`
+  - [ ] `p1` - `cpt-cf-usage-collector-fr-audit`
+
+- **Design Principles Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-fail-closed`
+  - [ ] `p1` - `cpt-cf-usage-collector-principle-tenant-from-ctx`
+
+- **Design Constraints Covered**:
+
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-security-context`
+  - [ ] `p1` - `cpt-cf-usage-collector-constraint-no-business-logic`
+
+- **Domain Model Entities**:
+  - `BackfillOperation`
+  - `WriteAuditEvent`
+
+- **Design Components**:
+
+  - [ ] `p2` - `cpt-cf-usage-collector-component-gateway` (backfill, amendment, deactivation, watermarks, audit)
+  - [ ] `p2` - `cpt-cf-usage-collector-component-storage-plugin` (backfill_ingest, amend_record, deactivate_record, get_watermarks)
+
+- **API**:
+  - POST /usage-collector/v1/backfill
+  - PATCH /usage-collector/v1/records/{id}
+  - POST /usage-collector/v1/records/{id}/deactivate
+  - GET /usage-collector/v1/metadata/watermarks
+
+- **Sequences**:
+
+  - `cpt-cf-usage-collector-seq-backfill`
+  - `cpt-cf-usage-collector-seq-amend`
+  - `cpt-cf-usage-collector-seq-deactivate`
+
+- **Data**:
+  - `usage-records` table (amendment and deactivation write path; watermarks read)
+
+- **Phases/Milestones**:
+  - Phase 1: Backfill endpoint (`POST /usage-collector/v1/backfill`) — gateway-local outbox, `backfill_ingest`, configurable time boundaries, independent rate limits
+  - Phase 2: Amendment (`PATCH /usage-collector/v1/records/{id}`) and deactivation (`POST /usage-collector/v1/records/{id}/deactivate`)
+  - Phase 3: Watermarks endpoint (`GET /usage-collector/v1/metadata/watermarks`) and structured `WriteAuditEvent` emission
+
+---
+
+## 3. Feature Dependencies
+
+```text
+cpt-cf-usage-collector-feature-sdk-and-ingest-core  (foundation)
+    ├─→ cpt-cf-usage-collector-feature-rest-ingest
+    ├─→ cpt-cf-usage-collector-feature-type-system
+    ├─→ cpt-cf-usage-collector-feature-rate-limiting
+    ├─→ cpt-cf-usage-collector-feature-query-api
+    │       └─→ cpt-cf-usage-collector-feature-production-storage-plugin
+    │               ├─→ cpt-cf-usage-collector-feature-retention-policies  (also ←F1)
+    │               └─→ cpt-cf-usage-collector-feature-operator-ops         (also ←F1, ←F3)
+    └─→ (see above: F7 depends on F1+F4; F8 depends on F1+F3+F4)
+```
+
+**Dependency Rationale**:
+
+- `cpt-cf-usage-collector-feature-rest-ingest` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core`: the REST client implements `UsageCollectorClientV1` defined in the SDK and delivers records to the gateway ingest endpoint introduced in Feature 1.
+- `cpt-cf-usage-collector-feature-query-api` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core`: query operations extend the `UsageCollectorPluginClientV1` trait and add gateway handlers that follow the same PDP + plugin delegation pattern established in Feature 1.
+- `cpt-cf-usage-collector-feature-production-storage-plugin` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core` and `cpt-cf-usage-collector-feature-query-api`: a production plugin must implement all plugin trait operations including `query_aggregated` and `query_raw` introduced in Feature 3.
+- `cpt-cf-usage-collector-feature-type-system` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core`: type validation integrates into the `authorize_for()` phase 1 flow and gateway ingest handler established in Feature 1; independent of query and plugin features.
+- `cpt-cf-usage-collector-feature-rate-limiting` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core`: quota checks extend the `authorize_for()` phase 1 flow and gateway ingest handler from Feature 1; independent of query and plugin features.
+- `cpt-cf-usage-collector-feature-retention-policies` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core` and `cpt-cf-usage-collector-feature-production-storage-plugin`: retention enforcement calls `plugin.enforce_retention()` which requires a real storage backend.
+- `cpt-cf-usage-collector-feature-operator-ops` requires `cpt-cf-usage-collector-feature-sdk-and-ingest-core`, `cpt-cf-usage-collector-feature-query-api`, and `cpt-cf-usage-collector-feature-production-storage-plugin`: backfill introduces a gateway-local outbox queue; amendment and deactivation extend the plugin write trait; watermarks extend the plugin query interface; all require a real storage backend.
+- `cpt-cf-usage-collector-feature-rest-ingest`, `cpt-cf-usage-collector-feature-type-system`, and `cpt-cf-usage-collector-feature-rate-limiting` are independent of each other and can be developed in parallel after Feature 1.
+- `cpt-cf-usage-collector-feature-retention-policies` and `cpt-cf-usage-collector-feature-operator-ops` are independent of each other and can be developed in parallel after Feature 4.

--- a/modules/system/usage-collector/docs/DESIGN.md
+++ b/modules/system/usage-collector/docs/DESIGN.md
@@ -1,3 +1,30 @@
+---
+cpt:
+  kind: DESIGN
+  version: "0.3.0"
+  changelog:
+    - version: "0.3.0"
+      date: "2026-04-28"
+      changes:
+        - "Made subject_id and subject_type optional (Option<T>) in UsageRecord; updated PDP authorization algorithm to skip subject properties when both fields are absent"
+        - "fr-subject-attribution (§1.2): updated to reflect optional-subject contract; PDP subject validation skipped when both fields are None"
+        - "cpt-cf-usage-collector-principle-two-phase-authz (§2.1): AuthorizedUsageEmitter bound context updated to reflect Option<T> subject fields"
+        - "UsageRecord relationships (§3.1): removed 'always derived from SecurityContext'; updated to optional-subject contract"
+        - "SDK emit() bullet (§3.2): replaced 'captures subject from SecurityContext' with optional-subject conditional logic"
+        - "Scoped Emit Client emit() operation (§3.3): updated to optional-subject contract"
+        - "Emit Usage Record sequence (§3.6): replaced single capture step with conditional alt branch for optional subject"
+    - version: "0.2.0"
+      date: "2026-04-27"
+      changes:
+        - "fr-subject-attribution (§1.2): subject identity now accepted from payload with PDP authz; falls back to SecurityContext when not supplied"
+        - "cpt-cf-usage-collector-principle-two-phase-authz (§2.1): bound context extended with subject_id and subject_type; AuthorizedUsageEmitter described as carrying subject identity"
+        - "AuthorizedUsageEmitter (§3.1): token description includes subject_id and subject_type as bound fields"
+    - version: "0.1.0"
+      date: "2026-04-01"
+      changes:
+        - "Initial design"
+---
+
 # Technical Design — Usage Collector
 
 
@@ -30,9 +57,14 @@
 
 Usage Collector follows the ModKit Gateway + Plugins pattern. The gateway module (`usage-collector`) is the single centralized service that receives usage records, enforces tenant isolation, and delegates all storage operations to the active plugin. Backend-specific persistence and query logic for ClickHouse or TimescaleDB is encapsulated in storage plugins that register via the GTS type system and are selected by operator configuration. The gateway contains no backend-specific logic.
 
-The SDK crate (`usage-collector-sdk`) defines two trait boundaries: `UsageCollectorClientV1` for usage sources and consumers, and `UsageCollectorPluginClientV1` for storage backend implementations. When a usage source emits a record, the SDK persists it to the source's local database within the same transaction as the caller's domain operation (transactional outbox pattern). The SDK initializes and owns an `OutboxHandle` whose background pipeline automatically delivers enqueued records to the collector gateway, providing at-least-once delivery even when the collector is temporarily unavailable.
+The SDK crate (`usage-collector-sdk`) defines two trait boundaries: `UsageCollectorClientV1` for delivery to the collector gateway (not registered in ClientHub — passing it through the hub would allow any module to push unvalidated records, bypassing authorization), and `UsageCollectorPluginClientV1` for storage backend implementations. The `usage-emitter` crate exposes `UsageEmitterV1`, registered in ClientHub by either the gateway module (in-process delivery) or `usage-collector-rest-client` (HTTP delivery to a remote collector); usage sources call `for_module()` on it to obtain a `ScopedUsageEmitter`. When a usage source emits a record, the emitter persists it to the source's local database within the same transaction as the caller's domain operation (transactional outbox pattern). The outbox background pipeline automatically delivers enqueued records to the collector gateway, providing at-least-once delivery even when the collector is temporarily unavailable.
 
-Once records arrive at the gateway, they are persisted via the active storage plugin and become available for aggregation and raw queries. All query operations are scoped to the authenticated tenant derived from the caller's SecurityContext. For ingest, tenant attribution is PDP-authorized at emit time: standard sources emit for their own tenant (derived from SecurityContext); sources explicitly authorized by the PDP to act on behalf of multiple tenants supply the target tenant in the record, which is validated against PDP-returned constraints before the outbox INSERT and re-validated at gateway ingest as a defense-in-depth check.
+There are two supported deployment modes, differing only in how the outbox background pipeline delivers records:
+
+- **In-process mode** (`usage-collector` registers `UsageEmitterV1`): the background delivery pipeline calls the gateway's `UsageCollectorLocalClient` directly as a Rust function call. Used when the usage source and the collector gateway run in the same process.
+- **Remote mode** (`usage-collector-rest-client` registers `UsageEmitterV1`): the background delivery pipeline sends an authenticated HTTP POST to the gateway's ingest endpoint (`POST /usage-collector/v1/records`), acquiring a bearer token via the platform AuthN resolver before each request. Used when the usage source runs in a separate process or service binary. The emit path (`authorize_for()` → `enqueue()`) is identical; only the delivery hop differs.
+
+Once records arrive at the gateway, they are persisted via the active storage plugin and become available for aggregation and raw queries. All query operations are scoped to the authenticated tenant derived from the caller's SecurityContext. For ingest, tenant attribution is PDP-authorized at emit time via the `USAGE_RECORD`/`CREATE` operation — the PDP decision covers both same-tenant and subtenant scenarios; the gateway does not perform a second tenant check on delivery.
 
 ### 1.2 Architecture Drivers
 
@@ -41,28 +73,28 @@ Once records arrive at the gateway, they are persisted via the active storage pl
 | Requirement | Design Response |
 |-------------|-----------------|
 | `cpt-cf-usage-collector-fr-ingestion` | SDK `emit()` persists record to local outbox within the caller's transaction; outbox library background pipeline delivers to gateway |
-| `cpt-cf-usage-collector-fr-idempotency` | Counter records require a non-null idempotency key; `emit()` rejects counter records without one (`EmitError::MissingIdempotencyKey`) before any outbox INSERT; gauge records accept a null key; idempotency key is carried in the outbox payload; storage plugin performs idempotent upsert on non-null keys at delivery |
+| `cpt-cf-usage-collector-fr-idempotency` | Counter records require a non-null idempotency key; `build_usage_record().enqueue()` rejects counter records without one (`UsageEmitterError::InvalidRecord`) before any outbox INSERT; gauge records auto-generate a UUID key when none is supplied; idempotency key is carried in the outbox payload; storage plugin performs idempotent upsert on non-null keys at delivery |
 | `cpt-cf-usage-collector-fr-delivery-guarantee` | Transactional outbox in source's local DB; outbox library retries with exponential backoff; messages that exhaust retry budget are moved to the dead-letter store and surfaced via monitoring |
-| `cpt-cf-usage-collector-fr-counter-semantics` | `ScopedUsageCollectorClientV1.emit()` rejects counter records with a negative value or a missing idempotency key before inserting the outbox row; delta records are stored per-event; the persistent total for a (tenant, metric) pair is the SUM of all active delta records — see §3.7 Counter Accumulation for the full strategy including plugin-level acceleration options |
-| `cpt-cf-usage-collector-fr-gauge-semantics` | Gauge records carry `metric_kind = gauge`; `emit()` applies no monotonicity validation; storage plugin stores values as-is |
-| `cpt-cf-usage-collector-fr-tenant-attribution` | `emit()` uses `record.tenant_id` as supplied by the caller and validates it against PDP constraints in `EmitAuthorization`: if the PDP returned a tenant `In` constraint, `record.tenant_id` must be a member of the allowed set; if no tenant constraint was returned, `record.tenant_id` must equal `ctx.subject_tenant_id()` (preserving standard single-tenant behavior). The validated `tenant_id` is stamped into the outbox row. Gateway validates tenant attribution on ingest: when `record.tenant_id ≠ ctx.subject_tenant_id()`, the gateway calls the PDP with `context_tenant_id(record.tenant_id)` and action `"emit_on_behalf"` to re-authorize before delegating to the plugin. |
-| `cpt-cf-usage-collector-fr-resource-attribution` | `UsageRecord` carries optional `resource_id` and `resource_type` fields; persisted in outbox payload and storage backend; gateway and plugin pass them through without interpretation |
-| `cpt-cf-usage-collector-fr-subject-attribution` | `ScopedUsageCollectorClientV1.emit()` captures `subject_id` and `subject_type` from the authenticated SecurityContext and includes them in the outbox payload; never accepted from request payload |
+| `cpt-cf-usage-collector-fr-counter-semantics` | `AuthorizedUsageEmitter.enqueue()` rejects counter records with a negative value or a missing idempotency key before inserting the outbox row; delta records are stored per-event; the persistent total for a (tenant, metric) pair is the SUM of all active delta records — see §3.7 Counter Accumulation for the full strategy including plugin-level acceleration options |
+| `cpt-cf-usage-collector-fr-gauge-semantics` | Gauge records carry `kind = gauge`; `enqueue()` applies no monotonicity validation; storage plugin stores values as-is |
+| `cpt-cf-usage-collector-fr-tenant-attribution` | The caller supplies `tenant_id` explicitly to `authorize_for()` (or the subject's home tenant is used via `authorize()`); the PDP `USAGE_RECORD`/`CREATE` check at that point authorizes the caller to emit for the specified tenant, covering both same-tenant and subtenant cases. The authorized `tenant_id` is bound into the `AuthorizedUsageEmitter` token and stamped into every outbox row produced by that token. The gateway accepts the `tenant_id` from the delivered record without a second PDP check. |
+| `cpt-cf-usage-collector-fr-resource-attribution` | `UsageRecord` carries required `resource_id` (UUID) and `resource_type` (string) fields; both are mandatory at emit time; persisted in outbox payload and storage backend; gateway and plugin pass them through without interpretation |
+| `cpt-cf-usage-collector-fr-subject-attribution` | Subject attribution is optional per usage record. `subject_id` and `subject_type` are `Option<T>` fields in `UsageRecord`. When supplied in the request payload, they are accepted with PDP authorization (via `authorize_for()`). When absent from the payload, they may be derived from `SecurityContext` via the `authorize()` convenience path. When both are `None`, PDP subject properties are omitted from the authorization request and subject validation is skipped entirely. |
 | `cpt-cf-usage-collector-fr-tenant-isolation` | Gateway enforces tenant scoping on all read and write operations; plugins filter by tenant ID; system fails closed on authorization failure |
-| `cpt-cf-usage-collector-fr-ingestion-authorization` | `ScopedUsageCollectorClientV1.authorize_emit()` calls the platform PDP before any transaction opens; returned `EmitAuthorization` carries PDP constraints (including an optional tenant `In` constraint for sources authorized to emit for multiple tenants), source-level rate limit quota snapshot, and the registered usage type schema — all evaluated in-memory by `emit()` before the outbox INSERT; denied or constraint-violating emissions are rejected before any record is persisted |
+| `cpt-cf-usage-collector-fr-ingestion-authorization` | `ScopedUsageEmitter.authorize_for()` / `ScopedUsageEmitter.authorize()` calls the platform PDP (`USAGE_RECORD`/`CREATE`) before any transaction opens; a denial is surfaced immediately with no record persisted; the returned `AuthorizedUsageEmitter` token carries the allowed-metrics list and authorization context evaluated in-memory by `enqueue()` before the outbox INSERT |
 | `cpt-cf-usage-collector-fr-pluggable-storage` | Gateway resolves active plugin via GTS; plugin implements write and read traits; operator selects backend via configuration |
 | `cpt-cf-usage-collector-fr-query-aggregation` | Gateway enforces PDP decision + constraint on each query; exposes aggregation query API with optional filters (usage type, subject, resource, source) and configurable GROUP BY dimensions (time bucket, usage type, subject, resource, source); delegates to plugin, which pushes aggregation (SUM, COUNT, MIN, MAX, AVG) and grouping down to the storage engine |
 | `cpt-cf-usage-collector-fr-query-raw` | Gateway enforces PDP decision + constraint on each query; exposes raw query API with optional filters (usage type, subject, resource) and cursor-based pagination; delegates to plugin |
 | `cpt-cf-usage-collector-fr-record-metadata` | Gateway enforces configurable 8 KB metadata size limit at ingest; plugin stores metadata as-is in a dedicated payload column; metadata is returned in query results without interpretation |
 | `cpt-cf-usage-collector-fr-retention-policies` | Gateway manages retention policy configuration (global, per-tenant, per-usage-type); plugin enforces retention via storage-native TTL or scheduled deletion |
-| `cpt-cf-usage-collector-fr-backfill-api` | Gateway accepts backfill requests and bulk-inserts historical records via the plugin; gateway calls the platform PDP to authorize the caller for the specified `tenant_id` before accepting the request — callers whose SecurityContext tenant differs from the requested `tenant_id` require a dedicated cross-tenant backfill PDP permission and the PDP must return a constraint that includes the target tenant; a PDP denial or constraint violation returns `403 PERMISSION_DENIED` immediately; existing records in the range are not modified; backfill path operates with independent rate limits; gateway emits `WriteAuditEvent` to `audit_service` on completion |
+| `cpt-cf-usage-collector-fr-backfill-api` | Gateway accepts backfill requests and bulk-inserts historical records via the plugin; gateway calls the platform PDP to authorize the caller for the specified `tenant_id` before accepting the request; a PDP denial returns `403 PERMISSION_DENIED` immediately; existing records in the range are not modified; backfill path operates with independent rate limits; gateway emits `WriteAuditEvent` to `audit_service` on completion |
 | `cpt-cf-usage-collector-fr-event-amendment` | Gateway exposes amendment and deactivation endpoints for individual events; plugin updates record status fields; gateway emits `WriteAuditEvent` to `audit_service` on each operation |
 | `cpt-cf-usage-collector-fr-audit` | Gateway emits a structured `WriteAuditEvent` to platform `audit_service` on every operator-initiated write (backfill, amendment, deactivation); event includes common envelope (operation, actor_id, tenant_id, timestamp, justification) and operation-specific context; no audit data is stored locally |
 | `cpt-cf-usage-collector-fr-backfill-boundaries` | Gateway enforces configurable maximum backfill window (default 90 days) and future timestamp tolerance (default 5 minutes); requests beyond the maximum window require elevated authorization verified before any plugin operation |
 | `cpt-cf-usage-collector-fr-metadata-exposure` | Gateway exposes a watermark API endpoint; plugin queries per-source and per-tenant event counts and latest ingested timestamps to populate the response |
-| `cpt-cf-usage-collector-fr-type-validation` | `authorize_emit()` fetches the registered usage type schema from types-registry; `emit()` validates the record against it in-memory before the outbox INSERT, rejecting invalid records immediately; gateway retains schema validation as a defense-in-depth check on delivered records before delegating to the plugin |
+| `cpt-cf-usage-collector-fr-type-validation` | `authorize_for()` fetches the registered usage type schema from types-registry; `enqueue()` validates the record against it in-memory before the outbox INSERT, rejecting invalid records immediately; gateway retains schema validation as a defense-in-depth check on delivered records before delegating to the plugin |
 | `cpt-cf-usage-collector-fr-custom-units` | Gateway exposes a usage type registration endpoint that delegates to types-registry; operator configures authorization policies per usage type after registration |
-| `cpt-cf-usage-collector-fr-rate-limiting` | `authorize_emit()` fetches the current source-level emission quota and window snapshot for the source module before any transaction opens; `emit()` evaluates the quota in-memory and rejects the emission before the outbox INSERT if the source quota is exhausted; gateway enforces per-(source, tenant) quota on ingest when `record.tenant_id` is known; rejections are surfaced via operational monitoring; rate limit configuration is managed by the platform operator |
+| `cpt-cf-usage-collector-fr-rate-limiting` | `authorize_for()` fetches the current source-level emission quota and window snapshot for the source module before any transaction opens; `enqueue()` evaluates the quota in-memory and rejects the emission before the outbox INSERT if the source quota is exhausted; gateway enforces per-(source, tenant) quota on ingest when `record.tenant_id` is known; rejections are surfaced via operational monitoring; rate limit configuration is managed by the platform operator |
 
 #### NFR Allocation
 
@@ -71,48 +103,64 @@ Once records arrive at the gateway, they are persisted via the active storage pl
 | `cpt-cf-usage-collector-nfr-query-latency` | Aggregation queries over 30-day range complete within 500ms at p95 | Storage Plugin | Aggregation pushed down to storage engine; plugins SHOULD maintain pre-aggregated acceleration structures (ClickHouse `AggregatingMergeTree` view, TimescaleDB continuous aggregate) to meet this threshold at production record volumes — see §3.7 Counter Accumulation for the full strategy and consistency model | Benchmark test with 30-day synthetic dataset at target production record volume at p95 |
 | `cpt-cf-usage-collector-nfr-availability` | 99.95% monthly availability for ingestion endpoints | Gateway, SDK | Stateless gateway enables horizontal replication; the SDK's outbox pipeline absorbs temporary gateway unavailability, preserving record capture continuity; liveness probes and graceful shutdown ensure fast instance recovery | SLO tracking on gateway uptime; synthetic availability probes on ingestion endpoint |
 | `cpt-cf-usage-collector-nfr-throughput` | ≥ 10,000 records/sec sustained ingestion | Gateway, Storage Plugin | Gateway dispatches records to the storage plugin for batched idempotent upsert; plugin pushes bulk INSERTs to append-optimized storage (ClickHouse column store, TimescaleDB hypertable); stateless gateway scales horizontally | Sustained load test at 10,000 records/sec for 10 minutes; verify no records lost and no latency degradation |
-| `cpt-cf-usage-collector-nfr-ingestion-latency` | Ingestion completes within 200ms at p95 | SDK | `emit()` is a local DB INSERT within the caller's transaction — no network I/O on the critical emission path; p95 latency is bounded by local DB write speed, well within the 200ms threshold | Benchmark `emit()` p95 latency under representative concurrent load |
+| `cpt-cf-usage-collector-nfr-ingestion-latency` | Ingestion completes within 200ms at p95 | SDK | `authorized.build_usage_record(...).enqueue()` is a local DB INSERT within the caller's transaction — no network I/O on the critical emission path; p95 latency is bounded by local DB write speed, well within the 200ms threshold | Benchmark `authorized.build_usage_record(...).enqueue()` p95 latency under representative concurrent load |
 | `cpt-cf-usage-collector-nfr-workload-isolation` | Ingestion p95 ≤ 200ms during concurrent query and retention workloads | Gateway, Storage Plugin | Query and retention workloads run on separate handler paths from the ingest handler; retention enforcement runs as a scheduled background task with lower priority; plugins leverage storage-native query prioritization (ClickHouse query priority classes, TimescaleDB resource groups) to prevent analytical workloads from starving ingest writes | Measure ingest p95 under concurrent aggregation queries and retention enforcement; verify it remains within `cpt-cf-usage-collector-nfr-ingestion-latency` threshold |
 | `cpt-cf-usage-collector-nfr-authentication` | Zero unauthenticated API access | Gateway | All gateway endpoints require a valid authenticated SecurityContext; unauthenticated requests are rejected by the ModKit request pipeline before any handler or plugin is invoked | Integration tests verifying all endpoints return a rejection for requests without valid authentication credentials |
-| `cpt-cf-usage-collector-nfr-authorization` | Zero unauthorized data access or write | Gateway, SDK | SDK `authorize_emit()` contacts the platform PDP before any transaction opens; gateway enforces PDP authorization on all query, backfill, amendment, and deactivation endpoints and applies returned constraints as additional query filters; system fails closed on any authorization failure (`cpt-cf-usage-collector-principle-fail-closed`) | Integration tests verifying unauthorized ingestion, query, backfill, and amendment requests are rejected with no data exposed or modified |
+| `cpt-cf-usage-collector-nfr-authorization` | Zero unauthorized data access or write | Gateway, Emitter | `ScopedUsageEmitter.authorize_for()` contacts the platform PDP (`USAGE_RECORD`/`CREATE`) before any transaction opens; gateway enforces PDP authorization on all query, backfill, amendment, and deactivation endpoints and applies returned constraints as additional query filters; system fails closed on any authorization failure (`cpt-cf-usage-collector-principle-fail-closed`) | Integration tests verifying unauthorized ingestion, query, backfill, and amendment requests are rejected with no data exposed or modified |
 | `cpt-cf-usage-collector-nfr-scalability` | Linear throughput scaling with added instances | Gateway | Gateway is stateless — all per-request state is carried in SecurityContext and request payload; horizontal scaling is achieved by adding gateway instances behind a load balancer with no coordination required | Load test demonstrating linear throughput increase as gateway instance count is increased from 1 to N |
-| `cpt-cf-usage-collector-nfr-fault-tolerance` | Zero data loss for durably captured records during storage backend failures | SDK, Gateway | The SDK's outbox pipeline retries failed gateway deliveries with exponential backoff; gateway retries plugin persist calls on transient storage errors; records durably captured in the source outbox are guaranteed to eventually reach the storage backend; messages that exhaust retry budget are moved to the dead-letter store and surfaced via operational monitoring | Chaos test: take storage backend offline, verify outbox rows survive and are delivered on recovery with zero data loss |
+| `cpt-cf-usage-collector-nfr-fault-tolerance` | Zero data loss for durably captured records during storage backend failures | SDK, Gateway | The SDK's outbox pipeline retries failed gateway deliveries with exponential backoff; gateway retries plugin `create_usage_record` calls on transient storage errors; records durably captured in the source outbox are guaranteed to eventually reach the storage backend; messages that exhaust retry budget are moved to the dead-letter store and surfaced via operational monitoring | Chaos test: take storage backend offline, verify outbox rows survive and are delivered on recovery with zero data loss |
 | `cpt-cf-usage-collector-nfr-recovery` | RTO ≤ 15 minutes from storage backend recovery | SDK, Gateway | The outbox library resumes delivery automatically once the gateway becomes reachable again; gateway re-establishes plugin connection on storage recovery without restart; the RTO bound is determined by the outbox retry schedule — `backoff_max` MUST be configured below 15 minutes to meet this threshold | Chaos test: restore storage backend after outage, measure elapsed time from backend availability to full outbox drain and query availability; verify elapsed time ≤ 15 minutes |
 | `cpt-cf-usage-collector-nfr-retention` | Configurable retention from 7 days to 7 years | Storage Plugin | Retention policy configuration is managed by the gateway; plugin enforces retention via storage-native TTL expressions (ClickHouse) or scheduled deletion (TimescaleDB); policies apply at global, per-tenant, and per-usage-type scope | Test retention enforcement for each plugin: records older than the configured duration are removed within the enforcement window |
-| `cpt-cf-usage-collector-nfr-graceful-degradation` | Zero ingestion failures due to downstream consumer unavailability | SDK | `emit()` writes to the source's local database within the caller's transaction — no runtime dependency on the collector or any downstream consumer; the outbox pipeline delivers asynchronously, fully decoupling the source's emission path from collector and consumer uptime | Integration test: take the collector gateway offline; verify sources continue emitting without errors and records are delivered on gateway recovery |
-| `cpt-cf-usage-collector-nfr-rpo` | RPO = 0 for all records for which `emit()` returned `Ok` | SDK | `emit()` calls `Outbox::enqueue()` within the caller's DB transaction — a record is durable the moment that transaction commits; no committed record can be lost by a subsequent gateway restart, dispatcher crash, or storage outage, because the outbox row persists independently in the source's local DB until confirmed delivered | Test: call `emit()` successfully, kill the gateway process immediately after commit, restart gateway; verify the record is delivered and queryable with no data loss |
+| `cpt-cf-usage-collector-nfr-graceful-degradation` | Zero ingestion failures due to downstream consumer unavailability | SDK | `authorized.build_usage_record(...).enqueue()` writes to the source's local database within the caller's transaction — no runtime dependency on the collector or any downstream consumer; the outbox pipeline delivers asynchronously, fully decoupling the source's emission path from collector and consumer uptime | Integration test: take the collector gateway offline; verify sources continue emitting without errors and records are delivered on gateway recovery |
+| `cpt-cf-usage-collector-nfr-rpo` | RPO = 0 for all records for which `authorized.build_usage_record(...).enqueue()` returned `Ok` | SDK | `authorized.build_usage_record(...).enqueue()` calls `Outbox::enqueue()` within the caller's DB transaction — a record is durable the moment that transaction commits; no committed record can be lost by a subsequent gateway restart, dispatcher crash, or storage outage, because the outbox row persists independently in the source's local DB until confirmed delivered | Test: call `authorized.build_usage_record(...).enqueue()` successfully, kill the gateway process immediately after commit, restart gateway; verify the record is delivered and queryable with no data loss |
 
 #### Key ADRs
 
 | ADR ID | Decision Summary |
 |--------|-----------------|
-| `cpt-cf-usage-collector-adr-scoped-emit-source` | `UsageCollectorClientV1.for_module()` returns a `ScopedUsageCollectorClientV1` bound to the source module's authoritative name; scoped client stamps source identity on every emit |
-| `cpt-cf-usage-collector-adr-two-phase-emit-authz` | `authorize_emit()` calls the PDP before any DB transaction; `emit()` evaluates returned constraints in-memory inside the transaction — no network I/O on the critical emission path |
+| `cpt-cf-usage-collector-adr-scoped-emit-source` | `UsageEmitterV1.for_module()` returns a `ScopedUsageEmitter` bound to the source module's authoritative name; scoped emitter stamps source identity on every emit |
+| `cpt-cf-usage-collector-adr-two-phase-emit-authz` | `authorize_for()` / `authorize()` calls the PDP before any DB transaction; `build_usage_record().enqueue()` evaluates returned constraints in-memory inside the transaction — no network I/O on the critical emission path |
 
 ### 1.3 Architecture Layers
 
-```
+**In-process mode** (source and gateway in the same process):
+
+```text
 ┌────────────────────────────────────────────────────────────────┐
-│                    Usage Sources                               │
-│            (LLM Gateway, Compute Service, etc.)                │
+│  Usage Source (same process as gateway)                        │
 ├────────────────────────────────────────────────────────────────┤
-│  usage-collector-sdk  │  emit() + outbox enqueue + delivery    │
+│  usage-emitter        │  UsageEmitterV1 (ClientHub); scoped    │
+│                       │  emit + outbox enqueue + delivery      │
+├────────────────────────────────────────────────────────────────┤
+│  usage-collector-sdk  │  UsageCollectorClientV1 (delivery);    │
+│                       │  UsageCollectorPluginClientV1 (plugin) │
 ├────────────────────────────────────────────────────────────────┤
 │  usage-collector      │  Gateway: ingest, query, tenant iso.   │
+│                       │  outbox bootstrap + migrations         │
 ├────────────────────────────────────────────────────────────────┤
 │  Plugins              │  Backend-specific storage adapters     │
-│  ┌──────────────────────┐  ┌───────────────────────────────┐   │
-│  │ clickhouse-plugin    │  │ timescaledb-plugin            │   │
-│  └──────────────────────┘  └───────────────────────────────┘   │
-├────────────────────────────────────────────────────────────────┤
-│  External              │  ClickHouse, TimescaleDB              │
 └────────────────────────────────────────────────────────────────┘
+```
+
+**Remote mode** (source and gateway in separate processes):
+
+```text
+┌─────────────────────────────────┐   ┌───────────────────────────────┐
+│  Usage Source Process           │   │  Collector Process            │
+│                                 │   │                               │
+│  usage-emitter                  │   │  usage-collector (gateway)    │
+│  usage-collector-rest-client    │──►│  POST /usage-collector/v1/    │
+│  (UsageEmitterV1 in ClientHub;  │   │  records (bearer token auth)  │
+│   HTTP delivery via authN token)│   │                               │
+└─────────────────────────────────┘   └───────────────────────────────┘
 ```
 
 | Layer | Responsibility | Technology |
 |-------|---------------|------------|
-| SDK | Emit API; outbox enqueue; owns `OutboxHandle` whose background pipeline automatically delivers records to the gateway | Rust crate (`usage-collector-sdk`), modkit-db outbox |
-| Gateway | Ingest, query, aggregation API; tenant isolation; plugin resolution | Rust crate (`usage-collector`), Axum |
+| Emitter | Source-facing emit API (`UsageEmitterV1`); `ScopedUsageEmitter` / `AuthorizedUsageEmitter`; two-phase auth; outbox enqueue; background delivery pipeline | Rust crate (`usage-emitter`), modkit-db outbox |
+| SDK | `UsageCollectorClientV1` delivery trait (not in ClientHub); `UsageCollectorPluginClientV1` plugin trait; shared model types | Rust crate (`usage-collector-sdk`) |
+| REST Client | Remote `UsageCollectorClientV1` implementation; registers `UsageEmitterV1` in ClientHub for out-of-process sources; acquires bearer token via AuthN resolver and HTTP-POSTs records to the gateway ingest endpoint | Rust crate (`usage-collector-rest-client`) |
+| Gateway | Ingest, query, aggregation API; tenant isolation; plugin resolution; outbox queue registration and schema migrations; registers `UsageEmitterV1` for in-process sources | Rust crate (`usage-collector`), Axum |
 | Plugins | Backend-specific record persistence and aggregation queries | Rust crates, ClickHouse / TimescaleDB drivers |
 | External | Durable time-series storage and query execution | ClickHouse or TimescaleDB |
 
@@ -136,7 +184,7 @@ All storage operations — write, aggregation query, and raw query — are deleg
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-principle-tenant-from-ctx`
 
-Tenant identity for usage attribution is always PDP-authorized — never freely accepted from request payloads. For standard sources, the SDK derives the tenant from `SecurityContext.subject_tenant_id()` and validates that `record.tenant_id` matches. For sources explicitly authorized by the PDP to emit on behalf of multiple tenants, the PDP returns a tenant `In` constraint; `emit()` validates `record.tenant_id` against that constraint before the outbox INSERT. The gateway re-validates tenant attribution independently on every ingest delivery. Queries are always scoped to the authenticated tenant from SecurityContext.
+Tenant identity for usage attribution is always PDP-authorized — never freely accepted from request payloads. The caller supplies the target `tenant_id` to `authorize_for()` (or uses the subject's home tenant via `authorize()`); the PDP `USAGE_RECORD`/`CREATE` decision covers both same-tenant and subtenant scenarios. The authorized `tenant_id` is bound into the `AuthorizedUsageEmitter` token and cannot be changed per-record. The gateway accepts the `tenant_id` from delivered records without re-checking. Queries are always scoped to the authenticated tenant from SecurityContext.
 
 #### Fail-Closed Security
 
@@ -152,7 +200,7 @@ On any authorization failure, the system rejects the request. No fallback to per
 
 **ADRs**: `cpt-cf-usage-collector-adr-scoped-emit-source`
 
-Each consuming module obtains a `ScopedUsageCollectorClientV1` by calling `for_module()` once at module initialization, passing its compile-time `MODULE_NAME` constant. The scoped client stamps every outbox row with the source module identity. Which metrics a source is permitted to emit is governed by authz policy. Source identity is never supplied per-call.
+Each consuming module obtains a `ScopedUsageEmitter` by calling `UsageEmitterV1::for_module()` once at module initialization, passing its compile-time `MODULE_NAME` constant. The scoped emitter stamps every outbox row with the source module identity. Which metrics a source is permitted to emit is governed by authz policy. Source identity is never supplied per-call.
 
 #### Two-Phase Emit
 
@@ -160,14 +208,14 @@ Each consuming module obtains a `ScopedUsageCollectorClientV1` by calling `for_m
 
 **ADRs**: `cpt-cf-usage-collector-adr-two-phase-emit-authz`
 
-Any logic that requires communication with external modules is consolidated in phase 1 (`authorize_emit()`), called before any DB transaction opens. Phase 1 accumulates all constraints and state into the returned `EmitAuthorization` token. Phase 2 (`emit()`) applies every accumulated constraint in-memory inside the caller's DB transaction — no external calls on the critical emission path.
+Any logic that requires communication with external modules is consolidated in phase 1 (`authorize_for()` / `authorize()`), called before any DB transaction opens. Phase 1 accumulates all constraints and state into the returned `AuthorizedUsageEmitter` token. Phase 2 (`build_usage_record().enqueue()`) applies every accumulated constraint in-memory inside the caller's DB transaction — no external calls on the critical emission path.
 
-`EmitAuthorization` acts as a pre-fetched, in-memory contract for the emission. It currently carries:
-- **PDP authorization constraints**: the platform PDP decision and any returned `Constraint` predicates, evaluated against the `UsageRecord` fields; for sources authorized to emit for multiple tenants, the PDP returns a tenant `In` constraint listing the allowed target tenant IDs
-- **Rate limit state**: the source-level emission quota and current window snapshot for the source module
-- **Usage type schema**: the registered schema for the metric being emitted, used for in-memory record validation
+`AuthorizedUsageEmitter` acts as a pre-fetched, in-memory contract for the emission. It currently carries:
+- **PDP authorization result**: the platform PDP permit decision for `USAGE_RECORD`/`CREATE` for the specified tenant and resource
+- **Allowed metrics list**: the set of metrics the source module is permitted to emit, fetched from the gateway during phase 1
+- **Bound context**: the authorized `tenant_id`, `resource_id`, `resource_type`, `subject_id`, and `subject_type` — every record produced by this token is stamped with these values; `subject_id` and `subject_type` are `Option<T>`; when both are `None`, PDP subject validation is skipped; when supplied (from payload with PDP authorization via `authorize_for()`, or from `SecurityContext` via `authorize()`), PDP subject properties are included and subject validation runs
 
-Any future requirement that depends on external state at emit time MUST be resolved in phase 1 and included in `EmitAuthorization`, not deferred to phase 2. A denial, quota exhaustion, or validation failure from `authorize_emit()` surfaces immediately to the caller as an error before any domain operation is committed.
+Any future requirement that depends on external state at emit time MUST be resolved in phase 1 and included in `AuthorizedUsageEmitter`, not deferred to phase 2. A denial, quota exhaustion, or validation failure from `authorize_for()` surfaces immediately to the caller as an error before any domain operation is committed.
 
 ### 2.2 Constraints
 
@@ -175,7 +223,7 @@ Any future requirement that depends on external state at emit time MUST be resol
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-constraint-outbox-infra`
 
-The SDK requires the modkit-db outbox schema to be present in the source's local database. The schema is installed by running `outbox_migrations()` from `modkit_db::outbox` as part of the source module's migration set. Usage sources that do not have a local database managed by modkit-db cannot use the SDK directly.
+The `usage-collector` gateway module registers the outbox queue and applies the modkit-db outbox schema migrations via its `DatabaseCapability::migrations()` implementation. Source modules that emit usage in-process MUST declare `usage-collector` as a ModKit dependency so that the outbox schema is applied automatically as part of the gateway's migration set. Usage sources that do not have a local database managed by modkit-db cannot use the emitter.
 
 #### Single Active Plugin
 
@@ -219,26 +267,26 @@ All plugin connections to ClickHouse and TimescaleDB MUST use TLS; connection pa
 
 **Technology**: Rust structs
 
-**Location**: [`modules/system/usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs)
+**Location**: [`modules/system/usage-collector/usage-collector-sdk/`](../../usage-collector/usage-collector-sdk/)
 
 **Core Entities**:
 
 | Entity | Description | Schema |
 |--------|-------------|--------|
-| `UsageRecord` | Single measurement of resource consumption: tenant ID, source module, metric kind (counter/gauge), metric name, numeric value, timestamp; idempotency key (required for counter metrics, optional for gauge metrics), resource ID/type, subject ID/type, metadata (opaque JSON); status (`active` \| `inactive`) | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `AggregationQuery` | Query parameters: tenant ID (derived from SecurityContext), time range (mandatory), aggregation function (SUM/COUNT/MIN/MAX/AVG); optional filters: usage type, subject (subject_id, subject_type), resource (resource_id, resource_type), source; optional GROUP BY dimensions: time bucket granularity, usage type, subject, resource, source | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `AggregationResult` | Result row: aggregation function applied, aggregated numeric value; dimension values present for each active GROUP BY dimension: time bucket start timestamp (when grouped by time), usage type (when grouped by usage type), subject ID + subject type (when grouped by subject), resource ID + resource type (when grouped by resource), source module (when grouped by source); absent dimensions are null | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `RawQuery` | Raw record query parameters: tenant ID (derived from SecurityContext), time range (mandatory), optional pagination cursor; optional filters: usage type, subject (subject_id, subject_type), resource (resource_id, resource_type) | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `EmitAuthorization` | Opaque token returned by `authorize_emit()`; carries all constraints evaluated in-memory by `emit()`: PDP authorization constraints (`Vec<Constraint>`, may include a tenant `In` constraint for sources authorized to emit for multiple tenants), source-level rate limit quota snapshot (emission count, window bounds, and configured limit for the source module), the registered usage type schema for the metric being emitted, and a monotonic issuance timestamp with a random nonce. `emit()` verifies the token has not exceeded its maximum age before evaluating any other constraint. | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `RetentionPolicy` | Retention rule: scope (`global` \| `tenant` \| `usage-type`), target identifier, retention duration. The global policy is mandatory and cannot be deleted; it applies when no more-specific policy matches. Precedence: per-usage-type > per-tenant > global. | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `BackfillOperation` | Backfill request: operator identity, target `tenant_id` (PDP-authorized: gateway verifies the caller is permitted to backfill for the specified tenant; cross-tenant operations require a dedicated PDP permission and the returned constraint must include the target tenant), usage type, time range, historical records to insert | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
-| `WriteAuditEvent` | Structured event emitted to platform `audit_service` for each operator-initiated write: operation type (`backfill` \| `amend` \| `deactivate`), actor_id, tenant_id, timestamp, justification, and a `WriteAuditContext` variant with operation-specific context — backfill: (usage type, time range, records added); amendment: (record ID, changed fields before/after); deactivation: (record ID). Not stored locally. | [`usage-collector-sdk/src/types.rs`](../../usage-collector-sdk/src/types.rs) |
+| `UsageRecord` | Single measurement of resource consumption: tenant ID, source module (`module` field), metric kind (`kind` field: counter/gauge), metric name, numeric value, timestamp; idempotency key (required for counter metrics, optional for gauge metrics), resource ID and resource type (both required), subject ID/type, metadata (opaque JSON); status (`active` \| `inactive`) | [`usage-collector-sdk/src/models.rs`](../../usage-collector/usage-collector-sdk/src/models.rs) |
+| `AggregationQuery` | Query parameters: tenant ID (derived from SecurityContext), time range (mandatory), aggregation function (SUM/COUNT/MIN/MAX/AVG); optional filters: usage type, subject (subject_id, subject_type), resource (resource_id, resource_type), source; optional GROUP BY dimensions: time bucket granularity, usage type, subject, resource, source | `AggregationQuery` is not yet present in the SDK (target-state) |
+| `AggregationResult` | Result row: aggregation function applied, aggregated numeric value; dimension values present for each active GROUP BY dimension: time bucket start timestamp (when grouped by time), usage type (when grouped by usage type), subject ID + subject type (when grouped by subject), resource ID + resource type (when grouped by resource), source module (when grouped by source); absent dimensions are null | `AggregationResult` is not yet present in the SDK (target-state) |
+| `RawQuery` | Raw record query parameters: tenant ID (derived from SecurityContext), time range (mandatory), optional pagination cursor; optional filters: usage type, subject (subject_id, subject_type), resource (resource_id, resource_type) | `RawQuery` is not yet present in the SDK (target-state) |
+| `AuthorizedUsageEmitter` | Time-limited authorization handle returned by `authorize_for()` / `authorize()`; carries the PDP permit result, the authorized `tenant_id`/`resource_id`/`resource_type`, the subject identity (`subject_id`/`subject_type`) bound at authorization time (accepted from the caller with PDP authorization or derived from `SecurityContext` when absent), the allowed-metrics list for the source module, and a monotonic issuance timestamp. `enqueue()` verifies the token has not exceeded its maximum age before proceeding. | `AuthorizedUsageEmitter` is not yet present in the SDK (target-state); see `usage-emitter` crate |
+| `RetentionPolicy` | Retention rule: scope (`global` \| `tenant` \| `usage-type`), target identifier, retention duration. The global policy is mandatory and cannot be deleted; it applies when no more-specific policy matches. Precedence: per-usage-type > per-tenant > global. | `RetentionPolicy` is not yet present in the SDK (target-state) |
+| `BackfillOperation` | Backfill request: operator identity, target `tenant_id` (PDP-authorized: gateway verifies the caller is permitted to backfill for the specified tenant before accepting the request), usage type, time range, historical records to insert | `BackfillOperation` is not yet present in the SDK (target-state) |
+| `WriteAuditEvent` | Structured event emitted to platform `audit_service` for each operator-initiated write: operation type (`backfill` \| `amend` \| `deactivate`), actor_id, tenant_id, timestamp, justification, and a `WriteAuditContext` variant with operation-specific context — backfill: (usage type, time range, records added); amendment: (record ID, changed fields before/after); deactivation: (record ID). Not stored locally. | `WriteAuditEvent` is not yet present in the SDK (target-state) |
 | `UsageType` | Registered usage type schema: type identifier, metric kind, unit label, validation rules | types-registry |
 
 **Relationships**:
 - `UsageRecord` belongs to exactly one tenant via `tenant_id`
-- `UsageRecord` optionally belongs to one resource via `resource_id`/`resource_type`
-- `UsageRecord` optionally belongs to one subject via `subject_id`/`subject_type`, always derived from SecurityContext
+- `UsageRecord` belongs to exactly one resource via `resource_id`/`resource_type` (both required)
+- `UsageRecord` optionally belongs to one subject via `subject_id`/`subject_type`; when present, subject is accepted from the request payload with PDP authorization or derived from `SecurityContext` via `authorize()`; when absent (both fields `None`), the record carries no subject attribution and PDP subject validation is skipped
 - `UsageRecord` carries optional `metadata` (opaque JSON); persisted and returned as-is without interpretation
 - `UsageRecord` status is `active` on creation; transitions to `inactive` on operator-initiated deactivation or amendment
 - `AggregationResult` carries dimension values only for dimensions active in the originating `AggregationQuery`; a query with no GROUP BY returns a single row with all dimension fields null
@@ -251,13 +299,22 @@ All plugin connections to ClickHouse and TimescaleDB MUST use TLS; connection pa
 
 ```mermaid
 graph TD
-    subgraph Source["Usage Source Process"]
-        App[Application Code]
-        SDK[usage-collector-sdk]
-        LDB[(Local DB)]
+    subgraph InProcess["In-Process Mode (source + gateway same process)"]
+        App1[Application Code]
+        Emitter1[usage-emitter]
+        LDB1[(Local DB)]
+        GW1[Gateway / UsageCollectorLocalClient]
     end
 
-    subgraph Collector["Usage Collector"]
+    subgraph Remote["Remote Mode (source in separate process)"]
+        App2[Application Code]
+        Emitter2[usage-emitter]
+        LDB2[(Local DB)]
+        RC[usage-collector-rest-client]
+        AuthN[authn-resolver]
+    end
+
+    subgraph Collector["Collector Process"]
         GW[Gateway]
         Plugin[Storage Plugin]
     end
@@ -268,34 +325,40 @@ graph TD
 
     Consumer[Usage Consumer]
 
-    App -->|emit| SDK
-    SDK -->|enqueue within caller tx| LDB
-    SDK -->|"deliver (outbox pipeline)"| GW
+    App1 -->|"authorize_for / enqueue"| Emitter1
+    Emitter1 -->|enqueue within caller tx| LDB1
+    Emitter1 -->|"outbox pipeline → in-process call"| GW1
+    GW1 --> GW
+
+    App2 -->|"authorize_for / enqueue"| Emitter2
+    Emitter2 -->|enqueue within caller tx| LDB2
+    Emitter2 -->|outbox pipeline| RC
+    RC -->|acquire token| AuthN
+    RC -->|"POST /usage-collector/v1/records (bearer)"| GW
+
     GW -->|write| Plugin
-    Plugin -->|persist| DB
+    Plugin -->|create_usage_record| DB
     Consumer -->|query| GW
     GW -->|read| Plugin
     Plugin -->|aggregate / paginate| DB
 ```
 
-#### Usage Collector SDK
+#### Usage Emitter
 
-- [ ] `p1` - **ID**: `cpt-cf-usage-collector-component-sdk`
-
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-component-emitter`
 
 ##### Why this component exists
 
-Provides the public API for usage sources to emit records. Handles transactional outbox persistence in the source's local database, decoupling sources from collector availability.
+Provides the source-facing API for emitting usage records. Registered in `ClientHub` as `UsageEmitterV1` by either the gateway module (in-process delivery) or `usage-collector-rest-client` (HTTP delivery to a remote collector). Handles two-phase authorization and transactional outbox persistence, decoupling sources from collector availability.
 
 ##### Responsibility scope
 
-- At SDK initialization: register the `"usage-records"` outbox queue (idempotent, 4 partitions), start the decoupled outbox pipeline with the SDK's internal delivery handler, and retain the resulting `OutboxHandle` for the process lifetime — no explicit shutdown coordination is required
-- Expose `for_module(name) -> ScopedUsageCollectorClientV1` on `UsageCollectorClientV1`; each consuming module calls this once at initialization with its compile-time `MODULE_NAME` constant
-- `ScopedUsageCollectorClientV1.authorize_emit(ctx, metric_name)` — called before any DB transaction opens; calls the platform PDP (authz constraints for the given metric, which may include a tenant `In` constraint for sources authorized to emit for multiple tenants), fetches the current source-level rate limit quota snapshot, and retrieves the registered usage type schema for `metric_name` from types-registry; returns an opaque `EmitAuthorization` token on success or an error on denial / quota exhaustion
-- `ScopedUsageCollectorClientV1.emit(ctx, record, &EmitAuthorization)` — called inside the caller's DB transaction; first verifies the token has not exceeded its maximum age (`EmitError::AuthorizationExpired` on expiry); then validates metric semantics (rejects counter records with a negative value or a missing idempotency key), captures subject ID and type from SecurityContext, stamps source module identity, then evaluates all `EmitAuthorization` constraints in-memory in order: usage type schema validation, source-level rate limit quota check, PDP constraint satisfaction (including tenant validation: if a tenant `In` constraint is present, `record.tenant_id` must be a member of the allowed set; if no tenant constraint is present, `record.tenant_id` must equal `ctx.subject_tenant_id()`); rejects before the outbox enqueue on any failure; on success stamps the outbox row with `record.tenant_id` and calls `Outbox::enqueue()` within the caller's transaction
-- Serialize the usage record (tenant ID, source module, metric kind, idempotency key, resource attribution, subject attribution) to bytes as the outbox payload with `payload_type = "usage-collector.record.v1"`
+- Expose `UsageEmitterV1::for_module(name) -> ScopedUsageEmitter`; each consuming module retrieves `UsageEmitterV1` from `ClientHub` and calls `for_module()` once at initialization with its compile-time `MODULE_NAME` constant
+- `ScopedUsageEmitter::authorize_for(ctx, tenant_id, resource_id, resource_type)` and `ScopedUsageEmitter::authorize(ctx, resource_id, resource_type)` — called before any DB transaction opens; call the platform PDP for `USAGE_RECORD`/`CREATE`, fetch the allowed-metrics configuration for this module from the gateway (`get_module_config()`); return an `AuthorizedUsageEmitter` token on success, or error on PDP denial / module not configured
+- `AuthorizedUsageEmitter::build_usage_record(metric, value).enqueue()` — called inside the caller's DB transaction; first verifies the token has not exceeded its maximum age (`EmitError::AuthorizationExpired` on expiry); then validates metric semantics (rejects counter records with a negative value or a missing idempotency key), reads optional `subject_id` and `subject_type` from the authorization context (both are `None` when neither caller-supplied via `authorize_for()` nor derivable from `SecurityContext`), stamps source module identity, then evaluates all `EmitAuthorization` constraints in-memory in order: usage type schema validation, source-level rate limit quota check, PDP constraint satisfaction (including tenant validation: if a tenant `In` constraint is present, `record.tenant_id` must be a member of the allowed set; if no tenant constraint is present, `record.tenant_id` must equal `ctx.subject_tenant_id()`); rejects before the outbox enqueue on any failure; on success stamps the outbox row with `record.tenant_id` and calls `Outbox::enqueue()` within the caller's transaction
+- Serialize the usage record (tenant ID, module, kind, idempotency key, resource attribution, subject attribution) to bytes as the outbox payload with `payload_type = "usage-collector.record.v1"`
 - Pass optional metadata field through to the payload without interpretation; enforce the configurable size limit (default 8 KB) before enqueuing
-- Internally implement a `MessageHandler` that the outbox library calls for each ready message: deserialize the payload, assemble a gateway ingest request, call `persist()`, and return `HandlerResult::Success` on confirmation, `HandlerResult::Retry` on transient failure, or `HandlerResult::Reject` on permanent non-retriable failure (e.g. deserialization error, gateway 400); `backoff_max` MUST be configured below 15 minutes to satisfy `cpt-cf-usage-collector-nfr-recovery`
+- Internally implement a `MessageHandler` that the outbox library calls for each ready message: deserialize the payload, assemble a gateway ingest request, call `UsageCollectorClientV1::create_usage_record()`, and return `HandlerResult::Success` on confirmation, `HandlerResult::Retry` on transient failure, or `HandlerResult::Reject` on permanent non-retriable failure (e.g. deserialization error, gateway 400); `backoff_max` MUST be configured below 15 minutes to satisfy `cpt-cf-usage-collector-nfr-recovery`
 
 ##### Responsibility boundaries
 
@@ -305,7 +368,34 @@ Provides the public API for usage sources to emit records. Handles transactional
 
 ##### Related components (by ID)
 
-- `cpt-cf-usage-collector-component-gateway` — delivery target for outbox messages
+- `cpt-cf-usage-collector-component-gateway` — delivery target for outbox messages; also constructs and registers `UsageEmitterV1` in `ClientHub` during `init()`
+
+---
+
+#### Usage Collector SDK
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-component-sdk`
+
+##### Why this component exists
+
+Defines the shared trait and model boundaries. `UsageCollectorClientV1` is the delivery trait implemented by the gateway's local client and remote REST client; it is **not** registered in `ClientHub` to prevent bypassing the authorized-emitter path. `UsageCollectorPluginClientV1` is the storage plugin trait.
+
+##### Responsibility scope
+
+- Define `UsageCollectorClientV1` with `create_usage_record()` and `get_module_config()` operations
+- Define `UsageCollectorPluginClientV1` with storage plugin operations
+- Define shared model types (`UsageRecord`, `ModuleConfig`, `AllowedMetric`, `UsageKind`, etc.)
+- Define GTS schema for storage plugin registration (`UsageCollectorStoragePluginSpecV1`)
+
+##### Responsibility boundaries
+
+- Does NOT contain emit, authorization, or outbox logic — those are in `cpt-cf-usage-collector-component-emitter`
+- Does NOT register anything in `ClientHub`
+
+##### Related components (by ID)
+
+- `cpt-cf-usage-collector-component-emitter` — consumes `UsageCollectorClientV1` for outbox delivery
+- `cpt-cf-usage-collector-component-gateway` — implements `UsageCollectorClientV1` via its local client
 
 #### Gateway
 
@@ -317,18 +407,19 @@ The centralized entry point for receiving delivered records and serving aggregat
 
 ##### Responsibility scope
 
-- Accept ingest requests from the SDK's outbox delivery pipeline
-- Derive and enforce tenant ID from SecurityContext on all query operations; on ingest, validate tenant attribution: when `record.tenant_id == ctx.subject_tenant_id()`, accept without additional check; when `record.tenant_id ≠ ctx.subject_tenant_id()`, call the PDP with `context_tenant_id(record.tenant_id)` and action `"emit_on_behalf"` — reject the record if the PDP denies (fail-closed); enforce per-(source, tenant) rate limits on ingest once the record's target tenant is known
+- Register the `"usage-records"` outbox queue (4 partitions, configurable) and apply outbox schema migrations (`outbox_migrations()` from `modkit_db::outbox`) via `DatabaseCapability::migrations()` during module init; construct and register `UsageEmitterV1` in `ClientHub` during `init()`
+- Accept ingest requests from the emitter's outbox delivery pipeline
+- Derive and enforce tenant ID from SecurityContext on all query operations; on ingest, accept the `tenant_id` from the delivered record without a second PDP check — tenant attribution was authorized at emit time via `USAGE_RECORD`/`CREATE`; enforce per-(source, tenant) rate limits on ingest
 - Resolve the active storage plugin via GTS
 - Expose aggregation and raw query API to usage consumers
 - Authorize each query via the platform PDP: verify the caller is permitted to query; apply PDP-returned constraints as additional query filters before delegating to the plugin
 - Delegate all storage reads and writes to the resolved plugin
 - Fail closed on authorization failures — no permissive fallback
 - Enforce configurable per-call timeout for all plugin operations (default 5 s); if a plugin call does not complete within the timeout, the gateway returns an error and does not retry within the same request — for ingest, retry is handled by the outbox library on the SDK side
-- Apply a circuit breaker per storage plugin instance: open the circuit after 5 consecutive plugin call failures within a 10-second window; return `503 Service Unavailable` while the circuit is open; probe with a single call after a configurable half-open interval (default 30 s)
+- Apply a circuit breaker per storage plugin instance: open the circuit after 5 consecutive plugin call failures within a 10-second window; return `503 Service Unavailable` while the circuit is open; admit exactly one probe call after a configurable half-open interval (default 30 s); all other concurrent requests during the half-open window are rejected until the probe completes
 - Enforce configurable metadata size limit (default 8 KB) at ingest; reject oversized records before delegating to plugin
 - Validate each inbound record against the schema registered in types-registry before delegating to plugin (defense-in-depth; primary validation occurs at SDK `emit()` time before the outbox INSERT)
-- Accept operator backfill requests; call the platform PDP to verify the caller is authorized to backfill for the specified `tenant_id` before accepting the request — a PDP denial or a `tenant_id` that violates the returned constraint returns `403 PERMISSION_DENIED` immediately; callers whose SecurityContext tenant differs from the requested `tenant_id` require a dedicated cross-tenant backfill PDP permission; validate time boundaries and authorization; enqueue each backfill record as a separate outbox message via `Outbox::enqueue_batch()` within the handler transaction; emit `WriteAuditEvent` to `audit_service` once all records are committed to the outbox; respond `202 Accepted` to the caller
+- Accept operator backfill requests; call the platform PDP to verify the caller is authorized to backfill for the specified `tenant_id` before accepting the request; a PDP denial returns `403 PERMISSION_DENIED` immediately; validate time boundaries and authorization; enqueue each backfill record as a separate outbox message via `Outbox::enqueue_batch()` within the handler transaction; emit `WriteAuditEvent` to `audit_service` once all records are committed to the outbox; respond `202 Accepted` to the caller
 - Internally implement a `MessageHandler` for the backfill outbox that the outbox library calls for each individual backfill record: deserialize the payload into a single `UsageRecord`, call `plugin.backfill_ingest()`, and return `HandlerResult::Success` on confirmation, `HandlerResult::Retry` on transient plugin failure, or `HandlerResult::Reject` on permanent failure; `backoff_max` bounds retry duration; delivery throughput to the plugin is naturally rate-limited by the outbox partition count and `msg_batch_size`
 - Expose amendment and deactivation endpoints for individual usage records; emit `WriteAuditEvent` to `audit_service` on each operation
 - Enforce configurable backfill time boundaries (max window, future tolerance); require elevated authorization for requests beyond the max window
@@ -346,6 +437,38 @@ The centralized entry point for receiving delivered records and serving aggregat
 
 - `cpt-cf-usage-collector-component-sdk` — inbound delivery via the SDK's outbox pipeline
 - `cpt-cf-usage-collector-component-storage-plugin` — delegates all storage operations to plugin
+
+#### REST Client
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-component-rest-client`
+
+##### Why this component exists
+
+Enables usage sources that run in a separate process or service binary (i.e., out-of-process from the collector gateway) to emit records using the same `UsageEmitterV1` API as in-process sources. The source's emit path and outbox persistence are identical; only the delivery hop is different — the outbox background pipeline POSTs each record to the gateway's HTTP ingest endpoint instead of calling it in-process.
+
+##### Responsibility scope
+
+- Register `UsageEmitterV1` in `ClientHub` during `init()`, backed by a `UsageCollectorRestClient` as the `UsageCollectorClientV1` implementation
+- Implement `UsageCollectorClientV1::create_usage_record()`: acquire a bearer token from the platform AuthN resolver (client credentials flow), then HTTP POST the record to `POST /usage-collector/v1/records`; return `HandlerResult::Retry` on network or transient HTTP errors (5xx, 429); return `HandlerResult::Reject` on permanent errors (4xx excluding 429)
+- Implement `UsageCollectorClientV1::get_module_config()`: HTTP GET `GET /usage-collector/v1/modules/{module_name}/config` with bearer token; called by `ScopedUsageEmitter.authorize_for()` during phase 1
+- Apply outbox schema migrations (same `outbox_migrations()` call as the in-process path) — this module owns the source's outbox, not the gateway
+
+##### Responsibility boundaries
+
+- Does NOT bypass the transactional outbox — `enqueue()` always writes to the source's local DB first; HTTP delivery happens asynchronously via the outbox background pipeline
+- Does NOT perform authorization — `authorize_for()` is still called by the source and contacts the PDP directly; this component only handles delivery
+- Does NOT implement gateway-side logic — it is a thin HTTP client over `UsageCollectorClientV1`
+
+##### Delivery guarantees
+
+Delivery guarantees are the same as in-process mode: at-least-once via the transactional outbox. The REST client transport adds a bearer token acquisition step and a network hop per delivery attempt. Token acquisition failures are treated as transient and trigger exponential backoff retry. All records durably committed to the source's local outbox are guaranteed to eventually reach the gateway.
+
+##### Related components (by ID)
+
+- `cpt-cf-usage-collector-component-emitter` — consumes this component's `UsageCollectorClientV1` for outbox delivery
+- `cpt-cf-usage-collector-component-gateway` — HTTP delivery target; exposes the ingest and module-config endpoints consumed by this component
+
+---
 
 #### Storage Plugin
 
@@ -380,35 +503,59 @@ Provides a backend-specific implementation for persisting and querying usage rec
 
 ### 3.3 API Contracts
 
-#### SDK Trait (`UsageCollectorClientV1`)
+#### Emitter Trait (`UsageEmitterV1`)
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-emitter-trait`
+
+**Technology**: Rust trait in `usage-emitter` crate; registered in `ClientHub` by the gateway module (in-process) or `usage-collector-rest-client` (HTTP)
+**Data Format**: Rust types shared with SDK
+
+**Operations**:
+
+| Operation | Caller | Description |
+|-----------|--------|-------------|
+| `for_module(name)` | Usage source at init | Returns a `ScopedUsageEmitter` bound to the source module's authoritative name |
+
+#### Scoped Emitter (`ScopedUsageEmitter`)
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-scoped-emitter`
+
+**Technology**: Rust struct in `usage-emitter` crate; obtained exclusively via `UsageEmitterV1::for_module()`
+**Data Format**: Rust types shared with SDK
+
+**Operations**:
+
+| Operation | Caller | Description |
+|-----------|--------|-------------|
+| `authorize_for(ctx, tenant_id, resource_id, resource_type)` | Usage source (before transaction) | Calls the platform PDP for `USAGE_RECORD`/`CREATE` with the specified tenant and resource; fetches allowed metrics for this module from the gateway (`get_module_config()`); returns `AuthorizedUsageEmitter` on success, or `UsageEmitterError` on denial / module not configured; never called inside an open DB transaction |
+| `authorize(ctx, resource_id, resource_type)` | Usage source (before transaction) | Convenience wrapper for `authorize_for` using `ctx.subject_tenant_id()` as `tenant_id` |
+
+#### Authorized Emitter (`AuthorizedUsageEmitter`)
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-authorized-emitter`
+
+**Technology**: Rust struct in `usage-emitter` crate; obtained exclusively via `ScopedUsageEmitter::authorize_for()` / `authorize()`; time-limited token
+
+**Operations**:
+
+| Operation | Caller | Description |
+|-----------|--------|-------------|
+| `build_usage_record(metric, value)` | Usage source (within transaction) | Entry point for the fluent builder; binds metric name and value to the authorized context |
+| `.enqueue()` (on builder) | Usage source (within transaction) | Validates metric semantics (rejects counter records with a negative value or a missing idempotency key), reads optional `subject_id` and `subject_type` from the authorization context (`None` when neither caller-supplied via `authorize_for()` nor derived from `SecurityContext`), then evaluates all `EmitAuthorization` constraints in-memory: schema validation, source-level rate limit quota, PDP constraint satisfaction including tenant validation (tenant `In` constraint present → `record.tenant_id ∈ allowed set`; no tenant constraint → `record.tenant_id == ctx.subject_tenant_id()`); when `subject_id` and `subject_type` are both `None`, PDP subject properties are omitted from the authorization request and subject validation is skipped; stamps outbox row with `record.tenant_id` on success; returns `EmitError::MissingIdempotencyKey`, `EmitError::SchemaViolation`, `EmitError::RateLimitExceeded`, or `EmitError::ConstraintViolation` on failure — no outbox INSERT on any error |
+
+#### Delivery Trait (`UsageCollectorClientV1`)
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-sdk-trait`
 
-**Technology**: Rust trait in `usage-collector-sdk` crate
-**Data Format**: Rust types (`UsageRecord`, `AggregationQuery`, `AggregationResult`, `RawQuery`, `PagedResult`)
+**Technology**: Rust trait in `usage-collector-sdk` crate; **not** registered in `ClientHub`; implemented by `UsageCollectorLocalClient` (gateway) and `usage-collector-rest-client`
+**Data Format**: Rust types (`UsageRecord`, `ModuleConfig`)
 
 **Operations**:
 
 | Operation | Caller | Description |
 |-----------|--------|-------------|
-| `for_module(name)` | Usage source at init | Returns a `ScopedUsageCollectorClientV1` bound to the source module's authoritative name |
-| `persist(records)` | SDK (outbox delivery handler) | Delivers a batch of records to the collector gateway; idempotent on `idempotency_key` |
-| `query_aggregated(ctx, query)` | Usage consumer | Returns aggregated usage data scoped to the authenticated tenant |
-| `query_raw(ctx, query)` | Usage consumer | Returns paginated raw usage records scoped to the authenticated tenant |
-
-#### Scoped Emit Client (`ScopedUsageCollectorClientV1`)
-
-- [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-scoped-client`
-
-**Technology**: Rust struct in `usage-collector-sdk` crate; obtained exclusively via `UsageCollectorClientV1::for_module()`
-**Data Format**: Rust types shared with SDK trait
-
-**Operations**:
-
-| Operation | Caller | Description |
-|-----------|--------|-------------|
-| `authorize_emit(ctx, metric_name)` | Usage source (before transaction) | Calls the platform PDP for the given metric (PDP may return a tenant `In` constraint for sources authorized to emit for multiple tenants), fetches the source-level rate limit quota snapshot, and fetches the registered usage type schema for `metric_name` from types-registry; returns `EmitAuthorization` on success, or `EmitError::Denied` / `EmitError::RateLimitExceeded` on failure; never called inside an open DB transaction |
-| `emit(ctx, record, &EmitAuthorization)` | Usage source (within transaction) | Validates metric semantics (rejects counter records with a negative value or a missing idempotency key), captures subject from SecurityContext, then evaluates all `EmitAuthorization` constraints in-memory: schema validation, source-level rate limit quota, PDP constraint satisfaction including tenant validation (tenant `In` constraint present → `record.tenant_id ∈ allowed set`; no tenant constraint → `record.tenant_id == ctx.subject_tenant_id()`); stamps outbox row with `record.tenant_id` on success; returns `EmitError::MissingIdempotencyKey`, `EmitError::SchemaViolation`, `EmitError::RateLimitExceeded`, or `EmitError::ConstraintViolation` on failure — no outbox INSERT on any error |
+| `create_usage_record(record)` | Emitter (outbox delivery handler) | Delivers one record to the collector gateway per outbox message; idempotent on `idempotency_key` |
+| `get_module_config(module_name)` | Emitter (`authorize_for` / `authorize`) | Returns allowed metrics (and future config) for the module; called by the scoped emitter during phase 1 authorization |
 
 #### Plugin Trait
 
@@ -421,7 +568,7 @@ Provides a backend-specific implementation for persisting and querying usage rec
 
 | Operation | Description |
 |-----------|-------------|
-| `persist(records)` | Persists usage records with idempotent upsert on `idempotency_key`; for counter metrics, each record's `value` is a non-negative delta — the record is stored as-is alongside other deltas; the persistent total for any `(tenant_id, metric)` pair is the SUM of all active delta records for that key (see §3.7 Counter Accumulation); for gauge metrics, values are stored as-is |
+| `create_usage_record(record)` | Stores one usage record with idempotent upsert on `idempotency_key`; for counter metrics, each record's `value` is a non-negative delta — the record is stored as-is alongside other deltas; the persistent total for any `(tenant_id, metric)` pair is the SUM of all active delta records for that key (see §3.7 Counter Accumulation); for gauge metrics, values are stored as-is |
 | `query_aggregated(ctx, query)` | Executes aggregation query within the storage engine; applies optional filters (usage type, subject, resource, source) and GROUP BY dimensions from `AggregationQuery`; pushes aggregation and grouping down to the storage engine |
 | `query_raw(ctx, query)` | Executes raw record query with cursor-based pagination; applies optional filters (usage type, subject, resource) from `RawQuery`; scoped to tenant |
 | `backfill_ingest(ctx, tenant, usage_type, records)` | Bulk-inserts historical records with idempotent upsert on `idempotency_key`; does not modify existing records |
@@ -439,18 +586,20 @@ Provides a backend-specific implementation for persisting and querying usage rec
 
 **Endpoints Overview**:
 
-| Method  | Path                                | Description                                                                                 | Stability |
-| ------- | ----------------------------------- | ------------------------------------------------------------------------------------------- | --------- |
-| `GET`   | `/v1/usage/aggregated`              | Query aggregated usage data for the authenticated tenant                                    | stable    |
-| `GET`   | `/v1/usage/raw`                     | Query raw usage records with cursor-based pagination for the authenticated tenant           | stable    |
-| `POST`  | `/v1/usage/backfill`                | Operator-initiated bulk insert of historical records for a tenant and usage type time range | stable    |
-| `PATCH` | `/v1/usage/records/{id}`            | Amend mutable fields on an individual active record                                         | stable    |
-| `POST`  | `/v1/usage/records/{id}/deactivate` | Deactivate an individual record (marks inactive, retains for audit)                         | stable    |
-| `GET`   | `/v1/usage/metadata/watermarks`     | Per-source and per-tenant event counts and latest timestamps                                | stable    |
-| `POST`  | `/v1/usage/types`                   | Register a custom usage type (name, metric kind, unit label); delegates to types-registry   | stable    |
-| `GET`   | `/v1/usage/retention`               | List configured retention policies                                                          | stable    |
-| `PUT`   | `/v1/usage/retention/{scope}`       | Create or update a retention policy for a scope (global / tenant / usage-type)              | stable    |
-| `DELETE` | `/v1/usage/retention/{scope}`      | Delete a non-global retention policy for a scope (tenant / usage-type); the global default policy cannot be deleted | stable    |
+| Method  | Path                                              | Description                                                                                 | Stability |
+| ------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------- | --------- |
+| `POST`  | `/usage-collector/v1/records`                     | Create a usage record; accepts payload and delegates storage to the configured plugin       | stable    |
+| `GET`   | `/usage-collector/v1/modules/{module_name}/config`| Allowed metrics (and future config) for the specified source module                         | stable    |
+| `GET`   | `/usage-collector/v1/aggregated`                  | Query aggregated usage data for the authenticated tenant                                    | stable    |
+| `GET`   | `/usage-collector/v1/raw`                         | Query raw usage records with cursor-based pagination for the authenticated tenant           | stable    |
+| `POST`  | `/usage-collector/v1/backfill`                    | Operator-initiated bulk insert of historical records for a tenant and usage type time range | stable    |
+| `PATCH` | `/usage-collector/v1/records/{id}`                | Amend mutable fields on an individual active record                                         | stable    |
+| `POST`  | `/usage-collector/v1/records/{id}/deactivate`     | Deactivate an individual record (marks inactive, retains for audit)                         | stable    |
+| `GET`   | `/usage-collector/v1/metadata/watermarks`         | Per-source and per-tenant event counts and latest timestamps                                | stable    |
+| `POST`  | `/usage-collector/v1/types`                       | Register a custom usage type (name, metric kind, unit label); delegates to types-registry   | stable    |
+| `GET`   | `/usage-collector/v1/retention`                   | List configured retention policies                                                          | stable    |
+| `PUT`   | `/usage-collector/v1/retention/{scope}`           | Create or update a retention policy for a scope (global / tenant / usage-type)              | stable    |
+| `DELETE`| `/usage-collector/v1/retention/{scope}`           | Delete a non-global retention policy for a scope (tenant / usage-type); the global default policy cannot be deleted | stable |
 
 #### Error Handling
 
@@ -471,10 +620,11 @@ All endpoints are **stable** (prefixed `/v1/`). Backward compatibility is guaran
 
 | Dependency Module | Interface Used | Purpose |
 |-------------------|----------------|---------|
-| modkit-db | `modkit_db::outbox` — `Outbox::enqueue()`, `OutboxHandle`, `outbox_migrations()`, dead-letter API | Durable outbox persistence, automatic background delivery pipeline, and dead-letter management for at-least-once delivery |
-| types-registry | GTS type system — plugin schema registration and instance resolution; types-registry SDK — usage type schema retrieval | Storage plugin discovery and instantiation at runtime; usage type schema fetching for in-memory validation at emit time (called by `ScopedUsageCollectorClientV1.authorize_emit()`) |
+| modkit-db | `modkit_db::outbox` — `Outbox::enqueue()`, `OutboxHandle`, `outbox_migrations()`, dead-letter API | Durable outbox persistence, automatic background delivery pipeline, and dead-letter management for at-least-once delivery; `outbox_migrations()` is applied by the gateway module (in-process) or the `usage-collector-rest-client` module (remote) |
+| types-registry | GTS type system — plugin schema registration and instance resolution; types-registry SDK — usage type schema retrieval | Storage plugin discovery and instantiation at runtime; usage type schema fetching for in-memory validation at emit time (called by `ScopedUsageEmitter.authorize_for()`) |
 | SecurityContext | Platform security primitive | Tenant identity, subject identity derivation and authorization enforcement on all operations |
-| authz-resolver | `authz-resolver-sdk` — `PolicyEnforcer` / `AuthZResolverClient` | Platform PDP for ingestion authorization; called by `ScopedUsageCollectorClientV1.authorize_emit()` to verify the source module is permitted to emit the target metrics |
+| authz-resolver | `authz-resolver-sdk` — `PolicyEnforcer` / `AuthZResolverClient` | Platform PDP for ingestion authorization; called by `ScopedUsageEmitter.authorize_for()` to verify the source module is permitted to emit for the target tenant and resource |
+| authn-resolver | `authn-resolver-sdk` — `AuthNResolverClient` | Bearer token acquisition (client credentials flow) for HTTP delivery by `usage-collector-rest-client`; used once per delivery attempt by the outbox background pipeline |
 
 **Dependency Rules** (per project conventions):
 - No circular dependencies
@@ -534,49 +684,51 @@ All endpoints are **stable** (prefixed `/v1/`). Backward compatibility is guaran
 ```mermaid
 sequenceDiagram
     participant App as Usage Source
-    participant SC as ScopedUsageCollectorClientV1
+    participant CH as ClientHub
+    participant UE as UsageEmitterV1
+    participant SC as ScopedUsageEmitter
+    participant AE as AuthorizedUsageEmitter
     participant PDP as authz-resolver (PDP)
-    participant TR as types-registry
+    participant GW as UC Gateway (UsageCollectorClientV1)
     participant LDB as Local DB
-    participant OB as Outbox Pipeline (SDK background)
-    participant GW as UC Gateway
+    participant OB as Outbox Pipeline (background)
     participant Plugin as Storage Plugin
     participant DB as ClickHouse / TimescaleDB
 
-    Note over App,SC: Module init (once)
-    App->>SC: for_module(MODULE_NAME)
+    Note over App,UE: Module init (once); gateway init() has registered UsageEmitterV1 in ClientHub
+    App->>CH: get::<dyn UsageEmitterV1>()
+    CH-->>App: &UsageEmitterV1
+    App->>UE: for_module(MODULE_NAME)
+    UE-->>App: ScopedUsageEmitter
 
     Note over App,LDB: Per-request, before transaction
-    App->>SC: authorize_emit(ctx, metric_name)
-    SC->>PDP: evaluate policy (source_module, metric_name)
-    SC->>TR: fetch schema for metric_name
-    SC->>SC: fetch source-level quota snapshot
-    PDP-->>SC: constraints (incl. optional tenant In constraint) | Denied
-    TR-->>SC: schema
-    SC-->>App: Ok(EmitAuthorization{constraints, schema, quota}) | Err(Denied | RateLimitExceeded)
+    App->>SC: authorize_for(ctx, tenant_id, resource_id, resource_type)
+    SC->>PDP: USAGE_RECORD/CREATE (source_module, tenant_id, resource)
+    SC->>GW: get_module_config(module_name) → allowed metrics
+    PDP-->>SC: permit | deny
+    GW-->>SC: ModuleConfig{allowed_metrics}
+    SC-->>App: Ok(AuthorizedUsageEmitter{tenant_id, resource_id, resource_type}) | Err(UsageEmitterError)
 
     Note over App,LDB: Inside caller's DB transaction
-    App->>SC: emit(ctx, record{tenant_id=T}, &auth)
-    SC->>SC: validate metric semantics (counter ≥ 0, gauge any)
-    SC->>SC: capture subject_id / subject_type from SecurityContext
-    SC->>SC: validate record against schema
-    SC->>SC: check source-level quota (emission count within window limit)
-    SC->>SC: evaluate PDP constraints incl. tenant: In constraint → record.tenant_id ∈ allowed set; no constraint → record.tenant_id == ctx.subject_tenant_id()
-    SC->>LDB: Outbox::enqueue(tenant_id=record.tenant_id) within caller's tx
-    LDB-->>SC: ok
-    SC-->>App: Ok | Err(SchemaViolation | RateLimitExceeded | ConstraintViolation)
+    App->>AE: build_usage_record("metric", value).enqueue()
+    AE->>AE: verify token freshness
+    AE->>AE: validate metric in allowed list
+    AE->>AE: validate metric semantics (counter ≥ 0, counter requires idempotency_key)
+    alt subject_id supplied in authorize_for() call
+        AE->>AE: validate subject identity via PDP (already in AuthorizedUsageEmitter token)
+        AE->>AE: bind caller-supplied subject_id / subject_type from token
+    else subject_id not supplied
+        AE->>AE: derive subject_id / subject_type from SecurityContext
+    end
+    AE->>LDB: Outbox::enqueue(record{tenant_id, resource_id, resource_type}) within caller's tx
+    LDB-->>AE: ok
+    AE-->>App: Ok | Err(UsageEmitterError)
 
     Note over OB: Outbox library background pipeline
-    OB->>GW: MessageHandler::handle() → persist(records)
+    OB->>GW: MessageHandler::handle() → create_usage_record(record)
     GW->>GW: validate SecurityContext
-    alt record.tenant_id == ctx.subject_tenant_id()
-        GW->>GW: tenant attribution valid (standard path)
-    else record.tenant_id ≠ ctx.subject_tenant_id()
-        GW->>PDP: emit_on_behalf? (source, record.tenant_id)
-        PDP-->>GW: permit | deny
-    end
     GW->>GW: enforce per-(source, tenant) rate limit
-    GW->>Plugin: persist(records)
+    GW->>Plugin: create_usage_record(record)
     Plugin->>DB: INSERT (idempotent upsert on idempotency_key)
     DB-->>Plugin: ok
     Plugin-->>GW: ok
@@ -584,7 +736,53 @@ sequenceDiagram
     Note over OB: On transient failure: HandlerResult::Retry → exponential backoff<br/>On permanent failure: HandlerResult::Reject → dead-letter store
 ```
 
-**Description**: At module initialization, the usage source calls `for_module()` to obtain a `ScopedUsageCollectorClientV1` bound to its platform identity. For each request that will emit usage, it calls `authorize_emit()` before opening any DB transaction — the scoped client contacts the PDP, fetches the registered usage type schema from types-registry, and fetches the current source-level rate limit quota snapshot; it returns an `EmitAuthorization` token bundling all three (including any tenant `In` constraint from the PDP for sources authorized to emit for multiple tenants), or an immediate `Denied` or `RateLimitExceeded` error. Inside the caller's transaction, `emit()` validates metric semantics, captures subject identity, evaluates all constraints in-memory including tenant validation (`record.tenant_id` must satisfy the PDP tenant constraint or equal `ctx.subject_tenant_id()` if no constraint was returned), and on success stamps the outbox row with `record.tenant_id` and calls `Outbox::enqueue()`. The outbox library's background pipeline then automatically picks up enqueued messages and invokes the SDK's internal `MessageHandler`. The gateway validates tenant attribution on delivery: standard records (where `record.tenant_id == ctx.subject_tenant_id()`) are accepted directly; cross-tenant records trigger a PDP `emit_on_behalf` check per unique target tenant in the batch before plugin delivery. The gateway also enforces per-(source, tenant) rate limits at this point. On `HandlerResult::Success` the outbox advances the partition cursor; on `HandlerResult::Retry` it applies exponential backoff and re-delivers; on `HandlerResult::Reject` it moves the message to the dead-letter store.
+**Description**: At module initialization, the usage source retrieves `UsageEmitterV1` from `ClientHub` (registered by the gateway module during service startup) and calls `for_module()` to obtain a `ScopedUsageEmitter` bound to its platform identity. For each request that will emit usage, it calls `authorize_for()` (or `authorize()` for the subject's home tenant) before opening any DB transaction — the scoped emitter contacts the PDP for `USAGE_RECORD`/`CREATE` with the specified `tenant_id` and resource, and fetches the allowed-metrics list from the gateway; it returns an `AuthorizedUsageEmitter` with the authorized `tenant_id`, `resource_id`, and `resource_type` bound in, or an immediate error on PDP denial. Inside the caller's transaction, `build_usage_record().enqueue()` validates metric semantics and allowed-list membership, resolves optional subject identity — when `subject_id`/`subject_type` are supplied to `authorize_for()`, the token carries the caller-supplied values accepted with PDP authorization; when not supplied, `subject_id`/`subject_type` are derived from `SecurityContext` at `enqueue()` time — stamps the bound context, and calls `Outbox::enqueue()`. The outbox library's background pipeline then automatically picks up enqueued messages and invokes the emitter's internal `MessageHandler`, calling `UsageCollectorClientV1::create_usage_record()` on the gateway. The gateway accepts the `tenant_id` from the delivered record without a second PDP check — tenant attribution was authorized at emit time. On `HandlerResult::Success` the outbox advances the partition cursor; on `HandlerResult::Retry` it applies exponential backoff and re-delivers; on `HandlerResult::Reject` it moves the message to the dead-letter store.
+
+#### Emit Usage Record — Remote Delivery (REST Client)
+
+**ID**: `cpt-cf-usage-collector-seq-emit-remote`
+
+**Use cases**: `cpt-cf-usage-collector-usecase-emit` (remote deployment mode)
+
+**Actors**: `cpt-cf-usage-collector-actor-usage-source` (out-of-process)
+
+The emit path (`authorize_for()` → `build_usage_record().enqueue()`) is identical to the in-process sequence. The difference is in the outbox delivery step: the background pipeline calls the REST client's `create_usage_record()`, which acquires a bearer token and HTTP-POSTs to the gateway.
+
+```mermaid
+sequenceDiagram
+    participant OB as Outbox Pipeline (background)
+    participant RC as UsageCollectorRestClient
+    participant AuthN as authn-resolver
+    participant GW as UC Gateway (HTTP)
+    participant Plugin as Storage Plugin
+    participant DB as ClickHouse / TimescaleDB
+
+    Note over OB: Outbox library background pipeline (source process)
+    OB->>RC: MessageHandler::handle() → create_usage_record(record)
+    RC->>AuthN: acquire bearer token (client credentials)
+    AuthN-->>RC: Bearer <token>
+    RC->>GW: POST /usage-collector/v1/records (Authorization: Bearer <token>, body: UsageRecord)
+    alt token invalid or expired
+        GW-->>RC: 401 Unauthenticated
+        RC-->>OB: HandlerResult::Retry
+    else permanent error (4xx except 429)
+        GW-->>RC: 4xx
+        RC-->>OB: HandlerResult::Reject → dead-letter store
+    else transient error (5xx, 429, network)
+        GW-->>RC: 5xx / timeout
+        RC-->>OB: HandlerResult::Retry → exponential backoff
+    else success
+        GW->>GW: validate SecurityContext; enforce rate limit
+        GW->>Plugin: create_usage_record(record)
+        Plugin->>DB: INSERT (idempotent upsert on idempotency_key)
+        DB-->>Plugin: ok
+        Plugin-->>GW: ok
+        GW-->>RC: 204 No Content
+        RC-->>OB: HandlerResult::Success (outbox advances cursor)
+    end
+```
+
+**Description**: The source's outbox background pipeline invokes the REST client's `MessageHandler`. The REST client acquires a bearer token from the platform AuthN resolver (client credentials flow) before each delivery attempt — token acquisition failure is treated as transient and triggers retry. The record is HTTP-POSTed to the gateway's ingest endpoint with the bearer token in the `Authorization` header. The gateway processes the ingest request identically to the in-process path: validates the security context, enforces rate limits, and delegates to the storage plugin. On `204 No Content` the outbox advances the partition cursor. On permanent 4xx (excluding 429) the message is moved to the dead-letter store. All other errors trigger exponential backoff retry. At-least-once delivery is guaranteed for all records durably committed to the source outbox.
 
 #### Query Aggregated Usage
 
@@ -602,7 +800,7 @@ sequenceDiagram
     participant Plugin as Storage Plugin
     participant DB as ClickHouse / TimescaleDB
 
-    Consumer->>GW: GET /usage/aggregated (ctx, query params)
+    Consumer->>GW: GET /usage-collector/v1/aggregated (ctx, query params)
     GW->>GW: derive tenant_id from SecurityContext
     GW->>PDP: authorize query (ctx, tenant, usage_type?)
     PDP-->>GW: decision + constraints
@@ -632,7 +830,7 @@ sequenceDiagram
     participant Plugin as Storage Plugin
     participant DB as ClickHouse / TimescaleDB
 
-    Consumer->>GW: GET /usage/raw (ctx, time range, filters, cursor)
+    Consumer->>GW: GET /usage-collector/v1/raw (ctx, time range, filters, cursor)
     GW->>GW: derive tenant_id from SecurityContext
     GW->>PDP: authorize query (ctx, tenant, usage_type?)
     PDP-->>GW: decision + constraints
@@ -664,7 +862,7 @@ sequenceDiagram
     participant DB as ClickHouse / TimescaleDB
     participant AS as audit_service
 
-    Op->>GW: POST /usage/backfill (tenant_id, usage_type, range, records)
+    Op->>GW: POST /usage-collector/v1/backfill (tenant_id, usage_type, range, records)
     GW->>PDP: authorize backfill for tenant_id (actor from SecurityContext)
     alt PDP denies or tenant_id violates returned constraint
         PDP-->>GW: deny
@@ -694,7 +892,7 @@ sequenceDiagram
     Note over OB: On transient failure: HandlerResult::Retry → exponential backoff<br/>On permanent failure: HandlerResult::Reject → dead-letter store
 ```
 
-**Description**: Platform operator submits a backfill request specifying `tenant_id`, usage type, time range, and historical records to insert. The gateway first calls the platform PDP to verify the caller is authorized to backfill for the specified `tenant_id`; a PDP denial or a `tenant_id` that violates the returned constraint returns `403 PERMISSION_DENIED` immediately without touching the outbox. Callers whose SecurityContext tenant differs from the requested `tenant_id` require a dedicated cross-tenant backfill PDP permission; the PDP must return a constraint that includes the target tenant. After PDP authorization succeeds, the gateway enforces time boundaries and requires elevated authorization for windows exceeding the configured maximum. On successful validation, the gateway enqueues all backfill records to a gateway-local backfill outbox in a single transaction, then emits a `WriteAuditEvent` to `audit_service` and returns `202 Accepted` to the caller. The outbox library's background pipeline then automatically calls the gateway's internal `MessageHandler` for each individual record. The plugin inserts each record using idempotent upsert — existing records are not modified. Real-time ingestion continues uninterrupted throughout the operation.
+**Description**: Platform operator submits a backfill request specifying `tenant_id`, usage type, time range, and historical records to insert. The gateway first calls the platform PDP to verify the caller is authorized to backfill for the specified `tenant_id`; a PDP denial returns `403 PERMISSION_DENIED` immediately without touching the outbox. After PDP authorization succeeds, the gateway enforces time boundaries and requires elevated authorization for windows exceeding the configured maximum. On successful validation, the gateway enqueues all backfill records to a gateway-local backfill outbox in a single transaction, then emits a `WriteAuditEvent` to `audit_service` and returns `202 Accepted` to the caller. The outbox library's background pipeline then automatically calls the gateway's internal `MessageHandler` for each individual record. The plugin inserts each record using idempotent upsert — existing records are not modified. Real-time ingestion continues uninterrupted throughout the operation.
 
 #### Amend Individual Record
 
@@ -713,7 +911,7 @@ sequenceDiagram
     participant DB as ClickHouse / TimescaleDB
     participant AS as audit_service
 
-    Op->>GW: PATCH /usage/records/{id} (ctx, justification, updated fields)
+    Op->>GW: PATCH /usage-collector/v1/records/{id} (ctx, justification, updated fields)
     GW->>GW: derive tenant_id from SecurityContext
     GW->>PDP: authorize amendment (ctx, tenant, record_id)
     PDP-->>GW: permit | deny
@@ -759,7 +957,7 @@ sequenceDiagram
     participant DB as ClickHouse / TimescaleDB
     participant AS as audit_service
 
-    Op->>GW: POST /usage/records/{id}/deactivate (ctx, justification)
+    Op->>GW: POST /usage-collector/v1/records/{id}/deactivate (ctx, justification)
     GW->>GW: derive tenant_id from SecurityContext
     GW->>PDP: authorize deactivation (ctx, tenant, record_id)
     PDP-->>GW: permit | deny
@@ -801,23 +999,25 @@ The outbox schema is owned by the `modkit-db` shared infrastructure and installe
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Tenant owning this usage record |
-| `source_module` | TEXT | Source module name from `ScopedUsageCollectorClientV1` |
-| `metric_kind` | TEXT | `"counter"` or `"gauge"` |
+| `module` | TEXT | Source module name from `ScopedUsageEmitter` |
+| `kind` | TEXT | `"counter"` or `"gauge"` |
 | `metric` | TEXT | Name of the measured resource metric |
 | `value` | NUMERIC | Numeric measurement value |
 | `timestamp` | TIMESTAMPTZ | When the measurement occurred |
-| `idempotency_key` | TEXT | Client-provided deduplication key; non-null for counter records (enforced by `emit()` before enqueue); nullable for gauge records |
-| `resource_id` | UUID (nullable) | Resource instance this record is attributed to |
-| `resource_type` | TEXT (nullable) | Resource type corresponding to `resource_id` |
+| `idempotency_key` | TEXT | Client-provided deduplication key; non-null for counter records (enforced by `enqueue()` before outbox INSERT); nullable for gauge records |
+| `resource_id` | UUID | Resource instance this record is attributed to (required) |
+| `resource_type` | TEXT | Resource type corresponding to `resource_id` (required) |
 | `subject_id` | UUID (nullable) | Subject (user/service account) from SecurityContext |
 | `subject_type` | TEXT (nullable) | Subject type corresponding to `subject_id` |
-| `metadata` | JSON object (nullable) | Optional opaque metadata; size validated by SDK before enqueue (default 8 KB limit) |
+| `metadata` | JSON object (nullable) | Optional opaque metadata; size validated by emitter before enqueue (default 8 KB limit) |
 
-**Payload invariants** (enforced by SDK before `Outbox::enqueue()` is called): `tenant_id`, `source_module`, `metric_kind`, `metric`, `value`, `timestamp` are all non-null. `idempotency_key` is non-null for counter records.
+**Payload invariants** (enforced by emitter before `Outbox::enqueue()` is called): `tenant_id`, `module`, `kind`, `metric`, `value`, `timestamp`, `resource_id`, `resource_type` are all non-null. `idempotency_key` is non-null for counter records.
 
 **Dead letters**: Messages permanently rejected by the SDK's delivery handler (`HandlerResult::Reject`) are moved to the outbox dead-letter store by the library. Dead-letter management (replay, resolve, discard) is available via the `Outbox` dead-letter API.
 
 #### Storage Backend Tables (plugin-owned)
+
+**ID**: `cpt-cf-usage-collector-dbtable-records`
 
 Storage table schemas are defined and owned by each plugin implementation. The gateway does not define, access, or migrate storage tables directly. Each plugin is responsible for its own schema migration lifecycle.
 
@@ -826,14 +1026,14 @@ Storage table schemas are defined and owned by each plugin implementation. The g
 | Column | Purpose |
 |--------|---------|
 | `tenant_id` | Tenant scoping and isolation; required filter on all queries |
-| `source_module` | Source module identity; enables per-module metric auditing |
-| `metric_kind` | `"counter"` or `"gauge"`; governs aggregation semantics |
+| `module` | Source module identity; enables per-module metric auditing |
+| `kind` | `"counter"` or `"gauge"`; governs aggregation semantics |
 | `metric` | Name of the measured resource metric |
 | `value` | Measured numeric value |
 | `timestamp` | Measurement time; primary partitioning and ordering dimension |
 | `idempotency_key` | Deduplication key; NOT NULL for counter records, nullable for gauge records; unique constraint or upsert target per plugin for non-null values |
-| `resource_id` | Resource instance attribution; nullable |
-| `resource_type` | Resource type attribution; nullable |
+| `resource_id` | Resource instance attribution; NOT NULL (required at emit time) |
+| `resource_type` | Resource type attribution; NOT NULL (required at emit time) |
 | `subject_id` | Subject attribution from SecurityContext; nullable |
 | `subject_type` | Subject type attribution; nullable |
 | `ingested_at` | When the collector received and persisted the record |
@@ -850,7 +1050,7 @@ Storage table schemas are defined and owned by each plugin implementation. The g
 | Metric filter index | `(tenant_id, metric, timestamp)` | Supports `usage_type` filter in aggregation and raw queries |
 | Subject filter index | `(tenant_id, subject_id, timestamp)` | Supports `subject` filter in aggregation and raw queries |
 | Resource filter index | `(tenant_id, resource_id, timestamp)` | Supports `resource` filter in aggregation and raw queries |
-| Idempotency deduplication | `(tenant_id, idempotency_key)` — unique or upsert target | Required for idempotent `persist()` and `backfill_ingest()` |
+| Idempotency deduplication | `(tenant_id, idempotency_key)` — unique or upsert target | Required for idempotent `create_usage_record()` and `backfill_ingest()` |
 
 Storage-native index types (ClickHouse sorting key, TimescaleDB btree/brin) are at the plugin's discretion, provided they satisfy the query latency NFR.
 
@@ -860,7 +1060,7 @@ Storage-native index types (ClickHouse sorting key, TimescaleDB btree/brin) are 
 
 Counter semantics (`cpt-cf-usage-collector-fr-counter-semantics`) define the total for a `(tenant_id, metric)` pair as a monotonically increasing value that grows as non-negative deltas are ingested.
 
-**Source of truth — delta records as the persistent store**: The plugin-owned usage records table is the authoritative record of all submitted deltas. There is no separate totals table in the baseline schema. The persistent total for any `(tenant_id, metric)` pair is computed as `SUM(value)` over all active records matching that key for the desired time range. Because all delta values are non-negative (enforced at emit time by `ScopedUsageCollectorClientV1.emit()`), the cumulative SUM is guaranteed to be monotonically increasing.
+**Source of truth — delta records as the persistent store**: The plugin-owned usage records table is the authoritative record of all submitted deltas. There is no separate totals table in the baseline schema. The persistent total for any `(tenant_id, metric)` pair is computed as `SUM(value)` over all active records matching that key for the desired time range. Because all delta values are non-negative (enforced at emit time by `AuthorizedUsageEmitter.enqueue()`), the cumulative SUM is guaranteed to be monotonically increasing.
 
 **Accumulation key vs. full attribution tuple**: `cpt-cf-usage-collector-fr-counter-semantics` scopes the total to `(tenant_id, metric)`. The full record carries additional attribution dimensions — `source_module`, `resource_id`, `resource_type`, `subject_id`, `subject_type` — that enable GROUP BY breakdowns within `query_aggregated`. The counter total per `(tenant_id, metric)` is the SUM across all attribution dimensions for that pair; narrower totals (e.g., per `resource_id`) are query-time GROUP BY variants of the same underlying delta records.
 
@@ -980,7 +1180,7 @@ The outbox pattern implementation relies on the modkit-db outbox infrastructure.
 | **Tampering** | Overwriting existing records on delivery | Idempotent upsert prevents silent overwrite; `version` field enforces optimistic concurrency on amendments; all operator-initiated writes produce a `WriteAuditEvent` to `audit_service` |
 | **Repudiation** | Operator denies issuing a backfill, amendment, or deactivation | `WriteAuditEvent` emitted to `audit_service` for every operator-initiated write; events are not stored locally to prevent local tampering (`cpt-cf-usage-collector-fr-audit`) |
 | **Information Disclosure** | Cross-tenant data access via query API | All queries scoped to the authenticated tenant from `SecurityContext`; PDP constraints applied as additional query filters; system fails closed on any authorization failure (`cpt-cf-usage-collector-principle-fail-closed`) |
-| **Denial of Service** | Outbox flooding or backfill saturation by a single source | Rate limiting enforced by `authorize_emit()` before any transaction (`cpt-cf-usage-collector-fr-rate-limiting`); independent rate limits on the backfill outbox pipeline prevent storage saturation; dead-letter state surfaces unhealthy sources via monitoring |
+| **Denial of Service** | Outbox flooding or backfill saturation by a single source | Rate limiting enforced by `authorize_for()` before any transaction (`cpt-cf-usage-collector-fr-rate-limiting`); independent rate limits on the backfill outbox pipeline prevent storage saturation; dead-letter state surfaces unhealthy sources via monitoring |
 | **Elevation of Privilege** | Accessing oversized backfill windows without elevated authorization | Elevated authorization required for requests exceeding the configured maximum backfill window; all authorization failures result in immediate rejection with no partial operation (`cpt-cf-usage-collector-principle-fail-closed`) |
 
 **Not applicable — Recovery architecture**: Backup strategy, point-in-time recovery, and disaster recovery for ClickHouse and TimescaleDB storage backends are governed by platform infrastructure policy and managed by the platform SRE team; this module's design does not define storage backup topology. The transactional outbox ensures that records durably captured in source outboxes can be re-delivered if storage data is restored from a backup.

--- a/modules/system/usage-collector/docs/PRD.md
+++ b/modules/system/usage-collector/docs/PRD.md
@@ -1,3 +1,22 @@
+---
+cpt:
+  kind: PRD
+  id: cpt-cf-usage-collector-prd
+  version: 0.2.0
+  changelog:
+    - version: 0.2.0
+      date: 2026-04-28
+      changes:
+        - "Updated functional requirements: `subject_id` and `subject_type` are now
+          optional fields; PDP validation is conditional on their presence.
+          Changed requirements: cpt-cf-usage-collector-fr-subject-attribution,
+          cpt-cf-usage-collector-fr-subject-attribution (acceptance criterion)."
+    - version: 0.1.0
+      date: 2026-01-01
+      changes:
+        - Initial version.
+---
+
 # PRD — Usage Collector
 
 
@@ -123,7 +142,7 @@ The Usage Collector addresses this by accepting usage records from sources and p
 
 **ID**: `cpt-cf-usage-collector-actor-usage-source`
 
-- **Role**: Any platform service that produces usage records (e.g., LLM Gateway, Compute Service, API Gateway). Uses the Usage Collector SDK to emit records.
+- **Role**: Any system that produces usage records. This includes in-process platform services using the SDK (e.g., LLM Gateway, Compute Service, API Gateway), remote CyberFabric nodes forwarding collected records via the REST API, and external non-CyberFabric systems submitting records directly via the REST API using OAuth2 client credentials.
 
 #### Usage Consumer
 
@@ -156,7 +175,7 @@ The Usage Collector addresses this by accepting usage records from sources and p
 | `cpt-cf-usage-collector-actor-platform-operator` | Configure and delete retention policies (except global default); submit backfill operations; amend and deactivate individual records; register custom usage types; view watermarks and ingestion metadata | Querying or modifying records belonging to any tenant without an explicit security context; deleting the global default retention policy |
 | `cpt-cf-usage-collector-actor-platform-developer` | Emit usage records via the SDK within the source module's authorized metric namespace and tenant scope | Emitting metrics outside the source module's authorized namespace; attributing records to subjects or resources outside the authorized scope |
 | `cpt-cf-usage-collector-actor-tenant-admin` | Query aggregated and raw usage records scoped to their own tenant; view watermarks for their tenant | Accessing usage data of any other tenant; invoking operator-only operations (backfill, amendment, deactivation, retention policy management) |
-| `cpt-cf-usage-collector-actor-usage-source` | Emit authorized metrics within the source module's namespace via the SDK; the scope of permitted metrics and target tenants is enforced by the platform PDP at emit time — sources authorized only for their own tenant may only emit for that tenant; sources explicitly authorized for multiple tenants may emit records attributed to any tenant within their PDP-returned allowed set | Emitting metrics outside the authorized namespace; emitting records attributed to tenants outside the PDP-authorized scope; bypassing `authorize_emit()`; submitting records attributed to other sources |
+| `cpt-cf-usage-collector-actor-usage-source` | Emit metrics valid for the claimed module type via the SDK or REST API; the scope of permitted target tenants is enforced by the platform PDP at emit time — the caller must be PDP-authorized for the tenant supplied in the record, covering both same-tenant and parent→subtenant scenarios | Emitting records attributed to tenants outside the PDP-authorized scope; emitting metrics not registered for the claimed module type |
 | `cpt-cf-usage-collector-actor-usage-consumer` | Query aggregated and raw usage data scoped to the authenticated tenant; subject to PDP constraint filters | Accessing cross-tenant data; mutating usage records |
 | `cpt-cf-usage-collector-actor-storage-backend` | Receive and persist usage records forwarded by the gateway plugin; respond to query and retention operations initiated by the plugin | Direct access from any actor other than the authorized storage plugin instance |
 | `cpt-cf-usage-collector-actor-types-registry` | Respond to schema registration and validation requests initiated by the gateway | N/A — passive service; does not initiate operations on the Usage Collector |
@@ -198,13 +217,26 @@ No module-specific environment constraints beyond project defaults.
 
 ### 5.1 Usage Ingestion
 
-#### Usage Record Ingestion
+#### SDK Usage Record Ingestion
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-ingestion`
 
-The system **MUST** accept usage records from platform services. Each usage record represents a single measurement of resource consumption attributed to a tenant.
+The system **MUST** accept usage records from in-process platform services via the Usage Collector SDK. Each usage record represents a single measurement of resource consumption attributed to a tenant.
 
 - **Rationale**: Centralizing usage ingestion ensures all downstream consumers operate on the same data.
+- **Actors**: `cpt-cf-usage-collector-actor-usage-source`
+
+#### REST API Usage Record Ingestion
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-rest-ingestion`
+
+The system **MUST** expose a REST API endpoint for usage record submission, enabling remote CyberFabric nodes and external non-CyberFabric systems to submit records over HTTP using OAuth2 client credentials. The REST ingestion path **MUST** be subject to identical PDP authorization and validation rules as the SDK ingestion path.
+
+For trusted CyberFabric forwarder modules (e.g., `usage-collector-rest-client`), a two-level authorization model applies: PDP authorization is enforced at the source side against the original caller's SecurityContext before any record enters the forwarder's outbox; the gateway REST endpoint then authenticates the forwarder via service-to-service bearer token and applies a gateway-level PDP check against the forwarder's service identity. Both checks must pass before any record is accepted for storage.
+
+For external non-CyberFabric systems calling the REST endpoint directly, the gateway PDP check against the caller's OAuth2 identity is the sole authorization boundary.
+
+- **Rationale**: Remote and external sources that cannot embed the SDK — such as remote collection agents forwarding records from distributed locations, or third-party systems integrated with the platform — must be able to contribute usage data through the same authoritative store without requiring a SDK dependency. The two-level model for CyberFabric forwarders preserves per-caller authorization at the source while maintaining gateway-level enforcement against the forwarder's service identity.
 - **Actors**: `cpt-cf-usage-collector-actor-usage-source`
 
 #### Idempotent Ingestion
@@ -264,27 +296,25 @@ The system **MUST** guarantee at-least-once delivery of usage records from sourc
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-tenant-attribution`
 
-The system **MUST** attribute all usage records to a tenant that is authorized by the platform PDP at emit time. For sources that emit only for their own tenant, the tenant is derived from the authenticated SecurityContext. For sources explicitly authorized by the PDP to emit on behalf of multiple tenants (e.g., a platform-level metering agent collecting data from a shared hypervisor), the tenant is taken from the record as supplied by the caller and **MUST** satisfy the PDP-returned tenant constraint evaluated in-memory by `emit()` before the record is accepted. In all cases, tenant identity **MUST NOT** be accepted from request payloads without prior PDP authorization. The gateway **MUST** independently validate tenant attribution on ingest as a defense-in-depth check.
+The system **MUST** attribute all usage records to a tenant supplied by the caller in the request. The system **MUST** authorize the caller's tenant attribution via the platform PDP before any record is accepted, verifying that the authenticated caller is permitted to emit records for the specified tenant. This covers both same-tenant emission and parent→subtenant scenarios (e.g., a platform-level metering agent collecting usage for resources owned by its subtenants). The gateway **MUST** independently validate tenant attribution on ingest as a defense-in-depth check.
 
-- **Rationale**: PDP-gated tenant attribution prevents spoofing while enabling platform-level metering agents that collect usage for resources (e.g., virtual machines) owned by multiple tenants from a single process. Without this capability, such agents would require per-tenant service account credentials, creating operational complexity proportional to tenant count. PDP authorization remains the single source of truth for what tenants any given source is permitted to report for.
+- **Rationale**: Requiring callers to supply the target tenant explicitly supports all emission scenarios — including remote forwarders and external systems that emit records on behalf of multiple tenants — through a single uniform path. PDP authorization remains the security boundary enforcing which tenants a given caller is permitted to report for.
 - **Actors**: `cpt-cf-usage-collector-actor-usage-source`
 
 #### Resource Attribution
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-resource-attribution`
 
-The system **MUST** support attributing usage records to specific resource instances within a tenant, identified by a resource ID and resource type.
+Every usage record **MUST** be attributed to a specific resource instance within a tenant, identified by a resource ID and resource type. Resource attribution is mandatory; the system **MUST** reject records that omit either field.
 
-- **Rationale**: Per-resource attribution enables granular billing, per-resource quota enforcement, and detailed usage analysis at the resource level.
+- **Rationale**: Per-resource attribution enables granular billing, per-resource quota enforcement, and detailed usage analysis at the resource level. Mandatory attribution ensures downstream consumers always have a resource scope to aggregate and filter on, without needing to handle the absence of this field.
 - **Actors**: `cpt-cf-usage-collector-actor-usage-source`
 
 #### Subject Attribution
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-subject-attribution`
 
-The system **MUST** support attributing usage records to a subject (user, service account, or other principal) within a tenant, identified by a subject ID and subject type. Subject attribution **MUST** always be derived from the authenticated SecurityContext — the system **MUST NOT** accept subject identity from request payloads.
-
-Subject attribution is optional per usage record to accommodate system-level resource consumption not attributable to a specific subject (e.g., background jobs where per-user attribution is not meaningful).
+The system **MUST** support attributing usage records to a subject (user, service account, or other principal) within a tenant, identified by a subject ID and subject type. Subject attribution is **optional** per usage record to accommodate system-level resource consumption not attributable to a specific subject (e.g., background jobs where per-user attribution is not meaningful). The system **MUST** accept usage records where `subject_id` and `subject_type` are not provided. When `subject_id` and `subject_type` are provided, the system **MUST** validate them against PDP authorization; when they are absent, PDP subject validation is skipped.
 
 - **Rationale**: Per-subject attribution enables chargeback, per-subject quota enforcement, and visibility into which principals drive consumption within a tenant. Deriving subject identity server-side from SecurityContext prevents spoofing.
 - **Actors**: `cpt-cf-usage-collector-actor-usage-source`
@@ -303,13 +333,16 @@ The system **MUST** enforce strict tenant isolation on all read and write operat
 
 - [ ] `p1` - **ID**: `cpt-cf-usage-collector-fr-ingestion-authorization`
 
-The system **MUST** authorize each usage record emission before it is persisted. Authorization **MUST** verify that the emitting source module is permitted to report the specific metrics being submitted, and that any attributed resource and subject are within the emitting module's authorized scope.
+The system **MUST** authorize each usage record emission before it is persisted. The security boundary for ingestion authorization is the PDP check on the caller's authenticated identity against the target tenant and resource — the system **MUST** verify the caller is permitted to emit records for the specified tenant and resource before any record is accepted.
 
-Each source module has a fixed, platform-assigned identity that is the basis for authorization. A source module **MUST** only be permitted to emit metrics within its authorized domain; emissions outside that domain **MUST** be rejected before any record is persisted.
+The `module` field in a usage record identifies the originating source for attribution and metric validation purposes. Its semantics differ by ingestion path:
 
-Authorization failures **MUST** be surfaced immediately to the caller before any domain operation is committed. The system **MUST** fail closed: unauthorized records are never persisted, and there is no silent discard of denied emissions.
+- **SDK ingestion**: module identity is set in-process at SDK client construction time and is implicitly trusted as the emitting service's own identity.
+- **REST API ingestion**: the `module` field is caller-supplied attribution metadata, accepted on trust. It is used to validate that the emitted metric is registered for the claimed module type (a data quality check), but it is not a security authorization principal — the PDP check on tenant and resource is the authoritative security enforcement.
 
-- **Rationale**: Without ingestion authorization, any module could report usage for metric types it does not own (e.g., a file-storage service reporting LLM token usage) or attribute usage to subjects and resources beyond its authorized scope, leading to inaccurate metering, billing errors, and cross-boundary data pollution. Binding source identity at initialization time rather than per-call makes the authorization scope auditable and eliminates per-call spoofing surface.
+The system **MUST** validate that the emitted metric is registered for the module type claimed in the record, rejecting records that reference metrics not associated with the claimed module. Authorization failures **MUST** be surfaced immediately to the caller before any domain operation is committed. The system **MUST** fail closed: unauthorized records are never persisted, and there is no silent discard of denied emissions.
+
+- **Rationale**: Decoupling module attribution from the authorization security boundary enables the REST ingestion path to support legitimate forwarding scenarios — such as a remote agent relaying records originally produced by multiple named source modules — without requiring per-module credentials. The PDP remains the authoritative enforcement point for what tenants and resources a caller may emit for. Metric validation against the claimed module type preserves data quality by ensuring records carry a plausible and registered module identity.
 - **Actors**: `cpt-cf-usage-collector-actor-usage-source`
 
 ### 5.5 Pluggable Storage
@@ -451,9 +484,9 @@ Routine ingestion and read operations are not audited via `audit_service`.
 
 The system **MUST** enforce rate limits on usage record emission at two levels:
 
-**Source-level (enforced at the SDK, before any outbox INSERT)**: A configurable per-source emission quota limits the total number of records a source module may emit across all tenants within a rate limit window. `authorize_emit()` fetches the current source-level quota snapshot before any DB transaction opens; `emit()` evaluates it in-memory and rejects the emission if the quota is exhausted. This provides low-latency, source-side flood prevention without requiring per-tenant quota pre-fetching at emit time.
+**Source-level (enforced at the SDK, before any outbox INSERT)**: A configurable per-source emission quota limits the total number of records a source module may emit across all tenants within a rate limit window. `authorize_for()` fetches the current source-level quota snapshot before any DB transaction opens; `enqueue()` evaluates it in-memory and rejects the emission if the quota is exhausted. This provides low-latency, source-side flood prevention without requiring per-tenant quota pre-fetching at emit time.
 
-**Per-tenant (enforced at the gateway on ingest)**: A configurable per-(source module, tenant) quota limits the number of records a source may deliver for any single tenant within a rate limit window. The gateway enforces this on the inbound `persist()` call, after the record's `tenant_id` is known. This provides granular per-tenant protection at delivery time.
+**Per-tenant (enforced at the gateway on ingest)**: A configurable per-(source module, tenant) quota limits the number of records a source may deliver for any single tenant within a rate limit window. The gateway enforces this on the inbound `create_usage_record()` call, after the record's `tenant_id` is known. This provides granular per-tenant protection at delivery time.
 
 Rate limits are configured by the platform operator. An operator **MAY** configure a default quota that applies when no explicit entry exists; if neither applies, no rate limit is enforced.
 
@@ -643,6 +676,15 @@ The following commonly applicable NFR categories are not applicable to this modu
 - **Description**: Public interface for emitting usage records and querying aggregated data; technical interface type and crate naming defined in DESIGN.md
 - **Breaking Change Policy**: Unstable during initial development; will stabilize in future version
 
+#### REST Ingestion API
+
+- [ ] `p1` - **ID**: `cpt-cf-usage-collector-interface-rest-ingestion`
+
+- **Type**: HTTP REST API
+- **Stability**: unstable (v0)
+- **Description**: HTTP endpoint for submitting usage records from remote or external sources; authentication via OAuth2 client credentials; request and response schema defined in DESIGN.md
+- **Breaking Change Policy**: Unstable during initial development; will stabilize in future version
+
 ### 7.2 External Integration Contracts
 
 #### Storage Plugin Contract
@@ -734,11 +776,11 @@ The following commonly applicable NFR categories are not applicable to this modu
 - [ ] Duplicate records with the same idempotency key result in a single stored record
 - [ ] Counter records with negative values are rejected at ingestion
 - [ ] Gauge records are stored as-is without monotonicity constraints
-- [ ] Usage records are attributed to the correct tenant, derived from SecurityContext
-- [ ] Usage records can be attributed to a specific resource (resource ID and type)
-- [ ] Usage records can be attributed to a specific subject (subject ID and type), derived from SecurityContext
+- [ ] Incoming usage records include an explicit tenant attribute; the platform PDP validates that the authenticated caller is authorized to emit records for the specified tenant before the record is accepted, and the gateway independently validates tenant attribution on ingest as a defense-in-depth check
+- [ ] Every usage record includes resource attribution (resource ID and type); records without either field are rejected
+- [ ] Usage records can optionally be attributed to a subject (subject ID and type); when supplied with PDP authorization, subject is accepted from the request payload; when absent, PDP subject validation is skipped
 - [ ] Authorization failures are surfaced immediately to the caller; no record is persisted on denial
-- [ ] An `EmitAuthorization` token older than `MAX_AUTH_AGE` (30 seconds) is rejected by `emit()` with an `AuthorizationExpired` error before any record is accepted for delivery
+- [ ] An `AuthorizedUsageEmitter` token older than `MAX_AUTH_AGE` (30 seconds) is rejected by `enqueue()` with an `UsageEmitterError::AuthorizationExpired` error before any record is accepted for delivery
 - [ ] A source module that exceeds its configured emission quota for a given tenant within the current rate limit window is rejected with an actionable error before any record is accepted for delivery
 - [ ] Rate limit configuration can be set per (source module, tenant) pair; a default per-source quota applies when no tenant-specific entry exists
 - [ ] Rate limit enforcement does not degrade ingestion latency for emissions within quota
@@ -768,6 +810,9 @@ The following commonly applicable NFR categories are not applicable to this modu
 - [ ] Every operator-initiated write operation (backfill, amendment, deactivation) emits a structured audit event to the platform `audit_service` with the required common fields and operation-specific context; justification is required and included in every such event
 - [ ] All API operations require authentication; unauthenticated requests are rejected before any operation is performed
 - [ ] Authorization is enforced on all read and write operations; unauthorized requests are rejected and no data is exposed or modified
+- [ ] The REST ingestion endpoint (`cpt-cf-usage-collector-fr-rest-ingestion`) rejects requests from `cpt-cf-usage-collector-actor-usage-source` that carry no bearer token or an invalid/expired OAuth2 client-credentials token with HTTP 401; requests carrying a valid token proceed to PDP evaluation
+- [ ] When a trusted CyberFabric forwarder (e.g., `usage-collector-rest-client`) acting as `cpt-cf-usage-collector-actor-usage-source` submits records via the REST endpoint (`cpt-cf-usage-collector-fr-rest-ingestion`), the source-side PDP check against the original caller's SecurityContext must pass before any record enters the forwarder's outbox, and the gateway-side PDP check against the forwarder's service identity must also pass; a failure at either level causes the record to be rejected
+- [ ] When an external non-CyberFabric `cpt-cf-usage-collector-actor-usage-source` calls the REST ingestion endpoint (`cpt-cf-usage-collector-fr-rest-ingestion`) directly, only the gateway PDP check against the caller's OAuth2 identity is applied; records are accepted when that check passes and rejected otherwise
 - [ ] Throughput scales linearly as additional instances are added
 - [ ] Durably captured records are eventually persisted to the storage backend and available for querying after storage backend recovery
 - [ ] Retention periods can be configured from 7 days to 7 years per usage type and per tenant

--- a/modules/system/usage-collector/docs/features/0001-cpt-cf-usage-collector-feature-sdk-and-ingest-core.md
+++ b/modules/system/usage-collector/docs/features/0001-cpt-cf-usage-collector-feature-sdk-and-ingest-core.md
@@ -1,0 +1,547 @@
+---
+cpt:
+  version: "1.10"
+  changelog:
+    - version: "1.10"
+      date: "2026-04-28"
+      changes:
+        - "Fix backoff_max → outbox_backoff_max rename (6 occurrences at lines 157, 260, 337, 444, 489, 521); rewrite hot-path annotation for get_module_config() to accurately describe REST HTTP GET to inst-cfg-2 and gateway in-memory config serving."
+    - version: "1.9"
+      date: "2026-04-28"
+      changes:
+        - "Make subject_id/subject_type optional in authorize_for() input (Option<Uuid>/Option<String>); update inst-authz-2 to pass SUBJECT_ID/SUBJECT_TYPE conditionally when present; update inst-authz-6 to bind subject as optional into token; update inst-enq-6 to validate subject match conditionally; update inst-enq-8 to note subject fields serialize as absent when None; update DoD emitter and SDK crate descriptions; add acceptance criteria for subject-absent path."
+    - version: "1.8"
+      date: "2026-04-27"
+      changes:
+        - "Add subject_id/subject_type to authorize_for() input; extend PDP call (inst-authz-2) with MODULE+SUBJECT properties; bind subject into token (inst-authz-6); replace SecurityContext capture with token validation in inst-enq-6."
+    - version: "1.7"
+      date: "2026-04-27"
+      changes:
+        - "§3 inst-enq-5, inst-enq-5b: define blank-as-missing semantics for idempotency_key — empty or whitespace-only strings MUST be treated as absent (equivalent to None)"
+    - version: "1.6"
+      date: "2026-04-27"
+      changes:
+        - "§3 authorize-for: added inst-authz-5b — collector infrastructure failures (PluginTimeout, CircuitOpen, Unavailable, Internal) now return UsageEmitterError::Internal instead of AuthorizationFailed; fixes misclassification of retryable failures as 403 policy denials"
+    - version: "1.5"
+      date: "2026-04-27"
+      changes:
+        - "§3 inst-dlv-6: clarified transient failure list to explicitly include connection/transport errors and AuthN service unavailability; introduces UsageCollectorError::Unavailable as the carrier for these cases"
+    - version: "1.4"
+      date: "2026-04-27"
+      changes:
+        - "§3: removed inst-authz-1 (no-open-transaction assertion — not implementable due to platform limitations); renumbered authorize-for steps; marked authorize-for algo [x]"
+        - "§3: added inst-enq-5b code marker; marked step [x]"
+        - "§1: updated featstatus and DECOMP ref to [x] — all p1 DoD items and CDSL blocks complete"
+    - version: "1.3"
+      date: "2026-04-26"
+      changes:
+        - "§3: added queue overflow, message ordering, optional field serialization, and cache integration N/A notes (fixes REL-FDESIGN-004, INT-FDESIGN-004, DATA-FDESIGN-003)"
+        - "§5.2: added data access patterns N/A, data archival N/A, connection management N/A notes (fixes DATA-FDESIGN-001, DATA-FDESIGN-004, INT-FDESIGN-002)"
+        - "§5.3: added recovery, data archival N/A, configuration table, health & diagnostics, encryption constraint deferral (fixes REL-FDESIGN-005, DATA-FDESIGN-004, OPS-FDESIGN-002/003)"
+        - "§2/§3/§5.4: added p2 deferral notes on deferred CDSL items (fix MAINT-FDESIGN-003)"
+        - "§5: added Known Limitations / Technical Debt subsection (fix MAINT-FDESIGN-003)"
+        - "§6: added test data requirements, test coverage guidance, success metrics (fixes TEST-FDESIGN-001/002, BIZ-FDESIGN-002)"
+    - version: "1.2"
+      date: "2026-04-26"
+      changes:
+        - "§3: added hot-path annotation for `authorize_for()` (fix PERF-FDESIGN-001)"
+        - "§5.2: added resource management, concurrency, and observability notes (fixes PERF-FDESIGN-002, PERF-FDESIGN-003, OPS-FDESIGN-001)"
+        - "§5.3: added observability and rollout/rollback notes (fixes OPS-FDESIGN-001, OPS-FDESIGN-004)"
+        - "§1.2: added NFR target reference (fix PERF-FDESIGN-004)"
+    - version: "1.1"
+      date: "2026-04-26"
+      changes:
+        - "§1.3: replaced inline actor definition table with PRD reference list (fix BIZ-FDESIGN-NO-001)"
+        - "§1.2: added `p2` priority annotation to `cpt-cf-usage-collector-fr-record-metadata` (fix SEM-FDESIGN-005)"
+---
+
+# Feature: Core SDK, Emitter & In-Process Ingest
+
+
+<!-- toc -->
+
+- [1. Feature Context](#1-feature-context)
+  - [1.1 Overview](#11-overview)
+  - [1.2 Purpose](#12-purpose)
+  - [1.3 Actors](#13-actors)
+  - [1.4 References](#14-references)
+- [2. Actor Flows (CDSL)](#2-actor-flows-cdsl)
+  - [Usage Emission Flow](#usage-emission-flow)
+  - [Module Config Retrieval Flow](#module-config-retrieval-flow)
+- [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
+  - [Phase 1: `authorize_for()` Authorization](#phase-1-authorize_for-authorization)
+  - [Phase 2: `build_usage_record().enqueue()` — In-Transaction Enqueue](#phase-2-build_usage_recordenqueue--in-transaction-enqueue)
+  - [Outbox Delivery `MessageHandler`](#outbox-delivery-messagehandler)
+  - [Gateway Ingest Handler](#gateway-ingest-handler)
+  - [Static Module Config Resolution](#static-module-config-resolution)
+- [4. States (CDSL)](#4-states-cdsl)
+- [5. Definitions of Done](#5-definitions-of-done)
+  - [SDK Crate (`usage-collector-sdk`)](#sdk-crate-usage-collector-sdk)
+  - [Emitter Crate (`usage-emitter`)](#emitter-crate-usage-emitter)
+  - [Gateway Crate (`usage-collector`) — Ingest & Config](#gateway-crate-usage-collector--ingest--config)
+  - [No-Op Storage Plugin (`noop-usage-collector-storage-plugin`)](#no-op-storage-plugin-noop-usage-collector-storage-plugin)
+  - [Known Limitations / Technical Debt](#known-limitations--technical-debt)
+- [6. Acceptance Criteria](#6-acceptance-criteria)
+- [7. Non-Applicability Notes](#7-non-applicability-notes)
+
+<!-- /toc -->
+
+- [x] `p2` - **ID**: `cpt-cf-usage-collector-featstatus-sdk-and-ingest-core`
+<!-- STATUS: IMPLEMENTED — all p1 DoD items and all CDSL blocks are [x]. -->
+
+<!-- reference to DECOMPOSITION entry -->
+- [x] `p1` - `cpt-cf-usage-collector-feature-sdk-and-ingest-core`
+## 1. Feature Context
+
+### 1.1 Overview
+
+Establishes the core Usage Collector data model, SDK trait boundaries, two-phase authorization emitter, transactional outbox pipeline, gateway ingest handler, static metric configuration, and no-op storage plugin — delivering the complete in-process emission path from `authorize_for()` through the outbox background pipeline to the gateway and plugin.
+
+### 1.2 Purpose
+
+Implements the foundation for all usage collection capabilities. Covers the SDK crate (`usage-collector-sdk`), the emitter crate (`usage-emitter`), the gateway crate (`usage-collector`) ingest and config endpoints, and the no-op storage plugin (`noop-usage-collector-storage-plugin`). This feature is the prerequisite for all other Usage Collector features.
+
+**Requirements**: `cpt-cf-usage-collector-fr-ingestion`, `cpt-cf-usage-collector-fr-idempotency`, `cpt-cf-usage-collector-fr-delivery-guarantee`, `cpt-cf-usage-collector-fr-counter-semantics`, `cpt-cf-usage-collector-fr-gauge-semantics`, `cpt-cf-usage-collector-fr-tenant-attribution`, `cpt-cf-usage-collector-fr-resource-attribution`, `cpt-cf-usage-collector-fr-subject-attribution`, `cpt-cf-usage-collector-fr-tenant-isolation`, `cpt-cf-usage-collector-fr-ingestion-authorization`, `cpt-cf-usage-collector-fr-pluggable-storage`, `cpt-cf-usage-collector-fr-record-metadata` (`p2`), `cpt-cf-usage-collector-nfr-availability`, `cpt-cf-usage-collector-nfr-ingestion-latency`, `cpt-cf-usage-collector-nfr-authentication`, `cpt-cf-usage-collector-nfr-authorization`, `cpt-cf-usage-collector-nfr-scalability`, `cpt-cf-usage-collector-nfr-fault-tolerance`, `cpt-cf-usage-collector-nfr-recovery`, `cpt-cf-usage-collector-nfr-graceful-degradation`, `cpt-cf-usage-collector-nfr-rpo`
+
+**NFR targets (from PRD)**: `cpt-cf-usage-collector-nfr-ingestion-latency`
+and `cpt-cf-usage-collector-nfr-availability` define numeric targets; values
+are defined in PRD §NFRs and are not reproduced here. See PRD for
+response-time and throughput targets.
+
+**Principles**: `cpt-cf-usage-collector-principle-source-side-persistence`, `cpt-cf-usage-collector-principle-pluggable-storage`, `cpt-cf-usage-collector-principle-tenant-from-ctx`, `cpt-cf-usage-collector-principle-fail-closed`, `cpt-cf-usage-collector-principle-scoped-source-attribution`, `cpt-cf-usage-collector-principle-two-phase-authz`
+
+### 1.3 Actors
+
+**Actors** (defined in PRD.md):
+- `cpt-cf-usage-collector-actor-usage-source` — initiates emission flows
+- `cpt-cf-usage-collector-actor-platform-developer` — SDK integrator
+- `cpt-cf-usage-collector-actor-storage-backend` — storage delegation target
+
+### 1.4 References
+
+- **PRD**: [PRD.md](../PRD.md)
+- **Design**: [DESIGN.md](../DESIGN.md)
+- **DECOMPOSITION**: [DECOMPOSITION.md](../DECOMPOSITION.md)
+- **Dependencies**: None
+
+## 2. Actor Flows (CDSL)
+
+### Usage Emission Flow
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-flow-sdk-and-ingest-core-emit`
+
+**Actor**: `cpt-cf-usage-collector-actor-usage-source`
+
+**Success Scenarios**:
+- Record is durably enqueued in the source's local outbox within the caller's DB transaction
+- Outbox background pipeline delivers the record to the gateway; plugin confirms storage
+
+**Error Scenarios**:
+- PDP denies `USAGE_RECORD`/`CREATE` → `UsageEmitterError::AuthorizationDenied`; no outbox INSERT
+- Module not configured → `UsageEmitterError::ModuleNotConfigured`; no outbox INSERT
+- Metric not in allowed list → `UsageEmitterError::MetricNotAllowed`; no outbox INSERT
+- Counter record with negative value or missing idempotency key → `UsageEmitterError::InvalidRecord`; no outbox INSERT
+- `AuthorizedUsageEmitter` token exceeded max age → `UsageEmitterError::TokenExpired`; no outbox INSERT
+- Metadata exceeds 8 KB → `UsageEmitterError::MetadataTooLarge`; no outbox INSERT
+- Outbox delivery fails after retry budget exhausted → message moved to dead-letter store; surfaced via monitoring
+
+**Steps**:
+1. [x] - `p1` - Source retrieves `UsageEmitterV1` from `ClientHub` at module initialization - `inst-emit-1`
+2. [x] - `p1` - Source calls `UsageEmitterV1::for_module(MODULE_NAME)` to obtain a `ScopedUsageEmitter` bound to the source module's identity - `inst-emit-2`
+3. [x] - `p1` - Before opening a DB transaction, source calls `ScopedUsageEmitter::authorize_for(ctx, tenant_id, resource_id, resource_type)` with optional `subject_id` and `subject_type` — triggers phase 1 authorization - `inst-emit-3`
+4. [x] - `p1` - **IF** PDP denies or module is not configured - `inst-emit-4`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError`; no record is persisted - `inst-emit-4a`
+5. [x] - `p1` - **RETURN** `AuthorizedUsageEmitter` token carrying PDP permit, allowed-metrics list, and bound `tenant_id`/`resource_id`/`resource_type` - `inst-emit-5`
+6. [x] - `p1` - Inside the source's DB transaction, source calls `AuthorizedUsageEmitter::build_usage_record(metric, value).enqueue()` — triggers phase 2 enqueue - `inst-emit-6`
+7. [x] - `p1` - **IF** any in-memory validation fails (token expired, metric disallowed, counter invalid, metadata oversized) - `inst-emit-7`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError`; outbox INSERT is not executed - `inst-emit-7a`
+8. [x] - `p1` - Outbox row is inserted into the source's local DB within the caller's transaction, serialized as `payload_type = "usage-collector.record.v1"` - `inst-emit-8`
+9. [x] - `p1` - Outbox background pipeline picks up the row and calls `UsageCollectorClientV1::create_usage_record()` on delivery - `inst-emit-9`
+10. [x] - `p1` - **IF** delivery fails transiently (network error, 5xx, 429) - `inst-emit-10`
+    1. [x] - `p1` - Retry with exponential backoff; `outbox_backoff_max` MUST be configured below 15 minutes - `inst-emit-10a`
+11. [x] - `p1` - **IF** delivery fails permanently (4xx excluding 429) - `inst-emit-11`
+    1. [x] - `p1` - Move message to dead-letter store and surface via monitoring - `inst-emit-11a`
+12. [x] - `p1` - **RETURN** delivery confirmed; record is available at the gateway - `inst-emit-12`
+
+### Module Config Retrieval Flow
+
+- [x] `p2` - **ID**: `cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config`
+
+> _(p2: deferred — static module config reload requires gateway restart; implementing dynamic config reload is out of scope for Feature 1)_
+
+**Actor**: `cpt-cf-usage-collector-actor-usage-source`
+
+**Success Scenarios**:
+- Gateway returns `ModuleConfig` with the static `allowed_metrics` list for the requesting module
+
+**Error Scenarios**:
+- Module not registered in static config → gateway returns 404; `authorize_for()` surfaces `UsageEmitterError::ModuleNotConfigured`
+
+**Steps**:
+1. [x] - `p2` - During `authorize_for()` phase 1, emitter calls `UsageCollectorClientV1::get_module_config(module_name)` - `inst-cfg-1`
+2. [x] - `p2` - Gateway receives `GET /usage-collector/v1/modules/{module_name}/config` authenticated via SecurityContext - `inst-cfg-2`
+3. [x] - `p2` - Gateway looks up static metric configuration for the module - `inst-cfg-3`
+4. [x] - `p2` - **IF** module not in static config - `inst-cfg-4`
+   1. [x] - `p2` - **RETURN** 404; emitter surfaces `UsageEmitterError::ModuleNotConfigured` - `inst-cfg-4a`
+5. [x] - `p2` - **RETURN** `ModuleConfig { module_name, allowed_metrics: [AllowedMetric { name, kind }] }` - `inst-cfg-5`
+
+## 3. Processes / Business Logic (CDSL)
+
+### Phase 1: `authorize_for()` Authorization
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for`
+
+**Input**: `SecurityContext`, `tenant_id: Uuid`, `resource_id: Uuid`, `resource_type: String`, `subject_id: Option<Uuid>`, `subject_type: Option<String>`
+
+**Output**: `Result<AuthorizedUsageEmitter, UsageEmitterError>`
+
+**Hot path**: `authorize_for()` (PDP call + config fetch) is the
+latency-critical path for SDK callers. `get_module_config()` issues a REST
+HTTP GET to the instance-configuration gateway (inst-cfg-2); the gateway
+serves this from static in-memory configuration loaded at startup — no DB
+I/O on the gateway side — so the per-call cost is network latency only, not
+a DB round-trip. Operators should budget one synchronous HTTP round-trip per
+`get_module_config()` call in the hot-path. Batch delivery and N+1 query
+optimisation are not applicable — records are enqueued individually by
+design.
+
+**Steps**:
+1. [x] - `p1` - Call platform PDP: `USAGE_RECORD`/`CREATE`, passing `tenant_id`, `resource_id`/`resource_type` as resource properties, MODULE (the scoped emitter's bound module name) as a resource property, and — **IF** `subject_id` and `subject_type` are present — SUBJECT_ID/SUBJECT_TYPE as resource properties; when absent, PDP subject properties are omitted from the request - `inst-authz-2`
+2. [x] - `p1` - **IF** PDP denies - `inst-authz-3`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::AuthorizationDenied` - `inst-authz-3a`
+3. [x] - `p1` - Call `get_module_config(module_name)` to fetch `AllowedMetric` list from gateway - `inst-authz-4`
+4. [x] - `p1` - **IF** module not in static config - `inst-authz-5`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::ModuleNotConfigured` - `inst-authz-5a`
+   2. [x] - `p1` - **ELSE IF** `get_module_config` returns any other error (e.g. plugin timeout, circuit open, unavailable, internal) - **RETURN** `UsageEmitterError::Internal` - `inst-authz-5b`
+5. [x] - `p1` - Bind PDP permit result, allowed-metrics list, `tenant_id`, `resource_id`, `resource_type`, optional `subject_id` (`Option<Uuid>`), optional `subject_type` (`Option<String>`), and issuance timestamp into `AuthorizedUsageEmitter` token - `inst-authz-6`
+6. [x] - `p1` - **RETURN** `AuthorizedUsageEmitter` token - `inst-authz-7`
+
+### Phase 2: `build_usage_record().enqueue()` — In-Transaction Enqueue
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue`
+
+**Input**: `AuthorizedUsageEmitter`, metric name, value, optional idempotency key, optional metadata JSON
+
+**Output**: `Result<(), UsageEmitterError>`
+
+**Optional field serialization**: `metadata` is optional. When absent it serializes as an absent JSON field (not `null`). Deserialization treats absent as `None` with no default substitution. `idempotency_key` is optional from the caller's perspective but is **always present in the serialized record** — when the caller omits it, a UUID v4 is auto-generated before enqueue so the wire format always carries a non-null key. Blank strings (`""` or whitespace-only) are semantically equivalent to `None` for this field and MUST NOT be stored as a valid key.
+
+**Steps**:
+1. [x] - `p1` - Verify `AuthorizedUsageEmitter` token has not exceeded its maximum age - `inst-enq-1`
+2. [x] - `p1` - **IF** token is expired - `inst-enq-2`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::TokenExpired` - `inst-enq-2a`
+3. [x] - `p1` - Verify metric name is present in the token's allowed-metrics list - `inst-enq-3`
+4. [x] - `p1` - **IF** metric not in allowed list - `inst-enq-4`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::MetricNotAllowed` - `inst-enq-4a`
+5. [x] - `p1` - **IF** metric kind is `counter` AND (value < 0 OR idempotency_key is None); an empty or whitespace-only string MUST be treated as absent (equivalent to `None`) - `inst-enq-5`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::InvalidRecord` - `inst-enq-5a`
+5a. [x] - `p1` - **IF** idempotency_key is None (gauge record without caller-supplied key) — generate a UUID v4 and assign it as the idempotency_key; an empty or whitespace-only string MUST be treated as absent and triggers the UUID fallback - `inst-enq-5b`
+6. [x] - `p1` - Validate `record.module` equals the token's bound module name; if mismatch RETURN `UsageEmitterError::InvalidRecord`. **IF** the token's `subject_id`/`subject_type` are present, validate `record.subject_id` and `record.subject_type` match them; if mismatch RETURN `UsageEmitterError::InvalidRecord`. **IF** the token's subject values are `None`, `record.subject_id` and `record.subject_type` MUST also be absent; if present RETURN `UsageEmitterError::InvalidRecord` - `inst-enq-6`
+7. [x] - `p1` - **IF** metadata is present AND byte length > 8192 - `inst-enq-7`
+   1. [x] - `p1` - **RETURN** `UsageEmitterError::MetadataTooLarge` - `inst-enq-7a`
+8. [x] - `p1` - Serialize `UsageRecord` (tenant_id, module, kind, metric, value, idempotency_key, resource_id, resource_type, subject_id, subject_type, metadata, timestamp) with `payload_type = "usage-collector.record.v1"`; `subject_id`, `subject_type`, and `metadata` serialize as absent JSON fields when `None` (not as `null`) - `inst-enq-8`
+9. [x] - `p1` - Call `Outbox::enqueue(payload, payload_type)` within the caller's active DB transaction - `inst-enq-9`
+10. [x] - `p1` - **RETURN** `Ok(())`; record is durably enqueued and delivery proceeds asynchronously - `inst-enq-10`
+
+### Outbox Delivery `MessageHandler`
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery`
+
+**Input**: Serialized outbox message with `payload_type = "usage-collector.record.v1"`
+
+**Output**: `HandlerResult`
+
+**Queue overflow**: The outbox grows as long as the storage plugin is unavailable. No max-rows limit is enforced by this feature — unbounded growth is an operational concern delegated to DB capacity management. `enqueue()` does not apply backpressure to the caller; callers experience DB write latency only. Operators should monitor outbox queue depth (see Observability) and provision DB capacity accordingly.
+
+**Message ordering**: Ordering across the 4 outbox partitions is not guaranteed. Per-partition ordering may be preserved by the `modkit-db` outbox library but is not relied upon by this feature. Idempotency keys on counter records provide at-least-once deduplication at the storage layer.
+
+**Steps**:
+1. [x] - `p1` - Deserialize outbox payload bytes into `UsageRecord` - `inst-dlv-1`
+2. [x] - `p1` - **IF** deserialization fails - `inst-dlv-2`
+   1. [x] - `p1` - **RETURN** `HandlerResult::Reject`; unrecoverable format error — message moved to dead-letter store - `inst-dlv-2a`
+3. [x] - `p1` - Assemble gateway ingest request from `UsageRecord` fields - `inst-dlv-3`
+4. [x] - `p1` - Call `UsageCollectorClientV1::create_usage_record(record)` - `inst-dlv-4`
+5. [x] - `p1` - **IF** call succeeds (204 No Content) - `inst-dlv-5`
+   1. [x] - `p1` - **RETURN** `HandlerResult::Success`; outbox row is deleted - `inst-dlv-5a`
+6. [x] - `p1` - **IF** transient failure (connection/transport error, AuthN service temporarily unreachable, network timeout, 5xx, 429) - `inst-dlv-6`
+   1. [x] - `p1` - **RETURN** `HandlerResult::Retry`; outbox library applies exponential backoff; `outbox_backoff_max` MUST be configured below 15 minutes to satisfy `cpt-cf-usage-collector-nfr-recovery` - `inst-dlv-6a`
+7. [x] - `p1` - **IF** permanent failure (4xx excluding 429) - `inst-dlv-7`
+   1. [x] - `p1` - **RETURN** `HandlerResult::Reject`; message moved to dead-letter store and surfaced via monitoring - `inst-dlv-7a`
+
+### Gateway Ingest Handler
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler`
+
+**Input**: `UsageRecord` delivered by the outbox pipeline, `SecurityContext`
+
+**Output**: 204 No Content or error response
+
+**Steps**:
+1. [x] - `p1` - Enforce metadata size limit: reject if `record.metadata` byte length > 8192 - `inst-gw-1`
+2. [x] - `p1` - Check circuit breaker state for the active plugin instance - `inst-gw-2`
+3. [x] - `p1` - **IF** circuit is open **OR** circuit is in half-open state with a probe already in-flight - `inst-gw-3`
+   1. [x] - `p1` - **RETURN** `503 Service Unavailable` - `inst-gw-3a`
+4. [x] - `p1` - Resolve the active storage plugin via GTS - `inst-gw-4`
+5. [x] - `p1` - Call `plugin.create_usage_record(record)` with configurable timeout (default 5 s) - `inst-gw-5`
+6. [x] - `p1` - **IF** plugin call times out or fails transiently - `inst-gw-6`
+   1. [x] - `p1` - Record failure against circuit breaker; open circuit after 5 consecutive failures within a 10 s window; half-open probe after configurable interval (default 30 s) - `inst-gw-6a`
+   2. [x] - `p1` - **RETURN** transient error; retry is handled by the outbox library on the SDK side - `inst-gw-6b`
+7. [x] - `p1` - **RETURN** 204 No Content on successful plugin confirmation - `inst-gw-7`
+
+### Static Module Config Resolution
+
+- [x] `p2` - **ID**: `cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config`
+
+> _(p2: deferred — static module config reload requires gateway restart; implementing dynamic config reload is out of scope for Feature 1)_
+
+**Input**: `module_name: String`, `SecurityContext`
+
+**Output**: `Result<ModuleConfig, ModuleConfigError>`
+
+**Cache integration**: Not applicable — `ModuleConfig` is loaded from static gateway
+configuration at startup. No runtime caching layer is introduced in this feature.
+
+**Steps**:
+1. [x] - `p2` - Authenticate request via SecurityContext; ModKit pipeline rejects unauthenticated requests before the handler - `inst-cfg-p-1`
+2. [x] - `p2` - Look up module name in the gateway's static `metrics` configuration - `inst-cfg-p-2`
+3. [x] - `p2` - **IF** module not found in static config - `inst-cfg-p-3`
+   1. [x] - `p2` - **RETURN** 404 Not Found - `inst-cfg-p-3a`
+4. [x] - `p2` - **RETURN** `ModuleConfig { module_name, allowed_metrics }` - `inst-cfg-p-4`
+
+## 4. States (CDSL)
+
+Not applicable for this feature. `UsageRecord.status` transitions (`active` → `inactive`) are owned by Feature 8 (operator amendment and deactivation). Outbox message lifecycle is managed by the `modkit-db` outbox library and is not a domain state machine defined here.
+
+## 5. Definitions of Done
+
+### SDK Crate (`usage-collector-sdk`)
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-sdk-and-ingest-core-sdk-crate`
+
+The system **MUST** implement the `usage-collector-sdk` crate providing: `UsageCollectorClientV1` delivery trait (`create_usage_record()`, `get_module_config()`), `UsageCollectorPluginClientV1` plugin trait (`create_usage_record()` write operation), shared model types (`UsageRecord`, `ModuleConfig`, `AllowedMetric`, `UsageKind`, error types), and the GTS schema `UsageCollectorStoragePluginSpecV1` for storage plugin registration.
+
+**Implements**:
+- `cpt-cf-usage-collector-component-sdk`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-modkit`
+
+**Touches**:
+- Entities: `UsageRecord`, `ModuleConfig`, `AllowedMetric`, `UsageKind`
+
+**Data Protection**: `UsageRecord` fields (`tenant_id`, `resource_id`, `resource_type`,
+`subject_id`, `subject_type`) are classified as internal billing identifiers —
+opaque UUIDs and numeric values — not PII under the project's data
+classification policy. `subject_id` and `subject_type` are optional fields (`Option<Uuid>` / `Option<String>`); when absent from a record, no subject attribution is stored. Data minimization: only fields required for billing
+attribution are collected. Data subject deletion rights: not applicable at the
+feature level; delegated to the storage plugin (Feature 4). Encryption at rest
+and in transit: not enforced by this feature; delegated to the storage plugin
+and its infrastructure (Feature 4 — Production Storage Plugin).
+
+### Emitter Crate (`usage-emitter`)
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-sdk-and-ingest-core-emitter-crate`
+
+The system **MUST** implement the `usage-emitter` crate providing: `UsageEmitterV1::for_module(name) -> ScopedUsageEmitter`, `ScopedUsageEmitter::authorize_for()` and `authorize()` (PDP call + module config fetch; `subject_id` and `subject_type` are optional — when absent, PDP subject properties are omitted from the authorization request), `AuthorizedUsageEmitter::build_usage_record().enqueue()` (all in-memory validations + `Outbox::enqueue()` within caller's transaction), the outbox `MessageHandler` with `outbox_backoff_max` configured below 15 minutes, and registration of `UsageEmitterV1` in `ClientHub` during gateway `init()`.
+
+**Implements**:
+- `cpt-cf-usage-collector-flow-sdk-and-ingest-core-emit`
+- `cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for`
+- `cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue`
+- `cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery`
+- `cpt-cf-usage-collector-component-emitter`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-outbox-infra`, `cpt-cf-usage-collector-constraint-security-context`, `cpt-cf-usage-collector-constraint-modkit`
+
+**Touches**:
+- DB: `outbox` (source's local DB, `cpt-cf-usage-collector-dbtable-outbox`)
+- Entities: `UsageRecord`, `AuthorizedUsageEmitter`
+
+**Audit logging**: Calls to `authorize_for()` are not individually audited at
+the SDK boundary — audit of usage-collector ingestion calls is delegated to
+the platform-wide API audit layer. Calls to `POST /usage-collector/v1/records`
+are similarly delegated. No feature-level audit log is produced.
+
+**Resource management**: `AuthorizedUsageEmitter` tokens may be reused for
+multiple `enqueue()` calls within `authorization_max_age` (default 30 s);
+freshness is time-based, not single-use. Tokens are dropped when the owning
+scope exits — no additional cleanup required. DB connection
+pooling for the outbox is fully managed by the `modkit-db` outbox library;
+this feature does not hold connections. `UsageCollectorClientV1` connection
+pool is managed by the ModKit HTTP client; no feature-owned connection
+lifecycle.
+
+**Concurrency**: `authorize_for()` and `enqueue()` are safe for concurrent
+calls — all state is per-call with no shared mutable state in the emitter.
+Rate limiting on `POST /usage-collector/v1/records` is not in scope for
+this feature; it is delegated to the platform API gateway.
+
+**Observability**: Structured log events MUST be emitted for: authorization
+denial (`WARN`), validation failure (`WARN`), delivery retry (`INFO`),
+dead-letter routing (`ERROR`), circuit breaker state transitions
+(`WARN`/`INFO`). Metrics: outbox queue depth, delivery attempt count,
+plugin call latency (histogram), circuit breaker open/closed state (gauge).
+OpenTelemetry trace propagation across the outbox pipeline boundary is
+deferred to a future observability feature; correlation IDs from inbound
+requests are not propagated in this feature.
+
+**Data access patterns**: Not applicable — DB access is fully mediated by the `modkit-db` outbox library. This feature constructs no raw queries; index usage, join patterns, and aggregation patterns are encapsulated by the library.
+
+**Data archival and retention**: Not applicable to this feature. Archival and retention compliance are delegated to the storage plugin implementation and its backing infrastructure. The outbox schema migration is forward-only via `DatabaseCapability::migrations()`; schema rollback is not supported.
+
+**Connection management**: Not applicable — connection management, query parameterization, and
+result handling are fully encapsulated by the `modkit-db` outbox library. This feature constructs
+no raw queries.
+
+### Gateway Crate (`usage-collector`) — Ingest & Config
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-sdk-and-ingest-core-gateway-crate`
+
+The system **MUST** implement in the `usage-collector` gateway crate: outbox queue registration (`"usage-records"`, 4 partitions, configurable) and schema migrations via `DatabaseCapability::migrations()`, `POST /usage-collector/v1/records` ingest handler (metadata size enforcement, GTS plugin resolution with timeout, circuit breaker — 5 failures / 10 s open, 30 s half-open probe), `GET /usage-collector/v1/modules/{module_name}/config` handler (static metric config lookup), and construction + registration of `UsageEmitterV1` (backed by `UsageCollectorLocalClient`) in `ClientHub` during `init()`.
+
+**Implements**:
+- `cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config`
+- `cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler`
+- `cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config`
+- `cpt-cf-usage-collector-component-gateway`
+
+**Constraints**: `cpt-cf-usage-collector-constraint-outbox-infra`, `cpt-cf-usage-collector-constraint-single-plugin`, `cpt-cf-usage-collector-constraint-modkit`, `cpt-cf-usage-collector-constraint-security-context`, `cpt-cf-usage-collector-constraint-no-business-logic`
+
+**Touches**:
+- API: `POST /usage-collector/v1/records`, `GET /usage-collector/v1/modules/{module_name}/config`
+- DB: `outbox` (`"usage-records"` queue, `cpt-cf-usage-collector-dbtable-outbox`)
+- Entities: `UsageRecord`, `ModuleConfig`
+
+**Audit logging**: Calls to `authorize_for()` are not individually audited at
+the SDK boundary — audit of usage-collector ingestion calls is delegated to
+the platform-wide API audit layer. Calls to `POST /usage-collector/v1/records`
+are similarly delegated. No feature-level audit log is produced.
+
+**Security error handling**: The gateway strips internal stack traces before
+returning 4xx/5xx responses to callers. `authorize_for()` timing: constant-time
+response patterns are not applied at the SDK layer; tenant-existence enumeration
+via PDP call timing is mitigated by the PDP's own response-time guarantees.
+Rate limiting on `authorize_for()` calls is out of scope for this feature —
+delegated to the platform gateway rate-limiting layer.
+
+**Observability**: Structured log events MUST be emitted for: authorization
+denial (`WARN`), validation failure (`WARN`), delivery retry (`INFO`),
+dead-letter routing (`ERROR`), circuit breaker state transitions
+(`WARN`/`INFO`). Metrics: outbox queue depth, delivery attempt count,
+plugin call latency (histogram), circuit breaker open/closed state (gauge).
+OpenTelemetry trace propagation across the outbox pipeline boundary is
+deferred to a future observability feature; correlation IDs from inbound
+requests are not propagated in this feature.
+
+**Rollout/rollback**: The outbox schema migration
+(`DatabaseCapability::migrations()`) is forward-only — rollback of the
+schema is not supported. Rollback of the gateway binary to a pre-feature
+version is safe only if no messages have been enqueued; enqueued rows will
+remain in the DB until the migrated gateway is redeployed. No feature flag
+guards the new endpoints in this feature — rollout strategy is managed at
+the platform level via standard deployment controls.
+
+**Recovery**: In-flight outbox messages survive a gateway upgrade — rows are durable in the DB and will be picked up by the restarted process. Circuit breaker state and plugin registration are recovered automatically on gateway restart (stateless configuration). Dead-lettered records: operators inspect via direct DB query on the dead-letter partition; reprocessing requires manual row deletion and re-insertion into the live queue, or a future admin API (out of scope). No compensating transaction is required for the delivery pipeline.
+
+**Data access patterns**: Not applicable — all storage I/O is delegated to the active storage plugin via `UsageCollectorPluginClientV1`. The gateway constructs no raw DB queries; plugin selection, connection pooling, and query execution are fully encapsulated by the plugin implementation.
+
+**Data archival and retention**: Not applicable to this feature. Archival and retention compliance are delegated to the storage plugin implementation and its backing infrastructure. The outbox schema migration is forward-only via `DatabaseCapability::migrations()`; schema rollback is not supported.
+
+**Configuration**:
+
+| Parameter | Type | Valid range | Default | Validation | Runtime-changeable |
+|-----------|------|-------------|---------|------------|--------------------|
+| `outbox_backoff_max` | duration | 1s–15m | 600s (10 min) | must be > 0 and < 900s | No — requires restart |
+| Plugin timeout | duration | 100ms–30s | 5s | must be > 0 | No |
+| Circuit breaker failure threshold | integer | 1–100 | 5 | must be ≥ 1 | No |
+| Circuit breaker recovery timeout | duration | 1s–5m | 30s | must be > 0 | No |
+| Queue partitions | integer | 1–64 | 4 | must be ≥ 1 | No |
+
+No feature flags are used; all configuration is static and requires gateway restart to change.
+
+**Health & diagnostics**: Circuit breaker state is not directly exposed via `GET /health` in this feature — it contributes to the platform-level health aggregate. Outbox queue depth is a recommended monitoring metric (see Observability). First-level troubleshooting: (1) check circuit breaker state via structured logs; (2) inspect outbox queue depth; (3) verify storage plugin connectivity; (4) check dead-letter partition for accumulated records.
+
+`cpt-cf-usage-collector-constraint-encryption` is not enforced by this feature — encryption at
+rest and in transit is deferred to Feature 4 (Production Storage Plugin) which owns the
+production storage backend.
+
+### No-Op Storage Plugin (`noop-usage-collector-storage-plugin`)
+
+- [x] `p1` - **ID**: `cpt-cf-usage-collector-dod-sdk-and-ingest-core-noop-plugin`
+
+> _(p2: deferred — noop plugin validation is a test-time concern; plugin interface is validated by integration tests)_
+
+The system **MUST** implement the `noop-usage-collector-storage-plugin` crate providing a no-op implementation of `UsageCollectorPluginClientV1` where all write operations succeed without persisting data and all read operations return empty results. Must register via `UsageCollectorStoragePluginSpecV1` GTS schema for selection by operator configuration in test and local-dev deployments.
+
+**Implements**:
+- `cpt-cf-usage-collector-component-storage-plugin` (no-op only)
+
+**Constraints**: `cpt-cf-usage-collector-constraint-single-plugin`, `cpt-cf-usage-collector-constraint-modkit`
+
+**Touches**:
+- Entities: `UsageRecord`
+
+### Known Limitations / Technical Debt
+
+- **Static `ModuleConfig`**: Has no dynamic update mechanism — changes require a gateway restart.
+- **Outbox payload versioning**: Payload type `usage-collector.record.v1` uses an opaque string
+  version with no schema registry or backward-compatibility contract defined in this feature.
+  Payload versioning strategy MUST be documented before Feature 2+ extends the record schema.
+
+## 6. Acceptance Criteria
+
+- [ ] A usage source can call `authorize_for()` and receive an `AuthorizedUsageEmitter` token when the PDP permits `USAGE_RECORD`/`CREATE` for the given tenant and resource
+- [ ] `enqueue()` persists a usage record to the source's local outbox within the caller's DB transaction; the transaction commit is the durability boundary for the record
+- [ ] Counter records without an idempotency key or with a negative value are rejected before the outbox INSERT; no outbox row is created
+- [ ] Gauge records without a caller-supplied idempotency key are accepted; the emitter auto-generates a UUID v4 and the stored record always carries a non-null key
+- [ ] Records with a metric name not in the module's allowed-metrics list are rejected by `enqueue()` in-memory before the outbox INSERT
+- [ ] PDP denial in `authorize_for()` surfaces as `UsageEmitterError::AuthorizationDenied` with no record persisted
+- [ ] The outbox delivery pipeline delivers records to the gateway with at-least-once semantics; transient failures trigger exponential backoff retry with `outbox_backoff_max` configured below 15 minutes
+- [ ] The gateway ingest endpoint enforces the 8 KB metadata limit, resolves the active plugin via GTS, and delegates record persistence with a 5 s default timeout
+- [ ] The circuit breaker opens after 5 consecutive plugin call failures within a 10 s window; the gateway returns `503 Service Unavailable` while open; exactly one probe call is admitted after 30 s, with all other concurrent requests during the half-open window rejected until the probe completes
+- [ ] `GET /usage-collector/v1/modules/{name}/config` returns the static allowed-metrics list for a configured module and 404 for an unknown module
+- [ ] The no-op plugin accepts all write calls with no side effects and returns empty results for reads; integration tests pass with the no-op backend selected
+- [ ] `UsageEmitterV1` is available in `ClientHub` after gateway `init()` completes; sources can call `for_module()` without additional setup
+- [ ] Invalid configuration values (out-of-range `plugin_timeout`,
+  `circuit_breaker_failure_threshold`, `circuit_breaker_recovery_timeout`,
+  or `outbox_backoff_max`) are rejected at module/emitter initialization
+  with a descriptive error; the process does not start.
+- [ ] `authorize_for()` succeeds when `subject_id` and `subject_type` are absent (`None`); the PDP call omits SUBJECT_ID/SUBJECT_TYPE resource properties and returns a valid `AuthorizedUsageEmitter` token with `None` subject fields
+- [ ] `enqueue()` accepts a `UsageRecord` with absent `subject_id`/`subject_type` when the token's subject fields are also absent; the serialized outbox record does not contain `subject_id` or `subject_type` JSON fields
+
+**Test data requirements**:
+(1) Static gateway config must include at least one module with a `counter` metric and one with a
+    `gauge` metric.
+(2) PDP stub must support permit/deny configuration for `USAGE_RECORD`/`CREATE` actions by
+    `tenant_id`/`resource_id` pair.
+(3) Integration tests use `noop-usage-collector-storage-plugin`.
+(4) Idempotency collision test: submit two records with the same `idempotency_key` for the same
+    metric and verify deduplication.
+
+**Test coverage guidance**:
+Unit: `authorize_for()` — PDP permit, PDP deny, token expiry, metric type mismatch;
+      `enqueue()` — each validation branch.
+Integration: full emission flow with noop plugin; circuit breaker open/close cycle;
+             dead-letter routing after max retries.
+E2E: noop plugin store remains empty after transaction commit (noop backend discards all writes; read returns no records).
+Performance baseline: measure `authorize_for()` + `enqueue()` round-trip latency against
+`nfr-ingestion-latency` target using noop backend.
+
+**Success metrics**:
+(1) At-least-once delivery rate ≥ 99.9% under normal conditions within `outbox_backoff_max` window.
+(2) Circuit breaker recovers within 30 s of storage plugin recovery.
+(3) Noop plugin integration test pass rate: 100% on CI.
+
+## 7. Non-Applicability Notes
+
+**COMPL (Regulatory & Privacy Compliance)**: Not applicable. This feature
+processes opaque UUIDs (`tenant_id`, `resource_id`, `subject_id`) and numeric
+counters/gauges for internal billing metrics. No regulated personal data is
+defined at the feature level. No audit trail, consent, data retention, or data
+subject rights apply to this in-process SDK. If future features extend this to
+personal data, COMPL must be revisited.
+
+**UX (User Experience & Accessibility)**: Not applicable. This feature provides
+an in-process SDK library (`usage-collector-sdk`, `usage-emitter`) and a gateway
+service with machine-to-machine REST endpoints. There is no user-facing UI, no
+end-user interaction model, no user-visible error messages, and no accessibility
+requirements.

--- a/modules/system/usage-collector/usage-collector-sdk/Cargo.toml
+++ b/modules/system/usage-collector/usage-collector-sdk/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "cf-usage-collector-sdk"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "SDK for usage-collector"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "usage_collector_sdk"
+
+[lints]
+workspace = true
+
+[dependencies]
+# ModKit dependencies
+modkit = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Data structures
+chrono = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+utoipa = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = { workspace = true }
+
+# GTS
+gts = { workspace = true }
+gts-macros = { workspace = true }
+
+[dev-dependencies]
+# Async runtime
+tokio = { workspace = true }

--- a/modules/system/usage-collector/usage-collector-sdk/README.md
+++ b/modules/system/usage-collector/usage-collector-sdk/README.md
@@ -1,0 +1,95 @@
+# Usage Collector SDK
+
+Transport-agnostic contracts for the usage-collector module family.
+
+## What this crate provides
+
+| Item | Description |
+|------|-------------|
+| `UsageCollectorClientV1` | Ingest trait implemented by client modules (`usage-collector`, `usage-collector-rest-client`). **Never registered in `ClientHub`** to prevent unauthorized usage emission. |
+| `UsageCollectorPluginClientV1` | Storage-plugin trait implemented by backend plugins. |
+| `UsageRecord`, `UsageKind` | Transport-agnostic models (`UsageRecord` fields are public for direct construction, serde, and tests). |
+| `ModuleConfig`, `AllowedMetric` | Per-module configuration returned by `get_module_config()`; `AllowedMetric` holds a metric name and its `UsageKind`. |
+| `UsageCollectorError` | Error type shared by both traits. |
+| `UsageCollectorStoragePluginSpecV1` | GTS schema for storage plugin registration. |
+
+> **Emitting usage** — use the `usage-emitter` crate, which wraps `UsageCollectorClientV1` with PDP authorization and outbox buffering.
+
+## Usage
+
+### Querying module config
+
+Source modules can fetch their allowed metrics at init time via `UsageCollectorClientV1`:
+
+```rust
+use usage_collector_sdk::UsageCollectorClientV1;
+
+let config = collector.get_module_config("my_module").await?;
+for metric in &config.allowed_metrics {
+    println!("{}: {:?}", metric.name, metric.kind);
+}
+```
+
+### Building a `UsageRecord` directly
+
+For tests, plugins, or offline construction, set fields on `UsageRecord` directly (public struct fields):
+
+```rust
+use chrono::Utc;
+use usage_collector_sdk::{UsageKind, UsageRecord};
+use uuid::Uuid;
+
+let record = UsageRecord {
+    module: "my_module".to_owned(),
+    tenant_id: Uuid::new_v4(),
+    metric: "requests".to_owned(),
+    kind: UsageKind::Counter,
+    value: 1.0,
+    resource_id: Uuid::new_v4(),
+    resource_type: "resource_type".to_owned(),
+    subject_id: Uuid::new_v4(),
+    subject_type: "subject_type".to_owned(),
+    idempotency_key: Uuid::new_v4().to_string(),
+    timestamp: Utc::now(),
+    metadata: None,
+};
+```
+
+### Implementing a storage plugin
+
+```rust
+use async_trait::async_trait;
+use usage_collector_sdk::{UsageCollectorError, UsageCollectorPluginClientV1, UsageRecord};
+
+struct MyStoragePlugin { /* ... */ }
+
+#[async_trait]
+impl UsageCollectorPluginClientV1 for MyStoragePlugin {
+    async fn create_usage_record(
+        &self,
+        record: UsageRecord,
+    ) -> Result<(), UsageCollectorError> {
+        // idempotent upsert keyed on record.idempotency_key
+        todo!()
+    }
+}
+```
+
+## Error handling
+
+```rust
+use usage_collector_sdk::UsageCollectorError;
+
+match result {
+    Ok(()) => {}
+    Err(UsageCollectorError::AuthorizationFailed { message }) => { /* PDP denied */ }
+    Err(UsageCollectorError::ModuleNotFound { module_name }) => { /* module has no configured metrics */ }
+    Err(UsageCollectorError::PluginTimeout) => { /* storage plugin timed out */ }
+    Err(UsageCollectorError::CircuitOpen) => { /* storage plugin circuit breaker open */ }
+    Err(UsageCollectorError::Internal { message }) => { /* unexpected error */ }
+}
+```
+
+## Security invariant
+
+`UsageCollectorClientV1` is **never** registered in `ClientHub`. It is passed directly to the emitter via constructor, ensuring the sole path to the collector is through a PDP-authorized emitter.

--- a/modules/system/usage-collector/usage-collector-sdk/src/api.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/api.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+
+use crate::error::UsageCollectorError;
+use crate::models::{ModuleConfig, UsageRecord};
+
+/// Gateway-facing API trait for the usage collector.
+///
+/// Implemented by the gateway module's local client (`UsageCollectorLocalClient`)
+/// and by remote client modules (e.g. `usage-collector-rest-client`).
+///
+/// # Security invariant
+///
+/// This trait is **never** registered in `ClientHub`. Passing it through the hub
+/// would allow any module to push unvalidated records directly to the collector,
+/// bypassing the authorized-emitter path. Always supply it by constructor argument
+/// to the emitter.
+#[async_trait]
+pub trait UsageCollectorClientV1: Send + Sync {
+    /// Create one usage record at the collector gateway (ingest).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageCollectorError`] on transient or permanent delivery failure.
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError>;
+
+    /// Retrieve per-module configuration from the collector.
+    ///
+    /// Returns the set of metrics `module_name` is allowed to emit.
+    /// Extensible: future versions may include rate limit config, max metadata size, etc.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageCollectorError`] if the module is not configured or the call fails.
+    async fn get_module_config(
+        &self,
+        module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError>;
+}

--- a/modules/system/usage-collector/usage-collector-sdk/src/error.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/error.rs
@@ -1,0 +1,86 @@
+/// Errors produced by the usage collector gateway, client trait, and storage plugins.
+#[derive(Debug, thiserror::Error)]
+pub enum UsageCollectorError {
+    /// Authorization or policy denial (e.g. emit-time PDP); retained for API compatibility.
+    #[error("authorization failed: {message}")]
+    AuthorizationFailed {
+        /// Human-readable failure description.
+        message: String,
+    },
+
+    /// Types-registry / plugin resolution / hub wiring failures and other unexpected conditions.
+    #[error("internal error: {message}")]
+    Internal {
+        /// Detail for operators and logs.
+        message: String,
+    },
+
+    /// No metrics are configured for this module in the gateway's static configuration.
+    #[error("module not found in configuration: {module_name}")]
+    ModuleNotFound {
+        /// Name of the module that has no configured metrics.
+        module_name: String,
+    },
+
+    /// Plugin call exceeded the configured timeout.
+    #[error("storage plugin call timed out")]
+    PluginTimeout,
+
+    /// Circuit breaker is open — storage plugin calls are suspended until the recovery window elapses.
+    #[error("storage plugin circuit breaker is open")]
+    CircuitOpen,
+
+    /// Transient infrastructure failure: connection/transport error or a dependent service
+    /// (e.g. the identity/AuthN service) is temporarily unreachable.
+    /// The operation may succeed on retry once the outage resolves.
+    #[error("service unavailable: {message}")]
+    Unavailable {
+        /// Detail for operators and logs.
+        message: String,
+    },
+}
+
+impl UsageCollectorError {
+    #[must_use]
+    pub fn authorization_failed(message: impl Into<String>) -> Self {
+        Self::AuthorizationFailed {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn module_not_found(module_name: impl Into<String>) -> Self {
+        Self::ModuleNotFound {
+            module_name: module_name.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn plugin_timeout() -> Self {
+        Self::PluginTimeout
+    }
+
+    #[must_use]
+    pub fn circuit_open() -> Self {
+        Self::CircuitOpen
+    }
+
+    #[must_use]
+    pub fn unavailable(message: impl Into<String>) -> Self {
+        Self::Unavailable {
+            message: message.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/modules/system/usage-collector/usage-collector-sdk/src/error_tests.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/error_tests.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+#[test]
+fn authorization_failed_constructor_sets_message() {
+    let e = UsageCollectorError::authorization_failed("denied");
+    assert!(
+        matches!(e, UsageCollectorError::AuthorizationFailed { ref message } if message == "denied")
+    );
+}
+
+#[test]
+fn internal_constructor_sets_message() {
+    let e = UsageCollectorError::internal("types-registry: boom");
+    assert!(
+        matches!(e, UsageCollectorError::Internal { ref message } if message == "types-registry: boom")
+    );
+}
+
+#[test]
+fn plugin_timeout_constructor() {
+    let e = UsageCollectorError::plugin_timeout();
+    assert!(matches!(e, UsageCollectorError::PluginTimeout));
+}
+
+#[test]
+fn unavailable_constructor_sets_message() {
+    let e = UsageCollectorError::unavailable("connection refused");
+    assert!(
+        matches!(e, UsageCollectorError::Unavailable { ref message } if message == "connection refused")
+    );
+}
+
+// ── Display ───────────────────────────────────────────────────────
+
+#[test]
+fn display_authorization_failed() {
+    let e = UsageCollectorError::authorization_failed("access denied");
+    assert_eq!(e.to_string(), "authorization failed: access denied");
+}
+
+#[test]
+fn display_internal() {
+    let e = UsageCollectorError::internal("types-registry unavailable");
+    assert_eq!(e.to_string(), "internal error: types-registry unavailable");
+}
+
+#[test]
+fn display_plugin_timeout() {
+    let e = UsageCollectorError::plugin_timeout();
+    assert_eq!(e.to_string(), "storage plugin call timed out");
+}
+
+#[test]
+fn display_unavailable() {
+    let e = UsageCollectorError::unavailable("identity service down");
+    assert_eq!(e.to_string(), "service unavailable: identity service down");
+}

--- a/modules/system/usage-collector/usage-collector-sdk/src/gts.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/gts.rs
@@ -1,0 +1,14 @@
+//! GTS schema for usage-collector storage plugin instances.
+
+use gts_macros::struct_to_gts_schema;
+use modkit::gts::BaseModkitPluginV1;
+
+/// GTS type for storage backend plugin instances registered with types-registry.
+#[struct_to_gts_schema(
+    dir_path = "schemas",
+    base = BaseModkitPluginV1,
+    schema_id = "gts.x.core.modkit.plugin.v1~cf.core.usage_collector.storage_plugin.v1~",
+    description = "Usage Collector storage plugin specification",
+    properties = ""
+)]
+pub struct UsageCollectorStoragePluginSpecV1;

--- a/modules/system/usage-collector/usage-collector-sdk/src/lib.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/lib.rs
@@ -1,0 +1,33 @@
+//! Usage Collector SDK
+//!
+//! Transport-agnostic contracts for the usage-collector module family.
+//!
+//! ## What this crate provides
+//!
+//! - [`UsageCollectorClientV1`] — ingest trait implemented by gateway/remote client modules
+//!   (passed by constructor argument to the emitter, never via `ClientHub`).
+//! - [`UsageCollectorPluginClientV1`] — storage-plugin trait implemented by backend plugins.
+//! - [`UsageRecord`], [`UsageKind`], [`ModuleConfig`], [`AllowedMetric`] — transport-agnostic models.
+//! - [`UsageCollectorError`] — error type shared by both traits.
+//! - [`UsageCollectorStoragePluginSpecV1`] — GTS schema for storage plugin registration.
+//!
+//! ## Emitting usage
+//!
+//! Use the `usage-emitter` crate, which wraps [`UsageCollectorClientV1`] with PDP authorization
+//! and outbox buffering.
+
+// @cpt-dod:cpt-cf-usage-collector-dod-sdk-and-ingest-core-sdk-crate:p1
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+pub mod api;
+pub mod error;
+pub mod gts;
+pub mod models;
+pub mod plugin_api;
+
+pub use api::UsageCollectorClientV1;
+pub use error::UsageCollectorError;
+pub use gts::UsageCollectorStoragePluginSpecV1;
+pub use models::{AllowedMetric, ModuleConfig, UsageKind, UsageRecord};
+pub use plugin_api::UsageCollectorPluginClientV1;

--- a/modules/system/usage-collector/usage-collector-sdk/src/models.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/models.rs
@@ -1,0 +1,72 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Kind of numeric usage observation (gauge vs counter).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageKind {
+    Gauge,
+    Counter,
+}
+
+/// A single allowed metric definition returned by [`crate::UsageCollectorClientV1::get_module_config`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AllowedMetric {
+    /// Metric name.
+    pub name: String,
+    /// Gauge vs counter semantics for this metric.
+    pub kind: UsageKind,
+}
+
+/// Per-module configuration returned by [`crate::UsageCollectorClientV1::get_module_config`].
+///
+/// Extensible: future fields may include rate limit config, max metadata size, etc.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleConfig {
+    /// Metrics this module is allowed to emit.
+    pub allowed_metrics: Vec<AllowedMetric>,
+}
+
+/// A single usage record submitted to the collector.
+///
+/// All fields are public for direct construction, serde, and tests.
+/// For emission from source modules, use the `usage-emitter` crate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageRecord {
+    /// Name of the module that emitted this record.
+    pub module: String,
+    /// Tenant that owns this usage observation.
+    pub tenant_id: Uuid,
+    /// Metric name for this observation.
+    pub metric: String,
+    /// Gauge vs counter semantics.
+    pub kind: UsageKind,
+    /// Numeric value for this usage observation.
+    pub value: f64,
+    /// Identifier of the metered resource instance.
+    pub resource_id: Uuid,
+    /// Logical type of the metered resource (e.g. GTS id or domain name).
+    pub resource_type: String,
+    /// Identifier of the subject (user or service) performing the metered action.
+    /// `None` when no subject context is available; PDP validation is skipped in that case.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub subject_id: Option<Uuid>,
+    /// Logical type of the subject (e.g. GTS id or domain name).
+    /// `None` when no subject context is available.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub subject_type: Option<String>,
+    /// Idempotency key for at-least-once delivery.
+    pub idempotency_key: String,
+    /// Timestamp of the observation.
+    pub timestamp: DateTime<Utc>,
+    /// Optional caller-supplied metadata (max 8 192 bytes serialized).
+    /// Absent when not provided; serializes as absent JSON field, not `null`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "models_tests.rs"]
+mod models_tests;

--- a/modules/system/usage-collector/usage-collector-sdk/src/models_tests.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/models_tests.rs
@@ -1,0 +1,61 @@
+use chrono::Utc;
+use uuid::Uuid;
+
+use super::{UsageKind, UsageRecord};
+
+fn make_record() -> UsageRecord {
+    UsageRecord {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::nil(),
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::nil(),
+        resource_type: "test.resource".to_owned(),
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+#[test]
+fn usage_record_roundtrip_serde() {
+    let mut rec = make_record();
+    rec.value = 42.0;
+    let json = serde_json::to_string(&rec).unwrap();
+    let deserialized: UsageRecord = serde_json::from_str(&json).unwrap();
+    assert!((deserialized.value - 42.0_f64).abs() < f64::EPSILON);
+    assert_eq!(deserialized.kind, UsageKind::Gauge);
+}
+
+#[test]
+fn usage_record_clone_copies_all_fields() {
+    let rec = make_record();
+    let cloned = rec.clone();
+    assert_eq!(cloned.tenant_id, rec.tenant_id);
+    assert!((cloned.value - rec.value).abs() < f64::EPSILON);
+    assert_eq!(cloned.resource_id, rec.resource_id);
+}
+
+#[test]
+fn usage_record_subject_none_serde() {
+    let rec = UsageRecord {
+        subject_id: None,
+        subject_type: None,
+        ..make_record()
+    };
+    let json = serde_json::to_string(&rec).unwrap();
+    assert!(
+        !json.contains("\"subject_id\""),
+        "subject_id must be absent from JSON when None, got: {json}"
+    );
+    assert!(
+        !json.contains("\"subject_type\""),
+        "subject_type must be absent from JSON when None, got: {json}"
+    );
+    let deserialized: UsageRecord = serde_json::from_str(&json).unwrap();
+    assert_eq!(deserialized.subject_id, None);
+    assert_eq!(deserialized.subject_type, None);
+}

--- a/modules/system/usage-collector/usage-collector-sdk/src/plugin_api.rs
+++ b/modules/system/usage-collector/usage-collector-sdk/src/plugin_api.rs
@@ -1,0 +1,15 @@
+//! Storage plugin trait for usage-collector backends.
+
+use async_trait::async_trait;
+
+use crate::error::UsageCollectorError;
+use crate::models::UsageRecord;
+
+/// Backend storage adapter for usage records.
+///
+/// Plugins register via GTS; the gateway resolves the active instance and delegates writes.
+#[async_trait]
+pub trait UsageCollectorPluginClientV1: Send + Sync {
+    /// Create one usage record in storage (idempotent upsert where applicable).
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError>;
+}


### PR DESCRIPTION
## Summary
- Introduces `usage-collector-sdk`: trait boundaries (`UsageCollectorClientV1`,
  `UsageCollectorPluginClientV1`), `UsageRecord` model, error types, and GTS
  plugin registration schema — the shared contract used by all other crates in
  this component
- Adds the DECOMPOSITION document decomposing the DESIGN into 8 features and
  the Feature 1 spec (Core SDK, Emitter & In-Process Ingest)
- Updates DESIGN to reflect the finalized architecture: emitter-based two-phase
  authorization (`authorize_for()` / `authorize()`), explicit in-process vs.
  remote delivery modes, and corrected FR alignment throughout
- Updates PRD to add REST API ingestion as a distinct FR and widen the
  `usage-source` actor definition to cover remote and external sources

 ## PR Train
 | # | PR | Description | Lines |
 |---|---|------------|------:|
 | 1  | [1620 (**this**)](https://github.com/cyberfabric/cyberfabric-core/pull/1620) | Feature 1 (Core SDK, Emitter & In-Process Ingest): SDK + docs | ~2000 |
 | 2 | [1733](https://github.com/cyberfabric/cyberfabric-core/pull/1733) | Feature 1 (Core SDK, Emitter & In-Process Ingest): `usage-collector` gateway + `usage-emitter` + `noop-usage-collector-storage-plugin` | ~4000 |
 | 3 | TBD | Feature 2 (REST Client & Remote Ingest Delivery): `usage-collector-rest-client` | ~1000 |
|  |  | ... to be continued ... | |

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] `cpt validate` — all checks passed
- [x] Tests pass (`cargo nextest run --workspace`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage Collector SDK added, including a stable SDK surface, public models, error types, and storage-plugin contract
  * REST ingestion path introduced for accepting external usage records
  * Emitter-centered two-phase authorize→enqueue flow implemented for validated, authorized submissions

* **Documentation**
  * Large expansion of architecture, design, PRD, ADRs, decomposition, feature specs, and README guidance

* **Chores**
  * Artifact collection exclusions extended to skip internal usage-collector paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->