### PR TITLE
feat: seed initial canonical-errors migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,7 @@ dependencies = [
  "axum",
  "calculator-sdk",
  "cf-modkit",
+ "cf-modkit-canonical-errors",
  "cf-modkit-macros",
  "cf-modkit-security",
  "http",
@@ -1349,6 +1350,7 @@ dependencies = [
  "bytes",
  "calamine",
  "cf-modkit",
+ "cf-modkit-canonical-errors",
  "cf-modkit-macros",
  "cf-modkit-security",
  "docx-rust",
@@ -1470,6 +1472,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
+ "cf-modkit-canonical-errors",
  "cf-modkit-db",
  "cf-modkit-errors",
  "cf-modkit-macros",
@@ -1558,12 +1561,16 @@ dependencies = [
 name = "cf-modkit-canonical-errors"
 version = "0.7.1"
 dependencies = [
+ "axum",
  "cf-modkit-canonical-errors-macro",
  "gts-id",
+ "http",
  "sea-orm",
  "serde",
  "serde_json",
+ "tracing",
  "trybuild",
+ "utoipa",
 ]
 
 [[package]]

--- a/examples/modkit/users-info/users-info/Cargo.toml
+++ b/examples/modkit/users-info/users-info/Cargo.toml
@@ -62,7 +62,7 @@ modkit-http = { workspace = true }
 modkit-db = { workspace = true, features = ["sqlite", "pg"] }
 modkit-db-macros = { workspace = true }
 modkit-security = { workspace = true }
-modkit-canonical-errors = { workspace = true }
+modkit-canonical-errors = { workspace = true, features = ["axum", "utoipa"] }
 modkit-odata = { workspace = true, features = ["with-utoipa"] }
 modkit-sdk = { workspace = true }
 modkit-macros = { workspace = true }

--- a/examples/modkit/users-info/users-info/src/api/rest/error.rs
+++ b/examples/modkit/users-info/users-info/src/api/rest/error.rs
@@ -1,16 +1,14 @@
-use modkit::api::problem::{Problem, ValidationViolation};
-use modkit_canonical_errors::{CanonicalError, FieldViolation, InvalidArgument};
+use modkit::api::canonical_prelude::*;
 
 use crate::domain::error::DomainError;
 
-// Resource-scoped canonical error types for each entity in this module.
-#[modkit_canonical_errors::resource_error("gts.hx.example1.users.user.v1~")]
+#[resource_error("gts.hx.example1.users.user.v1~")]
 struct UserResourceError;
 
-#[modkit_canonical_errors::resource_error("gts.hx.example1.users.city.v1~")]
+#[resource_error("gts.hx.example1.users.city.v1~")]
 struct CityResourceError;
 
-#[modkit_canonical_errors::resource_error("gts.hx.example1.users.address.v1~")]
+#[resource_error("gts.hx.example1.users.address.v1~")]
 struct AddressResourceError;
 
 /// Convert a [`DomainError`] into a [`CanonicalError`].
@@ -83,107 +81,20 @@ fn domain_error_to_canonical(e: &DomainError) -> CanonicalError {
     }
 }
 
-/// Convert a [`CanonicalError`] into the axum-compatible [`Problem`].
-fn canonical_to_problem(ce: &CanonicalError) -> Problem {
-    let status = http::StatusCode::from_u16(ce.status_code())
-        .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR);
-
-    let mut problem =
-        Problem::new(status, ce.title(), ce.detail()).with_type(format!("gts://{}", ce.gts_type()));
-
-    if let Some(diag) = ce.diagnostic() {
-        tracing::debug!(diagnostic = %diag, "Canonical error diagnostic");
-    }
-
-    // Build context from canonical error metadata
-    let mut ctx = serde_json::Map::new();
-    if let Some(rt) = ce.resource_type() {
-        ctx.insert(
-            "resource_type".to_owned(),
-            serde_json::Value::String(rt.to_owned()),
-        );
-    }
-    if let Some(rn) = ce.resource_name() {
-        ctx.insert(
-            "resource_name".to_owned(),
-            serde_json::Value::String(rn.to_owned()),
-        );
-    }
-    if !ctx.is_empty() {
-        problem = problem.with_context(serde_json::Value::Object(ctx));
-    }
-
-    // Extract structured violations from applicable error categories
-    let errors = extract_violations(ce);
-    if !errors.is_empty() {
-        problem = problem.with_errors(errors);
-    }
-
-    // Enrich trace_id from current span
-    if let Some(span_id) = tracing::Span::current().id() {
-        problem = problem.with_trace_id(span_id.into_u64().to_string());
-    }
-
-    problem
-}
-
-/// Implement `Into<Problem>` for `DomainError` so `?` works in handlers
 impl From<DomainError> for Problem {
     fn from(e: DomainError) -> Self {
         let ce = domain_error_to_canonical(&e);
-        canonical_to_problem(&ce)
-    }
-}
 
-/// Map a [`FieldViolation`] to a [`ValidationViolation`].
-fn field_violation_to_validation(fv: &FieldViolation) -> ValidationViolation {
-    ValidationViolation {
-        field: fv.field.clone(),
-        message: fv.description.clone(),
-        code: Some(fv.reason.clone()),
-    }
-}
+        if let Some(diag) = ce.diagnostic() {
+            tracing::debug!(diagnostic = %diag, "Canonical error diagnostic");
+        }
 
-/// Extract structured violations from a [`CanonicalError`] into a flat
-/// [`ValidationViolation`] list.  Covers every category that carries
-/// violation arrays: `InvalidArgument`, `OutOfRange`, `FailedPrecondition`,
-/// and `ResourceExhausted`.
-fn extract_violations(ce: &CanonicalError) -> Vec<ValidationViolation> {
-    match ce {
-        CanonicalError::InvalidArgument {
-            ctx: InvalidArgument::FieldViolations { field_violations },
-            ..
-        } => field_violations
-            .iter()
-            .map(field_violation_to_validation)
-            .collect(),
+        let mut problem = Problem::from(ce);
 
-        CanonicalError::OutOfRange { ctx, .. } => ctx
-            .field_violations
-            .iter()
-            .map(field_violation_to_validation)
-            .collect(),
+        if let Some(span_id) = tracing::Span::current().id() {
+            problem = problem.with_trace_id(span_id.into_u64().to_string());
+        }
 
-        CanonicalError::FailedPrecondition { ctx, .. } => ctx
-            .violations
-            .iter()
-            .map(|pv| ValidationViolation {
-                field: pv.subject.clone(),
-                message: pv.description.clone(),
-                code: Some(pv.type_.clone()),
-            })
-            .collect(),
-
-        CanonicalError::ResourceExhausted { ctx, .. } => ctx
-            .violations
-            .iter()
-            .map(|qv| ValidationViolation {
-                field: qv.subject.clone(),
-                message: qv.description.clone(),
-                code: None,
-            })
-            .collect(),
-
-        _ => Vec::new(),
+        problem
     }
 }

--- a/examples/modkit/users-info/users-info/src/api/rest/handlers/mod.rs
+++ b/examples/modkit/users-info/users-info/src/api/rest/handlers/mod.rs
@@ -5,8 +5,8 @@ use crate::api::rest::dto::{
     UserEvent, UserFullDto,
 };
 
-use modkit::api::prelude::*;
-use modkit::api::select::{apply_select, page_to_projected_json};
+use modkit::api::canonical_prelude::*;
+use modkit::api::select::page_to_projected_json;
 
 use modkit::SseBroadcaster;
 

--- a/examples/oop-modules/calculator-gateway/calculator-gateway/Cargo.toml
+++ b/examples/oop-modules/calculator-gateway/calculator-gateway/Cargo.toml
@@ -13,6 +13,7 @@ calculator-sdk = { path = "../../calculator/calculator-sdk" }
 
 # ModKit
 modkit = { workspace = true }
+modkit-canonical-errors = { workspace = true, features = ["axum"] }
 modkit-security = { workspace = true }
 modkit-macros = { workspace = true }
 

--- a/examples/oop-modules/calculator-gateway/calculator-gateway/src/api/rest/handlers.rs
+++ b/examples/oop-modules/calculator-gateway/calculator-gateway/src/api/rest/handlers.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 
-use axum::{Extension, Json};
+use axum::Extension;
 
-use modkit::api::problem::{Problem, internal_error};
+use modkit::api::canonical_prelude::*;
 use modkit_security::SecurityContext;
 
 use crate::domain::Service;
@@ -19,11 +19,11 @@ pub async fn handle_add(
     Extension(ctx): Extension<SecurityContext>,
     Extension(service): Extension<Arc<Service>>,
     Json(req): Json<AddRequest>,
-) -> Result<Json<AddResponse>, Problem> {
-    let sum = service
-        .add(&ctx, req.a, req.b)
-        .await
-        .map_err(|e| internal_error(format!("Addition failed: {}", e)))?;
+) -> ApiResult<Json<AddResponse>> {
+    let sum = service.add(&ctx, req.a, req.b).await.map_err(|e| {
+        tracing::error!(error = %e, "addition failed");
+        Problem::from(CanonicalError::internal(format!("Addition failed: {e}")).create())
+    })?;
 
     Ok(Json(AddResponse { sum }))
 }

--- a/libs/modkit-canonical-errors/Cargo.toml
+++ b/libs/modkit-canonical-errors/Cargo.toml
@@ -17,6 +17,8 @@ name = "modkit_canonical_errors"
 [features]
 default = []
 sea-orm = ["dep:sea-orm"]
+axum = ["dep:axum", "dep:http", "dep:tracing"]
+utoipa = ["dep:utoipa"]
 
 [lints]
 workspace = true
@@ -25,6 +27,10 @@ workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 sea-orm = { workspace = true, optional = true }
+axum = { workspace = true, optional = true }
+http = { workspace = true, optional = true }
+utoipa = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
 modkit-canonical-errors-macro = { workspace = true }
 
 [dev-dependencies]

--- a/libs/modkit-canonical-errors/src/problem.rs
+++ b/libs/modkit-canonical-errors/src/problem.rs
@@ -2,6 +2,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::CanonicalError;
 
+/// Media type for RFC 9457 `application/problem+json` responses.
+pub const APPLICATION_PROBLEM_JSON: &str = "application/problem+json";
+
 // ---------------------------------------------------------------------------
 // Problem (RFC 9457)
 // ---------------------------------------------------------------------------
@@ -130,5 +133,108 @@ impl From<CanonicalError> for Problem {
                 context: serde_json::Value::String(ser_err.to_string()),
             },
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// axum integration (feature = "axum")
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "axum")]
+impl axum::response::IntoResponse for Problem {
+    fn into_response(self) -> axum::response::Response {
+        match serde_json::to_vec(&self) {
+            Ok(body) => {
+                let status = http::StatusCode::from_u16(self.status)
+                    .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR);
+                (
+                    status,
+                    [(http::header::CONTENT_TYPE, APPLICATION_PROBLEM_JSON)],
+                    body,
+                )
+                    .into_response()
+            }
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    problem_type = %self.problem_type,
+                    status = self.status,
+                    "failed to serialize Problem; emitting fallback body",
+                );
+                let body: &[u8] = br#"{"type":"gts://gts.cf.core.errors.err.v1~cf.core.err.internal.v1~","title":"Internal","status":500,"detail":"failed to serialize problem","context":{}}"#;
+                (
+                    http::StatusCode::INTERNAL_SERVER_ERROR,
+                    [(http::header::CONTENT_TYPE, APPLICATION_PROBLEM_JSON)],
+                    body,
+                )
+                    .into_response()
+            }
+        }
+    }
+}
+
+#[cfg(feature = "axum")]
+impl axum::response::IntoResponse for CanonicalError {
+    fn into_response(self) -> axum::response::Response {
+        Problem::from(self).into_response()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// utoipa integration (feature = "utoipa")
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "utoipa")]
+impl utoipa::PartialSchema for Problem {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        use utoipa::openapi::schema::{KnownFormat, ObjectBuilder, SchemaFormat, SchemaType, Type};
+
+        ObjectBuilder::new()
+            .property(
+                "type",
+                ObjectBuilder::new().schema_type(SchemaType::Type(Type::String)),
+            )
+            .required("type")
+            .property(
+                "title",
+                ObjectBuilder::new().schema_type(SchemaType::Type(Type::String)),
+            )
+            .required("title")
+            .property(
+                "status",
+                ObjectBuilder::new()
+                    .schema_type(SchemaType::Type(Type::Integer))
+                    .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32))),
+            )
+            .required("status")
+            .property(
+                "detail",
+                ObjectBuilder::new().schema_type(SchemaType::Type(Type::String)),
+            )
+            .required("detail")
+            .property(
+                "instance",
+                ObjectBuilder::new().schema_type(SchemaType::Type(Type::String)),
+            )
+            .property(
+                "trace_id",
+                ObjectBuilder::new().schema_type(SchemaType::Type(Type::String)),
+            )
+            .property(
+                "context",
+                ObjectBuilder::new().schema_type(SchemaType::Type(Type::Object)),
+            )
+            .required("context")
+            .description(Some(
+                "RFC 9457 problem+json. `context` varies by error category.",
+            ))
+            .into()
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl utoipa::ToSchema for Problem {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("Problem")
     }
 }

