### PR TITLE
feat(usage-collector): add emitter, gateway, REST client, and noop storage plugin crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,6 +1877,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-noop-usage-collector-storage-plugin"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cf-modkit",
+ "cf-modkit-macros",
+ "cf-types-registry-sdk",
+ "cf-usage-collector-sdk",
+ "chrono",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "cf-oagw"
 version = "0.2.19"
 dependencies = [
@@ -2313,6 +2331,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cf-usage-collector"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "cf-authz-resolver-sdk",
+ "cf-modkit",
+ "cf-modkit-db",
+ "cf-modkit-macros",
+ "cf-modkit-security",
+ "cf-modkit-utils",
+ "cf-types-registry-sdk",
+ "cf-usage-collector-sdk",
+ "cf-usage-emitter",
+ "chrono",
+ "http",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
 name = "cf-usage-collector-sdk"
 version = "0.1.0"
 dependencies = [
@@ -2327,6 +2373,26 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "utoipa",
+ "uuid",
+]
+
+[[package]]
+name = "cf-usage-emitter"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cf-authz-resolver-sdk",
+ "cf-modkit-db",
+ "cf-modkit-security",
+ "cf-usage-collector-sdk",
+ "chrono",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,10 @@ members = [
     "modules/system/oagw/oagw-sdk",
     "modules/mini-chat/mini-chat-sdk",
     "modules/mini-chat/mini-chat",
+    "modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin",
+    "modules/system/usage-collector/usage-collector",
     "modules/system/usage-collector/usage-collector-sdk",
+    "modules/system/usage-collector/usage-emitter",
 ]
 exclude = ["tools/fuzz"]
 resolver = "3"
@@ -244,6 +247,7 @@ cf-system-sdk-directory = { version = "0.1.34", path = "libs/system-sdks/sdks/di
 # system modules SDKs
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.5", path = "modules/system/types-registry/types-registry-sdk" }
 tenant-resolver-sdk = { package = "cf-tenant-resolver-sdk", version = "0.3.0", path = "modules/system/tenant-resolver/tenant-resolver-sdk" }
+authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.10", path = "modules/system/authn-resolver/authn-resolver-sdk" }
 authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.3.0", path = "modules/system/authz-resolver/authz-resolver-sdk" }
 resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.0", path = "modules/system/resource-group/resource-group-sdk" }
 oagw-sdk = { package = "cf-oagw-sdk", version = "0.4.1", path = "modules/system/oagw/oagw-sdk" }
@@ -255,7 +259,9 @@ credstore-sdk = { package = "cf-credstore-sdk", version = "0.1.18", path = "modu
 mini-chat-sdk = { package = "cf-mini-chat-sdk", version = "0.10.0", path = "modules/mini-chat/mini-chat-sdk" }
 
 # usage-collector
+usage-collector = { package = "cf-usage-collector", version = "0.1.0", path = "modules/system/usage-collector/usage-collector" }
 usage-collector-sdk = { package = "cf-usage-collector-sdk", version = "0.1.0", path = "modules/system/usage-collector/usage-collector-sdk" }
+usage-emitter = { package = "cf-usage-emitter", version = "0.1.0", path = "modules/system/usage-collector/usage-emitter" }
 
 # system modules
 grpc_hub = { package = "cf-grpc-hub", version = "0.2.0", path = "modules/system/grpc-hub" }

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/Cargo.toml
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "cf-noop-usage-collector-storage-plugin"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "No-op usage-collector storage plugin for development and testing"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "noop_usage_collector_storage_plugin"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+types-registry-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-macros = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Data structures
+uuid = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+[dev-dependencies]
+# Data structures
+chrono = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/README.md
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/README.md
@@ -1,0 +1,35 @@
+# No-op Usage Collector Storage Plugin
+
+> **Development and testing plugin** — discards all usage records. It is not a production storage backend.
+
+No-op implementation of the usage-collector storage plugin contract: the gateway can resolve a plugin instance and call `create_usage_record`, but no data is retained.
+
+## Purpose
+
+Use this plugin when you want the usage-collector module and emitters to run without configuring a real storage implementation. Typical cases:
+
+- Local development and smoke tests
+- CI pipelines that exercise the ingestion path only
+- Demos where durable usage history is unnecessary
+
+**Do not use when you need metering data to be stored or queried.**
+
+## Configuration
+
+Add the plugin section under your module configuration:
+
+```yaml
+modules:
+  noop-usage-collector-storage-plugin:
+    config:
+      vendor: "hyperspot"
+      priority: 100
+```
+
+`vendor` must match the usage-collector gateway configuration so the gateway selects this instance.
+
+## Testing
+
+```bash
+cargo test -p cf-noop-usage-collector-storage-plugin
+```

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/config.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/config.rs
@@ -1,0 +1,28 @@
+//! Configuration for the no-op usage-collector storage plugin.
+
+use serde::Deserialize;
+
+/// Plugin configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct NoopUsageCollectorStorageConfig {
+    /// Vendor name (must match the usage-collector gateway `vendor`).
+    pub vendor: String,
+
+    /// Plugin priority (lower = higher priority when multiple instances exist).
+    pub priority: i16,
+}
+
+impl Default for NoopUsageCollectorStorageConfig {
+    fn default() -> Self {
+        Self {
+            vendor: "hyperspot".to_owned(),
+            priority: 100,
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/config_tests.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/config_tests.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+#[test]
+fn vendor_can_be_overridden_via_serde() {
+    let json = r#"{"vendor": "acme", "priority": 100}"#;
+    let cfg: NoopUsageCollectorStorageConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.vendor, "acme");
+}
+
+#[test]
+fn priority_can_be_overridden_via_serde() {
+    let json = r#"{"vendor": "hyperspot", "priority": 10}"#;
+    let cfg: NoopUsageCollectorStorageConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.priority, 10);
+}
+
+#[test]
+fn serde_default_applies_default_vendor_and_priority() {
+    let cfg: NoopUsageCollectorStorageConfig = serde_json::from_str("{}").unwrap();
+    assert_eq!(
+        cfg.vendor, "hyperspot",
+        "serde(default) must use Default impl"
+    );
+    assert_eq!(cfg.priority, 100, "serde(default) must use Default impl");
+}
+
+#[test]
+fn rejects_unknown_fields() {
+    let json = r#"{"vendor": "x", "priority": 1, "unexpected": true}"#;
+    assert!(serde_json::from_str::<NoopUsageCollectorStorageConfig>(json).is_err());
+}

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/client.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/client.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{UsageCollectorError, UsageCollectorPluginClientV1};
+
+use super::service::Service;
+
+#[async_trait]
+impl UsageCollectorPluginClientV1 for Service {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "client_tests.rs"]
+mod client_tests;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/client_tests.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/client_tests.rs
@@ -1,0 +1,42 @@
+use chrono::Utc;
+use usage_collector_sdk::{UsageCollectorPluginClientV1, UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use super::Service;
+
+fn make_record(tenant_id: Uuid) -> UsageRecord {
+    UsageRecord {
+        module: "test-module".to_owned(),
+        tenant_id,
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn create_usage_record_always_returns_ok() {
+    let service = Service::new();
+    let plugin: &dyn UsageCollectorPluginClientV1 = &service;
+    let rec = make_record(Uuid::new_v4());
+    let result = plugin.create_usage_record(rec).await;
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn create_usage_record_multiple_records_all_return_ok() {
+    let service = Service::new();
+    let plugin: &dyn UsageCollectorPluginClientV1 = &service;
+    for _ in 0..5 {
+        let rec = make_record(Uuid::new_v4());
+        let result = plugin.create_usage_record(rec).await;
+        assert!(result.is_ok());
+    }
+}

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/mod.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/mod.rs
@@ -1,0 +1,4 @@
+mod client;
+pub mod service;
+
+pub use service::Service;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/service.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/domain/service.rs
@@ -1,0 +1,14 @@
+//! No-op usage-collector storage domain service.
+
+use modkit_macros::domain_model;
+
+/// Stateless service backing the storage plugin client; records are not retained.
+#[domain_model]
+pub struct Service;
+
+impl Service {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/lib.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/lib.rs
@@ -1,0 +1,20 @@
+//! No-op Usage Collector Storage Plugin
+//!
+//! Registers a [`usage_collector_sdk::UsageCollectorPluginClientV1`] implementation that
+//! accepts `create_usage_record` calls and drops all data. Use when the usage-collector gateway should run
+//! end-to-end without a real storage backend.
+//!
+//! ## Configuration
+//!
+//! ```yaml
+//! modules:
+//!   noop_usage_collector_storage_plugin:
+//!     config:
+//!       vendor: "hyperspot"
+//!       priority: 100
+//! ```
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+mod config;
+mod domain;
+mod module;

--- a/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/module.rs
+++ b/modules/system/usage-collector/plugins/noop-usage-collector-storage-plugin/src/module.rs
@@ -1,0 +1,73 @@
+//! No-op usage-collector storage plugin module.
+//!
+//! Registers a GTS plugin instance in the types registry and exposes
+//! [`usage_collector_sdk::UsageCollectorPluginClientV1`] under a scope keyed by that instance.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit::Module;
+use modkit::client_hub::ClientScope;
+use modkit::context::ModuleCtx;
+use modkit::gts::BaseModkitPluginV1;
+use tracing::info;
+use types_registry_sdk::{RegisterResult, TypesRegistryClient};
+use usage_collector_sdk::{UsageCollectorPluginClientV1, UsageCollectorStoragePluginSpecV1};
+
+use crate::config::NoopUsageCollectorStorageConfig;
+use crate::domain::Service;
+
+/// No-op usage-collector storage plugin for development and testing.
+#[modkit::module(
+    name = "noop-usage-collector-storage-plugin",
+    deps = ["types-registry", "usage-collector"]
+)]
+#[derive(Default)]
+struct NoopUsageCollectorStoragePlugin;
+
+// @cpt-dod:cpt-cf-usage-collector-dod-sdk-and-ingest-core-noop-plugin:p1
+#[async_trait]
+impl Module for NoopUsageCollectorStoragePlugin {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        let cfg: NoopUsageCollectorStorageConfig = ctx.config()?;
+        info!(
+            %cfg.vendor,
+            cfg.priority,
+            "Loaded {} configuration",
+            Self::MODULE_NAME,
+        );
+
+        let instance_id = UsageCollectorStoragePluginSpecV1::gts_make_instance_id(
+            "cf.core._.noop_usage_collector_storage_plugin.v1",
+        );
+
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
+        let instance = BaseModkitPluginV1::<UsageCollectorStoragePluginSpecV1> {
+            id: instance_id.clone(),
+            vendor: cfg.vendor.clone(),
+            priority: cfg.priority,
+            properties: UsageCollectorStoragePluginSpecV1,
+        };
+        let instance_json = serde_json::to_value(&instance)?;
+
+        let results = registry.register(vec![instance_json]).await?;
+        RegisterResult::ensure_all_ok(&results)?;
+
+        let service = Service::new();
+
+        let api: Arc<dyn UsageCollectorPluginClientV1> = Arc::new(service);
+        ctx.client_hub()
+            .register_scoped::<dyn UsageCollectorPluginClientV1>(
+                ClientScope::gts_id(&instance_id),
+                api,
+            );
+
+        info!(
+            %instance_id,
+            "Registered {}",
+            Self::MODULE_NAME,
+        );
+
+        Ok(())
+    }
+}

--- a/modules/system/usage-collector/usage-collector/Cargo.toml
+++ b/modules/system/usage-collector/usage-collector/Cargo.toml
@@ -1,0 +1,63 @@
+[package]
+name = "cf-usage-collector"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Usage Collector gateway"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "usage_collector"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+authz-resolver-sdk = { workspace = true }
+types-registry-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+usage-emitter = { workspace = true }
+
+# ModKit dependencies
+modkit = { workspace = true }
+modkit-db = { workspace = true, features = ["preview-outbox"] }
+modkit-macros = { workspace = true }
+modkit-security = { workspace = true }
+modkit-utils = { workspace = true, features = ["humantime-serde"] }
+
+# REST
+axum = { workspace = true }
+http = { workspace = true }
+utoipa = { workspace = true }
+
+# Data structures
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# DB
+sea-orm-migration = { workspace = true }
+
+[dev-dependencies]
+# ModKit dependencies
+modkit-db = { workspace = true, features = ["sqlite"] }

--- a/modules/system/usage-collector/usage-collector/README.md
+++ b/modules/system/usage-collector/usage-collector/README.md
@@ -1,0 +1,46 @@
+# Usage Collector
+
+> **Gateway module** — hosts the Usage Collector gateway in-process: registers the storage-plugin GTS schema with `types-registry`, resolves the active storage plugin by `vendor`, exposes `dyn UsageCollectorClientV1` in `ClientHub` for the outbox delivery path, and serves a REST API for out-of-process emitters.
+
+ModKit module `usage-collector`: central ingest for usage observations (`UsageRecord`) from the outbox pipeline (`usage-emitter`) and delegation to the selected `UsageCollectorPluginClientV1` implementation.
+
+## Overview
+
+At startup the module:
+
+- Registers `UsageCollectorStoragePluginSpecV1` in the types registry so storage backends can be declared as GTS instances.
+- Builds the domain `Service` that lists plugin instances, picks one for the configured `vendor`, and forwards `create_usage_record` calls with a bounded timeout.
+- Registers **`UsageCollectorLocalClient`** as `dyn UsageCollectorClientV1` so code in the **same binary** can call `create_usage_record` and `get_module_config` (which filters the metrics whitelist to only the metrics allowed for the calling module) without a network hop.
+- Initializes the embedded **`UsageEmitter`** (from `usage-emitter`) and registers it in `ClientHub`; the emitter handles authorization (PDP) and the outbox delivery path before forwarding records to the local client.
+
+Source modules should emit through **`usage-emitter`** (PDP + outbox). This crate implements the gateway side of `UsageCollectorClientV1::create_usage_record` and the storage-plugin selection logic.
+
+## Dependencies
+
+- **At least one storage plugin** — a module that registers `dyn UsageCollectorPluginClientV1` in `ClientHub` for the GTS instance id chosen for your `vendor`. For dev/tests, see **`cf-noop-usage-collector-storage-plugin`**.
+
+## Configuration
+
+`vendor` must match the `vendor` field on the storage plugin GTS content so `choose_plugin_instance` selects the right instance. `plugin_timeout` bounds each `create_usage_record` call; exceeded waits become `UsageCollectorError::PluginTimeout`. `emitter` holds nested `UsageEmitterConfig` for outbox and authorization tuning. `metrics` is a whitelist of allowed metric names, each with a `kind` (`gauge` or `counter`) and an optional `modules` list (if absent, all modules may emit that metric).
+
+```yaml
+modules:
+  usage-collector:
+    config:
+      vendor: "hyperspot"
+      plugin_timeout: "5s"
+      emitter:
+        # UsageEmitterConfig fields (outbox, auth tuning)
+      metrics:
+        "storage.bytes_used":
+          kind: "gauge"
+          modules: ["storage-service"]   # omit to allow all modules
+        "api.requests":
+          kind: "counter"
+```
+
+## Testing
+
+```bash
+cargo test -p cf-usage-collector
+```

--- a/modules/system/usage-collector/usage-collector/src/api/mod.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/mod.rs
@@ -1,0 +1,3 @@
+//! API layer for the usage-collector module.
+
+pub mod rest;

--- a/modules/system/usage-collector/usage-collector/src/api/rest/dto.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/dto.rs
@@ -1,0 +1,57 @@
+//! REST DTOs for the usage-collector gateway.
+
+use chrono::{DateTime, Utc};
+use usage_collector_sdk::models::UsageKind;
+use uuid::Uuid;
+
+/// Request body to create one usage record (ingest).
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(request)]
+pub struct CreateUsageRecordRequest {
+    /// Name of the module emitting this record.
+    pub module: String,
+    /// Tenant that owns the record.
+    pub tenant_id: Uuid,
+    /// Logical type of the metered resource.
+    pub resource_type: String,
+    /// Identifier of the metered resource instance.
+    pub resource_id: Uuid,
+    /// Identifier of the subject (user/service account) performing the request.
+    /// `None` when no subject context is available; PDP subject validation is skipped in that case.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_id: Option<String>,
+    /// Type of the subject (e.g. `"user"`, `"service_account"`).
+    /// `None` when no subject context is available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_type: Option<String>,
+    /// Metric name for this observation.
+    pub metric: String,
+    /// Optional idempotency key; if omitted, one is generated when building the record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotency_key: Option<String>,
+    /// Numeric value for this usage observation.
+    pub value: f64,
+    /// Observation timestamp (UTC).
+    pub timestamp: DateTime<Utc>,
+    /// Optional caller-supplied metadata. Serialized size MUST NOT exceed 8 192 bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// One allowed metric entry in a module config response.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct AllowedMetricResponse {
+    /// Metric name.
+    pub name: String,
+    /// Gauge vs counter semantics.
+    pub kind: UsageKind,
+}
+
+/// Response body for the get-module-config endpoint.
+#[derive(Debug, Clone)]
+#[modkit_macros::api_dto(response)]
+pub struct ModuleConfigResponse {
+    /// Metrics the module is allowed to emit.
+    pub allowed_metrics: Vec<AllowedMetricResponse>,
+}

--- a/modules/system/usage-collector/usage-collector/src/api/rest/handlers.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/handlers.rs
@@ -1,0 +1,219 @@
+//! REST handlers for the usage-collector gateway.
+
+use std::sync::Arc;
+
+use axum::extract::Path;
+use axum::{Extension, Json};
+use http::StatusCode;
+use modkit::api::problem::{Problem, internal_error};
+use modkit_security::SecurityContext;
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use usage_emitter::{UsageEmitterError, UsageEmitterV1};
+
+use super::dto::{AllowedMetricResponse, CreateUsageRecordRequest, ModuleConfigResponse};
+
+/// Handler for `POST /usage-collector/v1/records`.
+pub async fn handle_create_usage_record(
+    Extension(ctx): Extension<SecurityContext>,
+    Extension(emitter): Extension<Arc<dyn UsageEmitterV1>>,
+    Json(req): Json<CreateUsageRecordRequest>,
+) -> Result<StatusCode, Problem> {
+    // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-1
+    if let Some(err) = validate_metadata_size(req.metadata.as_ref()) {
+        return Err(err);
+    }
+    // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-1
+
+    let authorized = authorize_request(&ctx, &emitter, &req).await?;
+
+    let mut builder = authorized
+        .build_usage_record(req.metric, req.value)
+        .with_timestamp(req.timestamp);
+
+    if let Some(key) = req.idempotency_key.filter(|k| !k.is_empty()) {
+        builder = builder.with_idempotency_key(key);
+    }
+
+    if let Some(meta) = req.metadata {
+        builder = builder.with_metadata(meta);
+    }
+
+    builder.enqueue().await.map_err(emitter_error_to_problem)?;
+
+    // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-7
+    Ok(StatusCode::NO_CONTENT)
+    // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-7
+}
+
+fn validate_metadata_size(metadata: Option<&serde_json::Value>) -> Option<Problem> {
+    let meta = metadata?;
+    let byte_len = serde_json::to_vec(meta).map_or(0, |v| v.len());
+    if byte_len > 8192 {
+        tracing::warn!(
+            byte_len,
+            limit = 8192,
+            "Metadata byte length exceeds limit; rejecting record"
+        );
+        return Some(Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Metadata too large",
+            format!("metadata byte length {byte_len} exceeds limit of 8192"),
+        ));
+    }
+    None
+}
+
+async fn authorize_request(
+    ctx: &SecurityContext,
+    emitter: &Arc<dyn UsageEmitterV1>,
+    req: &CreateUsageRecordRequest,
+) -> Result<usage_emitter::AuthorizedUsageEmitter, Problem> {
+    match (&req.subject_id, &req.subject_type) {
+        (None, None) => {
+            // No subject — skip PDP authorization.
+            tracing::debug!("No subject fields present; skipping PDP authorization");
+            emitter
+                .for_module(&req.module)
+                .authorize_for(
+                    ctx,
+                    req.tenant_id,
+                    req.resource_id,
+                    req.resource_type.clone(),
+                    None,
+                    None,
+                )
+                .await
+                .map_err(emitter_error_to_problem)
+        }
+        (Some(sid_str), _) => {
+            // subject_id present (subject_type optional) — authorize via PDP.
+            let subject_id = sid_str.parse::<uuid::Uuid>().map_err(|_| {
+                Problem::new(
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "Invalid subject_id",
+                    "subject_id must be a valid UUID",
+                )
+            })?;
+            emitter
+                .for_module(&req.module)
+                .authorize_for(
+                    ctx,
+                    req.tenant_id,
+                    req.resource_id,
+                    req.resource_type.clone(),
+                    Some(subject_id),
+                    req.subject_type.clone(),
+                )
+                .await
+                .map_err(emitter_error_to_problem)
+        }
+        _ => {
+            // subject_type present without subject_id — invalid.
+            Err(Problem::new(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "Invalid subject",
+                "subject_type requires subject_id to be present",
+            ))
+        }
+    }
+}
+
+/// Handler for `GET /usage-collector/v1/modules/{module_name}/config`.
+// @cpt-flow:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2
+pub async fn handle_get_module_config(
+    Path(module_name): Path<String>,
+    Extension(collector): Extension<Arc<dyn UsageCollectorClientV1>>,
+) -> Result<Json<ModuleConfigResponse>, Problem> {
+    // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-2
+    // Authenticated request received; ModKit pipeline enforces authentication before handler entry.
+    // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-2
+
+    // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-3
+    let result = collector.get_module_config(&module_name).await;
+    // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-3
+
+    // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-4
+    let config = match result {
+        // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-4a
+        Err(UsageCollectorError::ModuleNotFound {
+            module_name: ref name,
+        }) => {
+            return Err(Problem::new(
+                StatusCode::NOT_FOUND,
+                "Module not found",
+                format!("module '{name}' is not configured"),
+            ));
+        }
+        // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-4a
+        Err(e) => return Err(internal_error(e.to_string())),
+        Ok(c) => c,
+    };
+    // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-4
+
+    // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-5
+    let response = ModuleConfigResponse {
+        allowed_metrics: config
+            .allowed_metrics
+            .into_iter()
+            .map(|m| AllowedMetricResponse {
+                name: m.name,
+                kind: m.kind,
+            })
+            .collect(),
+    };
+
+    Ok(Json(response))
+    // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-5
+}
+
+fn emitter_error_to_problem(e: UsageEmitterError) -> Problem {
+    match e {
+        UsageEmitterError::AuthorizationFailed { message } => {
+            Problem::new(StatusCode::FORBIDDEN, "Forbidden", message)
+        }
+        UsageEmitterError::AuthorizationExpired => {
+            Problem::new(StatusCode::FORBIDDEN, "Forbidden", e.to_string())
+        }
+        UsageEmitterError::InvalidRecord { message } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Invalid usage record",
+            message,
+        ),
+        UsageEmitterError::MetricNotAllowed { metric } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Metric not allowed",
+            format!("metric not allowed for this module: {metric}"),
+        ),
+        UsageEmitterError::MetricKindMismatch {
+            metric,
+            expected,
+            actual,
+        } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Metric kind mismatch",
+            format!("metric '{metric}' expects kind {expected:?} but record specifies {actual:?}"),
+        ),
+        UsageEmitterError::NegativeCounterValue { value } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Invalid usage record",
+            format!("counter usage record has a negative value: {value}"),
+        ),
+        UsageEmitterError::MetadataTooLarge { len } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Metadata too large",
+            format!("metadata byte length {len} exceeds the 8192-byte limit"),
+        ),
+        UsageEmitterError::ModuleNotConfigured { module_name } => Problem::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Module not configured",
+            format!("module '{module_name}' is not configured in the gateway"),
+        ),
+        UsageEmitterError::Internal { message } => internal_error(message),
+        UsageEmitterError::Outbox(err) => internal_error(err.to_string()),
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "handlers_tests.rs"]
+mod handlers_tests;

