### PR TITLE
feat(types-registry): rework SDK with typed schema/instance APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
  "aliri_braid",
  "aliri_clock",
  "async-trait",
- "rand 0.8.6",
+ "rand 0.8.5",
  "serde",
  "thiserror 1.0.69",
  "tokio",
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -718,7 +718,7 @@ dependencies = [
  "getrandom 0.2.17",
  "instant",
  "pin-project-lite",
- "rand 0.8.6",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -1312,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2436,9 +2436,11 @@ dependencies = [
  "cf-modkit",
  "cf-modkit-macros",
  "cf-modkit-security",
+ "cf-modkit-utils",
  "cf-types-registry-sdk",
  "gts",
  "inventory",
+ "lru 0.16.4",
  "parking_lot",
  "serde",
  "serde_json",
@@ -2579,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2601,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2672,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.38"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "brotli 8.0.2",
  "compression-core",
@@ -2684,9 +2686,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.32"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "comrak"
@@ -2827,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.5.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -3045,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "dbase"
@@ -3511,12 +3513,12 @@ dependencies = [
 
 [[package]]
 name = "ferroid"
-version = "2.0.0"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
+checksum = "bb330bbd4cb7a5b9f559427f06f98a4f853a137c8298f3bd3f8ca57663e21986"
 dependencies = [
  "portable-atomic",
- "rand 0.10.1",
+ "rand 0.9.4",
  "web-time",
 ]
 
@@ -3648,9 +3650,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.4"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
 dependencies = [
  "lazy_static",
  "num",
@@ -4333,7 +4335,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4559,9 +4561,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -4753,9 +4755,9 @@ checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -4768,9 +4770,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4810,9 +4812,9 @@ checksum = "206bf4773a58f2a051a24fb77cb6c5eeaa84403c0dc5d072ec460ed1648db594"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -5068,9 +5070,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -5110,11 +5112,12 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.47"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
+ "libc",
 ]
 
 [[package]]
@@ -5164,9 +5167,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "local-ip-address"
-version = "0.6.12"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b0187df4e614e42405b49511b82ff7a1774fbd9a816060ee465067847cac22"
+checksum = "d4a59a0cb1c7f84471ad5cd38d768c2a29390d17f1ff2827cdf49bc53e8ac70b"
 dependencies = [
  "libc",
  "neli",
@@ -5368,9 +5371,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.50"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -5457,7 +5460,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
- "rand 0.8.6",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5648,7 +5651,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.5",
  "smallvec 1.15.1",
  "zeroize",
 ]
@@ -5821,9 +5824,9 @@ dependencies = [
 
 [[package]]
 name = "octocrab"
-version = "0.49.9"
+version = "0.49.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddbc3bb87e8c680febf16f56855bbd8b44a38e18c913334213ab34908e71a09"
+checksum = "63f6687a23731011d0117f9f4c3cdabaa7b5e42ca671f42b5cc0657c492540e3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -6381,7 +6384,7 @@ dependencies = [
  "pingora-http",
  "pingora-lru",
  "pingora-timeout",
- "rand 0.8.6",
+ "rand 0.8.5",
  "regex",
  "rmp",
  "rmp-serde",
@@ -6427,7 +6430,7 @@ dependencies = [
  "pingora-rustls",
  "pingora-timeout",
  "prometheus",
- "rand 0.8.6",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_yaml",
@@ -6504,7 +6507,7 @@ dependencies = [
  "pingora-http",
  "pingora-ketama",
  "pingora-runtime",
- "rand 0.8.6",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -6515,9 +6518,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91bb5030596a3d442c0866ac68afe29c14ba558e77c726dcdf7016b0dbb359d9"
 dependencies = [
  "arrayvec",
- "hashbrown 0.12.3",
+ "hashbrown 0.17.0",
  "parking_lot",
- "rand 0.8.6",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -6569,7 +6572,7 @@ dependencies = [
  "pingora-core",
  "pingora-error",
  "pingora-http",
- "rand 0.8.6",
+ "rand 0.8.5",
  "regex",
  "tokio",
 ]
@@ -6581,7 +6584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e371315b1c44c2e5a8788fdc61577527b785e121e6ff49144755f40d86511430"
 dependencies = [
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.5",
  "thread_local",
  "tokio",
 ]
@@ -6689,9 +6692,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -6851,8 +6854,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.13.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -6873,7 +6876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6896,9 +6899,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psl"
-version = "2.1.205"
+version = "2.1.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194b4aac978e4e46f782a95ecdb06bc69919c935e783984e5f5b817545881beb"
+checksum = "76c0777260d32b76a8c3c197646707085d37e79d63b5872a29192c8d4f60f50b"
 dependencies = [
  "psl-types",
 ]
@@ -6959,9 +6962,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.29"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quanta"
@@ -7042,9 +7045,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -7516,7 +7519,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -7568,9 +7571,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -7618,9 +7621,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
@@ -7995,7 +7998,7 @@ checksum = "546b4da4f679832602a8f8ab8ddc10b6b1d2e1a13b4f9dddcaee499436fa06ad"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64 0.21.7",
+ "base64 0.22.1",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "nohash-hasher",
@@ -8362,7 +8365,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8527,7 +8530,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.6",
+ "rand 0.8.5",
  "rsa",
  "rust_decimal",
  "serde",
@@ -8569,7 +8572,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.5",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -8771,12 +8774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8897,9 +8894,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.27.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
+checksum = "0bd36b06a2a6c0c3c81a83be1ab05fe86460d054d4d51bf513bc56b3e15bdc22"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",
@@ -9375,12 +9372,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -9563,9 +9559,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "types"
@@ -9906,9 +9902,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -10004,11 +10000,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen 0.57.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -10017,7 +10013,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -10028,9 +10024,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10042,9 +10038,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10052,9 +10048,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10062,9 +10058,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -10075,9 +10071,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -10131,9 +10127,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10168,14 +10164,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -10218,7 +10214,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10507,9 +10503,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -10522,12 +10518,6 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/modules/credstore/credstore/Cargo.toml
+++ b/modules/credstore/credstore/Cargo.toml
@@ -35,3 +35,6 @@ thiserror = { workspace = true }
 modkit = { workspace = true }
 modkit-security = { workspace = true }
 modkit-macros = { workspace = true }
+
+[dev-dependencies]
+types-registry-sdk = { workspace = true, features = ["test-util"] }

--- a/modules/credstore/credstore/src/domain/local_client_tests.rs
+++ b/modules/credstore/credstore/src/domain/local_client_tests.rs
@@ -6,12 +6,12 @@ use credstore_sdk::{
     SharingMode, TenantId,
 };
 use modkit::client_hub::{ClientHub, ClientScope};
-use types_registry_sdk::{GtsEntity, TypesRegistryClient};
-use uuid::Uuid;
+use types_registry_sdk::TypesRegistryClient;
+use types_registry_sdk::testing::{MockTypesRegistryClient, make_test_instance};
 
 use super::*;
 use crate::domain::Service;
-use crate::domain::test_support::{MockPlugin, MockRegistry, test_ctx};
+use crate::domain::test_support::{MockPlugin, test_ctx};
 
 fn make_client() -> CredStoreLocalClient {
     let hub = Arc::new(ClientHub::default());
@@ -21,25 +21,22 @@ fn make_client() -> CredStoreLocalClient {
 
 fn make_wired_client(plugin: Arc<dyn CredStorePluginClientV1>) -> CredStoreLocalClient {
     let instance_id = format!(
-        "{}test._.local_client_test.v1",
+        "{}test.credstore.mock.local_client.v1",
         CredStorePluginSpecV1::gts_schema_id()
     );
     let hub = Arc::new(ClientHub::default());
 
-    let entity = GtsEntity {
-        id: Uuid::nil(),
-        gts_id: instance_id.clone(),
-        segments: vec![],
-        is_schema: false,
-        content: serde_json::json!({
+    let instance = make_test_instance(
+        &instance_id,
+        serde_json::json!({
             "id": instance_id,
             "vendor": "hyperspot",
             "priority": 0,
             "properties": {}
         }),
-        description: None,
-    };
-    let reg: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![entity]));
+    );
+    let reg: Arc<dyn TypesRegistryClient> =
+        Arc::new(MockTypesRegistryClient::new().with_instances([instance]));
     hub.register::<dyn TypesRegistryClient>(reg);
     hub.register_scoped::<dyn CredStorePluginClientV1>(ClientScope::gts_id(&instance_id), plugin);
 

--- a/modules/credstore/credstore/src/domain/service.rs
+++ b/modules/credstore/credstore/src/domain/service.rs
@@ -14,7 +14,7 @@ use modkit::telemetry::ThrottledLog;
 use modkit_macros::domain_model;
 use modkit_security::SecurityContext;
 use tracing::info;
-use types_registry_sdk::{ListQuery, TypesRegistryClient};
+use types_registry_sdk::{InstanceQuery, TypesRegistryClient};
 
 use super::error::DomainError;
 
@@ -87,16 +87,12 @@ impl Service {
         let plugin_type_id = CredStorePluginSpecV1::gts_schema_id().clone();
 
         let instances = registry
-            .list(
-                ListQuery::new()
-                    .with_pattern(format!("{plugin_type_id}*"))
-                    .with_is_type(false),
-            )
+            .list_instances(InstanceQuery::new().with_pattern(format!("{plugin_type_id}*")))
             .await?;
 
         let gts_id = choose_plugin_instance::<CredStorePluginSpecV1>(
             &self.vendor,
-            instances.iter().map(|e| (e.gts_id.as_str(), &e.content)),
+            instances.iter().map(|e| (e.id.as_ref(), &e.object)),
         )?;
         info!(plugin_gts_id = %gts_id, "Selected credstore plugin instance");
 

--- a/modules/credstore/credstore/src/domain/service_tests.rs
+++ b/modules/credstore/credstore/src/domain/service_tests.rs
@@ -1,14 +1,13 @@
 // Created: 2026-04-07 by Constructor Tech
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 
 use credstore_sdk::{OwnerId, SecretMetadata, SecretValue, SharingMode, TenantId};
 use modkit::client_hub::{ClientHub, ClientScope};
-use types_registry_sdk::{GtsEntity, TypesRegistryError};
-use uuid::Uuid;
+use types_registry_sdk::TypesRegistryError;
+use types_registry_sdk::testing::{MockTypesRegistryClient, make_test_instance};
 
 use super::*;
-use crate::domain::test_support::{MockPlugin, MockRegistry, test_ctx};
+use crate::domain::test_support::{MockPlugin, test_ctx};
 
 // ── helpers ──────────────────────────────────────────────────────────────
 
@@ -18,8 +17,11 @@ fn empty_hub() -> Arc<ClientHub> {
 
 /// Build the GTS instance ID string for a credstore plugin test instance.
 fn test_instance_id() -> String {
-    // schema prefix + instance suffix
-    format!("{}test._.mock.v1", CredStorePluginSpecV1::gts_schema_id())
+    // schema prefix + instance suffix (5-token: vendor.package.namespace.type.vMAJOR)
+    format!(
+        "{}test.credstore.mock.instance.v1",
+        CredStorePluginSpecV1::gts_schema_id()
+    )
 }
 
 /// Build the JSON content for a `BaseModkitPluginV1`<CredStorePluginSpecV1>
@@ -35,24 +37,17 @@ fn plugin_content(gts_id: &str, vendor: &str) -> serde_json::Value {
 
 // ── helper to build a fully-wired hub ────────────────────────────────────
 
-/// Wires a counting `MockRegistry` and a scoped plugin into a `ClientHub`.
-/// Returns `(hub, registry_arc)` so tests can inspect `list_calls`.
+/// Wires a counting `MockTypesRegistryClient` and a scoped plugin into a `ClientHub`.
+/// Returns `(hub, registry_arc)` so tests can inspect `list_instance_calls()`.
 fn hub_with_counting_registry_and_plugin(
     instance_id: &str,
     vendor: &str,
     plugin: Arc<dyn CredStorePluginClientV1>,
-) -> (Arc<ClientHub>, Arc<MockRegistry>) {
+) -> (Arc<ClientHub>, Arc<MockTypesRegistryClient>) {
     let hub = Arc::new(ClientHub::default());
 
-    let entity = GtsEntity {
-        id: Uuid::nil(),
-        gts_id: instance_id.to_owned(),
-        segments: vec![],
-        is_schema: false,
-        content: plugin_content(instance_id, vendor),
-        description: None,
-    };
-    let registry = Arc::new(MockRegistry::new(vec![entity]));
+    let instance = make_test_instance(instance_id, plugin_content(instance_id, vendor));
+    let registry = Arc::new(MockTypesRegistryClient::new().with_instances([instance]));
     hub.register::<dyn TypesRegistryClient>(registry.clone() as Arc<dyn TypesRegistryClient>);
 
     hub.register_scoped::<dyn CredStorePluginClientV1>(ClientScope::gts_id(instance_id), plugin);
@@ -85,15 +80,15 @@ async fn get_retries_resolution_on_each_call_when_registry_absent() {
     // Use a failing registry (not an empty hub) so list() is actually invoked and
     // we can assert the call count proves no caching.
     let hub = Arc::new(ClientHub::default());
-    let registry = Arc::new(MockRegistry::failing(TypesRegistryError::internal(
-        "unavailable",
-    )));
+    let registry = Arc::new(
+        MockTypesRegistryClient::new().with_list_error(TypesRegistryError::internal("unavailable")),
+    );
     hub.register::<dyn TypesRegistryClient>(registry.clone() as Arc<dyn TypesRegistryClient>);
     let svc = Service::new(hub, "hyperspot".into());
     let key = SecretRef::new("my-key").unwrap();
     assert!(svc.get(&test_ctx(), &key).await.is_err());
     assert!(svc.get(&test_ctx(), &key).await.is_err());
-    assert_eq!(registry.list_calls.load(Ordering::SeqCst), 2);
+    assert_eq!(registry.list_instance_calls(), 2);
 }
 
 // ── resolve_plugin ───────────────────────────────────────────────────────
@@ -101,7 +96,7 @@ async fn get_retries_resolution_on_each_call_when_registry_absent() {
 #[tokio::test]
 async fn resolve_plugin_returns_plugin_not_found_when_no_instances() {
     let hub = Arc::new(ClientHub::default());
-    let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![]));
+    let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockTypesRegistryClient::new());
     hub.register::<dyn TypesRegistryClient>(registry);
 
     let svc = Service::new(hub, "hyperspot".into());
@@ -116,15 +111,9 @@ async fn resolve_plugin_returns_plugin_not_found_when_no_instances() {
 async fn resolve_plugin_returns_plugin_not_found_when_vendor_mismatch() {
     let instance_id = test_instance_id();
     let hub = Arc::new(ClientHub::default());
-    let entity = GtsEntity {
-        id: Uuid::nil(),
-        gts_id: instance_id.clone(),
-        segments: vec![],
-        is_schema: false,
-        content: plugin_content(&instance_id, "other-vendor"),
-        description: None,
-    };
-    let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![entity]));
+    let instance = make_test_instance(&instance_id, plugin_content(&instance_id, "other-vendor"));
+    let registry: Arc<dyn TypesRegistryClient> =
+        Arc::new(MockTypesRegistryClient::new().with_instances([instance]));
     hub.register::<dyn TypesRegistryClient>(registry);
 
     let svc = Service::new(hub, "hyperspot".into());
@@ -139,15 +128,12 @@ async fn resolve_plugin_returns_plugin_not_found_when_vendor_mismatch() {
 async fn resolve_plugin_returns_invalid_when_content_malformed() {
     let instance_id = test_instance_id();
     let hub = Arc::new(ClientHub::default());
-    let entity = GtsEntity {
-        id: Uuid::nil(),
-        gts_id: instance_id.clone(),
-        segments: vec![],
-        is_schema: false,
-        content: serde_json::json!({ "not": "valid-plugin-content" }),
-        description: None,
-    };
-    let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![entity]));
+    let instance = make_test_instance(
+        &instance_id,
+        serde_json::json!({ "not": "valid-plugin-content" }),
+    );
+    let registry: Arc<dyn TypesRegistryClient> =
+        Arc::new(MockTypesRegistryClient::new().with_instances([instance]));
     hub.register::<dyn TypesRegistryClient>(registry);
 
     let svc = Service::new(hub, "hyperspot".into());
@@ -161,9 +147,9 @@ async fn resolve_plugin_returns_invalid_when_content_malformed() {
 #[tokio::test]
 async fn resolve_plugin_returns_internal_when_registry_list_fails() {
     let hub = Arc::new(ClientHub::default());
-    let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::failing(
-        TypesRegistryError::internal("db down"),
-    ));
+    let registry: Arc<dyn TypesRegistryClient> = Arc::new(
+        MockTypesRegistryClient::new().with_list_error(TypesRegistryError::internal("db down")),
+    );
     hub.register::<dyn TypesRegistryClient>(registry);
 
     let svc = Service::new(hub, "hyperspot".into());
@@ -191,15 +177,9 @@ async fn get_plugin_returns_unavailable_when_not_in_hub() {
     // Registry resolves successfully, but the scoped client is absent.
     let instance_id = test_instance_id();
     let hub = Arc::new(ClientHub::default());
-    let entity = GtsEntity {
-        id: Uuid::nil(),
-        gts_id: instance_id.clone(),
-        segments: vec![],
-        is_schema: false,
-        content: plugin_content(&instance_id, "hyperspot"),
-        description: None,
-    };
-    let registry: Arc<dyn TypesRegistryClient> = Arc::new(MockRegistry::new(vec![entity]));
+    let instance = make_test_instance(&instance_id, plugin_content(&instance_id, "hyperspot"));
+    let registry: Arc<dyn TypesRegistryClient> =
+        Arc::new(MockTypesRegistryClient::new().with_instances([instance]));
     hub.register::<dyn TypesRegistryClient>(registry);
 
     let svc = Service::new(hub, "hyperspot".into());
@@ -221,7 +201,7 @@ async fn get_plugin_caches_resolved_instance() {
     let p2 = svc.get_plugin().await.unwrap();
 
     assert_eq!(
-        registry.list_calls.load(Ordering::SeqCst),
+        registry.list_instance_calls(),
         1,
         "resolve_plugin should be called exactly once; second call must use cached value"
     );

--- a/modules/credstore/credstore/src/domain/test_support.rs
+++ b/modules/credstore/credstore/src/domain/test_support.rs
@@ -1,10 +1,9 @@
 //! Shared test infrastructure for domain-layer unit tests.
 //!
-//! Provides `MockRegistry` and `MockPlugin` used by both `service` and
-//! `local_client` test modules.
+//! For the GTS registry mock, use `MockTypesRegistryClient` and
+//! `make_test_instance` from `types_registry_sdk::testing` directly.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use async_trait::async_trait;
 use credstore_sdk::{
@@ -12,9 +11,6 @@ use credstore_sdk::{
     TenantId,
 };
 use modkit_security::SecurityContext;
-use types_registry_sdk::{
-    GtsEntity, ListQuery, RegisterResult, TypesRegistryClient, TypesRegistryError,
-};
 use uuid::Uuid;
 
 use credstore_sdk::SecretRef;
@@ -33,60 +29,6 @@ pub fn test_ctx() -> SecurityContext {
         .subject_tenant_id(Uuid::nil())
         .build()
         .unwrap()
-}
-
-// ── MockRegistry ──────────────────────────────────────────────────────────────
-
-pub struct MockRegistry {
-    pub instances: Vec<GtsEntity>,
-    pub list_calls: AtomicUsize,
-    list_error: Option<TypesRegistryError>,
-}
-
-impl MockRegistry {
-    #[must_use]
-    pub fn new(instances: Vec<GtsEntity>) -> Self {
-        Self {
-            instances,
-            list_calls: AtomicUsize::new(0),
-            list_error: None,
-        }
-    }
-
-    #[must_use]
-    pub fn failing(err: TypesRegistryError) -> Self {
-        Self {
-            instances: vec![],
-            list_calls: AtomicUsize::new(0),
-            list_error: Some(err),
-        }
-    }
-}
-
-#[async_trait]
-impl TypesRegistryClient for MockRegistry {
-    async fn list(&self, _query: ListQuery) -> Result<Vec<GtsEntity>, TypesRegistryError> {
-        self.list_calls.fetch_add(1, Ordering::SeqCst);
-        if let Some(ref e) = self.list_error {
-            return Err(e.clone());
-        }
-        Ok(self.instances.clone())
-    }
-
-    async fn get(&self, gts_id: &str) -> Result<GtsEntity, TypesRegistryError> {
-        self.instances
-            .iter()
-            .find(|e| e.gts_id == gts_id)
-            .cloned()
-            .ok_or_else(|| TypesRegistryError::not_found(gts_id))
-    }
-
-    async fn register(
-        &self,
-        _entities: Vec<serde_json::Value>,
-    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
-        Ok(vec![])
-    }
 }
 
 // ── MockPlugin ────────────────────────────────────────────────────────────────

--- a/modules/mini-chat/mini-chat/src/infra/audit_gateway.rs
+++ b/modules/mini-chat/mini-chat/src/infra/audit_gateway.rs
@@ -4,7 +4,7 @@ use mini_chat_sdk::{MiniChatAuditPluginClientV1, MiniChatAuditPluginSpecV1};
 use modkit::client_hub::{ClientHub, ClientScope};
 use modkit::plugins::{ChoosePluginError, GtsPluginSelector, choose_plugin_instance};
 use tracing::warn;
-use types_registry_sdk::{ListQuery, TypesRegistryClient};
+use types_registry_sdk::{InstanceQuery, TypesRegistryClient};
 
 /// Resolves and dispatches to the registered audit plugin instance.
 ///
@@ -112,16 +112,12 @@ impl AuditGateway {
         let registry = self.hub.get::<dyn TypesRegistryClient>()?;
         let plugin_type_id = MiniChatAuditPluginSpecV1::gts_schema_id().clone();
         let instances = registry
-            .list(
-                ListQuery::new()
-                    .with_pattern(format!("{plugin_type_id}*"))
-                    .with_is_type(false),
-            )
+            .list_instances(InstanceQuery::new().with_pattern(format!("{plugin_type_id}*")))
             .await?;
 
         match choose_plugin_instance::<MiniChatAuditPluginSpecV1>(
             &self.vendor,
-            instances.iter().map(|e| (e.gts_id.as_str(), &e.content)),
+            instances.iter().map(|e| (e.id.as_ref(), &e.object)),
         ) {
             Ok(gts_id) => Ok(gts_id),
             // No matching instances — audit is optional; cache a sentinel so we

--- a/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
+++ b/modules/mini-chat/mini-chat/src/infra/model_policy/mod.rs
@@ -6,7 +6,7 @@ use mini_chat_sdk::{
 };
 use modkit::client_hub::{ClientHub, ClientScope};
 use modkit::plugins::{GtsPluginSelector, choose_plugin_instance};
-use types_registry_sdk::{ListQuery, TypesRegistryClient};
+use types_registry_sdk::{InstanceQuery, TypesRegistryClient};
 use uuid::Uuid;
 
 use mini_chat_sdk::UserLimits;
@@ -69,16 +69,12 @@ impl ModelPolicyGateway {
         let registry = self.hub.get::<dyn TypesRegistryClient>()?;
         let plugin_type_id = MiniChatModelPolicyPluginSpecV1::gts_schema_id().clone();
         let instances = registry
-            .list(
-                ListQuery::new()
-                    .with_pattern(format!("{plugin_type_id}*"))
-                    .with_is_type(false),
-            )
+            .list_instances(InstanceQuery::new().with_pattern(format!("{plugin_type_id}*")))
             .await?;
 
         let gts_id = choose_plugin_instance::<MiniChatModelPolicyPluginSpecV1>(
             &self.vendor,
-            instances.iter().map(|e| (e.gts_id.as_str(), &e.content)),
+            instances.iter().map(|e| (e.id.as_ref(), &e.object)),
         )?;
 
         Ok(gts_id)

--- a/modules/system/authn-resolver/authn-resolver/src/domain/service.rs
+++ b/modules/system/authn-resolver/authn-resolver/src/domain/service.rs
@@ -15,7 +15,7 @@ use modkit::plugins::{GtsPluginSelector, choose_plugin_instance};
 use modkit::telemetry::ThrottledLog;
 use modkit_macros::domain_model;
 use tracing::info;
-use types_registry_sdk::{ListQuery, TypesRegistryClient};
+use types_registry_sdk::{InstanceQuery, TypesRegistryClient};
 
 use super::error::DomainError;
 
@@ -83,16 +83,12 @@ impl Service {
         let plugin_type_id = AuthNResolverPluginSpecV1::gts_schema_id().clone();
 
         let instances = registry
-            .list(
-                ListQuery::new()
-                    .with_pattern(format!("{plugin_type_id}*"))
-                    .with_is_type(false),
-            )
+            .list_instances(InstanceQuery::new().with_pattern(format!("{plugin_type_id}*")))
             .await?;
 
         let gts_id = choose_plugin_instance::<AuthNResolverPluginSpecV1>(
             &self.vendor,
-            instances.iter().map(|e| (e.gts_id.as_str(), &e.content)),
+            instances.iter().map(|e| (e.id.as_ref(), &e.object)),
         )?;
         info!(plugin_gts_id = %gts_id, "Selected authn_resolver plugin instance");
 

--- a/modules/system/authz-resolver/authz-resolver/src/domain/service.rs
+++ b/modules/system/authz-resolver/authz-resolver/src/domain/service.rs
@@ -11,7 +11,7 @@ use modkit::plugins::{GtsPluginSelector, choose_plugin_instance};
 use modkit::telemetry::ThrottledLog;
 use modkit_macros::domain_model;
 use tracing::info;
-use types_registry_sdk::{ListQuery, TypesRegistryClient};
+use types_registry_sdk::{InstanceQuery, TypesRegistryClient};
 
 use super::error::DomainError;
 
@@ -74,16 +74,12 @@ impl Service {
         let plugin_type_id = AuthZResolverPluginSpecV1::gts_schema_id().clone();
 
         let instances = registry
-            .list(
-                ListQuery::new()
-                    .with_pattern(format!("{plugin_type_id}*"))
-                    .with_is_type(false),
-            )
+            .list_instances(InstanceQuery::new().with_pattern(format!("{plugin_type_id}*")))
             .await?;
 
         let gts_id = choose_plugin_instance::<AuthZResolverPluginSpecV1>(
             &self.vendor,
-            instances.iter().map(|e| (e.gts_id.as_str(), &e.content)),
+            instances.iter().map(|e| (e.id.as_ref(), &e.object)),
         )?;
         info!(plugin_gts_id = %gts_id, "Selected authz_resolver plugin instance");
 

--- a/modules/system/oagw/oagw/Cargo.toml
+++ b/modules/system/oagw/oagw/Cargo.toml
@@ -72,6 +72,7 @@ rustls = { workspace = true, optional = true }
 
 [dev-dependencies]
 cf-oagw = { path = ".", features = ["test-utils"] }
+types-registry-sdk = { workspace = true, features = ["test-util"] }
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread", "time", "net"] }
 tower = { workspace = true, features = ["util"] }
 hyper = { workspace = true }

--- a/modules/system/oagw/oagw/src/infra/type_provisioning.rs
+++ b/modules/system/oagw/oagw/src/infra/type_provisioning.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde::Deserialize;
-use types_registry_sdk::{ListQuery, TypesRegistryClient};
+use types_registry_sdk::{InstanceQuery, TypesRegistryClient};
 use uuid::Uuid;
 
 use crate::domain::error::DomainError;
@@ -716,27 +716,25 @@ impl TypeProvisioningServiceImpl {
 #[async_trait]
 impl TypeProvisioningService for TypeProvisioningServiceImpl {
     async fn list_upstreams(&self) -> Result<Vec<ProvisionedUpstream>, DomainError> {
-        let query = ListQuery::new()
-            .with_pattern(format!("{UPSTREAM_SCHEMA}*"))
-            .with_is_type(false);
+        let query = InstanceQuery::new().with_pattern(format!("{UPSTREAM_SCHEMA}*"));
 
-        let entities = self
+        let instances = self
             .registry
-            .list(query)
+            .list_instances(query)
             .await
             .map_err(|e| DomainError::internal(e.to_string()))?;
 
-        let mut result = Vec::with_capacity(entities.len());
-        for entity in entities {
-            let gts_instance_id = require_gts_instance_uuid(&entity.gts_id)?;
-            match serde_json::from_value::<UpstreamPayload>(entity.content.clone()) {
+        let mut result = Vec::with_capacity(instances.len());
+        for instance in instances {
+            let gts_instance_id = require_gts_instance_uuid(instance.id.as_ref())?;
+            match serde_json::from_value::<UpstreamPayload>(instance.object.clone()) {
                 Ok(payload) => {
                     result.push(payload.into_provisioned(Some(gts_instance_id)));
                 }
                 Err(e) => {
                     return Err(DomainError::validation(format!(
-                        "Upstream '{}': failed to deserialize GTS entity content: {e}",
-                        entity.gts_id
+                        "Upstream '{}': failed to deserialize GTS instance object: {e}",
+                        instance.id
                     )));
                 }
             }
@@ -746,27 +744,25 @@ impl TypeProvisioningService for TypeProvisioningServiceImpl {
     }
 
     async fn list_routes(&self) -> Result<Vec<ProvisionedRoute>, DomainError> {
-        let query = ListQuery::new()
-            .with_pattern(format!("{ROUTE_SCHEMA}*"))
-            .with_is_type(false);
+        let query = InstanceQuery::new().with_pattern(format!("{ROUTE_SCHEMA}*"));
 
-        let entities = self
+        let instances = self
             .registry
-            .list(query)
+            .list_instances(query)
             .await
             .map_err(|e| DomainError::internal(e.to_string()))?;
 
-        let mut result = Vec::with_capacity(entities.len());
-        for entity in entities {
-            let gts_instance_id = require_gts_instance_uuid(&entity.gts_id)?;
-            match serde_json::from_value::<RoutePayload>(entity.content.clone()) {
+        let mut result = Vec::with_capacity(instances.len());
+        for instance in instances {
+            let gts_instance_id = require_gts_instance_uuid(instance.id.as_ref())?;
+            match serde_json::from_value::<RoutePayload>(instance.object.clone()) {
                 Ok(payload) => {
-                    result.push(payload.into_provisioned(&entity.gts_id, gts_instance_id)?);
+                    result.push(payload.into_provisioned(instance.id.as_ref(), gts_instance_id)?);
                 }
                 Err(e) => {
                     return Err(DomainError::validation(format!(
-                        "Route '{}': failed to deserialize GTS entity content: {e}",
-                        entity.gts_id
+                        "Route '{}': failed to deserialize GTS instance object: {e}",
+                        instance.id
                     )));
                 }
             }
@@ -778,42 +774,19 @@ impl TypeProvisioningService for TypeProvisioningServiceImpl {
 
 #[cfg(test)]
 mod tests {
-    use types_registry_sdk::{GtsEntity, RegisterResult, TypesRegistryError};
+    use types_registry_sdk::{
+        GtsInstance, TypesRegistryError,
+        testing::{MockTypesRegistryClient, make_test_instance},
+    };
 
     use super::*;
 
-    type ListFn =
-        Box<dyn Fn(ListQuery) -> Result<Vec<GtsEntity>, TypesRegistryError> + Send + Sync>;
-
-    /// Mock `TypesRegistryClient` for unit testing.
-    struct MockRegistry {
-        list_fn: ListFn,
+    fn make_upstream_instance(gts_id: &str, object: serde_json::Value) -> GtsInstance {
+        make_test_instance(gts_id, object)
     }
 
-    #[async_trait]
-    impl TypesRegistryClient for MockRegistry {
-        async fn register(
-            &self,
-            _entities: Vec<serde_json::Value>,
-        ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
-            unimplemented!()
-        }
-
-        async fn list(&self, query: ListQuery) -> Result<Vec<GtsEntity>, TypesRegistryError> {
-            (self.list_fn)(query)
-        }
-
-        async fn get(&self, _gts_id: &str) -> Result<GtsEntity, TypesRegistryError> {
-            unimplemented!()
-        }
-    }
-
-    fn make_upstream_entity(gts_id: &str, content: serde_json::Value) -> GtsEntity {
-        GtsEntity::new(Uuid::new_v4(), gts_id, vec![], false, content, None)
-    }
-
-    fn make_route_entity(gts_id: &str, content: serde_json::Value) -> GtsEntity {
-        GtsEntity::new(Uuid::new_v4(), gts_id, vec![], false, content, None)
+    fn make_route_instance(gts_id: &str, object: serde_json::Value) -> GtsInstance {
+        make_test_instance(gts_id, object)
     }
 
     fn upstream_content(tenant_id: Uuid) -> serde_json::Value {
@@ -851,9 +824,10 @@ mod tests {
         let content = upstream_content(tenant);
         let gts_id = format!("gts.x.core.oagw.upstream.v1~{instance_id}");
 
-        let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(move |_| Ok(vec![make_upstream_entity(&gts_id, content.clone())])),
-        });
+        let registry = Arc::new(
+            MockTypesRegistryClient::new()
+                .with_instances([make_upstream_instance(&gts_id, content)]),
+        );
         let svc = TypeProvisioningServiceImpl::new(registry);
 
         let upstreams = svc.list_upstreams().await.unwrap();
@@ -865,14 +839,13 @@ mod tests {
 
     #[tokio::test]
     async fn list_upstreams_rejects_non_uuid_instance_id() {
-        let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(|_| {
-                Ok(vec![make_upstream_entity(
+        let registry =
+            Arc::new(
+                MockTypesRegistryClient::new().with_instances([make_upstream_instance(
                     "gts.x.core.oagw.upstream.v1~x.core.oagw.test.v1",
                     upstream_content(Uuid::new_v4()),
-                )])
-            }),
-        });
+                )]),
+            );
         let svc = TypeProvisioningServiceImpl::new(registry);
 
         let err = svc.list_upstreams().await.unwrap_err();
@@ -887,14 +860,13 @@ mod tests {
     async fn list_upstreams_rejects_invalid_content() {
         let instance_id = Uuid::new_v4();
         let gts_id = format!("gts.x.core.oagw.upstream.v1~{instance_id}");
-        let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(move |_| {
-                Ok(vec![make_upstream_entity(
+        let registry =
+            Arc::new(
+                MockTypesRegistryClient::new().with_instances([make_upstream_instance(
                     &gts_id,
                     serde_json::json!({"invalid": true}),
-                )])
-            }),
-        });
+                )]),
+            );
         let svc = TypeProvisioningServiceImpl::new(registry);
 
         let err = svc.list_upstreams().await.unwrap_err();
@@ -907,9 +879,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_upstreams_returns_empty_when_none_registered() {
-        let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(|_| Ok(vec![])),
-        });
+        let registry = Arc::new(MockTypesRegistryClient::new());
         let svc = TypeProvisioningServiceImpl::new(registry);
 
         let upstreams = svc.list_upstreams().await.unwrap();
@@ -918,9 +888,10 @@ mod tests {
 
     #[tokio::test]
     async fn list_upstreams_propagates_registry_error() {
-        let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(|_| Err(TypesRegistryError::internal("connection lost"))),
-        });
+        let registry = Arc::new(
+            MockTypesRegistryClient::new()
+                .with_list_error(TypesRegistryError::internal("connection lost")),
+        );
         let svc = TypeProvisioningServiceImpl::new(registry);
 
         let result = svc.list_upstreams().await;
@@ -935,9 +906,9 @@ mod tests {
         let content = route_content(tenant, upstream_id);
         let gts_id = format!("gts.x.core.oagw.route.v1~{route_instance_id}");
 
-        let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(move |_| Ok(vec![make_route_entity(&gts_id, content.clone())])),
-        });
+        let registry = Arc::new(
+            MockTypesRegistryClient::new().with_instances([make_route_instance(&gts_id, content)]),
+        );
         let svc = TypeProvisioningServiceImpl::new(registry);
 
         let routes = svc.list_routes().await.unwrap();
@@ -950,14 +921,13 @@ mod tests {
 
     #[tokio::test]
     async fn list_routes_rejects_non_uuid_instance_id() {
-        let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(|_| {
-                Ok(vec![make_route_entity(
+        let registry =
+            Arc::new(
+                MockTypesRegistryClient::new().with_instances([make_route_instance(
                     "gts.x.core.oagw.route.v1~x.core.oagw.test.v1",
                     route_content(Uuid::new_v4(), Uuid::new_v4()),
-                )])
-            }),
-        });
+                )]),
+            );
         let svc = TypeProvisioningServiceImpl::new(registry);
 
         let err = svc.list_routes().await.unwrap_err();
@@ -972,14 +942,13 @@ mod tests {
     async fn list_routes_rejects_invalid_content() {
         let instance_id = Uuid::new_v4();
         let gts_id = format!("gts.x.core.oagw.route.v1~{instance_id}");
-        let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(move |_| {
-                Ok(vec![make_route_entity(
+        let registry =
+            Arc::new(
+                MockTypesRegistryClient::new().with_instances([make_route_instance(
                     &gts_id,
                     serde_json::json!({"garbage": true}),
-                )])
-            }),
-        });
+                )]),
+            );
         let svc = TypeProvisioningServiceImpl::new(registry);
 
         let err = svc.list_routes().await.unwrap_err();
@@ -992,9 +961,9 @@ mod tests {
 
     #[tokio::test]
     async fn list_routes_propagates_registry_error() {
-        let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(|_| Err(TypesRegistryError::internal("timeout"))),
-        });
+        let registry = Arc::new(
+            MockTypesRegistryClient::new().with_list_error(TypesRegistryError::internal("timeout")),
+        );
         let svc = TypeProvisioningServiceImpl::new(registry);
 
         let result = svc.list_routes().await;
@@ -1003,33 +972,30 @@ mod tests {
 
     #[tokio::test]
     async fn list_upstreams_uses_correct_pattern() {
-        let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(|query| {
-                assert_eq!(
-                    query.pattern.as_deref(),
-                    Some("gts.x.core.oagw.upstream.v1~*")
-                );
-                assert_eq!(query.is_type, Some(false));
-                Ok(vec![])
-            }),
-        });
-        let svc = TypeProvisioningServiceImpl::new(registry);
+        let registry = Arc::new(MockTypesRegistryClient::new());
+        let svc = TypeProvisioningServiceImpl::new(registry.clone());
 
         let _ = svc.list_upstreams().await;
+        let queries = registry.received_instance_queries();
+        assert_eq!(queries.len(), 1);
+        assert_eq!(
+            queries[0].pattern.as_deref(),
+            Some("gts.x.core.oagw.upstream.v1~*")
+        );
     }
 
     #[tokio::test]
     async fn list_routes_uses_correct_pattern() {
-        let registry = Arc::new(MockRegistry {
-            list_fn: Box::new(|query| {
-                assert_eq!(query.pattern.as_deref(), Some("gts.x.core.oagw.route.v1~*"));
-                assert_eq!(query.is_type, Some(false));
-                Ok(vec![])
-            }),
-        });
-        let svc = TypeProvisioningServiceImpl::new(registry);
+        let registry = Arc::new(MockTypesRegistryClient::new());
+        let svc = TypeProvisioningServiceImpl::new(registry.clone());
 
         let _ = svc.list_routes().await;
+        let queries = registry.received_instance_queries();
+        assert_eq!(queries.len(), 1);
+        assert_eq!(
+            queries[0].pattern.as_deref(),
+            Some("gts.x.core.oagw.route.v1~*")
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/modules/system/resource-group/resource-group/src/domain/validation.rs
+++ b/modules/system/resource-group/resource-group/src/domain/validation.rs
@@ -119,12 +119,13 @@ pub async fn validate_metadata_via_gts(
         return Ok(());
     };
 
-    // Fetch the GTS entity — its content contains the resolved schema
-    // including allOf composition and $ref resolution from types-registry.
-    let entity = match types_registry.get(type_code).await {
-        Ok(entity) => entity,
+    // Fetch the GTS schema. Local client pre-links ancestors via Arc, so
+    // `effective_properties()` returns the chain-resolved property map (own
+    // overrides + inherited).
+    let schema = match types_registry.get_type_schema(type_code).await {
+        Ok(schema) => schema,
         // No registered schema for this type -- skip metadata validation.
-        Err(types_registry_sdk::TypesRegistryError::NotFound(_)) => return Ok(()),
+        Err(types_registry_sdk::TypesRegistryError::GtsTypeSchemaNotFound(_)) => return Ok(()),
         Err(e) => {
             return Err(DomainError::validation(format!(
                 "Failed to resolve GTS type '{type_code}' for metadata validation: {e}"
@@ -132,13 +133,10 @@ pub async fn validate_metadata_via_gts(
         }
     };
 
-    // Extract metadata sub-schema from the GTS entity content.
-    // The chained RG type schema defines a `metadata` property within
-    // its `properties` object.
-    let metadata_schema = entity
-        .content
-        .get("properties")
-        .and_then(|p| p.get("metadata"));
+    // The chained RG type schema may declare `metadata` at any level of
+    // the inheritance chain — `effective_properties` collects them all.
+    let merged = schema.effective_properties();
+    let metadata_schema = merged.get("metadata");
 
     let Some(metadata_schema) = metadata_schema else {
         // No metadata property in the schema — any metadata accepted.

--- a/modules/system/resource-group/resource-group/tests/common/mod.rs
+++ b/modules/system/resource-group/resource-group/tests/common/mod.rs
@@ -47,18 +47,134 @@ impl types_registry_sdk::TypesRegistryClient for StubTypesRegistry {
         Ok(vec![])
     }
 
-    async fn list(
+    async fn register_type_schemas(
         &self,
-        _query: types_registry_sdk::ListQuery,
-    ) -> Result<Vec<types_registry_sdk::GtsEntity>, types_registry_sdk::TypesRegistryError> {
+        _type_schemas: Vec<serde_json::Value>,
+    ) -> Result<Vec<types_registry_sdk::RegisterResult>, types_registry_sdk::TypesRegistryError>
+    {
         Ok(vec![])
     }
 
-    async fn get(
+    async fn get_type_schema(
         &self,
-        gts_id: &str,
-    ) -> Result<types_registry_sdk::GtsEntity, types_registry_sdk::TypesRegistryError> {
-        Err(types_registry_sdk::TypesRegistryError::not_found(gts_id))
+        type_id: &str,
+    ) -> Result<types_registry_sdk::GtsTypeSchema, types_registry_sdk::TypesRegistryError> {
+        Err(types_registry_sdk::TypesRegistryError::gts_type_schema_not_found(type_id))
+    }
+
+    async fn get_type_schema_by_uuid(
+        &self,
+        type_uuid: Uuid,
+    ) -> Result<types_registry_sdk::GtsTypeSchema, types_registry_sdk::TypesRegistryError> {
+        Err(
+            types_registry_sdk::TypesRegistryError::gts_type_schema_not_found(
+                type_uuid.to_string(),
+            ),
+        )
+    }
+
+    async fn get_type_schemas(
+        &self,
+        type_ids: Vec<String>,
+    ) -> std::collections::HashMap<
+        String,
+        Result<types_registry_sdk::GtsTypeSchema, types_registry_sdk::TypesRegistryError>,
+    > {
+        type_ids
+            .into_iter()
+            .map(|id| {
+                let err = types_registry_sdk::TypesRegistryError::gts_type_schema_not_found(&id);
+                (id, Err(err))
+            })
+            .collect()
+    }
+
+    async fn get_type_schemas_by_uuid(
+        &self,
+        type_uuids: Vec<Uuid>,
+    ) -> std::collections::HashMap<
+        Uuid,
+        Result<types_registry_sdk::GtsTypeSchema, types_registry_sdk::TypesRegistryError>,
+    > {
+        type_uuids
+            .into_iter()
+            .map(|uuid| {
+                let err = types_registry_sdk::TypesRegistryError::gts_type_schema_not_found(
+                    uuid.to_string(),
+                );
+                (uuid, Err(err))
+            })
+            .collect()
+    }
+
+    async fn list_type_schemas(
+        &self,
+        _query: types_registry_sdk::TypeSchemaQuery,
+    ) -> Result<Vec<types_registry_sdk::GtsTypeSchema>, types_registry_sdk::TypesRegistryError>
+    {
+        Ok(vec![])
+    }
+
+    async fn register_instances(
+        &self,
+        _instances: Vec<serde_json::Value>,
+    ) -> Result<Vec<types_registry_sdk::RegisterResult>, types_registry_sdk::TypesRegistryError>
+    {
+        Ok(vec![])
+    }
+
+    async fn get_instance(
+        &self,
+        id: &str,
+    ) -> Result<types_registry_sdk::GtsInstance, types_registry_sdk::TypesRegistryError> {
+        Err(types_registry_sdk::TypesRegistryError::gts_instance_not_found(id))
+    }
+
+    async fn get_instance_by_uuid(
+        &self,
+        uuid: Uuid,
+    ) -> Result<types_registry_sdk::GtsInstance, types_registry_sdk::TypesRegistryError> {
+        Err(types_registry_sdk::TypesRegistryError::gts_instance_not_found(uuid.to_string()))
+    }
+
+    async fn get_instances(
+        &self,
+        ids: Vec<String>,
+    ) -> std::collections::HashMap<
+        String,
+        Result<types_registry_sdk::GtsInstance, types_registry_sdk::TypesRegistryError>,
+    > {
+        ids.into_iter()
+            .map(|id| {
+                let err = types_registry_sdk::TypesRegistryError::gts_instance_not_found(&id);
+                (id, Err(err))
+            })
+            .collect()
+    }
+
+    async fn get_instances_by_uuid(
+        &self,
+        uuids: Vec<Uuid>,
+    ) -> std::collections::HashMap<
+        Uuid,
+        Result<types_registry_sdk::GtsInstance, types_registry_sdk::TypesRegistryError>,
+    > {
+        uuids
+            .into_iter()
+            .map(|uuid| {
+                let err = types_registry_sdk::TypesRegistryError::gts_instance_not_found(
+                    uuid.to_string(),
+                );
+                (uuid, Err(err))
+            })
+            .collect()
+    }
+
+    async fn list_instances(
+        &self,
+        _query: types_registry_sdk::InstanceQuery,
+    ) -> Result<Vec<types_registry_sdk::GtsInstance>, types_registry_sdk::TypesRegistryError> {
+        Ok(vec![])
     }
 }
 

--- a/modules/system/tenant-resolver/tenant-resolver/src/domain/service.rs
+++ b/modules/system/tenant-resolver/tenant-resolver/src/domain/service.rs
@@ -17,7 +17,7 @@ use tenant_resolver_sdk::{
     TenantResolverPluginSpecV1,
 };
 use tracing::info;
-use types_registry_sdk::{ListQuery, TypesRegistryClient};
+use types_registry_sdk::{InstanceQuery, TypesRegistryClient};
 
 use super::error::DomainError;
 
@@ -95,16 +95,12 @@ impl Service {
         let plugin_type_id = TenantResolverPluginSpecV1::gts_schema_id().clone();
 
         let instances = registry
-            .list(
-                ListQuery::new()
-                    .with_pattern(format!("{plugin_type_id}*"))
-                    .with_is_type(false),
-            )
+            .list_instances(InstanceQuery::new().with_pattern(format!("{plugin_type_id}*")))
             .await?;
 
         let gts_id = choose_plugin_instance::<TenantResolverPluginSpecV1>(
             &self.vendor,
-            instances.iter().map(|e| (e.gts_id.as_str(), &e.content)),
+            instances.iter().map(|e| (e.id.as_ref(), &e.object)),
         )?;
         info!(plugin_gts_id = %gts_id, "Selected tenant resolver plugin instance");
 

--- a/modules/system/types-registry/types-registry-sdk/Cargo.toml
+++ b/modules/system/types-registry/types-registry-sdk/Cargo.toml
@@ -17,6 +17,13 @@ name = "types_registry_sdk"
 [lints]
 workspace = true
 
+[features]
+# Default: production build, no test utilities.
+default = []
+# Exposes `pub mod testing` with a stateful `MockTypesRegistryClient` mock for
+# consumers that need a `dyn TypesRegistryClient` in their unit tests.
+test-util = []
+
 [dependencies]
 # Core dependencies for API trait
 async-trait = { workspace = true }

--- a/modules/system/types-registry/types-registry-sdk/src/api.rs
+++ b/modules/system/types-registry/types-registry-sdk/src/api.rs
@@ -1,92 +1,185 @@
-//! `TypesRegistryApi` trait definition.
+//! `TypesRegistryClient` trait definition.
 //!
 //! This trait defines the public API for the `types-registry` module.
-//! GTS schemas and instances are global resources, so no security context is required.
+//! GTS type-schemas and instances are global resources, so no security context
+//! is required.
+
+use std::collections::HashMap;
 
 use async_trait::async_trait;
+use uuid::Uuid;
 
 use crate::error::TypesRegistryError;
-use crate::models::{GtsEntity, ListQuery, RegisterResult};
+use crate::models::{GtsInstance, GtsTypeSchema, InstanceQuery, RegisterResult, TypeSchemaQuery};
 
 /// Public API trait for the `types-registry` module.
 ///
 /// This trait can be consumed by other modules via `ClientHub`:
 /// ```ignore
-/// let client = hub.get::<dyn TypesRegistryApi>()?;
-/// let entity = client.get("gts.acme.core.events.user_created.v1~").await?;
+/// let client = hub.get::<dyn TypesRegistryClient>()?;
+/// let schema = client.get_type_schema("gts.acme.core.events.user.v1~").await?;
 /// ```
 ///
-/// GTS schemas and instances are global resources (not tenant-scoped),
+/// GTS type-schemas and instances are global resources (not tenant-scoped),
 /// so no security context is required for these operations.
 #[async_trait]
 pub trait TypesRegistryClient: Send + Sync {
-    /// Register GTS entities (types or instances) in batch.
+    // ------------------------------------------------------------------
+    // Generic batch register (kind detected from gts_id suffix per item).
+    // ------------------------------------------------------------------
+
+    /// Register GTS entities (type-schemas or instances) in batch.
     ///
-    /// Each JSON value in the input should contain a valid GTS entity
-    /// with a `$id` field containing the GTS identifier.
+    /// Each JSON value must contain a valid GTS identifier in one of the
+    /// configured ID fields (`$id`, `gtsId`, `id`). The batch is sorted
+    /// lexicographically by GTS id before processing so parents are
+    /// registered before their children within the same batch.
     ///
-    /// # Arguments
-    ///
-    /// * `entities` - JSON values representing GTS entities to register
-    ///
-    /// # Returns
-    ///
-    /// A vector of `RegisterResult` for each input entity, preserving order.
-    /// Each result indicates success (with the registered entity) or failure
-    /// (with the error and attempted GTS ID if available).
-    ///
-    /// Use `RegisterSummary::from_results(&results)` for aggregate counts.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let results = registry.register(entities).await?;
-    /// let summary = RegisterSummary::from_results(&results);
-    /// println!("Registered {}/{} entities", summary.succeeded, summary.total());
-    ///
-    /// for result in results {
-    ///     match result {
-    ///         RegisterResult::Ok(entity) => println!("OK: {}", entity.gts_id),
-    ///         RegisterResult::Err { gts_id, error } => {
-    ///             eprintln!("FAIL {}: {}", gts_id.as_deref().unwrap_or("?"), error);
-    ///         }
-    ///     }
-    /// }
-    /// ```
+    /// Per-item failures are reported via [`RegisterResult::Err`]; success
+    /// carries only the canonical [`gts_id`](RegisterResult::Ok). To inspect
+    /// the typed view of a registered entity, follow up with
+    /// [`Self::get_type_schema`] / [`Self::get_instance`].
     ///
     /// # Errors
     ///
-    /// Returns `Err` only for catastrophic failures (e.g., database unavailable).
-    /// Per-item errors are returned in the `RegisterResult::Err` variant.
+    /// Returns `Err` only for catastrophic failures (e.g., backend unavailable).
     async fn register(
         &self,
         entities: Vec<serde_json::Value>,
     ) -> Result<Vec<RegisterResult>, TypesRegistryError>;
 
-    /// List GTS entities with optional filtering.
-    ///
-    /// # Arguments
-    ///
-    /// * `query` - Query parameters for filtering results
-    ///
-    /// # Returns
-    ///
-    /// A vector of `GtsEntity` objects matching the query.
-    async fn list(&self, query: ListQuery) -> Result<Vec<GtsEntity>, TypesRegistryError>;
+    // ------------------------------------------------------------------
+    // Type-schema operations (internal — no tenant scoping).
+    // ------------------------------------------------------------------
 
-    /// Retrieve a single GTS entity by its identifier.
+    /// Register GTS type-schemas in batch.
     ///
-    /// # Arguments
-    ///
-    /// * `gts_id` - The GTS identifier string
-    ///
-    /// # Returns
-    ///
-    /// The `GtsEntity` if found.
+    /// Each input value must have a GTS id ending with `~`. Inputs whose
+    /// identifier does not match the type-schema kind are returned as
+    /// per-item `RegisterResult::Err` with `InvalidGtsTypeId`. In ready
+    /// phase, items whose chain parent is not yet registered fail with
+    /// `ParentTypeSchemaNotRegistered` (callers may register the parent
+    /// then retry the failed item).
     ///
     /// # Errors
     ///
-    /// * `NotFound` - If no entity with the given GTS ID exists
-    /// * `InvalidGtsId` - If the GTS ID format is invalid
-    async fn get(&self, gts_id: &str) -> Result<GtsEntity, TypesRegistryError>;
+    /// Returns `Err` only for catastrophic failures.
+    async fn register_type_schemas(
+        &self,
+        type_schemas: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError>;
+
+    /// Retrieve a registered GTS type-schema by its type id.
+    ///
+    /// # Errors
+    ///
+    /// * `GtsTypeSchemaNotFound` — no type-schema with this id is registered.
+    /// * `InvalidGtsTypeId` — id format is invalid, kind-mismatched, or
+    ///   resolves to a non-type-schema entity.
+    async fn get_type_schema(&self, type_id: &str) -> Result<GtsTypeSchema, TypesRegistryError>;
+
+    /// Retrieve a registered GTS type-schema by its deterministic UUID v5.
+    ///
+    /// # Errors
+    ///
+    /// * `GtsTypeSchemaNotFound` — no type-schema is registered with this UUID
+    ///   (also returned when the UUID exists but points to an instance).
+    async fn get_type_schema_by_uuid(
+        &self,
+        type_uuid: Uuid,
+    ) -> Result<GtsTypeSchema, TypesRegistryError>;
+
+    /// Retrieve multiple type-schemas by id in one call.
+    ///
+    /// Returns a map keyed by the input ids; each value is a per-item
+    /// `Result` carrying either the resolved schema or the per-item error
+    /// ([`GtsTypeSchemaNotFound`](TypesRegistryError::GtsTypeSchemaNotFound),
+    /// [`InvalidGtsTypeId`](TypesRegistryError::InvalidGtsTypeId), …).
+    /// Duplicate ids in the input collapse to a single entry. The map
+    /// always has a value for every distinct input id.
+    async fn get_type_schemas(
+        &self,
+        type_ids: Vec<String>,
+    ) -> HashMap<String, Result<GtsTypeSchema, TypesRegistryError>>;
+
+    /// Retrieve multiple type-schemas by deterministic UUID v5 in one call.
+    ///
+    /// Same per-key semantics as [`Self::get_type_schemas`]: a map keyed
+    /// by the input UUIDs, per-item failures carried in the inner
+    /// `Result`. Duplicates collapse.
+    async fn get_type_schemas_by_uuid(
+        &self,
+        type_uuids: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsTypeSchema, TypesRegistryError>>;
+
+    /// List registered GTS type-schemas matching the query.
+    async fn list_type_schemas(
+        &self,
+        query: TypeSchemaQuery,
+    ) -> Result<Vec<GtsTypeSchema>, TypesRegistryError>;
+
+    // ------------------------------------------------------------------
+    // Instance operations (internal — no tenant scoping).
+    // ------------------------------------------------------------------
+
+    /// Register GTS instances in batch.
+    ///
+    /// Each input value must have a GTS id that does NOT end with `~`. Inputs
+    /// whose identifier does not match the instance kind are returned as
+    /// per-item `RegisterResult::Err` with `InvalidGtsInstanceId`. In ready
+    /// phase, items whose declaring type-schema is not yet registered fail
+    /// with `ParentTypeSchemaNotRegistered`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` only for catastrophic failures.
+    async fn register_instances(
+        &self,
+        instances: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError>;
+
+    /// Retrieve a registered GTS instance by its instance id.
+    ///
+    /// # Errors
+    ///
+    /// * `GtsInstanceNotFound` — no instance with this id is registered.
+    /// * `InvalidGtsInstanceId` — id format is invalid, kind-mismatched, or
+    ///   resolves to a non-instance entity.
+    async fn get_instance(&self, id: &str) -> Result<GtsInstance, TypesRegistryError>;
+
+    /// Retrieve a registered GTS instance by its deterministic UUID v5.
+    ///
+    /// # Errors
+    ///
+    /// * `GtsInstanceNotFound` — no instance is registered with this UUID
+    ///   (also returned when the UUID exists but points to a type-schema).
+    async fn get_instance_by_uuid(&self, uuid: Uuid) -> Result<GtsInstance, TypesRegistryError>;
+
+    /// Retrieve multiple instances by id in one call.
+    ///
+    /// Returns a map keyed by the input ids; each value is a per-item
+    /// `Result` carrying either the resolved instance or the per-item
+    /// error ([`GtsInstanceNotFound`](TypesRegistryError::GtsInstanceNotFound),
+    /// [`InvalidGtsInstanceId`](TypesRegistryError::InvalidGtsInstanceId),
+    /// …). Duplicate ids in the input collapse to a single entry.
+    async fn get_instances(
+        &self,
+        ids: Vec<String>,
+    ) -> HashMap<String, Result<GtsInstance, TypesRegistryError>>;
+
+    /// Retrieve multiple instances by deterministic UUID v5 in one call.
+    ///
+    /// Same per-key semantics as [`Self::get_instances`]: a map keyed by
+    /// the input UUIDs, per-item failures carried in the inner `Result`.
+    /// Duplicates collapse.
+    async fn get_instances_by_uuid(
+        &self,
+        uuids: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsInstance, TypesRegistryError>>;
+
+    /// List registered GTS instances matching the query.
+    async fn list_instances(
+        &self,
+        query: InstanceQuery,
+    ) -> Result<Vec<GtsInstance>, TypesRegistryError>;
 }

--- a/modules/system/types-registry/types-registry-sdk/src/error.rs
+++ b/modules/system/types-registry/types-registry-sdk/src/error.rs
@@ -1,31 +1,77 @@
 //! Public error types for the `types-registry` module.
 //!
-//! These errors are safe to expose to other modules and consumers.
+//! These errors are safe to expose to other modules and consumers. The
+//! taxonomy is symmetric across kinds: every kind-specific failure gets a
+//! kind-specific variant (`*GtsTypeSchema*` vs `*GtsInstance*`) so callers
+//! can match on the variant they care about without parsing messages.
+
+use std::time::Duration;
 
 use thiserror::Error;
 
-/// Errors that can be returned by the `TypesRegistryApi`.
+/// Errors that can be returned by the `TypesRegistryClient`.
 #[derive(Error, Debug, Clone)]
 pub enum TypesRegistryError {
-    /// The GTS ID format is invalid.
-    #[error("Invalid GTS ID: {0}")]
-    InvalidGtsId(String),
+    /// The string is not a valid GTS type-schema identifier.
+    ///
+    /// Covers parse failures, kind mismatches (an instance id was passed
+    /// where a type-schema id was expected), and lookups that resolved to
+    /// a non-type-schema entity.
+    #[error("Invalid GTS type-schema id: {0}")]
+    InvalidGtsTypeId(String),
 
-    /// The requested entity was not found.
-    #[error("Entity not found: {0}")]
-    NotFound(String),
+    /// The string is not a valid GTS instance identifier.
+    ///
+    /// Covers parse failures, kind mismatches, missing chain prefix, and
+    /// chain-prefix mismatches against a passed type-schema.
+    #[error("Invalid GTS instance id: {0}")]
+    InvalidGtsInstanceId(String),
+
+    /// No GTS type-schema is registered under the given id or UUID.
+    #[error("GTS type-schema not found: {0}")]
+    GtsTypeSchemaNotFound(String),
+
+    /// No GTS instance is registered under the given id or UUID.
+    #[error("GTS instance not found: {0}")]
+    GtsInstanceNotFound(String),
+
+    /// Cannot register an entity because its required parent type-schema is
+    /// not yet registered. The client should register the parent first and
+    /// retry the failed entity.
+    #[error(
+        "Cannot register {dependent_id}: required type-schema {parent_type_id} is not registered"
+    )]
+    ParentTypeSchemaNotRegistered {
+        /// The parent type-schema id that must be registered first.
+        parent_type_id: String,
+        /// The id of the entity whose registration failed.
+        dependent_id: String,
+    },
 
     /// An entity with the same GTS ID already exists.
     #[error("Entity already exists: {0}")]
     AlreadyExists(String),
 
+    /// The list/query parameters are syntactically invalid (e.g., a pattern
+    /// that doesn't follow GTS wildcard rules — section 10 of the GTS spec
+    /// requires a single trailing `*` anchored at a segment boundary).
+    #[error("Invalid query: {0}")]
+    InvalidQuery(String),
+
     /// Validation of the entity content failed.
     #[error("Validation failed: {0}")]
     ValidationFailed(String),
 
-    /// The operation requires ready mode.
-    #[error("Not in ready mode")]
-    NotInReadyMode,
+    /// The service is not currently available (e.g., still initializing).
+    /// `retry_after` is a hint for how long the caller should wait before
+    /// retrying; `message` carries a human-readable reason.
+    #[error("Service unavailable: {message} (retry after {retry_after:?})")]
+    ServiceUnavailable {
+        /// Human-readable reason the service is not available.
+        message: String,
+        /// Suggested delay before retrying.
+        retry_after: Duration,
+    },
 
     /// An internal error occurred.
     #[error("Internal error: {0}")]
@@ -33,16 +79,40 @@ pub enum TypesRegistryError {
 }
 
 impl TypesRegistryError {
-    /// Creates an `InvalidGtsId` error.
+    /// Creates an `InvalidGtsTypeId` error.
     #[must_use]
-    pub fn invalid_gts_id(message: impl Into<String>) -> Self {
-        Self::InvalidGtsId(message.into())
+    pub fn invalid_gts_type_id(message: impl Into<String>) -> Self {
+        Self::InvalidGtsTypeId(message.into())
     }
 
-    /// Creates a `NotFound` error.
+    /// Creates an `InvalidGtsInstanceId` error.
     #[must_use]
-    pub fn not_found(gts_id: impl Into<String>) -> Self {
-        Self::NotFound(gts_id.into())
+    pub fn invalid_gts_instance_id(message: impl Into<String>) -> Self {
+        Self::InvalidGtsInstanceId(message.into())
+    }
+
+    /// Creates a `GtsTypeSchemaNotFound` error.
+    #[must_use]
+    pub fn gts_type_schema_not_found(id_or_uuid: impl Into<String>) -> Self {
+        Self::GtsTypeSchemaNotFound(id_or_uuid.into())
+    }
+
+    /// Creates a `GtsInstanceNotFound` error.
+    #[must_use]
+    pub fn gts_instance_not_found(id_or_uuid: impl Into<String>) -> Self {
+        Self::GtsInstanceNotFound(id_or_uuid.into())
+    }
+
+    /// Creates a `ParentTypeSchemaNotRegistered` error.
+    #[must_use]
+    pub fn parent_type_schema_not_registered(
+        parent_type_id: impl Into<String>,
+        dependent_id: impl Into<String>,
+    ) -> Self {
+        Self::ParentTypeSchemaNotRegistered {
+            parent_type_id: parent_type_id.into(),
+            dependent_id: dependent_id.into(),
+        }
     }
 
     /// Creates an `AlreadyExists` error.
@@ -51,16 +121,32 @@ impl TypesRegistryError {
         Self::AlreadyExists(gts_id.into())
     }
 
+    /// Creates an `InvalidQuery` error.
+    #[must_use]
+    pub fn invalid_query(message: impl Into<String>) -> Self {
+        Self::InvalidQuery(message.into())
+    }
+
     /// Creates a `ValidationFailed` error.
     #[must_use]
     pub fn validation_failed(message: impl Into<String>) -> Self {
         Self::ValidationFailed(message.into())
     }
 
-    /// Creates a `NotInReadyMode` error.
+    /// Creates a `ServiceUnavailable` error with a human-readable `message`
+    /// and a `retry_after` hint.
     #[must_use]
-    pub const fn not_in_ready_mode() -> Self {
-        Self::NotInReadyMode
+    pub fn service_unavailable(message: impl Into<String>, retry_after: Duration) -> Self {
+        Self::ServiceUnavailable {
+            message: message.into(),
+            retry_after,
+        }
+    }
+
+    /// Returns `true` if this is a `ServiceUnavailable` error.
+    #[must_use]
+    pub const fn is_service_unavailable(&self) -> bool {
+        matches!(self, Self::ServiceUnavailable { .. })
     }
 
     /// Creates an `Internal` error.
@@ -69,16 +155,56 @@ impl TypesRegistryError {
         Self::Internal(message.into())
     }
 
-    /// Returns `true` if this is a not found error.
+    /// Returns `true` if this is an `InvalidGtsTypeId` error.
     #[must_use]
-    pub const fn is_not_found(&self) -> bool {
-        matches!(self, Self::NotFound(_))
+    pub const fn is_invalid_gts_type_id(&self) -> bool {
+        matches!(self, Self::InvalidGtsTypeId(_))
     }
 
-    /// Returns `true` if this is an already exists error.
+    /// Returns `true` if this is an `InvalidGtsInstanceId` error.
+    #[must_use]
+    pub const fn is_invalid_gts_instance_id(&self) -> bool {
+        matches!(self, Self::InvalidGtsInstanceId(_))
+    }
+
+    /// Returns `true` if this is a `GtsTypeSchemaNotFound` error.
+    #[must_use]
+    pub const fn is_gts_type_schema_not_found(&self) -> bool {
+        matches!(self, Self::GtsTypeSchemaNotFound(_))
+    }
+
+    /// Returns `true` if this is a `GtsInstanceNotFound` error.
+    #[must_use]
+    pub const fn is_gts_instance_not_found(&self) -> bool {
+        matches!(self, Self::GtsInstanceNotFound(_))
+    }
+
+    /// Returns `true` if this is any kind of not-found error
+    /// (`GtsTypeSchemaNotFound` or `GtsInstanceNotFound`).
+    #[must_use]
+    pub const fn is_not_found(&self) -> bool {
+        matches!(
+            self,
+            Self::GtsTypeSchemaNotFound(_) | Self::GtsInstanceNotFound(_)
+        )
+    }
+
+    /// Returns `true` if this is a `ParentTypeSchemaNotRegistered` error.
+    #[must_use]
+    pub const fn is_parent_type_schema_not_registered(&self) -> bool {
+        matches!(self, Self::ParentTypeSchemaNotRegistered { .. })
+    }
+
+    /// Returns `true` if this is an already-exists error.
     #[must_use]
     pub const fn is_already_exists(&self) -> bool {
         matches!(self, Self::AlreadyExists(_))
+    }
+
+    /// Returns `true` if this is an `InvalidQuery` error.
+    #[must_use]
+    pub const fn is_invalid_query(&self) -> bool {
+        matches!(self, Self::InvalidQuery(_))
     }
 
     /// Returns `true` if this is a validation error.
@@ -86,64 +212,8 @@ impl TypesRegistryError {
     pub const fn is_validation_failed(&self) -> bool {
         matches!(self, Self::ValidationFailed(_))
     }
-
-    /// Returns `true` if this is an invalid GTS ID error.
-    #[must_use]
-    pub const fn is_invalid_gts_id(&self) -> bool {
-        matches!(self, Self::InvalidGtsId(_))
-    }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_error_constructors() {
-        let err = TypesRegistryError::invalid_gts_id("missing vendor");
-        assert!(err.is_invalid_gts_id());
-        assert!(err.to_string().contains("missing vendor"));
-
-        let err = TypesRegistryError::not_found("gts.acme.core.events.test.v1~");
-        assert!(err.is_not_found());
-
-        let err = TypesRegistryError::already_exists("gts.acme.core.events.test.v1~");
-        assert!(err.is_already_exists());
-
-        let err = TypesRegistryError::validation_failed("schema invalid");
-        assert!(err.is_validation_failed());
-
-        let err = TypesRegistryError::not_in_ready_mode();
-        assert!(matches!(err, TypesRegistryError::NotInReadyMode));
-
-        let err = TypesRegistryError::internal("database error");
-        assert!(matches!(err, TypesRegistryError::Internal(_)));
-    }
-
-    #[test]
-    fn test_error_display() {
-        let err = TypesRegistryError::InvalidGtsId("bad format".to_owned());
-        assert_eq!(err.to_string(), "Invalid GTS ID: bad format");
-
-        let err = TypesRegistryError::NotFound("gts.x.core.events.test.v1~".to_owned());
-        assert_eq!(
-            err.to_string(),
-            "Entity not found: gts.x.core.events.test.v1~"
-        );
-
-        let err = TypesRegistryError::AlreadyExists("gts.x.core.events.test.v1~".to_owned());
-        assert_eq!(
-            err.to_string(),
-            "Entity already exists: gts.x.core.events.test.v1~"
-        );
-
-        let err = TypesRegistryError::ValidationFailed("missing required field".to_owned());
-        assert_eq!(err.to_string(), "Validation failed: missing required field");
-
-        let err = TypesRegistryError::NotInReadyMode;
-        assert_eq!(err.to_string(), "Not in ready mode");
-
-        let err = TypesRegistryError::Internal("unexpected".to_owned());
-        assert_eq!(err.to_string(), "Internal error: unexpected");
-    }
-}
+#[path = "error_tests.rs"]
+mod tests;

--- a/modules/system/types-registry/types-registry-sdk/src/error_tests.rs
+++ b/modules/system/types-registry/types-registry-sdk/src/error_tests.rs
@@ -1,0 +1,106 @@
+//! Unit tests for [`TypesRegistryError`](super::TypesRegistryError).
+//!
+//! Kept in a sibling `_tests.rs` file per the `de1101_tests_in_separate_files`
+//! repo lint. Linked into `error.rs` via `#[path = "error_tests.rs"] mod tests;`,
+//! so the module sees `error.rs` as `super`.
+
+use std::time::Duration;
+
+use super::TypesRegistryError;
+
+#[test]
+fn test_invalid_query_constructor() {
+    let err = TypesRegistryError::invalid_query("bad pattern: too many wildcards");
+    assert!(err.is_invalid_query());
+    assert!(err.to_string().contains("bad pattern"));
+}
+
+#[test]
+fn test_invalid_query_distinct_from_invalid_gts_ids() {
+    let err = TypesRegistryError::invalid_query("foo");
+    assert!(!err.is_invalid_gts_type_id());
+    assert!(!err.is_invalid_gts_instance_id());
+}
+
+#[test]
+fn test_error_constructors() {
+    let err = TypesRegistryError::invalid_gts_type_id("missing vendor");
+    assert!(err.is_invalid_gts_type_id());
+    assert!(err.to_string().contains("missing vendor"));
+
+    let err = TypesRegistryError::invalid_gts_instance_id("no chain prefix");
+    assert!(err.is_invalid_gts_instance_id());
+
+    let err = TypesRegistryError::gts_type_schema_not_found("gts.acme.core.events.test.v1~");
+    assert!(err.is_gts_type_schema_not_found());
+    assert!(err.is_not_found());
+
+    let err = TypesRegistryError::gts_instance_not_found(
+        "gts.acme.core.events.test.v1~acme.core.instances.u1.v1",
+    );
+    assert!(err.is_gts_instance_not_found());
+    assert!(err.is_not_found());
+
+    let err = TypesRegistryError::parent_type_schema_not_registered(
+        "gts.acme.core.events.base.v1~",
+        "gts.acme.core.events.base.v1~acme.core.events.derived.v1.0~",
+    );
+    assert!(err.is_parent_type_schema_not_registered());
+
+    let err = TypesRegistryError::already_exists("gts.acme.core.events.test.v1~");
+    assert!(err.is_already_exists());
+
+    let err = TypesRegistryError::validation_failed("schema invalid");
+    assert!(err.is_validation_failed());
+
+    let err =
+        TypesRegistryError::service_unavailable("registry is initializing", Duration::from_secs(1));
+    assert!(err.is_service_unavailable());
+
+    let err = TypesRegistryError::internal("database error");
+    assert!(matches!(err, TypesRegistryError::Internal(_)));
+}
+
+#[test]
+fn test_error_display() {
+    let err = TypesRegistryError::InvalidGtsTypeId("bad format".to_owned());
+    assert_eq!(err.to_string(), "Invalid GTS type-schema id: bad format");
+
+    let err = TypesRegistryError::InvalidGtsInstanceId("bad format".to_owned());
+    assert_eq!(err.to_string(), "Invalid GTS instance id: bad format");
+
+    let err = TypesRegistryError::GtsTypeSchemaNotFound("gts.x.core.events.test.v1~".to_owned());
+    assert_eq!(
+        err.to_string(),
+        "GTS type-schema not found: gts.x.core.events.test.v1~"
+    );
+
+    let err = TypesRegistryError::GtsInstanceNotFound(
+        "gts.x.core.events.test.v1~x.core.instances.u1.v1".to_owned(),
+    );
+    assert_eq!(
+        err.to_string(),
+        "GTS instance not found: gts.x.core.events.test.v1~x.core.instances.u1.v1"
+    );
+
+    let err = TypesRegistryError::AlreadyExists("gts.x.core.events.test.v1~".to_owned());
+    assert_eq!(
+        err.to_string(),
+        "Entity already exists: gts.x.core.events.test.v1~"
+    );
+
+    let err = TypesRegistryError::ValidationFailed("missing required field".to_owned());
+    assert_eq!(err.to_string(), "Validation failed: missing required field");
+
+    let err = TypesRegistryError::ServiceUnavailable {
+        message: "registry is initializing".to_owned(),
+        retry_after: Duration::from_secs(2),
+    };
+    assert_eq!(
+        err.to_string(),
+        "Service unavailable: registry is initializing (retry after 2s)"
+    );
+
+    let err = TypesRegistryError::Internal("unexpected".to_owned());
+    assert_eq!(err.to_string(), "Internal error: unexpected");
+}

--- a/modules/system/types-registry/types-registry-sdk/src/lib.rs
+++ b/modules/system/types-registry/types-registry-sdk/src/lib.rs
@@ -1,29 +1,24 @@
 //! Types Registry SDK
 //!
 //! This crate provides the public API for the `types-registry` module:
-//! - `TypesRegistryApi` trait for inter-module communication
-//! - `GtsEntity` model representing registered GTS entities
-//! - `ListQuery` for filtering entity listings
+//! - `TypesRegistryClient` trait for inter-module communication
+//! - `GtsTypeSchema` / `GtsInstance` typed entity models
+//! - `TypeSchemaQuery` / `InstanceQuery` for filtering
+//! - `GtsTypeId` / `GtsInstanceId` typed identifiers
 //! - `TypesRegistryError` for error handling
 //!
 //! ## Usage
 //!
 //! Consumers obtain the client from `ClientHub`:
 //! ```ignore
-//! use types_registry_sdk::TypesRegistryApi;
+//! use types_registry_sdk::{TypeSchemaQuery, TypesRegistryClient};
 //!
-//! // Get the client from ClientHub
-//! let client = hub.get::<dyn TypesRegistryApi>()?;
+//! let client = hub.get::<dyn TypesRegistryClient>()?;
 //!
-//! // Register entities
-//! let entities = client.register(&ctx, json_values).await?;
-//!
-//! // List entities with filtering
-//! let query = ListQuery::default().with_vendor("acme");
-//! let entities = client.list(&ctx, query).await?;
-//!
-//! // Get a single entity
-//! let entity = client.get(&ctx, "gts.acme.core.events.user_created.v1~").await?;
+//! let schema = client.get_type_schema("gts.acme.core.events.user.v1~").await?;
+//! let schemas = client
+//!     .list_type_schemas(TypeSchemaQuery::default().with_pattern("gts.acme.*"))
+//!     .await?;
 //! ```
 
 #![forbid(unsafe_code)]
@@ -33,10 +28,16 @@ pub mod api;
 pub mod error;
 pub mod models;
 
-// Re-export main types at crate root for convenience
+#[cfg(feature = "test-util")]
+pub mod testing;
+
 pub use api::TypesRegistryClient;
 pub use error::TypesRegistryError;
 pub use models::{
-    DynGtsEntity, DynRegisterResult, GtsEntity, GtsInstanceEntity, GtsTypeEntity, InstanceObject,
-    ListQuery, RegisterResult, RegisterSummary, SegmentMatchScope, TypeSchema,
+    GtsInstance, GtsTypeId, GtsTypeSchema, InstanceQuery, RegisterResult, RegisterSummary,
+    TypeSchemaQuery, is_type_schema_id,
 };
+
+// Re-export the underlying gts identifier types so consumers don't need a
+// direct dependency on `gts` for typed IDs.
+pub use gts::GtsInstanceId;

--- a/modules/system/types-registry/types-registry-sdk/src/models.rs
+++ b/modules/system/types-registry/types-registry-sdk/src/models.rs
@@ -3,304 +3,600 @@
 //! These are transport-agnostic data structures that define the contract
 //! between the `types-registry` module and its consumers.
 
-use gts::GtsIdSegment;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use gts::{GtsID, GtsIdSegment, GtsInstanceId, GtsSchemaId};
+use serde_json::{Map, Value};
 use uuid::Uuid;
 
-/// A registered GTS entity.
-///
-/// This represents either a type definition or an instance that has been
-/// registered in the Types Registry.
-///
-/// # Type Parameter
-///
-/// - `C`: The content type. Use `serde_json::Value` for dynamic content,
-///   or a concrete struct for type-safe access.
-///
-/// # Example
-///
-/// ```ignore
-/// // Dynamic entity (default)
-/// let entity: GtsEntity = registry.get(&ctx, "gts.acme.core.events.user_created.v1~").await?;
-///
-/// // Type-safe entity
-/// let entity: GtsEntity<MySchema> = registry.get(&ctx, gts_id).await?;
-/// ```
-#[derive(Debug, Clone, PartialEq)]
-pub struct GtsEntity<C = serde_json::Value> {
-    /// Deterministic UUID generated from the GTS ID.
-    ///
-    /// This UUID is generated using UUID v5 with a GTS-specific namespace.
-    /// The namespace is derived as `Uuid::new_v5(&Uuid::NAMESPACE_URL, b"gts")`,
-    /// which is a GTS specification-defined constant ensuring consistent
-    /// UUID generation across all implementations.
-    pub id: Uuid,
+use crate::error::TypesRegistryError;
 
-    /// The full GTS identifier string.
-    ///
-    /// For types: `gts.vendor.package.namespace.name.version~`
-    /// For instances: `gts.vendor.package.namespace.name.version~instance.id`
-    pub gts_id: String,
+/// SDK-facing alias for a GTS type-schema identifier.
+///
+/// Backed by [`gts::GtsSchemaId`] from the `gts` crate. Exposed under the
+/// `GtsTypeId` name to keep the SDK's vocabulary consistent — within the
+/// types-registry SDK, schemas are *type-schemas* and their identifiers are
+/// *type ids*.
+pub type GtsTypeId = GtsSchemaId;
+
+/// Returns `true` if `s` is shaped like a type-schema GTS id (ends with `~`).
+///
+/// Type-schema ids and instance ids are lexically distinct in GTS: type-schema
+/// ids end with `~`, instance ids do not. Centralizing the predicate here so
+/// that callers don't sprinkle raw `ends_with('~')` checks across kind-aware
+/// code (`local_client`, mocks, etc.). Pure string predicate — does not parse
+/// or otherwise validate the id.
+///
+// TODO(#1752): drop this helper once `GtsSchemaId::try_new` /
+// `GtsInstanceId::try_new` land upstream in `gts-rust`. Callers should
+// consume `&GtsTypeId` / `&GtsInstanceId` directly and the kind invariant
+// becomes a type-system property instead of a runtime predicate.
+#[must_use]
+pub fn is_type_schema_id(s: &str) -> bool {
+    s.ends_with('~')
+}
+
+/// A registered GTS type-schema (type definition).
+///
+/// In addition to the common fields, the schema-specific extensions
+/// `x-gts-traits-schema` and `x-gts-traits` are extracted into top-level
+/// fields, and the GTS chain parent is pre-resolved into [`Self::parent`]
+/// (Arc-shared, deduplicated by the registry's local-client cache).
+///
+/// Use [`Self::effective_schema`], [`Self::effective_properties`],
+/// [`Self::effective_required`], [`Self::effective_traits`] to inspect the schema
+/// across the inheritance chain without manual walking.
+///
+/// `x-gts-final` / `x-gts-abstract` modifiers are intentionally not surfaced
+/// here yet — support will be added later.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GtsTypeSchema {
+    /// Deterministic UUID v5 derived from the type id.
+    pub type_uuid: Uuid,
+
+    /// The full GTS type identifier. Always ends with `~`.
+    pub type_id: GtsTypeId,
 
     /// All parsed segments from the GTS ID.
-    ///
-    /// For simple IDs, this contains one segment.
-    /// For chained IDs (instances), this contains multiple segments.
     pub segments: Vec<GtsIdSegment>,
 
-    /// Whether this entity is a schema (type definition).
+    /// This type-schema's own raw JSON Schema body.
     ///
-    /// - `true`: This is a type definition (GTS ID ends with `~`)
-    /// - `false`: This is an instance (GTS ID does not end with `~`)
-    pub is_schema: bool,
+    /// `allOf[].$ref` references are kept verbatim — use [`Self::effective_schema`]
+    /// to obtain a representation with the parent inlined.
+    pub raw_schema: Value,
 
-    /// The entity content (schema for types, object for instances).
-    pub content: C,
+    /// This type-schema's own `x-gts-traits` values, if present.
+    pub traits: Option<Value>,
+
+    /// This type-schema's own `x-gts-traits-schema`, if present.
+    pub traits_schema: Option<Value>,
+
+    /// Resolved parent type-schema in the inheritance chain.
+    ///
+    /// `None` for root type-schemas (no parent in the chain) or when the parent
+    /// hasn't been resolved by the producer.
+    pub parent: Option<Arc<GtsTypeSchema>>,
+
+    /// Optional human-readable title (`title` field of the JSON Schema).
+    pub title: Option<String>,
+
+    /// Optional human-readable description.
+    pub description: Option<String>,
+}
+
+impl GtsTypeSchema {
+    /// Constructs a `GtsTypeSchema` from its canonical inputs.
+    ///
+    /// `type_uuid` and `segments` are derived from `type_id` via gts-rust's
+    /// canonical parser — there is only one source of truth (the id string).
+    /// `traits` / `traits_schema` / `title` are extracted from `raw_schema`.
+    /// `parent` is pre-resolved by the caller (typically the local client
+    /// via its type-schema cache); presence/absence of `parent` is enforced
+    /// against the chain shape of `type_id` — a derived id MUST carry its
+    /// parent, a root id MUST NOT — so that
+    /// [`ancestors`](Self::ancestors) / [`effective_schema`](Self::effective_schema)
+    /// always observe a complete chain. A mismatched parent (chain-prefix
+    /// disagreement) is also rejected.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidGtsTypeId`](TypesRegistryError::InvalidGtsTypeId)
+    /// in any of these cases:
+    /// - `type_id` does not end with `~` (looks like an instance id);
+    /// - `type_id` does not parse as a valid GTS identifier;
+    /// - `parent` is `Some(_)` but its `type_id` does not match the chain
+    ///   prefix derived from this `type_id`;
+    /// - `parent` is `Some(_)` but this `type_id` is a root (no chain prefix
+    ///   exists, so the schema cannot have a parent);
+    /// - `parent` is `None` but this `type_id` is derived (its chain prefix
+    ///   is non-empty, so the schema requires its parent to be passed in).
+    pub fn try_new(
+        type_id: GtsTypeId,
+        raw_schema: Value,
+        description: Option<String>,
+        parent: Option<Arc<GtsTypeSchema>>,
+    ) -> Result<Self, TypesRegistryError> {
+        if !is_type_schema_id(type_id.as_ref()) {
+            return Err(TypesRegistryError::invalid_gts_type_id(format!(
+                "{type_id} does not end with `~`",
+            )));
+        }
+        match (
+            parent.as_ref(),
+            Self::derive_parent_type_id(type_id.as_ref()),
+        ) {
+            (Some(parent_schema), Some(expected)) if expected != parent_schema.type_id => {
+                return Err(TypesRegistryError::invalid_gts_type_id(format!(
+                    "type-schema {type_id} expects parent {expected}, got {}",
+                    parent_schema.type_id,
+                )));
+            }
+            (Some(_), None) => {
+                return Err(TypesRegistryError::invalid_gts_type_id(format!(
+                    "root type-schema {type_id} cannot have a parent",
+                )));
+            }
+            (None, Some(expected)) => {
+                return Err(TypesRegistryError::invalid_gts_type_id(format!(
+                    "derived type-schema {type_id} requires parent {expected}, got None",
+                )));
+            }
+            // (Some, Some) where prefixes match  →  ok
+            // (None, None) — root with no parent  →  ok
+            _ => {}
+        }
+        let parsed = GtsID::new(type_id.as_ref())
+            .map_err(|e| TypesRegistryError::invalid_gts_type_id(format!("{e}")))?;
+        let type_uuid = parsed.to_uuid();
+        let segments = parsed.gts_id_segments;
+        let traits = Self::extract_traits(&raw_schema);
+        let traits_schema = Self::extract_traits_schema(&raw_schema);
+        let title = Self::extract_title(&raw_schema);
+        Ok(Self {
+            type_uuid,
+            type_id,
+            segments,
+            raw_schema,
+            traits,
+            traits_schema,
+            parent,
+            title,
+            description,
+        })
+    }
+
+    /// Derives the GTS parent's `type_id` by stripping the last `~`-segment.
+    ///
+    /// Mirrors gts-rust's chain semantics: for a chained type id like
+    /// `gts.x.core.events.type.v1~x.commerce.orders.order.v1.0~`, the parent
+    /// is `gts.x.core.events.type.v1~`. Returns `None` for root (single-segment)
+    /// type-schemas or for ids that don't end with `~`.
+    #[must_use]
+    pub fn derive_parent_type_id(type_id: &str) -> Option<GtsTypeId> {
+        let trimmed = type_id.strip_suffix('~')?;
+        let last_tilde = trimmed.rfind('~')?;
+        Some(GtsTypeId::new(&type_id[..=last_tilde]))
+    }
+
+    /// Reads `x-gts-traits` from the top level of a schema value.
+    #[must_use]
+    pub fn extract_traits(schema: &Value) -> Option<Value> {
+        schema.get("x-gts-traits").cloned()
+    }
+
+    /// Reads `x-gts-traits-schema` from the top level of a schema value.
+    #[must_use]
+    pub fn extract_traits_schema(schema: &Value) -> Option<Value> {
+        schema.get("x-gts-traits-schema").cloned()
+    }
+
+    /// Collects parent GTS IDs from `allOf[].$ref` (with `gts://` prefix stripped).
+    #[must_use]
+    pub fn extract_allof_refs(schema: &Value) -> Vec<String> {
+        let Some(arr) = schema.get("allOf").and_then(|v| v.as_array()) else {
+            return Vec::new();
+        };
+        arr.iter()
+            .filter_map(|item| item.get("$ref").and_then(|r| r.as_str()))
+            .map(|r| r.strip_prefix("gts://").unwrap_or(r).to_owned())
+            .collect()
+    }
+
+    /// Reads the optional `title` field.
+    #[must_use]
+    pub fn extract_title(schema: &Value) -> Option<String> {
+        schema
+            .get("title")
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned)
+    }
+
+    /// Returns the primary segment (first segment in the chain).
+    #[must_use]
+    pub fn primary_segment(&self) -> Option<&GtsIdSegment> {
+        self.segments.first()
+    }
+
+    /// Returns the vendor from the primary segment.
+    #[must_use]
+    pub fn vendor(&self) -> Option<&str> {
+        self.primary_segment().map(|s| s.vendor.as_str())
+    }
+
+    /// Iteration over the inheritance chain (this schema first, then parent,
+    /// then grandparent, ...). Linear walk via [`Self::parent`].
+    #[must_use]
+    pub fn ancestors(&self) -> AncestorIter<'_> {
+        AncestorIter {
+            current: Some(self),
+        }
+    }
+
+    /// Returns this schema's body with the GTS parent's `$ref` inlined where
+    /// it appears in `allOf` (parent body expanded in place). The shape of
+    /// the JSON Schema is preserved — `allOf`, `oneOf`, `anyOf`, `enum`, etc.
+    /// stay valid.
+    ///
+    /// Non-parent `allOf[].$ref` items (mixin references) are left as-is.
+    #[must_use]
+    pub fn effective_schema(&self) -> Value {
+        merge_schema_with_parent(&self.raw_schema, self.parent.as_deref())
+    }
+
+    /// Properties merged across the full chain. This schema wins on key
+    /// collisions; parent fills in inherited keys.
+    #[must_use]
+    pub fn effective_properties(&self) -> BTreeMap<String, Value> {
+        let mut out = self
+            .parent
+            .as_ref()
+            .map_or_else(BTreeMap::new, |p| p.effective_properties());
+        for (k, v) in collect_own_properties(&self.raw_schema) {
+            out.insert(k, v);
+        }
+        out
+    }
+
+    /// `required` field merged across the full chain (de-duplicated, order
+    /// preserved by first occurrence in pre-order walk).
+    #[must_use]
+    pub fn effective_required(&self) -> Vec<String> {
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for ancestor in self.ancestors() {
+            for r in collect_own_required(&ancestor.raw_schema) {
+                if seen.insert(r.clone()) {
+                    out.push(r);
+                }
+            }
+        }
+        out
+    }
+
+    /// Trait values merged across the chain.
+    ///
+    /// Resolution order (priority high → low):
+    /// 1. Declared `x-gts-traits` values from `self` and ancestors —
+    ///    rightmost wins, so a leaf's value overrides any parent's.
+    /// 2. Defaults from `x-gts-traits-schema.properties[*].default`
+    ///    declared anywhere in the chain. When two levels both declare a
+    ///    default for the same property, the **deepest** (closest to base)
+    ///    wins — mirroring gts-rust's locking rule that descendants cannot
+    ///    redefine an ancestor's default during schema-trait validation.
+    ///
+    /// Returns `Value::Null` only when neither declared traits nor
+    /// schema-declared defaults exist anywhere in the chain.
+    // TODO(#1723): replace with gts-rust's resolve_schema(...).effective_traits
+    // once that helper is exposed publicly.
+    #[must_use]
+    pub fn effective_traits(&self) -> Value {
+        let mut acc: Map<String, Value> = Map::new();
+        // Phase 1: declared traits. Walk own → ancestors and only insert
+        // when the key is absent so own (rightmost) wins over ancestors.
+        for s in self.ancestors() {
+            if let Some(Value::Object(traits)) = s.traits.as_ref() {
+                for (k, v) in traits {
+                    acc.entry(k.clone()).or_insert_with(|| v.clone());
+                }
+            }
+        }
+        // Phase 2: defaults from x-gts-traits-schema. Walk from deepest
+        // base to leaf so the **earliest** default wins on a given key,
+        // matching the locking semantics gts-rust enforces during
+        // validation. `or_insert_with` on the already-populated map means
+        // declared values still beat defaults.
+        let chain: Vec<&GtsTypeSchema> = self.ancestors().collect();
+        for s in chain.iter().rev() {
+            let Some(traits_schema) = s.traits_schema.as_ref() else {
+                continue;
+            };
+            let Some(Value::Object(props)) = traits_schema.get("properties") else {
+                continue;
+            };
+            for (k, prop) in props {
+                if let Some(default) = prop.get("default") {
+                    acc.entry(k.clone()).or_insert_with(|| default.clone());
+                }
+            }
+        }
+        if acc.is_empty() {
+            Value::Null
+        } else {
+            Value::Object(acc)
+        }
+    }
+
+    /// All `x-gts-traits-schema` blocks collected across the chain, ordered
+    /// from deepest base to this schema. Use to compose the effective trait
+    /// schema (e.g. via `allOf`) when validating trait values.
+    #[must_use]
+    pub fn effective_traits_schema(&self) -> Vec<Value> {
+        // Pre-order is self → ancestors; reverse to get deepest-base-first.
+        let mut out: Vec<Value> = self
+            .ancestors()
+            .filter_map(|s| s.traits_schema.clone())
+            .collect();
+        out.reverse();
+        out
+    }
+}
+
+/// Iterator over a type-schema's inheritance chain (self first, then each
+/// ancestor by following [`GtsTypeSchema::parent`]).
+pub struct AncestorIter<'a> {
+    current: Option<&'a GtsTypeSchema>,
+}
+
+impl<'a> Iterator for AncestorIter<'a> {
+    type Item = &'a GtsTypeSchema;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let curr = self.current.take()?;
+        self.current = curr.parent.as_deref();
+        Some(curr)
+    }
+}
+
+fn collect_own_properties(schema: &Value) -> BTreeMap<String, Value> {
+    let mut out = BTreeMap::new();
+    // Top-level properties.
+    if let Some(props) = schema.get("properties").and_then(|v| v.as_object()) {
+        for (k, v) in props {
+            out.insert(k.clone(), v.clone());
+        }
+    }
+    // Properties declared inside allOf branches that are NOT pure $refs
+    // (the parent's body comes from `self.parent`). Inline overlays count as "own".
+    if let Some(arr) = schema.get("allOf").and_then(|v| v.as_array()) {
+        for item in arr {
+            // Skip pure-$ref entries (resolved via `parent`).
+            let is_pure_ref = item
+                .as_object()
+                .is_some_and(|m| m.len() == 1 && m.contains_key("$ref"));
+            if is_pure_ref {
+                continue;
+            }
+            if let Some(props) = item.get("properties").and_then(|v| v.as_object()) {
+                for (k, v) in props {
+                    out.insert(k.clone(), v.clone());
+                }
+            }
+        }
+    }
+    out
+}
+
+fn collect_own_required(schema: &Value) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Some(req) = schema.get("required").and_then(|v| v.as_array()) {
+        for r in req {
+            if let Some(s) = r.as_str() {
+                out.push(s.to_owned());
+            }
+        }
+    }
+    if let Some(arr) = schema.get("allOf").and_then(|v| v.as_array()) {
+        for item in arr {
+            let is_pure_ref = item
+                .as_object()
+                .is_some_and(|m| m.len() == 1 && m.contains_key("$ref"));
+            if is_pure_ref {
+                continue;
+            }
+            if let Some(req) = item.get("required").and_then(|v| v.as_array()) {
+                for r in req {
+                    if let Some(s) = r.as_str() {
+                        out.push(s.to_owned());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Returns `schema` with the entry `allOf[i] = {$ref: gts://parent.type_id}`
+/// replaced by the merged body of the GTS parent. Other `allOf` entries
+/// (non-ref overlays, mixin `$ref`s pointing elsewhere) are left as-is.
+/// `$id` and `$schema` are stripped from the inlined parent to keep the
+/// merged document a valid composite schema.
+fn merge_schema_with_parent(schema: &Value, parent: Option<&GtsTypeSchema>) -> Value {
+    let Value::Object(map) = schema else {
+        return schema.clone();
+    };
+    let Some(parent) = parent else {
+        return Value::Object(map.clone());
+    };
+    let mut out = map.clone();
+
+    if let Some(Value::Array(items)) = out.get_mut("allOf").cloned().as_ref() {
+        let mut new_items = Vec::with_capacity(items.len());
+        for item in items {
+            let resolved = if let Some(obj) = item.as_object()
+                && obj.len() == 1
+                && let Some(ref_uri) = obj.get("$ref").and_then(|r| r.as_str())
+                && {
+                    let target = ref_uri.strip_prefix("gts://").unwrap_or(ref_uri);
+                    parent.type_id == target
+                } {
+                let mut merged = parent.effective_schema();
+                if let Value::Object(ref mut m) = merged {
+                    m.remove("$id");
+                    m.remove("$schema");
+                }
+                merged
+            } else {
+                item.clone()
+            };
+            new_items.push(resolved);
+        }
+        out.insert("allOf".to_owned(), Value::Array(new_items));
+    }
+
+    Value::Object(out)
+}
+
+/// A registered GTS instance.
+///
+/// The instance carries an `Arc`-shared reference to its [`GtsTypeSchema`],
+/// pre-resolved by the registry's local client (with full ancestor chain
+/// already linked). Inspect via `instance.type_schema.effective_*` directly.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GtsInstance {
+    /// Deterministic UUID v5 derived from the GTS ID.
+    pub uuid: Uuid,
+
+    /// The full GTS instance identifier. Never ends with `~`.
+    pub id: GtsInstanceId,
+
+    /// All parsed segments from the GTS ID.
+    pub segments: Vec<GtsIdSegment>,
+
+    /// The full instance object (raw `Value`).
+    pub object: Value,
+
+    /// Resolved type-schema this instance conforms to (Arc-shared with the
+    /// registry's cache).
+    pub type_schema: Arc<GtsTypeSchema>,
 
     /// Optional description of the entity.
     pub description: Option<String>,
 }
 
-/// Type alias for dynamic GTS entities using `serde_json::Value` as content.
-pub type DynGtsEntity = GtsEntity<serde_json::Value>;
+impl GtsInstance {
+    /// Constructs a `GtsInstance` from its canonical inputs plus a
+    /// pre-resolved type-schema reference.
+    ///
+    /// `uuid` and `segments` are derived from `id` via gts-rust's canonical
+    /// parser — there is only one source of truth (the id string). `id` must
+    /// NOT end with `~` and must contain at least one `~`. The passed
+    /// `type_schema.type_id` is verified to match the chain prefix derived
+    /// from `id` (everything up to and including the last `~`) so a
+    /// mismatched type-schema can't silently mislabel the instance.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InvalidGtsInstanceId`](TypesRegistryError::InvalidGtsInstanceId)
+    /// in any of these cases:
+    /// - `id` ends with `~` (looks like a type-schema id);
+    /// - `id` contains no `~` at all (no type-schema chain prefix);
+    /// - `id` does not parse as a valid GTS identifier;
+    /// - `type_schema.type_id` does not match the chain prefix derived from `id`.
+    pub fn try_new(
+        id: GtsInstanceId,
+        object: Value,
+        description: Option<String>,
+        type_schema: Arc<GtsTypeSchema>,
+    ) -> Result<Self, TypesRegistryError> {
+        if is_type_schema_id(id.as_ref()) {
+            return Err(TypesRegistryError::invalid_gts_instance_id(format!(
+                "{id} ends with `~` (looks like a type-schema id)",
+            )));
+        }
+        let derived = Self::derive_type_id(id.as_ref()).ok_or_else(|| {
+            TypesRegistryError::invalid_gts_instance_id(format!(
+                "instance id {id} has no type-schema chain (no `~`)"
+            ))
+        })?;
+        if derived != type_schema.type_id {
+            return Err(TypesRegistryError::invalid_gts_instance_id(format!(
+                "instance id {id} chain prefix {derived} does not match type-schema {0}",
+                type_schema.type_id
+            )));
+        }
+        let parsed = GtsID::new(id.as_ref())
+            .map_err(|e| TypesRegistryError::invalid_gts_instance_id(format!("{e}")))?;
+        let uuid = parsed.to_uuid();
+        let segments = parsed.gts_id_segments;
+        Ok(Self {
+            uuid,
+            id,
+            segments,
+            object,
+            type_schema,
+            description,
+        })
+    }
 
-/// Wrapper for JSON Schema content in type definitions.
-///
-/// This newtype provides semantic clarity when working with GTS type entities,
-/// indicating that the content represents a JSON Schema definition.
-///
-/// # Examples
-///
-/// ## Creating a schema
-///
-/// ```
-/// use types_registry_sdk::TypeSchema;
-///
-/// // Direct construction
-/// let schema = TypeSchema::new(serde_json::json!({
-///     "type": "object",
-///     "properties": {
-///         "name": { "type": "string" },
-///         "age": { "type": "integer" }
-///     },
-///     "required": ["name"]
-/// }));
-///
-/// // From conversion
-/// let schema: TypeSchema = serde_json::json!({"type": "string"}).into();
-/// ```
-///
-/// ## Accessing the inner value
-///
-/// ```
-/// use types_registry_sdk::TypeSchema;
-///
-/// let schema = TypeSchema::new(serde_json::json!({"type": "object"}));
-///
-/// // Via Deref (most idiomatic)
-/// assert!(schema.is_object());
-///
-/// // Via AsRef
-/// let value: &serde_json::Value = schema.as_ref();
-///
-/// // Consuming
-/// let value: serde_json::Value = schema.into_inner();
-/// ```
-#[derive(Debug, Clone, PartialEq, Default)]
-pub struct TypeSchema(pub serde_json::Value);
-
-impl TypeSchema {
-    /// Creates a new `TypeSchema` from a JSON value.
+    /// `type_id` of the type-schema this instance conforms to. Always ends with `~`.
     #[must_use]
-    pub fn new(value: serde_json::Value) -> Self {
-        Self(value)
+    pub fn type_id(&self) -> &GtsTypeId {
+        &self.type_schema.type_id
     }
 
-    /// Consumes self and returns the inner JSON value.
+    /// Derives the type-schema (parent type) GTS ID from an instance `id`.
+    ///
+    /// Returns everything up to and including the last `~`. `None` when the
+    /// `id` contains no `~`.
     #[must_use]
-    pub fn into_inner(self) -> serde_json::Value {
-        self.0
+    pub fn derive_type_id(id: &str) -> Option<GtsTypeId> {
+        id.rfind('~').map(|i| GtsTypeId::new(&id[..=i]))
     }
-}
 
-impl std::ops::Deref for TypeSchema {
-    type Target = serde_json::Value;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl AsRef<serde_json::Value> for TypeSchema {
-    fn as_ref(&self) -> &serde_json::Value {
-        &self.0
-    }
-}
-
-impl From<serde_json::Value> for TypeSchema {
-    fn from(value: serde_json::Value) -> Self {
-        Self(value)
-    }
-}
-
-impl From<TypeSchema> for serde_json::Value {
-    fn from(schema: TypeSchema) -> Self {
-        schema.0
-    }
-}
-
-/// Wrapper for instance object content.
-///
-/// This newtype provides semantic clarity when working with GTS instance entities,
-/// indicating that the content represents an instance object (data conforming to a schema).
-///
-/// # Examples
-///
-/// ## Creating an instance
-///
-/// ```
-/// use types_registry_sdk::InstanceObject;
-///
-/// // Direct construction
-/// let instance = InstanceObject::new(serde_json::json!({
-///     "name": "John Doe",
-///     "email": "john@example.com",
-///     "age": 30
-/// }));
-///
-/// // From conversion
-/// let instance: InstanceObject = serde_json::json!({"id": 123}).into();
-/// ```
-///
-/// ## Accessing the inner value
-///
-/// ```
-/// use types_registry_sdk::InstanceObject;
-///
-/// let instance = InstanceObject::new(serde_json::json!({"name": "Alice"}));
-///
-/// // Via Deref (most idiomatic) - access serde_json::Value methods directly
-/// assert!(instance.is_object());
-/// assert_eq!(instance["name"], "Alice");
-///
-/// // Via AsRef
-/// let value: &serde_json::Value = instance.as_ref();
-///
-/// // Consuming
-/// let value: serde_json::Value = instance.into_inner();
-/// ```
-#[derive(Debug, Clone, PartialEq, Default)]
-pub struct InstanceObject(pub serde_json::Value);
-
-impl InstanceObject {
-    /// Creates a new `InstanceObject` from a JSON value.
+    /// Returns the primary segment (first segment in the chain).
     #[must_use]
-    pub fn new(value: serde_json::Value) -> Self {
-        Self(value)
+    pub fn primary_segment(&self) -> Option<&GtsIdSegment> {
+        self.segments.first()
     }
 
-    /// Consumes self and returns the inner JSON value.
+    /// Returns the vendor from the primary segment.
     #[must_use]
-    pub fn into_inner(self) -> serde_json::Value {
-        self.0
+    pub fn vendor(&self) -> Option<&str> {
+        self.primary_segment().map(|s| s.vendor.as_str())
     }
 }
-
-impl std::ops::Deref for InstanceObject {
-    type Target = serde_json::Value;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl AsRef<serde_json::Value> for InstanceObject {
-    fn as_ref(&self) -> &serde_json::Value {
-        &self.0
-    }
-}
-
-impl From<serde_json::Value> for InstanceObject {
-    fn from(value: serde_json::Value) -> Self {
-        Self(value)
-    }
-}
-
-impl From<InstanceObject> for serde_json::Value {
-    fn from(instance: InstanceObject) -> Self {
-        instance.0
-    }
-}
-
-/// Type alias for GTS type definition entities.
-///
-/// Use this when you specifically expect a type definition (GTS ID ends with `~`).
-/// The content is a [`TypeSchema`] representing the JSON Schema.
-///
-/// # Example
-///
-/// ```ignore
-/// // Retrieve a type definition
-/// let type_entity: GtsTypeEntity = registry.get_type(&ctx, "gts.acme.core.events.user.v1~").await?;
-///
-/// // Access the schema directly via Deref
-/// if type_entity.content.is_object() {
-///     println!("Schema: {}", type_entity.content);
-/// }
-/// ```
-pub type GtsTypeEntity = GtsEntity<TypeSchema>;
-
-/// Type alias for GTS instance entities.
-///
-/// Use this when you specifically expect an instance (GTS ID does not end with `~`).
-/// The content is an [`InstanceObject`] representing data conforming to a schema.
-///
-/// # Example
-///
-/// ```ignore
-/// // Retrieve an instance
-/// let instance: GtsInstanceEntity = registry.get_instance(&ctx, "gts.acme.core.events.user.v1~user123").await?;
-///
-/// // Access instance data directly via Deref
-/// let name = &instance.content["name"];
-/// ```
-pub type GtsInstanceEntity = GtsEntity<InstanceObject>;
 
 /// Result of registering a single GTS entity in a batch operation.
 ///
-/// This type provides per-item success/error reporting for batch registration,
-/// allowing partial success and detailed error information for each item.
-///
-/// # Example
-///
-/// ```ignore
-/// let results = registry.register(&ctx, entities).await?;
-/// for (index, result) in results.iter().enumerate() {
-///     match result {
-///         RegisterResult::Ok(entity) => println!("Registered: {}", entity.gts_id),
-///         RegisterResult::Err { gts_id, error } => {
-///             eprintln!("Failed to register {}: {}", gts_id.as_deref().unwrap_or("unknown"), error);
-///         }
-///     }
-/// }
-/// ```
+/// Successful registration carries only the canonical (server-normalized)
+/// GTS id of the persisted entity. Callers that need a typed view of the
+/// registered entity should follow up with [`TypesRegistryClient::get_type_schema`]
+/// / [`TypesRegistryClient::get_instance`] — keeping registration's
+/// responsibility narrow ("did it persist?") and reads' responsibility narrow
+/// ("give me the resolved typed value").
 #[derive(Debug, Clone)]
-pub enum RegisterResult<C = serde_json::Value> {
-    /// Successfully registered entity.
-    Ok(GtsEntity<C>),
-    /// Failed to register entity.
+pub enum RegisterResult {
+    /// Successfully registered.
+    Ok {
+        /// The canonical GTS id of the registered entity.
+        gts_id: String,
+    },
+    /// Failed to register.
     Err {
         /// The GTS ID that was attempted, if it could be extracted from the input.
         gts_id: Option<String>,
         /// The error that occurred during registration.
-        error: crate::TypesRegistryError,
+        error: TypesRegistryError,
     },
 }
 
-impl<C> RegisterResult<C> {
+impl RegisterResult {
     /// Returns `true` if the registration was successful.
     #[must_use]
     pub const fn is_ok(&self) -> bool {
-        matches!(self, Self::Ok(_))
+        matches!(self, Self::Ok { .. })
     }
 
     /// Returns `true` if the registration failed.
@@ -309,57 +605,56 @@ impl<C> RegisterResult<C> {
         matches!(self, Self::Err { .. })
     }
 
-    /// Converts to `Result<&GtsEntity<C>, &TypesRegistryError>`.
+    /// Converts to `Result<&str, &TypesRegistryError>` — the success arm
+    /// borrows the canonical `gts_id`.
     ///
     /// # Errors
     ///
     /// Returns `Err` with a reference to the error if this is a failed registration.
-    pub fn as_result(&self) -> Result<&GtsEntity<C>, &crate::TypesRegistryError> {
+    pub fn as_result(&self) -> Result<&str, &TypesRegistryError> {
         match self {
-            Self::Ok(entity) => Ok(entity),
+            Self::Ok { gts_id } => Ok(gts_id),
             Self::Err { error, .. } => Err(error),
         }
     }
 
-    /// Converts into `Result<GtsEntity<C>, TypesRegistryError>`.
+    /// Converts into `Result<String, TypesRegistryError>` — the success arm
+    /// owns the canonical `gts_id`.
     ///
     /// # Errors
     ///
     /// Returns `Err` with the error if this is a failed registration.
-    pub fn into_result(self) -> Result<GtsEntity<C>, crate::TypesRegistryError> {
+    pub fn into_result(self) -> Result<String, TypesRegistryError> {
         match self {
-            Self::Ok(entity) => Ok(entity),
+            Self::Ok { gts_id } => Ok(gts_id),
             Self::Err { error, .. } => Err(error),
         }
     }
 
-    /// Returns the entity if successful, `None` otherwise.
+    /// Returns the registered `gts_id` if successful, `None` otherwise.
     #[must_use]
-    pub fn ok(self) -> Option<GtsEntity<C>> {
+    pub fn ok(self) -> Option<String> {
         match self {
-            Self::Ok(entity) => Some(entity),
+            Self::Ok { gts_id } => Some(gts_id),
             Self::Err { .. } => None,
         }
     }
 
     /// Returns the error if failed, `None` otherwise.
     #[must_use]
-    pub fn err(self) -> Option<crate::TypesRegistryError> {
+    pub fn err(self) -> Option<TypesRegistryError> {
         match self {
-            Self::Ok(_) => None,
+            Self::Ok { .. } => None,
             Self::Err { error, .. } => Some(error),
         }
     }
 
     /// Returns `Ok(())` if all results are successful, or the first error.
     ///
-    /// Useful during module initialization to fail fast when GTS registration
-    /// encounters per-item errors.
-    ///
     /// # Errors
     ///
-    /// Returns the first `TypesRegistryError` found in the results.
-    pub fn ensure_all_ok(results: &[Self]) -> Result<(), crate::TypesRegistryError> {
+    /// Returns the first `TypesRegistryError` encountered in `results`.
+    pub fn ensure_all_ok(results: &[Self]) -> Result<(), TypesRegistryError> {
         for result in results {
             if let Self::Err { error, .. } = result {
                 return Err(error.clone());
@@ -369,12 +664,7 @@ impl<C> RegisterResult<C> {
     }
 }
 
-/// Type alias for dynamic register results using `serde_json::Value` as content.
-pub type DynRegisterResult = RegisterResult<serde_json::Value>;
-
 /// Summary of a batch registration operation.
-///
-/// Provides aggregate counts for quick success/failure assessment.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RegisterSummary {
     /// Number of successfully registered entities.
@@ -386,7 +676,7 @@ pub struct RegisterSummary {
 impl RegisterSummary {
     /// Creates a new summary from a slice of register results.
     #[must_use]
-    pub fn from_results<C>(results: &[RegisterResult<C>]) -> Self {
+    pub fn from_results(results: &[RegisterResult]) -> Self {
         let succeeded = results.iter().filter(|r| r.is_ok()).count();
         let failed = results.len() - succeeded;
         Self { succeeded, failed }
@@ -411,314 +701,56 @@ impl RegisterSummary {
     }
 }
 
-impl<C> GtsEntity<C> {
-    /// Creates a new `GtsEntity` with the given components.
-    #[must_use]
-    pub fn new(
-        id: Uuid,
-        gts_id: impl Into<String>,
-        segments: Vec<GtsIdSegment>,
-        is_schema: bool,
-        content: C,
-        description: Option<String>,
-    ) -> Self {
-        Self {
-            id,
-            gts_id: gts_id.into(),
-            segments,
-            is_schema,
-            content,
-            description,
-        }
-    }
-
-    /// Returns `true` if this entity is a type definition (schema).
-    #[must_use]
-    pub const fn is_type(&self) -> bool {
-        self.is_schema
-    }
-
-    /// Returns `true` if this entity is an instance.
-    #[must_use]
-    pub const fn is_instance(&self) -> bool {
-        !self.is_schema
-    }
-
-    /// Returns the primary segment (first segment in the chain).
-    #[must_use]
-    pub fn primary_segment(&self) -> Option<&GtsIdSegment> {
-        self.segments.first()
-    }
-
-    /// Returns the vendor from the primary segment.
-    #[must_use]
-    pub fn vendor(&self) -> Option<&str> {
-        self.primary_segment().map(|s| s.vendor.as_str())
-    }
-
-    /// Returns the package from the primary segment.
-    #[must_use]
-    pub fn package(&self) -> Option<&str> {
-        self.primary_segment().map(|s| s.package.as_str())
-    }
-
-    /// Returns the namespace from the primary segment.
-    #[must_use]
-    pub fn namespace(&self) -> Option<&str> {
-        self.primary_segment().map(|s| s.namespace.as_str())
-    }
-}
-
-/// Specifies which segments in a chained GTS ID the filters should match against.
-///
-/// GTS IDs can be chained (e.g., `gts.vendor.pkg.ns.type.v1~instance.id`),
-/// containing multiple segments. This enum controls whether filters like
-/// `vendor`, `package`, and `namespace` apply to just the primary (first)
-/// segment or to any segment in the chain.
-///
-/// # Example
-///
-/// For a chained GTS ID like `gts.acme.core.events.order.v1~acme.billing.invoices.line_item.v1`:
-/// - `Primary`: Only matches against `acme.core.events.order.v1`
-/// - `Any`: Matches against both segments
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum SegmentMatchScope {
-    /// Match filters against only the primary (first) GTS ID segment.
-    Primary,
-    /// Match filters against any segment in the GTS ID chain.
-    #[default]
-    Any,
-}
-
-impl SegmentMatchScope {
-    /// Returns `true` if this scope matches only the primary segment.
-    #[must_use]
-    pub const fn is_primary(self) -> bool {
-        matches!(self, Self::Primary)
-    }
-
-    /// Returns `true` if this scope matches any segment.
-    #[must_use]
-    pub const fn is_any(self) -> bool {
-        matches!(self, Self::Any)
-    }
-}
-
-/// Query parameters for listing GTS entities.
-///
-/// All fields are optional. When a field is `None`, no filtering
-/// is applied for that field.
-///
-/// # Segment Matching
-///
-/// The `segment_scope` field controls how `vendor`, `package`, and `namespace`
-/// filters are applied to chained GTS IDs. By default, filters match
-/// any segment in the chain.
-///
-/// # Example
-///
-/// ```
-/// use types_registry_sdk::{ListQuery, SegmentMatchScope};
-///
-/// // List all entities
-/// let query = ListQuery::default();
-///
-/// // List only types from vendor "acme" (matches any segment by default)
-/// let query = ListQuery::default()
-///     .with_is_type(true)
-///     .with_vendor("acme");
-///
-/// // List entities where only the primary segment has vendor "acme"
-/// let query = ListQuery::default()
-///     .with_vendor("acme")
-///     .with_segment_scope(SegmentMatchScope::Primary);
-///
-/// // List entities matching a pattern
-/// let query = ListQuery::default()
-///     .with_pattern("gts.acme.core.*");
-/// ```
+/// Query parameters for listing GTS type-schemas.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ListQuery {
-    /// Optional wildcard pattern for GTS ID matching.
-    ///
-    /// Supports `*` as a wildcard character.
+pub struct TypeSchemaQuery {
+    /// Optional GTS wildcard pattern (e.g. `gts.acme.*`).
     pub pattern: Option<String>,
-
-    /// Filter for entity kind: `true` for types, `false` for instances.
-    pub is_type: Option<bool>,
-
-    /// Filter by vendor.
-    ///
-    /// Which segments this applies to is controlled by `segment_scope`.
-    pub vendor: Option<String>,
-
-    /// Filter by package.
-    ///
-    /// Which segments this applies to is controlled by `segment_scope`.
-    pub package: Option<String>,
-
-    /// Filter by namespace.
-    ///
-    /// Which segments this applies to is controlled by `segment_scope`.
-    pub namespace: Option<String>,
-
-    /// Controls which segments the `vendor`, `package`, and `namespace`
-    /// filters are matched against.
-    ///
-    /// Defaults to `Any` (matches any segment in the chain).
-    pub segment_scope: SegmentMatchScope,
 }
 
-impl ListQuery {
-    /// Creates a new empty `ListQuery`.
+impl TypeSchemaQuery {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Sets the pattern filter.
     #[must_use]
     pub fn with_pattern(mut self, pattern: impl Into<String>) -> Self {
         self.pattern = Some(pattern.into());
         self
     }
 
-    /// Sets the `is_type` filter.
-    #[must_use]
-    pub const fn with_is_type(mut self, is_type: bool) -> Self {
-        self.is_type = Some(is_type);
-        self
-    }
-
-    /// Sets the vendor filter.
-    #[must_use]
-    pub fn with_vendor(mut self, vendor: impl Into<String>) -> Self {
-        self.vendor = Some(vendor.into());
-        self
-    }
-
-    /// Sets the package filter.
-    #[must_use]
-    pub fn with_package(mut self, package: impl Into<String>) -> Self {
-        self.package = Some(package.into());
-        self
-    }
-
-    /// Sets the namespace filter.
-    #[must_use]
-    pub fn with_namespace(mut self, namespace: impl Into<String>) -> Self {
-        self.namespace = Some(namespace.into());
-        self
-    }
-
-    /// Sets the segment match scope.
-    #[must_use]
-    pub const fn with_segment_scope(mut self, scope: SegmentMatchScope) -> Self {
-        self.segment_scope = scope;
-        self
-    }
-
-    /// Returns `true` if no filters are set.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.pattern.is_none()
-            && self.is_type.is_none()
-            && self.vendor.is_none()
-            && self.package.is_none()
-            && self.namespace.is_none()
+    }
+}
+
+/// Query parameters for listing GTS instances.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct InstanceQuery {
+    /// Optional GTS wildcard pattern (e.g. `gts.acme.events.user.v1~*`).
+    pub pattern: Option<String>,
+}
+
+impl InstanceQuery {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn with_pattern(mut self, pattern: impl Into<String>) -> Self {
+        self.pattern = Some(pattern.into());
+        self
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.pattern.is_none()
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_gts_id_segment_from_gts_rust() {
-        // GtsIdSegment::new(num, offset, segment_str) parses a GTS segment string
-        let segment = GtsIdSegment::new(0, 0, "acme.core.events.user_created.v1~").unwrap();
-        assert_eq!(segment.vendor, "acme");
-        assert_eq!(segment.package, "core");
-        assert_eq!(segment.namespace, "events");
-        assert_eq!(segment.type_name, "user_created");
-        assert_eq!(segment.ver_major, 1);
-        assert!(segment.is_type);
-    }
-
-    #[test]
-    fn test_gts_entity_accessors() {
-        let segment = GtsIdSegment::new(0, 0, "acme.core.events.user_created.v1~").unwrap();
-        let entity = GtsEntity::new(
-            Uuid::nil(),
-            "gts.acme.core.events.user_created.v1~",
-            vec![segment],
-            true, // is_schema
-            serde_json::json!({"type": "object"}),
-            Some("A user created event".to_owned()),
-        );
-
-        assert!(entity.is_type());
-        assert!(!entity.is_instance());
-        assert_eq!(entity.vendor(), Some("acme"));
-        assert_eq!(entity.package(), Some("core"));
-        assert_eq!(entity.namespace(), Some("events"));
-
-        // Test instance
-        let instance = GtsEntity::new(
-            Uuid::nil(),
-            "gts.acme.core.events.user_created.v1~acme.core.instances.instance1.v1",
-            vec![],
-            false, // is_schema
-            serde_json::json!({"data": "value"}),
-            None,
-        );
-        assert!(!instance.is_type());
-        assert!(instance.is_instance());
-    }
-
-    #[test]
-    fn test_list_query_builder() {
-        let query = ListQuery::new()
-            .with_pattern("gts.acme.*")
-            .with_is_type(true)
-            .with_vendor("acme")
-            .with_package("core")
-            .with_namespace("events");
-
-        assert_eq!(query.pattern, Some("gts.acme.*".to_owned()));
-        assert_eq!(query.is_type, Some(true));
-        assert_eq!(query.vendor, Some("acme".to_owned()));
-        assert_eq!(query.package, Some("core".to_owned()));
-        assert_eq!(query.namespace, Some("events".to_owned()));
-        assert_eq!(query.segment_scope, SegmentMatchScope::Any);
-        assert!(!query.is_empty());
-    }
-
-    #[test]
-    fn test_list_query_empty() {
-        let query = ListQuery::default();
-        assert!(query.is_empty());
-        assert_eq!(query.segment_scope, SegmentMatchScope::Any);
-    }
-
-    #[test]
-    fn test_segment_match_scope() {
-        assert!(SegmentMatchScope::Primary.is_primary());
-        assert!(!SegmentMatchScope::Primary.is_any());
-        assert!(SegmentMatchScope::Any.is_any());
-        assert!(!SegmentMatchScope::Any.is_primary());
-
-        // Default is Any
-        assert_eq!(SegmentMatchScope::default(), SegmentMatchScope::Any);
-    }
-
-    #[test]
-    fn test_list_query_with_segment_scope() {
-        let query = ListQuery::new()
-            .with_vendor("acme")
-            .with_segment_scope(SegmentMatchScope::Any);
-
-        assert_eq!(query.vendor, Some("acme".to_owned()));
-        assert_eq!(query.segment_scope, SegmentMatchScope::Any);
-    }
-}
+#[path = "models_tests.rs"]
+mod tests;

--- a/modules/system/types-registry/types-registry-sdk/src/models_tests.rs
+++ b/modules/system/types-registry/types-registry-sdk/src/models_tests.rs
@@ -1,0 +1,755 @@
+//! Unit tests for the public model types in `models.rs`
+//! ([`GtsTypeSchema`], [`GtsInstance`], [`RegisterResult`], etc.).
+//!
+//! Kept in a sibling `_tests.rs` file per the `de1101_tests_in_separate_files`
+//! repo lint. Linked into `models.rs` via
+//! `#[path = "models_tests.rs"] mod tests;`, so `super::*` pulls every
+//! item declared at the top of `models.rs` (`GtsTypeSchema`, `GtsInstance`,
+//! `RegisterResult`, etc.) into scope.
+
+#![allow(clippy::needless_pass_by_value)]
+
+use super::*;
+use serde_json::json;
+
+fn make_type_schema(
+    type_id: &str,
+    schema: Value,
+    parent: Option<Arc<GtsTypeSchema>>,
+) -> GtsTypeSchema {
+    GtsTypeSchema::try_new(GtsTypeId::new(type_id), schema, None, parent).unwrap()
+}
+
+// Reusable chain-form ids (string-shape valid for derive_parent_type_id).
+const BASE_ID: &str = "gts.acme.core.events.base.v1~";
+const DERIVED_ID: &str = "gts.acme.core.events.base.v1~acme.core.events.derived.v1.0~";
+const LEAF_ID: &str =
+    "gts.acme.core.events.base.v1~acme.core.events.derived.v1.0~vendor.x.y.leaf.v1.0~";
+
+#[test]
+fn test_type_schema_try_new_extracts_traits() {
+    let s = make_type_schema(
+        BASE_ID,
+        json!({
+            "title": "User",
+            "x-gts-traits": { "topicRef": "x" },
+            "x-gts-traits-schema": { "type": "object" }
+        }),
+        None,
+    );
+    assert_eq!(s.title.as_deref(), Some("User"));
+    assert!(s.traits.is_some());
+    assert!(s.traits_schema.is_some());
+    assert!(s.parent.is_none());
+}
+
+#[test]
+fn test_derive_parent_type_id() {
+    // Root (single segment) → no parent.
+    assert!(GtsTypeSchema::derive_parent_type_id(BASE_ID).is_none());
+    // Derived → strips last segment, returns parent.
+    assert_eq!(
+        GtsTypeSchema::derive_parent_type_id(DERIVED_ID).map(GtsTypeId::into_string),
+        Some(BASE_ID.to_owned())
+    );
+    // Three-level → parent is the two-level.
+    assert_eq!(
+        GtsTypeSchema::derive_parent_type_id(LEAF_ID).map(GtsTypeId::into_string),
+        Some(DERIVED_ID.to_owned())
+    );
+    // Instance (no trailing `~`) → no parent (helper is type-schemas-only).
+    assert!(GtsTypeSchema::derive_parent_type_id("gts.foo.bar.baz.v1~inst").is_none());
+}
+
+#[test]
+fn test_type_schema_rejects_instance_id() {
+    let err = GtsTypeSchema::try_new(
+        GtsTypeId::new("gts.acme.core.events.user.v1~acme.core.instances.u1.v1"),
+        json!({}),
+        None,
+        None,
+    )
+    .unwrap_err();
+    assert!(err.is_invalid_gts_type_id());
+}
+
+#[test]
+fn test_type_schema_rejects_mismatched_parent() {
+    // BASE_ID and "gts.other.vendor.events.x.v1~" are unrelated; passing
+    // the wrong one as parent of DERIVED_ID must error rather than
+    // silently corrupt the chain.
+    let wrong_parent = Arc::new(make_type_schema(
+        "gts.other.vendor.events.base.v1~",
+        json!({}),
+        None,
+    ));
+    let err = GtsTypeSchema::try_new(
+        GtsTypeId::new(DERIVED_ID),
+        json!({}),
+        None,
+        Some(wrong_parent),
+    )
+    .unwrap_err();
+    assert!(err.is_invalid_gts_type_id());
+}
+
+#[test]
+fn test_type_schema_rejects_root_with_parent() {
+    // BASE_ID is a root (single segment) — providing any parent is wrong.
+    let stray_parent = Arc::new(make_type_schema(BASE_ID, json!({}), None));
+    let err = GtsTypeSchema::try_new(GtsTypeId::new(BASE_ID), json!({}), None, Some(stray_parent))
+        .unwrap_err();
+    assert!(err.is_invalid_gts_type_id());
+}
+
+#[test]
+fn test_type_schema_rejects_derived_without_parent() {
+    // DERIVED_ID has a chain prefix — `parent: None` would silently produce a
+    // schema whose `ancestors()` walk is incomplete. The constructor must
+    // reject this and force the caller to pass the chain.
+    let err =
+        GtsTypeSchema::try_new(GtsTypeId::new(DERIVED_ID), json!({}), None, None).unwrap_err();
+    assert!(err.is_invalid_gts_type_id());
+}
+
+#[test]
+fn test_effective_properties_deep_merge() {
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "type": "object", "properties": { "id": { "type": "string" } } }),
+        None,
+    ));
+    let child = make_type_schema(
+        DERIVED_ID,
+        json!({
+            "allOf": [
+                { "$ref": format!("gts://{BASE_ID}") },
+                { "properties": { "name": { "type": "string" } } }
+            ]
+        }),
+        Some(Arc::clone(&base)),
+    );
+    let merged = child.effective_properties();
+    assert!(merged.contains_key("id")); // inherited
+    assert!(merged.contains_key("name")); // own
+}
+
+#[test]
+fn test_effective_properties_child_overrides_parent() {
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "properties": { "field": { "type": "string", "title": "from-base" } } }),
+        None,
+    ));
+    let child = make_type_schema(
+        DERIVED_ID,
+        json!({
+            "allOf": [{ "$ref": format!("gts://{BASE_ID}") }],
+            "properties": { "field": { "type": "string", "title": "from-child" } }
+        }),
+        Some(base),
+    );
+    let merged = child.effective_properties();
+    let field = merged.get("field").unwrap();
+    assert_eq!(
+        field.get("title").and_then(|v| v.as_str()),
+        Some("from-child")
+    );
+}
+
+#[test]
+fn test_effective_required_dedup() {
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "required": ["id"] }),
+        None,
+    ));
+    let child = make_type_schema(
+        DERIVED_ID,
+        json!({
+            "allOf": [
+                { "$ref": format!("gts://{BASE_ID}") },
+                { "required": ["name", "id"] }
+            ]
+        }),
+        Some(base),
+    );
+    let req = child.effective_required();
+    assert_eq!(req.iter().filter(|s| *s == "id").count(), 1);
+    assert!(req.contains(&"name".to_owned()));
+}
+
+#[test]
+fn test_effective_traits_rightmost_wins() {
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "x-gts-traits": { "retention": "P30D", "scope": "global" } }),
+        None,
+    ));
+    let child = make_type_schema(
+        DERIVED_ID,
+        json!({ "x-gts-traits": { "retention": "P90D" } }),
+        Some(base),
+    );
+    let merged = child.effective_traits();
+    let m = merged.as_object().unwrap();
+    assert_eq!(m.get("retention").and_then(|v| v.as_str()), Some("P90D"));
+    assert_eq!(m.get("scope").and_then(|v| v.as_str()), Some("global"));
+}
+
+#[test]
+fn test_effective_traits_schema_chain_order() {
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "x-gts-traits-schema": { "type": "object", "properties": { "a": {} } } }),
+        None,
+    ));
+    let child = make_type_schema(
+        DERIVED_ID,
+        json!({ "x-gts-traits-schema": { "type": "object", "properties": { "b": {} } } }),
+        Some(base),
+    );
+    let chain = child.effective_traits_schema();
+    assert_eq!(chain.len(), 2);
+    // Deepest base first.
+    assert!(chain[0]["properties"]["a"].is_object());
+    assert!(chain[1]["properties"]["b"].is_object());
+}
+
+#[test]
+fn test_effective_schema_inlines_refs() {
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "type": "object", "properties": { "id": { "type": "string" } } }),
+        None,
+    ));
+    let child = make_type_schema(
+        DERIVED_ID,
+        json!({
+            "allOf": [
+                { "$ref": format!("gts://{BASE_ID}") },
+                { "properties": { "name": { "type": "string" } } }
+            ]
+        }),
+        Some(base),
+    );
+    let merged = child.effective_schema();
+    let all_of = merged["allOf"].as_array().unwrap();
+    // First entry is the inlined base (no longer a $ref).
+    assert!(all_of[0].get("$ref").is_none());
+    assert!(all_of[0]["properties"]["id"].is_object());
+    // Second entry is the own overlay, untouched.
+    assert!(all_of[1]["properties"]["name"].is_object());
+}
+
+#[test]
+fn test_effective_properties_three_level_chain() {
+    // grandparent → parent → child. Properties from each level surface
+    // in `effective_properties`; later levels win on key collisions.
+    let grand = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "properties": {
+            "a": { "type": "string", "title": "from-grand" },
+            "shared": { "type": "string", "title": "from-grand" }
+        }}),
+        None,
+    ));
+    let parent = Arc::new(make_type_schema(
+        DERIVED_ID,
+        json!({
+            "allOf": [{ "$ref": format!("gts://{BASE_ID}") }],
+            "properties": {
+                "b": { "type": "string", "title": "from-parent" },
+                "shared": { "type": "string", "title": "from-parent" }
+            }
+        }),
+        Some(grand),
+    ));
+    let child = make_type_schema(
+        LEAF_ID,
+        json!({
+            "allOf": [{ "$ref": format!("gts://{DERIVED_ID}") }],
+            "properties": {
+                "c": { "type": "string", "title": "from-child" },
+                "shared": { "type": "string", "title": "from-child" }
+            }
+        }),
+        Some(parent),
+    );
+    let merged = child.effective_properties();
+    assert!(merged.contains_key("a")); // from grandparent
+    assert!(merged.contains_key("b")); // from parent
+    assert!(merged.contains_key("c")); // from child
+    // child wins on `shared` over grandparent and parent.
+    assert_eq!(
+        merged
+            .get("shared")
+            .unwrap()
+            .get("title")
+            .and_then(|v| v.as_str()),
+        Some("from-child")
+    );
+}
+
+#[test]
+fn test_effective_properties_root_no_parent() {
+    // Root schema (no parent) — effective_properties returns own only.
+    let schema = make_type_schema(
+        BASE_ID,
+        json!({ "properties": {
+            "x": { "type": "integer" },
+            "y": { "type": "string" }
+        }}),
+        None,
+    );
+    let merged = schema.effective_properties();
+    assert_eq!(merged.len(), 2);
+    assert!(merged.contains_key("x"));
+    assert!(merged.contains_key("y"));
+}
+
+#[test]
+fn test_effective_properties_from_allof_inline_overlay() {
+    // Properties declared inside allOf overlay branches (non-$ref) are
+    // counted as "own" — the parent's body comes from `self.parent`.
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "properties": { "inherited": { "type": "string" } } }),
+        None,
+    ));
+    let child = make_type_schema(
+        DERIVED_ID,
+        json!({
+            "allOf": [
+                { "$ref": format!("gts://{BASE_ID}") },
+                { "properties": { "from_overlay": { "type": "string" } } }
+            ]
+        }),
+        Some(base),
+    );
+    let merged = child.effective_properties();
+    assert!(merged.contains_key("inherited"));
+    assert!(merged.contains_key("from_overlay"));
+}
+
+#[test]
+fn test_effective_required_three_level_dedup_and_order() {
+    // Each level adds new required fields; duplicates dedup, order is
+    // preserved by first occurrence in pre-order walk (self → ancestors).
+    let grand = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "required": ["id"] }),
+        None,
+    ));
+    let parent = Arc::new(make_type_schema(
+        DERIVED_ID,
+        json!({
+            "allOf": [{ "$ref": format!("gts://{BASE_ID}") }],
+            "required": ["name", "id"]
+        }),
+        Some(grand),
+    ));
+    let child = make_type_schema(
+        LEAF_ID,
+        json!({
+            "allOf": [{ "$ref": format!("gts://{DERIVED_ID}") }],
+            "required": ["age", "name"]
+        }),
+        Some(parent),
+    );
+    let req = child.effective_required();
+    // All three unique keys present.
+    assert!(req.contains(&"id".to_owned()));
+    assert!(req.contains(&"name".to_owned()));
+    assert!(req.contains(&"age".to_owned()));
+    // Each appears exactly once (dedup across levels).
+    assert_eq!(req.iter().filter(|s| *s == "id").count(), 1);
+    assert_eq!(req.iter().filter(|s| *s == "name").count(), 1);
+    assert_eq!(req.iter().filter(|s| *s == "age").count(), 1);
+    // Pre-order is self → ancestors, so child's "age" precedes
+    // parent's "name", which precedes grandparent's "id".
+    let pos = |s: &str| req.iter().position(|r| r == s).unwrap();
+    assert!(pos("age") < pos("name"));
+    assert!(pos("name") < pos("id"));
+}
+
+#[test]
+fn test_effective_required_root_no_parent() {
+    let schema = make_type_schema(BASE_ID, json!({ "required": ["a", "b", "c"] }), None);
+    let req = schema.effective_required();
+    assert_eq!(req, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn test_effective_traits_three_level_rightmost_wins() {
+    // Rightmost (= self in our walk) wins; deeper ancestors fill
+    // missing keys.
+    let grand = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "x-gts-traits": {
+            "from_grand_only": "g",
+            "shared": "from-grand"
+        }}),
+        None,
+    ));
+    let parent = Arc::new(make_type_schema(
+        DERIVED_ID,
+        json!({ "x-gts-traits": {
+            "from_parent_only": "p",
+            "shared": "from-parent"
+        }}),
+        Some(grand),
+    ));
+    let child = make_type_schema(
+        LEAF_ID,
+        json!({ "x-gts-traits": {
+            "from_child_only": "c",
+            "shared": "from-child"
+        }}),
+        Some(parent),
+    );
+    let merged = child.effective_traits();
+    let m = merged.as_object().unwrap();
+    assert_eq!(m.get("from_grand_only").and_then(|v| v.as_str()), Some("g"));
+    assert_eq!(
+        m.get("from_parent_only").and_then(|v| v.as_str()),
+        Some("p")
+    );
+    assert_eq!(m.get("from_child_only").and_then(|v| v.as_str()), Some("c"));
+    assert_eq!(m.get("shared").and_then(|v| v.as_str()), Some("from-child"));
+}
+
+#[test]
+fn test_effective_traits_returns_null_when_chain_has_none() {
+    // No level declares x-gts-traits → effective_traits returns Null.
+    let base = Arc::new(make_type_schema(BASE_ID, json!({}), None));
+    let child = make_type_schema(DERIVED_ID, json!({}), Some(base));
+    assert!(child.effective_traits().is_null());
+}
+
+#[test]
+fn test_effective_traits_partial_chain_coverage() {
+    // Only a middle-of-chain ancestor declares traits — they should
+    // surface even though closer levels (self, deepest) declare nothing.
+    let grand = Arc::new(make_type_schema(BASE_ID, json!({}), None));
+    let parent = Arc::new(make_type_schema(
+        DERIVED_ID,
+        json!({ "x-gts-traits": { "scope": "tenant" } }),
+        Some(grand),
+    ));
+    let child = make_type_schema(LEAF_ID, json!({}), Some(parent));
+    let merged = child.effective_traits();
+    assert_eq!(
+        merged
+            .as_object()
+            .and_then(|m| m.get("scope"))
+            .and_then(|v| v.as_str()),
+        Some("tenant")
+    );
+}
+
+#[test]
+fn test_effective_traits_applies_defaults_from_traits_schema() {
+    // Base declares a traits-schema with defaults; nothing declares the
+    // values. effective_traits must surface the defaults.
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({
+            "x-gts-traits-schema": {
+                "type": "object",
+                "properties": {
+                    "allowed_parent_types": { "type": "array", "default": [] },
+                    "idp_provisioning":     { "type": "boolean", "default": false }
+                }
+            }
+        }),
+        None,
+    ));
+    let child = make_type_schema(DERIVED_ID, json!({}), Some(base));
+    let merged = child.effective_traits();
+    let m = merged.as_object().expect("not null");
+    assert!(
+        m.get("allowed_parent_types")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(m.get("idp_provisioning"), Some(&json!(false)));
+}
+
+#[test]
+fn test_effective_traits_declared_value_beats_default() {
+    // Default says false, leaf declares true. Declared wins.
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({
+            "x-gts-traits-schema": {
+                "properties": {
+                    "idp_provisioning": { "type": "boolean", "default": false }
+                }
+            }
+        }),
+        None,
+    ));
+    let child = make_type_schema(
+        DERIVED_ID,
+        json!({ "x-gts-traits": { "idp_provisioning": true } }),
+        Some(base),
+    );
+    let merged = child.effective_traits();
+    assert_eq!(
+        merged.get("idp_provisioning").and_then(Value::as_bool),
+        Some(true)
+    );
+}
+
+#[test]
+fn test_effective_traits_default_from_descendant_traits_schema() {
+    // Narrowing: the descendant introduces a NEW property in its
+    // traits-schema with a default. Even though the schema declaration
+    // lives below the base, its default still surfaces (no ancestor
+    // declared this property).
+    let base = Arc::new(make_type_schema(BASE_ID, json!({}), None));
+    let child = make_type_schema(
+        DERIVED_ID,
+        json!({
+            "x-gts-traits-schema": {
+                "properties": {
+                    "retention": { "type": "string", "default": "P30D" }
+                }
+            }
+        }),
+        Some(base),
+    );
+    let merged = child.effective_traits();
+    assert_eq!(
+        merged.get("retention").and_then(|v| v.as_str()),
+        Some("P30D")
+    );
+}
+
+#[test]
+fn test_effective_traits_only_defaults_no_declared_values() {
+    // Verifies that effective_traits is NOT Null when only defaults exist
+    // (no x-gts-traits declared anywhere).
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({
+            "x-gts-traits-schema": {
+                "properties": {
+                    "scope": { "type": "string", "default": "global" }
+                }
+            }
+        }),
+        None,
+    ));
+    let child = make_type_schema(DERIVED_ID, json!({}), Some(base));
+    let merged = child.effective_traits();
+    assert_eq!(merged.get("scope").and_then(|v| v.as_str()), Some("global"));
+}
+
+#[test]
+fn test_effective_traits_returns_null_with_default_less_traits_schema() {
+    // A traits-schema that declares no defaults must not push spurious
+    // entries into the result. Result remains Null when nothing is declared.
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({
+            "x-gts-traits-schema": {
+                "properties": {
+                    "scope": { "type": "string" }
+                }
+            }
+        }),
+        None,
+    ));
+    let child = make_type_schema(DERIVED_ID, json!({}), Some(base));
+    assert!(child.effective_traits().is_null());
+}
+
+#[test]
+fn test_effective_traits_schema_three_level_chain_order() {
+    // Order is deepest-base first → self last.
+    let grand = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "x-gts-traits-schema": { "marker": "grand" } }),
+        None,
+    ));
+    let parent = Arc::new(make_type_schema(
+        DERIVED_ID,
+        json!({ "x-gts-traits-schema": { "marker": "parent" } }),
+        Some(grand),
+    ));
+    let child = make_type_schema(
+        LEAF_ID,
+        json!({ "x-gts-traits-schema": { "marker": "child" } }),
+        Some(parent),
+    );
+    let chain = child.effective_traits_schema();
+    assert_eq!(chain.len(), 3);
+    assert_eq!(chain[0]["marker"].as_str(), Some("grand"));
+    assert_eq!(chain[1]["marker"].as_str(), Some("parent"));
+    assert_eq!(chain[2]["marker"].as_str(), Some("child"));
+}
+
+#[test]
+fn test_effective_traits_schema_skips_levels_without_block() {
+    // Only the levels that declare x-gts-traits-schema appear.
+    let grand = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({ "x-gts-traits-schema": { "marker": "grand" } }),
+        None,
+    ));
+    let parent = Arc::new(make_type_schema(DERIVED_ID, json!({}), Some(grand)));
+    let child = make_type_schema(
+        LEAF_ID,
+        json!({ "x-gts-traits-schema": { "marker": "child" } }),
+        Some(parent),
+    );
+    let chain = child.effective_traits_schema();
+    assert_eq!(chain.len(), 2);
+    assert_eq!(chain[0]["marker"].as_str(), Some("grand"));
+    assert_eq!(chain[1]["marker"].as_str(), Some("child"));
+}
+
+#[test]
+fn test_effective_schema_root_returns_body_unchanged() {
+    // Root: no parent, no inlining; the body is returned as-is.
+    let body = json!({
+        "type": "object",
+        "properties": { "id": { "type": "string" } }
+    });
+    let schema = make_type_schema(BASE_ID, body.clone(), None);
+    assert_eq!(schema.effective_schema(), body);
+}
+
+#[test]
+fn test_effective_schema_strips_id_and_schema_from_inlined_parent() {
+    // Parent's `$id` and `$schema` are stripped when inlined to keep
+    // the merged document a valid composite schema.
+    let base = Arc::new(make_type_schema(
+        BASE_ID,
+        json!({
+            "$id": format!("gts://{BASE_ID}"),
+            "$schema": "https://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": { "id": { "type": "string" } }
+        }),
+        None,
+    ));
+    let child = make_type_schema(
+        DERIVED_ID,
+        json!({
+            "allOf": [{ "$ref": format!("gts://{BASE_ID}") }]
+        }),
+        Some(base),
+    );
+    let merged = child.effective_schema();
+    let inlined = &merged["allOf"][0];
+    assert!(inlined.get("$id").is_none());
+    assert!(inlined.get("$schema").is_none());
+    // But the actual content survives.
+    assert!(inlined["properties"]["id"].is_object());
+}
+
+#[test]
+fn test_effective_schema_leaves_non_parent_refs_alone() {
+    // A `$ref` in `allOf` that points to something OTHER than the GTS
+    // parent (a "mixin") is left as-is — only the parent's body is inlined.
+    let base = Arc::new(make_type_schema(BASE_ID, json!({"type": "object"}), None));
+    let mixin_id = "gts.other.vendor.events.mixin.v1~";
+    let child = make_type_schema(
+        DERIVED_ID,
+        json!({
+            "allOf": [
+                { "$ref": format!("gts://{BASE_ID}") },
+                { "$ref": format!("gts://{mixin_id}") }
+            ]
+        }),
+        Some(base),
+    );
+    let merged = child.effective_schema();
+    let all_of = merged["allOf"].as_array().unwrap();
+    // Parent inlined.
+    assert!(all_of[0].get("$ref").is_none());
+    // Mixin ref preserved.
+    assert_eq!(
+        all_of[1]["$ref"].as_str(),
+        Some(format!("gts://{mixin_id}").as_str())
+    );
+}
+
+#[test]
+fn test_ancestors_chain_walk() {
+    let grandparent = Arc::new(make_type_schema(BASE_ID, json!({}), None));
+    let parent = Arc::new(make_type_schema(
+        DERIVED_ID,
+        json!({}),
+        Some(Arc::clone(&grandparent)),
+    ));
+    let child = make_type_schema(LEAF_ID, json!({}), Some(parent));
+    let ids: Vec<String> = child.ancestors().map(|s| s.type_id.to_string()).collect();
+    assert_eq!(ids, vec![LEAF_ID, DERIVED_ID, BASE_ID]);
+}
+
+#[test]
+fn test_instance_try_new_validates_chain_match() {
+    let type_schema = Arc::new(make_type_schema(
+        "gts.acme.core.events.user.v1~",
+        json!({}),
+        None,
+    ));
+    let inst = GtsInstance::try_new(
+        GtsInstanceId::new("gts.acme.core.events.user.v1~", "acme.core.instances.u1.v1"),
+        json!({ "id": "acme.core.instances.u1.v1" }),
+        None,
+        type_schema,
+    )
+    .unwrap();
+    assert_eq!(inst.type_id().as_ref(), "gts.acme.core.events.user.v1~");
+}
+
+#[test]
+fn test_instance_try_new_rejects_mismatched_type_schema() {
+    let type_schema = Arc::new(make_type_schema(
+        "gts.acme.other.pkg.type.v1~",
+        json!({}),
+        None,
+    ));
+    let err = GtsInstance::try_new(
+        GtsInstanceId::new("gts.acme.core.events.user.v1~", "u1"),
+        json!({}),
+        None,
+        type_schema,
+    )
+    .unwrap_err();
+    assert!(err.is_invalid_gts_instance_id());
+}
+
+#[test]
+fn test_instance_rejects_type_id() {
+    let type_schema = Arc::new(make_type_schema(
+        "gts.acme.core.users.user.v1~",
+        json!({}),
+        None,
+    ));
+    let err = GtsInstance::try_new(
+        GtsInstanceId::new("gts.acme.core.users.user.v1~", ""),
+        json!({}),
+        None,
+        type_schema,
+    )
+    .unwrap_err();
+    assert!(err.is_invalid_gts_instance_id());
+}
+
+#[test]
+fn test_type_schema_query_builder() {
+    let empty = TypeSchemaQuery::new();
+    assert!(empty.is_empty());
+
+    let q = TypeSchemaQuery::new().with_pattern("gts.acme.*");
+    assert!(!q.is_empty());
+    assert_eq!(q.pattern.as_deref(), Some("gts.acme.*"));
+}

--- a/modules/system/types-registry/types-registry-sdk/src/testing.rs
+++ b/modules/system/types-registry/types-registry-sdk/src/testing.rs
@@ -1,0 +1,330 @@
+//! Test utilities for [`TypesRegistryClient`] consumers.
+//!
+//! [`MockTypesRegistryClient`] is a hand-rolled, stateful mock backend: pre-populate
+//! it with [`with_type_schemas`](MockTypesRegistryClient::with_type_schemas) /
+//! [`with_instances`](MockTypesRegistryClient::with_instances), hand it to the code
+//! under test as `Arc<dyn TypesRegistryClient>`, and let it answer `get_*` /
+//! `list_*` calls against the in-memory data.
+//!
+//! Helper builders [`make_test_type_schema`] and [`make_test_instance`]
+//! produce minimal valid values for tests where the schema / instance content
+//! is not the focus of the assertion.
+//!
+//! Available with the `test-util` cargo feature.
+
+// Test infrastructure: `expect`/`unwrap` are appropriate for synthetic-data
+// builders and lock-poisoning paths inside a mock that is only used in tests.
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::missing_panics_doc)]
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::api::TypesRegistryClient;
+use crate::error::TypesRegistryError;
+use crate::models::{
+    GtsInstance, GtsTypeId, GtsTypeSchema, InstanceQuery, RegisterResult, TypeSchemaQuery,
+    is_type_schema_id,
+};
+use gts::GtsInstanceId;
+
+/// Stateful in-memory implementation of [`TypesRegistryClient`] for tests.
+///
+/// The mock is read-mostly: build it with the builder methods, then hand to
+/// the code under test. `register_*` methods are **not implemented** —
+/// calling any of them with a non-empty input panics. Pre-populate via
+/// [`with_type_schemas`](Self::with_type_schemas) /
+/// [`with_instances`](Self::with_instances) builders instead. Empty-input
+/// `register_*` calls return an empty result vector to keep the trait
+/// shape consistent for tests that pass `vec![]` defensively.
+///
+/// `list_*` methods return all stored entries verbatim and ignore the
+/// query (callers wanting filtered results should pre-filter what they
+/// put in); the query passed in is captured for assertions via
+/// [`received_instance_queries`](Self::received_instance_queries).
+#[derive(Default)]
+pub struct MockTypesRegistryClient {
+    type_schemas: Vec<GtsTypeSchema>,
+    instances: Vec<GtsInstance>,
+    list_error: Option<TypesRegistryError>,
+    received_type_schema_queries: Mutex<Vec<TypeSchemaQuery>>,
+    received_instance_queries: Mutex<Vec<InstanceQuery>>,
+}
+
+impl MockTypesRegistryClient {
+    /// Creates an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds the given type-schemas to the registry.
+    #[must_use]
+    pub fn with_type_schemas(mut self, items: impl IntoIterator<Item = GtsTypeSchema>) -> Self {
+        self.type_schemas.extend(items);
+        self
+    }
+
+    /// Adds the given instances to the registry.
+    #[must_use]
+    pub fn with_instances(mut self, items: impl IntoIterator<Item = GtsInstance>) -> Self {
+        self.instances.extend(items);
+        self
+    }
+
+    /// Configures the registry so that every `list_*` call fails with the
+    /// given error. Useful for testing error-propagation paths.
+    #[must_use]
+    pub fn with_list_error(mut self, err: TypesRegistryError) -> Self {
+        self.list_error = Some(err);
+        self
+    }
+
+    /// Number of times [`list_type_schemas`](Self::list_type_schemas) was
+    /// called.
+    #[must_use]
+    pub fn list_type_schema_calls(&self) -> usize {
+        self.received_type_schema_queries
+            .lock()
+            .expect("MockTypesRegistryClient: type-schema query log poisoned")
+            .len()
+    }
+
+    /// Number of times [`list_instances`](Self::list_instances) was called.
+    #[must_use]
+    pub fn list_instance_calls(&self) -> usize {
+        self.received_instance_queries
+            .lock()
+            .expect("MockTypesRegistryClient: instance query log poisoned")
+            .len()
+    }
+
+    /// Snapshot of every [`TypeSchemaQuery`] passed to
+    /// [`list_type_schemas`](Self::list_type_schemas), in call order.
+    #[must_use]
+    pub fn received_type_schema_queries(&self) -> Vec<TypeSchemaQuery> {
+        self.received_type_schema_queries
+            .lock()
+            .expect("MockTypesRegistryClient: type-schema query log poisoned")
+            .clone()
+    }
+
+    /// Snapshot of every [`InstanceQuery`] passed to
+    /// [`list_instances`](Self::list_instances), in call order.
+    #[must_use]
+    pub fn received_instance_queries(&self) -> Vec<InstanceQuery> {
+        self.received_instance_queries
+            .lock()
+            .expect("MockTypesRegistryClient: instance query log poisoned")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl TypesRegistryClient for MockTypesRegistryClient {
+    async fn register(
+        &self,
+        entities: Vec<Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        assert!(
+            entities.is_empty(),
+            "MockTypesRegistryClient::register is not implemented; \
+             pre-populate via `MockTypesRegistryClient::new().with_type_schemas(...).with_instances(...)`",
+        );
+        Ok(vec![])
+    }
+
+    async fn register_type_schemas(
+        &self,
+        type_schemas: Vec<Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        assert!(
+            type_schemas.is_empty(),
+            "MockTypesRegistryClient::register_type_schemas is not implemented; \
+             pre-populate via `MockTypesRegistryClient::new().with_type_schemas(...)`",
+        );
+        Ok(vec![])
+    }
+
+    async fn get_type_schema(&self, type_id: &str) -> Result<GtsTypeSchema, TypesRegistryError> {
+        if !is_type_schema_id(type_id) {
+            return Err(TypesRegistryError::invalid_gts_type_id(format!(
+                "{type_id} does not end with `~`",
+            )));
+        }
+        self.type_schemas
+            .iter()
+            .find(|s| s.type_id == type_id)
+            .cloned()
+            .ok_or_else(|| TypesRegistryError::gts_type_schema_not_found(type_id))
+    }
+
+    async fn get_type_schema_by_uuid(
+        &self,
+        type_uuid: Uuid,
+    ) -> Result<GtsTypeSchema, TypesRegistryError> {
+        self.type_schemas
+            .iter()
+            .find(|s| s.type_uuid == type_uuid)
+            .cloned()
+            .ok_or_else(|| TypesRegistryError::gts_type_schema_not_found(type_uuid.to_string()))
+    }
+
+    async fn get_type_schemas(
+        &self,
+        type_ids: Vec<String>,
+    ) -> HashMap<String, Result<GtsTypeSchema, TypesRegistryError>> {
+        let mut out = HashMap::with_capacity(type_ids.len());
+        for id in type_ids {
+            let res = self.get_type_schema(&id).await;
+            out.insert(id, res);
+        }
+        out
+    }
+
+    async fn get_type_schemas_by_uuid(
+        &self,
+        type_uuids: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsTypeSchema, TypesRegistryError>> {
+        let mut out = HashMap::with_capacity(type_uuids.len());
+        for uuid in type_uuids {
+            let res = self.get_type_schema_by_uuid(uuid).await;
+            out.insert(uuid, res);
+        }
+        out
+    }
+
+    async fn list_type_schemas(
+        &self,
+        query: TypeSchemaQuery,
+    ) -> Result<Vec<GtsTypeSchema>, TypesRegistryError> {
+        self.received_type_schema_queries
+            .lock()
+            .expect("MockTypesRegistryClient: type-schema query log poisoned")
+            .push(query);
+        if let Some(ref err) = self.list_error {
+            return Err(err.clone());
+        }
+        Ok(self.type_schemas.clone())
+    }
+
+    async fn register_instances(
+        &self,
+        instances: Vec<Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        assert!(
+            instances.is_empty(),
+            "MockTypesRegistryClient::register_instances is not implemented; \
+             pre-populate via `MockTypesRegistryClient::new().with_instances(...)`",
+        );
+        Ok(vec![])
+    }
+
+    async fn get_instance(&self, id: &str) -> Result<GtsInstance, TypesRegistryError> {
+        if is_type_schema_id(id) {
+            return Err(TypesRegistryError::invalid_gts_instance_id(format!(
+                "{id} ends with `~` (looks like a type-schema id)",
+            )));
+        }
+        self.instances
+            .iter()
+            .find(|e| e.id == id)
+            .cloned()
+            .ok_or_else(|| TypesRegistryError::gts_instance_not_found(id))
+    }
+
+    async fn get_instance_by_uuid(&self, uuid: Uuid) -> Result<GtsInstance, TypesRegistryError> {
+        self.instances
+            .iter()
+            .find(|e| e.uuid == uuid)
+            .cloned()
+            .ok_or_else(|| TypesRegistryError::gts_instance_not_found(uuid.to_string()))
+    }
+
+    async fn get_instances(
+        &self,
+        ids: Vec<String>,
+    ) -> HashMap<String, Result<GtsInstance, TypesRegistryError>> {
+        let mut out = HashMap::with_capacity(ids.len());
+        for id in ids {
+            let res = self.get_instance(&id).await;
+            out.insert(id, res);
+        }
+        out
+    }
+
+    async fn get_instances_by_uuid(
+        &self,
+        uuids: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsInstance, TypesRegistryError>> {
+        let mut out = HashMap::with_capacity(uuids.len());
+        for uuid in uuids {
+            let res = self.get_instance_by_uuid(uuid).await;
+            out.insert(uuid, res);
+        }
+        out
+    }
+
+    async fn list_instances(
+        &self,
+        query: InstanceQuery,
+    ) -> Result<Vec<GtsInstance>, TypesRegistryError> {
+        self.received_instance_queries
+            .lock()
+            .expect("MockTypesRegistryClient: instance query log poisoned")
+            .push(query);
+        if let Some(ref err) = self.list_error {
+            return Err(err.clone());
+        }
+        Ok(self.instances.clone())
+    }
+}
+
+/// Builds a synthetic [`GtsTypeSchema`] with the given `type_id` and an empty
+/// JSON Schema body. Convenient for tests that need a `GtsTypeSchema` value
+/// but don't care about the schema content.
+///
+/// For derived ids, the parent chain is built recursively by emitting one
+/// synthetic schema per chain hop (root → ... → leaf). Chain-aware methods
+/// like [`GtsTypeSchema::ancestors`] / [`GtsTypeSchema::effective_schema`]
+/// therefore observe a complete chain matching `type_id`. Each synthetic
+/// schema along the chain carries an empty body, so semantic content from
+/// real schemas is not modelled — tests that rely on parent-body details
+/// must construct the chain manually.
+///
+/// # Panics
+///
+/// Panics if `type_id` is not a valid GTS type-schema identifier (must end
+/// with `~` and parse as a full GTS id).
+#[must_use]
+pub fn make_test_type_schema(type_id: &str) -> GtsTypeSchema {
+    let parent = GtsTypeSchema::derive_parent_type_id(type_id)
+        .map(|p| Arc::new(make_test_type_schema(p.as_ref())));
+    GtsTypeSchema::try_new(GtsTypeId::new(type_id), serde_json::json!({}), None, parent)
+        .expect("synthetic type-schema is valid")
+}
+
+/// Builds a synthetic [`GtsInstance`] with the given content body, attached
+/// to a synthetic type-schema chain matching the instance id's prefix.
+///
+/// The instance's `id` must contain at least one `~`. The prefix (everything
+/// up to and including the last `~`) is used as the parent type-schema's
+/// `type_id`, and the full chain leading up to it is built via
+/// [`make_test_type_schema`].
+///
+/// # Panics
+///
+/// Panics if `gts_id` doesn't contain a `~` (no chain prefix) or doesn't
+/// parse as a valid GTS identifier.
+#[must_use]
+pub fn make_test_instance(gts_id: &str, content: Value) -> GtsInstance {
+    let type_id = GtsInstance::derive_type_id(gts_id)
+        .unwrap_or_else(|| panic!("synthetic gts_id {gts_id} has no chain prefix"));
+    let type_schema = Arc::new(make_test_type_schema(type_id.as_ref()));
+    let segment = &gts_id[type_id.as_ref().len()..];
+    let id = GtsInstanceId::new(type_id.as_ref(), segment);
+    GtsInstance::try_new(id, content, None, type_schema).expect("synthetic instance is valid")
+}

--- a/modules/system/types-registry/types-registry/Cargo.toml
+++ b/modules/system/types-registry/types-registry/Cargo.toml
@@ -37,11 +37,13 @@ axum = { workspace = true, features = ["macros"] }
 uuid = { workspace = true, features = ["v5"] }
 thiserror = { workspace = true }
 parking_lot = { workspace = true }
+lru = "0.16"
 
 # Local dependencies
 modkit = { workspace = true }
 modkit-macros = { workspace = true }
 modkit-security = { workspace = true }
+modkit-utils = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/modules/system/types-registry/types-registry/src/api/rest/dto.rs
+++ b/modules/system/types-registry/types-registry/src/api/rest/dto.rs
@@ -3,7 +3,9 @@
 use uuid::Uuid;
 
 use gts::GtsIdSegment;
-use types_registry_sdk::{GtsEntity, RegisterResult, RegisterSummary, SegmentMatchScope};
+use types_registry_sdk::RegisterSummary;
+
+use crate::domain::model::{GtsEntity, ListQuery, SegmentMatchScope};
 
 /// DTO for a GTS ID segment.
 #[derive(Debug, Clone)]
@@ -58,10 +60,10 @@ pub struct GtsEntityDto {
 impl From<GtsEntity> for GtsEntityDto {
     fn from(entity: GtsEntity) -> Self {
         Self {
-            id: entity.id,
+            id: entity.uuid,
             gts_id: entity.gts_id.clone(),
             segments: entity.segments.iter().map(GtsIdSegmentDto::from).collect(),
-            is_schema: entity.is_schema,
+            is_schema: entity.is_type_schema,
             content: entity.content.clone(),
             description: entity.description.clone(),
         }
@@ -96,20 +98,6 @@ pub enum RegisterResultDto {
         /// Error message.
         error: String,
     },
-}
-
-impl From<RegisterResult> for RegisterResultDto {
-    fn from(result: RegisterResult) -> Self {
-        match result {
-            RegisterResult::Ok(entity) => Self::Ok {
-                entity: entity.into(),
-            },
-            RegisterResult::Err { gts_id, error } => Self::Error {
-                gts_id,
-                error: error.to_string(),
-            },
-        }
-    }
 }
 
 /// Response DTO for batch registration.
@@ -154,25 +142,31 @@ pub struct ListEntitiesQuery {
     /// Filter by schema type: true for types, false for instances.
     #[serde(default)]
     pub is_schema: Option<bool>,
-    /// Filter by vendor.
+    /// Filter by vendor. Applied to segments per `segment_scope`.
     #[serde(default)]
     pub vendor: Option<String>,
-    /// Filter by package.
+    /// Filter by package. Applied to segments per `segment_scope`.
     #[serde(default)]
     pub package: Option<String>,
-    /// Filter by namespace.
+    /// Filter by namespace. Applied to segments per `segment_scope`.
     #[serde(default)]
     pub namespace: Option<String>,
-    /// Segment match scope: "primary" or "any" (default).
+    /// Controls which chain segments the vendor / package / namespace filters
+    /// match against. Either `"primary"` (first segment only) or `"any"`
+    /// (any segment in the chain). Defaults to `"any"` when omitted.
     #[serde(default)]
     pub segment_scope: Option<String>,
 }
 
 impl ListEntitiesQuery {
-    /// Converts this DTO to the SDK `ListQuery`.
+    /// Converts this DTO to the internal `ListQuery`.
+    ///
+    /// An unknown `segment_scope` value silently falls back to the default
+    /// (`Any`) — query params are best-effort. Tightening this to a 400
+    /// would change the wire contract.
     #[must_use]
-    pub fn to_list_query(&self) -> types_registry_sdk::ListQuery {
-        let mut query = types_registry_sdk::ListQuery::default();
+    pub fn to_list_query(&self) -> ListQuery {
+        let mut query = ListQuery::default();
 
         if let Some(ref pattern) = self.pattern {
             query = query.with_pattern(pattern);
@@ -195,11 +189,11 @@ impl ListEntitiesQuery {
         }
 
         if let Some(ref scope) = self.segment_scope {
-            match scope.as_str() {
-                "primary" => query = query.with_segment_scope(SegmentMatchScope::Primary),
-                "any" => query = query.with_segment_scope(SegmentMatchScope::Any),
-                _ => {}
-            }
+            let parsed = match scope.as_str() {
+                "primary" => SegmentMatchScope::Primary,
+                _ => SegmentMatchScope::Any,
+            };
+            query = query.with_segment_scope(parsed);
         }
 
         query
@@ -220,7 +214,6 @@ pub struct ListEntitiesResponse {
 mod tests {
     use super::*;
     use gts::GtsIdSegment;
-    use types_registry_sdk::TypesRegistryError;
 
     #[test]
     fn test_gts_entity_dto_from_entity() {
@@ -359,17 +352,12 @@ mod tests {
             #[allow(de0901_gts_string_pattern)]
             pattern: Some("gts.acme.*".to_owned()),
             is_schema: Some(true),
-            vendor: Some("acme".to_owned()),
-            package: None,
-            namespace: None,
-            segment_scope: Some("primary".to_owned()),
+            ..ListEntitiesQuery::default()
         };
 
         let query = dto.to_list_query();
         assert_eq!(query.pattern, Some("gts.acme.*".to_owned()));
         assert_eq!(query.is_type, Some(true));
-        assert_eq!(query.vendor, Some("acme".to_owned()));
-        assert_eq!(query.segment_scope, SegmentMatchScope::Primary);
     }
 
     #[test]
@@ -377,32 +365,38 @@ mod tests {
         let dto = ListEntitiesQuery {
             pattern: None,
             is_schema: Some(false),
-            vendor: None,
-            package: Some("core".to_owned()),
-            namespace: Some("events".to_owned()),
-            segment_scope: Some("any".to_owned()),
+            ..ListEntitiesQuery::default()
         };
 
         let query = dto.to_list_query();
         assert_eq!(query.is_type, Some(false));
-        assert_eq!(query.package, Some("core".to_owned()));
-        assert_eq!(query.namespace, Some("events".to_owned()));
-        assert_eq!(query.segment_scope, SegmentMatchScope::Any);
     }
 
     #[test]
-    fn test_list_entities_query_invalid_segment_scope() {
+    fn test_list_entities_query_segment_filters() {
         let dto = ListEntitiesQuery {
-            pattern: None,
-            is_schema: None,
-            vendor: None,
-            package: None,
-            namespace: None,
-            segment_scope: Some("invalid".to_owned()),
+            vendor: Some("acme".to_owned()),
+            package: Some("core".to_owned()),
+            namespace: Some("events".to_owned()),
+            segment_scope: Some("primary".to_owned()),
+            ..ListEntitiesQuery::default()
         };
 
         let query = dto.to_list_query();
-        assert_eq!(query.is_type, None);
+        assert_eq!(query.vendor, Some("acme".to_owned()));
+        assert_eq!(query.package, Some("core".to_owned()));
+        assert_eq!(query.namespace, Some("events".to_owned()));
+        assert_eq!(query.segment_scope, SegmentMatchScope::Primary);
+    }
+
+    #[test]
+    fn test_list_entities_query_segment_scope_unknown_falls_back_to_any() {
+        let dto = ListEntitiesQuery {
+            segment_scope: Some("garbage".to_owned()),
+            ..ListEntitiesQuery::default()
+        };
+
+        let query = dto.to_list_query();
         assert_eq!(query.segment_scope, SegmentMatchScope::Any);
     }
 
@@ -412,32 +406,6 @@ mod tests {
         let query = dto.to_list_query();
         assert_eq!(query.pattern, None);
         assert_eq!(query.is_type, None);
-        assert_eq!(query.vendor, None);
-    }
-
-    #[test]
-    fn test_register_result_dto_ok() {
-        let entity = GtsEntity::new(
-            Uuid::nil(),
-            "gts.test.pkg.ns.type.v1~",
-            vec![],
-            true, // is_schema
-            serde_json::json!({}),
-            None,
-        );
-        let result = RegisterResult::Ok(entity);
-        let dto: RegisterResultDto = result.into();
-        assert!(matches!(dto, RegisterResultDto::Ok { .. }));
-    }
-
-    #[test]
-    fn test_register_result_dto_err() {
-        let result: RegisterResult = RegisterResult::Err {
-            gts_id: Some("gts.x.core.events.test.v1~".to_owned()),
-            error: TypesRegistryError::validation_failed("test error"),
-        };
-        let dto: RegisterResultDto = result.into();
-        assert!(matches!(dto, RegisterResultDto::Error { .. }));
     }
 
     #[test]

--- a/modules/system/types-registry/types-registry/src/api/rest/error.rs
+++ b/modules/system/types-registry/types-registry/src/api/rest/error.rs
@@ -18,11 +18,11 @@ impl From<DomainError> for Problem {
                 "Invalid GTS ID",
                 msg.clone(),
             ),
-            DomainError::NotFound(id) => (
+            DomainError::NotFound { kind, target } => (
                 StatusCode::NOT_FOUND,
                 "TYPES_REGISTRY_NOT_FOUND",
                 "Entity not found",
-                format!("No entity with GTS ID: {id}"),
+                format!("No entity with {kind}: {target}"),
             ),
             DomainError::AlreadyExists(id) => (
                 StatusCode::CONFLICT,
@@ -34,6 +34,12 @@ impl From<DomainError> for Problem {
                 StatusCode::UNPROCESSABLE_ENTITY,
                 "TYPES_REGISTRY_VALIDATION_FAILED",
                 "Validation failed",
+                msg.clone(),
+            ),
+            DomainError::InvalidQuery(msg) => (
+                StatusCode::BAD_REQUEST,
+                "TYPES_REGISTRY_INVALID_QUERY",
+                "Invalid query",
                 msg.clone(),
             ),
             DomainError::NotInReadyMode => (
@@ -86,10 +92,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_domain_error_to_problem_not_found() {
-        let err = DomainError::not_found("gts.x.core.events.test.v1~");
+    fn test_domain_error_to_problem_not_found_by_id() {
+        let err = DomainError::not_found_by_id("gts.x.core.events.test.v1~");
         let problem: Problem = err.into();
         assert_eq!(problem.status, StatusCode::NOT_FOUND);
+        assert!(
+            problem
+                .detail
+                .contains("GTS ID: gts.x.core.events.test.v1~"),
+            "expected GTS-id-keyed detail, got {:?}",
+            problem.detail,
+        );
+    }
+
+    #[test]
+    fn test_domain_error_to_problem_not_found_by_uuid() {
+        let err = DomainError::not_found_by_uuid(uuid::Uuid::nil());
+        let problem: Problem = err.into();
+        assert_eq!(problem.status, StatusCode::NOT_FOUND);
+        assert!(
+            problem
+                .detail
+                .contains("UUID: 00000000-0000-0000-0000-000000000000"),
+            "expected UUID-keyed detail, got {:?}",
+            problem.detail,
+        );
     }
 
     #[test]
@@ -137,5 +164,12 @@ mod tests {
         let err = DomainError::Internal(anyhow::anyhow!("test error"));
         let problem: Problem = err.into();
         assert_eq!(problem.status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_domain_error_to_problem_invalid_query() {
+        let err = DomainError::invalid_query("bad pattern");
+        let problem: Problem = err.into();
+        assert_eq!(problem.status, StatusCode::BAD_REQUEST);
     }
 }

--- a/modules/system/types-registry/types-registry/src/api/rest/handlers.rs
+++ b/modules/system/types-registry/types-registry/src/api/rest/handlers.rs
@@ -6,7 +6,6 @@ use axum::Json;
 use axum::extract::{Extension, Path, Query};
 use modkit::api::prelude::*;
 use modkit::api::problem::Problem;
-use types_registry_sdk::RegisterSummary;
 
 use super::dto::{
     GtsEntityDto, ListEntitiesQuery, ListEntitiesResponse, RegisterEntitiesRequest,
@@ -28,13 +27,33 @@ pub async fn register_entities(
         return Err(DomainError::NotInReadyMode.into());
     }
 
-    let results = service.register_validated(req.entities);
+    let outcomes = service.register_validated(req.entities);
 
-    let summary = RegisterSummary::from_results(&results);
-    let result_dtos: Vec<RegisterResultDto> = results.into_iter().map(Into::into).collect();
+    let total = outcomes.len();
+    let mut succeeded = 0_usize;
+    let mut result_dtos: Vec<RegisterResultDto> = Vec::with_capacity(total);
+    for (gts_id, outcome) in outcomes {
+        match outcome {
+            Ok(entity) => {
+                succeeded += 1;
+                result_dtos.push(RegisterResultDto::Ok {
+                    entity: entity.into(),
+                });
+            }
+            Err(e) => result_dtos.push(RegisterResultDto::Error {
+                gts_id,
+                error: e.to_string(),
+            }),
+        }
+    }
+    let failed = total - succeeded;
 
     let response = RegisterEntitiesResponse {
-        summary: RegisterSummaryDto::from(summary),
+        summary: RegisterSummaryDto {
+            total,
+            succeeded,
+            failed,
+        },
         results: result_dtos,
     };
 

--- a/modules/system/types-registry/types-registry/src/config.rs
+++ b/modules/system/types-registry/types-registry/src/config.rs
@@ -1,7 +1,11 @@
 //! Configuration for the Types Registry module.
 
+use std::time::Duration;
+
 use serde::Deserialize;
 use uuid::Uuid;
+
+use crate::infra::cache::{CacheConfig, DEFAULT_CACHE_CAPACITY, DEFAULT_CACHE_TTL};
 
 /// Configuration for the Types Registry module.
 #[derive(Debug, Clone, Deserialize)]
@@ -29,6 +33,67 @@ pub struct TypesRegistryConfig {
     /// `gtsId`/`id`) field. Entities are registered in order.
     #[serde(default)]
     pub entities: Vec<serde_json::Value>,
+
+    /// Tuning for the in-process [`TypesRegistryLocalClient`](crate::domain::local_client::TypesRegistryLocalClient).
+    ///
+    /// Currently only carries cache settings, but lives under its own
+    /// section so future local-client knobs (resolver pools, retry
+    /// policies, etc.) don't crowd the top level.
+    #[serde(default)]
+    pub local_client: LocalClientSettings,
+}
+
+/// Settings for the in-process local client adapter.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct LocalClientSettings {
+    /// Per-kind cache tuning. Defaults match
+    /// [`DEFAULT_CACHE_CAPACITY`] / [`DEFAULT_CACHE_TTL`].
+    pub cache: CacheSettings,
+}
+
+/// Per-kind cache settings.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct CacheSettings {
+    /// Cache settings for the type-schema cache.
+    pub type_schemas: SingleCacheSettings,
+    /// Cache settings for the instance cache.
+    pub instances: SingleCacheSettings,
+}
+
+/// Settings for a single LRU cache.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct SingleCacheSettings {
+    /// Maximum number of entries before LRU eviction. Clamped to `1` if `0`.
+    pub capacity: usize,
+    /// Maximum age of an entry before it's treated as a miss. Accepts a
+    /// human-readable duration string (e.g. `"60s"`, `"2m"`); explicit
+    /// `null` disables TTL entirely. Omitting the field falls back to
+    /// [`DEFAULT_CACHE_TTL`].
+    #[serde(with = "modkit_utils::humantime_serde::option")]
+    pub ttl: Option<Duration>,
+}
+
+impl Default for SingleCacheSettings {
+    fn default() -> Self {
+        Self {
+            capacity: DEFAULT_CACHE_CAPACITY,
+            ttl: Some(DEFAULT_CACHE_TTL),
+        }
+    }
+}
+
+impl SingleCacheSettings {
+    /// Converts to the infra-layer [`CacheConfig`].
+    #[must_use]
+    pub const fn to_cache_config(&self) -> CacheConfig {
+        CacheConfig {
+            capacity: self.capacity,
+            ttl: self.ttl,
+        }
+    }
 }
 
 fn default_tenant_id() -> Uuid {
@@ -42,6 +107,7 @@ impl Default for TypesRegistryConfig {
             schema_id_fields: vec!["$schema".to_owned(), "gtsTid".to_owned(), "type".to_owned()],
             default_tenant_id: default_tenant_id(),
             entities: Vec::new(),
+            local_client: LocalClientSettings::default(),
         }
     }
 }
@@ -79,5 +145,94 @@ mod tests {
         let gts_cfg = cfg.to_gts_config();
         assert_eq!(gts_cfg.entity_id_fields, cfg.entity_id_fields);
         assert_eq!(gts_cfg.schema_id_fields, cfg.schema_id_fields);
+    }
+
+    #[test]
+    fn test_default_cache_settings_match_infra_constants() {
+        let cfg = TypesRegistryConfig::default();
+        assert_eq!(
+            cfg.local_client.cache.type_schemas.capacity,
+            DEFAULT_CACHE_CAPACITY
+        );
+        assert_eq!(
+            cfg.local_client.cache.type_schemas.ttl,
+            Some(DEFAULT_CACHE_TTL)
+        );
+        assert_eq!(
+            cfg.local_client.cache.instances.capacity,
+            DEFAULT_CACHE_CAPACITY
+        );
+        assert_eq!(
+            cfg.local_client.cache.instances.ttl,
+            Some(DEFAULT_CACHE_TTL)
+        );
+    }
+
+    #[test]
+    fn test_cache_settings_with_explicit_values() {
+        // JSON shape matches YAML 1:1 for the fields we care about (humantime
+        // accepts duration strings via Visitor::visit_str regardless of the
+        // input format).
+        let json = serde_json::json!({
+            "local_client": {
+                "cache": {
+                    "type_schemas": { "capacity": 2048, "ttl": "2m" },
+                    "instances":    { "capacity": 512,  "ttl": "30s" },
+                }
+            }
+        });
+        let cfg: TypesRegistryConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(cfg.local_client.cache.type_schemas.capacity, 2048);
+        assert_eq!(
+            cfg.local_client.cache.type_schemas.ttl,
+            Some(std::time::Duration::from_mins(2))
+        );
+        assert_eq!(cfg.local_client.cache.instances.capacity, 512);
+        assert_eq!(
+            cfg.local_client.cache.instances.ttl,
+            Some(std::time::Duration::from_secs(30))
+        );
+    }
+
+    #[test]
+    fn test_cache_settings_null_ttl_disables() {
+        let json = serde_json::json!({
+            "local_client": {
+                "cache": {
+                    "type_schemas": { "capacity": 100, "ttl": null },
+                    "instances":    { "capacity": 100, "ttl": null },
+                }
+            }
+        });
+        let cfg: TypesRegistryConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(cfg.local_client.cache.type_schemas.ttl, None);
+        assert_eq!(cfg.local_client.cache.instances.ttl, None);
+    }
+
+    #[test]
+    fn test_cache_settings_omitted_falls_back_to_default() {
+        // Whole `cache` block missing — defaults must come from
+        // SingleCacheSettings::default(), keeping parity with InMemoryCache's
+        // hardcoded defaults.
+        let cfg: TypesRegistryConfig = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(
+            cfg.local_client.cache.type_schemas.capacity,
+            DEFAULT_CACHE_CAPACITY
+        );
+        assert_eq!(
+            cfg.local_client.cache.type_schemas.ttl,
+            Some(DEFAULT_CACHE_TTL)
+        );
+    }
+
+    #[test]
+    fn test_to_cache_config_round_trip() {
+        let settings = SingleCacheSettings {
+            capacity: 7,
+            ttl: Some(std::time::Duration::from_secs(11)),
+        };
+        let cache_cfg = settings.to_cache_config();
+        assert_eq!(cache_cfg.capacity, 7);
+        assert_eq!(cache_cfg.ttl, Some(std::time::Duration::from_secs(11)));
     }
 }

--- a/modules/system/types-registry/types-registry/src/domain/error.rs
+++ b/modules/system/types-registry/types-registry/src/domain/error.rs
@@ -43,6 +43,13 @@ impl std::fmt::Display for ValidationError {
 }
 
 /// Domain-level errors for the Types Registry module.
+///
+/// This enum is intentionally **kind-agnostic** — the storage layer doesn't
+/// know whether a string identifies a type-schema or an instance, it just
+/// stores and retrieves entities by their GTS ID. The kind context is added
+/// at the SDK boundary by the local client, which knows what kind the caller
+/// asked for and converts via [`Self::into_sdk_for_type_schema`] /
+/// [`Self::into_sdk_for_instance`].
 #[domain_model]
 #[derive(Error, Debug)]
 pub enum DomainError {
@@ -50,13 +57,22 @@ pub enum DomainError {
     #[error("Invalid GTS ID: {0}")]
     InvalidGtsId(String),
 
-    /// The requested entity was not found.
-    #[error("Entity not found: {0}")]
-    NotFound(String),
+    /// The requested entity was not found. `kind` records which lookup
+    /// surface the caller used (GTS id vs. UUID v5) so the REST layer
+    /// renders an accurate "No entity with X: …" message and SDK
+    /// conversions stay symmetric.
+    #[error("Entity not found ({kind}): {target}")]
+    NotFound { kind: LookupKind, target: String },
 
     /// An entity with the same GTS ID already exists.
     #[error("Entity already exists: {0}")]
     AlreadyExists(String),
+
+    /// The list/query parameters are syntactically invalid (e.g. an
+    /// out-of-spec wildcard pattern). Distinct from `InvalidGtsId`, which
+    /// covers id-shaped inputs.
+    #[error("Invalid query: {0}")]
+    InvalidQuery(String),
 
     /// Validation of the entity content failed.
     #[error("Validation failed: {0}")]
@@ -75,6 +91,39 @@ pub enum DomainError {
     Internal(#[from] anyhow::Error),
 }
 
+/// Indicates which kind of entity the caller was looking up, so kind-agnostic
+/// `DomainError`s can be lifted into kind-specific [`TypesRegistryError`]
+/// variants at the SDK boundary.
+#[domain_model]
+#[derive(Debug, Clone, Copy)]
+pub enum SdkErrorKind {
+    /// The caller asked for a type-schema.
+    TypeSchema,
+    /// The caller asked for an instance.
+    Instance,
+}
+
+/// Identifies which surface a `NotFound` lookup used. Carried inside
+/// [`DomainError::NotFound`] so renderers (REST, logs) can produce
+/// accurate "No entity with X" messages.
+#[domain_model]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LookupKind {
+    /// Lookup by canonical GTS id string.
+    GtsId,
+    /// Lookup by deterministic UUID v5.
+    Uuid,
+}
+
+impl std::fmt::Display for LookupKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GtsId => f.write_str("GTS ID"),
+            Self::Uuid => f.write_str("UUID"),
+        }
+    }
+}
+
 impl DomainError {
     /// Creates an `InvalidGtsId` error.
     #[must_use]
@@ -82,16 +131,34 @@ impl DomainError {
         Self::InvalidGtsId(message.into())
     }
 
-    /// Creates a `NotFound` error.
+    /// Creates a `NotFound` error for a GTS-id-keyed lookup miss.
     #[must_use]
-    pub fn not_found(gts_id: impl Into<String>) -> Self {
-        Self::NotFound(gts_id.into())
+    pub fn not_found_by_id(gts_id: impl Into<String>) -> Self {
+        Self::NotFound {
+            kind: LookupKind::GtsId,
+            target: gts_id.into(),
+        }
+    }
+
+    /// Creates a `NotFound` error for a UUID-keyed lookup miss.
+    #[must_use]
+    pub fn not_found_by_uuid(uuid: uuid::Uuid) -> Self {
+        Self::NotFound {
+            kind: LookupKind::Uuid,
+            target: uuid.to_string(),
+        }
     }
 
     /// Creates an `AlreadyExists` error.
     #[must_use]
     pub fn already_exists(gts_id: impl Into<String>) -> Self {
         Self::AlreadyExists(gts_id.into())
+    }
+
+    /// Creates an `InvalidQuery` error.
+    #[must_use]
+    pub fn invalid_query(message: impl Into<String>) -> Self {
+        Self::InvalidQuery(message.into())
     }
 
     /// Creates a `ValidationFailed` error.
@@ -108,17 +175,49 @@ impl DomainError {
             _ => None,
         }
     }
-}
 
-impl From<DomainError> for TypesRegistryError {
-    fn from(e: DomainError) -> Self {
-        match e {
-            DomainError::InvalidGtsId(msg) => TypesRegistryError::invalid_gts_id(msg),
-            DomainError::NotFound(id) => TypesRegistryError::not_found(id),
-            DomainError::AlreadyExists(id) => TypesRegistryError::already_exists(id),
-            DomainError::ValidationFailed(msg) => TypesRegistryError::validation_failed(msg),
-            DomainError::NotInReadyMode => TypesRegistryError::not_in_ready_mode(),
-            DomainError::ReadyCommitFailed(errors) => {
+    /// Converts to [`TypesRegistryError`] under the assumption that the caller
+    /// was looking up a **type-schema**.
+    ///
+    /// `NotFound` becomes `GtsTypeSchemaNotFound`; `InvalidGtsId` becomes
+    /// `InvalidGtsTypeId`; the rest map straight.
+    #[must_use]
+    pub fn into_sdk_for_type_schema(self) -> TypesRegistryError {
+        self.into_sdk(SdkErrorKind::TypeSchema)
+    }
+
+    /// Converts to [`TypesRegistryError`] under the assumption that the caller
+    /// was looking up an **instance**.
+    ///
+    /// `NotFound` becomes `GtsInstanceNotFound`; `InvalidGtsId` becomes
+    /// `InvalidGtsInstanceId`; the rest map straight.
+    #[must_use]
+    pub fn into_sdk_for_instance(self) -> TypesRegistryError {
+        self.into_sdk(SdkErrorKind::Instance)
+    }
+
+    fn into_sdk(self, kind: SdkErrorKind) -> TypesRegistryError {
+        match (self, kind) {
+            (Self::InvalidGtsId(msg), SdkErrorKind::TypeSchema) => {
+                TypesRegistryError::invalid_gts_type_id(msg)
+            }
+            (Self::InvalidGtsId(msg), SdkErrorKind::Instance) => {
+                TypesRegistryError::invalid_gts_instance_id(msg)
+            }
+            (Self::NotFound { target, .. }, SdkErrorKind::TypeSchema) => {
+                TypesRegistryError::gts_type_schema_not_found(target)
+            }
+            (Self::NotFound { target, .. }, SdkErrorKind::Instance) => {
+                TypesRegistryError::gts_instance_not_found(target)
+            }
+            (Self::AlreadyExists(id), _) => TypesRegistryError::already_exists(id),
+            (Self::InvalidQuery(msg), _) => TypesRegistryError::invalid_query(msg),
+            (Self::ValidationFailed(msg), _) => TypesRegistryError::validation_failed(msg),
+            (Self::NotInReadyMode, _) => TypesRegistryError::service_unavailable(
+                "types registry is still initializing",
+                std::time::Duration::from_secs(1),
+            ),
+            (Self::ReadyCommitFailed(errors), _) => {
                 let error_strings: Vec<String> = errors
                     .iter()
                     .map(std::string::ToString::to_string)
@@ -129,7 +228,7 @@ impl From<DomainError> for TypesRegistryError {
                     error_strings.join("; ")
                 ))
             }
-            DomainError::Internal(e) => TypesRegistryError::internal(e.to_string()),
+            (Self::Internal(e), _) => TypesRegistryError::internal(e.to_string()),
         }
     }
 }
@@ -143,8 +242,23 @@ mod tests {
         let err = DomainError::invalid_gts_id("missing vendor");
         assert!(matches!(err, DomainError::InvalidGtsId(_)));
 
-        let err = DomainError::not_found("gts.acme.core.events.test.v1~");
-        assert!(matches!(err, DomainError::NotFound(_)));
+        let err = DomainError::not_found_by_id("gts.acme.core.events.test.v1~");
+        assert!(matches!(
+            err,
+            DomainError::NotFound {
+                kind: LookupKind::GtsId,
+                ..
+            }
+        ));
+
+        let err = DomainError::not_found_by_uuid(uuid::Uuid::nil());
+        assert!(matches!(
+            err,
+            DomainError::NotFound {
+                kind: LookupKind::Uuid,
+                ..
+            }
+        ));
 
         let err = DomainError::already_exists("gts.acme.core.events.test.v1~");
         assert!(matches!(err, DomainError::AlreadyExists(_)));
@@ -154,29 +268,44 @@ mod tests {
     }
 
     #[test]
-    fn test_domain_to_sdk_error_conversion() {
-        let domain_err = DomainError::not_found("gts.x.core.events.test.v1~");
-        let sdk_err: TypesRegistryError = domain_err.into();
-        assert!(sdk_err.is_not_found());
+    fn test_domain_to_sdk_error_conversion_for_type_schema() {
+        let sdk_err =
+            DomainError::not_found_by_id("gts.x.core.events.test.v1~").into_sdk_for_type_schema();
+        assert!(sdk_err.is_gts_type_schema_not_found());
 
-        let domain_err = DomainError::already_exists("gts.x.core.events.test.v1~");
-        let sdk_err: TypesRegistryError = domain_err.into();
+        // UUID-keyed not-found also surfaces as `GtsTypeSchemaNotFound` —
+        // the SDK error doesn't model the lookup kind, only the kind of
+        // the entity the caller was after. The lookup-kind distinction
+        // matters only for REST rendering.
+        let sdk_err = DomainError::not_found_by_uuid(uuid::Uuid::nil()).into_sdk_for_type_schema();
+        assert!(sdk_err.is_gts_type_schema_not_found());
+
+        let sdk_err = DomainError::invalid_gts_id("bad format").into_sdk_for_type_schema();
+        assert!(sdk_err.is_invalid_gts_type_id());
+
+        let sdk_err =
+            DomainError::already_exists("gts.x.core.events.test.v1~").into_sdk_for_type_schema();
         assert!(sdk_err.is_already_exists());
 
-        let domain_err = DomainError::validation_failed("bad schema");
-        let sdk_err: TypesRegistryError = domain_err.into();
+        let sdk_err = DomainError::validation_failed("bad schema").into_sdk_for_type_schema();
         assert!(sdk_err.is_validation_failed());
+    }
 
-        let domain_err = DomainError::invalid_gts_id("bad format");
-        let sdk_err: TypesRegistryError = domain_err.into();
-        assert!(sdk_err.is_invalid_gts_id());
+    #[test]
+    fn test_domain_to_sdk_error_conversion_for_instance() {
+        let sdk_err =
+            DomainError::not_found_by_id("gts.x.core.events.test.v1~x.core.instances.u1.v1")
+                .into_sdk_for_instance();
+        assert!(sdk_err.is_gts_instance_not_found());
+
+        let sdk_err = DomainError::invalid_gts_id("no chain prefix").into_sdk_for_instance();
+        assert!(sdk_err.is_invalid_gts_instance_id());
     }
 
     #[test]
     fn test_domain_to_sdk_error_not_in_ready_mode() {
-        let domain_err = DomainError::NotInReadyMode;
-        let sdk_err: TypesRegistryError = domain_err.into();
-        assert!(matches!(sdk_err, TypesRegistryError::NotInReadyMode));
+        let sdk_err = DomainError::NotInReadyMode.into_sdk_for_type_schema();
+        assert!(sdk_err.is_service_unavailable());
     }
 
     #[test]
@@ -185,16 +314,23 @@ mod tests {
             ValidationError::new("gts.test1~", "error1"),
             ValidationError::new("gts.test2~", "error2"),
         ];
-        let domain_err = DomainError::ReadyCommitFailed(errors);
-        let sdk_err: TypesRegistryError = domain_err.into();
+        let sdk_err = DomainError::ReadyCommitFailed(errors).into_sdk_for_type_schema();
         assert!(sdk_err.is_validation_failed());
     }
 
     #[test]
     fn test_domain_to_sdk_error_internal() {
-        let domain_err = DomainError::Internal(anyhow::anyhow!("test error"));
-        let sdk_err: TypesRegistryError = domain_err.into();
+        let sdk_err =
+            DomainError::Internal(anyhow::anyhow!("test error")).into_sdk_for_type_schema();
         assert!(matches!(sdk_err, TypesRegistryError::Internal(_)));
+    }
+
+    #[test]
+    fn test_domain_to_sdk_error_invalid_query() {
+        let sdk_err = DomainError::invalid_query("bad pattern").into_sdk_for_type_schema();
+        assert!(sdk_err.is_invalid_query());
+        let sdk_err = DomainError::invalid_query("bad pattern").into_sdk_for_instance();
+        assert!(sdk_err.is_invalid_query());
     }
 
     #[test]
@@ -202,10 +338,16 @@ mod tests {
         let err = DomainError::InvalidGtsId("bad format".to_owned());
         assert_eq!(err.to_string(), "Invalid GTS ID: bad format");
 
-        let err = DomainError::NotFound("gts.x.core.events.test.v1~".to_owned());
+        let err = DomainError::not_found_by_id("gts.x.core.events.test.v1~");
         assert_eq!(
             err.to_string(),
-            "Entity not found: gts.x.core.events.test.v1~"
+            "Entity not found (GTS ID): gts.x.core.events.test.v1~"
+        );
+
+        let err = DomainError::not_found_by_uuid(uuid::Uuid::nil());
+        assert_eq!(
+            err.to_string(),
+            "Entity not found (UUID): 00000000-0000-0000-0000-000000000000"
         );
 
         let err = DomainError::AlreadyExists("gts.x.core.events.test.v1~".to_owned());

--- a/modules/system/types-registry/types-registry/src/domain/local_client.rs
+++ b/modules/system/types-registry/types-registry/src/domain/local_client.rs
@@ -1,30 +1,307 @@
-//! Local client implementing the `TypesRegistryApi` trait.
+//! Local client implementing the `TypesRegistryClient` trait.
+//!
+//! Owns kind discrimination, recursive parent resolution, and the type-schema /
+//! instance caches — service stays kind-agnostic.
 
+// Local client is a thin adapter between the domain service (kind-agnostic
+// reads/writes) and the infra-layer caches that hold `Arc<GtsTypeSchema>` /
+// `Arc<GtsInstance>`. Exposing those caches via a domain-level trait would
+// just be ceremony — the client owns them by construction.
+#![allow(unknown_lints)]
+#![allow(de0301_no_infra_in_domain)]
+
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use modkit_macros::domain_model;
 use types_registry_sdk::{
-    GtsEntity, ListQuery, RegisterResult, TypesRegistryClient, TypesRegistryError,
+    GtsInstance, GtsInstanceId, GtsTypeId, GtsTypeSchema, InstanceQuery, RegisterResult,
+    TypeSchemaQuery, TypesRegistryClient, TypesRegistryError, is_type_schema_id,
 };
+use uuid::Uuid;
 
+use crate::domain::error::DomainError;
+use crate::domain::model::{GtsEntity, ListQuery};
 use crate::domain::service::TypesRegistryService;
+use crate::infra::cache::{CacheConfig, InMemoryCache, InstanceCache, TypeSchemaCache};
 
 /// Local client for the Types Registry module.
 ///
-/// This client implements the `TypesRegistryApi` trait and delegates
-/// to the domain service. It is registered in the `ClientHub` for
-/// inter-module communication.
+/// Implements the public [`TypesRegistryClient`] trait by wrapping
+/// [`TypesRegistryService`] and adding kind discrimination, recursive
+/// parent resolution, and TTL-aware caches of `Arc<GtsTypeSchema>` and
+/// `Arc<GtsInstance>` so chain ancestors are deduplicated across calls.
+///
+/// Each cache also internally maintains a `UUID` → canonical `gts_id`
+/// reverse index, populated atomically with every `put`, so `*_by_uuid`
+/// lookups can short-circuit the linear storage scan once a UUID has been
+/// observed. The two caches are independent: a `*_by_uuid` query only
+/// consults the index of its own kind. Cross-kind UUID observations are
+/// not tracked — a kind-mismatch error path costs one extra storage scan,
+/// which we treat as acceptable.
 #[domain_model]
 pub struct TypesRegistryLocalClient {
     service: Arc<TypesRegistryService>,
+    type_schemas: TypeSchemaCache,
+    instances: InstanceCache,
 }
 
 impl TypesRegistryLocalClient {
-    /// Creates a new local client with the given service.
+    /// Creates a new local client with default cache configurations
+    /// ([`CacheConfig::type_schemas`] and [`CacheConfig::instances`]).
     #[must_use]
     pub fn new(service: Arc<TypesRegistryService>) -> Self {
-        Self { service }
+        Self::with_cache_configs(
+            service,
+            CacheConfig::type_schemas(),
+            CacheConfig::instances(),
+        )
+    }
+
+    /// Creates a new local client with custom cache configurations.
+    #[must_use]
+    pub fn with_cache_configs(
+        service: Arc<TypesRegistryService>,
+        type_schemas: CacheConfig,
+        instances: CacheConfig,
+    ) -> Self {
+        Self {
+            service,
+            type_schemas: Box::new(InMemoryCache::new(type_schemas)),
+            instances: Box::new(InMemoryCache::new(instances)),
+        }
+    }
+
+    /// Drops every cached type-schema and instance, including each cache's
+    /// internal UUID-index.
+    ///
+    /// Useful after `service.switch_to_ready()` if some entries had been built
+    /// pre-ready with best-effort parents, or as a recovery hatch for tests.
+    pub fn clear_caches(&self) {
+        self.type_schemas.clear();
+        self.instances.clear();
+    }
+
+    /// Cascade-invalidates cached entries when the type-schema with `type_id`
+    /// is being rewritten. Derived type-schemas in [`Self::type_schemas`]
+    /// keep `Arc<GtsTypeSchema>` parents in their chain, and instances in
+    /// [`Self::instances`] embed an `Arc<GtsTypeSchema>` directly — if we
+    /// drop only the rewritten key, dependents continue to return stale
+    /// views. We drop every cached entry whose ancestor chain transitively
+    /// references `type_id`.
+    fn invalidate_type_schema_cascade(&self, type_id: &str) {
+        self.type_schemas
+            .retain(&|s| !s.ancestors().any(|a| a.type_id == type_id));
+        self.instances
+            .retain(&|i| !i.type_schema.ancestors().any(|a| a.type_id == type_id));
+    }
+
+    /// Drops the cached entry for the given type-schema id and any cached
+    /// dependents (derived type-schemas, instances) that transitively
+    /// reference it through their resolved chain. No-op if absent.
+    pub fn invalidate_type_schema(&self, type_id: &str) {
+        self.invalidate_type_schema_cascade(type_id);
+    }
+
+    /// Removes one instance entry from the cache. No-op if absent.
+    pub fn invalidate_instance(&self, id: &str) {
+        self.instances.invalidate(id);
+    }
+
+    /// Returns the type-schema as a fully-resolved `Arc<GtsTypeSchema>` (with
+    /// all ancestors recursively populated). Caches the result.
+    ///
+    /// `type_id` must end with `~` — instance ids are rejected with
+    /// `InvalidGtsTypeId` before any storage lookup, since type-schema and
+    /// instance ids are lexically distinct.
+    fn resolve_type_schema_arc(
+        &self,
+        type_id: &str,
+    ) -> Result<Arc<GtsTypeSchema>, TypesRegistryError> {
+        if !is_type_schema_id(type_id) {
+            return Err(TypesRegistryError::invalid_gts_type_id(format!(
+                "{type_id} does not end with `~`",
+            )));
+        }
+        if let Some(cached) = self.type_schemas.get(type_id) {
+            return Ok(cached);
+        }
+        let entity = self
+            .service
+            .get(type_id)
+            .map_err(DomainError::into_sdk_for_type_schema)?;
+        let arc = self.build_type_schema_arc(entity)?;
+        self.type_schemas
+            .put(arc.type_id.to_string(), Arc::clone(&arc));
+        Ok(arc)
+    }
+
+    /// Storage-backed resolution for `get_*_by_uuid` cache misses. Skips
+    /// the by-uuid cache check (callers already established the miss);
+    /// fetches the entity from storage by UUID, validates kind, then
+    /// delegates to [`Self::get_type_schema`] so the typed cache absorbs
+    /// the build (and the reverse `uuid → gts_id` index gets populated for
+    /// next time). TODO(#1630): replace the linear scan in
+    /// `service.get_by_uuid` with an indexed lookup.
+    async fn fetch_type_schema_by_uuid_uncached(
+        &self,
+        type_uuid: Uuid,
+    ) -> Result<GtsTypeSchema, TypesRegistryError> {
+        let entity = self
+            .service
+            .get_by_uuid(type_uuid)
+            .map_err(DomainError::into_sdk_for_type_schema)?;
+        if !entity.is_type_schema {
+            // The UUID exists but points to an instance — from the
+            // type-schema namespace's perspective, it's not registered.
+            return Err(TypesRegistryError::gts_type_schema_not_found(
+                type_uuid.to_string(),
+            ));
+        }
+        let gts_id = entity.gts_id.clone();
+        self.get_type_schema(&gts_id).await
+    }
+
+    /// Symmetric of [`Self::fetch_type_schema_by_uuid_uncached`] for
+    /// instances.
+    async fn fetch_instance_by_uuid_uncached(
+        &self,
+        uuid: Uuid,
+    ) -> Result<GtsInstance, TypesRegistryError> {
+        let entity = self
+            .service
+            .get_by_uuid(uuid)
+            .map_err(DomainError::into_sdk_for_instance)?;
+        if entity.is_type_schema {
+            // The UUID exists but points to a type-schema — from the
+            // instance namespace's perspective, it's not registered.
+            return Err(TypesRegistryError::gts_instance_not_found(uuid.to_string()));
+        }
+        let gts_id = entity.gts_id.clone();
+        self.get_instance(&gts_id).await
+    }
+
+    /// Returns the instance as a fully-resolved `Arc<GtsInstance>`. Caches
+    /// the result. Type-schema reference is resolved via the type-schema cache.
+    ///
+    /// `id` must NOT end with `~` — type-schema ids are rejected with
+    /// `InvalidGtsInstanceId` before any storage lookup.
+    fn resolve_instance_arc(&self, id: &str) -> Result<Arc<GtsInstance>, TypesRegistryError> {
+        if is_type_schema_id(id) {
+            return Err(TypesRegistryError::invalid_gts_instance_id(format!(
+                "{id} ends with `~` (looks like a type-schema id)",
+            )));
+        }
+        if let Some(cached) = self.instances.get(id) {
+            return Ok(cached);
+        }
+        let entity = self
+            .service
+            .get(id)
+            .map_err(DomainError::into_sdk_for_instance)?;
+        let inst = self.build_instance(entity)?;
+        let arc = Arc::new(inst);
+        self.instances.put(arc.id.to_string(), Arc::clone(&arc));
+        Ok(arc)
+    }
+
+    /// Builds an `Arc<GtsTypeSchema>` from an internal entity, resolving the
+    /// GTS chain parent (derived from the type's own `gts_id`) through the
+    /// type-schema cache. Mirrors gts-rust's chain semantics in
+    /// `validate_schema_chain` — the parent is the type whose id is `gts_id`
+    /// minus the trailing `~`-segment. Mixin `$ref`s in `allOf` (if any) are
+    /// not surfaced as parents — they're left in `schema.schema` for
+    /// `effective_schema()` to observe but pass through.
+    ///
+    /// Does not itself insert into the cache (caller decides).
+    ///
+    // TODO(#1723): once gts-rust exposes a `resolve_schema(gts_id)` helper
+    // returning a fully-resolved view, replace this manual chain walk with
+    // a single delegation.
+    fn build_type_schema_arc(
+        &self,
+        entity: GtsEntity,
+    ) -> Result<Arc<GtsTypeSchema>, TypesRegistryError> {
+        let parent = if let Some(parent_id) = GtsTypeSchema::derive_parent_type_id(&entity.gts_id) {
+            Some(
+                self.resolve_type_schema_arc(parent_id.as_ref())
+                    .map_err(|e| {
+                        if e.is_gts_type_schema_not_found() {
+                            TypesRegistryError::invalid_gts_type_id(format!(
+                                "type-schema {} references missing parent {parent_id}",
+                                entity.gts_id
+                            ))
+                        } else {
+                            e
+                        }
+                    })?,
+            )
+        } else {
+            None
+        };
+        let type_id = GtsTypeId::new(&entity.gts_id);
+        let schema = GtsTypeSchema::try_new(type_id, entity.content, entity.description, parent)?;
+        Ok(Arc::new(schema))
+    }
+
+    /// Parent existence pre-check used by `register_*` methods in ready
+    /// phase. Returns `Some(error)` if the entity has a parent type-schema
+    /// that is not yet registered; `None` if the entity is a root type-
+    /// schema, has no extractable id, or its parent is registered.
+    ///
+    /// For type-schemas, the parent is the chain prefix (`derive_parent_type_id`).
+    /// For instances, the parent is the declaring type-schema (`derive_type_id`).
+    fn parent_pre_check(&self, gts_id: Option<&str>) -> Option<TypesRegistryError> {
+        let id = gts_id?;
+        let parent_type_id = if is_type_schema_id(id) {
+            // Type-schema: parent only exists for chained (non-root) ids.
+            GtsTypeSchema::derive_parent_type_id(id)?
+        } else {
+            // Instance: declaring type-schema is required.
+            GtsInstance::derive_type_id(id)?
+        };
+        if self.service.exists(parent_type_id.as_ref()) {
+            None
+        } else {
+            Some(TypesRegistryError::parent_type_schema_not_registered(
+                parent_type_id.into_string(),
+                id,
+            ))
+        }
+    }
+
+    /// Builds a `GtsInstance` from an internal entity by resolving its
+    /// type-schema through the cache.
+    fn build_instance(&self, entity: GtsEntity) -> Result<GtsInstance, TypesRegistryError> {
+        if entity.is_type_schema {
+            return Err(TypesRegistryError::invalid_gts_instance_id(format!(
+                "{} is a type-schema, not an instance",
+                entity.gts_id,
+            )));
+        }
+        let type_id = GtsInstance::derive_type_id(&entity.gts_id).ok_or_else(|| {
+            TypesRegistryError::invalid_gts_instance_id(format!(
+                "instance gts_id {} has no type-schema chain (no `~`)",
+                entity.gts_id
+            ))
+        })?;
+        let type_schema = self.resolve_type_schema_arc(type_id.as_ref())?;
+        let segment = &entity.gts_id[type_id.as_ref().len()..];
+        let instance_id = GtsInstanceId::new(type_id.as_ref(), segment);
+        GtsInstance::try_new(instance_id, entity.content, entity.description, type_schema)
+    }
+}
+
+/// Lexicographic comparator for optional GTS ids. `None` (no extractable
+/// id from the input JSON) sorts last, so format-rejection happens at the
+/// end of the batch.
+fn compare_optional_gts_ids(a: Option<&str>, b: Option<&str>) -> std::cmp::Ordering {
+    match (a, b) {
+        (Some(x), Some(y)) => x.cmp(y),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
     }
 }
 
@@ -34,103 +311,466 @@ impl TypesRegistryClient for TypesRegistryLocalClient {
         &self,
         entities: Vec<serde_json::Value>,
     ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
-        Ok(self.service.register(entities))
+        // Sort by extracted gts_id so parents register before children within
+        // the same batch (items without an extractable id go to the end —
+        // they'll fail in service.register with InvalidGtsId), but keep the
+        // original index so the returned vec stays positionally aligned with
+        // the caller's input. Caller-side correlation is the only way to
+        // recover identity for items where extract_gts_id returned None.
+        let mut indexed: Vec<(usize, Option<String>, serde_json::Value)> = entities
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| (i, self.service.extract_gts_id(&v), v))
+            .collect();
+        indexed.sort_by(|a, b| compare_optional_gts_ids(a.1.as_deref(), b.1.as_deref()));
+
+        let total = indexed.len();
+        let mut slots: Vec<Option<RegisterResult>> = (0..total).map(|_| None).collect();
+        for (orig_idx, gts_id, value) in indexed {
+            // Pre-check parent in ready phase. Skipped in config phase
+            // because temporary storage holds yet-unvalidated chains.
+            if self.service.is_ready()
+                && let Some(err) = self.parent_pre_check(gts_id.as_deref())
+            {
+                slots[orig_idx] = Some(RegisterResult::Err {
+                    gts_id: gts_id.clone(),
+                    error: err,
+                });
+                continue;
+            }
+            let single = self.service.register(vec![value]);
+            if let Some(result) = single.into_iter().next() {
+                // Invalidate caches only after the write commits — evicting
+                // pre-write opens a TOCTOU window where a concurrent reader
+                // can repopulate the cache with the old entity from storage.
+                // Use the canonical persisted id from `RegisterResult::Ok`
+                // rather than the request-extracted `gts_id`: if the service
+                // ever canonicalises an id (whitespace, prefix, casing),
+                // invalidating by the un-canonicalised input would leave the
+                // real cache entry stale. For type-schemas we also
+                // cascade-invalidate dependents whose chain references this id.
+                if let RegisterResult::Ok {
+                    gts_id: persisted_id,
+                } = &result
+                {
+                    if is_type_schema_id(persisted_id) {
+                        self.invalidate_type_schema_cascade(persisted_id);
+                    } else {
+                        self.instances.invalidate(persisted_id);
+                    }
+                }
+                slots[orig_idx] = Some(result);
+            }
+        }
+        Ok(slots.into_iter().map(Option::unwrap).collect())
     }
 
-    async fn list(&self, query: ListQuery) -> Result<Vec<GtsEntity>, TypesRegistryError> {
-        self.service.list(&query).map_err(TypesRegistryError::from)
+    async fn register_type_schemas(
+        &self,
+        type_schemas: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        // See `register` for the sort-then-write-back-by-original-index pattern:
+        // sort lets parents register before children in the batch, but the
+        // returned vec must still line up with the caller's input order.
+        let mut indexed: Vec<(usize, Option<String>, serde_json::Value)> = type_schemas
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| (i, self.service.extract_gts_id(&v), v))
+            .collect();
+        indexed.sort_by(|a, b| compare_optional_gts_ids(a.1.as_deref(), b.1.as_deref()));
+
+        let total = indexed.len();
+        let mut slots: Vec<Option<RegisterResult>> = (0..total).map(|_| None).collect();
+        for (orig_idx, gts_id, value) in indexed {
+            // Missing id: caller invoked the type-schema-typed endpoint, so
+            // we owe a kind-typed error.
+            let Some(ref id) = gts_id else {
+                slots[orig_idx] = Some(RegisterResult::Err {
+                    gts_id: None,
+                    error: TypesRegistryError::invalid_gts_type_id(
+                        "no GTS id field found in entity",
+                    ),
+                });
+                continue;
+            };
+            // Kind check: type-schema id must end with `~`.
+            if !is_type_schema_id(id) {
+                slots[orig_idx] = Some(RegisterResult::Err {
+                    gts_id: gts_id.clone(),
+                    error: TypesRegistryError::invalid_gts_type_id(format!(
+                        "{id} does not end with `~`",
+                    )),
+                });
+                continue;
+            }
+            // Parent pre-check (ready phase only).
+            if self.service.is_ready()
+                && let Some(err) = self.parent_pre_check(Some(id))
+            {
+                slots[orig_idx] = Some(RegisterResult::Err {
+                    gts_id: gts_id.clone(),
+                    error: err,
+                });
+                continue;
+            }
+            let single = self.service.register(vec![value]);
+            if let Some(result) = single.into_iter().next() {
+                // Cascade-invalidate after the write commits, keyed on the
+                // canonical persisted id from `RegisterResult::Ok` rather
+                // than the request-extracted `id` — see the matching
+                // comment in `register` for the rationale.
+                if let RegisterResult::Ok {
+                    gts_id: persisted_id,
+                } = &result
+                {
+                    self.invalidate_type_schema_cascade(persisted_id);
+                }
+                slots[orig_idx] = Some(result);
+            }
+        }
+        Ok(slots.into_iter().map(Option::unwrap).collect())
     }
 
-    async fn get(&self, gts_id: &str) -> Result<GtsEntity, TypesRegistryError> {
-        self.service.get(gts_id).map_err(TypesRegistryError::from)
+    async fn get_type_schema(&self, type_id: &str) -> Result<GtsTypeSchema, TypesRegistryError> {
+        let arc = self.resolve_type_schema_arc(type_id)?;
+        Ok((*arc).clone())
+    }
+
+    async fn get_type_schema_by_uuid(
+        &self,
+        type_uuid: Uuid,
+    ) -> Result<GtsTypeSchema, TypesRegistryError> {
+        // Fast path: full cache hit by UUID. (Cache puts populate the
+        // reverse uuid → gts_id index atomically, so anything previously
+        // resolved on the type-schema side is reachable from here.)
+        if let Some(arc) = self.type_schemas.get_by_uuid(type_uuid) {
+            return Ok((*arc).clone());
+        }
+        self.fetch_type_schema_by_uuid_uncached(type_uuid).await
+    }
+
+    async fn get_type_schemas(
+        &self,
+        type_ids: Vec<String>,
+    ) -> HashMap<String, Result<GtsTypeSchema, TypesRegistryError>> {
+        let mut out = HashMap::with_capacity(type_ids.len());
+
+        // Phase 1: format check + dedup. Format-rejected ids land directly
+        // in the result map; the rest go to phase 2 for cache lookup.
+        let mut to_resolve: Vec<String> = Vec::new();
+        for id in type_ids {
+            if out.contains_key(&id) {
+                continue;
+            }
+            if is_type_schema_id(&id) {
+                to_resolve.push(id);
+            } else {
+                out.insert(
+                    id.clone(),
+                    Err(TypesRegistryError::invalid_gts_type_id(format!(
+                        "{id} does not end with `~`",
+                    ))),
+                );
+            }
+        }
+        if to_resolve.is_empty() {
+            return out;
+        }
+
+        // Phase 2: single-lock cache lookup for the whole batch.
+        let key_refs: Vec<&str> = to_resolve.iter().map(String::as_str).collect();
+        let cached = self.type_schemas.get_many(&key_refs);
+        let mut to_build: Vec<String> = Vec::new();
+        for (id, hit) in to_resolve.into_iter().zip(cached) {
+            match hit {
+                Some(arc) => {
+                    out.insert(id, Ok((*arc).clone()));
+                }
+                None => to_build.push(id),
+            }
+        }
+
+        // Phase 3: storage round-trip for misses, batched put back.
+        let mut to_put: Vec<(String, Arc<GtsTypeSchema>)> = Vec::new();
+        for id in to_build {
+            let result = match self
+                .service
+                .get(&id)
+                .map_err(DomainError::into_sdk_for_type_schema)
+            {
+                Ok(entity) => match self.build_type_schema_arc(entity) {
+                    Ok(arc) => {
+                        to_put.push((arc.type_id.to_string(), Arc::clone(&arc)));
+                        Ok((*arc).clone())
+                    }
+                    Err(e) => Err(e),
+                },
+                Err(e) => Err(e),
+            };
+            out.insert(id, result);
+        }
+        if !to_put.is_empty() {
+            self.type_schemas.put_many(to_put);
+        }
+
+        out
+    }
+
+    async fn get_type_schemas_by_uuid(
+        &self,
+        type_uuids: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsTypeSchema, TypesRegistryError>> {
+        // Phase 1: single-lock fast path — fully cached hits come back as
+        // values; misses (uuid never observed, or value evicted) come back
+        // as `None`.
+        let cached = self.type_schemas.get_many_by_uuid(&type_uuids);
+
+        // Phase 2: hits use the cached value; misses go straight to the
+        // storage-backed slow path. TODO(#1630): batch the slow path once
+        // `service.get_by_uuid` supports it.
+        let mut out = HashMap::with_capacity(type_uuids.len());
+        for (uuid, hit) in type_uuids.into_iter().zip(cached) {
+            if out.contains_key(&uuid) {
+                continue;
+            }
+            let result = match hit {
+                Some(arc) => Ok((*arc).clone()),
+                None => self.fetch_type_schema_by_uuid_uncached(uuid).await,
+            };
+            out.insert(uuid, result);
+        }
+        out
+    }
+
+    async fn list_type_schemas(
+        &self,
+        query: TypeSchemaQuery,
+    ) -> Result<Vec<GtsTypeSchema>, TypesRegistryError> {
+        let entities = self
+            .service
+            .list(&ListQuery::from_type_schema_query(query))
+            .map_err(DomainError::into_sdk_for_type_schema)?;
+        let mut out = Vec::with_capacity(entities.len());
+        for e in entities {
+            if !e.is_type_schema {
+                return Err(TypesRegistryError::invalid_gts_type_id(format!(
+                    "{} is not a type-schema",
+                    e.gts_id,
+                )));
+            }
+            // Prefer cache to share Arcs with other call sites. Cache puts
+            // also populate the uuid → gts_id index automatically.
+            let gts_id = e.gts_id.clone();
+            let arc = if let Some(cached) = self.type_schemas.get(&gts_id) {
+                cached
+            } else {
+                let built = self.build_type_schema_arc(e)?;
+                self.type_schemas
+                    .put(built.type_id.to_string(), Arc::clone(&built));
+                built
+            };
+            out.push((*arc).clone());
+        }
+        Ok(out)
+    }
+
+    async fn register_instances(
+        &self,
+        instances: Vec<serde_json::Value>,
+    ) -> Result<Vec<RegisterResult>, TypesRegistryError> {
+        // See `register` for the sort-then-write-back-by-original-index pattern.
+        let mut indexed: Vec<(usize, Option<String>, serde_json::Value)> = instances
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| (i, self.service.extract_gts_id(&v), v))
+            .collect();
+        indexed.sort_by(|a, b| compare_optional_gts_ids(a.1.as_deref(), b.1.as_deref()));
+
+        let total = indexed.len();
+        let mut slots: Vec<Option<RegisterResult>> = (0..total).map(|_| None).collect();
+        for (orig_idx, gts_id, value) in indexed {
+            // Missing id: the caller invoked the instance-typed endpoint, so
+            // we owe a kind-typed error instead of letting the kind-agnostic
+            // service path infer the wrong variant.
+            let Some(ref id) = gts_id else {
+                slots[orig_idx] = Some(RegisterResult::Err {
+                    gts_id: None,
+                    error: TypesRegistryError::invalid_gts_instance_id(
+                        "no GTS id field found in entity",
+                    ),
+                });
+                continue;
+            };
+            // Kind check: instance id must NOT end with `~`.
+            if is_type_schema_id(id) {
+                slots[orig_idx] = Some(RegisterResult::Err {
+                    gts_id: gts_id.clone(),
+                    error: TypesRegistryError::invalid_gts_instance_id(format!(
+                        "{id} ends with `~` (looks like a type-schema id)",
+                    )),
+                });
+                continue;
+            }
+            // Parent (declaring type-schema) pre-check (ready phase only).
+            if self.service.is_ready()
+                && let Some(err) = self.parent_pre_check(Some(id))
+            {
+                slots[orig_idx] = Some(RegisterResult::Err {
+                    gts_id: gts_id.clone(),
+                    error: err,
+                });
+                continue;
+            }
+            let single = self.service.register(vec![value]);
+            if let Some(result) = single.into_iter().next() {
+                // Invalidate after the write commits, keyed on the canonical
+                // persisted id from `RegisterResult::Ok` rather than the
+                // request-extracted `id` — see the matching comment in
+                // `register` for the rationale.
+                if let RegisterResult::Ok {
+                    gts_id: persisted_id,
+                } = &result
+                {
+                    self.instances.invalidate(persisted_id);
+                }
+                slots[orig_idx] = Some(result);
+            }
+        }
+        Ok(slots.into_iter().map(Option::unwrap).collect())
+    }
+
+    async fn get_instance(&self, id: &str) -> Result<GtsInstance, TypesRegistryError> {
+        let arc = self.resolve_instance_arc(id)?;
+        Ok((*arc).clone())
+    }
+
+    async fn get_instance_by_uuid(&self, uuid: Uuid) -> Result<GtsInstance, TypesRegistryError> {
+        // Fast path: full cache hit by UUID.
+        if let Some(arc) = self.instances.get_by_uuid(uuid) {
+            return Ok((*arc).clone());
+        }
+        self.fetch_instance_by_uuid_uncached(uuid).await
+    }
+
+    async fn get_instances(
+        &self,
+        ids: Vec<String>,
+    ) -> HashMap<String, Result<GtsInstance, TypesRegistryError>> {
+        let mut out = HashMap::with_capacity(ids.len());
+
+        // Phase 1: format check + dedup.
+        let mut to_resolve: Vec<String> = Vec::new();
+        for id in ids {
+            if out.contains_key(&id) {
+                continue;
+            }
+            if is_type_schema_id(&id) {
+                out.insert(
+                    id.clone(),
+                    Err(TypesRegistryError::invalid_gts_instance_id(format!(
+                        "{id} ends with `~` (looks like a type-schema id)",
+                    ))),
+                );
+            } else {
+                to_resolve.push(id);
+            }
+        }
+        if to_resolve.is_empty() {
+            return out;
+        }
+
+        // Phase 2: single-lock cache lookup for the whole batch.
+        let key_refs: Vec<&str> = to_resolve.iter().map(String::as_str).collect();
+        let cached = self.instances.get_many(&key_refs);
+        let mut to_build: Vec<String> = Vec::new();
+        for (id, hit) in to_resolve.into_iter().zip(cached) {
+            match hit {
+                Some(arc) => {
+                    out.insert(id, Ok((*arc).clone()));
+                }
+                None => to_build.push(id),
+            }
+        }
+
+        // Phase 3: storage round-trip for misses, batched put back.
+        let mut to_put: Vec<(String, Arc<GtsInstance>)> = Vec::new();
+        for id in to_build {
+            let result = match self
+                .service
+                .get(&id)
+                .map_err(DomainError::into_sdk_for_instance)
+            {
+                Ok(entity) => match self.build_instance(entity) {
+                    Ok(inst) => {
+                        let arc = Arc::new(inst);
+                        to_put.push((arc.id.to_string(), Arc::clone(&arc)));
+                        Ok((*arc).clone())
+                    }
+                    Err(e) => Err(e),
+                },
+                Err(e) => Err(e),
+            };
+            out.insert(id, result);
+        }
+        if !to_put.is_empty() {
+            self.instances.put_many(to_put);
+        }
+
+        out
+    }
+
+    async fn get_instances_by_uuid(
+        &self,
+        uuids: Vec<Uuid>,
+    ) -> HashMap<Uuid, Result<GtsInstance, TypesRegistryError>> {
+        // Phase 1: single-lock fast path. Hits come back as values; misses
+        // (uuid never observed, or value evicted) come back as `None`.
+        let cached = self.instances.get_many_by_uuid(&uuids);
+
+        // Phase 2: hits use the cached value; misses go straight to the
+        // storage-backed slow path. TODO(#1630): batch the slow path once
+        // `service.get_by_uuid` supports it.
+        let mut out = HashMap::with_capacity(uuids.len());
+        for (uuid, hit) in uuids.into_iter().zip(cached) {
+            if out.contains_key(&uuid) {
+                continue;
+            }
+            let result = match hit {
+                Some(arc) => Ok((*arc).clone()),
+                None => self.fetch_instance_by_uuid_uncached(uuid).await,
+            };
+            out.insert(uuid, result);
+        }
+        out
+    }
+
+    async fn list_instances(
+        &self,
+        query: InstanceQuery,
+    ) -> Result<Vec<GtsInstance>, TypesRegistryError> {
+        let entities = self
+            .service
+            .list(&ListQuery::from_instance_query(query))
+            .map_err(DomainError::into_sdk_for_instance)?;
+        let mut out = Vec::with_capacity(entities.len());
+        for e in entities {
+            // Cache puts populate the uuid → gts_id index automatically.
+            let gts_id = e.gts_id.clone();
+            let arc = if let Some(cached) = self.instances.get(&gts_id) {
+                cached
+            } else {
+                let inst = self.build_instance(e)?;
+                let new_arc = Arc::new(inst);
+                self.instances
+                    .put(new_arc.id.to_string(), Arc::clone(&new_arc));
+                new_arc
+            };
+            out.push((*arc).clone());
+        }
+        Ok(out)
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::infra::InMemoryGtsRepository;
-    use gts::GtsConfig;
-    use serde_json::json;
-
-    const JSON_SCHEMA_DRAFT_07: &str = "https://json-schema.org/draft-07/schema#";
-
-    fn default_config() -> GtsConfig {
-        crate::config::TypesRegistryConfig::default().to_gts_config()
-    }
-
-    fn create_client() -> TypesRegistryLocalClient {
-        let repo = Arc::new(InMemoryGtsRepository::new(default_config()));
-        let service = Arc::new(TypesRegistryService::new(
-            repo,
-            crate::config::TypesRegistryConfig::default(),
-        ));
-        TypesRegistryLocalClient::new(service)
-    }
-
-    #[tokio::test]
-    async fn test_register_and_get() {
-        let client = create_client();
-
-        let entity = json!({
-            "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": JSON_SCHEMA_DRAFT_07,
-            "type": "object",
-            "properties": {
-                "userId": { "type": "string" }
-            }
-        });
-
-        let results = client.register(vec![entity]).await.unwrap();
-        assert_eq!(results.len(), 1);
-        assert!(results[0].is_ok());
-
-        client.service.switch_to_ready().unwrap();
-
-        let retrieved = client
-            .get("gts.acme.core.events.user_created.v1~")
-            .await
-            .unwrap();
-        assert_eq!(retrieved.gts_id, "gts.acme.core.events.user_created.v1~");
-    }
-
-    #[tokio::test]
-    async fn test_list_entities() {
-        let client = create_client();
-
-        let type1 = json!({
-            "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": JSON_SCHEMA_DRAFT_07,
-            "type": "object"
-        });
-        let type2 = json!({
-            "$id": "gts://gts.globex.core.events.order_placed.v1~",
-            "$schema": JSON_SCHEMA_DRAFT_07,
-            "type": "object"
-        });
-
-        client.register(vec![type1, type2]).await.unwrap();
-        client.service.switch_to_ready().unwrap();
-
-        let all = client.list(ListQuery::default()).await.unwrap();
-        assert_eq!(all.len(), 2);
-
-        let acme_only = client
-            .list(ListQuery::default().with_vendor("acme"))
-            .await
-            .unwrap();
-        assert_eq!(acme_only.len(), 1);
-        assert_eq!(acme_only[0].vendor(), Some("acme"));
-    }
-
-    #[tokio::test]
-    async fn test_get_not_found() {
-        let client = create_client();
-
-        client.service.switch_to_ready().unwrap();
-
-        let result = client.get("gts.unknown.pkg.ns.type.v1~").await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().is_not_found());
-    }
-}
+#[path = "local_client_tests.rs"]
+mod tests;

--- a/modules/system/types-registry/types-registry/src/domain/local_client_tests.rs
+++ b/modules/system/types-registry/types-registry/src/domain/local_client_tests.rs
@@ -1,0 +1,846 @@
+//! Unit tests for [`TypesRegistryLocalClient`](super::TypesRegistryLocalClient).
+//!
+//! Kept in a sibling `_tests.rs` file per the `de1101_tests_in_separate_files`
+//! repo lint. Linked into `local_client.rs` via
+//! `#[path = "local_client_tests.rs"] mod tests;`, so the module sees
+//! `local_client.rs` as `super`.
+
+use super::*;
+use crate::infra::InMemoryGtsRepository;
+use gts::GtsConfig;
+use serde_json::json;
+use std::time::Duration;
+
+const JSON_SCHEMA_DRAFT_07: &str = "https://json-schema.org/draft-07/schema#";
+
+fn default_config() -> GtsConfig {
+    crate::config::TypesRegistryConfig::default().to_gts_config()
+}
+
+fn create_client() -> TypesRegistryLocalClient {
+    let repo = Arc::new(InMemoryGtsRepository::new(default_config()));
+    let service = Arc::new(TypesRegistryService::new(
+        repo,
+        crate::config::TypesRegistryConfig::default(),
+    ));
+    TypesRegistryLocalClient::new(service)
+}
+
+#[tokio::test]
+async fn test_register_and_get_type_schema() {
+    let client = create_client();
+    let entity = json!({
+        "$id": "gts://gts.acme.core.events.user_created.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+        "properties": { "userId": { "type": "string" } }
+    });
+    let results = client.register(vec![entity]).await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert!(results[0].is_ok());
+
+    client.service.switch_to_ready().unwrap();
+
+    let retrieved = client
+        .get_type_schema("gts.acme.core.events.user_created.v1~")
+        .await
+        .unwrap();
+    assert_eq!(
+        retrieved.type_id.as_ref(),
+        "gts.acme.core.events.user_created.v1~"
+    );
+    assert!(retrieved.parent.is_none());
+}
+
+#[tokio::test]
+async fn test_get_type_schema_resolves_parent_chain() {
+    let client = create_client();
+    let base_id = "gts.acme.core.events.base.v1~";
+    let derived_id = "gts.acme.core.events.base.v1~acme.core.events.derived.v1.0~";
+    let base = json!({
+        "$id": format!("gts://{base_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+        "properties": { "id": { "type": "string" } }
+    });
+    let derived = json!({
+        "$id": format!("gts://{derived_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+        "allOf": [
+            { "$ref": format!("gts://{base_id}") },
+            { "properties": { "name": { "type": "string" } } }
+        ]
+    });
+    client.register(vec![base, derived]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    let schema = client.get_type_schema(derived_id).await.unwrap();
+    let parent = schema.parent.as_ref().expect("parent must be resolved");
+    assert_eq!(parent.type_id.as_ref(), base_id);
+
+    let merged = schema.effective_properties();
+    assert!(merged.contains_key("id"));
+    assert!(merged.contains_key("name"));
+}
+
+#[tokio::test]
+async fn test_type_schema_cache_dedups_parents() {
+    let client = create_client();
+    let base_id = "gts.acme.core.events.base.v1~";
+    let d1_id = "gts.acme.core.events.base.v1~acme.core.events.d1.v1.0~";
+    let d2_id = "gts.acme.core.events.base.v1~acme.core.events.d2.v1.0~";
+    let base = json!({
+        "$id": format!("gts://{base_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+        "properties": { "id": { "type": "string" } }
+    });
+    let d1 = json!({
+        "$id": format!("gts://{d1_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+        "allOf": [{ "$ref": format!("gts://{base_id}") }]
+    });
+    let d2 = json!({
+        "$id": format!("gts://{d2_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+        "allOf": [{ "$ref": format!("gts://{base_id}") }]
+    });
+    client.register(vec![base, d1, d2]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    let s1 = client.get_type_schema(d1_id).await.unwrap();
+    let s2 = client.get_type_schema(d2_id).await.unwrap();
+    let p1 = s1.parent.as_ref().expect("d1 has a parent");
+    let p2 = s2.parent.as_ref().expect("d2 has a parent");
+    assert!(Arc::ptr_eq(p1, p2));
+}
+
+#[tokio::test]
+async fn test_get_instance_carries_type_schema_arc() {
+    let client = create_client();
+    let schema = json!({
+        "$id": "gts://gts.acme.core.events.user.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    let instance = json!({
+        "id": "gts.acme.core.events.user.v1~acme.core.instances.u1.v1",
+        "type": "gts.acme.core.events.user.v1~"
+    });
+    client.register(vec![schema, instance]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    let inst = client
+        .get_instance("gts.acme.core.events.user.v1~acme.core.instances.u1.v1")
+        .await
+        .unwrap();
+    assert_eq!(inst.type_id().as_ref(), "gts.acme.core.events.user.v1~");
+    assert_eq!(
+        inst.type_schema.type_id.as_ref(),
+        "gts.acme.core.events.user.v1~"
+    );
+}
+
+#[tokio::test]
+async fn test_instance_cache_returns_same_value() {
+    // After get_instance, a second get_instance hits the cache and
+    // returns an equal value.
+    let client = create_client();
+    let schema = json!({
+        "$id": "gts://gts.acme.core.events.user.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    let instance = json!({
+        "id": "gts.acme.core.events.user.v1~acme.core.instances.u1.v1",
+        "type": "gts.acme.core.events.user.v1~"
+    });
+    client.register(vec![schema, instance]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    let id = "gts.acme.core.events.user.v1~acme.core.instances.u1.v1";
+    let i1 = client.get_instance(id).await.unwrap();
+    let i2 = client.get_instance(id).await.unwrap();
+    assert_eq!(i1.id, i2.id);
+    // Type-schema Arc is the same instance — proves both went through the
+    // shared cache.
+    assert!(Arc::ptr_eq(&i1.type_schema, &i2.type_schema));
+}
+
+#[tokio::test]
+async fn test_clear_caches_drops_type_schema_arcs() {
+    let client = create_client();
+    let schema = json!({
+        "$id": "gts://gts.acme.core.events.user.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    client.register(vec![schema]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    let s1 = client
+        .get_type_schema("gts.acme.core.events.user.v1~")
+        .await
+        .unwrap();
+    // After the get, the cache must hold the entry — both LRU and the
+    // reverse uuid index.
+    assert_eq!(client.type_schemas.len(), 1);
+    assert!(client.type_schemas.get_by_uuid(s1.type_uuid).is_some());
+
+    client.clear_caches();
+    // Cache state must be observably empty before we trigger any rebuild.
+    assert_eq!(client.type_schemas.len(), 0);
+    assert!(client.type_schemas.get_by_uuid(s1.type_uuid).is_none());
+
+    // Subsequent get rebuilds and repopulates the cache.
+    let s2 = client
+        .get_type_schema("gts.acme.core.events.user.v1~")
+        .await
+        .unwrap();
+    assert_eq!(s2.type_id, s1.type_id);
+    assert_eq!(client.type_schemas.len(), 1);
+}
+
+#[tokio::test]
+async fn test_invalidate_type_schema_drops_only_one_entry() {
+    let client = create_client();
+    let s1 = json!({
+        "$id": "gts://gts.acme.core.events.a.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    let s2 = json!({
+        "$id": "gts://gts.acme.core.events.b.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    client.register(vec![s1, s2]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    client
+        .get_type_schema("gts.acme.core.events.a.v1~")
+        .await
+        .unwrap();
+    client
+        .get_type_schema("gts.acme.core.events.b.v1~")
+        .await
+        .unwrap();
+    assert_eq!(client.type_schemas.len(), 2);
+
+    client.invalidate_type_schema("gts.acme.core.events.a.v1~");
+    assert_eq!(client.type_schemas.len(), 1);
+}
+
+#[tokio::test]
+async fn test_custom_cache_configs_apply() {
+    let repo = Arc::new(InMemoryGtsRepository::new(default_config()));
+    let service = Arc::new(TypesRegistryService::new(
+        repo,
+        crate::config::TypesRegistryConfig::default(),
+    ));
+    let client = TypesRegistryLocalClient::with_cache_configs(
+        service,
+        CacheConfig::type_schemas()
+            .with_capacity(2)
+            .with_ttl(Duration::from_millis(50)),
+        CacheConfig::instances().with_capacity(8),
+    );
+    let s = json!({
+        "$id": "gts://gts.acme.core.events.user.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    client.register(vec![s]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+    let _ = client
+        .get_type_schema("gts.acme.core.events.user.v1~")
+        .await
+        .unwrap();
+    assert_eq!(client.type_schemas.len(), 1);
+
+    // After TTL elapses, the cached entry must observably go away. We
+    // check via a `get` (which triggers TTL eviction as a side effect)
+    // that returns None, then check len. Asserting only `len() == 1`
+    // post-rebuild would be a false positive — len stays 1 whether the
+    // entry expired and was rebuilt or never expired at all.
+    std::thread::sleep(Duration::from_millis(80));
+    assert!(
+        client
+            .type_schemas
+            .get("gts.acme.core.events.user.v1~")
+            .is_none(),
+        "TTL did not evict expired entry"
+    );
+    assert_eq!(client.type_schemas.len(), 0);
+
+    // Subsequent get rebuilds and repopulates the cache.
+    let _ = client
+        .get_type_schema("gts.acme.core.events.user.v1~")
+        .await
+        .unwrap();
+    assert_eq!(client.type_schemas.len(), 1);
+}
+
+#[tokio::test]
+async fn test_get_type_schema_rejects_instance() {
+    let client = create_client();
+    let schema = json!({
+        "$id": "gts://gts.acme.core.events.user.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    let instance = json!({
+        "id": "gts.acme.core.events.user.v1~acme.core.instances.u1.v1",
+        "type": "gts.acme.core.events.user.v1~"
+    });
+    client.register(vec![schema, instance]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    let err = client
+        .get_type_schema("gts.acme.core.events.user.v1~acme.core.instances.u1.v1")
+        .await
+        .unwrap_err();
+    assert!(err.is_invalid_gts_type_id());
+}
+
+#[tokio::test]
+async fn test_register_type_schemas_rejects_instance_input() {
+    let client = create_client();
+    let instance = json!({
+        "id": "gts.acme.core.events.user.v1~acme.core.instances.u1.v1",
+        "type": "gts.acme.core.events.user.v1~"
+    });
+    let results = client.register_type_schemas(vec![instance]).await.unwrap();
+    assert_eq!(results.len(), 1);
+    match &results[0] {
+        RegisterResult::Err { error, .. } => assert!(error.is_invalid_gts_type_id()),
+        RegisterResult::Ok { .. } => panic!("expected Err for instance input"),
+    }
+}
+
+#[tokio::test]
+async fn test_register_type_schemas_unsorted_batch_succeeds() {
+    // Batch order [derived, base] is reordered by sort to [base, derived]
+    // so the parent registers before its child within a single call.
+    let client = create_client();
+    let base_id = "gts.acme.core.events.base.v1~";
+    let derived_id = "gts.acme.core.events.base.v1~acme.core.events.derived.v1.0~";
+    let base = json!({
+        "$id": format!("gts://{base_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+    });
+    let derived = json!({
+        "$id": format!("gts://{derived_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+        "allOf": [{ "$ref": format!("gts://{base_id}") }]
+    });
+    // Pass derived first; sort should put base first.
+    let results = client
+        .register_type_schemas(vec![derived, base])
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(results.iter().all(RegisterResult::is_ok));
+}
+
+#[tokio::test]
+async fn test_register_type_schemas_orphan_derived_in_ready_fails() {
+    // After switch_to_ready, registering a derived schema whose parent
+    // is not in persistent storage must fail with
+    // ParentTypeSchemaNotRegistered (no persist) — config-phase
+    // permissiveness is gone.
+    let client = create_client();
+    client.service.switch_to_ready().unwrap();
+
+    let derived_id = "gts.acme.core.events.base.v1~acme.core.events.derived.v1.0~";
+    let derived = json!({
+        "$id": format!("gts://{derived_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+    });
+    let results = client.register_type_schemas(vec![derived]).await.unwrap();
+    assert_eq!(results.len(), 1);
+    match &results[0] {
+        RegisterResult::Err { error, .. } => {
+            assert!(error.is_parent_type_schema_not_registered());
+        }
+        RegisterResult::Ok { .. } => panic!("expected Err for orphan derived in ready"),
+    }
+}
+
+#[tokio::test]
+async fn test_register_instances_orphan_in_ready_fails() {
+    // Symmetric to the above: instance whose declaring type-schema is
+    // not registered must fail with ParentTypeSchemaNotRegistered.
+    let client = create_client();
+    client.service.switch_to_ready().unwrap();
+
+    let instance = json!({
+        "id": "gts.acme.core.events.user.v1~acme.core.instances.u1.v1",
+        "type": "gts.acme.core.events.user.v1~"
+    });
+    let results = client.register_instances(vec![instance]).await.unwrap();
+    assert_eq!(results.len(), 1);
+    match &results[0] {
+        RegisterResult::Err { error, .. } => {
+            assert!(error.is_parent_type_schema_not_registered());
+        }
+        RegisterResult::Ok { .. } => panic!("expected Err for orphan instance in ready"),
+    }
+}
+
+#[tokio::test]
+async fn test_list_type_schemas_and_instances_filtered() {
+    let client = create_client();
+    let schema = json!({
+        "$id": "gts://gts.acme.core.events.user.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    let instance = json!({
+        "id": "gts.acme.core.events.user.v1~acme.core.instances.u1.v1",
+        "type": "gts.acme.core.events.user.v1~"
+    });
+    client.register(vec![schema, instance]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    let schemas = client
+        .list_type_schemas(TypeSchemaQuery::default())
+        .await
+        .unwrap();
+    assert_eq!(schemas.len(), 1);
+    assert!(schemas[0].type_id.as_ref().ends_with('~'));
+
+    let instances = client
+        .list_instances(InstanceQuery::default())
+        .await
+        .unwrap();
+    assert_eq!(instances.len(), 1);
+    assert!(!instances[0].id.as_ref().ends_with('~'));
+}
+
+#[tokio::test]
+async fn test_get_type_schema_by_uuid() {
+    let client = create_client();
+    let schema = json!({
+        "$id": "gts://gts.acme.core.events.user.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    client.register(vec![schema]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    let listed = client
+        .list_type_schemas(TypeSchemaQuery::default())
+        .await
+        .unwrap();
+    let uuid = listed[0].type_uuid;
+    let by_uuid = client.get_type_schema_by_uuid(uuid).await.unwrap();
+    assert_eq!(by_uuid.type_id.as_ref(), "gts.acme.core.events.user.v1~");
+
+    let unknown = client
+        .get_type_schema_by_uuid(Uuid::nil())
+        .await
+        .unwrap_err();
+    assert!(unknown.is_gts_type_schema_not_found());
+}
+
+#[tokio::test]
+async fn test_uuid_index_populated_by_get() {
+    // After a successful get_type_schema(gts_id), the UUID→gts_id mapping
+    // must be in the index so that a subsequent get_type_schema_by_uuid
+    // can take the fast path.
+    let client = create_client();
+    let schema = json!({
+        "$id": "gts://gts.acme.core.events.user.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    client.register(vec![schema]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    // First call by gts_id — populates type_schema cache, which writes the
+    // uuid → gts_id mapping into the cache's internal reverse index.
+    let by_id = client
+        .get_type_schema("gts.acme.core.events.user.v1~")
+        .await
+        .unwrap();
+    assert!(client.type_schemas.get_by_uuid(by_id.type_uuid).is_some());
+
+    // Second call by UUID hits the fast path and returns the same value.
+    let by_uuid = client
+        .get_type_schema_by_uuid(by_id.type_uuid)
+        .await
+        .unwrap();
+    assert_eq!(by_uuid.type_id, by_id.type_id);
+}
+
+#[tokio::test]
+async fn test_invalidate_type_schema_cascades_to_dependents() {
+    // Re-registering a base type-schema must drop cached derived
+    // schemas whose chain references the base. Cache walks the
+    // resolved Arc chain via `ancestors()`.
+    let client = create_client();
+    let base_id = "gts.acme.core.events.base.v1~";
+    let derived_id = "gts.acme.core.events.base.v1~acme.core.events.derived.v1.0~";
+    let base = json!({
+        "$id": format!("gts://{base_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+    });
+    let derived = json!({
+        "$id": format!("gts://{derived_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+        "allOf": [
+            { "$ref": format!("gts://{base_id}") },
+            { "properties": { "extra": { "type": "string" } } }
+        ],
+    });
+    client.register(vec![base, derived]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    // Warm caches: derived resolution pulls base into the cache too.
+    let _ = client.get_type_schema(derived_id).await.unwrap();
+    assert_eq!(client.type_schemas.len(), 2); // base + derived
+
+    // Cascade-invalidate base — derived references base in its chain,
+    // so both cache entries must drop.
+    client.invalidate_type_schema(base_id);
+    assert_eq!(client.type_schemas.len(), 0);
+}
+
+#[tokio::test]
+async fn test_clear_caches_resets_uuid_index() {
+    let client = create_client();
+    let schema = json!({
+        "$id": "gts://gts.acme.core.events.user.v1~",
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    client.register(vec![schema]).await.unwrap();
+    client.service.switch_to_ready().unwrap();
+    let warmed = client
+        .get_type_schema("gts.acme.core.events.user.v1~")
+        .await
+        .unwrap();
+    assert!(client.type_schemas.get_by_uuid(warmed.type_uuid).is_some());
+
+    client.clear_caches();
+    assert!(client.type_schemas.get_by_uuid(warmed.type_uuid).is_none());
+}
+
+// ── Batch get_*  tests ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_get_type_schemas_returns_keyed_map() {
+    let client = create_client();
+    client
+        .register(vec![
+            json!({"$id": "gts://gts.acme.core.events.alpha.v1~", "$schema": JSON_SCHEMA_DRAFT_07, "type": "object"}),
+            json!({"$id": "gts://gts.acme.core.events.beta.v1~",  "$schema": JSON_SCHEMA_DRAFT_07, "type": "object"}),
+            json!({"$id": "gts://gts.acme.core.events.gamma.v1~", "$schema": JSON_SCHEMA_DRAFT_07, "type": "object"}),
+        ])
+        .await
+        .unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    let ids = vec![
+        "gts.acme.core.events.gamma.v1~".to_owned(),
+        "gts.acme.core.events.alpha.v1~".to_owned(),
+        "gts.acme.core.events.beta.v1~".to_owned(),
+    ];
+    let results = client.get_type_schemas(ids.clone()).await;
+    assert_eq!(results.len(), 3);
+    for id in &ids {
+        let got = results
+            .get(id)
+            .expect("present")
+            .as_ref()
+            .expect("ok")
+            .type_id
+            .as_ref();
+        assert_eq!(got, id);
+    }
+}
+
+#[tokio::test]
+async fn test_get_type_schemas_partial_failures() {
+    let client = create_client();
+    client
+        .register(vec![
+            json!({"$id": "gts://gts.acme.core.events.alpha.v1~", "$schema": JSON_SCHEMA_DRAFT_07, "type": "object"}),
+            json!({"$id": "gts://gts.acme.core.events.gamma.v1~", "$schema": JSON_SCHEMA_DRAFT_07, "type": "object"}),
+        ])
+        .await
+        .unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    let alpha = "gts.acme.core.events.alpha.v1~";
+    let missing = "gts.acme.core.events.missing.v1~";
+    let gamma = "gts.acme.core.events.gamma.v1~";
+    let results = client
+        .get_type_schemas(vec![alpha.to_owned(), missing.to_owned(), gamma.to_owned()])
+        .await;
+    assert!(results.get(alpha).expect("present").is_ok());
+    assert!(
+        results
+            .get(missing)
+            .expect("present")
+            .as_ref()
+            .err()
+            .unwrap()
+            .is_gts_type_schema_not_found()
+    );
+    assert!(results.get(gamma).expect("present").is_ok());
+}
+
+#[tokio::test]
+async fn test_get_type_schemas_kind_mismatch() {
+    // An instance-shaped id (no trailing `~`) passed to get_type_schemas
+    // must surface as InvalidGtsTypeId for that single item, not fail
+    // the whole batch.
+    let client = create_client();
+    let bad = "gts.acme.core.events.user.v1~acme.core.instances.u1.v1";
+    let results = client.get_type_schemas(vec![bad.to_owned()]).await;
+    assert_eq!(results.len(), 1);
+    assert!(
+        results
+            .get(bad)
+            .expect("present")
+            .as_ref()
+            .err()
+            .unwrap()
+            .is_invalid_gts_type_id()
+    );
+}
+
+#[tokio::test]
+async fn test_get_type_schemas_by_uuid_warm_cache_uses_index() {
+    // Warm the uuid_index via get_type_schema(id), then batch-by-uuid
+    // must succeed without storage scan (index already has the mapping).
+    let client = create_client();
+    client
+        .register(vec![
+            json!({"$id": "gts://gts.acme.core.events.alpha.v1~", "$schema": JSON_SCHEMA_DRAFT_07, "type": "object"}),
+        ])
+        .await
+        .unwrap();
+    client.service.switch_to_ready().unwrap();
+    let warmed = client
+        .get_type_schema("gts.acme.core.events.alpha.v1~")
+        .await
+        .unwrap();
+    assert!(client.type_schemas.get_by_uuid(warmed.type_uuid).is_some());
+
+    let results = client
+        .get_type_schemas_by_uuid(vec![warmed.type_uuid])
+        .await;
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results
+            .get(&warmed.type_uuid)
+            .expect("present")
+            .as_ref()
+            .expect("ok")
+            .type_id,
+        warmed.type_id,
+    );
+}
+
+#[tokio::test]
+async fn test_get_type_schemas_by_uuid_cold_falls_back_to_storage() {
+    let client = create_client();
+    client
+        .register(vec![
+            json!({"$id": "gts://gts.acme.core.events.alpha.v1~", "$schema": JSON_SCHEMA_DRAFT_07, "type": "object"}),
+        ])
+        .await
+        .unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    // Find the uuid via list_*; then clear_caches to drop the type-schema
+    // cache (and its uuid index).
+    let listed = client
+        .list_type_schemas(TypeSchemaQuery::default())
+        .await
+        .unwrap();
+    let uuid = listed[0].type_uuid;
+    client.clear_caches();
+    assert!(client.type_schemas.get_by_uuid(uuid).is_none());
+
+    let results = client.get_type_schemas_by_uuid(vec![uuid]).await;
+    assert_eq!(results.len(), 1);
+    assert!(results.get(&uuid).expect("present").is_ok());
+    // After cold lookup, the cache's uuid index is repopulated.
+    assert!(client.type_schemas.get_by_uuid(uuid).is_some());
+}
+
+#[tokio::test]
+async fn test_get_instances_keyed_with_partial_failures() {
+    let client = create_client();
+    client
+        .register(vec![
+            json!({"$id": "gts://gts.acme.core.events.user.v1~",            "$schema": JSON_SCHEMA_DRAFT_07, "type": "object"}),
+            json!({"id": "gts.acme.core.events.user.v1~acme.core.instances.u1.v1"}),
+            json!({"id": "gts.acme.core.events.user.v1~acme.core.instances.u2.v1"}),
+        ])
+        .await
+        .unwrap();
+    client.service.switch_to_ready().unwrap();
+
+    let u2 = "gts.acme.core.events.user.v1~acme.core.instances.u2.v1";
+    let missing = "gts.acme.core.events.user.v1~acme.core.instances.missing.v1";
+    let u1 = "gts.acme.core.events.user.v1~acme.core.instances.u1.v1";
+    let results = client
+        .get_instances(vec![u2.to_owned(), missing.to_owned(), u1.to_owned()])
+        .await;
+    assert_eq!(results.len(), 3);
+    assert_eq!(
+        results.get(u2).expect("present").as_ref().expect("ok").id,
+        u2
+    );
+    assert!(
+        results
+            .get(missing)
+            .expect("present")
+            .as_ref()
+            .err()
+            .unwrap()
+            .is_gts_instance_not_found()
+    );
+    assert_eq!(
+        results.get(u1).expect("present").as_ref().expect("ok").id,
+        u1
+    );
+}
+
+#[tokio::test]
+async fn test_get_instances_by_uuid_warm_cache_uses_index() {
+    let client = create_client();
+    client
+        .register(vec![
+            json!({"$id": "gts://gts.acme.core.events.user.v1~", "$schema": JSON_SCHEMA_DRAFT_07, "type": "object"}),
+            json!({"id": "gts.acme.core.events.user.v1~acme.core.instances.u1.v1"}),
+        ])
+        .await
+        .unwrap();
+    client.service.switch_to_ready().unwrap();
+    let warmed = client
+        .get_instance("gts.acme.core.events.user.v1~acme.core.instances.u1.v1")
+        .await
+        .unwrap();
+    assert!(client.instances.get_by_uuid(warmed.uuid).is_some());
+
+    let results = client.get_instances_by_uuid(vec![warmed.uuid]).await;
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results
+            .get(&warmed.uuid)
+            .expect("present")
+            .as_ref()
+            .expect("ok")
+            .id,
+        warmed.id
+    );
+}
+
+#[tokio::test]
+async fn test_get_batch_empty_input() {
+    let client = create_client();
+    client.service.switch_to_ready().unwrap();
+
+    assert!(client.get_type_schemas(vec![]).await.is_empty());
+    assert!(client.get_type_schemas_by_uuid(vec![]).await.is_empty());
+    assert!(client.get_instances(vec![]).await.is_empty());
+    assert!(client.get_instances_by_uuid(vec![]).await.is_empty());
+}
+
+/// Caller order must survive the parent-before-child sort that
+/// `register*` does internally. We pass `[child, parent]` (child sorts
+/// later by id) and require `results[0]` to correspond to the child and
+/// `results[1]` to the parent, matching the input order.
+#[tokio::test]
+async fn test_register_preserves_caller_order() {
+    let client = create_client();
+    let base_id = "gts.acme.core.events.base.v1~";
+    let derived_id = "gts.acme.core.events.base.v1~acme.core.events.derived.v1.0~";
+    let base = json!({
+        "$id": format!("gts://{base_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    let derived = json!({
+        "$id": format!("gts://{derived_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+        "allOf": [{ "$ref": format!("gts://{base_id}") }]
+    });
+
+    // Caller passes child first, parent second. Internal sort flips this so
+    // the parent is registered first, but the returned vec must still align
+    // with caller order.
+    let results = client
+        .register(vec![derived.clone(), base.clone()])
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].as_result().ok(), Some(derived_id));
+    assert_eq!(results[1].as_result().ok(), Some(base_id));
+}
+
+/// `register_type_schemas` / `register_instances` share the same sort
+/// trick — same regression risk. Verify both preserve caller order.
+#[tokio::test]
+async fn test_register_typed_preserves_caller_order() {
+    let client = create_client();
+    let base_id = "gts.acme.core.events.base.v1~";
+    let derived_id = "gts.acme.core.events.base.v1~acme.core.events.derived.v1.0~";
+    let base = json!({
+        "$id": format!("gts://{base_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object"
+    });
+    let derived = json!({
+        "$id": format!("gts://{derived_id}"),
+        "$schema": JSON_SCHEMA_DRAFT_07,
+        "type": "object",
+        "allOf": [{ "$ref": format!("gts://{base_id}") }]
+    });
+
+    let schema_results = client
+        .register_type_schemas(vec![derived.clone(), base.clone()])
+        .await
+        .unwrap();
+    assert_eq!(schema_results.len(), 2);
+    assert_eq!(schema_results[0].as_result().ok(), Some(derived_id));
+    assert_eq!(schema_results[1].as_result().ok(), Some(base_id));
+
+    // For instances, register a parent schema first, then verify caller order
+    // for two instances of it.
+    let parent_id = "gts.acme.core.events.parent.v1~";
+    let earlier = "gts.acme.core.events.parent.v1~acme.core.evt.a.v1";
+    let later = "gts.acme.core.events.parent.v1~acme.core.evt.b.v1";
+    client
+        .register(vec![json!({
+            "$id": format!("gts://{parent_id}"),
+            "$schema": JSON_SCHEMA_DRAFT_07,
+            "type": "object"
+        })])
+        .await
+        .unwrap();
+    // Pass `later` before `earlier`; `later` sorts after `earlier` by id, so
+    // the internal sort would otherwise flip them.
+    let instance_results = client
+        .register_instances(vec![json!({ "$id": later }), json!({ "$id": earlier })])
+        .await
+        .unwrap();
+    assert_eq!(instance_results.len(), 2);
+    assert_eq!(instance_results[0].as_result().ok(), Some(later));
+    assert_eq!(instance_results[1].as_result().ok(), Some(earlier));
+}

--- a/modules/system/types-registry/types-registry/src/domain/mod.rs
+++ b/modules/system/types-registry/types-registry/src/domain/mod.rs
@@ -3,6 +3,7 @@
 //! Contains business logic, error types, and repository traits.
 
 pub mod error;
+pub mod model;
 pub mod repo;
 pub mod service;
 // === LOCAL CLIENT ===

--- a/modules/system/types-registry/types-registry/src/domain/model.rs
+++ b/modules/system/types-registry/types-registry/src/domain/model.rs
@@ -1,0 +1,218 @@
+//! Internal domain models for the Types Registry module.
+//!
+//! These types are NOT part of the public SDK surface — external modules
+//! consume the typed [`GtsTypeSchema`](types_registry_sdk::GtsTypeSchema) /
+//! [`GtsInstance`](types_registry_sdk::GtsInstance) views. The kind-agnostic
+//! `GtsEntity` and `ListQuery` types are kept here as the contract between
+//! the domain service and the storage layer (`GtsRepository`).
+
+use gts::GtsIdSegment;
+use modkit_macros::domain_model;
+use uuid::Uuid;
+
+/// A registered GTS entity, kind-agnostic.
+///
+/// Used internally between the storage layer and the domain service. The
+/// service maps it to typed [`GtsTypeSchema`](types_registry_sdk::GtsTypeSchema)
+/// or [`GtsInstance`](types_registry_sdk::GtsInstance) before exposing values
+/// to external callers.
+#[domain_model]
+#[derive(Debug, Clone, PartialEq)]
+pub struct GtsEntity<C = serde_json::Value> {
+    /// Deterministic UUID v5 derived from the GTS ID.
+    pub uuid: Uuid,
+    /// The full GTS identifier string.
+    pub gts_id: String,
+    /// All parsed segments from the GTS ID.
+    pub segments: Vec<GtsIdSegment>,
+    /// Whether this entity is a type-schema (GTS ID ends with `~`).
+    pub is_type_schema: bool,
+    /// The entity content (schema body for type-schemas, object for instances).
+    pub content: C,
+    /// Optional description.
+    pub description: Option<String>,
+}
+
+/// Type alias for dynamic GTS entities using `serde_json::Value` as content.
+pub type DynGtsEntity = GtsEntity<serde_json::Value>;
+
+impl<C> GtsEntity<C> {
+    /// Creates a new `GtsEntity` with the given components.
+    #[must_use]
+    pub fn new(
+        uuid: Uuid,
+        gts_id: impl Into<String>,
+        segments: Vec<GtsIdSegment>,
+        is_type_schema: bool,
+        content: C,
+        description: Option<String>,
+    ) -> Self {
+        Self {
+            uuid,
+            gts_id: gts_id.into(),
+            segments,
+            is_type_schema,
+            content,
+            description,
+        }
+    }
+
+    /// Returns `true` if this entity is a type-schema definition.
+    #[must_use]
+    pub const fn is_type(&self) -> bool {
+        self.is_type_schema
+    }
+
+    /// Returns `true` if this entity is an instance.
+    #[must_use]
+    pub const fn is_instance(&self) -> bool {
+        !self.is_type_schema
+    }
+
+    /// Returns the primary segment (first segment in the chain).
+    #[must_use]
+    pub fn primary_segment(&self) -> Option<&GtsIdSegment> {
+        self.segments.first()
+    }
+
+    /// Returns the vendor from the primary segment.
+    #[must_use]
+    pub fn vendor(&self) -> Option<&str> {
+        self.primary_segment().map(|s| s.vendor.as_str())
+    }
+
+    /// Returns the package from the primary segment.
+    #[must_use]
+    pub fn package(&self) -> Option<&str> {
+        self.primary_segment().map(|s| s.package.as_str())
+    }
+
+    /// Returns the namespace from the primary segment.
+    #[must_use]
+    pub fn namespace(&self) -> Option<&str> {
+        self.primary_segment().map(|s| s.namespace.as_str())
+    }
+}
+
+/// Controls which segments of a chained GTS id the `vendor`, `package`, and
+/// `namespace` filters in [`ListQuery`] are matched against.
+#[domain_model]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SegmentMatchScope {
+    /// Match filters against only the primary (first) GTS id segment.
+    Primary,
+    /// Match filters against any segment in the GTS id chain.
+    #[default]
+    Any,
+}
+
+/// Query parameters for listing GTS entities (kind-agnostic).
+///
+/// Internal to the parent module. SDK callers use [`TypeSchemaQuery`] /
+/// [`InstanceQuery`] (pattern-only) and the service translates those to this
+/// struct. The REST handler builds the full struct directly so the wire
+/// contract retains the per-segment `vendor` / `package` / `namespace`
+/// filters.
+///
+/// [`TypeSchemaQuery`]: types_registry_sdk::TypeSchemaQuery
+/// [`InstanceQuery`]: types_registry_sdk::InstanceQuery
+#[domain_model]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ListQuery {
+    /// Optional wildcard pattern for GTS ID matching. Supports `*`.
+    pub pattern: Option<String>,
+    /// Filter for entity kind: `true` for schemas, `false` for instances.
+    pub is_type: Option<bool>,
+    /// Filter by vendor. Which segments this applies to is controlled by
+    /// [`Self::segment_scope`].
+    pub vendor: Option<String>,
+    /// Filter by package. Which segments this applies to is controlled by
+    /// [`Self::segment_scope`].
+    pub package: Option<String>,
+    /// Filter by namespace. Which segments this applies to is controlled by
+    /// [`Self::segment_scope`].
+    pub namespace: Option<String>,
+    /// Controls which chain segments the `vendor` / `package` / `namespace`
+    /// filters match against. Defaults to [`SegmentMatchScope::Any`].
+    pub segment_scope: SegmentMatchScope,
+}
+
+impl ListQuery {
+    /// Creates a new empty `ListQuery`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the pattern filter.
+    #[must_use]
+    pub fn with_pattern(mut self, pattern: impl Into<String>) -> Self {
+        self.pattern = Some(pattern.into());
+        self
+    }
+
+    /// Sets the `is_type` filter.
+    #[must_use]
+    pub const fn with_is_type(mut self, is_type: bool) -> Self {
+        self.is_type = Some(is_type);
+        self
+    }
+
+    /// Sets the vendor filter.
+    #[must_use]
+    pub fn with_vendor(mut self, vendor: impl Into<String>) -> Self {
+        self.vendor = Some(vendor.into());
+        self
+    }
+
+    /// Sets the package filter.
+    #[must_use]
+    pub fn with_package(mut self, package: impl Into<String>) -> Self {
+        self.package = Some(package.into());
+        self
+    }
+
+    /// Sets the namespace filter.
+    #[must_use]
+    pub fn with_namespace(mut self, namespace: impl Into<String>) -> Self {
+        self.namespace = Some(namespace.into());
+        self
+    }
+
+    /// Sets the segment match scope.
+    #[must_use]
+    pub const fn with_segment_scope(mut self, scope: SegmentMatchScope) -> Self {
+        self.segment_scope = scope;
+        self
+    }
+
+    /// Returns `true` if no filters are set.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.pattern.is_none()
+            && self.is_type.is_none()
+            && self.vendor.is_none()
+            && self.package.is_none()
+            && self.namespace.is_none()
+    }
+
+    /// Builds an internal `ListQuery` from an SDK `TypeSchemaQuery` (kind = schema).
+    #[must_use]
+    pub fn from_type_schema_query(q: types_registry_sdk::TypeSchemaQuery) -> Self {
+        Self {
+            pattern: q.pattern,
+            is_type: Some(true),
+            ..Self::default()
+        }
+    }
+
+    /// Builds an internal `ListQuery` from an SDK `InstanceQuery` (kind = instance).
+    #[must_use]
+    pub fn from_instance_query(q: types_registry_sdk::InstanceQuery) -> Self {
+        Self {
+            pattern: q.pattern,
+            is_type: Some(false),
+            ..Self::default()
+        }
+    }
+}

--- a/modules/system/types-registry/types-registry/src/domain/repo.rs
+++ b/modules/system/types-registry/types-registry/src/domain/repo.rs
@@ -1,6 +1,8 @@
 //! Repository trait for GTS entity storage.
 
-use types_registry_sdk::{GtsEntity, ListQuery};
+use uuid::Uuid;
+
+use crate::domain::model::{GtsEntity, ListQuery};
 
 use super::error::DomainError;
 
@@ -37,6 +39,13 @@ pub trait GtsRepository: Send + Sync {
     ///
     /// Returns `NotFound` if the entity doesn't exist.
     fn get(&self, gts_id: &str) -> Result<GtsEntity, DomainError>;
+
+    /// Retrieves a GTS entity by its deterministic UUID v5.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound` if no entity is registered with the given UUID.
+    fn get_by_uuid(&self, id: Uuid) -> Result<GtsEntity, DomainError>;
 
     /// Lists GTS entities matching the given query.
     ///

--- a/modules/system/types-registry/types-registry/src/domain/service.rs
+++ b/modules/system/types-registry/types-registry/src/domain/service.rs
@@ -1,18 +1,33 @@
 //! Domain service for the Types Registry module.
+//!
+//! Kind-agnostic: returns the internal [`GtsEntity`] / [`ListQuery`] types.
+//! All kind discrimination, parent resolution, caching, and SDK type
+//! construction live in [`crate::domain::local_client`].
 
 use std::sync::Arc;
 
 use modkit_macros::domain_model;
-use types_registry_sdk::{GtsEntity, ListQuery, RegisterResult};
+use types_registry_sdk::RegisterResult;
+use uuid::Uuid;
 
 use super::error::DomainError;
+use super::model::{GtsEntity, ListQuery};
 use super::repo::GtsRepository;
 use crate::config::TypesRegistryConfig;
 
+/// Outcome of registering one entity in [`TypesRegistryService::register_validated`]:
+/// `(extracted_gts_id, persisted_entity_or_error)`.
+///
+/// The first element is the best-effort GTS id parsed from the input (so error
+/// responses can echo the attempted id even when validation rejects it).
+pub type RegisterEntityOutcome = (Option<String>, Result<GtsEntity, DomainError>);
+
 /// Domain service for GTS entity operations.
 ///
-/// This service orchestrates business logic and delegates storage
-/// operations to the repository.
+/// Orchestrates business logic and delegates storage to the repository.
+/// Returns the internal [`GtsEntity`] (kind-agnostic) — the local client
+/// builds typed [`types_registry_sdk::GtsSchema`] / [`types_registry_sdk::GtsInstance`]
+/// values on top of these.
 #[domain_model]
 pub struct TypesRegistryService {
     repo: Arc<dyn GtsRepository>,
@@ -32,7 +47,9 @@ impl TypesRegistryService {
     /// - Configuration phase (not ready): No validation (for internal/system types)
     /// - Ready phase: Full validation
     ///
-    /// Returns a `RegisterResult` for each input entity, preserving order.
+    /// Successful results carry only the canonical [`gts_id`](RegisterResult::Ok)
+    /// — callers that need a typed view of the registered entity should follow
+    /// up with [`Self::get`].
     #[must_use]
     pub fn register(&self, entities: Vec<serde_json::Value>) -> Vec<RegisterResult> {
         let validate = self.repo.is_ready();
@@ -41,13 +58,20 @@ impl TypesRegistryService {
 
     /// Registers GTS entities in batch with forced validation.
     ///
-    /// This method always validates entities regardless of ready state.
     /// Used by REST API to ensure all externally registered entities are validated.
-    ///
-    /// Returns a `RegisterResult` for each input entity, preserving order.
+    /// See [`RegisterEntityOutcome`] for the tuple shape.
     #[must_use]
-    pub fn register_validated(&self, entities: Vec<serde_json::Value>) -> Vec<RegisterResult> {
-        self.register_internal(entities, true)
+    pub fn register_validated(
+        &self,
+        entities: Vec<serde_json::Value>,
+    ) -> Vec<RegisterEntityOutcome> {
+        let mut out = Vec::with_capacity(entities.len());
+        for entity in entities {
+            let gts_id = self.extract_gts_id(&entity);
+            let result = self.repo.register(&entity, true);
+            out.push((gts_id, result));
+        }
+        out
     }
 
     /// Internal registration method with explicit validation control.
@@ -57,25 +81,37 @@ impl TypesRegistryService {
         validate: bool,
     ) -> Vec<RegisterResult> {
         let mut results = Vec::with_capacity(entities.len());
-
         for entity in entities {
             let gts_id = self.extract_gts_id(&entity);
             let result = match self.repo.register(&entity, validate) {
-                Ok(registered) => RegisterResult::Ok(registered),
-                Err(e) => RegisterResult::Err {
-                    gts_id,
-                    error: e.into(),
+                Ok(registered) => RegisterResult::Ok {
+                    gts_id: registered.gts_id,
                 },
+                Err(e) => {
+                    // Best-effort kind detection from the extracted gts_id so
+                    // the SDK error variant matches the input shape. Unknown
+                    // gts_id falls back to the type-schema variant — the kind-
+                    // agnostic `register()` consumer doesn't distinguish them.
+                    let error = match gts_id.as_deref() {
+                        Some(s) if !s.ends_with('~') => e.into_sdk_for_instance(),
+                        _ => e.into_sdk_for_type_schema(),
+                    };
+                    RegisterResult::Err { gts_id, error }
+                }
             };
             results.push(result);
         }
-
         results
     }
 
     /// Retrieves a single GTS entity by its identifier.
     pub fn get(&self, gts_id: &str) -> Result<GtsEntity, DomainError> {
         self.repo.get(gts_id)
+    }
+
+    /// Retrieves a single GTS entity by its deterministic UUID v5.
+    pub fn get_by_uuid(&self, id: Uuid) -> Result<GtsEntity, DomainError> {
+        self.repo.get_by_uuid(id)
     }
 
     /// Lists GTS entities matching the given query.
@@ -85,8 +121,8 @@ impl TypesRegistryService {
 
     /// Switches the registry from configuration mode to ready mode.
     ///
-    /// This validates all entities in temporary storage and moves them
-    /// to persistent storage if validation succeeds.
+    /// Validates all entities in temporary storage and moves them to
+    /// persistent storage if validation succeeds.
     ///
     /// # Errors
     ///
@@ -109,14 +145,22 @@ impl TypesRegistryService {
         self.repo.is_ready()
     }
 
-    /// Extracts the GTS ID from an entity JSON value.
+    /// Returns `true` if an entity with the given GTS id is registered in
+    /// persistent storage. Used for parent existence pre-checks during
+    /// ready-phase registration.
+    #[must_use]
+    pub fn exists(&self, gts_id: &str) -> bool {
+        self.repo.exists(gts_id)
+    }
+
+    /// Extracts the GTS ID from an entity JSON value using configured fields.
     ///
-    /// Strips the `gts://` URI prefix from `$id` fields for JSON Schema compatibility (gts-rust v0.6.0+).
-    fn extract_gts_id(&self, entity: &serde_json::Value) -> Option<String> {
+    /// Strips the `gts://` URI prefix from `$id` fields for JSON Schema
+    /// compatibility (gts-rust v0.6.0+).
+    pub(crate) fn extract_gts_id(&self, entity: &serde_json::Value) -> Option<String> {
         if let Some(obj) = entity.as_object() {
             for field in &self.config.entity_id_fields {
                 if let Some(id) = obj.get(field.as_str()).and_then(|v| v.as_str()) {
-                    // Strip gts:// prefix from $id field (JSON Schema URI format)
                     let cleaned_id = if field == "$id" {
                         id.strip_prefix("gts://").unwrap_or(id)
                     } else {
@@ -179,7 +223,7 @@ mod tests {
                 Uuid::nil(),
                 gts_id.to_owned(),
                 vec![],
-                true, // is_schema
+                true,
                 entity.clone(),
                 None,
             ))
@@ -187,16 +231,20 @@ mod tests {
 
         fn get(&self, gts_id: &str) -> Result<GtsEntity, DomainError> {
             if gts_id.contains("notfound") {
-                return Err(DomainError::not_found(gts_id));
+                return Err(DomainError::not_found_by_id(gts_id));
             }
             Ok(GtsEntity::new(
                 Uuid::nil(),
                 gts_id.to_owned(),
                 vec![],
-                true, // is_schema
+                true,
                 json!({}),
                 None,
             ))
+        }
+
+        fn get_by_uuid(&self, id: Uuid) -> Result<GtsEntity, DomainError> {
+            Err(DomainError::not_found_by_uuid(id))
         }
 
         fn list(&self, _query: &ListQuery) -> Result<Vec<GtsEntity>, DomainError> {
@@ -204,7 +252,7 @@ mod tests {
                 Uuid::nil(),
                 "gts.test.pkg.ns.type.v1~".to_owned(),
                 vec![],
-                true, // is_schema
+                true,
                 json!({}),
                 None,
             )])
@@ -220,7 +268,6 @@ mod tests {
 
         fn switch_to_ready(&self) -> Result<(), Vec<String>> {
             if self.fail_switch {
-                // Return errors in "gts_id: message" format for ValidationError::from_string
                 return Err(vec![
                     "gts.test1~: error1".to_owned(),
                     "gts.test2~: error2".to_owned(),
@@ -250,16 +297,7 @@ mod tests {
             Some("gts.acme.core.events.test.v1~".to_owned())
         );
 
-        let entity = json!({"id": "gts.acme.core.events.test.v1~"});
-        assert_eq!(
-            service.extract_gts_id(&entity),
-            Some("gts.acme.core.events.test.v1~".to_owned())
-        );
-
         let entity = json!({"other": "value"});
-        assert_eq!(service.extract_gts_id(&entity), None);
-
-        let entity = json!("not an object");
         assert_eq!(service.extract_gts_id(&entity), None);
     }
 
@@ -358,8 +396,6 @@ mod tests {
                 assert_eq!(errors.len(), 2);
                 assert_eq!(errors[0].gts_id, "gts.test1~");
                 assert_eq!(errors[0].message, "error1");
-                assert_eq!(errors[1].gts_id, "gts.test2~");
-                assert_eq!(errors[1].message, "error2");
             }
             _ => panic!("Expected ReadyCommitFailed"),
         }

--- a/modules/system/types-registry/types-registry/src/infra/cache/cache.rs
+++ b/modules/system/types-registry/types-registry/src/infra/cache/cache.rs
@@ -1,0 +1,506 @@
+//! Cache infrastructure for [`TypesRegistryLocalClient`](crate::domain::local_client::TypesRegistryLocalClient).
+//!
+//! Provides bounded LRU caches for resolved [`GtsTypeSchema`] and [`GtsInstance`]
+//! values, keyed by GTS id. Both kinds share a generic [`Cache<V>`] backbone.
+//!
+//! # TTL
+//!
+//! TTL is enabled by default ([`DEFAULT_CACHE_TTL`]). The local client
+//! invalidates its own entries on writes it observes, but registry mutations
+//! can also reach the underlying store from other processes (out-of-process
+//! modules) or from peers in a future distributed deployment — there's no
+//! in-process notification when that happens. TTL bounds how long a stale
+//! entry can survive in those cases. Callers can override with
+//! [`CacheConfig::with_ttl`] / [`CacheConfig::without_ttl`].
+//!
+//! # Lock ordering
+//!
+//! Each cache owns one `parking_lot::Mutex`. The local client holds at most
+//! one cache lock at a time and never acquires the storage repository lock
+//! while holding a cache lock.
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use lru::LruCache;
+use modkit_macros::domain_model;
+use parking_lot::Mutex;
+use types_registry_sdk::{GtsInstance, GtsTypeSchema};
+use uuid::Uuid;
+
+/// Provides the deterministic UUID v5 of an entity for indexing inside the
+/// cache.
+///
+/// Both [`GtsTypeSchema`] (with `type_uuid`) and [`GtsInstance`] (with `uuid`)
+/// carry a UUID derived from the GTS id, but under different field names.
+/// This trait gives [`InMemoryCache`] a uniform extractor so it can populate
+/// its internal `uuid → gts_id` reverse index atomically with every `put`.
+///
+/// Kept private to the cache module — it's an impl detail of
+/// [`InMemoryCache`], not part of the SDK contract.
+pub trait HasUuid {
+    /// Returns the entity's deterministic UUID v5.
+    fn entity_uuid(&self) -> Uuid;
+}
+
+impl HasUuid for GtsTypeSchema {
+    fn entity_uuid(&self) -> Uuid {
+        self.type_uuid
+    }
+}
+
+impl HasUuid for GtsInstance {
+    fn entity_uuid(&self) -> Uuid {
+        self.uuid
+    }
+}
+
+impl<T: HasUuid + ?Sized> HasUuid for Arc<T> {
+    fn entity_uuid(&self) -> Uuid {
+        T::entity_uuid(self)
+    }
+}
+
+/// Default cache capacity (entries) for both type-schema and instance caches.
+pub const DEFAULT_CACHE_CAPACITY: usize = 1024;
+
+/// Default TTL for cached entries: 60 seconds.
+///
+/// Bounds staleness when the underlying store is mutated outside the local
+/// client's awareness (e.g. by an out-of-process module sharing the registry
+/// or a peer node in a future distributed deployment).
+pub const DEFAULT_CACHE_TTL: Duration = Duration::from_mins(1);
+
+/// Per-kind cache configuration.
+#[domain_model]
+#[derive(Debug, Clone, Copy)]
+pub struct CacheConfig {
+    /// Maximum number of entries before LRU eviction. Clamped to `1` if `0`.
+    pub capacity: usize,
+    /// Maximum age of an entry before it's treated as a miss. `None` disables
+    /// TTL entirely (entries live until evicted by capacity pressure).
+    pub ttl: Option<Duration>,
+}
+
+impl CacheConfig {
+    /// Default config for the type-schema cache: [`DEFAULT_CACHE_CAPACITY`]
+    /// entries, [`DEFAULT_CACHE_TTL`].
+    #[must_use]
+    pub const fn type_schemas() -> Self {
+        Self {
+            capacity: DEFAULT_CACHE_CAPACITY,
+            ttl: Some(DEFAULT_CACHE_TTL),
+        }
+    }
+
+    /// Default config for the instance cache: [`DEFAULT_CACHE_CAPACITY`]
+    /// entries, [`DEFAULT_CACHE_TTL`].
+    #[must_use]
+    pub const fn instances() -> Self {
+        Self {
+            capacity: DEFAULT_CACHE_CAPACITY,
+            ttl: Some(DEFAULT_CACHE_TTL),
+        }
+    }
+
+    /// Builder: set capacity.
+    #[must_use]
+    pub const fn with_capacity(mut self, capacity: usize) -> Self {
+        self.capacity = capacity;
+        self
+    }
+
+    /// Builder: set TTL.
+    #[must_use]
+    pub const fn with_ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = Some(ttl);
+        self
+    }
+
+    /// Builder: disable TTL.
+    #[must_use]
+    pub const fn without_ttl(mut self) -> Self {
+        self.ttl = None;
+        self
+    }
+}
+
+#[domain_model]
+#[derive(Debug, Clone)]
+struct Entry<V> {
+    value: V,
+    inserted: Instant,
+}
+
+/// Abstract cache contract used by [`TypesRegistryLocalClient`](crate::domain::local_client::TypesRegistryLocalClient).
+///
+/// Designed for swappable implementations: today the registry runs entirely
+/// in-process with [`InMemoryCache`], tomorrow we may add a Redis-backed
+/// implementation for sharing cache state across pods. All methods take
+/// `&self` (interior mutability inside the impl) and are sync — async
+/// implementations should buffer batches behind a sync façade.
+///
+/// In addition to the LRU value cache, every implementation must maintain a
+/// reverse `uuid → gts_id` index populated atomically on `put` /
+/// `put_many` and pruned in lock-step on every removal — capacity-driven
+/// LRU eviction, TTL expiry inside `get*`, [`Self::invalidate`],
+/// [`Self::retain`], and [`Self::clear`]. The index size therefore tracks
+/// the LRU's. The fast paths into the index are [`Self::get_by_uuid`] /
+/// [`Self::get_many_by_uuid`].
+pub trait Cache<V>: Send + Sync
+where
+    V: Clone + HasUuid,
+{
+    /// Looks up an entry. `None` if absent or expired.
+    fn get(&self, key: &str) -> Option<V>;
+
+    /// Bulk lookup with single-acquisition semantics. Returns one entry per
+    /// input key in the same order, with `None` for misses.
+    fn get_many(&self, keys: &[&str]) -> Vec<Option<V>>;
+
+    /// Looks up a cached value by its UUID v5. Returns `Some(value)` only
+    /// when the UUID has been observed (via `put` / `put_many`) **and** the
+    /// resolved LRU entry is still present and not expired. A
+    /// previously-observed UUID whose value has been evicted by LRU
+    /// capacity or TTL returns `None` — callers fall through to their
+    /// usual slow path, which will re-cache and re-index on the way back.
+    fn get_by_uuid(&self, uuid: Uuid) -> Option<V>;
+
+    /// Bulk variant of [`Self::get_by_uuid`] under a single lock.
+    fn get_many_by_uuid(&self, uuids: &[Uuid]) -> Vec<Option<V>>;
+
+    /// Inserts (or replaces) an entry. Atomically records the
+    /// `value.entity_uuid() → key` mapping in the reverse index.
+    fn put(&self, key: String, value: V);
+
+    /// Bulk insert with single-acquisition semantics. All entries enter the
+    /// cache as if put together (shared TTL clock if applicable). Atomically
+    /// records every `value.entity_uuid() → key` mapping in the reverse
+    /// index.
+    fn put_many(&self, entries: Vec<(String, V)>);
+
+    /// Removes a single entry. No-op if absent. The matching `uuid → gts_id`
+    /// mapping is pruned along with the LRU entry.
+    fn invalidate(&self, key: &str);
+
+    /// Drops every entry whose value fails the predicate. Used for cascade
+    /// invalidation. Object-safe form: takes `&dyn Fn` instead of generic
+    /// `F: Fn`. Reverse `uuid → gts_id` mappings of removed entries are
+    /// pruned in lock-step.
+    fn retain(&self, predicate: &dyn Fn(&V) -> bool);
+
+    /// Drops every entry, including the `uuid → gts_id` index.
+    fn clear(&self);
+
+    /// Number of entries currently held (including not-yet-expired stale ones).
+    fn len(&self) -> usize;
+
+    /// Returns `true` if the cache has no entries.
+    fn is_empty(&self) -> bool;
+}
+
+/// LRU + reverse `uuid → gts_id` index, both behind one mutex.
+///
+/// Wrapping these together (rather than two independent `Mutex`es) gives
+/// every `put` true atomicity — readers either see both maps populated or
+/// neither, never an in-between state where the index points at an entry
+/// the LRU hasn't received yet. Every method that mutates the LRU also
+/// prunes the matching `uuid_to_id` entry (see [`Inner::pop_with_cleanup`]
+/// / [`Inner::push_with_cleanup`]) so the index stays bounded by the LRU
+/// capacity rather than growing for the lifetime of the process.
+struct Inner<V> {
+    lru: LruCache<String, Entry<V>>,
+    /// Reverse `uuid → gts_id` index. Kept in sync with the LRU so its
+    /// memory footprint matches the LRU's: every entry that leaves the
+    /// LRU (capacity eviction, TTL expiry, invalidate, retain) also
+    /// drops here.
+    uuid_to_id: HashMap<Uuid, String>,
+}
+
+impl<V: Clone + HasUuid> Inner<V> {
+    /// Pops the LRU entry for `key` and removes its `uuid → key` mapping
+    /// from the reverse index. Keeps the two maps in lock-step.
+    fn pop_with_cleanup(&mut self, key: &str) -> Option<Entry<V>> {
+        let entry = self.lru.pop(key)?;
+        self.uuid_to_id.remove(&entry.value.entity_uuid());
+        Some(entry)
+    }
+
+    /// Inserts `entry` at `key`, replacing any existing entry. If the
+    /// insert evicts another entry (capacity-driven eviction or same-key
+    /// replace), prunes the evicted entry's `uuid → key` mapping before
+    /// recording the new one.
+    fn push_with_cleanup(&mut self, key: String, entry: Entry<V>) {
+        let new_uuid = entry.value.entity_uuid();
+        if let Some((_, evicted)) = self.lru.push(key.clone(), entry) {
+            self.uuid_to_id.remove(&evicted.value.entity_uuid());
+        }
+        // Insert AFTER the cleanup: in the deterministic case
+        // (same-key replace where new and old uuids are equal) the
+        // cleanup above removed our mapping, so we restore it here.
+        self.uuid_to_id.insert(new_uuid, key);
+    }
+}
+
+/// Bounded LRU cache with optional TTL, keyed by GTS id `String`. Every
+/// stored value also feeds a reverse `uuid → gts_id` index (built from
+/// [`HasUuid::entity_uuid`]) so `*_by_uuid` lookups can short-circuit the
+/// linear storage scan once a UUID has been observed.
+///
+/// Cache hits return cloned values. For `Arc<T>` this is a refcount bump.
+#[domain_model]
+pub struct InMemoryCache<V: Clone + HasUuid> {
+    inner: Mutex<Inner<V>>,
+    ttl: Option<Duration>,
+}
+
+impl<V: Clone + HasUuid> InMemoryCache<V> {
+    /// Creates a new cache with the given config.
+    ///
+    /// `config.capacity == 0` is silently clamped to `1`.
+    #[must_use]
+    pub fn new(config: CacheConfig) -> Self {
+        let capacity = NonZeroUsize::new(config.capacity).unwrap_or(NonZeroUsize::MIN);
+        Self {
+            inner: Mutex::new(Inner {
+                lru: LruCache::new(capacity),
+                uuid_to_id: HashMap::new(),
+            }),
+            ttl: config.ttl,
+        }
+    }
+
+    /// Looks up an entry. Returns `None` if absent or expired (and removes the
+    /// expired entry as a side effect).
+    pub fn get(&self, key: &str) -> Option<V> {
+        let mut guard = self.inner.lock();
+        let entry = guard.lru.get(key)?;
+        if let Some(ttl) = self.ttl
+            && entry.inserted.elapsed() > ttl
+        {
+            guard.pop_with_cleanup(key);
+            return None;
+        }
+        Some(entry.value.clone())
+    }
+
+    /// Bulk lookup: acquires the lock once for the whole batch and returns
+    /// one entry per input key, in the same order.
+    ///
+    /// Per-key semantics match [`Self::get`]: a hit refreshes LRU recency,
+    /// expired entries are evicted as a side effect (deferred until the
+    /// end of the batch so we don't churn the lock state mid-iteration).
+    ///
+    /// Designed for upcoming database-backed implementations where issuing
+    /// one query for many keys (e.g. `WHERE gts_id IN (...)`) is dramatically
+    /// cheaper than N round-trips, and for amortizing the in-memory mutex
+    /// across batch fast-paths in clients.
+    pub fn get_many(&self, keys: &[&str]) -> Vec<Option<V>> {
+        let mut guard = self.inner.lock();
+        let mut to_evict: Vec<String> = Vec::new();
+        let mut results: Vec<Option<V>> = Vec::with_capacity(keys.len());
+        for key in keys {
+            match guard.lru.get(*key) {
+                Some(entry) => {
+                    let expired = self.ttl.is_some_and(|ttl| entry.inserted.elapsed() > ttl);
+                    if expired {
+                        to_evict.push((*key).to_owned());
+                        results.push(None);
+                    } else {
+                        results.push(Some(entry.value.clone()));
+                    }
+                }
+                None => results.push(None),
+            }
+        }
+        for key in &to_evict {
+            guard.pop_with_cleanup(key.as_str());
+        }
+        results
+    }
+
+    /// Inserts or replaces an entry. Resets the TTL clock for the key, and
+    /// atomically records the `value.entity_uuid() → key` mapping in the
+    /// reverse `uuid → gts_id` index (same lock as the LRU). If the put
+    /// triggers capacity eviction, the evicted entry's reverse mapping is
+    /// also dropped.
+    pub fn put(&self, key: String, value: V) {
+        let mut guard = self.inner.lock();
+        guard.push_with_cleanup(
+            key,
+            Entry {
+                value,
+                inserted: Instant::now(),
+            },
+        );
+    }
+
+    /// Bulk insert: all entries are written under a single lock acquisition
+    /// and share the same TTL clock origin. Existing entries with the same
+    /// key are replaced. Every value's `entity_uuid() → key` mapping is
+    /// recorded in the reverse `uuid → gts_id` index, and any entries
+    /// evicted by capacity pressure during the batch have their mappings
+    /// pruned in lock-step.
+    ///
+    /// Designed for batch fast-paths in clients: when a `get_*` batch fills
+    /// in N cache misses by fetching from storage, those N freshly-built
+    /// entries can be installed in one shot rather than N individual `put`s.
+    pub fn put_many(&self, entries: Vec<(String, V)>) {
+        let mut guard = self.inner.lock();
+        let now = Instant::now();
+        for (key, value) in entries {
+            guard.push_with_cleanup(
+                key,
+                Entry {
+                    value,
+                    inserted: now,
+                },
+            );
+        }
+    }
+
+    /// Looks up a cached value by its UUID v5. Returns `Some(value)` only
+    /// when the UUID has been observed and the LRU entry is still present
+    /// and unexpired. A reverse-index hit followed by an LRU miss yields
+    /// `None`; callers handle it like any other cache miss.
+    pub fn get_by_uuid(&self, uuid: Uuid) -> Option<V> {
+        let mut guard = self.inner.lock();
+        let id = guard.uuid_to_id.get(&uuid).cloned()?;
+        let entry = guard.lru.get(id.as_str())?;
+        if let Some(ttl) = self.ttl
+            && entry.inserted.elapsed() > ttl
+        {
+            guard.pop_with_cleanup(id.as_str());
+            return None;
+        }
+        Some(entry.value.clone())
+    }
+
+    /// Bulk variant of [`Self::get_by_uuid`] — single lock acquisition for
+    /// the whole batch. Returns one entry per input UUID, in input order.
+    pub fn get_many_by_uuid(&self, uuids: &[Uuid]) -> Vec<Option<V>> {
+        let mut guard = self.inner.lock();
+        let mut to_evict: Vec<String> = Vec::new();
+        let mut results: Vec<Option<V>> = Vec::with_capacity(uuids.len());
+        for uuid in uuids {
+            let Some(id) = guard.uuid_to_id.get(uuid).cloned() else {
+                results.push(None);
+                continue;
+            };
+            match guard.lru.get(id.as_str()) {
+                Some(entry) => {
+                    let expired = self.ttl.is_some_and(|ttl| entry.inserted.elapsed() > ttl);
+                    if expired {
+                        to_evict.push(id);
+                        results.push(None);
+                    } else {
+                        results.push(Some(entry.value.clone()));
+                    }
+                }
+                None => results.push(None),
+            }
+        }
+        for id in &to_evict {
+            guard.pop_with_cleanup(id.as_str());
+        }
+        results
+    }
+
+    /// Removes a single entry by key. No-op if absent. The matching
+    /// `uuid → gts_id` mapping is dropped in lock-step.
+    pub fn invalidate(&self, key: &str) {
+        self.inner.lock().pop_with_cleanup(key);
+    }
+
+    /// Drops every entry whose value fails the predicate. Used for cascade
+    /// invalidation when a parent type-schema is rewritten — derived
+    /// type-schemas and instances embedding `Arc`s to the old parent must
+    /// be dropped, otherwise reads return stale views. The reverse
+    /// `uuid → gts_id` index is pruned in lock-step.
+    pub fn retain(&self, predicate: &dyn Fn(&V) -> bool) {
+        let mut guard = self.inner.lock();
+        let to_remove: Vec<String> = guard
+            .lru
+            .iter()
+            .filter(|(_, entry)| !predicate(&entry.value))
+            .map(|(k, _)| k.clone())
+            .collect();
+        for key in to_remove {
+            guard.pop_with_cleanup(&key);
+        }
+    }
+
+    /// Clears every entry, including the reverse `uuid → gts_id` index.
+    pub fn clear(&self) {
+        let mut guard = self.inner.lock();
+        guard.lru.clear();
+        guard.uuid_to_id.clear();
+    }
+
+    /// Number of entries currently held (including not-yet-expired stale ones).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.lock().lru.len()
+    }
+
+    /// Returns `true` if the cache has no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().lru.is_empty()
+    }
+}
+
+impl<V> Cache<V> for InMemoryCache<V>
+where
+    V: Clone + HasUuid + Send + Sync + 'static,
+{
+    fn get(&self, key: &str) -> Option<V> {
+        Self::get(self, key)
+    }
+    fn get_many(&self, keys: &[&str]) -> Vec<Option<V>> {
+        Self::get_many(self, keys)
+    }
+    fn get_by_uuid(&self, uuid: Uuid) -> Option<V> {
+        Self::get_by_uuid(self, uuid)
+    }
+    fn get_many_by_uuid(&self, uuids: &[Uuid]) -> Vec<Option<V>> {
+        Self::get_many_by_uuid(self, uuids)
+    }
+    fn put(&self, key: String, value: V) {
+        Self::put(self, key, value);
+    }
+    fn put_many(&self, entries: Vec<(String, V)>) {
+        Self::put_many(self, entries);
+    }
+    fn invalidate(&self, key: &str) {
+        Self::invalidate(self, key);
+    }
+    fn retain(&self, predicate: &dyn Fn(&V) -> bool) {
+        Self::retain(self, predicate);
+    }
+    fn clear(&self) {
+        Self::clear(self);
+    }
+    fn len(&self) -> usize {
+        Self::len(self)
+    }
+    fn is_empty(&self) -> bool {
+        Self::is_empty(self)
+    }
+}
+
+/// Boxed [`Cache`] of resolved type-schemas (Arc-shared so ancestor chains
+/// dedupe). The local client owns this as a trait object so the concrete
+/// backend (in-memory today, Redis tomorrow) can be swapped without
+/// touching consumer code.
+pub type TypeSchemaCache = Box<dyn Cache<Arc<GtsTypeSchema>>>;
+
+/// Boxed [`Cache`] of resolved instances. Same swap-friendly shape as
+/// [`TypeSchemaCache`].
+pub type InstanceCache = Box<dyn Cache<Arc<GtsInstance>>>;
+
+#[cfg(test)]
+#[path = "cache_tests.rs"]
+mod tests;

--- a/modules/system/types-registry/types-registry/src/infra/cache/cache_tests.rs
+++ b/modules/system/types-registry/types-registry/src/infra/cache/cache_tests.rs
@@ -1,0 +1,337 @@
+//! Unit tests for [`InMemoryCache`](super::InMemoryCache).
+//!
+//! Kept in a sibling `_tests.rs` file per the `de1101_tests_in_separate_files`
+//! repo lint. Linked into `cache.rs` via `#[path = "cache_tests.rs"] mod tests;`,
+//! so the module sees `cache.rs` as `super`.
+
+use super::*;
+use serde_json::json;
+use std::thread::sleep;
+use types_registry_sdk::GtsTypeId;
+
+fn make_type_schema(type_id: &str) -> Arc<GtsTypeSchema> {
+    Arc::new(GtsTypeSchema::try_new(GtsTypeId::new(type_id), json!({}), None, None).unwrap())
+}
+
+#[test]
+fn test_get_miss_returns_none() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig::type_schemas());
+    assert!(cache.get("gts.x.y.z.t.v1~").is_none());
+}
+
+#[test]
+fn test_put_then_get_returns_value() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig::type_schemas());
+    let schema = make_type_schema("gts.x.y.z.t.v1~");
+    cache.put("gts.x.y.z.t.v1~".to_owned(), Arc::clone(&schema));
+    let hit = cache.get("gts.x.y.z.t.v1~").unwrap();
+    assert!(Arc::ptr_eq(&hit, &schema));
+}
+
+#[test]
+fn test_invalidate_removes_entry() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig::type_schemas());
+    let schema = make_type_schema("gts.x.y.z.t.v1~");
+    cache.put("gts.x.y.z.t.v1~".to_owned(), schema);
+    cache.invalidate("gts.x.y.z.t.v1~");
+    assert!(cache.get("gts.x.y.z.t.v1~").is_none());
+}
+
+#[test]
+fn test_clear_drops_all() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig::type_schemas());
+    cache.put("a~".to_owned(), make_type_schema("gts.x.y.z.a.v1~"));
+    cache.put("b~".to_owned(), make_type_schema("gts.x.y.z.b.v1~"));
+    assert_eq!(cache.len(), 2);
+    cache.clear();
+    assert!(cache.is_empty());
+}
+
+#[test]
+fn test_lru_eviction_at_capacity() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> = InMemoryCache::<Arc<GtsTypeSchema>>::new(
+        CacheConfig::type_schemas().with_capacity(2).without_ttl(),
+    );
+    cache.put("a".to_owned(), make_type_schema("gts.x.y.z.a.v1~"));
+    cache.put("b".to_owned(), make_type_schema("gts.x.y.z.b.v1~"));
+    cache.put("c".to_owned(), make_type_schema("gts.x.y.z.c.v1~"));
+    // a was the least recently used → evicted.
+    assert!(cache.get("a").is_none());
+    assert!(cache.get("b").is_some());
+    assert!(cache.get("c").is_some());
+}
+
+#[test]
+fn test_ttl_expiry() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> = InMemoryCache::<Arc<GtsTypeSchema>>::new(
+        CacheConfig::type_schemas().with_ttl(Duration::from_millis(50)),
+    );
+    cache.put("a".to_owned(), make_type_schema("gts.x.y.z.a.v1~"));
+    assert!(cache.get("a").is_some());
+    sleep(Duration::from_millis(80));
+    assert!(cache.get("a").is_none());
+}
+
+#[test]
+fn test_no_ttl_keeps_entry() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> = InMemoryCache::<Arc<GtsTypeSchema>>::new(
+        CacheConfig::type_schemas().without_ttl().with_capacity(8),
+    );
+    cache.put("a".to_owned(), make_type_schema("gts.x.y.z.a.v1~"));
+    sleep(Duration::from_millis(20));
+    assert!(cache.get("a").is_some());
+}
+
+#[test]
+fn test_zero_capacity_clamped_to_one() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig {
+            capacity: 0,
+            ttl: None,
+        });
+    cache.put("a".to_owned(), make_type_schema("gts.x.y.z.a.v1~"));
+    // capacity = 1 means second put evicts the first.
+    cache.put("b".to_owned(), make_type_schema("gts.x.y.z.b.v1~"));
+    assert!(cache.get("a").is_none());
+    assert!(cache.get("b").is_some());
+}
+
+#[test]
+fn test_default_configs() {
+    let s = CacheConfig::type_schemas();
+    assert_eq!(s.capacity, DEFAULT_CACHE_CAPACITY);
+    assert_eq!(s.ttl, Some(DEFAULT_CACHE_TTL));
+
+    let i = CacheConfig::instances();
+    assert_eq!(i.capacity, DEFAULT_CACHE_CAPACITY);
+    assert_eq!(i.ttl, Some(DEFAULT_CACHE_TTL));
+}
+
+// ── Cache::get_many ──────────────────────────────────────────────────
+
+#[test]
+fn test_get_many_preserves_order_and_gaps() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig::type_schemas());
+    let a = make_type_schema("gts.x.y.z.a.v1~");
+    let c = make_type_schema("gts.x.y.z.c.v1~");
+    cache.put("gts.x.y.z.a.v1~".to_owned(), Arc::clone(&a));
+    cache.put("gts.x.y.z.c.v1~".to_owned(), Arc::clone(&c));
+
+    let results = cache.get_many(&[
+        "gts.x.y.z.a.v1~",
+        "gts.x.y.z.b.v1~", // not in cache
+        "gts.x.y.z.c.v1~",
+    ]);
+    assert_eq!(results.len(), 3);
+    assert!(Arc::ptr_eq(results[0].as_ref().unwrap(), &a));
+    assert!(results[1].is_none());
+    assert!(Arc::ptr_eq(results[2].as_ref().unwrap(), &c));
+}
+
+#[test]
+fn test_get_many_empty_input() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig::type_schemas());
+    let results = cache.get_many(&[]);
+    assert!(results.is_empty());
+}
+
+#[test]
+fn test_get_many_all_misses() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig::type_schemas());
+    let results = cache.get_many(&["gts.x.y.z.a.v1~", "gts.x.y.z.b.v1~"]);
+    assert_eq!(results.len(), 2);
+    assert!(results[0].is_none());
+    assert!(results[1].is_none());
+}
+
+#[test]
+fn test_get_many_evicts_expired_entries() {
+    // Mixed batch where some entries are TTL-expired and some are fresh.
+    // Expired ones must surface as None and be evicted from the cache;
+    // fresh ones surface as Some and stay.
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> = InMemoryCache::<Arc<GtsTypeSchema>>::new(
+        CacheConfig::type_schemas().with_ttl(Duration::from_millis(50)),
+    );
+    cache.put(
+        "gts.x.y.z.expired.v1~".to_owned(),
+        make_type_schema("gts.x.y.z.expired.v1~"),
+    );
+    sleep(Duration::from_millis(80));
+    // Fresh entry inserted AFTER the sleep — its TTL clock is reset.
+    cache.put(
+        "gts.x.y.z.fresh.v1~".to_owned(),
+        make_type_schema("gts.x.y.z.fresh.v1~"),
+    );
+
+    let results = cache.get_many(&["gts.x.y.z.expired.v1~", "gts.x.y.z.fresh.v1~"]);
+    assert!(results[0].is_none());
+    assert!(results[1].is_some());
+
+    // Expired entry must be evicted as a side effect.
+    assert!(cache.get("gts.x.y.z.expired.v1~").is_none());
+    assert!(cache.get("gts.x.y.z.fresh.v1~").is_some());
+    assert_eq!(cache.len(), 1);
+}
+
+// ── Cache::put_many ──────────────────────────────────────────────────
+
+#[test]
+fn test_put_many_inserts_all_entries() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig::type_schemas());
+    cache.put_many(vec![
+        (
+            "gts.x.y.z.a.v1~".to_owned(),
+            make_type_schema("gts.x.y.z.a.v1~"),
+        ),
+        (
+            "gts.x.y.z.b.v1~".to_owned(),
+            make_type_schema("gts.x.y.z.b.v1~"),
+        ),
+        (
+            "gts.x.y.z.c.v1~".to_owned(),
+            make_type_schema("gts.x.y.z.c.v1~"),
+        ),
+    ]);
+    assert_eq!(cache.len(), 3);
+    assert!(cache.get("gts.x.y.z.a.v1~").is_some());
+    assert!(cache.get("gts.x.y.z.b.v1~").is_some());
+    assert!(cache.get("gts.x.y.z.c.v1~").is_some());
+}
+
+#[test]
+fn test_put_many_replaces_existing() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig::type_schemas());
+    let v1 = make_type_schema("gts.x.y.z.a.v1~");
+    let v2 = make_type_schema("gts.x.y.z.a.v1~");
+    cache.put("gts.x.y.z.a.v1~".to_owned(), Arc::clone(&v1));
+    cache.put_many(vec![("gts.x.y.z.a.v1~".to_owned(), Arc::clone(&v2))]);
+    assert_eq!(cache.len(), 1);
+    // The replacement won — same key now points to v2's Arc.
+    assert!(Arc::ptr_eq(&cache.get("gts.x.y.z.a.v1~").unwrap(), &v2));
+}
+
+#[test]
+fn test_put_many_empty_input_is_noop() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig::type_schemas());
+    cache.put_many(vec![]);
+    assert!(cache.is_empty());
+}
+
+#[test]
+fn test_put_many_respects_capacity() {
+    // capacity=2, put_many of 3 entries — last two win, first is evicted.
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> = InMemoryCache::<Arc<GtsTypeSchema>>::new(
+        CacheConfig::type_schemas().with_capacity(2).without_ttl(),
+    );
+    cache.put_many(vec![
+        (
+            "gts.x.y.z.a.v1~".to_owned(),
+            make_type_schema("gts.x.y.z.a.v1~"),
+        ),
+        (
+            "gts.x.y.z.b.v1~".to_owned(),
+            make_type_schema("gts.x.y.z.b.v1~"),
+        ),
+        (
+            "gts.x.y.z.c.v1~".to_owned(),
+            make_type_schema("gts.x.y.z.c.v1~"),
+        ),
+    ]);
+    assert_eq!(cache.len(), 2);
+    assert!(cache.get("gts.x.y.z.a.v1~").is_none()); // evicted (LRU)
+    assert!(cache.get("gts.x.y.z.b.v1~").is_some());
+    assert!(cache.get("gts.x.y.z.c.v1~").is_some());
+}
+
+// ── reverse `uuid → gts_id` index pruning ────────────────────────────────
+
+#[test]
+fn test_reverse_index_pruned_on_capacity_eviction() {
+    // Regression for the previously-unbounded reverse index. With
+    // capacity=2 and 5 distinct entries put in sequence, only the
+    // most-recent 2 should remain reachable via `get_by_uuid`, and
+    // the index size must track the LRU's.
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> = InMemoryCache::<Arc<GtsTypeSchema>>::new(
+        CacheConfig::type_schemas().with_capacity(2).without_ttl(),
+    );
+    let schemas: Vec<Arc<GtsTypeSchema>> = (0..5)
+        .map(|i| make_type_schema(&format!("gts.x.y.z.s{i}.v1~")))
+        .collect();
+    for s in &schemas {
+        cache.put(s.type_id.to_string(), Arc::clone(s));
+    }
+    // Old entries fully gone — both LRU and reverse index.
+    for s in &schemas[..3] {
+        assert!(
+            cache.get_by_uuid(s.type_uuid).is_none(),
+            "evicted entry still reachable by uuid"
+        );
+    }
+    // Survivors reachable.
+    for s in &schemas[3..] {
+        assert!(cache.get_by_uuid(s.type_uuid).is_some());
+    }
+}
+
+#[test]
+fn test_reverse_index_pruned_on_invalidate() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> =
+        InMemoryCache::<Arc<GtsTypeSchema>>::new(CacheConfig::type_schemas());
+    let s = make_type_schema("gts.x.y.z.t.v1~");
+    let uuid = s.type_uuid;
+    cache.put(s.type_id.to_string(), s);
+    assert!(cache.get_by_uuid(uuid).is_some());
+    cache.invalidate("gts.x.y.z.t.v1~");
+    // After invalidate, the reverse index must not retain a dangling
+    // mapping that points at a now-evicted LRU entry.
+    assert!(cache.get_by_uuid(uuid).is_none());
+}
+
+#[test]
+fn test_reverse_index_pruned_on_retain() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> = InMemoryCache::<Arc<GtsTypeSchema>>::new(
+        CacheConfig::type_schemas().with_capacity(4).without_ttl(),
+    );
+    let kept = make_type_schema("gts.x.y.z.keep.v1~");
+    let first_dropped = make_type_schema("gts.x.y.z.drop_a.v1~");
+    let second_dropped = make_type_schema("gts.x.y.z.drop_b.v1~");
+    let kept_uuid = kept.type_uuid;
+    let first_uuid = first_dropped.type_uuid;
+    let second_uuid = second_dropped.type_uuid;
+    cache.put(kept.type_id.to_string(), kept);
+    cache.put(first_dropped.type_id.to_string(), first_dropped);
+    cache.put(second_dropped.type_id.to_string(), second_dropped);
+
+    // Drop everything containing "drop" in the type id.
+    cache.retain(&|s: &Arc<GtsTypeSchema>| !s.type_id.as_ref().contains("drop"));
+
+    assert!(cache.get_by_uuid(kept_uuid).is_some());
+    assert!(cache.get_by_uuid(first_uuid).is_none());
+    assert!(cache.get_by_uuid(second_uuid).is_none());
+}
+
+#[test]
+fn test_reverse_index_pruned_on_ttl_expiry() {
+    let cache: InMemoryCache<Arc<GtsTypeSchema>> = InMemoryCache::<Arc<GtsTypeSchema>>::new(
+        CacheConfig::type_schemas().with_ttl(Duration::from_millis(50)),
+    );
+    let s = make_type_schema("gts.x.y.z.t.v1~");
+    let uuid = s.type_uuid;
+    cache.put(s.type_id.to_string(), s);
+    sleep(Duration::from_millis(80));
+    // First lookup observes expiry and evicts the LRU entry; the
+    // reverse mapping must drop in the same step so the second lookup
+    // doesn't see a dangling pointer.
+    assert!(cache.get("gts.x.y.z.t.v1~").is_none());
+    assert!(cache.get_by_uuid(uuid).is_none());
+}

--- a/modules/system/types-registry/types-registry/src/infra/cache/mod.rs
+++ b/modules/system/types-registry/types-registry/src/infra/cache/mod.rs
@@ -1,0 +1,9 @@
+//! Cache infrastructure for the Types Registry module.
+
+#[allow(clippy::module_inception)]
+mod cache;
+
+pub use cache::{
+    Cache, CacheConfig, DEFAULT_CACHE_CAPACITY, DEFAULT_CACHE_TTL, HasUuid, InMemoryCache,
+    InstanceCache, TypeSchemaCache,
+};

--- a/modules/system/types-registry/types-registry/src/infra/mod.rs
+++ b/modules/system/types-registry/types-registry/src/infra/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Contains storage implementations and adapters.
 
+pub mod cache;
 pub mod storage;
 
 pub use storage::InMemoryGtsRepository;

--- a/modules/system/types-registry/types-registry/src/infra/storage/in_memory_repo.rs
+++ b/modules/system/types-registry/types-registry/src/infra/storage/in_memory_repo.rs
@@ -4,12 +4,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use gts::{GtsConfig, GtsID, GtsIdSegment, GtsOps, GtsWildcard};
 use parking_lot::Mutex;
-use types_registry_sdk::{GtsEntity, ListQuery, SegmentMatchScope};
+use uuid::Uuid;
 
 use super::debug_diagnostics::{
     log_instance_validation_failure, log_registration_failure, log_schema_validation_failure,
 };
 use crate::domain::error::DomainError;
+use crate::domain::model::{GtsEntity, ListQuery, SegmentMatchScope};
 use crate::domain::repo::GtsRepository;
 
 /// In-memory repository for GTS entities using gts-rust.
@@ -88,17 +89,28 @@ impl InMemoryGtsRepository {
         None
     }
 
-    /// Checks if an entity matches the given query filters.
-    fn matches_query(entity: &GtsEntity, query: &ListQuery) -> bool {
-        if let Some(ref pattern) = query.pattern
-            && let Ok(wildcard) = GtsWildcard::new(pattern)
-        {
-            if let Ok(gts_id) = GtsID::new(&entity.gts_id) {
-                if !gts_id.wildcard_match(&wildcard) {
-                    return false;
+    /// Checks if an entity matches a pre-parsed wildcard plus the kind filter.
+    ///
+    /// The pattern is parsed once at the start of [`Self::list`] (so an
+    /// invalid pattern fails the whole call rather than silently passing
+    /// through every entity) and the resulting [`GtsWildcard`] is threaded
+    /// in here.
+    fn matches_query(
+        entity: &GtsEntity,
+        wildcard: Option<&GtsWildcard>,
+        query: &ListQuery,
+    ) -> bool {
+        if let Some(wildcard) = wildcard {
+            match GtsID::new(&entity.gts_id) {
+                Ok(gts_id) => {
+                    if !gts_id.wildcard_match(wildcard) {
+                        return false;
+                    }
                 }
-            } else {
-                return false;
+                // Stored entity has an unparseable GTS id — treat as no-match
+                // for any filtered query (it shouldn't have been registered,
+                // but better to hide than to crash on rendering).
+                Err(_) => return false,
             }
         }
 
@@ -202,16 +214,53 @@ impl GtsRepository for InMemoryGtsRepository {
             return Self::to_gts_entity(gts_id, &entity.content);
         }
 
-        Err(DomainError::not_found(gts_id))
+        Err(DomainError::not_found_by_id(gts_id))
+    }
+
+    // TODO(#1630): replace linear scan with O(1) UUID lookup once gts-rust
+    // exposes a UUID-keyed index on `GtsOps`. Today every lookup re-parses
+    // each gts_id and recomputes UUID v5 (SHA-1) per entity.
+    // https://github.com/cyberfabric/cyberfabric-core/issues/1630
+    fn get_by_uuid(&self, id: Uuid) -> Result<GtsEntity, DomainError> {
+        let persistent = self.persistent.lock();
+        for (gts_id, gts_entity) in persistent.store.items() {
+            // UUIDs are deterministic v5 from gts_id; recompute and compare.
+            if let Ok(parsed) = GtsID::new(gts_id)
+                && parsed.to_uuid() == id
+            {
+                return Self::to_gts_entity(gts_id, &gts_entity.content);
+            }
+        }
+        Err(DomainError::not_found_by_uuid(id))
     }
 
     fn list(&self, query: &ListQuery) -> Result<Vec<GtsEntity>, DomainError> {
+        // Validate the pattern once up front. `None` means "no filter".
+        // `Some("")` is a caller bug — it's distinct from `None` but can't
+        // mean anything meaningful, and `GtsWildcard::new("")` may not
+        // surface a user-friendly diagnostic. An invalid wildcard (multiple
+        // `*`s, mid-pattern `*`, segment-boundary violation — see GTS spec
+        // section 10) is also a caller bug that previously slipped through
+        // as "no filter applied"; surface both as `InvalidQuery` so they
+        // can't hide.
+        let wildcard = match query.pattern.as_deref() {
+            Some("") => {
+                return Err(DomainError::invalid_query(
+                    "pattern is empty (use `None` to mean \"no filter\")",
+                ));
+            }
+            Some(p) => Some(GtsWildcard::new(p).map_err(|e| {
+                DomainError::invalid_query(format!("invalid GTS wildcard pattern `{p}`: {e}"))
+            })?),
+            None => None,
+        };
+
         let persistent = self.persistent.lock();
         let mut results = Vec::new();
 
         for (gts_id, gts_entity) in persistent.store.items() {
             if let Ok(entity) = Self::to_gts_entity(gts_id, &gts_entity.content)
-                && Self::matches_query(&entity, query)
+                && Self::matches_query(&entity, wildcard.as_ref(), query)
             {
                 results.push(entity);
             }
@@ -232,20 +281,26 @@ impl GtsRepository for InMemoryGtsRepository {
     fn switch_to_ready(&self) -> Result<(), Vec<String>> {
         let mut errors = Vec::new();
 
-        // Collect all GTS IDs, separating schemas (ending with ~) from instances
-        let (schema_ids, instance_ids): (Vec<String>, Vec<String>) = {
+        // Collect all GTS IDs from temporary, sorted lexicographically.
+        //
+        // Lexicographic order on GTS chain ids implies parent-before-child:
+        // a parent type-schema id is a strict prefix of its derived schema's
+        // id (parent ends with `~`, derived continues past it), and a
+        // type-schema id is a strict prefix of any instance declared from
+        // it. Walking ids in lex order therefore registers every parent
+        // before any of its descendants, in a single pass — no separate
+        // schemas-then-instances split needed.
+        let sorted_ids: Vec<String> = {
             let temporary = self.temporary.lock();
-            temporary
-                .store
-                .items()
-                .map(|(id, _)| id.clone())
-                .partition(|id| id.ends_with('~'))
+            let mut ids: Vec<String> = temporary.store.items().map(|(id, _)| id.clone()).collect();
+            ids.sort();
+            ids
         };
 
         // Validate all entities in temporary storage
         {
             let mut temporary = self.temporary.lock();
-            for gts_id in schema_ids.iter().chain(instance_ids.iter()) {
+            for gts_id in &sorted_ids {
                 let result = temporary.validate_entity(gts_id);
                 if !result.ok {
                     // Debug logging for validation failure
@@ -271,38 +326,26 @@ impl GtsRepository for InMemoryGtsRepository {
             return Err(errors);
         }
 
-        // Move to persistent: schemas first, then instances
-        // This ensures schemas are available when validating instances
+        // Move to persistent in the same lex order (parents before children).
         {
             let mut temporary = self.temporary.lock();
             let mut persistent = self.persistent.lock();
 
-            // Add schemas first (with validation)
-            for gts_id in &schema_ids {
+            for gts_id in &sorted_ids {
                 if let Some(entity) = temporary.store.get(gts_id) {
                     let content = entity.content.clone();
                     let result = persistent.add_entity(&content, true);
                     if !result.ok {
-                        // Debug logging for schema commit failure
-                        log_schema_validation_failure(gts_id, &content, &result.error);
-                        errors.push(format!("{gts_id}: {}", result.error));
-                    }
-                }
-            }
-
-            // Then add instances (with validation against already-added schemas)
-            for gts_id in &instance_ids {
-                if let Some(entity) = temporary.store.get(gts_id) {
-                    let content = entity.content.clone();
-                    let result = persistent.add_entity(&content, true);
-                    if !result.ok {
-                        // Debug logging for instance commit failure
-                        log_instance_validation_failure(
-                            gts_id,
-                            &content,
-                            &result.error,
-                            &mut persistent,
-                        );
+                        if gts_id.ends_with('~') {
+                            log_schema_validation_failure(gts_id, &content, &result.error);
+                        } else {
+                            log_instance_validation_failure(
+                                gts_id,
+                                &content,
+                                &result.error,
+                                &mut persistent,
+                            );
+                        }
                         errors.push(format!("{gts_id}: {}", result.error));
                     }
                 }
@@ -445,7 +488,7 @@ mod tests {
     }
 
     #[test]
-    fn test_list_with_filters() {
+    fn test_list_default_returns_all() {
         let repo = InMemoryGtsRepository::new(default_config());
 
         let type1 = json!({
@@ -463,13 +506,7 @@ mod tests {
         repo.register(&type2, false).unwrap();
         repo.switch_to_ready().unwrap();
 
-        let query = ListQuery::default().with_vendor("acme");
-        let results = repo.list(&query).unwrap();
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].vendor(), Some("acme"));
-
-        let query = ListQuery::default();
-        let results = repo.list(&query).unwrap();
+        let results = repo.list(&ListQuery::default()).unwrap();
         assert_eq!(results.len(), 2);
     }
 
@@ -479,7 +516,7 @@ mod tests {
         repo.switch_to_ready().unwrap();
 
         let result = repo.get("gts.unknown.pkg.ns.type.v1~");
-        assert!(matches!(result, Err(DomainError::NotFound(_))));
+        assert!(matches!(result, Err(DomainError::NotFound { .. })));
     }
 
     #[test]
@@ -582,50 +619,6 @@ mod tests {
     }
 
     #[test]
-    fn test_list_with_package_filter() {
-        let repo = InMemoryGtsRepository::new(default_config());
-
-        let entity = json!({
-            "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": JSON_SCHEMA_DRAFT_07,
-            "type": "object"
-        });
-
-        repo.register(&entity, false).unwrap();
-        repo.switch_to_ready().unwrap();
-
-        let query = ListQuery::default().with_package("core");
-        let results = repo.list(&query).unwrap();
-        assert_eq!(results.len(), 1);
-
-        let query = ListQuery::default().with_package("other");
-        let results = repo.list(&query).unwrap();
-        assert_eq!(results.len(), 0);
-    }
-
-    #[test]
-    fn test_list_with_namespace_filter() {
-        let repo = InMemoryGtsRepository::new(default_config());
-
-        let entity = json!({
-            "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": JSON_SCHEMA_DRAFT_07,
-            "type": "object"
-        });
-
-        repo.register(&entity, false).unwrap();
-        repo.switch_to_ready().unwrap();
-
-        let query = ListQuery::default().with_namespace("events");
-        let results = repo.list(&query).unwrap();
-        assert_eq!(results.len(), 1);
-
-        let query = ListQuery::default().with_namespace("other");
-        let results = repo.list(&query).unwrap();
-        assert_eq!(results.len(), 0);
-    }
-
-    #[test]
     fn test_list_with_pattern_filter() {
         let repo = InMemoryGtsRepository::new(default_config());
 
@@ -648,23 +641,61 @@ mod tests {
     }
 
     #[test]
-    fn test_list_with_segment_scope_primary() {
+    fn test_list_with_empty_pattern_returns_invalid_query() {
+        // `Some("")` is not equivalent to `None`. Empty pattern is a caller
+        // bug (often a default-constructed value or a malformed query
+        // string) and must be rejected, not silently treated as "no filter".
         let repo = InMemoryGtsRepository::new(default_config());
-
-        let entity = json!({
-            "$id": "gts://gts.acme.core.events.user_created.v1~",
-            "$schema": JSON_SCHEMA_DRAFT_07,
-            "type": "object"
-        });
-
-        repo.register(&entity, false).unwrap();
         repo.switch_to_ready().unwrap();
 
-        let query = ListQuery::default()
-            .with_vendor("acme")
-            .with_segment_scope(SegmentMatchScope::Primary);
-        let results = repo.list(&query).unwrap();
-        assert_eq!(results.len(), 1);
+        let query = ListQuery::default().with_pattern("");
+        match repo.list(&query) {
+            Err(DomainError::InvalidQuery(msg)) => {
+                assert!(msg.contains("empty"), "msg should mention empty: {msg}");
+            }
+            Err(e) => panic!("expected InvalidQuery, got {e:?}"),
+            Ok(items) => panic!(
+                "expected InvalidQuery error; got {} items (silent fall-through)",
+                items.len()
+            ),
+        }
+    }
+
+    #[test]
+    // Test exists specifically to assert that an invalid wildcard pattern is
+    // surfaced as `InvalidQuery`; the literal must stay in source.
+    #[allow(unknown_lints, de0901_gts_string_pattern)]
+    fn test_list_with_invalid_pattern_returns_invalid_query() {
+        // GTS spec section 10: at most one trailing wildcard. Multiple `*` or
+        // mid-pattern `*` must be surfaced as InvalidQuery, not silently
+        // skipped (which would have made every entity match).
+        let repo = InMemoryGtsRepository::new(default_config());
+        repo.register(
+            &json!({
+                "$id": "gts://gts.acme.core.events.x.v1~",
+                "$schema": JSON_SCHEMA_DRAFT_07,
+                "type": "object"
+            }),
+            false,
+        )
+        .unwrap();
+        repo.switch_to_ready().unwrap();
+
+        // Multi-wildcard pattern → invalid per spec.
+        let query = ListQuery::default().with_pattern("gts.*.*.rg.*");
+        match repo.list(&query) {
+            Err(DomainError::InvalidQuery(msg)) => {
+                assert!(
+                    msg.contains("gts.*.*.rg.*"),
+                    "msg should cite the input: {msg}"
+                );
+            }
+            Err(e) => panic!("expected InvalidQuery, got {e:?}"),
+            Ok(items) => panic!(
+                "expected InvalidQuery error; got {} items (silent fall-through)",
+                items.len()
+            ),
+        }
     }
 
     #[test]

--- a/modules/system/types-registry/types-registry/src/lib.rs
+++ b/modules/system/types-registry/types-registry/src/lib.rs
@@ -14,9 +14,8 @@
 
 // === PUBLIC API (from SDK) ===
 pub use types_registry_sdk::{
-    DynGtsEntity, DynRegisterResult, GtsEntity, GtsInstanceEntity, GtsTypeEntity, InstanceObject,
-    ListQuery, RegisterResult, RegisterSummary, SegmentMatchScope, TypeSchema, TypesRegistryClient,
-    TypesRegistryError,
+    GtsInstance, GtsInstanceId, GtsTypeId, GtsTypeSchema, InstanceQuery, RegisterResult,
+    RegisterSummary, TypeSchemaQuery, TypesRegistryClient, TypesRegistryError,
 };
 
 // === MODULE DEFINITION ===

--- a/modules/system/types-registry/types-registry/src/module.rs
+++ b/modules/system/types-registry/types-registry/src/module.rs
@@ -34,12 +34,14 @@ use crate::infra::InMemoryGtsRepository;
 )]
 pub struct TypesRegistryModule {
     service: OnceLock<Arc<TypesRegistryService>>,
+    local_client: OnceLock<Arc<TypesRegistryLocalClient>>,
 }
 
 impl Default for TypesRegistryModule {
     fn default() -> Self {
         Self {
             service: OnceLock::new(),
+            local_client: OnceLock::new(),
         }
     }
 }
@@ -49,13 +51,22 @@ impl Module for TypesRegistryModule {
     async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
         let cfg: TypesRegistryConfig = ctx.config_or_default()?;
         debug!(
-            "Loaded types_registry config: entity_id_fields={:?}, schema_id_fields={:?}",
-            cfg.entity_id_fields, cfg.schema_id_fields
+            "Loaded types_registry config: entity_id_fields={:?}, schema_id_fields={:?}, \
+             local_client.cache.type_schemas={{capacity={}, ttl={:?}}}, \
+             local_client.cache.instances={{capacity={}, ttl={:?}}}",
+            cfg.entity_id_fields,
+            cfg.schema_id_fields,
+            cfg.local_client.cache.type_schemas.capacity,
+            cfg.local_client.cache.type_schemas.ttl,
+            cfg.local_client.cache.instances.capacity,
+            cfg.local_client.cache.instances.ttl,
         );
 
         let gts_config = cfg.to_gts_config();
         let static_entities = cfg.entities.clone();
         let default_tenant_id = cfg.default_tenant_id;
+        let type_schemas_cache_cfg = cfg.local_client.cache.type_schemas.to_cache_config();
+        let instances_cache_cfg = cfg.local_client.cache.instances.to_cache_config();
 
         let repo = Arc::new(InMemoryGtsRepository::new(gts_config));
         let service = Arc::new(TypesRegistryService::new(repo, cfg));
@@ -105,7 +116,16 @@ impl Module for TypesRegistryModule {
             .set(service.clone())
             .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
 
-        let api: Arc<dyn TypesRegistryClient> = Arc::new(TypesRegistryLocalClient::new(service));
+        let local_client = Arc::new(TypesRegistryLocalClient::with_cache_configs(
+            service,
+            type_schemas_cache_cfg,
+            instances_cache_cfg,
+        ));
+        self.local_client
+            .set(local_client.clone())
+            .map_err(|_| anyhow::anyhow!("{} module already initialized", Self::MODULE_NAME))?;
+
+        let api: Arc<dyn TypesRegistryClient> = local_client;
         ctx.client_hub().register::<dyn TypesRegistryClient>(api);
 
         Ok(())
@@ -148,6 +168,14 @@ impl SystemCapability for TypesRegistryModule {
             }
             anyhow::anyhow!("Failed to switch to ready mode: {e}")
         })?;
+
+        // Drop any cached entries built before the ready transition (e.g.
+        // best-effort builds that may have had unresolved parents). After
+        // switch_to_ready, the persistent store has the final picture and
+        // subsequent get_*/list_* calls rebuild against it.
+        if let Some(client) = self.local_client.get() {
+            client.clear_caches();
+        }
 
         info!("types_registry switched to ready mode successfully");
         Ok(())

--- a/modules/system/types-registry/types-registry/tests/query_tests.rs
+++ b/modules/system/types-registry/types-registry/tests/query_tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-//! Integration tests for list and query operations
+//! Integration tests for list and query operations.
 
 mod common;
 
@@ -8,106 +8,11 @@ use axum::extract::Json;
 use common::create_service;
 use serde_json::json;
 use types_registry::api::rest::dto::ListEntitiesQuery;
-use types_registry_sdk::ListQuery;
+use types_registry::domain::model::ListQuery;
 
 // =============================================================================
 // List and Query Tests
 // =============================================================================
-
-#[tokio::test]
-async fn test_list_entities_with_vendor_filter() {
-    let service = create_service();
-
-    // Register entities from different vendors
-    let entities = vec![
-        json!({ "$id": "gts://gts.acme.core.events.type1.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.acme.core.events.type2.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.globex.core.events.type3.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.initech.core.events.type4.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-    ];
-
-    _ = service.register(entities);
-    service.switch_to_ready().unwrap();
-
-    // Filter by vendor "acme"
-    let query = ListQuery::default().with_vendor("acme");
-    let results = service.list(&query).unwrap();
-    assert_eq!(results.len(), 2);
-    assert!(results.iter().all(|e| e.vendor() == Some("acme")));
-
-    // Filter by vendor "globex"
-    let query = ListQuery::default().with_vendor("globex");
-    let results = service.list(&query).unwrap();
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].vendor(), Some("globex"));
-}
-
-#[tokio::test]
-async fn test_list_entities_with_package_filter() {
-    let service = create_service();
-
-    let entities = vec![
-        json!({ "$id": "gts://gts.acme.core.events.type1.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.acme.billing.events.type2.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.acme.core.events.type3.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-    ];
-
-    _ = service.register(entities);
-    service.switch_to_ready().unwrap();
-
-    let query = ListQuery::default().with_package("core");
-    let results = service.list(&query).unwrap();
-    assert_eq!(results.len(), 2);
-    assert!(results.iter().all(|e| e.package() == Some("core")));
-
-    let query = ListQuery::default().with_package("billing");
-    let results = service.list(&query).unwrap();
-    assert_eq!(results.len(), 1);
-}
-
-#[tokio::test]
-async fn test_list_entities_with_namespace_filter() {
-    let service = create_service();
-
-    let entities = vec![
-        json!({ "$id": "gts://gts.acme.core.events.type1.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.acme.core.commands.type2.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.acme.core.events.type3.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-    ];
-
-    _ = service.register(entities);
-    service.switch_to_ready().unwrap();
-
-    let query = ListQuery::default().with_namespace("events");
-    let results = service.list(&query).unwrap();
-    assert_eq!(results.len(), 2);
-
-    let query = ListQuery::default().with_namespace("commands");
-    let results = service.list(&query).unwrap();
-    assert_eq!(results.len(), 1);
-}
-
-#[tokio::test]
-async fn test_list_entities_with_combined_filters() {
-    let service = create_service();
-
-    let entities = vec![
-        json!({ "$id": "gts://gts.acme.core.events.type1.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.acme.billing.events.type2.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.globex.core.events.type3.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-    ];
-
-    _ = service.register(entities);
-    service.switch_to_ready().unwrap();
-
-    // Combined filter: vendor=acme AND package=core
-    let query = ListQuery::default()
-        .with_vendor("acme")
-        .with_package("core");
-    let results = service.list(&query).unwrap();
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].gts_id, "gts.acme.core.events.type1.v1~");
-}
 
 #[tokio::test]
 async fn test_list_with_pattern_filter() {
@@ -117,27 +22,36 @@ async fn test_list_with_pattern_filter() {
         json!({ "$id": "gts://gts.acme.core.events.user_created.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
         json!({ "$id": "gts://gts.acme.core.events.user_updated.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
         json!({ "$id": "gts://gts.acme.core.events.order_created.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.acme.core.commands.create_user.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
+        json!({ "$id": "gts://gts.globex.core.events.shipment.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
     ];
 
     _ = service.register(entities);
     service.switch_to_ready().unwrap();
 
-    // Pattern matching for "user" in the name
-    let query = ListQuery::default().with_pattern("user");
-    let results = service.list(&query).unwrap();
-    // Should match user_created, user_updated, create_user
-    assert!(
-        results.len() >= 2,
-        "Pattern 'user' should match multiple entities"
-    );
+    // Wildcard limited to one vendor.
+    let acme = service
+        .list(&ListQuery::default().with_pattern("gts.acme.*"))
+        .unwrap();
+    assert_eq!(acme.len(), 3);
+    assert!(acme.iter().all(|e| e.vendor() == Some("acme")));
+
+    // Tighter wildcard: vendor + package.
+    let acme_core = service
+        .list(&ListQuery::default().with_pattern("gts.acme.core.*"))
+        .unwrap();
+    assert_eq!(acme_core.len(), 3);
+
+    // No matches.
+    let none = service
+        .list(&ListQuery::default().with_pattern("gts.nope.*"))
+        .unwrap();
+    assert!(none.is_empty());
 }
 
 #[tokio::test]
 async fn test_list_with_is_type_filter() {
     let service = create_service();
 
-    // Register a type
     let type_schema = json!({
         "$id": "gts://gts.acme.core.models.filter_test.v1~",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -148,7 +62,6 @@ async fn test_list_with_is_type_filter() {
     _ = service.register(vec![type_schema]);
     service.switch_to_ready().unwrap();
 
-    // Register instances
     let instances = vec![
         json!({
             "id": "gts.acme.core.models.filter_test.v1~acme.core.instances.i1.v1",
@@ -159,96 +72,26 @@ async fn test_list_with_is_type_filter() {
             "name": "instance2"
         }),
     ];
-
     _ = service.register(instances);
 
-    // Filter for types only
     let types = service
         .list(&ListQuery::default().with_is_type(true))
         .unwrap();
     assert_eq!(types.len(), 1);
     assert!(types[0].is_type());
 
-    // Filter for instances only
-    let instances = service
+    let only_instances = service
         .list(&ListQuery::default().with_is_type(false))
         .unwrap();
-    assert_eq!(instances.len(), 2);
-    assert!(instances.iter().all(types_registry::GtsEntity::is_instance));
+    assert_eq!(only_instances.len(), 2);
+    assert!(
+        only_instances
+            .iter()
+            .all(types_registry::domain::model::GtsEntity::is_instance)
+    );
 
-    // No filter - get all
     let all = service.list(&ListQuery::default()).unwrap();
     assert_eq!(all.len(), 3);
-}
-
-#[tokio::test]
-async fn test_multiple_vendors_isolation() {
-    let service = create_service();
-
-    // Register entities from multiple vendors
-    let entities = vec![
-        json!({ "$id": "gts://gts.vendor_a.pkg.ns.type1.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.vendor_a.pkg.ns.type2.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.vendor_b.pkg.ns.type1.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.vendor_c.pkg.ns.type1.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-    ];
-
-    _ = service.register(entities);
-    service.switch_to_ready().unwrap();
-
-    // Each vendor filter should return correct count
-    assert_eq!(
-        service
-            .list(&ListQuery::default().with_vendor("vendor_a"))
-            .unwrap()
-            .len(),
-        2
-    );
-    assert_eq!(
-        service
-            .list(&ListQuery::default().with_vendor("vendor_b"))
-            .unwrap()
-            .len(),
-        1
-    );
-    assert_eq!(
-        service
-            .list(&ListQuery::default().with_vendor("vendor_c"))
-            .unwrap()
-            .len(),
-        1
-    );
-    assert_eq!(
-        service
-            .list(&ListQuery::default().with_vendor("vendor_d"))
-            .unwrap()
-            .len(),
-        0
-    );
-}
-
-#[tokio::test]
-async fn test_combined_vendor_package_namespace_filter() {
-    let service = create_service();
-
-    let entities = vec![
-        json!({ "$id": "gts://gts.acme.billing.invoices.invoice.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.acme.billing.payments.payment.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.acme.core.events.event.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-        json!({ "$id": "gts://gts.globex.billing.invoices.invoice.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
-    ];
-
-    _ = service.register(entities);
-    service.switch_to_ready().unwrap();
-
-    // Triple filter: vendor + package + namespace
-    let query = ListQuery::default()
-        .with_vendor("acme")
-        .with_package("billing")
-        .with_namespace("invoices");
-    let results = service.list(&query).unwrap();
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].gts_id, "gts.acme.billing.invoices.invoice.v1~");
 }
 
 // =============================================================================
@@ -262,16 +105,14 @@ async fn test_rest_list_handler_integration() {
 
     let service = create_service();
 
-    // Register entities via internal API (before ready)
     _ = service.register(vec![
         json!({ "$id": "gts://gts.acme.core.events.list_test1.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
         json!({ "$id": "gts://gts.acme.core.events.list_test2.v1~", "$schema": "http://json-schema.org/draft-07/schema#", "type": "object" }),
     ]);
     service.switch_to_ready().unwrap();
 
-    // Test list handler (now service is ready)
     let query = ListEntitiesQuery {
-        vendor: Some("acme".to_owned()),
+        pattern: Some("gts.acme.*".to_owned()),
         ..Default::default()
     };
 
@@ -290,9 +131,8 @@ async fn test_rest_list_empty_results() {
     let service = create_service();
     service.switch_to_ready().unwrap();
 
-    // Query with filter that matches nothing
     let query = ListEntitiesQuery {
-        vendor: Some("nonexistent_vendor".to_owned()),
+        pattern: Some("gts.nonexistent.*".to_owned()),
         ..Default::default()
     };
 
@@ -315,7 +155,6 @@ async fn test_rest_get_handler_integration() {
 
     let service = create_service();
 
-    // Register entity via internal API (before ready)
     _ = service.register(vec![json!({
         "$id": "gts://gts.acme.core.events.get_test.v1~",
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -324,7 +163,6 @@ async fn test_rest_get_handler_integration() {
     })]);
     service.switch_to_ready().unwrap();
 
-    // Test get handler (now service is ready)
     let result = get_entity(
         Extension(service),
         Path("gts.acme.core.events.get_test.v1~".to_owned()),

--- a/modules/system/types-registry/types-registry/tests/ready_mode_tests.rs
+++ b/modules/system/types-registry/types-registry/tests/ready_mode_tests.rs
@@ -6,7 +6,7 @@ mod common;
 
 use common::create_service;
 use serde_json::json;
-use types_registry_sdk::ListQuery;
+use types_registry::domain::model::ListQuery;
 
 // =============================================================================
 // Ready Mode Immediate Validation Tests

--- a/modules/system/types-registry/types-registry/tests/registration_tests.rs
+++ b/modules/system/types-registry/types-registry/tests/registration_tests.rs
@@ -8,7 +8,7 @@ use axum::http::StatusCode;
 use common::create_service;
 use serde_json::json;
 use types_registry::api::rest::dto::RegisterEntitiesRequest;
-use types_registry_sdk::ListQuery;
+use types_registry::domain::model::ListQuery;
 
 // =============================================================================
 // Anonymous Entity Rejection Tests

--- a/modules/system/types-registry/types-registry/tests/rg_gts_type_system_tests.rs
+++ b/modules/system/types-registry/types-registry/tests/rg_gts_type_system_tests.rs
@@ -13,7 +13,7 @@ mod common;
 
 use common::create_service;
 use serde_json::json;
-use types_registry_sdk::ListQuery;
+use types_registry::domain::model::ListQuery;
 
 // =============================================================================
 // Helpers: schema factories (from ADR-001, metadata approach)
@@ -366,26 +366,26 @@ async fn test_vendor_isolation_across_rg_types() {
     let service = setup_rg_type_system();
     assert!(
         service
-            .list(&ListQuery::default().with_vendor("x"))
+            .list(&ListQuery::default().with_pattern("gts.x.*"))
             .unwrap()
             .len()
             >= 3
     );
     assert!(
         !service
-            .list(&ListQuery::default().with_vendor("y"))
+            .list(&ListQuery::default().with_pattern("gts.y.*"))
             .unwrap()
             .is_empty()
     );
     assert!(
         !service
-            .list(&ListQuery::default().with_vendor("w"))
+            .list(&ListQuery::default().with_pattern("gts.w.*"))
             .unwrap()
             .is_empty()
     );
     assert!(
         service
-            .list(&ListQuery::default().with_vendor("z"))
+            .list(&ListQuery::default().with_pattern("gts.z.*"))
             .unwrap()
             .len()
             >= 2
@@ -831,10 +831,14 @@ async fn test_wildcard_query_all_rg_chained_types() {
 }
 
 #[tokio::test]
-async fn test_query_by_namespace_rg() {
+async fn test_query_by_x_core_rg_prefix() {
+    // GTS spec section 10 requires a single trailing `*`, so we can only
+    // express vendor/package/namespace as a contiguous prefix — here all
+    // schemas under `gts.x.core.rg.*`, which covers the rg base type, the
+    // rg branch type, and every chain derived from `gts.x.core.rg.type.v1~`.
     let service = setup_rg_type_system();
     let results = service
-        .list(&ListQuery::default().with_namespace("rg"))
+        .list(&ListQuery::default().with_pattern("gts.x.core.rg.*"))
         .unwrap();
     assert!(!results.is_empty());
 }

--- a/modules/system/types-registry/types-registry/tests/type_instance_tests.rs
+++ b/modules/system/types-registry/types-registry/tests/type_instance_tests.rs
@@ -6,7 +6,7 @@ mod common;
 
 use common::create_service;
 use serde_json::json;
-use types_registry_sdk::ListQuery;
+use types_registry::domain::model::ListQuery;
 
 // =============================================================================
 // Type-Instance Validation Tests


### PR DESCRIPTION
- Replace `TypesRegistryApi` with `TypesRegistryClient`. Kind-agnostic
  `get`/`list`/`register` is split into typed pairs for type-schemas and
  instances, with by-id, by-UUID, and bulk variants (the latter return
  `HashMap<K, Result<V, _>>` so callers see per-key outcomes). The mixed
  `register()` is kept for batches containing both kinds.
- Add typed SDK views (`GtsTypeSchema`, `GtsInstance`, `TypeSchemaQuery`,
  `InstanceQuery`) and re-export `GtsTypeId` / `GtsInstanceId`.
- Expand `TypesRegistryError` with kind-aware variants and wire them into
  REST via Problem mapping.
- Add a per-kind bounded LRU with optional TTL in the local client,
  configurable under `local_client.cache.*`.
- Introduce an internal kind-agnostic `GtsEntity` as the service<->repo
  contract; map to typed SDK views at the boundary.
- Add `MockTypesRegistryClient` + test builders behind the `test-util`
  feature, plus unit tests for the new SDK and cache.
- Update callers (oagw, resource-group, authn/authz/tenant resolvers,
  mini-chat, credstore) and refresh docs/api/api.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Separate typed APIs for type-schemas and instances (improved query semantics).
  * TTL-aware, configurable LRU caching for type schemas and instances.
  * New testing utilities: in-memory mock registry and helpers for test fixtures.

* **Improvements**
  * More granular, kind-specific error variants and clearer error diagnostics.
  * Configurable local-client cache settings exposed in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

new issues were created: #1723, #1630, #1752
closes #1627