--- a/libs/modkit-canonical-errors/tests/axum_integration.rs
+++ b/libs/modkit-canonical-errors/tests/axum_integration.rs
@@ -1,0 +1,50 @@
+#![cfg(feature = "axum")]
+
+use axum::response::IntoResponse;
+use modkit_canonical_errors::problem::APPLICATION_PROBLEM_JSON;
+use modkit_canonical_errors::resource_error;
+use modkit_canonical_errors::{CanonicalError, Problem};
+
+#[resource_error("gts.cf.core.test.axum.v1~")]
+struct AxumTestR;
+
+#[test]
+fn problem_into_response_sets_status_and_content_type() {
+    let err = AxumTestR::not_found("missing")
+        .with_resource("abc")
+        .create();
+    let response = Problem::from(err).into_response();
+
+    assert_eq!(response.status(), http::StatusCode::NOT_FOUND);
+    assert_eq!(
+        response
+            .headers()
+            .get(http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some(APPLICATION_PROBLEM_JSON)
+    );
+}
+
+#[test]
+fn canonical_error_into_response_delegates_through_problem() {
+    let err = CanonicalError::internal("db failure").create();
+    let response = err.into_response();
+
+    assert_eq!(response.status(), http::StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        response
+            .headers()
+            .get(http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some(APPLICATION_PROBLEM_JSON)
+    );
+}
+
+#[test]
+fn invalid_argument_maps_to_400() {
+    let err = AxumTestR::invalid_argument()
+        .with_field_violation("name", "must not be empty", "REQUIRED")
+        .create();
+    let response = err.into_response();
+    assert_eq!(response.status(), http::StatusCode::BAD_REQUEST);
+}

--- a/libs/modkit-canonical-errors/tests/utoipa_integration.rs
+++ b/libs/modkit-canonical-errors/tests/utoipa_integration.rs
@@ -1,0 +1,56 @@
+#![cfg(feature = "utoipa")]
+
+use modkit_canonical_errors::Problem;
+use utoipa::{PartialSchema, ToSchema};
+
+#[test]
+fn problem_to_schema_reports_expected_name() {
+    assert_eq!(<Problem as ToSchema>::name(), "Problem");
+}
+
+#[test]
+fn problem_schema_contains_top_level_fields() {
+    let schema = <Problem as PartialSchema>::schema();
+    let json = serde_json::to_value(&schema).unwrap();
+
+    let properties = json
+        .get("properties")
+        .expect("schema should have properties");
+
+    for field in [
+        "type", "title", "status", "detail", "instance", "trace_id", "context",
+    ] {
+        assert!(
+            properties.get(field).is_some(),
+            "missing property {field} in schema: {json}"
+        );
+    }
+}
+
+#[test]
+fn problem_schema_marks_core_fields_required() {
+    let schema = <Problem as PartialSchema>::schema();
+    let json = serde_json::to_value(&schema).unwrap();
+
+    let required = json
+        .get("required")
+        .and_then(|v| v.as_array())
+        .expect("schema should declare required fields");
+    let required: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+
+    for field in ["type", "title", "status", "detail", "context"] {
+        assert!(
+            required.contains(&field),
+            "expected {field} to be required, required = {required:?}"
+        );
+    }
+}
+
+#[test]
+fn problem_schema_types_status_as_integer() {
+    let schema = <Problem as PartialSchema>::schema();
+    let json = serde_json::to_value(&schema).unwrap();
+
+    let status = &json["properties"]["status"];
+    assert_eq!(status["type"], "integer");
+}

--- a/libs/modkit/Cargo.toml
+++ b/libs/modkit/Cargo.toml
@@ -57,6 +57,7 @@ bootstrap = [
 # Project-local crates
 modkit-macros = { workspace = true }
 modkit-errors = { workspace = true, features = ["utoipa", "axum"] }
+modkit-canonical-errors = { workspace = true, features = ["axum", "utoipa"] }
 modkit-db = { workspace = true, optional = true }
 sea-orm-migration = { workspace = true, optional = true }
 modkit-odata = { workspace = true }

--- a/libs/modkit/src/api/mod.rs
+++ b/libs/modkit/src/api/mod.rs
@@ -50,3 +50,27 @@ pub mod prelude {
     // Useful axum bits (common in handlers)
     pub use axum::{Json, http::StatusCode, response::IntoResponse};
 }
+
+/// Parallel prelude for modules migrated to the canonical error catalog.
+///
+/// Mirrors [`prelude`] but re-exports `Problem` and `ApiResult` from
+/// `modkit-canonical-errors` so handlers can write the usual
+/// `ApiResult<JsonBody<T>>` signature without name clashes against the legacy
+/// types. Each per-module migration PR swaps `use modkit::api::prelude::*;`
+/// for `use modkit::api::canonical_prelude::*;` — no per-signature edits.
+///
+/// This module is collapsed into [`prelude`] and
+/// the legacy entries above are deleted.
+pub mod canonical_prelude {
+    // Canonical error types
+    pub use modkit_canonical_errors::{CanonicalError, Problem, resource_error};
+
+    /// Result type alias matching `prelude::ApiResult` but parameterised on
+    /// canonical `Problem`.
+    pub type ApiResult<T = ()> = std::result::Result<T, Problem>;
+
+    // Same response sugar / OData / axum re-exports as the legacy prelude
+    pub use super::response::{JsonBody, JsonPage, created_json, no_content, ok_json};
+    pub use super::select::apply_select;
+    pub use axum::{Json, http::StatusCode, response::IntoResponse};
+}

--- a/modules/file-parser/Cargo.toml
+++ b/modules/file-parser/Cargo.toml
@@ -68,5 +68,6 @@ docx-rust = { workspace = true }
 
 # Local dependencies
 modkit = { workspace = true }
+modkit-canonical-errors = { workspace = true, features = ["axum"] }
 modkit-security = { workspace = true }
 modkit-macros = { workspace = true }

--- a/modules/file-parser/src/api/rest/error.rs
+++ b/modules/file-parser/src/api/rest/error.rs
@@ -1,43 +1,58 @@
-use http::StatusCode;
-use modkit::api::problem::Problem;
+use modkit_canonical_errors::{CanonicalError, Problem, resource_error};
 
 use crate::domain::error::DomainError;
 
+#[resource_error("gts.cf.file_parser.parser.file.v1~")]
+pub struct FileParserError;
+
 /// Convert domain errors to HTTP Problem responses
+#[must_use]
 pub fn domain_error_to_problem(err: DomainError) -> Problem {
     match err {
-        DomainError::FileNotFound { path } => Problem::new(
-            StatusCode::NOT_FOUND,
-            "File Not Found",
-            format!("File not found: {path}"),
-        ),
+        DomainError::FileNotFound { path } => FileParserError::not_found("File not found")
+            .with_resource(path)
+            .create()
+            .into(),
 
-        DomainError::UnsupportedFileType { extension } => Problem::new(
-            StatusCode::BAD_REQUEST,
-            "Unsupported File Type",
-            format!("Unsupported file type: {extension}"),
-        ),
+        DomainError::UnsupportedFileType { extension } => FileParserError::invalid_argument()
+            .with_field_violation(
+                "content_type",
+                format!("Unsupported file type: {extension}"),
+                "UNSUPPORTED_CONTENT_TYPE",
+            )
+            .create()
+            .into(),
 
-        DomainError::NoParserAvailable { extension } => Problem::new(
-            StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            "No Parser Available",
-            format!("No parser available for extension: {extension}"),
-        ),
+        DomainError::NoParserAvailable { extension } => FileParserError::invalid_argument()
+            .with_field_violation(
+                "content_type",
+                format!("No parser available for extension: {extension}"),
+                "UNSUPPORTED_CONTENT_TYPE",
+            )
+            .create()
+            .into(),
 
-        DomainError::ParseError { message } => {
-            Problem::new(StatusCode::UNPROCESSABLE_ENTITY, "Parse Error", message)
-        }
+        DomainError::ParseError { message } => FileParserError::invalid_argument()
+            .with_field_violation("body", message, "PARSE_ERROR")
+            .create()
+            .into(),
 
         DomainError::IoError { message } => {
-            Problem::new(StatusCode::INTERNAL_SERVER_ERROR, "IO Error", message)
+            tracing::error!(error = %message, "file-parser I/O error");
+            CanonicalError::internal(message).create().into()
         }
 
-        DomainError::InvalidRequest { message } => {
-            Problem::new(StatusCode::BAD_REQUEST, "Invalid Request", message)
-        }
+        DomainError::InvalidRequest { message } => FileParserError::invalid_argument()
+            .with_constraint(message)
+            .create()
+            .into(),
 
         DomainError::PathTraversalBlocked { message } => {
-            Problem::new(StatusCode::FORBIDDEN, "Path Traversal Blocked", message)
+            tracing::warn!(error = %message, "path traversal blocked");
+            FileParserError::permission_denied()
+                .with_reason("PATH_TRAVERSAL_BLOCKED")
+                .create()
+                .into()
         }
     }
 }

--- a/modules/file-parser/src/api/rest/handlers.rs
+++ b/modules/file-parser/src/api/rest/handlers.rs
@@ -16,7 +16,7 @@ use crate::api::rest::dto::{
 use crate::domain::error::DomainError;
 use crate::domain::markdown::MarkdownRenderer;
 use crate::domain::service::FileParserService;
-use modkit::api::prelude::*;
+use modkit::api::canonical_prelude::*;
 use modkit_security::SecurityContext;
 
 /// Query parameter for `render_markdown` flag

--- a/tools/dylint_lints/Cargo.lock
+++ b/tools/dylint_lints/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum 0.8.9",
+ "cf-modkit-canonical-errors",
  "cf-modkit-db",
  "cf-modkit-errors",
  "cf-modkit-macros",
@@ -584,6 +585,29 @@ dependencies = [
  "utoipa",
  "uuid",
  "zip",
+]
+
+[[package]]
+name = "cf-modkit-canonical-errors"
+version = "0.7.1"
+dependencies = [
+ "axum 0.8.9",
+ "cf-modkit-canonical-errors-macro",
+ "http",
+ "serde",
+ "serde_json",
+ "tracing",
+ "utoipa",
+]
+
+[[package]]
+name = "cf-modkit-canonical-errors-macro"
+version = "0.6.1"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]


### PR DESCRIPTION
- Adds modkit-canonical-errors crate alongside legacy modkit-errors
- Adds modkit::api::canonical_prelude — canonical Problem + ApiResult under familiar names; migration is a one-line `use` swap
- Migrates three callers: calculator-gateway, users-info, cf-file-parser
- Framework (libs/modkit/src/api/*) and modkit-odata stay on legacy and must flip together (odata/error.rs delegates to modkit_odata's `From<Error> for Problem`)
- Six remaining modules (api-gateway, oagw, mini-chat, nodes-registry, types-registry, simple-user-settings) follow as separate PRs
- canonical_prelude collapses into the default prelude at the end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized error responses across APIs using RFC 9457 Problem format, providing consistent error structure with status codes, titles, and detailed messages.
  * Added OpenAPI schema generation for error responses, improving API documentation completeness.

* **Improvements**
  * Enhanced error handling with improved logging and diagnostic tracing capabilities.
  * More consistent error response patterns across modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->