--- a/modules/system/usage-collector/usage-collector/src/api/rest/handlers_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/handlers_tests.rs
@@ -1,0 +1,498 @@
+//! Unit tests for REST handlers and `emitter_error_to_problem`.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use authz_resolver_sdk::models::{
+    EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError};
+use axum::Extension;
+use axum::Json;
+use axum::extract::Path;
+use chrono::Utc;
+use http::StatusCode;
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::outbox_migrations;
+use modkit_db::{ConnectOpts, connect_db};
+use modkit_security::SecurityContext;
+use usage_collector_sdk::{
+    AllowedMetric, ModuleConfig, UsageCollectorClientV1, UsageCollectorError, UsageKind,
+    UsageRecord,
+};
+use usage_emitter::{UsageEmitter, UsageEmitterError, UsageEmitterV1};
+use uuid::Uuid;
+
+use super::emitter_error_to_problem;
+use super::handle_create_usage_record;
+use super::handle_get_module_config;
+use crate::api::rest::dto::CreateUsageRecordRequest;
+
+// ── emitter_error_to_problem ──────────────────────────────────────
+
+#[test]
+fn authorization_failed_maps_to_forbidden() {
+    let err = UsageEmitterError::authorization_failed("pdp denied");
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::FORBIDDEN);
+    assert_eq!(p.detail, "pdp denied");
+}
+
+#[test]
+fn authorization_expired_maps_to_forbidden() {
+    let err = UsageEmitterError::authorization_expired();
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::FORBIDDEN);
+}
+
+#[test]
+fn invalid_record_maps_to_unprocessable_entity() {
+    let err = UsageEmitterError::invalid_record("missing metric");
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(p.detail, "missing metric");
+}
+
+#[test]
+fn metric_not_allowed_maps_to_unprocessable_entity() {
+    let err = UsageEmitterError::metric_not_allowed("cpu.usage");
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(
+        p.detail.contains("cpu.usage"),
+        "detail should name the metric"
+    );
+}
+
+#[test]
+fn metric_kind_mismatch_maps_to_unprocessable_entity() {
+    let err =
+        UsageEmitterError::metric_kind_mismatch("req.count", UsageKind::Counter, UsageKind::Gauge);
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(p.detail.contains("req.count"));
+}
+
+#[test]
+fn negative_counter_value_maps_to_unprocessable_entity() {
+    let err = UsageEmitterError::negative_counter_value(-1.5);
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(p.detail.contains("-1.5"));
+}
+
+#[test]
+fn internal_error_maps_to_500() {
+    let err = UsageEmitterError::internal("something broke");
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[test]
+fn outbox_error_maps_to_500() {
+    let err = UsageEmitterError::Outbox(modkit_db::outbox::OutboxError::QueueNotRegistered(
+        "usage".to_owned(),
+    ));
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+// ── handle_get_module_config ──────────────────────────────────────
+
+struct MockCollector {
+    config: ModuleConfig,
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for MockCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Ok(self.config.clone())
+    }
+}
+
+struct FailingCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for FailingCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Err(UsageCollectorError::internal("unavailable"))
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Err(UsageCollectorError::internal("unavailable"))
+    }
+}
+
+struct NotFoundCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for NotFoundCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Err(UsageCollectorError::module_not_found(module_name))
+    }
+}
+
+#[tokio::test]
+async fn get_module_config_handler_returns_allowed_metrics() {
+    let collector = Arc::new(MockCollector {
+        config: ModuleConfig {
+            allowed_metrics: vec![AllowedMetric {
+                name: "cpu.usage".to_owned(),
+                kind: UsageKind::Gauge,
+            }],
+        },
+    }) as Arc<dyn UsageCollectorClientV1>;
+
+    let result = handle_get_module_config(Path("my-module".to_owned()), Extension(collector)).await;
+
+    let axum::Json(resp) = result.expect("handler should succeed");
+    assert_eq!(resp.allowed_metrics.len(), 1);
+    assert_eq!(resp.allowed_metrics[0].name, "cpu.usage");
+}
+
+#[tokio::test]
+async fn get_module_config_handler_propagates_collector_error_as_500() {
+    let collector = Arc::new(FailingCollector) as Arc<dyn UsageCollectorClientV1>;
+
+    let result = handle_get_module_config(Path("my-module".to_owned()), Extension(collector)).await;
+
+    let err = result.expect_err("handler should fail");
+    assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn get_module_config_handler_returns_404_for_unknown_module() {
+    let collector = Arc::new(NotFoundCollector) as Arc<dyn UsageCollectorClientV1>;
+
+    let result =
+        handle_get_module_config(Path("unknown-module".to_owned()), Extension(collector)).await;
+
+    let err = result.expect_err("handler should return 404");
+    assert_eq!(err.status, StatusCode::NOT_FOUND);
+    assert!(err.detail.contains("unknown-module"));
+}
+
+#[test]
+fn module_not_configured_maps_to_unprocessable_entity() {
+    let err = UsageEmitterError::module_not_configured("my-module");
+    let p = emitter_error_to_problem(err);
+    assert_eq!(p.status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(p.detail.contains("my-module"));
+}
+
+// ── handle_create_usage_record ────────────────────────────────────────────────
+
+/// PDP mock that captures the `subject_id` and `subject_type` resource properties from the
+/// incoming evaluation request, then allows the request to proceed.
+struct CapturingSubjectAuthZ {
+    captured_subject_id: Arc<Mutex<Option<String>>>,
+    captured_subject_type: Arc<Mutex<Option<String>>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for CapturingSubjectAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let subj_id = request
+            .resource
+            .properties
+            .get("subject_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        let subj_type = request
+            .resource
+            .properties
+            .get("subject_type")
+            .and_then(|v| v.as_str())
+            .map(str::to_owned);
+        *self.captured_subject_id.lock().unwrap() = subj_id;
+        *self.captured_subject_type.lock().unwrap() = subj_type;
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+/// Collector that returns a fixed `ModuleConfig` with one allowed metric.
+struct FixedConfigCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for FixedConfigCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        Ok(ModuleConfig {
+            allowed_metrics: vec![AllowedMetric {
+                name: "test.gauge".to_owned(),
+                kind: UsageKind::Gauge,
+            }],
+        })
+    }
+}
+
+async fn build_handler_emitter(authz: Arc<dyn AuthZResolverClient>) -> Arc<dyn UsageEmitterV1> {
+    let db_name = format!("hw_{}", Uuid::new_v4().simple());
+    let url = format!("sqlite:file:{db_name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    let emitter = UsageEmitter::build(
+        usage_emitter::UsageEmitterConfig::default(),
+        db,
+        authz,
+        Arc::new(FixedConfigCollector),
+    )
+    .await
+    .unwrap();
+    Arc::new(emitter) as Arc<dyn UsageEmitterV1>
+}
+
+#[tokio::test]
+async fn ingest_handler_passes_subject_fields_to_authorize_for() {
+    let subject_id = Uuid::new_v4();
+    let subject_type = "test.service_account".to_owned();
+
+    let captured_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_type: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let authz = Arc::new(CapturingSubjectAuthZ {
+        captured_subject_id: Arc::clone(&captured_id),
+        captured_subject_type: Arc::clone(&captured_type),
+    });
+
+    let emitter = build_handler_emitter(authz).await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    let req = CreateUsageRecordRequest {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        resource_id: Uuid::new_v4(),
+        subject_id: Some(subject_id.to_string()),
+        subject_type: Some(subject_type.clone()),
+        metric: "test.gauge".to_owned(),
+        idempotency_key: None,
+        value: 1.0,
+        timestamp: Utc::now(),
+        metadata: None,
+    };
+
+    let result = handle_create_usage_record(Extension(ctx), Extension(emitter), Json(req)).await;
+
+    assert!(result.is_ok(), "handler should succeed: {result:?}");
+
+    assert_eq!(
+        captured_id.lock().unwrap().as_deref(),
+        Some(subject_id.to_string().as_str()),
+        "subject_id must be forwarded to the PDP request"
+    );
+    assert_eq!(
+        captured_type.lock().unwrap().as_deref(),
+        Some(subject_type.as_str()),
+        "subject_type must be forwarded to the PDP request"
+    );
+}
+
+#[tokio::test]
+async fn ingest_handler_succeeds_when_subject_fields_absent() {
+    // Both subject fields absent: handler must skip PDP and return 204.
+    let captured_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_type: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let authz = Arc::new(CapturingSubjectAuthZ {
+        captured_subject_id: Arc::clone(&captured_id),
+        captured_subject_type: Arc::clone(&captured_type),
+    });
+
+    let emitter = build_handler_emitter(authz).await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    let req = CreateUsageRecordRequest {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        resource_id: Uuid::new_v4(),
+        subject_id: None,
+        subject_type: None,
+        metric: "test.gauge".to_owned(),
+        idempotency_key: None,
+        value: 1.0,
+        timestamp: Utc::now(),
+        metadata: None,
+    };
+
+    let result = handle_create_usage_record(Extension(ctx), Extension(emitter), Json(req)).await;
+
+    assert!(
+        result.is_ok(),
+        "handler should succeed when subject is absent: {result:?}"
+    );
+
+    // PDP was not called with subject properties: captured values remain None.
+    assert!(
+        captured_id.lock().unwrap().is_none(),
+        "subject_id must not be forwarded to PDP when absent"
+    );
+    assert!(
+        captured_type.lock().unwrap().is_none(),
+        "subject_type must not be forwarded to PDP when absent"
+    );
+}
+
+#[tokio::test]
+async fn ingest_handler_succeeds_when_subject_id_present_without_subject_type() {
+    // subject_id present, subject_type absent: valid — must route to PDP and return 204.
+    let subject_id = Uuid::new_v4();
+
+    let captured_id: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_type: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let authz = Arc::new(CapturingSubjectAuthZ {
+        captured_subject_id: Arc::clone(&captured_id),
+        captured_subject_type: Arc::clone(&captured_type),
+    });
+
+    let emitter = build_handler_emitter(authz).await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    let req = CreateUsageRecordRequest {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        resource_id: Uuid::new_v4(),
+        subject_id: Some(subject_id.to_string()),
+        subject_type: None,
+        metric: "test.gauge".to_owned(),
+        idempotency_key: None,
+        value: 1.0,
+        timestamp: Utc::now(),
+        metadata: None,
+    };
+
+    let result = handle_create_usage_record(Extension(ctx), Extension(emitter), Json(req)).await;
+
+    assert!(
+        result.is_ok(),
+        "handler should succeed when subject_type is absent: {result:?}"
+    );
+    assert_eq!(
+        captured_id.lock().unwrap().as_deref(),
+        Some(subject_id.to_string().as_str()),
+        "subject_id must be forwarded to PDP when subject_type is absent"
+    );
+    assert!(
+        captured_type.lock().unwrap().is_none(),
+        "subject_type must not be forwarded to PDP when absent"
+    );
+}
+
+#[tokio::test]
+async fn ingest_handler_returns_error_when_only_subject_type_present() {
+    // Only subject_type present: partial presence must return 422.
+    let authz = Arc::new(CapturingSubjectAuthZ {
+        captured_subject_id: Arc::new(Mutex::new(None)),
+        captured_subject_type: Arc::new(Mutex::new(None)),
+    });
+
+    let emitter = build_handler_emitter(authz).await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap();
+
+    let req = CreateUsageRecordRequest {
+        module: "test-module".to_owned(),
+        tenant_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        resource_id: Uuid::new_v4(),
+        subject_id: None,
+        subject_type: Some("user".to_owned()),
+        metric: "test.gauge".to_owned(),
+        idempotency_key: None,
+        value: 1.0,
+        timestamp: Utc::now(),
+        metadata: None,
+    };
+
+    let result = handle_create_usage_record(Extension(ctx), Extension(emitter), Json(req)).await;
+
+    let err = result.expect_err("handler should return an error for partial subject");
+    assert_eq!(
+        err.status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "partial subject presence must return 422"
+    );
+}
+
+#[test]
+fn ingest_handler_subject_fields_absent_deserializes_to_none() {
+    // `subject_id` and `subject_type` now carry `#[serde(default)]`, so a JSON body
+    // that omits them must deserialize successfully with both fields as `None`.
+    let body_without_subject = serde_json::json!({
+        "module": "test-module",
+        "tenant_id": Uuid::new_v4(),
+        "resource_type": "test.resource",
+        "resource_id": Uuid::new_v4(),
+        "metric": "test.gauge",
+        "value": 1.0,
+        "timestamp": Utc::now()
+    });
+    let result: Result<CreateUsageRecordRequest, _> = serde_json::from_value(body_without_subject);
+    let req = result.expect("deserialization must succeed when subject fields are absent");
+    assert!(
+        req.subject_id.is_none(),
+        "subject_id must be None when absent from JSON"
+    );
+    assert!(
+        req.subject_type.is_none(),
+        "subject_type must be None when absent from JSON"
+    );
+}

--- a/modules/system/usage-collector/usage-collector/src/api/rest/mod.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/mod.rs
@@ -1,0 +1,5 @@
+//! REST API layer for the usage-collector module.
+
+pub mod dto;
+pub mod handlers;
+pub mod routes;

--- a/modules/system/usage-collector/usage-collector/src/api/rest/routes.rs
+++ b/modules/system/usage-collector/usage-collector/src/api/rest/routes.rs
@@ -1,0 +1,73 @@
+//! Route registration for the usage-collector REST API.
+
+use std::sync::Arc;
+
+use axum::{Extension, Router};
+
+use modkit::api::operation_builder::LicenseFeature;
+use modkit::api::{OpenApiRegistry, OperationBuilder};
+use usage_collector_sdk::UsageCollectorClientV1;
+use usage_emitter::UsageEmitterV1;
+
+use super::dto::{CreateUsageRecordRequest, ModuleConfigResponse};
+use super::handlers;
+
+const API_TAG: &str = "Usage Collector";
+
+struct License;
+
+impl AsRef<str> for License {
+    fn as_ref(&self) -> &'static str {
+        "gts.x.core.lic.feat.v1~x.core.global.base.v1"
+    }
+}
+
+impl LicenseFeature for License {}
+
+/// Register all REST routes for the usage-collector module.
+pub fn register_routes(
+    router: Router,
+    openapi: &dyn OpenApiRegistry,
+    emitter: Arc<dyn UsageEmitterV1>,
+    collector: Arc<dyn UsageCollectorClientV1>,
+) -> Router {
+    let router = OperationBuilder::post("/usage-collector/v1/records")
+        .operation_id("usage_collector.create_usage_record")
+        .summary("Create a usage record")
+        .description(
+            "Accepts a usage record payload and delegates storage to the configured storage plugin.",
+        )
+        .tag(API_TAG)
+        .authenticated()
+        .require_license_features::<License>([])
+        .json_request::<CreateUsageRecordRequest>(openapi, "Usage record to create")
+        .allow_content_types(&["application/json"])
+        .handler(handlers::handle_create_usage_record)
+        .json_response(http::StatusCode::NO_CONTENT, "Record accepted and stored")
+        .error_403(openapi)
+        .error_422(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    let router = OperationBuilder::get("/usage-collector/v1/modules/{module_name}/config")
+        .operation_id("usage_collector.get_module_config")
+        .summary("Get module configuration")
+        .description(
+            "Returns the allowed metrics (and future configuration) for the specified module.",
+        )
+        .tag(API_TAG)
+        .authenticated()
+        .require_license_features::<License>([])
+        .path_param("module_name", "Module name")
+        .handler(handlers::handle_get_module_config)
+        .json_response_with_schema::<ModuleConfigResponse>(
+            openapi,
+            http::StatusCode::OK,
+            "Module configuration",
+        )
+        .error_404(openapi)
+        .error_500(openapi)
+        .register(router, openapi);
+
+    router.layer(Extension(emitter)).layer(Extension(collector))
+}

--- a/modules/system/usage-collector/usage-collector/src/config.rs
+++ b/modules/system/usage-collector/usage-collector/src/config.rs
@@ -1,0 +1,94 @@
+//! Configuration for the usage-collector gateway module.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde::Deserialize;
+use usage_collector_sdk::UsageKind;
+use usage_emitter::UsageEmitterConfig;
+
+/// Per-metric allowed configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricConfig {
+    /// Gauge vs counter semantics.
+    pub kind: UsageKind,
+    /// Modules allowed to emit this metric. If absent, all modules are allowed.
+    pub modules: Option<Vec<String>>,
+}
+
+/// Module configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct UsageCollectorConfig {
+    /// Vendor selector used to pick a storage plugin instance from types-registry.
+    pub vendor: String,
+
+    /// Timeout for each storage plugin `create_usage_record()` call.
+    /// Valid range: 100ms–30s. Default: 5s.
+    #[serde(with = "modkit_utils::humantime_serde")]
+    pub plugin_timeout: Duration,
+
+    /// Number of consecutive failures within `circuit_breaker_window` that will open the circuit.
+    /// Valid range: 1–100. Default: 5.
+    pub circuit_breaker_failure_threshold: u32,
+
+    /// Rolling window for counting consecutive failures.
+    /// Default: 10s.
+    #[serde(with = "modkit_utils::humantime_serde")]
+    pub circuit_breaker_window: Duration,
+
+    /// Duration to wait in the open state before allowing a half-open probe.
+    /// Valid range: 1s–5m. Default: 30s.
+    #[serde(with = "modkit_utils::humantime_serde")]
+    pub circuit_breaker_recovery_timeout: Duration,
+
+    /// Outbox/authorization tuning for the embedded usage emitter.
+    pub emitter: UsageEmitterConfig,
+
+    /// Allowed metrics configuration. Key is the metric name.
+    pub metrics: HashMap<String, MetricConfig>,
+}
+
+impl UsageCollectorConfig {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.plugin_timeout.is_zero() {
+            anyhow::bail!("plugin_timeout must be greater than zero");
+        }
+        if self.plugin_timeout > std::time::Duration::from_secs(30) {
+            anyhow::bail!("plugin_timeout must not exceed 30s");
+        }
+        if self.circuit_breaker_failure_threshold < 1 {
+            anyhow::bail!("circuit_breaker_failure_threshold must be at least 1");
+        }
+        if self.circuit_breaker_failure_threshold > 100 {
+            anyhow::bail!("circuit_breaker_failure_threshold must not exceed 100");
+        }
+        if self.circuit_breaker_recovery_timeout.is_zero() {
+            anyhow::bail!("circuit_breaker_recovery_timeout must be greater than zero");
+        }
+        if self.circuit_breaker_recovery_timeout > std::time::Duration::from_mins(5) {
+            anyhow::bail!("circuit_breaker_recovery_timeout must not exceed 5min");
+        }
+        Ok(())
+    }
+}
+
+impl Default for UsageCollectorConfig {
+    fn default() -> Self {
+        Self {
+            vendor: "hyperspot".to_owned(),
+            plugin_timeout: Duration::from_secs(5),
+            circuit_breaker_failure_threshold: 5,
+            circuit_breaker_window: Duration::from_secs(10),
+            circuit_breaker_recovery_timeout: Duration::from_secs(30),
+            emitter: UsageEmitterConfig::default(),
+            metrics: HashMap::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/modules/system/usage-collector/usage-collector/src/config_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/config_tests.rs
@@ -1,0 +1,148 @@
+use std::time::Duration;
+
+use usage_collector_sdk::UsageKind;
+
+use super::UsageCollectorConfig;
+
+#[test]
+fn test_validate_rejects_plugin_timeout_zero() {
+    let cfg = UsageCollectorConfig {
+        plugin_timeout: Duration::ZERO,
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("plugin_timeout"),
+        "error must mention plugin_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_plugin_timeout_above_30s() {
+    let cfg = UsageCollectorConfig {
+        plugin_timeout: Duration::from_secs(31),
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("plugin_timeout"),
+        "error must mention plugin_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_failure_threshold_zero() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker_failure_threshold: 0,
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("circuit_breaker_failure_threshold"),
+        "error must mention circuit_breaker_failure_threshold, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_failure_threshold_above_100() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker_failure_threshold: 101,
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("circuit_breaker_failure_threshold"),
+        "error must mention circuit_breaker_failure_threshold, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_recovery_timeout_zero() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker_recovery_timeout: Duration::ZERO,
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("circuit_breaker_recovery_timeout"),
+        "error must mention circuit_breaker_recovery_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_rejects_circuit_breaker_recovery_timeout_above_5min() {
+    let cfg = UsageCollectorConfig {
+        circuit_breaker_recovery_timeout: Duration::from_secs(301),
+        ..UsageCollectorConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(
+        err.to_string().contains("circuit_breaker_recovery_timeout"),
+        "error must mention circuit_breaker_recovery_timeout, got: {err}"
+    );
+}
+
+#[test]
+fn test_validate_accepts_defaults() {
+    let cfg = UsageCollectorConfig::default();
+    assert!(cfg.validate().is_ok());
+}
+
+#[test]
+fn vendor_can_be_overridden_via_serde() {
+    let json = r#"{"vendor": "acme"}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.vendor, "acme");
+}
+
+#[test]
+fn serde_default_applies_default_vendor() {
+    let cfg: UsageCollectorConfig = serde_json::from_str("{}").unwrap();
+    assert_eq!(
+        cfg.vendor, "hyperspot",
+        "serde(default) must use Default impl"
+    );
+}
+
+#[test]
+fn plugin_timeout_can_be_overridden_via_serde() {
+    let json = r#"{"plugin_timeout": "10s"}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(cfg.plugin_timeout, Duration::from_secs(10));
+}
+
+#[test]
+fn serde_default_applies_default_plugin_timeout() {
+    let cfg: UsageCollectorConfig = serde_json::from_str("{}").unwrap();
+    assert_eq!(
+        cfg.plugin_timeout,
+        Duration::from_secs(5),
+        "serde(default) must use Default impl"
+    );
+}
+
+#[test]
+fn rejects_unknown_fields() {
+    let json = r#"{"vendor": "x", "unexpected": true}"#;
+    assert!(serde_json::from_str::<UsageCollectorConfig>(json).is_err());
+}
+
+#[test]
+fn metrics_config_parses_with_modules() {
+    let json = r#"{"metrics": {"cpu.usage": {"kind": "gauge", "modules": ["mod-a"]}}}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    let m = &cfg.metrics["cpu.usage"];
+    assert!(matches!(m.kind, UsageKind::Gauge));
+    assert_eq!(m.modules.as_deref(), Some(["mod-a".to_owned()].as_slice()));
+}
+
+#[test]
+fn metrics_config_parses_without_modules() {
+    let json = r#"{"metrics": {"req.count": {"kind": "counter"}}}"#;
+    let cfg: UsageCollectorConfig = serde_json::from_str(json).unwrap();
+    let m = &cfg.metrics["req.count"];
+    assert!(matches!(m.kind, UsageKind::Counter));
+    assert!(m.modules.is_none());
+}

--- a/modules/system/usage-collector/usage-collector/src/domain/local_client.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/local_client.rs
@@ -1,0 +1,339 @@
+//! Local client registered in `ClientHub` as `dyn UsageCollectorClientV1`.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use modkit::client_hub::{ClientHub, ClientScope};
+use modkit::plugins::{GtsPluginSelector, choose_plugin_instance};
+use modkit::telemetry::ThrottledLog;
+use modkit_macros::domain_model;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+use tracing::{debug, info, warn};
+use types_registry_sdk::{ListQuery, TypesRegistryClient};
+use usage_collector_sdk::AllowedMetric;
+use usage_collector_sdk::ModuleConfig;
+use usage_collector_sdk::UsageCollectorClientV1;
+use usage_collector_sdk::UsageCollectorError;
+use usage_collector_sdk::UsageRecord;
+use usage_collector_sdk::{UsageCollectorPluginClientV1, UsageCollectorStoragePluginSpecV1};
+
+use crate::config::UsageCollectorConfig;
+
+const UNAVAILABLE_LOG_THROTTLE: Duration = Duration::from_secs(10);
+
+/// Circuit breaker state.
+#[domain_model]
+#[derive(Debug)]
+enum CircuitState {
+    /// Normal operation; plugin calls are forwarded.
+    Closed,
+    /// Circuit is open; plugin calls are rejected without attempting the plugin.
+    Open {
+        /// When the circuit was opened (used to compute half-open probe eligibility).
+        opened_at: Instant,
+    },
+    /// A single probe call is in-flight; treat any failure as re-open.
+    HalfOpen,
+}
+
+/// Minimal sliding-window circuit breaker.
+///
+/// Opens after `failure_threshold` consecutive failures within `window`.
+/// Transitions to half-open after `recovery_timeout`.
+#[domain_model]
+#[derive(Debug)]
+struct CircuitBreaker {
+    /// Failure threshold before the circuit opens.
+    failure_threshold: u32,
+    /// Rolling window for failure counting.
+    window: Duration,
+    /// How long to wait in the open state before probing.
+    recovery_timeout: Duration,
+    /// Current circuit state.
+    state: CircuitState,
+    /// Timestamps of recent failures within the current window.
+    failure_timestamps: Vec<Instant>,
+}
+
+impl CircuitBreaker {
+    fn new(failure_threshold: u32, window: Duration, recovery_timeout: Duration) -> Self {
+        Self {
+            failure_threshold,
+            window,
+            recovery_timeout,
+            state: CircuitState::Closed,
+            failure_timestamps: Vec::new(),
+        }
+    }
+
+    /// Returns `true` if the circuit is currently open (caller should return `CircuitOpen`).
+    fn is_open(&mut self) -> bool {
+        match &self.state {
+            CircuitState::Open { opened_at } => {
+                if opened_at.elapsed() >= self.recovery_timeout {
+                    // Transition to half-open to allow a probe.
+                    info!("Circuit breaker transitioning from Open to HalfOpen for probe");
+                    self.state = CircuitState::HalfOpen;
+                    false
+                } else {
+                    true
+                }
+            }
+            CircuitState::Closed => false,
+            // Probe is already in-flight; reject all other callers until the probe completes.
+            CircuitState::HalfOpen => true,
+        }
+    }
+
+    /// Record a failure. Opens the circuit if threshold exceeded within the window.
+    fn record_failure(&mut self) {
+        let now = Instant::now();
+
+        // Prune failures outside the rolling window.
+        self.failure_timestamps
+            .retain(|t| now.duration_since(*t) < self.window);
+
+        self.failure_timestamps.push(now);
+
+        // Failure threshold is at most u32::MAX; the window prunes old entries so this
+        // count is bounded by `failure_threshold` which is u32.
+        #[allow(clippy::cast_possible_truncation)]
+        let consecutive = self.failure_timestamps.len() as u32;
+
+        if consecutive >= self.failure_threshold {
+            match self.state {
+                CircuitState::Closed | CircuitState::HalfOpen => {
+                    warn!(
+                        consecutive_failures = consecutive,
+                        threshold = self.failure_threshold,
+                        "Circuit breaker opening after consecutive failures"
+                    );
+                    self.state = CircuitState::Open { opened_at: now };
+                    self.failure_timestamps.clear();
+                }
+                CircuitState::Open { .. } => {
+                    // Already open; update timestamp.
+                    self.state = CircuitState::Open { opened_at: now };
+                }
+            }
+        }
+    }
+
+    /// Record a successful call — reset failure window and close circuit.
+    fn record_success(&mut self) {
+        match self.state {
+            CircuitState::HalfOpen => {
+                info!(
+                    "Circuit breaker transitioning from HalfOpen to Closed after successful probe"
+                );
+                self.state = CircuitState::Closed;
+                self.failure_timestamps.clear();
+            }
+            CircuitState::Closed => {
+                self.failure_timestamps.clear();
+            }
+            CircuitState::Open { .. } => {
+                // Should not happen (success while open), but reset to closed.
+                warn!("Circuit breaker received success while Open; resetting to Closed");
+                self.state = CircuitState::Closed;
+                self.failure_timestamps.clear();
+            }
+        }
+    }
+}
+
+/// Local `ClientHub` implementation of [`UsageCollectorClientV1`].
+///
+/// Resolves the configured GTS storage plugin on first use and delegates
+/// record creation to it, while also serving per-module metric config from
+/// the static configuration.
+#[domain_model]
+pub struct UsageCollectorLocalClient {
+    hub: Arc<ClientHub>,
+    selector: GtsPluginSelector,
+    config: UsageCollectorConfig,
+    unavailable_log_throttle: ThrottledLog,
+    circuit_breaker: Mutex<CircuitBreaker>,
+}
+
+impl UsageCollectorLocalClient {
+    #[must_use]
+    pub fn new(config: UsageCollectorConfig, hub: Arc<ClientHub>) -> Self {
+        let cb = CircuitBreaker::new(
+            config.circuit_breaker_failure_threshold,
+            config.circuit_breaker_window,
+            config.circuit_breaker_recovery_timeout,
+        );
+        Self {
+            hub,
+            selector: GtsPluginSelector::new(),
+            config,
+            unavailable_log_throttle: ThrottledLog::new(UNAVAILABLE_LOG_THROTTLE),
+            circuit_breaker: Mutex::new(cb),
+        }
+    }
+
+    async fn get_plugin(
+        &self,
+    ) -> Result<Arc<dyn UsageCollectorPluginClientV1>, UsageCollectorError> {
+        let instance_id = self.selector.get_or_init(|| self.resolve_plugin()).await?;
+        let scope = ClientScope::gts_id(instance_id.as_ref());
+
+        if let Some(client) = self
+            .hub
+            .try_get_scoped::<dyn UsageCollectorPluginClientV1>(&scope)
+        {
+            Ok(client)
+        } else {
+            if self.unavailable_log_throttle.should_log() {
+                warn!(
+                    plugin_gts_id = %instance_id,
+                    self.config.vendor,
+                    "Plugin client not registered yet"
+                );
+            }
+            Err(UsageCollectorError::internal(format!(
+                "plugin client not registered for {instance_id}"
+            )))
+        }
+    }
+
+    #[tracing::instrument(skip_all, fields(vendor = %self.config.vendor))]
+    async fn resolve_plugin(&self) -> Result<String, UsageCollectorError> {
+        info!("Resolving usage-collector storage plugin");
+
+        let registry = self
+            .hub
+            .get::<dyn TypesRegistryClient>()
+            .map_err(|e| UsageCollectorError::internal(e.to_string()))?;
+
+        let plugin_type_id = UsageCollectorStoragePluginSpecV1::gts_schema_id().clone();
+
+        let instances = registry
+            .list(
+                ListQuery::new()
+                    .with_pattern(format!("{plugin_type_id}*"))
+                    .with_is_type(false),
+            )
+            .await
+            .map_err(|e| UsageCollectorError::internal(e.to_string()))?;
+
+        let gts_id = choose_plugin_instance::<UsageCollectorStoragePluginSpecV1>(
+            &self.config.vendor,
+            instances.iter().map(|e| (e.gts_id.as_str(), &e.content)),
+        )
+        .map_err(|e| UsageCollectorError::internal(e.to_string()))?;
+
+        info!(plugin_gts_id = %gts_id, "Selected usage-collector storage plugin instance");
+        Ok(gts_id)
+    }
+}
+
+// @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:p1
+// @cpt-dod:cpt-cf-usage-collector-dod-sdk-and-ingest-core-gateway-crate:p1
+#[async_trait]
+impl UsageCollectorClientV1 for UsageCollectorLocalClient {
+    /// # Errors
+    ///
+    /// Returns `UsageCollectorError::CircuitOpen` if the circuit breaker is open.
+    /// Returns `UsageCollectorError::Internal` if no storage plugin is available or
+    /// if the plugin call fails. Returns `UsageCollectorError::PluginTimeout` if the
+    /// plugin does not respond within the configured deadline.
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-2
+        let circuit_open = self.circuit_breaker.lock().await.is_open();
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-2
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-3
+        if circuit_open {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-3a
+            warn!("Circuit breaker is open; rejecting usage record without calling plugin");
+            return Err(UsageCollectorError::circuit_open());
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-3a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-4
+        let plugin = self.get_plugin().await?;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-4
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-5
+        let call = timeout(
+            self.config.plugin_timeout,
+            plugin.create_usage_record(record),
+        );
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-5
+
+        match call.await {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6
+            Err(_elapsed) => {
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6a
+                self.circuit_breaker.lock().await.record_failure();
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6a
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6b
+                Err(UsageCollectorError::plugin_timeout())
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6b
+            }
+            Ok(Err(e)) => {
+                warn!(error = %e, "storage plugin call failed transiently; recording circuit breaker failure");
+                self.circuit_breaker.lock().await.record_failure();
+                Err(e)
+            }
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-6
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-7
+            Ok(Ok(())) => {
+                debug!("usage record created successfully");
+                self.circuit_breaker.lock().await.record_success();
+                Ok(())
+            } // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-gateway-ingest-handler:inst-gw-7
+        }
+    }
+
+    // @cpt-flow:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2
+    // @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2
+    async fn get_module_config(
+        &self,
+        module_name: &str,
+    ) -> Result<ModuleConfig, UsageCollectorError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-1
+        // Authentication is enforced by the ModKit pipeline (`.authenticated()` in routes.rs);
+        // unauthenticated requests are rejected before this function is reached.
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-1
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-2
+        let allowed_metrics: Vec<AllowedMetric> = self
+            .config
+            .metrics
+            .iter()
+            .filter(|(_, cfg)| {
+                cfg.modules
+                    .as_ref()
+                    .is_none_or(|mods| mods.iter().any(|m| m == module_name))
+            })
+            .map(|(name, cfg)| AllowedMetric {
+                name: name.clone(),
+                kind: cfg.kind,
+            })
+            .collect();
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-2
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3
+        if allowed_metrics.is_empty() {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3a
+            return Err(UsageCollectorError::module_not_found(module_name));
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-4
+        Ok(ModuleConfig { allowed_metrics })
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-get-module-config:p2:inst-cfg-p-4
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "local_client_tests.rs"]
+mod local_client_tests;

--- a/modules/system/usage-collector/usage-collector/src/domain/local_client_tests.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/local_client_tests.rs
@@ -1,0 +1,744 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use chrono::Utc;
+use modkit::client_hub::{ClientHub, ClientScope};
+use types_registry_sdk::{
+    GtsEntity, ListQuery, RegisterResult, TypesRegistryClient, TypesRegistryError,
+};
+use usage_collector_sdk::UsageCollectorClientV1;
+use usage_collector_sdk::UsageKind;
+use usage_collector_sdk::UsageRecord;
+use usage_collector_sdk::{
+    UsageCollectorError, UsageCollectorPluginClientV1, UsageCollectorStoragePluginSpecV1,
+};
+use uuid::Uuid;
+
+use super::UsageCollectorLocalClient;
+use crate::config::{MetricConfig, UsageCollectorConfig};
+
+// ── MockRegistry ──────────────────────────────────────────────────
+
+struct MockRegistry {
+    instances: Vec<GtsEntity>,
+    list_calls: std::sync::atomic::AtomicUsize,
+}
+
+impl MockRegistry {
+    fn new(instances: Vec<GtsEntity>) -> Self {
+        Self {
+            instances,
+            list_calls: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TypesRegistryClient for MockRegistry {
+    async fn list(&self, _query: ListQuery) -> Result<Vec<GtsEntity>, TypesRegistryError> {
+        self.list_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(self.instances.clone())
+    }
+
+    async fn get(&self, gts_id: &str) -> Result<GtsEntity, TypesRegistryError> {
+        self.instances
+            .iter()
+            .find(|e| e.gts_id == gts_id)
+            .cloned()
+            .ok_or_else(|| TypesRegistryError::not_found(gts_id))
+    }
+
+    async fn register(
+        &self,
+        _entities: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        Ok(vec![])
+    }
+}
+
+struct OkPlugin;
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for OkPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+}
+
+fn plugin_content(gts_id: &str, vendor: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": gts_id,
+        "vendor": vendor,
+        "priority": 0,
+        "properties": {}
+    })
+}
+
+fn hub_with_plugin(
+    instance_id: &str,
+    vendor: &str,
+    plugin: Arc<dyn UsageCollectorPluginClientV1>,
+) -> Arc<ClientHub> {
+    let hub = Arc::new(ClientHub::default());
+    let entity = GtsEntity {
+        id: Uuid::nil(),
+        gts_id: instance_id.to_owned(),
+        segments: vec![],
+        is_schema: false,
+        content: plugin_content(instance_id, vendor),
+        description: None,
+    };
+    let reg: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![entity]));
+    hub.register::<dyn TypesRegistryClient>(reg);
+    hub.register_scoped::<dyn UsageCollectorPluginClientV1>(
+        ClientScope::gts_id(instance_id),
+        plugin,
+    );
+    hub
+}
+
+fn make_client() -> UsageCollectorLocalClient {
+    let instance_id = format!(
+        "{}test._.lc_test.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let hub = Arc::new(ClientHub::default());
+    let entity = GtsEntity {
+        id: Uuid::nil(),
+        gts_id: instance_id.clone(),
+        segments: vec![],
+        is_schema: false,
+        content: plugin_content(&instance_id, "hyperspot"),
+        description: None,
+    };
+    let reg: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![entity]));
+    hub.register::<dyn TypesRegistryClient>(reg);
+    hub.register_scoped::<dyn UsageCollectorPluginClientV1>(
+        ClientScope::gts_id(&instance_id),
+        Arc::new(OkPlugin),
+    );
+    UsageCollectorLocalClient::new(UsageCollectorConfig::default(), hub)
+}
+
+fn make_client_with_vendor(hub: Arc<ClientHub>, vendor: &str) -> UsageCollectorLocalClient {
+    UsageCollectorLocalClient::new(
+        UsageCollectorConfig {
+            vendor: vendor.to_owned(),
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    )
+}
+
+fn record(tenant_id: Uuid) -> UsageRecord {
+    UsageRecord {
+        tenant_id,
+        module: "test-module".to_owned(),
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+// PDP validation is enforced at the REST handler layer before the domain client is called.
+// The domain client forwards UsageRecord to the storage plugin without inspecting subject fields.
+fn record_no_subject(tenant_id: Uuid) -> UsageRecord {
+    UsageRecord {
+        tenant_id,
+        module: "test-module".to_owned(),
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        subject_id: None,
+        subject_type: None,
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+#[tokio::test]
+async fn create_usage_record_delegates_success_to_plugin() {
+    let client = make_client();
+    let tenant = Uuid::new_v4();
+    let rec = record(tenant);
+    assert!(client.create_usage_record(rec).await.is_ok());
+}
+
+// PDP is enforced at the REST handler layer; the domain client accepts records with or without
+// subject fields and forwards them to the storage plugin unconditionally.
+#[tokio::test]
+async fn create_usage_record_with_no_subject_succeeds() {
+    let client = make_client();
+    let tenant = Uuid::new_v4();
+    let rec = record_no_subject(tenant);
+    assert!(client.create_usage_record(rec).await.is_ok());
+}
+
+#[tokio::test]
+async fn create_usage_record_with_subject_succeeds() {
+    let client = make_client();
+    let tenant = Uuid::new_v4();
+    let rec = record(tenant);
+    assert!(client.create_usage_record(rec).await.is_ok());
+}
+
+// ── plugin timeout ────────────────────────────────────────────────
+
+struct SlowPlugin;
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for SlowPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        tokio::time::sleep(Duration::from_mins(1)).await;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn plugin_timeout_returns_plugin_timeout_error() {
+    let instance_id = format!(
+        "{}test._.lc_test.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let hub = hub_with_plugin(&instance_id, "hyperspot", Arc::new(SlowPlugin));
+    let client = UsageCollectorLocalClient::new(
+        UsageCollectorConfig {
+            vendor: "hyperspot".to_owned(),
+            plugin_timeout: Duration::from_millis(1),
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    );
+    let tenant = Uuid::new_v4();
+    let rec = record(tenant);
+    let err = client.create_usage_record(rec).await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::PluginTimeout));
+}
+
+// ── GTS plugin resolution caching ─────────────────────────────────
+
+#[tokio::test]
+async fn gts_plugin_selector_calls_registry_only_once_across_multiple_create_usage_records() {
+    let instance_id = format!(
+        "{}test._.lc_test.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let reg = Arc::new(MockRegistry::new(vec![GtsEntity {
+        id: Uuid::nil(),
+        gts_id: instance_id.clone(),
+        segments: vec![],
+        is_schema: false,
+        content: plugin_content(&instance_id, "hyperspot"),
+        description: None,
+    }]));
+    let hub = Arc::new(ClientHub::default());
+    hub.register::<dyn TypesRegistryClient>(Arc::clone(&reg) as Arc<dyn TypesRegistryClient>);
+    hub.register_scoped::<dyn UsageCollectorPluginClientV1>(
+        ClientScope::gts_id(&instance_id),
+        Arc::new(OkPlugin),
+    );
+    let client = make_client_with_vendor(hub, "hyperspot");
+    let tenant = Uuid::new_v4();
+
+    let rec1 = record(tenant);
+    client.create_usage_record(rec1).await.unwrap();
+    let rec2 = record(tenant);
+    client.create_usage_record(rec2).await.unwrap();
+    let rec3 = record(tenant);
+    client.create_usage_record(rec3).await.unwrap();
+
+    assert_eq!(
+        reg.list_calls.load(Ordering::SeqCst),
+        1,
+        "GTS registry should be queried exactly once after initial resolution"
+    );
+}
+
+// ── no plugin registered in hub ───────────────────────────────────
+
+#[tokio::test]
+async fn no_plugin_client_in_hub_returns_internal_error() {
+    let instance_id = format!(
+        "{}test._.lc_test.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    // Register the entity in types-registry but deliberately omit the plugin client.
+    let hub = Arc::new(ClientHub::default());
+    let entity = GtsEntity {
+        id: Uuid::nil(),
+        gts_id: instance_id.clone(),
+        segments: vec![],
+        is_schema: false,
+        content: plugin_content(&instance_id, "hyperspot"),
+        description: None,
+    };
+    let reg: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![entity]));
+    hub.register::<dyn TypesRegistryClient>(reg);
+    // plugin client NOT registered
+    let client = make_client_with_vendor(hub, "hyperspot");
+    let tenant = Uuid::new_v4();
+    let rec = record(tenant);
+    let err = client.create_usage_record(rec).await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::Internal { .. }));
+}
+
+// ── get_module_config ─────────────────────────────────────────────
+
+fn config_with_metrics(metrics: HashMap<String, MetricConfig>) -> UsageCollectorConfig {
+    UsageCollectorConfig {
+        metrics,
+        ..UsageCollectorConfig::default()
+    }
+}
+
+#[tokio::test]
+async fn get_module_config_returns_not_found_when_no_metrics_configured() {
+    let client = UsageCollectorLocalClient::new(
+        UsageCollectorConfig::default(),
+        Arc::new(ClientHub::default()),
+    );
+    let err = client.get_module_config("any-module").await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::ModuleNotFound { .. }));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_metric_when_modules_restriction_is_absent() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "cpu.usage".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Gauge,
+            modules: None,
+        },
+    );
+    let client = UsageCollectorLocalClient::new(
+        config_with_metrics(metrics),
+        Arc::new(ClientHub::default()),
+    );
+    let cfg = client.get_module_config("any-module").await.unwrap();
+    assert_eq!(cfg.allowed_metrics.len(), 1);
+    assert_eq!(cfg.allowed_metrics[0].name, "cpu.usage");
+    assert!(matches!(cfg.allowed_metrics[0].kind, UsageKind::Gauge));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_metric_when_module_is_in_allow_list() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "req.count".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Counter,
+            modules: Some(vec!["my-module".to_owned()]),
+        },
+    );
+    let client = UsageCollectorLocalClient::new(
+        config_with_metrics(metrics),
+        Arc::new(ClientHub::default()),
+    );
+    let cfg = client.get_module_config("my-module").await.unwrap();
+    assert_eq!(cfg.allowed_metrics.len(), 1);
+    assert_eq!(cfg.allowed_metrics[0].name, "req.count");
+    assert!(matches!(cfg.allowed_metrics[0].kind, UsageKind::Counter));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_not_found_when_module_not_in_allow_list() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "cpu.usage".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Gauge,
+            modules: Some(vec!["other-module".to_owned()]),
+        },
+    );
+    let client = UsageCollectorLocalClient::new(
+        config_with_metrics(metrics),
+        Arc::new(ClientHub::default()),
+    );
+    let err = client.get_module_config("my-module").await.unwrap_err();
+    assert!(matches!(err, UsageCollectorError::ModuleNotFound { .. }));
+}
+
+#[tokio::test]
+async fn get_module_config_returns_only_matching_metrics_from_mixed_config() {
+    let mut metrics = HashMap::new();
+    metrics.insert(
+        "cpu.usage".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Gauge,
+            modules: None,
+        },
+    );
+    metrics.insert(
+        "disk.io".to_owned(),
+        MetricConfig {
+            kind: UsageKind::Counter,
+            modules: Some(vec!["storage".to_owned()]),
+        },
+    );
+    let client = UsageCollectorLocalClient::new(
+        config_with_metrics(metrics),
+        Arc::new(ClientHub::default()),
+    );
+    let cfg = client.get_module_config("my-module").await.unwrap();
+    assert_eq!(cfg.allowed_metrics.len(), 1);
+    assert_eq!(cfg.allowed_metrics[0].name, "cpu.usage");
+}
+
+// ── circuit breaker ──────────────────────────────────────────────────────────
+
+/// A storage plugin that always returns an error.
+struct FailPlugin;
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for FailPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Err(UsageCollectorError::internal("simulated plugin failure"))
+    }
+}
+
+/// A storage plugin that counts every `store` invocation via an atomic counter.
+/// Succeeds or fails depending on the `should_fail` flag.
+struct CountingPlugin {
+    counter: Arc<AtomicUsize>,
+    should_fail: bool,
+}
+
+impl CountingPlugin {
+    fn failing(counter: Arc<AtomicUsize>) -> Self {
+        Self {
+            counter,
+            should_fail: true,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl UsageCollectorPluginClientV1 for CountingPlugin {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        self.counter.fetch_add(1, Ordering::SeqCst);
+        if self.should_fail {
+            Err(UsageCollectorError::internal("simulated plugin failure"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Construct a `UsageCollectorLocalClient` backed by the given plugin, with configurable
+/// circuit breaker parameters for fast, deterministic tests.
+fn make_cb_client(
+    plugin: Arc<dyn UsageCollectorPluginClientV1>,
+    threshold: u32,
+    window: Duration,
+    recovery: Duration,
+) -> UsageCollectorLocalClient {
+    let instance_id = format!(
+        "{}test._.cb_test.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let hub = hub_with_plugin(&instance_id, "hyperspot", plugin);
+    UsageCollectorLocalClient::new(
+        UsageCollectorConfig {
+            vendor: "hyperspot".to_owned(),
+            circuit_breaker_failure_threshold: threshold,
+            circuit_breaker_window: window,
+            circuit_breaker_recovery_timeout: recovery,
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    )
+}
+
+/// After N consecutive failures, the (N+1)-th call must return `CircuitOpen`.
+#[tokio::test]
+async fn circuit_opens_after_n_consecutive_failures() {
+    let threshold = 2u32;
+    let client = make_cb_client(
+        Arc::new(FailPlugin),
+        threshold,
+        Duration::from_secs(10),
+        Duration::from_millis(1),
+    );
+
+    for _ in 0..threshold {
+        drop(client.create_usage_record(record(Uuid::new_v4())).await);
+    }
+
+    let err = client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, UsageCollectorError::CircuitOpen),
+        "expected CircuitOpen after {threshold} failures, got {err:?}"
+    );
+}
+
+/// Once the circuit is open, every call must return `CircuitOpen` without invoking the plugin.
+#[tokio::test]
+async fn open_circuit_rejects_without_calling_plugin() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let threshold = 2u32;
+    let client = make_cb_client(
+        Arc::new(CountingPlugin::failing(Arc::clone(&counter))),
+        threshold,
+        Duration::from_secs(10),
+        Duration::from_millis(1),
+    );
+
+    // Drive to open state — these N calls do reach the plugin.
+    for _ in 0..threshold {
+        drop(client.create_usage_record(record(Uuid::new_v4())).await);
+    }
+    let calls_to_open = counter.load(Ordering::SeqCst);
+
+    // All subsequent calls must be rejected without touching the plugin.
+    for _ in 0..3 {
+        let err = client
+            .create_usage_record(record(Uuid::new_v4()))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, UsageCollectorError::CircuitOpen),
+            "expected CircuitOpen, got {err:?}"
+        );
+    }
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        calls_to_open,
+        "plugin must not be invoked while circuit is open"
+    );
+}
+
+/// In `HalfOpen` state exactly one concurrent caller is admitted as the probe; all others are
+/// rejected with `CircuitOpen`.
+#[tokio::test]
+async fn half_open_admits_exactly_one_concurrent_probe_others_rejected() {
+    // Use a TogglePlugin: fails during the open-driving phase, then succeeds for the probe.
+    // The probe yields via `tokio::task::yield_now()` so that the other two concurrent tasks
+    // get a chance to call `is_open()` (which sees `HalfOpen` → returns `CircuitOpen`) before
+    // the probe completes and transitions the circuit back to `Closed`.
+    use std::sync::atomic::AtomicBool;
+
+    struct TogglePlugin {
+        counter: Arc<AtomicUsize>,
+        fail: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl UsageCollectorPluginClientV1 for TogglePlugin {
+        async fn create_usage_record(
+            &self,
+            _record: UsageRecord,
+        ) -> Result<(), UsageCollectorError> {
+            self.counter.fetch_add(1, Ordering::SeqCst);
+            if self.fail.load(Ordering::SeqCst) {
+                return Err(UsageCollectorError::internal("toggle fail"));
+            }
+            // Yield so that other spawned tasks can run and see the HalfOpen state before
+            // this probe completes and closes the circuit.
+            tokio::task::yield_now().await;
+            Ok(())
+        }
+    }
+
+    let threshold = 2u32;
+    let fail_flag = Arc::new(AtomicBool::new(true));
+    let probe_counter = Arc::new(AtomicUsize::new(0));
+    let toggle_plugin = Arc::new(TogglePlugin {
+        counter: Arc::clone(&probe_counter),
+        fail: Arc::clone(&fail_flag),
+    });
+
+    let instance_id = format!(
+        "{}test._.cb_halfopen.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let hub = hub_with_plugin(&instance_id, "hyperspot", toggle_plugin);
+    let client = Arc::new(UsageCollectorLocalClient::new(
+        UsageCollectorConfig {
+            vendor: "hyperspot".to_owned(),
+            circuit_breaker_failure_threshold: threshold,
+            circuit_breaker_window: Duration::from_secs(10),
+            circuit_breaker_recovery_timeout: Duration::from_millis(1),
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    ));
+
+    // Open the circuit.
+    for _ in 0..threshold {
+        drop(client.create_usage_record(record(Uuid::new_v4())).await);
+    }
+    let calls_during_open = probe_counter.load(Ordering::SeqCst);
+
+    // Wait for recovery timeout to elapse so the circuit transitions to HalfOpen on next call.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    // Switch plugin to succeed so the probe can close the circuit.
+    fail_flag.store(false, Ordering::SeqCst);
+
+    // Fire 3 concurrent calls. Exactly 1 should reach the plugin (the HalfOpen probe);
+    // the other 2 must get `CircuitOpen` because they see the `HalfOpen` state in `is_open()`.
+    let mut set = tokio::task::JoinSet::new();
+    for _ in 0..3 {
+        let c = Arc::clone(&client);
+        set.spawn(async move { c.create_usage_record(record(Uuid::new_v4())).await });
+    }
+
+    let mut circuit_open_count = 0usize;
+    let mut success_count = 0usize;
+    while let Some(result) = set.join_next().await {
+        match result.expect("task panicked") {
+            Ok(()) => success_count += 1,
+            Err(UsageCollectorError::CircuitOpen) => circuit_open_count += 1,
+            Err(e) => panic!("unexpected error: {e:?}"),
+        }
+    }
+
+    // Exactly one probe reached the plugin (the rest were rejected at is_open()).
+    let probe_calls = probe_counter.load(Ordering::SeqCst) - calls_during_open;
+    assert_eq!(
+        probe_calls, 1,
+        "exactly one concurrent call should reach the plugin in HalfOpen"
+    );
+    assert_eq!(success_count, 1, "the single probe should succeed");
+    assert_eq!(
+        circuit_open_count, 2,
+        "the other two callers should get CircuitOpen"
+    );
+}
+
+/// After a successful probe from `HalfOpen`, the circuit closes and the next call succeeds.
+#[tokio::test]
+async fn successful_probe_closes_circuit() {
+    // Use a CountingPlugin that fails for the first `threshold` calls then succeeds.
+    use std::sync::atomic::AtomicBool;
+
+    struct TogglePlugin {
+        fail: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl UsageCollectorPluginClientV1 for TogglePlugin {
+        async fn create_usage_record(
+            &self,
+            _record: UsageRecord,
+        ) -> Result<(), UsageCollectorError> {
+            if self.fail.load(Ordering::SeqCst) {
+                Err(UsageCollectorError::internal("toggle fail"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    let threshold = 2u32;
+
+    let fail_flag = Arc::new(AtomicBool::new(true));
+    let instance_id = format!(
+        "{}test._.cb_close.v1",
+        UsageCollectorStoragePluginSpecV1::gts_schema_id()
+    );
+    let hub = hub_with_plugin(
+        &instance_id,
+        "hyperspot",
+        Arc::new(TogglePlugin {
+            fail: Arc::clone(&fail_flag),
+        }),
+    );
+    let client = UsageCollectorLocalClient::new(
+        UsageCollectorConfig {
+            vendor: "hyperspot".to_owned(),
+            circuit_breaker_failure_threshold: threshold,
+            circuit_breaker_window: Duration::from_secs(10),
+            circuit_breaker_recovery_timeout: Duration::from_millis(1),
+            ..UsageCollectorConfig::default()
+        },
+        hub,
+    );
+
+    // Open the circuit.
+    for _ in 0..threshold {
+        drop(client.create_usage_record(record(Uuid::new_v4())).await);
+    }
+
+    // Wait for recovery timeout; circuit should be ready to transition to HalfOpen.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    // Switch plugin to succeed so the probe closes the circuit.
+    fail_flag.store(false, Ordering::SeqCst);
+
+    // The probe call: transitions Open → HalfOpen (via is_open()) then succeeds → Closed.
+    client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .expect("probe call should succeed and close circuit");
+
+    // Next call should also succeed (circuit is Closed).
+    client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .expect("circuit should be closed after successful probe");
+}
+
+/// After a failed probe from `HalfOpen`, the circuit re-opens and the next call returns `CircuitOpen`.
+#[tokio::test]
+async fn failed_probe_reopens_circuit() {
+    // Use threshold=1 so that a single probe failure immediately re-opens the circuit.
+    let threshold = 1u32;
+    let client = make_cb_client(
+        Arc::new(FailPlugin),
+        threshold,
+        Duration::from_secs(10),
+        Duration::from_millis(1),
+    );
+
+    // Open the circuit with 1 failure.
+    drop(client.create_usage_record(record(Uuid::new_v4())).await);
+
+    // Verify circuit is open.
+    let err = client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, UsageCollectorError::CircuitOpen));
+
+    // Wait for recovery timeout.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    // The probe call: Open → HalfOpen (via is_open()), then fails → re-opens circuit.
+    let probe_err = client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    // The probe itself returns the plugin error, not CircuitOpen.
+    assert!(
+        matches!(probe_err, UsageCollectorError::Internal { .. }),
+        "probe should propagate plugin error, got {probe_err:?}"
+    );
+
+    // Next call should see the circuit open again.
+    let err = client
+        .create_usage_record(record(Uuid::new_v4()))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, UsageCollectorError::CircuitOpen),
+        "circuit should be open again after failed probe, got {err:?}"
+    );
+}

--- a/modules/system/usage-collector/usage-collector/src/domain/mod.rs
+++ b/modules/system/usage-collector/usage-collector/src/domain/mod.rs
@@ -1,0 +1,5 @@
+//! Gateway domain: [`UsageCollectorLocalClient`].
+
+mod local_client;
+
+pub use local_client::UsageCollectorLocalClient;

--- a/modules/system/usage-collector/usage-collector/src/lib.rs
+++ b/modules/system/usage-collector/usage-collector/src/lib.rs
@@ -1,0 +1,11 @@
+//! Usage Collector gateway.
+//!
+//! Centralized ingest for usage records from the SDK outbox pipeline and
+//! delegation to the GTS-selected storage plugin.
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+mod api;
+mod config;
+mod domain;
+mod module;

--- a/modules/system/usage-collector/usage-collector/src/module.rs
+++ b/modules/system/usage-collector/usage-collector/src/module.rs
@@ -1,0 +1,120 @@
+//! Usage-collector gateway `ModKit` module.
+
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use authz_resolver_sdk::AuthZResolverClient;
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::contracts::{DatabaseCapability, RestApiCapability};
+use modkit::{Module, ModuleCtx};
+use sea_orm_migration::MigrationTrait;
+use tracing::info;
+use types_registry_sdk::{RegisterResult, TypesRegistryClient};
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorStoragePluginSpecV1};
+use usage_emitter::{UsageEmitter, UsageEmitterV1};
+
+use crate::api::rest::routes;
+use crate::config::UsageCollectorConfig;
+use crate::domain::UsageCollectorLocalClient;
+
+/// Usage collector gateway: registers storage plugin schema, resolves plugins via GTS,
+/// exposes `dyn UsageCollectorClientV1` for outbox delivery, and wires REST endpoints
+/// via `DatabaseCapability` and `RestApiCapability`.
+#[modkit::module(
+    name = "usage-collector",
+    deps = ["authz-resolver", "types-registry"],
+    capabilities = [db, rest],
+)]
+#[derive(Default)]
+pub struct UsageCollectorModule {
+    /// Stored during `init()` for use in `register_rest()`.
+    collector: OnceLock<Arc<dyn UsageCollectorClientV1>>,
+}
+
+#[async_trait]
+impl Module for UsageCollectorModule {
+    #[tracing::instrument(skip_all, fields(vendor))]
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        let cfg: UsageCollectorConfig = ctx.config_or_default()?;
+        cfg.validate()?;
+        tracing::Span::current().record("vendor", &cfg.vendor);
+        info!(
+            cfg.vendor,
+            ?cfg.plugin_timeout,
+            "Loaded {} configuration",
+            Self::MODULE_NAME,
+        );
+
+        let registry = ctx.client_hub().get::<dyn TypesRegistryClient>()?;
+        let schema_str = UsageCollectorStoragePluginSpecV1::gts_schema_with_refs_as_string();
+        let schema_json: serde_json::Value = serde_json::from_str(&schema_str)?;
+        let results = registry.register(vec![schema_json]).await?;
+        RegisterResult::ensure_all_ok(&results)?;
+        info!(
+            schema_id = %UsageCollectorStoragePluginSpecV1::gts_schema_id(),
+            "Registered {} storage plugin schema in types-registry",
+            Self::MODULE_NAME,
+        );
+
+        let db = ctx
+            .db_required()
+            .map_err(|e| anyhow::anyhow!("{}: db not available: {e}", Self::MODULE_NAME))?
+            .db();
+
+        let authz = ctx
+            .client_hub()
+            .get::<dyn AuthZResolverClient>()
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "{}: AuthZResolverClient not registered: {e}",
+                    Self::MODULE_NAME
+                )
+            })?;
+
+        let collector = UsageCollectorLocalClient::new(cfg.clone(), ctx.client_hub());
+        let collector = Arc::new(collector) as Arc<dyn UsageCollectorClientV1>;
+
+        let emitter = UsageEmitter::build(cfg.emitter, db, authz, Arc::clone(&collector)).await?;
+        ctx.client_hub()
+            .register::<dyn UsageEmitterV1>(Arc::new(emitter));
+
+        self.collector
+            .set(collector)
+            .map_err(|_| anyhow::anyhow!("{}: collector already initialized", Self::MODULE_NAME))?;
+
+        Ok(())
+    }
+}
+
+impl DatabaseCapability for UsageCollectorModule {
+    fn migrations(&self) -> Vec<Box<dyn MigrationTrait>> {
+        info!("Providing {} database migrations", Self::MODULE_NAME);
+        modkit_db::outbox::outbox_migrations()
+    }
+}
+
+impl RestApiCapability for UsageCollectorModule {
+    fn register_rest(
+        &self,
+        ctx: &ModuleCtx,
+        router: Router,
+        openapi: &dyn OpenApiRegistry,
+    ) -> anyhow::Result<Router> {
+        tracing::info!("Registering {} REST routes", Self::MODULE_NAME);
+
+        let emitter = ctx.client_hub().get::<dyn UsageEmitterV1>().map_err(|e| {
+            anyhow::anyhow!("{}: UsageEmitterV1 not registered: {e}", Self::MODULE_NAME)
+        })?;
+
+        let collector = self
+            .collector
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("{}: collector not initialized", Self::MODULE_NAME))?;
+
+        let router = routes::register_routes(router, openapi, emitter, Arc::clone(collector));
+
+        tracing::info!("{} REST routes registered", Self::MODULE_NAME);
+        Ok(router)
+    }
+}

