### PR TITLE
chore(dylint): bump lint toolchain to nightly-2026-01-22 (rustc 1.95)

### DIFF
--- a/tools/dylint_lints/Cargo.lock
+++ b/tools/dylint_lints/Cargo.lock
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit"
-version = "0.6.3"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-db"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-odata"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64",
  "bigdecimal",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-sdk"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "cf-modkit-odata",
  "cf-modkit-security",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "cf-modkit-utils"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "humantime",
  "regex",
@@ -1630,8 +1630,8 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -5813,20 +5813,23 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
- "displaydoc",
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.18",
  "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/tools/dylint_lints/de03_domain_layer/de0301_no_infra_in_domain/rust-toolchain
+++ b/tools/dylint_lints/de03_domain_layer/de0301_no_infra_in_domain/rust-toolchain
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly-2026-01-22"
-components = ["llvm-tools-preview", "rustc-dev"]

--- a/tools/dylint_lints/de03_domain_layer/de0308_no_http_in_domain/rust-toolchain
+++ b/tools/dylint_lints/de03_domain_layer/de0308_no_http_in_domain/rust-toolchain
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly-2026-01-22"
-components = ["llvm-tools-preview", "rustc-dev"]

--- a/tools/dylint_lints/de07_security/de0706_no_direct_sqlx/rust-toolchain
+++ b/tools/dylint_lints/de07_security/de0706_no_direct_sqlx/rust-toolchain
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "nightly-2026-01-22"
-components = ["llvm-tools-preview", "rustc-dev"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain from `nightly-2025-09-18` to `nightly-2026-01-22`
  * Updated `clippy_utils` dependency to a newer upstream revision
  * Removed redundant local toolchain configuration files
  * Enhanced lint compatibility with updated compiler infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->