### PR TITLE
feat(resource-group): add tenant_id to GroupFilterField whitelist

### DIFF
--- a/modules/system/resource-group/docs/DECOMPOSITION.md
+++ b/modules/system/resource-group/docs/DECOMPOSITION.md
@@ -178,7 +178,7 @@ The Resource Group DESIGN is decomposed into seven features organized around the
   - Hierarchy queries: ancestors/descendants ordered by depth via indexed closure table lookups
   - Hierarchy depth endpoint: `GET /groups/{group_id}/hierarchy` returning `ResourceGroupWithDepth` with relative depth (positive = descendants, negative = ancestors, 0 = self) and OData filtering on `hierarchy/depth`
   - Query profile enforcement: configurable `max_depth`/`max_width` on writes, no truncation on reads for already-existing data, deterministic `DepthLimitExceeded`/`WidthLimitExceeded` errors
-  - Group REST endpoints: CRUD under `/api/resource-group/v1/groups` with OData `$filter` on `type`, `hierarchy/parent_id`, `id`, `name`
+  - Group REST endpoints: CRUD under `/api/resource-group/v1/groups` with OData `$filter` on `type`, `hierarchy/parent_id`, `tenant_id`, `id`, `name`
   - Force delete: optional `?force=true` for cascade deletion of subtree and associated memberships
   - Group data seeding: idempotent seed with parent-child link and type compatibility validation
   - Write concurrency: SERIALIZABLE isolation with bounded retry for serialization conflicts

--- a/modules/system/resource-group/docs/DESIGN.md
+++ b/modules/system/resource-group/docs/DESIGN.md
@@ -502,7 +502,7 @@ Query support on all list endpoints:
 - `cursor` — opaque token from previous response for next/previous page
 - Ordering is undefined but consistent — no `$orderby`
 
-Group list (`listGroups`) `$filter` fields: `type` (eq, ne, in), `hierarchy/parent_id` (eq, ne, in — direct parent only, depth=1; for ancestor traversal use `listGroupHierarchy`), `id` (eq, ne, in), `name` (eq, ne, in).
+Group list (`listGroups`) `$filter` fields: `type` (eq, ne, in), `hierarchy/parent_id` (eq, ne, in — direct parent only, depth=1; for ancestor traversal use `listGroupHierarchy`), `tenant_id` (eq, ne, in — narrows the AuthZ-scoped result to a specific tenant; cannot widen access), `id` (eq, ne, in), `name` (eq, ne, in).
 
 Group depth (`listGroupHierarchy`) `$filter` fields: `hierarchy/depth` (eq, ne, gt, ge, lt, le), `type` (eq, ne, in).
 

--- a/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
+++ b/modules/system/resource-group/docs/features/0001-sdk-module-foundation.md
@@ -451,15 +451,15 @@ OData filter fields use manual `FilterField` trait implementations with string f
 
 #### TC-ODATA-01: GroupFilterField names [P1]
 - **Covers**: G42
-- **Assert**: `Type.name() == "type"`, `HierarchyParentId.name() == "hierarchy/parent_id"`, `Id.name() == "id"`, `Name.name() == "name"`
+- **Assert**: `Type.name() == "type"`, `HierarchyParentId.name() == "hierarchy/parent_id"`, `TenantId.name() == "tenant_id"`, `Id.name() == "id"`, `Name.name() == "name"`
 
 #### TC-ODATA-02: GroupFilterField kinds [P1]
 - **Covers**: G42
-- **Assert**: `Type -> I64`, `HierarchyParentId -> Uuid`, `Id -> Uuid`, `Name -> String`
+- **Assert**: `Type -> String`, `HierarchyParentId -> Uuid`, `TenantId -> Uuid`, `Id -> Uuid`, `Name -> String`
 
 #### TC-ODATA-03: GroupFilterField FIELDS constant completeness [P2]
 - **Covers**: G42
-- **Assert**: `FIELDS.len() == 4`, contains all variants
+- **Assert**: `FIELDS.len() == 5`, contains all variants
 
 #### TC-ODATA-04: HierarchyFilterField names and kinds [P1]
 - **Covers**: G43