--- a/modules/system/usage-collector/usage-emitter/Cargo.toml
+++ b/modules/system/usage-collector/usage-emitter/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "cf-usage-emitter"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Durable usage emission: two-phase PDP authorization, transactional outbox enqueue, async delivery to the collector"
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-system"]
+categories = ["development-tools"]
+
+[lib]
+name = "usage_emitter"
+
+[lints]
+workspace = true
+
+[dependencies]
+# Local dependencies
+authz-resolver-sdk = { workspace = true }
+usage-collector-sdk = { workspace = true }
+
+# ModKit dependencies
+modkit-db = { workspace = true, features = ["preview-outbox"] }
+modkit-security = { workspace = true }
+
+# Async runtime
+async-trait = { workspace = true }
+tokio = { workspace = true }
+
+# Data structures
+chrono = { workspace = true }
+uuid = { workspace = true }
+
+# Error handling
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# DB
+sea-orm-migration = { workspace = true }
+
+[dev-dependencies]
+# ModKit dependencies
+modkit-db = { workspace = true, features = ["sqlite"] }
+
+# Data structures
+chrono = { workspace = true }

--- a/modules/system/usage-collector/usage-emitter/README.md
+++ b/modules/system/usage-collector/usage-emitter/README.md
@@ -1,0 +1,110 @@
+# Usage Emitter
+
+> **Emitter library** — two-phase PDP authorization, transactional outbox enqueue, and async delivery to the usage collector.
+
+A plain library crate (no `#[modkit::module]`). Each host module (`usage-collector`, `usage-collector-rest-client`, future gRPC client) calls `UsageEmitter::build(config, db, authz, collector)` in its own `init()` and registers the result as `dyn UsageEmitterV1` in `ClientHub`.
+
+## Security invariant
+
+`UsageCollectorClientV1` is **never** registered in `ClientHub`. It is supplied to `UsageEmitter::build` as a constructor argument and stays private inside the emitter. Only `dyn UsageEmitterV1` is published to the hub, so the sole path a source module has to the collector is through a PDP-authorized, tenant/resource-bound `AuthorizedUsageEmitter::enqueue*`. The PDP resource type and action constants (`gts.x.core.usage.record.v1 / create`) are `pub(crate)` in this crate and cannot be referenced externally.
+
+## API
+
+| Item | Description |
+|------|-------------|
+| `UsageEmitterV1` | Source-facing trait. Obtain from `ClientHub`. Call `for_module(MODULE_NAME)` once (e.g. in `init()`) to get a `ScopedUsageEmitter`. |
+| `UsageEmitter` | Concrete implementation; built with `UsageEmitter::build`. |
+| `ScopedUsageEmitter` | Returned by `for_module`; carries the module name and knows the allowed metrics list. Call `authorize_for` or `authorize` to get a time-limited handle. |
+| `AuthorizedUsageEmitter` | Time-limited handle returned by `authorize` / `authorize_for`. Call `enqueue`, `enqueue_in`, or `build_usage_record`. |
+| `UsageRecordBuilder` | Returned by `AuthorizedUsageEmitter::build_usage_record(metric, value)`; tenant, resource, module, and kind come from the authorized handle. Optionally set `with_idempotency_key` / `with_timestamp`, then `enqueue` / `enqueue_in`. |
+| `UsageEmitterConfig` | Tunable authorization TTL, outbox queue name, partition count. Embedded in the host module's own config struct. |
+| `UsageEmitterError` | Typed errors for authorization, validation, and enqueue phases. |
+
+## Emitting a usage record
+
+```rust
+use usage_emitter::UsageEmitterV1;
+
+// In init(): obtain from ClientHub and scope to this module's name.
+let emitter = hub.get::<dyn UsageEmitterV1>()?;
+let scoped = emitter.for_module(Self::MODULE_NAME);
+
+// In a handler — Phase 1: authorize (calls PDP + fetches allowed metrics;
+// valid for UsageEmitterConfig::authorization_max_age).
+let authorized = scoped
+    .authorize_for(&ctx, tenant_id, resource_id, resource_type.clone())
+    .await?;
+// Or for the subject's home tenant: scoped.authorize(&ctx, resource_id, resource_type).await?
+
+// Phase 2a: build and enqueue on the emitter's DB connection.
+authorized
+    .build_usage_record("requests", 1.0)
+    .enqueue()
+    .await?;
+
+// Phase 2b: enqueue inside a caller transaction (atomic with your write).
+// authorized.build_usage_record("requests", 1.0).enqueue_in(&txn).await?;
+
+// Optional: set idempotency key or timestamp.
+// authorized
+//     .build_usage_record("requests", 1.0)
+//     .with_idempotency_key("key123")
+//     .with_timestamp(Utc::now())
+//     .enqueue()
+//     .await?;
+```
+
+## Configuration
+
+`UsageEmitterConfig` is embedded in the host module's own config struct with `#[serde(default)]`, so all fields are optional in YAML:
+
+```yaml
+modules:
+  usage-collector:         # or usage-collector-rest-client
+    config:
+      emitter:
+        authorization_max_age: "30s"   # default
+        outbox_queue: "usage-records"  # default
+        outbox_partition_count: 4      # default; power of 2 in 1–64
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `authorization_max_age` | `30s` | Maximum age of an `AuthorizedUsageEmitter` handle before `enqueue*` rejects it with `AuthorizationExpired` |
+| `outbox_queue` | `usage-records` | Outbox queue name |
+| `outbox_partition_count` | `4` | Partition count (power of 2 in 1–64) |
+
+## Error handling
+
+```rust
+use usage_emitter::UsageEmitterError;
+
+match authorized.enqueue(record).await {
+    Ok(()) => {}
+    Err(UsageEmitterError::AuthorizationExpired) => { /* re-authorize and retry */ }
+    Err(UsageEmitterError::AuthorizationFailed { message }) => { /* PDP denied */ }
+    Err(UsageEmitterError::MetricNotAllowed { metric }) => { /* metric not configured for this module */ }
+    Err(UsageEmitterError::NegativeCounterValue { value }) => { /* counter delta must be >= 0 */ }
+    Err(UsageEmitterError::InvalidRecord { message }) => { /* incomplete builder / record */ }
+    Err(UsageEmitterError::Outbox(e)) => { /* transactional DB write failed */ }
+    Err(UsageEmitterError::Internal { message }) => { /* unexpected PDP or runtime error */ }
+}
+```
+
+## Background delivery
+
+The outbox worker dequeues from the queue configured via `outbox_queue` (host overrides apply) and calls `UsageCollectorClientV1::create_usage_record` per message:
+
+- **`Ok`** — message acknowledged
+- **`PluginTimeout`** — transient (plugin timeout, HTTP 429, HTTP 5xx); message is retried
+- **`CircuitOpen`** — transient (circuit breaker open); message is retried
+- **`Unavailable`** — transient (connection/transport error, identity service unreachable); message is retried
+- **Other errors** — permanent (`AuthorizationFailed`, `ModuleNotFound`, `Internal`); message is dead-lettered
+
+Delivery is independent of the request that enqueued the record and survives process restarts through the durable outbox.
+
+## Testing
+
+```bash
+devbox run cargo test -p cf-usage-emitter
+```

--- a/modules/system/usage-collector/usage-emitter/src/api.rs
+++ b/modules/system/usage-collector/usage-emitter/src/api.rs
@@ -1,0 +1,33 @@
+use crate::scoped_emitter::ScopedUsageEmitter;
+
+/// Source-facing trait for emitting usage records with module-scoped authorization.
+///
+/// Obtain from `ClientHub`: `hub.get::<dyn UsageEmitterV1>()?`
+///
+/// The emitter is registered in `ClientHub` by the `usage-collector` module (in-process delivery)
+/// or the `usage-collector-rest-client` module (HTTP delivery to a remote collector).
+///
+/// Call [`Self::for_module`] with the module's name constant to obtain a [`ScopedUsageEmitter`]
+/// that carries the module name and knows the allowed metrics for that module.
+///
+/// ```ignore
+/// // In init():
+/// let emitter = hub.get::<dyn UsageEmitterV1>()?;
+/// let scoped = emitter.for_module(Self::MODULE_NAME);
+///
+/// // In handlers:
+/// let authorized = scoped
+///     .authorize(&ctx, resource_id, "resource_type".to_owned())
+///     .await?;
+/// authorized
+///     .build_usage_record("requests", 1.0)
+///     .enqueue()
+///     .await?;
+/// ```
+pub trait UsageEmitterV1: Send + Sync {
+    /// Obtain a [`ScopedUsageEmitter`] bound to `module_name`.
+    ///
+    /// The scoped emitter stores the module name and uses it to fetch the allowed metrics list
+    /// from the collector during [`ScopedUsageEmitter::authorize_for`].
+    fn for_module(&self, module_name: &str) -> ScopedUsageEmitter;
+}