@@ -475,7 +475,7 @@ OData filter fields use manual `FilterField` trait implementations with string f
 
 #### TC-ODATA-07: GroupODataMapper field-to-column mapping [P2]
 - **Covers**: G45
-- **Assert**: `Type -> GtsTypeId`, `HierarchyParentId -> ParentId`, `Id -> Id`, `Name -> Name`
+- **Assert**: `Type -> GtsTypeId`, `HierarchyParentId -> ParentId`, `TenantId -> TenantId`, `Id -> Id`, `Name -> Name`
 
 #### TC-ODATA-08: MembershipODataMapper field-to-column mapping [P2]
 - **Covers**: G45

--- a/modules/system/resource-group/docs/features/0003-entity-hierarchy.md
+++ b/modules/system/resource-group/docs/features/0003-entity-hierarchy.md
@@ -356,7 +356,7 @@ The system **MUST** implement a Hierarchy Service that maintains the closure tab
 The system **MUST** implement REST endpoint handlers for group management under `/api/resource-group/v1/groups` and the hierarchy depth endpoint.
 
 **Required endpoints**:
-- `GET /groups` — list groups with OData `$filter` (fields: `type`, `hierarchy/parent_id`, `id`, `name`; operators: `eq`, `ne`, `in`) and cursor-based pagination
+- `GET /groups` — list groups with OData `$filter` (fields: `type`, `hierarchy/parent_id`, `tenant_id`, `id`, `name`; operators: `eq`, `ne`, `in`) and cursor-based pagination
 - `POST /groups` — create group, return 201 Created
 - `GET /groups/{group_id}` — get group by UUID, return 404 if not found
 - `PUT /groups/{group_id}` — update group (name, type, metadata) or move group (hierarchy.parent_id), return 200 OK

--- a/modules/system/resource-group/docs/openapi.yaml
+++ b/modules/system/resource-group/docs/openapi.yaml
@@ -510,13 +510,14 @@ paths:
         For hierarchy traversal (ancestors, descendants, depth),
         use the dedicated `/{group_id}/hierarchy` endpoint.
 
-        - `$filter`: `type` (eq, ne, in), `parent_id` (eq, ne, in), `id` (eq, ne, in), `name` (eq, ne, in)
+        - `$filter`: `type` (eq, ne, in), `hierarchy/parent_id` (eq, ne, in), `tenant_id` (eq, ne, in), `id` (eq, ne, in), `name` (eq, ne, in)
         - `limit`: page size (1..200), default 25
         - `cursor`: opaque token for pagination
       x-odata-filter:
         supported_fields:
           type: [eq, ne, in]
-          parent_id: [eq, ne, in]
+          hierarchy/parent_id: [eq, ne, in]
+          tenant_id: [eq, ne, in]
           id: [eq, ne, in]
           name: [eq, ne, in]
       parameters:
@@ -587,7 +588,7 @@ paths:
                       limit: 25
 
                 parent-id-eq:
-                  summary: "$filter=parent_id eq '11111111-...'"
+                  summary: "$filter=hierarchy/parent_id eq '11111111-...'"
                   description: Direct children of T1.
                   value:
                     items:

--- a/modules/system/resource-group/resource-group-sdk/src/odata/groups.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/groups.rs
@@ -3,7 +3,7 @@
 //! `OData` filter field definitions for resource group entities.
 //!
 //! Group list `$filter` fields: `type` (eq, ne, in), `hierarchy/parent_id` (eq, ne, in),
-//! `id` (eq, ne, in), `name` (eq, ne, in).
+//! `tenant_id` (eq, ne, in), `id` (eq, ne, in), `name` (eq, ne, in).
 //!
 //! The `hierarchy/parent_id` field uses `OData` nested path syntax; since the
 //! `ODataFilterable` derive macro does not support slash-separated names,