--- a/modules/system/usage-collector/usage-emitter/src/authorized_emitter.rs
+++ b/modules/system/usage-collector/usage-emitter/src/authorized_emitter.rs
@@ -1,0 +1,242 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use modkit_db::Db;
+use modkit_db::outbox::Outbox;
+use modkit_db::secure::DBRunner;
+use tracing::debug;
+use usage_collector_sdk::models::{AllowedMetric, UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use crate::config::UsageEmitterConfig;
+use crate::error::UsageEmitterError;
+use crate::usage_builder::UsageRecordBuilder;
+
+/// Emitter state after successful PDP authorization; call [`Self::enqueue`] or
+/// [`Self::enqueue_in`] on the returned handle.
+///
+/// Constructed via [`crate::ScopedUsageEmitter::authorize_for`]; callers cannot forge handles.
+pub struct AuthorizedUsageEmitter {
+    config: Arc<UsageEmitterConfig>,
+    pub(crate) db: Db,
+    outbox: Arc<Outbox>,
+    pub(crate) module: String,
+    pub(crate) tenant_id: Uuid,
+    pub(crate) resource_id: Uuid,
+    pub(crate) resource_type: String,
+    pub(crate) allowed_metrics: Vec<AllowedMetric>,
+    pub(crate) subject_id: Option<Uuid>,
+    pub(crate) subject_type: Option<String>,
+    issued_at: Instant,
+}
+
+impl AuthorizedUsageEmitter {
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        config: Arc<UsageEmitterConfig>,
+        db: Db,
+        outbox: Arc<Outbox>,
+        module: String,
+        tenant_id: Uuid,
+        resource_id: Uuid,
+        resource_type: String,
+        allowed_metrics: Vec<AllowedMetric>,
+        subject_id: Option<Uuid>,
+        subject_type: Option<String>,
+    ) -> Self {
+        Self {
+            config,
+            db,
+            outbox,
+            module,
+            tenant_id,
+            resource_id,
+            resource_type,
+            allowed_metrics,
+            subject_id,
+            subject_type,
+            issued_at: Instant::now(),
+        }
+    }
+
+    /// Enqueue a usage record using this emitter's database connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError`] when obtaining a connection fails, the authorization handle
+    /// expired, or the outbox enqueue fails.
+    pub async fn enqueue(&self, record: UsageRecord) -> Result<(), UsageEmitterError> {
+        let conn = self
+            .db
+            .conn()
+            .map_err(|e| UsageEmitterError::internal(e.to_string()))?;
+        self.enqueue_in(&conn, record).await
+    }
+
+    /// Enqueue a usage record on the given database runner (connection or transaction).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError`] when the authorization handle expired, the record does not
+    /// match the authorized tenant/resource, the metric is not allowed for this module, a counter
+    /// record has a negative value, or the outbox enqueue fails.
+    pub async fn enqueue_in(
+        &self,
+        db: &(dyn DBRunner + Sync),
+        record: UsageRecord,
+    ) -> Result<(), UsageEmitterError> {
+        self.validate_authorization_freshness()?;
+        self.validate_authorized_tenant(&record)?;
+        self.validate_authorized_resource(&record)?;
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-6
+        self.validate_authorized_module(&record)?;
+        self.validate_authorized_subject(&record)?;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-6
+        self.validate_allowed_metric(&record)?;
+        self.validate_metric_kind(&record)?;
+        Self::validate_counter_value(&record)?;
+
+        // Derive partition from the first UUID byte for even load distribution across tenants.
+        let bytes = record.tenant_id.as_bytes();
+        let partition = u32::from(bytes[0]) % u32::from(self.config.outbox_partition_count);
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-8
+        let payload = serde_json::to_vec(&record).map_err(|e| {
+            UsageEmitterError::internal(format!("payload serialization failed: {e}"))
+        })?;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-8
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-9
+        self.outbox
+            .enqueue(
+                db,
+                &self.config.outbox_queue,
+                partition,
+                payload,
+                "usage-collector.record.v1",
+            )
+            .await?;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-9
+
+        debug!(%self.tenant_id, "usage record enqueued");
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-10
+        Ok(())
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-10
+    }
+
+    fn validate_authorization_freshness(&self) -> Result<(), UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-1
+        let elapsed = self.issued_at.elapsed();
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-1
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2
+        if elapsed > self.config.authorization_max_age {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2a
+            return Err(UsageEmitterError::authorization_expired());
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-2
+        Ok(())
+    }
+
+    fn validate_authorized_tenant(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.tenant_id != self.tenant_id {
+            return Err(UsageEmitterError::authorization_failed(
+                "usage record tenant_id does not match authorized tenant",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_authorized_resource(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.resource_id != self.resource_id {
+            return Err(UsageEmitterError::authorization_failed(
+                "usage record resource_id does not match authorized resource",
+            ));
+        }
+
+        if record.resource_type != self.resource_type {
+            return Err(UsageEmitterError::authorization_failed(
+                "usage record resource_type does not match authorized resource",
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn validate_authorized_module(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.module != self.module {
+            return Err(UsageEmitterError::invalid_record(
+                "record module does not match authorized token",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_authorized_subject(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.subject_id != self.subject_id
+            || record.subject_type.as_deref() != self.subject_type.as_deref()
+        {
+            return Err(UsageEmitterError::invalid_record(
+                "record subject does not match authorized token",
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_allowed_metric(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-3
+        let metric_allowed = self.allowed_metrics.iter().any(|m| m.name == record.metric);
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4
+        if !metric_allowed {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4a
+            return Err(UsageEmitterError::metric_not_allowed(&record.metric));
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-4
+        Ok(())
+    }
+
+    fn validate_metric_kind(&self, record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if let Some(allowed) = self
+            .allowed_metrics
+            .iter()
+            .find(|m| m.name == record.metric)
+            && allowed.kind != record.kind
+        {
+            return Err(UsageEmitterError::metric_kind_mismatch(
+                &record.metric,
+                allowed.kind,
+                record.kind,
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_counter_value(record: &UsageRecord) -> Result<(), UsageEmitterError> {
+        if record.kind == UsageKind::Counter && record.value < 0.0 {
+            return Err(UsageEmitterError::negative_counter_value(record.value));
+        }
+        Ok(())
+    }
+
+    /// Starts a [`UsageRecordBuilder`] with `module`, `tenant_id`, `resource_id`, and
+    /// `resource_type` from this authorization handle.
+    #[must_use]
+    pub fn build_usage_record(
+        &self,
+        metric: impl Into<String>,
+        value: f64,
+    ) -> UsageRecordBuilder<'_> {
+        UsageRecordBuilder::new(self, metric, value)
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "authorized_emitter_tests.rs"]
+mod authorized_emitter_tests;

--- a/modules/system/usage-collector/usage-emitter/src/authorized_emitter_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/authorized_emitter_tests.rs
@@ -1,0 +1,319 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::{
+    LeasedMessageHandler, MessageResult, Outbox, OutboxHandle, OutboxMessage, Partitions,
+    outbox_migrations,
+};
+use modkit_db::{ConnectOpts, Db, connect_db};
+use usage_collector_sdk::models::{UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use super::AuthorizedUsageEmitter;
+use crate::config::UsageEmitterConfig;
+use crate::error::UsageEmitterError;
+
+// ── Infrastructure ────────────────────────────────────────────────────────────
+
+struct NoopHandler;
+
+#[async_trait]
+impl LeasedMessageHandler for NoopHandler {
+    async fn handle(&self, _msg: &OutboxMessage) -> MessageResult {
+        MessageResult::Ok
+    }
+}
+
+async fn build_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    db
+}
+
+async fn build_outbox(db: Db) -> OutboxHandle {
+    let cfg = UsageEmitterConfig::default();
+    Outbox::builder(db)
+        .queue(
+            cfg.outbox_queue.as_str(),
+            Partitions::of(cfg.outbox_partition_count),
+        )
+        .leased(NoopHandler)
+        .start()
+        .await
+        .unwrap()
+}
+
+const FIXTURE_RESOURCE_TYPE: &str = "test.resource";
+
+// ── Test fixture ──────────────────────────────────────────────────────────────
+
+struct Fixture {
+    db: Db,
+    _handle: OutboxHandle,
+    emitter: AuthorizedUsageEmitter,
+    tenant: Uuid,
+    resource_id: Uuid,
+}
+
+impl Fixture {
+    async fn build(name: &str) -> Self {
+        Self::build_with_config(name, UsageEmitterConfig::default()).await
+    }
+
+    async fn build_with_config(name: &str, config: UsageEmitterConfig) -> Self {
+        use usage_collector_sdk::models::AllowedMetric;
+
+        let db = build_db(name).await;
+        let handle = build_outbox(db.clone()).await;
+        let outbox = Arc::clone(handle.outbox());
+        let tenant = Uuid::new_v4();
+        let resource_id = Uuid::new_v4();
+        let allowed_metrics = vec![
+            AllowedMetric {
+                name: "test.gauge".to_owned(),
+                kind: UsageKind::Gauge,
+            },
+            AllowedMetric {
+                name: "test.counter".to_owned(),
+                kind: UsageKind::Counter,
+            },
+        ];
+        let emitter = AuthorizedUsageEmitter::new(
+            Arc::new(config),
+            db.clone(),
+            outbox,
+            "test-module".to_owned(),
+            tenant,
+            resource_id,
+            FIXTURE_RESOURCE_TYPE.to_owned(),
+            allowed_metrics,
+            Some(Uuid::nil()),
+            Some("test.subject".to_owned()),
+        );
+        Self {
+            db,
+            _handle: handle,
+            emitter,
+            tenant,
+            resource_id,
+        }
+    }
+
+    fn record(&self) -> UsageRecord {
+        UsageRecord {
+            tenant_id: self.tenant,
+            module: "test-module".to_owned(),
+            metric: "test.gauge".to_owned(),
+            kind: UsageKind::Gauge,
+            value: 1.0,
+            resource_id: self.resource_id,
+            resource_type: FIXTURE_RESOURCE_TYPE.to_owned(),
+            subject_id: Some(Uuid::nil()),
+            subject_type: Some("test.subject".to_owned()),
+            idempotency_key: Uuid::new_v4().to_string(),
+            timestamp: Utc::now(),
+            metadata: None,
+        }
+    }
+
+    fn record_with_kind(&self, kind: UsageKind, value: f64) -> UsageRecord {
+        let metric = match kind {
+            UsageKind::Gauge => "test.gauge",
+            UsageKind::Counter => "test.counter",
+        }
+        .to_owned();
+        UsageRecord {
+            metric,
+            kind,
+            value,
+            ..self.record()
+        }
+    }
+
+    fn conn(&self) -> modkit_db::DbConn<'_> {
+        self.db.conn().unwrap()
+    }
+}
+
+// ── Expiry ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_expired_authorization() {
+    let f = Fixture::build_with_config(
+        "ap_expired",
+        UsageEmitterConfig {
+            authorization_max_age: Duration::ZERO,
+            ..Default::default()
+        },
+    )
+    .await;
+    let err = f
+        .emitter
+        .enqueue_in(&f.conn(), f.record())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationExpired));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_usage_record() {
+    let f = Fixture::build("ap_pos_val").await;
+    f.emitter.enqueue_in(&f.conn(), f.record()).await.unwrap();
+}
+
+// ── Authorization scope ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_tenant() {
+    let f = Fixture::build("ap_bad_tenant").await;
+    let record = UsageRecord {
+        tenant_id: Uuid::new_v4(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_resource_id() {
+    let f = Fixture::build("ap_bad_res").await;
+    let record = UsageRecord {
+        resource_id: Uuid::new_v4(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_resource_type() {
+    let f = Fixture::build("ap_bad_rt").await;
+    let record = UsageRecord {
+        resource_type: "other.resource".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+// ── Counter value ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_negative_counter_value() {
+    let f = Fixture::build("ap_neg_ctr").await;
+    let record = f.record_with_kind(UsageKind::Counter, -1.0);
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageEmitterError::NegativeCounterValue { value } if (value + 1.0).abs() < f64::EPSILON
+    ));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_zero_counter_value() {
+    let f = Fixture::build("ap_zero_ctr").await;
+    f.emitter
+        .enqueue_in(&f.conn(), f.record_with_kind(UsageKind::Counter, 0.0))
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn enqueue_accepts_negative_gauge_value() {
+    let f = Fixture::build("ap_neg_gauge").await;
+    f.emitter
+        .enqueue_in(&f.conn(), f.record_with_kind(UsageKind::Gauge, -1.0))
+        .await
+        .unwrap();
+}
+
+// ── Metric validation ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_metric_not_in_allowed_list() {
+    let f = Fixture::build("ap_metric_disallowed").await;
+    let record = UsageRecord {
+        metric: "not.allowed.metric".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(
+        matches!(err, UsageEmitterError::MetricNotAllowed { ref metric } if metric == "not.allowed.metric")
+    );
+}
+
+#[tokio::test]
+async fn enqueue_rejects_metric_kind_mismatch() {
+    let f = Fixture::build("ap_kind_mismatch").await;
+    // "test.counter" is registered as Counter; submitting it as Gauge is a kind mismatch.
+    let record = UsageRecord {
+        metric: "test.counter".to_owned(),
+        kind: UsageKind::Gauge,
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(
+        err,
+        UsageEmitterError::MetricKindMismatch {
+            ref metric,
+            expected: UsageKind::Counter,
+            actual: UsageKind::Gauge,
+        } if metric == "test.counter"
+    ));
+}
+
+// ── Module and subject mismatch rejection ─────────────────────────────────────
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_module() {
+    let f = Fixture::build("ap_bad_module").await;
+    let record = UsageRecord {
+        module: "wrong-module".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_subject_id() {
+    let f = Fixture::build("ap_bad_subj_id").await;
+    let record = UsageRecord {
+        subject_id: Some(Uuid::new_v4()), // differs from Some(Uuid::nil()) in the token
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_rejects_mismatched_subject_type() {
+    let f = Fixture::build("ap_bad_subj_type").await;
+    let record = UsageRecord {
+        subject_type: Some("other.subject".to_owned()), // differs from Some("test.subject") in the token
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn enqueue_accepts_record_when_module_and_subject_match_token() {
+    let f = Fixture::build("ap_match_ok").await;
+    // f.record() already has module="test-module", subject_id=Some(Uuid::nil()), subject_type=Some("test.subject")
+    f.emitter.enqueue_in(&f.conn(), f.record()).await.unwrap();
+}

--- a/modules/system/usage-collector/usage-emitter/src/config.rs
+++ b/modules/system/usage-collector/usage-emitter/src/config.rs
@@ -1,0 +1,80 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// Configuration for [`crate::UsageEmitter`].
+///
+/// Host modules embed this inside their own config struct and forward it to
+/// [`crate::UsageEmitter::build`]. All fields have sensible defaults so
+/// `#[serde(default)]` on the embedding struct is sufficient for zero-config usage.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct UsageEmitterConfig {
+    /// Maximum age of an [`crate::AuthorizedUsageEmitter`] handle after
+    /// [`crate::UsageEmitterV1::authorize`] before
+    /// [`crate::AuthorizedUsageEmitter::enqueue`] / [`crate::AuthorizedUsageEmitter::enqueue_in`]
+    /// reject it with [`crate::UsageEmitterError::AuthorizationExpired`].
+    pub authorization_max_age: Duration,
+
+    /// Outbox queue name for usage records delivered to the collector.
+    pub outbox_queue: String,
+
+    /// Number of outbox partitions. Must be a power of 2 in 1-64.
+    pub outbox_partition_count: u16,
+
+    /// Maximum exponential-backoff delay for outbox delivery retries.
+    ///
+    /// Maps to [`modkit_db::outbox::WorkerTuning::retry_max`].
+    /// MUST remain below 15 minutes to satisfy `cpt-cf-usage-collector-nfr-recovery`
+    /// (inst-dlv-6a / inst-emit-10a).
+    pub outbox_backoff_max: Duration,
+}
+
+impl Default for UsageEmitterConfig {
+    fn default() -> Self {
+        Self {
+            authorization_max_age: Duration::from_secs(30),
+            outbox_queue: "usage-records".to_owned(),
+            outbox_partition_count: 4,
+            outbox_backoff_max: Duration::from_mins(10), // 10 minutes — well below the 15-minute NFR ceiling
+        }
+    }
+}
+
+impl UsageEmitterConfig {
+    /// # Errors
+    ///
+    /// Returns an error when any configuration field is invalid.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.outbox_queue.trim().is_empty(),
+            "outbox_queue must not be empty"
+        );
+        anyhow::ensure!(
+            (1..=64).contains(&self.outbox_partition_count)
+                && self.outbox_partition_count.is_power_of_two(),
+            "outbox_partition_count must be a power of 2 in 1-64, got {}",
+            self.outbox_partition_count
+        );
+        anyhow::ensure!(
+            !self.authorization_max_age.is_zero(),
+            "authorization_max_age must be > 0"
+        );
+        anyhow::ensure!(
+            self.outbox_backoff_max > Duration::ZERO,
+            "outbox_backoff_max must be greater than zero"
+        );
+        anyhow::ensure!(
+            self.outbox_backoff_max < Duration::from_mins(15),
+            "outbox_backoff_max must be below 15 minutes (cpt-cf-usage-collector-nfr-recovery), got {:?}",
+            self.outbox_backoff_max
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "config_tests.rs"]
+mod config_tests;

--- a/modules/system/usage-collector/usage-emitter/src/config_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/config_tests.rs
@@ -1,0 +1,111 @@
+use std::time::Duration;
+
+use super::UsageEmitterConfig;
+
+#[test]
+fn default_authorization_max_age_is_30_seconds() {
+    let cfg = UsageEmitterConfig::default();
+    assert_eq!(cfg.authorization_max_age, Duration::from_secs(30));
+}
+
+#[test]
+fn default_outbox_queue_is_usage_records() {
+    let cfg = UsageEmitterConfig::default();
+    assert_eq!(cfg.outbox_queue, "usage-records");
+}
+
+#[test]
+fn default_outbox_partition_count_is_4() {
+    let cfg = UsageEmitterConfig::default();
+    assert_eq!(cfg.outbox_partition_count, 4);
+}
+
+#[test]
+fn validate_accepts_defaults() {
+    UsageEmitterConfig::default().validate().unwrap();
+}
+
+#[test]
+fn validate_rejects_empty_outbox_queue() {
+    let cfg = UsageEmitterConfig {
+        outbox_queue: "   ".to_owned(),
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_queue"));
+}
+
+#[test]
+fn validate_rejects_invalid_outbox_partition_count_zero() {
+    let cfg = UsageEmitterConfig {
+        outbox_partition_count: 0,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_partition_count"));
+}
+
+#[test]
+fn validate_rejects_invalid_outbox_partition_count_not_power_of_two() {
+    let cfg = UsageEmitterConfig {
+        outbox_partition_count: 3,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_partition_count"));
+}
+
+#[test]
+fn validate_rejects_invalid_outbox_partition_count_above_64() {
+    let cfg = UsageEmitterConfig {
+        outbox_partition_count: 65,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_partition_count"));
+}
+
+#[test]
+fn validate_rejects_zero_authorization_max_age() {
+    let cfg = UsageEmitterConfig {
+        authorization_max_age: Duration::ZERO,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("authorization_max_age"));
+}
+
+#[test]
+fn default_outbox_backoff_max_is_10_minutes() {
+    let cfg = UsageEmitterConfig::default();
+    assert_eq!(cfg.outbox_backoff_max, Duration::from_mins(10));
+}
+
+#[test]
+fn validate_rejects_zero_outbox_backoff_max() {
+    let cfg = UsageEmitterConfig {
+        outbox_backoff_max: Duration::ZERO,
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_backoff_max"));
+}
+
+#[test]
+fn validate_rejects_outbox_backoff_max_at_or_above_15_minutes() {
+    let cfg = UsageEmitterConfig {
+        outbox_backoff_max: Duration::from_mins(15),
+        ..UsageEmitterConfig::default()
+    };
+    let err = cfg.validate().unwrap_err();
+    assert!(err.to_string().contains("outbox_backoff_max"));
+}
+
+#[test]
+fn validate_accepts_outbox_backoff_max_below_15_minutes() {
+    let cfg = UsageEmitterConfig {
+        outbox_backoff_max: Duration::from_secs(899),
+        ..UsageEmitterConfig::default()
+    };
+    cfg.validate().unwrap();
+}

--- a/modules/system/usage-collector/usage-emitter/src/domain/authz.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/authz.rs
@@ -1,0 +1,44 @@
+//! PDP resource type and action constants for usage-record authorization.
+//!
+//! These constants are implementation details of [`crate::UsageEmitter::authorize_for`].
+//! They are intentionally `pub(crate)` — no external crate can construct a
+//! `PolicyEnforcer` call against `gts.x.core.usage.record.v1 / create` using
+//! names exported from this crate.
+
+use authz_resolver_sdk::pep::ResourceType;
+use modkit_security::pep_properties;
+
+/// Property names for usage record ABAC (beyond shared `pep_properties`).
+pub mod properties {
+    /// Metered resource instance identifier (usage record resource property).
+    pub const RESOURCE_ID: &str = "resource_id";
+    /// Metered resource type (usage record resource property).
+    pub const RESOURCE_TYPE: &str = "resource_type";
+    /// Source module identity (usage record resource property).
+    pub const MODULE: &str = "module";
+    /// Subject UUID (usage record resource property).
+    pub const SUBJECT_ID: &str = "subject_id";
+    /// Subject kind (usage record resource property).
+    pub const SUBJECT_TYPE: &str = "subject_type";
+}
+
+/// Usage record resource type used by [`crate::UsageEmitter::authorize_for`].
+///
+/// Resource properties include `owner_tenant_id`, `resource_id`, `resource_type`,
+/// `module`, `subject_id`, and `subject_type`.
+pub const USAGE_RECORD: ResourceType = ResourceType {
+    name: "gts.x.core.usage.record.v1~",
+    supported_properties: &[
+        pep_properties::OWNER_TENANT_ID,
+        properties::RESOURCE_ID,
+        properties::RESOURCE_TYPE,
+        properties::MODULE,
+        properties::SUBJECT_ID,
+        properties::SUBJECT_TYPE,
+    ],
+};
+
+/// Authorization action name used when calling the PDP.
+pub mod actions {
+    pub const CREATE: &str = "create";
+}

--- a/modules/system/usage-collector/usage-emitter/src/domain/mod.rs
+++ b/modules/system/usage-collector/usage-emitter/src/domain/mod.rs
@@ -1,0 +1,1 @@
+pub mod authz;

--- a/modules/system/usage-collector/usage-emitter/src/emitter.rs
+++ b/modules/system/usage-collector/usage-emitter/src/emitter.rs
@@ -1,0 +1,110 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::AuthZResolverClient;
+use authz_resolver_sdk::EnforcerError;
+use modkit_db::Db;
+use modkit_db::outbox::WorkerTuning;
+use modkit_db::outbox::{Outbox, OutboxHandle, Partitions};
+use usage_collector_sdk::UsageCollectorClientV1;
+
+use crate::api::UsageEmitterV1;
+use crate::config::UsageEmitterConfig;
+use crate::infra::delivery_handler::DeliveryHandler;
+use crate::scoped_emitter::ScopedUsageEmitter;
+
+/// An emitter that starts the usage outbox worker and issues scoped emit handles.
+///
+/// Constructed via [`UsageEmitter::build`]. Call [`UsageEmitterV1::for_module`] to obtain a
+/// [`ScopedUsageEmitter`] bound to a module name, then use its `authorize_for` / `authorize` to
+/// get a time-limited [`crate::AuthorizedUsageEmitter`].
+pub struct UsageEmitter {
+    config: Arc<UsageEmitterConfig>,
+    db: Db,
+    authz: Arc<dyn AuthZResolverClient>,
+    collector: Arc<dyn UsageCollectorClientV1>,
+    outbox_handle: OutboxHandle,
+}
+
+impl UsageEmitter {
+    /// Build a [`UsageEmitter`] and start the background outbox worker.
+    ///
+    /// Registers the `usage-records` queue, attaches `delivery_handler` for async delivery to
+    /// `collector`, and wires the [`authz_resolver_sdk::pep::PolicyEnforcer`] for per-call PDP checks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the outbox worker fails to start (e.g. DB unavailable or
+    /// queue registration fails).
+    pub async fn build(
+        config: UsageEmitterConfig,
+        db: Db,
+        authz: Arc<dyn AuthZResolverClient>,
+        collector: Arc<dyn UsageCollectorClientV1>,
+    ) -> anyhow::Result<Self> {
+        config.validate()?;
+
+        let delivery_handler = DeliveryHandler::new(Arc::clone(&collector));
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+        let processor_tuning =
+            WorkerTuning::processor_default().retry_max(config.outbox_backoff_max);
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+
+        let outbox_handle = Outbox::builder(db.clone())
+            .processor_tuning(processor_tuning)
+            .queue(
+                &config.outbox_queue,
+                Partitions::of(config.outbox_partition_count),
+            )
+            .leased(delivery_handler)
+            .start()
+            .await
+            .map_err(anyhow::Error::from)?;
+
+        Ok(Self {
+            config: Arc::new(config),
+            db,
+            authz,
+            collector,
+            outbox_handle,
+        })
+    }
+}
+
+impl UsageEmitterV1 for UsageEmitter {
+    fn for_module(&self, module_name: &str) -> ScopedUsageEmitter {
+        ScopedUsageEmitter::new(
+            module_name.to_owned(),
+            Arc::clone(&self.authz),
+            Arc::clone(&self.collector),
+            self.db.clone(),
+            Arc::clone(&self.config),
+            Arc::clone(self.outbox_handle.outbox()),
+        )
+    }
+}
+
+pub fn enforcer_error_to_emitter_error(e: EnforcerError) -> crate::error::UsageEmitterError {
+    use crate::error::UsageEmitterError;
+    use authz_resolver_sdk::EnforcerError;
+    match e {
+        EnforcerError::Denied { deny_reason } => {
+            let message = deny_reason.map_or_else(
+                || "access denied by policy".to_owned(),
+                |r| format!("{}: {}", r.error_code, r.details.unwrap_or_default()),
+            );
+            UsageEmitterError::authorization_failed(message)
+        }
+        EnforcerError::CompileFailed(_) => {
+            UsageEmitterError::internal("authorization constraint compilation failed")
+        }
+        EnforcerError::EvaluationFailed(_) => {
+            UsageEmitterError::internal("authorization evaluation failed")
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "emitter_tests.rs"]
+mod emitter_tests;

--- a/modules/system/usage-collector/usage-emitter/src/emitter_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/emitter_tests.rs
@@ -1,0 +1,711 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use authz_resolver_sdk::models::{
+    BarrierMode, EvaluationRequest, EvaluationResponse, EvaluationResponseContext,
+};
+use authz_resolver_sdk::pep::ConstraintCompileError;
+use authz_resolver_sdk::{AuthZResolverClient, AuthZResolverError, DenyReason, EnforcerError};
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::outbox_migrations;
+use modkit_db::{ConnectOpts, Db, connect_db};
+use modkit_security::SecurityContext;
+use modkit_security::pep_properties;
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use uuid::Uuid;
+
+use super::{UsageEmitter, enforcer_error_to_emitter_error};
+use crate::UsageEmitterV1;
+use crate::config::UsageEmitterConfig;
+use crate::error::UsageEmitterError;
+
+const TEST_MODULE: &str = "test-module";
+
+// ── Mock AuthZ clients ────────────────────────────────────────────────────────
+
+struct AllowAllAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for AllowAllAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+struct DenyAllAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for DenyAllAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Ok(EvaluationResponse {
+            decision: false,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+struct FailingAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for FailingAuthZ {
+    async fn evaluate(
+        &self,
+        _request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        Err(AuthZResolverError::Internal("PDP unavailable".to_owned()))
+    }
+}
+
+/// PDP mock: allow only if `owner_tenant_id` matches the subject's home tenant or an allowed extra id.
+struct AllowOwnerTenantIfInSet {
+    /// Tenants allowed in addition to the subject's `tenant_id` (e.g. sub-tenants).
+    extra_allowed: Vec<Uuid>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AllowOwnerTenantIfInSet {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let subject_tenant = request
+            .subject
+            .properties
+            .get("tenant_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok());
+
+        let Some(subject_tenant) = subject_tenant else {
+            return Ok(EvaluationResponse {
+                decision: false,
+                context: EvaluationResponseContext::default(),
+            });
+        };
+
+        let owner = request
+            .resource
+            .properties
+            .get(pep_properties::OWNER_TENANT_ID)
+            .and_then(|v| v.as_str())
+            .and_then(|s| Uuid::parse_str(s).ok());
+
+        let Some(owner) = owner else {
+            return Ok(EvaluationResponse {
+                decision: false,
+                context: EvaluationResponseContext::default(),
+            });
+        };
+
+        let allowed = owner == subject_tenant || self.extra_allowed.contains(&owner);
+
+        Ok(EvaluationResponse {
+            decision: allowed,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+/// Asserts `tenant_context.barrier_mode` is `Ignore` and returns allow.
+struct AssertBarrierIgnoreAuthZ;
+
+#[async_trait]
+impl AuthZResolverClient for AssertBarrierIgnoreAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        let barrier = request
+            .context
+            .tenant_context
+            .as_ref()
+            .expect("tenant_context set by AccessRequest::barrier_mode")
+            .barrier_mode;
+        assert_eq!(barrier, BarrierMode::Ignore);
+        Ok(EvaluationResponse {
+            decision: true,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+// ── Mock collector ────────────────────────────────────────────────────────────
+
+struct NoopCollector;
+
+#[async_trait]
+impl UsageCollectorClientV1 for NoopCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+        })
+    }
+}
+
+struct FailingCollector {
+    error: fn() -> UsageCollectorError,
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for FailingCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Err((self.error)())
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async fn build_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    db
+}
+
+async fn build_emitter(db: Db, authz: Arc<dyn AuthZResolverClient>) -> UsageEmitter {
+    UsageEmitter::build(
+        UsageEmitterConfig::default(),
+        db,
+        authz,
+        Arc::new(NoopCollector),
+    )
+    .await
+    .unwrap()
+}
+
+async fn build_emitter_with_collector(
+    db: Db,
+    authz: Arc<dyn AuthZResolverClient>,
+    collector: Arc<dyn UsageCollectorClientV1>,
+) -> UsageEmitter {
+    UsageEmitter::build(UsageEmitterConfig::default(), db, authz, collector)
+        .await
+        .unwrap()
+}
+
+fn make_ctx() -> SecurityContext {
+    SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(Uuid::new_v4())
+        .build()
+        .unwrap()
+}
+
+// ── enforcer_error_to_emitter_error ──────────────────────────────────────────
+
+#[test]
+fn enforcer_denied_without_reason_uses_default_message() {
+    let err = enforcer_error_to_emitter_error(EnforcerError::Denied { deny_reason: None });
+    assert!(
+        matches!(err, UsageEmitterError::AuthorizationFailed { ref message } if message == "access denied by policy")
+    );
+}
+
+#[test]
+fn enforcer_denied_with_code_and_details() {
+    let deny_reason = Some(DenyReason {
+        error_code: "ERR_FORBIDDEN".to_owned(),
+        details: Some("tenant not allowed".to_owned()),
+    });
+    let err = enforcer_error_to_emitter_error(EnforcerError::Denied { deny_reason });
+    assert!(
+        matches!(err, UsageEmitterError::AuthorizationFailed { ref message } if message == "ERR_FORBIDDEN: tenant not allowed")
+    );
+}
+
+#[test]
+fn enforcer_denied_with_code_no_details() {
+    let deny_reason = Some(DenyReason {
+        error_code: "ERR_FORBIDDEN".to_owned(),
+        details: None,
+    });
+    let err = enforcer_error_to_emitter_error(EnforcerError::Denied { deny_reason });
+    assert!(
+        matches!(err, UsageEmitterError::AuthorizationFailed { ref message } if message == "ERR_FORBIDDEN: ")
+    );
+}
+
+#[test]
+fn enforcer_compile_failed_maps_to_internal() {
+    let err = enforcer_error_to_emitter_error(EnforcerError::CompileFailed(
+        ConstraintCompileError::ConstraintsRequiredButAbsent,
+    ));
+    assert!(matches!(err, UsageEmitterError::Internal { .. }));
+}
+
+#[test]
+fn enforcer_evaluation_failed_maps_to_internal() {
+    let err = enforcer_error_to_emitter_error(EnforcerError::EvaluationFailed(
+        AuthZResolverError::Internal("rpc error".to_owned()),
+    ));
+    assert!(matches!(err, UsageEmitterError::Internal { .. }));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn build_creates_emitter_with_valid_config() {
+    let db = build_db("emit_build").await;
+    build_emitter(db, Arc::new(AllowAllAuthZ)).await;
+}
+
+#[tokio::test]
+async fn authorize_returns_handle_on_allow_all_authz() {
+    let db = build_db("emit_authz_allow").await;
+    let emitter = build_emitter(db, Arc::new(AllowAllAuthZ)).await;
+    let ctx = make_ctx();
+    emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn authorize_returns_error_on_deny_all_authz() {
+    let db = build_db("emit_authz_deny").await;
+    let emitter = build_emitter(db, Arc::new(DenyAllAuthZ)).await;
+    let ctx = make_ctx();
+    let Err(err) = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn authorize_returns_internal_error_on_authz_failure() {
+    let db = build_db("emit_authz_fail").await;
+    let emitter = build_emitter(db, Arc::new(FailingAuthZ)).await;
+    let ctx = make_ctx();
+    let Err(err) = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::Internal { .. }));
+}
+
+#[tokio::test]
+async fn authorize_for_denies_when_pdp_rejects_owner_tenant() {
+    let db = build_db("emit_pdp_deny_foreign").await;
+    let emitter = build_emitter(
+        db,
+        Arc::new(AllowOwnerTenantIfInSet {
+            extra_allowed: vec![],
+        }),
+    )
+    .await;
+
+    let subject_tenant = Uuid::new_v4();
+    let foreign_tenant = Uuid::new_v4();
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(subject_tenant)
+        .build()
+        .unwrap();
+
+    let Err(err) = emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            foreign_tenant,
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            Some(Uuid::new_v4()),
+            Some("test.subject".to_owned()),
+        )
+        .await
+    else {
+        panic!("expected authorization to fail");
+    };
+    assert!(matches!(err, UsageEmitterError::AuthorizationFailed { .. }));
+}
+
+#[tokio::test]
+async fn authorize_for_allows_subtenant_when_pdp_allows_extra_tenant() {
+    let db = build_db("emit_pdp_allow_child").await;
+    let parent = Uuid::new_v4();
+    let child = Uuid::new_v4();
+    let emitter = build_emitter(
+        db,
+        Arc::new(AllowOwnerTenantIfInSet {
+            extra_allowed: vec![child],
+        }),
+    )
+    .await;
+
+    let ctx = SecurityContext::builder()
+        .subject_id(Uuid::new_v4())
+        .subject_tenant_id(parent)
+        .build()
+        .unwrap();
+
+    emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            child,
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            Some(Uuid::new_v4()),
+            Some("test.subject".to_owned()),
+        )
+        .await
+        .expect("PDP allows emit for allowed sub-tenant");
+}
+
+#[tokio::test]
+async fn authorize_for_sends_barrier_mode_ignore_to_pdp() {
+    let db = build_db("emit_barrier_ignore").await;
+    let emitter = build_emitter(db, Arc::new(AssertBarrierIgnoreAuthZ)).await;
+    let ctx = make_ctx();
+    emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            ctx.subject_tenant_id(),
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            Some(Uuid::new_v4()),
+            Some("test.subject".to_owned()),
+        )
+        .await
+        .expect("barrier assert + allow");
+}
+
+// ── Collector infrastructure failures map to Internal (not AuthorizationFailed) ──
+
+#[tokio::test]
+async fn authorize_for_maps_collector_plugin_timeout_to_internal() {
+    let db = build_db("emit_collector_timeout").await;
+    let emitter = build_emitter_with_collector(
+        db,
+        Arc::new(AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: UsageCollectorError::plugin_timeout,
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+#[tokio::test]
+async fn authorize_for_maps_collector_circuit_open_to_internal() {
+    let db = build_db("emit_collector_circuit_open").await;
+    let emitter = build_emitter_with_collector(
+        db,
+        Arc::new(AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: UsageCollectorError::circuit_open,
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+#[tokio::test]
+async fn authorize_for_maps_collector_unavailable_to_internal() {
+    let db = build_db("emit_collector_unavailable").await;
+    let emitter = build_emitter_with_collector(
+        db,
+        Arc::new(AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: || UsageCollectorError::unavailable("gateway unreachable"),
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+#[tokio::test]
+async fn authorize_for_maps_collector_internal_error_to_internal() {
+    let db = build_db("emit_collector_internal").await;
+    let emitter = build_emitter_with_collector(
+        db,
+        Arc::new(AllowAllAuthZ),
+        Arc::new(FailingCollector {
+            error: || UsageCollectorError::internal("unexpected state"),
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize(&ctx, Uuid::new_v4(), "test.resource".to_owned())
+        .await;
+    assert!(matches!(result, Err(UsageEmitterError::Internal { .. })));
+}
+
+// ── PDP resource property assertions ─────────────────────────────────────────
+
+/// PDP mock that asserts the MODULE resource property equals the expected value,
+/// denies if the assertion fails, otherwise allows.
+struct AssertModulePropertyAuthZ {
+    expected_module: String,
+    matched: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AssertModulePropertyAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        use crate::domain::authz::properties;
+        let module_val = request
+            .resource
+            .properties
+            .get(properties::MODULE)
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let ok = module_val == self.expected_module;
+        *self.matched.lock().unwrap() = ok;
+        Ok(EvaluationResponse {
+            decision: ok,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+/// PDP mock that asserts `SUBJECT_ID` and `SUBJECT_TYPE` resource properties equal
+/// the expected values, denies if either assertion fails, otherwise allows.
+struct AssertSubjectPropertiesAuthZ {
+    expected_subject_id: String,
+    expected_subject_type: String,
+    matched: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AssertSubjectPropertiesAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        use crate::domain::authz::properties;
+        let subj_id = request
+            .resource
+            .properties
+            .get(properties::SUBJECT_ID)
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let subj_type = request
+            .resource
+            .properties
+            .get(properties::SUBJECT_TYPE)
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let ok = subj_id == self.expected_subject_id && subj_type == self.expected_subject_type;
+        *self.matched.lock().unwrap() = ok;
+        Ok(EvaluationResponse {
+            decision: ok,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn authorize_for_pdp_request_includes_module_resource_property() {
+    let matched = Arc::new(Mutex::new(false));
+    let db = build_db("emit_module_prop").await;
+    let emitter = build_emitter(
+        db,
+        Arc::new(AssertModulePropertyAuthZ {
+            expected_module: TEST_MODULE.to_owned(),
+            matched: Arc::clone(&matched),
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    drop(
+        emitter
+            .for_module(TEST_MODULE)
+            .authorize_for(
+                &ctx,
+                ctx.subject_tenant_id(),
+                Uuid::new_v4(),
+                "test.resource".to_owned(),
+                Some(Uuid::new_v4()),
+                Some("test.subject".to_owned()),
+            )
+            .await,
+    );
+    assert!(
+        *matched.lock().unwrap(),
+        "PDP request must include MODULE resource property equal to the module name"
+    );
+}
+
+/// PDP mock that asserts `SUBJECT_ID` and `SUBJECT_TYPE` resource properties equal
+/// the expected values (with subject present), denies if either assertion fails, otherwise allows.
+/// This mock documents the "with subject" variant of the subject-properties test.
+#[tokio::test]
+async fn authorize_for_pdp_request_includes_subject_id_and_subject_type_resource_properties() {
+    let matched = Arc::new(Mutex::new(false));
+    let subject_id = Uuid::new_v4();
+    let subject_type = "test.subject.type".to_owned();
+    let db = build_db("emit_subject_props").await;
+    let emitter = build_emitter(
+        db,
+        Arc::new(AssertSubjectPropertiesAuthZ {
+            expected_subject_id: subject_id.to_string(),
+            expected_subject_type: subject_type.clone(),
+            matched: Arc::clone(&matched),
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    drop(
+        emitter
+            .for_module(TEST_MODULE)
+            .authorize_for(
+                &ctx,
+                ctx.subject_tenant_id(),
+                Uuid::new_v4(),
+                "test.resource".to_owned(),
+                Some(subject_id),
+                Some(subject_type),
+            )
+            .await,
+    );
+    assert!(
+        *matched.lock().unwrap(),
+        "PDP request must include SUBJECT_ID and SUBJECT_TYPE resource properties with the passed values"
+    );
+}
+
+/// PDP mock that asserts neither `SUBJECT_ID` nor `SUBJECT_TYPE` resource property is present
+/// in the PDP request, returns allow if the assertion passes, deny otherwise.
+struct AssertNoSubjectPropertiesAuthZ {
+    asserted: Arc<Mutex<bool>>,
+}
+
+#[async_trait]
+impl AuthZResolverClient for AssertNoSubjectPropertiesAuthZ {
+    async fn evaluate(
+        &self,
+        request: EvaluationRequest,
+    ) -> Result<EvaluationResponse, AuthZResolverError> {
+        use crate::domain::authz::properties;
+        let has_subject_id = request
+            .resource
+            .properties
+            .contains_key(properties::SUBJECT_ID);
+        let has_subject_type = request
+            .resource
+            .properties
+            .contains_key(properties::SUBJECT_TYPE);
+        let ok = !has_subject_id && !has_subject_type;
+        *self.asserted.lock().unwrap() = ok;
+        Ok(EvaluationResponse {
+            decision: ok,
+            context: EvaluationResponseContext::default(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn authorize_for_without_subject_succeeds() {
+    let db = build_db("emit_no_subject_allow").await;
+    let emitter = build_emitter(db, Arc::new(AllowAllAuthZ)).await;
+    let ctx = make_ctx();
+    let result = emitter
+        .for_module(TEST_MODULE)
+        .authorize_for(
+            &ctx,
+            ctx.subject_tenant_id(),
+            Uuid::new_v4(),
+            "test.resource".to_owned(),
+            None,
+            None,
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "authorize_for with None subject must succeed when PDP allows"
+    );
+}
+
+#[tokio::test]
+async fn authorize_for_pdp_request_omits_subject_properties_when_none() {
+    let asserted = Arc::new(Mutex::new(false));
+    let db = build_db("emit_no_subject_props").await;
+    let emitter = build_emitter(
+        db,
+        Arc::new(AssertNoSubjectPropertiesAuthZ {
+            asserted: Arc::clone(&asserted),
+        }),
+    )
+    .await;
+    let ctx = make_ctx();
+    drop(
+        emitter
+            .for_module(TEST_MODULE)
+            .authorize_for(
+                &ctx,
+                ctx.subject_tenant_id(),
+                Uuid::new_v4(),
+                "test.resource".to_owned(),
+                None,
+                None,
+            )
+            .await,
+    );
+    assert!(
+        *asserted.lock().unwrap(),
+        "PDP request must NOT include SUBJECT_ID or SUBJECT_TYPE resource properties when subject is None"
+    );
+}

--- a/modules/system/usage-collector/usage-emitter/src/error.rs
+++ b/modules/system/usage-collector/usage-emitter/src/error.rs
@@ -1,0 +1,130 @@
+//! Error type for [`crate::ScopedUsageEmitter::authorize_for`],
+//! [`crate::AuthorizedUsageEmitter::enqueue`], [`crate::AuthorizedUsageEmitter::enqueue_in`],
+//! and [`crate::UsageRecordBuilder::enqueue`].
+
+use modkit_db::outbox::OutboxError as ModkitOutboxError;
+use usage_collector_sdk::models::UsageKind;
+
+/// Errors returned from [`crate::ScopedUsageEmitter::authorize_for`],
+/// [`crate::AuthorizedUsageEmitter::enqueue`], [`crate::AuthorizedUsageEmitter::enqueue_in`],
+/// and [`crate::UsageRecordBuilder::enqueue`].
+///
+/// All variants are produced *before* any DB write unless otherwise noted.
+#[derive(Debug, thiserror::Error)]
+pub enum UsageEmitterError {
+    /// The authorized emitter handle exceeded [`crate::UsageEmitterConfig::authorization_max_age`]
+    /// at [`crate::AuthorizedUsageEmitter::enqueue`] / [`crate::AuthorizedUsageEmitter::enqueue_in`]
+    /// evaluation time.
+    #[error("emit authorization token has expired")]
+    AuthorizationExpired,
+
+    /// PDP explicitly denied the source module.
+    #[error("authorization failed: {message}")]
+    AuthorizationFailed { message: String },
+
+    /// Required fields were missing when finishing a [`crate::UsageRecordBuilder`] enqueue path.
+    #[error("invalid usage record: {message}")]
+    InvalidRecord { message: String },
+
+    /// The usage record's kind does not match the registered kind for that metric.
+    #[error("metric '{metric}' expects kind {expected:?} but record specifies {actual:?}")]
+    MetricKindMismatch {
+        metric: String,
+        expected: UsageKind,
+        actual: UsageKind,
+    },
+
+    /// The metric is not in the allowed metrics list for this module.
+    #[error("metric not allowed for this module: {metric}")]
+    MetricNotAllowed { metric: String },
+
+    /// A counter [`usage_collector_sdk::models::UsageRecord`] was submitted with a negative `value`.
+    #[error("counter usage record has a negative value: {value}")]
+    NegativeCounterValue { value: f64 },
+
+    /// PDP communication failures and other unexpected conditions not covered by specific variants.
+    #[error("internal error: {message}")]
+    Internal { message: String },
+
+    /// The module is not registered in the gateway's static metric configuration.
+    #[error("module not configured: {module_name}")]
+    ModuleNotConfigured { module_name: String },
+
+    /// Metadata JSON exceeded the 8192-byte limit.
+    #[error("metadata byte length {len} exceeds the 8192-byte limit")]
+    MetadataTooLarge { len: usize },
+
+    /// Transactional outbox error (DB write failure, queue not registered, etc.).
+    #[error(transparent)]
+    Outbox(#[from] ModkitOutboxError),
+}
+
+impl UsageEmitterError {
+    #[must_use]
+    pub fn authorization_expired() -> Self {
+        Self::AuthorizationExpired
+    }
+
+    #[must_use]
+    pub fn authorization_failed(message: impl Into<String>) -> Self {
+        Self::AuthorizationFailed {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn invalid_record(message: impl Into<String>) -> Self {
+        Self::InvalidRecord {
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn metric_kind_mismatch(
+        metric: impl Into<String>,
+        expected: UsageKind,
+        actual: UsageKind,
+    ) -> Self {
+        Self::MetricKindMismatch {
+            metric: metric.into(),
+            expected,
+            actual,
+        }
+    }
+
+    #[must_use]
+    pub fn metric_not_allowed(metric: impl Into<String>) -> Self {
+        Self::MetricNotAllowed {
+            metric: metric.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn negative_counter_value(value: f64) -> Self {
+        Self::NegativeCounterValue { value }
+    }
+
+    #[must_use]
+    pub fn module_not_configured(module_name: impl Into<String>) -> Self {
+        Self::ModuleNotConfigured {
+            module_name: module_name.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn metadata_too_large(len: usize) -> Self {
+        Self::MetadataTooLarge { len }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "error_tests.rs"]
+mod error_tests;

--- a/modules/system/usage-collector/usage-emitter/src/error_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/error_tests.rs
@@ -1,0 +1,57 @@
+use usage_collector_sdk::models::UsageKind;
+
+use super::*;
+
+// ── Display ───────────────────────────────────────────────────────
+
+#[test]
+fn display_authorization_expired() {
+    let err = UsageEmitterError::authorization_expired();
+    assert_eq!(err.to_string(), "emit authorization token has expired");
+}
+
+#[test]
+fn display_authorization_failed() {
+    let err = UsageEmitterError::authorization_failed("denied by policy");
+    assert_eq!(err.to_string(), "authorization failed: denied by policy");
+}
+
+#[test]
+fn display_negative_counter_value() {
+    let err = UsageEmitterError::negative_counter_value(-1.0);
+    assert_eq!(
+        err.to_string(),
+        "counter usage record has a negative value: -1"
+    );
+}
+
+#[test]
+fn display_invalid_record() {
+    let err = UsageEmitterError::invalid_record("missing tenant_id");
+    assert_eq!(err.to_string(), "invalid usage record: missing tenant_id");
+}
+
+#[test]
+fn display_metric_kind_mismatch() {
+    let err =
+        UsageEmitterError::metric_kind_mismatch("cpu.usage", UsageKind::Counter, UsageKind::Gauge);
+    assert_eq!(
+        err.to_string(),
+        "metric 'cpu.usage' expects kind Counter but record specifies Gauge"
+    );
+}
+
+#[test]
+fn display_metric_not_allowed() {
+    let err = UsageEmitterError::metric_not_allowed("unknown.metric");
+    assert_eq!(
+        err.to_string(),
+        "metric not allowed for this module: unknown.metric"
+    );
+}
+
+#[test]
+fn display_internal() {
+    let err = UsageEmitterError::internal("connection timeout");
+    assert_eq!(err.to_string(), "internal error: connection timeout");
+}

--- a/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler.rs
+++ b/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use modkit_db::outbox::{LeasedMessageHandler, MessageResult, OutboxMessage};
+use tracing::{debug, error, info, warn};
+use usage_collector_sdk::models::UsageRecord;
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+
+/// Outbox delivery handler that forwards dequeued usage records to the usage collector,
+/// calling [`UsageCollectorClientV1::create_usage_record`] once per message.
+///
+/// Implements [`LeasedMessageHandler`]:
+/// - Deserialization failures dead-letter the message (permanent: corrupt payload).
+/// - [`UsageCollectorError::PluginTimeout`], [`UsageCollectorError::CircuitOpen`], and
+///   [`UsageCollectorError::Unavailable`] trigger retry (transient: timeout, open circuit,
+///   connection/transport error, or identity service temporarily unreachable).
+/// - All other collector errors dead-letter the message (permanent: auth denial,
+///   module not configured, or unexpected condition).
+pub struct DeliveryHandler {
+    collector: Arc<dyn UsageCollectorClientV1>,
+}
+
+impl DeliveryHandler {
+    #[must_use]
+    pub fn new(collector: Arc<dyn UsageCollectorClientV1>) -> Self {
+        Self { collector }
+    }
+}
+
+#[async_trait]
+impl LeasedMessageHandler for DeliveryHandler {
+    // @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1
+    // @cpt-flow:cpt-cf-usage-collector-flow-sdk-and-ingest-core-emit:p1
+    async fn handle(&self, msg: &OutboxMessage) -> MessageResult {
+        // Processor may pass several messages per lease cycle (see WorkerTuning::batch_size);
+        // this handler still delivers each payload individually.
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-1
+        let record_result = serde_json::from_slice::<UsageRecord>(&msg.payload);
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-1
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2
+        if let Err(ref err) = record_result {
+            warn!(
+                msg.seq,
+                msg.partition_id,
+                %err,
+                "usage record deserialization failed"
+            );
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2a
+            return MessageResult::Reject(err.to_string());
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-2
+
+        // inst-dlv-3: gateway ingest request assembly from UsageRecord fields is performed
+        // inside UsageCollectorClientV1::create_usage_record — see rest_client.rs
+        // (UsageRecord IS the request at this layer; DTO assembly is an implementation detail
+        //  of the REST client adapter).
+        // SAFETY: the Err branch above always returns; this value is Ok.
+        #[allow(clippy::unwrap_used)]
+        let record = record_result.unwrap();
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-4
+        let delivery_result = self.collector.create_usage_record(record).await;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-4
+
+        match delivery_result {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5
+            Ok(()) => {
+                debug!("usage record delivered to collector");
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5a
+                MessageResult::Ok
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5a
+            }
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-5
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6
+            Err(
+                e @ (UsageCollectorError::PluginTimeout
+                | UsageCollectorError::CircuitOpen
+                | UsageCollectorError::Unavailable { .. }),
+            ) => {
+                // PluginTimeout: network timeout, HTTP 429, HTTP 5xx (see rest_client.rs).
+                // CircuitOpen: gateway circuit breaker is open; retry after backoff.
+                // Unavailable: connection/transport error or identity service temporarily
+                //   unreachable; the request never reached the gateway (see rest_client.rs).
+                info!(error = %e, "transient collector delivery error; will retry");
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+                MessageResult::Retry
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6a
+            }
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-6
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7
+            Err(e) => {
+                error!(error = %e, "permanent collector delivery error; dead-lettering message");
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7a
+                MessageResult::Reject(e.to_string())
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7a
+            } // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-outbox-delivery:p1:inst-dlv-7
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "delivery_handler_tests.rs"]
+mod delivery_handler_tests;

--- a/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/infra/delivery_handler_tests.rs
@@ -1,0 +1,211 @@
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use modkit_db::outbox::{LeasedMessageHandler, MessageResult, OutboxMessage};
+use usage_collector_sdk::models::{UsageKind, UsageRecord};
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use uuid::Uuid;
+
+use super::DeliveryHandler;
+
+enum CollectorOutcome {
+    Ok,
+    Transient,
+    Permanent,
+    Unavailable,
+}
+
+struct MockCollector {
+    outcome: CollectorOutcome,
+}
+
+impl MockCollector {
+    fn ok() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Ok,
+        })
+    }
+
+    fn transient() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Transient,
+        })
+    }
+
+    fn permanent() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Permanent,
+        })
+    }
+
+    fn unavailable() -> Arc<Self> {
+        Arc::new(Self {
+            outcome: CollectorOutcome::Unavailable,
+        })
+    }
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for MockCollector {
+    async fn create_usage_record(&self, _record: UsageRecord) -> Result<(), UsageCollectorError> {
+        match self.outcome {
+            CollectorOutcome::Ok => Ok(()),
+            CollectorOutcome::Transient => Err(UsageCollectorError::plugin_timeout()),
+            CollectorOutcome::Permanent => {
+                Err(UsageCollectorError::authorization_failed("permanent"))
+            }
+            CollectorOutcome::Unavailable => {
+                Err(UsageCollectorError::unavailable("connection refused"))
+            }
+        }
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+        })
+    }
+}
+
+fn valid_usage_record() -> UsageRecord {
+    UsageRecord {
+        tenant_id: Uuid::new_v4(),
+        module: "test-module".to_owned(),
+        metric: "test.metric".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id: Uuid::new_v4(),
+        resource_type: "test.resource".to_owned(),
+        subject_id: Some(Uuid::nil()),
+        subject_type: Some("test.subject".to_owned()),
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: Utc::now(),
+        metadata: None,
+    }
+}
+
+fn make_msg(payload_bytes: Vec<u8>) -> OutboxMessage {
+    OutboxMessage {
+        partition_id: 0,
+        seq: 1,
+        payload: payload_bytes,
+        payload_type: "application/json".to_owned(),
+        created_at: Utc::now(),
+        attempts: 0,
+    }
+}
+
+fn handler(collector: Arc<dyn UsageCollectorClientV1>) -> DeliveryHandler {
+    DeliveryHandler::new(collector)
+}
+
+#[tokio::test]
+async fn handle_invalid_json_payload_is_rejected() {
+    let h = handler(MockCollector::ok());
+    let msg = make_msg(b"not-json".to_vec());
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Reject(_)));
+}
+
+#[tokio::test]
+async fn handle_collector_transient_error_returns_retry() {
+    let h = handler(MockCollector::transient());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Retry));
+}
+
+#[tokio::test]
+async fn handle_collector_permanent_error_returns_reject() {
+    let h = handler(MockCollector::permanent());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Reject(_)));
+}
+
+#[tokio::test]
+async fn handle_collector_unavailable_error_returns_retry() {
+    let h = handler(MockCollector::unavailable());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Retry));
+}
+
+#[tokio::test]
+async fn handle_success_returns_ok() {
+    let h = handler(MockCollector::ok());
+    let payload = serde_json::to_vec(&valid_usage_record()).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Ok));
+}
+
+// ── Subject fields deserialization ────────────────────────────────────────────
+
+struct CapturingCollector {
+    captured: Arc<Mutex<Option<UsageRecord>>>,
+}
+
+impl CapturingCollector {
+    fn new(captured: Arc<Mutex<Option<UsageRecord>>>) -> Arc<Self> {
+        Arc::new(Self { captured })
+    }
+}
+
+#[async_trait]
+impl UsageCollectorClientV1 for CapturingCollector {
+    async fn create_usage_record(&self, record: UsageRecord) -> Result<(), UsageCollectorError> {
+        *self.captured.lock().unwrap() = Some(record);
+        Ok(())
+    }
+
+    async fn get_module_config(
+        &self,
+        _module_name: &str,
+    ) -> Result<usage_collector_sdk::ModuleConfig, UsageCollectorError> {
+        Ok(usage_collector_sdk::ModuleConfig {
+            allowed_metrics: vec![],
+        })
+    }
+}
+
+#[tokio::test]
+async fn handle_delivery_preserves_subject_fields_through_deserialization() {
+    let known_subject_id = Uuid::new_v4();
+    let record = UsageRecord {
+        subject_id: Some(known_subject_id),
+        subject_type: Some("real.subject".to_owned()),
+        ..valid_usage_record()
+    };
+
+    let captured: Arc<Mutex<Option<UsageRecord>>> = Arc::new(Mutex::new(None));
+    let collector = CapturingCollector::new(Arc::clone(&captured));
+    let h = handler(collector);
+    let payload = serde_json::to_vec(&record).unwrap();
+    let msg = make_msg(payload);
+    let result = h.handle(&msg).await;
+    assert!(matches!(result, MessageResult::Ok));
+
+    let received = captured
+        .lock()
+        .unwrap()
+        .take()
+        .expect("collector must have received the record");
+    assert_eq!(
+        received.subject_id,
+        Some(known_subject_id),
+        "subject_id must survive serialisation round-trip"
+    );
+    assert_eq!(
+        received.subject_type.as_deref(),
+        Some("real.subject"),
+        "subject_type must survive serialisation round-trip"
+    );
+}

--- a/modules/system/usage-collector/usage-emitter/src/infra/mod.rs
+++ b/modules/system/usage-collector/usage-emitter/src/infra/mod.rs
@@ -1,0 +1,2 @@
+// @cpt-dod:cpt-cf-usage-collector-dod-sdk-and-ingest-core-emitter-crate:p1
+pub mod delivery_handler;

--- a/modules/system/usage-collector/usage-emitter/src/lib.rs
+++ b/modules/system/usage-collector/usage-emitter/src/lib.rs
@@ -1,0 +1,45 @@
+//! Durable usage emission for source modules.
+//!
+//! Provides the complete emitter pipeline: module-scoped PDP authorization, transactional
+//! outbox enqueue, and async delivery to the usage collector via `modkit-db` outbox workers.
+//!
+//! # Usage
+//!
+//! Source modules should not construct `UsageEmitter` directly. The `usage-collector`
+//! or `usage-collector-rest-client` `ModKit` module builds and registers
+//! `dyn UsageEmitterV1` in `ClientHub` during `init()`.
+//!
+//! ```ignore
+//! // In init():
+//! let emitter = hub.get::<dyn UsageEmitterV1>()?;
+//! let scoped = emitter.for_module(Self::MODULE_NAME);
+//!
+//! // In a handler:
+//! let authorized = scoped
+//!     .authorize(&ctx, resource_id, "resource_type".to_owned())
+//!     .await?;
+//! authorized
+//!     .build_usage_record("requests", 1.0)
+//!     .enqueue()
+//!     .await?;
+//! ```
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+mod api;
+mod authorized_emitter;
+mod config;
+mod domain;
+mod emitter;
+mod error;
+mod infra;
+mod scoped_emitter;
+mod usage_builder;
+
+pub use api::UsageEmitterV1;
+pub use authorized_emitter::AuthorizedUsageEmitter;
+pub use config::UsageEmitterConfig;
+pub use emitter::UsageEmitter;
+pub use error::UsageEmitterError;
+pub use scoped_emitter::ScopedUsageEmitter;
+pub use usage_builder::UsageRecordBuilder;

--- a/modules/system/usage-collector/usage-emitter/src/scoped_emitter.rs
+++ b/modules/system/usage-collector/usage-emitter/src/scoped_emitter.rs
@@ -1,0 +1,188 @@
+use std::sync::Arc;
+
+use authz_resolver_sdk::AuthZResolverClient;
+use authz_resolver_sdk::models::BarrierMode;
+use authz_resolver_sdk::pep::{AccessRequest, PolicyEnforcer};
+use modkit_db::Db;
+use modkit_db::outbox::Outbox;
+use modkit_security::{SecurityContext, pep_properties};
+use usage_collector_sdk::{UsageCollectorClientV1, UsageCollectorError};
+use uuid::Uuid;
+
+use crate::authorized_emitter::AuthorizedUsageEmitter;
+use crate::config::UsageEmitterConfig;
+use crate::domain::authz;
+use crate::emitter::enforcer_error_to_emitter_error;
+use crate::error::UsageEmitterError;
+
+/// A usage emitter scoped to a specific module.
+///
+/// Constructed via [`crate::UsageEmitterV1::for_module`]. Call [`Self::authorize_for`] or
+/// [`Self::authorize`] to obtain a time-limited [`AuthorizedUsageEmitter`] after PDP authorization
+/// and allowed-metrics retrieval for this module.
+///
+/// # Example
+///
+/// ```ignore
+/// // In init():
+/// let scoped = emitter.for_module(Self::MODULE_NAME);
+///
+/// // In a handler (with subject):
+/// let authorized = scoped
+///     .authorize_for(&ctx, tenant_id, resource_id, resource_type, Some(subject_id), Some(subject_type))
+///     .await?;
+/// authorized.build_usage_record("requests", 1.0).enqueue().await?;
+///
+/// // In a handler (without subject):
+/// let authorized = scoped
+///     .authorize_for(&ctx, tenant_id, resource_id, resource_type, None, None)
+///     .await?;
+/// authorized.build_usage_record("requests", 1.0).enqueue().await?;
+/// ```
+#[derive(Clone)]
+pub struct ScopedUsageEmitter {
+    module: String,
+    authz: Arc<dyn AuthZResolverClient>,
+    collector: Arc<dyn UsageCollectorClientV1>,
+    db: Db,
+    config: Arc<UsageEmitterConfig>,
+    outbox: Arc<Outbox>,
+}
+
+impl ScopedUsageEmitter {
+    pub(crate) fn new(
+        module: String,
+        authz: Arc<dyn AuthZResolverClient>,
+        collector: Arc<dyn UsageCollectorClientV1>,
+        db: Db,
+        config: Arc<UsageEmitterConfig>,
+        outbox: Arc<Outbox>,
+    ) -> Self {
+        Self {
+            module,
+            authz,
+            collector,
+            db,
+            config,
+            outbox,
+        }
+    }
+
+    /// Obtain a time-limited [`AuthorizedUsageEmitter`] by calling the PDP for `USAGE_RECORD`/`CREATE`
+    /// and fetching the allowed metrics for this module from the collector.
+    ///
+    /// The returned handle is bound to the module name, tenant, metered resource, and subject
+    /// identity; every enqueued record must match and its metric must be in the allowed list.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError`] if PDP denies, the module is not configured, or the collector
+    /// call fails.
+    // @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1
+    pub async fn authorize_for(
+        &self,
+        ctx: &SecurityContext,
+        tenant_id: Uuid,
+        resource_id: Uuid,
+        resource_type: String,
+        subject_id: Option<Uuid>,
+        subject_type: Option<String>,
+    ) -> Result<AuthorizedUsageEmitter, UsageEmitterError> {
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-2
+        let mut request = AccessRequest::new()
+            .require_constraints(false)
+            .barrier_mode(BarrierMode::Ignore)
+            .resource_property(pep_properties::OWNER_TENANT_ID, tenant_id)
+            .resource_property(authz::properties::RESOURCE_ID, resource_id)
+            .resource_property(authz::properties::RESOURCE_TYPE, resource_type.as_str())
+            .resource_property(authz::properties::MODULE, self.module.clone());
+        if let Some(ref sid) = subject_id {
+            request = request.resource_property(authz::properties::SUBJECT_ID, sid.to_string());
+        }
+        if let Some(ref stype) = subject_type {
+            request = request.resource_property(authz::properties::SUBJECT_TYPE, stype.as_str());
+        }
+        let pdp_result = PolicyEnforcer::new(Arc::clone(&self.authz))
+            .access_scope_with(
+                ctx,
+                &authz::USAGE_RECORD,
+                authz::actions::CREATE,
+                None,
+                &request,
+            )
+            .await;
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-2
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3
+        if let Err(e) = pdp_result {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3a
+            return Err(enforcer_error_to_emitter_error(e));
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-3
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-4
+        // @cpt-begin:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-1
+        let module_cfg_result = self.collector.get_module_config(&self.module).await;
+        // @cpt-end:cpt-cf-usage-collector-flow-sdk-and-ingest-core-fetch-module-config:p2:inst-cfg-1
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-4
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5
+        let module_cfg = match module_cfg_result {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5a
+            Err(UsageCollectorError::ModuleNotFound { module_name }) => {
+                return Err(UsageEmitterError::module_not_configured(module_name));
+            }
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5a
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5b
+            Err(e) => return Err(UsageEmitterError::internal(e.to_string())),
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5b
+            Ok(cfg) => cfg,
+        };
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-5
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-6
+        let authorized = AuthorizedUsageEmitter::new(
+            Arc::clone(&self.config),
+            self.db.clone(),
+            Arc::clone(&self.outbox),
+            self.module.clone(),
+            tenant_id,
+            resource_id,
+            resource_type,
+            module_cfg.allowed_metrics,
+            subject_id,
+            subject_type,
+        );
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-6
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-7
+        Ok(authorized)
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-authorize-for:p1:inst-authz-7
+    }
+
+    /// Same as [`Self::authorize_for`] using the subject's home tenant from `ctx`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError`] if PDP denies, the module is not configured, or the collector
+    /// call fails.
+    pub async fn authorize(
+        &self,
+        ctx: &SecurityContext,
+        resource_id: Uuid,
+        resource_type: String,
+    ) -> Result<AuthorizedUsageEmitter, UsageEmitterError> {
+        let subject_id = Some(ctx.subject_id());
+        let subject_type = Some(ctx.subject_type().unwrap_or("").to_owned());
+        self.authorize_for(
+            ctx,
+            ctx.subject_tenant_id(),
+            resource_id,
+            resource_type,
+            subject_id,
+            subject_type,
+        )
+        .await
+    }
+}

--- a/modules/system/usage-collector/usage-emitter/src/usage_builder.rs
+++ b/modules/system/usage-collector/usage-emitter/src/usage_builder.rs
@@ -1,0 +1,165 @@
+//! [`UsageRecordBuilder`] for chaining optional fields and enqueueing through an
+//! [`AuthorizedUsageEmitter`](crate::AuthorizedUsageEmitter). Tenant, resource, module,
+//! and kind are taken from the authorized handle; kind is resolved from the allowed metrics list.
+//!
+//! Construct via [`AuthorizedUsageEmitter::build_usage_record`](crate::AuthorizedUsageEmitter::build_usage_record).
+
+use chrono::{DateTime, Utc};
+use modkit_db::secure::DBRunner;
+use serde_json::Value as JsonValue;
+use usage_collector_sdk::models::{UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use crate::authorized_emitter::AuthorizedUsageEmitter;
+use crate::error::UsageEmitterError;
+
+/// Fluent builder tied to an [`AuthorizedUsageEmitter`]. Optionally set idempotency key or
+/// timestamp, then [`Self::enqueue`] or [`Self::enqueue_in`].
+///
+/// `kind` is resolved automatically from the allowed metrics list; no `.counter()` or `.gauge()`
+/// call is required.
+pub struct UsageRecordBuilder<'a> {
+    emitter: &'a AuthorizedUsageEmitter,
+    metric: String,
+    idempotency_key: Option<String>,
+    value: f64,
+    timestamp: Option<DateTime<Utc>>,
+    metadata: Option<JsonValue>,
+}
+
+impl<'a> UsageRecordBuilder<'a> {
+    /// Starts a builder with the required `metric` and `value` set.
+    #[must_use]
+    pub fn new(emitter: &'a AuthorizedUsageEmitter, metric: impl Into<String>, value: f64) -> Self {
+        Self {
+            emitter,
+            metric: metric.into(),
+            idempotency_key: None,
+            value,
+            timestamp: None,
+            metadata: None,
+        }
+    }
+
+    /// Sets a caller-provided idempotency key. If omitted, a new UUID string is used on enqueue.
+    #[must_use]
+    pub fn with_idempotency_key(self, key: impl Into<String>) -> Self {
+        Self {
+            idempotency_key: Some(key.into()),
+            ..self
+        }
+    }
+
+    /// Sets the observation timestamp. If omitted, the current UTC time is used on enqueue.
+    #[must_use]
+    pub fn with_timestamp(self, timestamp: DateTime<Utc>) -> Self {
+        Self {
+            timestamp: Some(timestamp),
+            ..self
+        }
+    }
+
+    /// Sets optional metadata JSON. Must serialize to ≤ 8192 bytes or enqueue will return
+    /// [`UsageEmitterError::MetadataTooLarge`].
+    #[must_use]
+    pub fn with_metadata(self, metadata: JsonValue) -> Self {
+        Self {
+            metadata: Some(metadata),
+            ..self
+        }
+    }
+
+    /// Builds, then enqueues on this emitter's database connection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError::InvalidRecord`] if the metric is not in the allowed list,
+    /// or any error from [`AuthorizedUsageEmitter::enqueue_in`].
+    pub async fn enqueue(self) -> Result<(), UsageEmitterError> {
+        let conn = self
+            .emitter
+            .db
+            .conn()
+            .map_err(|e| UsageEmitterError::internal(e.to_string()))?;
+        self.enqueue_in(&conn).await
+    }
+
+    /// Builds, then enqueues on the given database runner (connection or transaction).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UsageEmitterError::InvalidRecord`] if the metric is not in the allowed list,
+    /// or any error from [`AuthorizedUsageEmitter::enqueue_in`].
+    // @cpt-algo:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1
+    pub async fn enqueue_in(self, db: &(dyn DBRunner + Sync)) -> Result<(), UsageEmitterError> {
+        let kind = self
+            .emitter
+            .allowed_metrics
+            .iter()
+            .find(|m| m.name == self.metric)
+            .map_or(UsageKind::Gauge, |m| m.kind);
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5
+        if kind == UsageKind::Counter
+            && (self.value < 0.0
+                || self
+                    .idempotency_key
+                    .as_deref()
+                    .is_none_or(|s| s.trim().is_empty()))
+        {
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5a
+            return Err(UsageEmitterError::invalid_record(
+                "counter records require a non-negative value and an idempotency key",
+            ));
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5a
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-6
+        let subject_id = self.emitter.subject_id;
+        let subject_type = self.emitter.subject_type.clone();
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-6
+
+        // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7
+        if let Some(ref metadata) = self.metadata {
+            let len = serde_json::to_vec(metadata)
+                .map_err(|e| {
+                    UsageEmitterError::internal(format!("metadata serialization failed: {e}"))
+                })?
+                .len();
+            if len > 8192 {
+                // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7a
+                return Err(UsageEmitterError::metadata_too_large(len));
+                // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7a
+            }
+        }
+        // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-7
+
+        let record = UsageRecord {
+            tenant_id: self.emitter.tenant_id,
+            module: self.emitter.module.clone(),
+            resource_id: self.emitter.resource_id,
+            resource_type: self.emitter.resource_type.clone(),
+            subject_id,
+            subject_type,
+            metric: self.metric,
+            kind,
+            // @cpt-begin:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5b
+            idempotency_key: match self.idempotency_key.as_deref() {
+                Some(k) if !k.trim().is_empty() => k.to_owned(),
+                _ => Uuid::new_v4().to_string(),
+            },
+            // @cpt-end:cpt-cf-usage-collector-algo-sdk-and-ingest-core-enqueue:p1:inst-enq-5b
+            value: self.value,
+            timestamp: self.timestamp.unwrap_or_else(Utc::now),
+            metadata: self.metadata,
+        };
+
+        self.emitter.enqueue_in(db, record).await
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[path = "usage_builder_tests.rs"]
+mod usage_builder_tests;

--- a/modules/system/usage-collector/usage-emitter/src/usage_builder_tests.rs
+++ b/modules/system/usage-collector/usage-emitter/src/usage_builder_tests.rs
@@ -1,0 +1,458 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use modkit_db::migration_runner::run_migrations_for_testing;
+use modkit_db::outbox::{
+    LeasedMessageHandler, MessageResult, Outbox, OutboxHandle, OutboxMessage, Partitions,
+    outbox_migrations,
+};
+use modkit_db::{ConnectOpts, Db, connect_db};
+use usage_collector_sdk::models::{AllowedMetric, UsageKind, UsageRecord};
+use uuid::Uuid;
+
+use crate::authorized_emitter::AuthorizedUsageEmitter;
+use crate::config::UsageEmitterConfig;
+use crate::error::UsageEmitterError;
+
+// ── Infrastructure ────────────────────────────────────────────────────────────
+
+struct NoopHandler;
+
+#[async_trait]
+impl LeasedMessageHandler for NoopHandler {
+    async fn handle(&self, _msg: &OutboxMessage) -> MessageResult {
+        MessageResult::Ok
+    }
+}
+
+async fn build_db(name: &str) -> Db {
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = connect_db(
+        &url,
+        ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    run_migrations_for_testing(&db, outbox_migrations())
+        .await
+        .unwrap();
+    db
+}
+
+async fn build_outbox(db: Db) -> OutboxHandle {
+    let cfg = UsageEmitterConfig::default();
+    Outbox::builder(db)
+        .queue(
+            cfg.outbox_queue.as_str(),
+            Partitions::of(cfg.outbox_partition_count),
+        )
+        .leased(NoopHandler)
+        .start()
+        .await
+        .unwrap()
+}
+
+// ── Test fixture ──────────────────────────────────────────────────────────────
+
+struct Fixture {
+    db: Db,
+    _handle: OutboxHandle,
+    emitter: AuthorizedUsageEmitter,
+    tenant_id: Uuid,
+    resource_id: Uuid,
+}
+
+impl Fixture {
+    async fn build(name: &str) -> Self {
+        let db = build_db(name).await;
+        let handle = build_outbox(db.clone()).await;
+        let tenant_id = Uuid::new_v4();
+        let resource_id = Uuid::new_v4();
+        let allowed_metrics = vec![
+            AllowedMetric {
+                name: "test.gauge".to_owned(),
+                kind: UsageKind::Gauge,
+            },
+            AllowedMetric {
+                name: "test.counter".to_owned(),
+                kind: UsageKind::Counter,
+            },
+        ];
+        let emitter = AuthorizedUsageEmitter::new(
+            Arc::new(UsageEmitterConfig::default()),
+            db.clone(),
+            Arc::clone(handle.outbox()),
+            "test-module".to_owned(),
+            tenant_id,
+            resource_id,
+            "test.resource".to_owned(),
+            allowed_metrics,
+            Some(Uuid::nil()),
+            Some("test.subject".to_owned()),
+        );
+        Self {
+            db,
+            _handle: handle,
+            emitter,
+            tenant_id,
+            resource_id,
+        }
+    }
+
+    fn conn(&self) -> modkit_db::DbConn<'_> {
+        self.db.conn().unwrap()
+    }
+
+    /// Build a valid `UsageRecord` that matches the authorized token fields.
+    fn record(&self) -> UsageRecord {
+        UsageRecord {
+            tenant_id: self.tenant_id,
+            module: "test-module".to_owned(),
+            metric: "test.gauge".to_owned(),
+            kind: UsageKind::Gauge,
+            value: 1.0,
+            resource_id: self.resource_id,
+            resource_type: "test.resource".to_owned(),
+            subject_id: Some(Uuid::nil()),
+            subject_type: Some("test.subject".to_owned()),
+            idempotency_key: Uuid::new_v4().to_string(),
+            timestamp: Utc::now(),
+            metadata: None,
+        }
+    }
+}
+
+// ── Metric kind resolution ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn builder_enqueues_gauge_metric() {
+    let f = Fixture::build("ub_gauge").await;
+    f.emitter
+        .build_usage_record("test.gauge", 42.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_enqueues_counter_metric_with_positive_value() {
+    let f = Fixture::build("ub_counter_pos").await;
+    f.emitter
+        .build_usage_record("test.counter", 1.0)
+        .with_idempotency_key("idem-key")
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_rejects_counter_metric_with_negative_value() {
+    let f = Fixture::build("ub_counter_neg").await;
+    let err = f
+        .emitter
+        .build_usage_record("test.counter", -1.0)
+        .with_idempotency_key("idem-key")
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn builder_rejects_counter_metric_without_idempotency_key() {
+    let f = Fixture::build("ub_counter_no_idem").await;
+    let err = f
+        .emitter
+        .build_usage_record("test.counter", 1.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn builder_accepts_gauge_metric_with_negative_value() {
+    let f = Fixture::build("ub_gauge_neg").await;
+    f.emitter
+        .build_usage_record("test.gauge", -5.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_rejects_unknown_metric() {
+    let f = Fixture::build("ub_unknown_metric").await;
+    let err = f
+        .emitter
+        .build_usage_record("unknown.metric", 1.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, UsageEmitterError::MetricNotAllowed { ref metric } if metric == "unknown.metric")
+    );
+}
+
+// ── Optional fields ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn builder_with_idempotency_key_enqueues_successfully() {
+    let f = Fixture::build("ub_idem_key").await;
+    f.emitter
+        .build_usage_record("test.gauge", 1.0)
+        .with_idempotency_key("my-stable-key")
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_with_timestamp_enqueues_successfully() {
+    let f = Fixture::build("ub_timestamp").await;
+    let ts = DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    f.emitter
+        .build_usage_record("test.gauge", 1.0)
+        .with_timestamp(ts)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_without_optional_fields_enqueues_successfully() {
+    let f = Fixture::build("ub_defaults").await;
+    f.emitter
+        .build_usage_record("test.gauge", 0.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+// ── Blank idempotency key handling ────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_counter_with_blank_idempotency_key_is_rejected() {
+    let f = Fixture::build("ub_counter_blank_idem").await;
+    let err = f
+        .emitter
+        .build_usage_record("test.counter", 1.0)
+        .with_idempotency_key("")
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, UsageEmitterError::InvalidRecord { .. }));
+}
+
+#[tokio::test]
+async fn test_gauge_with_blank_idempotency_key_uses_uuid_fallback() {
+    use std::sync::{Arc, Mutex};
+    use usage_collector_sdk::models::UsageRecord;
+
+    struct CaptureHandler {
+        captured: Arc<Mutex<Option<Vec<u8>>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LeasedMessageHandler for CaptureHandler {
+        async fn handle(&self, msg: &OutboxMessage) -> MessageResult {
+            let mut guard = self.captured.lock().unwrap();
+            *guard = Some(msg.payload.clone());
+            MessageResult::Ok
+        }
+    }
+
+    let name = "ub_gauge_blank_idem";
+    let url = format!("sqlite:file:{name}?mode=memory&cache=shared");
+    let db = modkit_db::connect_db(
+        &url,
+        modkit_db::ConnectOpts {
+            max_conns: Some(1),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    modkit_db::migration_runner::run_migrations_for_testing(
+        &db,
+        modkit_db::outbox::outbox_migrations(),
+    )
+    .await
+    .unwrap();
+
+    let captured: Arc<Mutex<Option<Vec<u8>>>> = Arc::new(Mutex::new(None));
+    let cfg = crate::config::UsageEmitterConfig::default();
+    let handle = Outbox::builder(db.clone())
+        .queue(
+            cfg.outbox_queue.as_str(),
+            Partitions::of(cfg.outbox_partition_count),
+        )
+        .leased(CaptureHandler {
+            captured: Arc::clone(&captured),
+        })
+        .start()
+        .await
+        .unwrap();
+
+    let allowed_metrics = vec![usage_collector_sdk::models::AllowedMetric {
+        name: "test.gauge".to_owned(),
+        kind: usage_collector_sdk::models::UsageKind::Gauge,
+    }];
+    let emitter = crate::authorized_emitter::AuthorizedUsageEmitter::new(
+        Arc::new(cfg),
+        db.clone(),
+        Arc::clone(handle.outbox()),
+        "test-module".to_owned(),
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        "test.resource".to_owned(),
+        allowed_metrics,
+        Some(Uuid::nil()),
+        Some("test.subject".to_owned()),
+    );
+
+    {
+        let conn = db.conn().unwrap();
+        emitter
+            .build_usage_record("test.gauge", 1.0)
+            .with_idempotency_key("")
+            .enqueue_in(&conn)
+            .await
+            .unwrap();
+    }
+
+    // Wait for the outbox to deliver the message to the handler.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        {
+            let guard = captured.lock().unwrap();
+            if guard.is_some() {
+                break;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for outbox delivery"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let payload = captured.lock().unwrap().take().unwrap();
+    let record: UsageRecord = serde_json::from_slice(&payload).unwrap();
+    assert!(
+        !record.idempotency_key.is_empty(),
+        "expected a non-empty UUID, got an empty string"
+    );
+    assert_ne!(
+        record.idempotency_key, "",
+        "blank idempotency key must not be stored as-is"
+    );
+}
+
+// ── Authorization scope mismatch rejection ────────────────────────────────────
+
+#[tokio::test]
+async fn builder_rejects_mismatched_module_name() {
+    let f = Fixture::build("ub_bad_module").await;
+    let record = UsageRecord {
+        module: "wrong-module".to_owned(),
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::UsageEmitterError::InvalidRecord { .. }),
+        "expected InvalidRecord for mismatched module, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn builder_rejects_mismatched_subject_id() {
+    let f = Fixture::build("ub_bad_subj_id").await;
+    let record = UsageRecord {
+        subject_id: Some(Uuid::new_v4()), // differs from Some(Uuid::nil()) in the token
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::UsageEmitterError::InvalidRecord { .. }),
+        "expected InvalidRecord for mismatched subject_id, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn builder_rejects_mismatched_subject_type() {
+    let f = Fixture::build("ub_bad_subj_type").await;
+    let record = UsageRecord {
+        subject_type: Some("other.subject".to_owned()), // differs from Some("test.subject") in the token
+        ..f.record()
+    };
+    let err = f.emitter.enqueue_in(&f.conn(), record).await.unwrap_err();
+    assert!(
+        matches!(err, crate::error::UsageEmitterError::InvalidRecord { .. }),
+        "expected InvalidRecord for mismatched subject_type, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn builder_enqueues_record_with_subject() {
+    // The current Fixture always has subject_id/subject_type set (via Uuid::nil() / "test.subject").
+    // After Phase 5, enqueue_in produces Some(subject_id) / Some(subject_type) from the emitter,
+    // and the record built by Fixture::record() matches — enqueue must succeed.
+    let f = Fixture::build("ub_with_subject").await;
+    f.emitter
+        .build_usage_record("test.gauge", 1.0)
+        .enqueue_in(&f.conn())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn builder_enqueues_record_without_subject() {
+    // Exercises the no-subject path: both subject_id and subject_type are None.
+    let db = build_db("ub_without_subject").await;
+    let handle = build_outbox(db.clone()).await;
+    let tenant_id = Uuid::new_v4();
+    let resource_id = Uuid::new_v4();
+    let allowed_metrics = vec![AllowedMetric {
+        name: "test.gauge".to_owned(),
+        kind: UsageKind::Gauge,
+    }];
+    let emitter = AuthorizedUsageEmitter::new(
+        Arc::new(UsageEmitterConfig::default()),
+        db.clone(),
+        Arc::clone(handle.outbox()),
+        "test-module".to_owned(),
+        tenant_id,
+        resource_id,
+        "test.resource".to_owned(),
+        allowed_metrics,
+        None, // subject_id absent
+        None, // subject_type absent
+    );
+    // A record with no subject fields must match the None-subject token.
+    let record = UsageRecord {
+        tenant_id,
+        module: "test-module".to_owned(),
+        metric: "test.gauge".to_owned(),
+        kind: UsageKind::Gauge,
+        value: 1.0,
+        resource_id,
+        resource_type: "test.resource".to_owned(),
+        subject_id: None,
+        subject_type: None,
+        idempotency_key: Uuid::new_v4().to_string(),
+        timestamp: chrono::Utc::now(),
+        metadata: None,
+    };
+    let conn = db.conn().unwrap();
+    emitter
+        .enqueue_in(&conn, record)
+        .await
+        .expect("enqueue must succeed when subject is absent in both token and record");
+}


### PR DESCRIPTION
Introduces the core ingest-path crates completing Feature 1 (SDK & Ingest Core):

- `usage-emitter`: two-phase PDP authorization (`authorize_for` / `authorize`), `UsageRecordBuilder` fluent API, transactional outbox enqueue (`enqueue` / `enqueue_in`), and async delivery worker forwarding to `UsageCollectorClientV1`. The security invariant ensures `UsageCollectorClientV1` is never published to `ClientHub`; source modules can only reach the collector through a PDP-authorized, tenant/resource-bound `AuthorizedUsageEmitter`.

- `usage-collector`: gateway ModKit module; resolves the active storage plugin by vendor, registers `UsageCollectorLocalClient` as `dyn UsageCollectorClientV1`, wires in the embedded emitter, and serves the REST ingestion API for out-of-process callers.

- `usage-collector-rest-client`: separate-binary bridge; exchanges client credentials for a bearer token and forwards `create_usage_record` / `get_module_config` calls to the remote gateway REST API; provides outbox migrations required by the embedded emitter.

- `noop-usage-collector-storage-plugin`: discard-all storage plugin for local dev, CI, and smoke tests.

Updates DESIGN, DECOMPOSITION, and Feature 1 spec (→ v1.4) to reflect the implemented emitter API (`authorized.build_usage_record(...).enqueue()`), correct entity locations, and mark all p1 DoD items and CDSL blocks complete (status: IMPLEMENTED).

 ## PR Train
 | # | PR | Description | Lines |
 |---|---|------------|------:|
 | 1  | [1620](https://github.com/cyberfabric/cyberfabric-core/pull/1620) | Feature 1 (Core SDK, Emitter & In-Process Ingest): SDK + docs | ~2000 |
 | 2 | [1733 (**this**)](https://github.com/cyberfabric/cyberfabric-core/pull/1733) | Feature 1 (Core SDK, Emitter & In-Process Ingest): `usage-collector` gateway + `usage-emitter` + `noop-usage-collector-storage-plugin` | ~4000 |
 | 3 | TBD | Feature 2 (REST Client & Remote Ingest Delivery): `usage-collector-rest-client` | ~1000 |
|  |  | ... to be continued ... | |

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No linting errors (`cargo clippy --workspace --all-targets --all-features -- -D warnings -D clippy::perf`)
- [x] Code is properly formatted (`cargo fmt`)
- [x] `cpt validate` — all checks passed
- [x] Tests pass (`cargo nextest run --workspace`)