@@ -18,6 +18,8 @@ pub enum GroupFilterField {
     Type,
     /// Filter by parent group ID (direct parent only).
     HierarchyParentId,
+    /// Filter by owning tenant ID.
+    TenantId,
     /// Filter by group ID.
     Id,
     /// Filter by group name.
@@ -25,12 +27,19 @@ pub enum GroupFilterField {
 }
 
 impl FilterField for GroupFilterField {
-    const FIELDS: &'static [Self] = &[Self::Type, Self::HierarchyParentId, Self::Id, Self::Name];
+    const FIELDS: &'static [Self] = &[
+        Self::Type,
+        Self::HierarchyParentId,
+        Self::TenantId,
+        Self::Id,
+        Self::Name,
+    ];
 
     fn name(&self) -> &'static str {
         match self {
             Self::Type => "type",
             Self::HierarchyParentId => "hierarchy/parent_id",
+            Self::TenantId => "tenant_id",
             Self::Id => "id",
             Self::Name => "name",
         }
@@ -41,7 +50,7 @@ impl FilterField for GroupFilterField {
             // Type is a GTS type path string in the public API; the persistence
             // layer resolves string paths to SMALLINT IDs after OData validation.
             Self::Type | Self::Name => FieldKind::String,
-            Self::HierarchyParentId | Self::Id => FieldKind::Uuid,
+            Self::HierarchyParentId | Self::TenantId | Self::Id => FieldKind::Uuid,
         }
     }
 }

--- a/modules/system/resource-group/resource-group-sdk/src/odata/groups_tests.rs
+++ b/modules/system/resource-group/resource-group-sdk/src/odata/groups_tests.rs
@@ -9,6 +9,7 @@ fn group_filter_field_names_correct() {
         GroupFilterField::HierarchyParentId.name(),
         "hierarchy/parent_id"
     );
+    assert_eq!(GroupFilterField::TenantId.name(), "tenant_id");
     assert_eq!(GroupFilterField::Id.name(), "id");
     assert_eq!(GroupFilterField::Name.name(), "name");
 }
@@ -18,6 +19,7 @@ fn group_filter_field_names_correct() {
 fn group_filter_field_kinds_correct() {
     assert_eq!(GroupFilterField::Type.kind(), FieldKind::String);
     assert_eq!(GroupFilterField::HierarchyParentId.kind(), FieldKind::Uuid);
+    assert_eq!(GroupFilterField::TenantId.kind(), FieldKind::Uuid);
     assert_eq!(GroupFilterField::Id.kind(), FieldKind::Uuid);
     assert_eq!(GroupFilterField::Name.kind(), FieldKind::String);
 }
@@ -25,5 +27,5 @@ fn group_filter_field_kinds_correct() {
 // TC-ODATA-03: FIELDS completeness
 #[test]
 fn group_filter_field_completeness() {
-    assert_eq!(GroupFilterField::FIELDS.len(), 4);
+    assert_eq!(GroupFilterField::FIELDS.len(), 5);
 }

--- a/modules/system/resource-group/resource-group/src/infra/storage/odata_mapper.rs
+++ b/modules/system/resource-group/resource-group/src/infra/storage/odata_mapper.rs
@@ -54,6 +54,7 @@ impl FieldToColumn<GroupFilterField> for GroupODataMapper {
         match field {
             GroupFilterField::Type => GroupColumn::GtsTypeId,
             GroupFilterField::HierarchyParentId => GroupColumn::ParentId,
+            GroupFilterField::TenantId => GroupColumn::TenantId,
             GroupFilterField::Id => GroupColumn::Id,
             GroupFilterField::Name => GroupColumn::Name,
         }
@@ -71,6 +72,7 @@ impl ODataFieldMapping<GroupFilterField> for GroupODataMapper {
                 Some(pid) => sea_orm::Value::Uuid(Some(Box::new(pid))),
                 None => sea_orm::Value::Uuid(None),
             },
+            GroupFilterField::TenantId => sea_orm::Value::Uuid(Some(Box::new(model.tenant_id))),
             GroupFilterField::Type => sea_orm::Value::SmallInt(Some(model.gts_type_id)),
         }
     }


### PR DESCRIPTION
Allows callers to scope list_groups to a single tenant via $filter=tenant_id eq <uuid>. Required by AM's soft_delete precondition (does this child own any RG?) per #1626.

Closes #1626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant ID filtering is now supported for groups in OData queries, letting users filter and retrieve groups by associated tenant.

* **Tests**
  * Added/updated tests to validate tenant ID field mapping, OData naming, and UUID type classification.

* **Documentation**
  * API docs, design, and feature docs updated to list tenant_id as a supported OData filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->