### PR TITLE
chore(release): publish resource-group crates and unblock cf-rg-tr-plugin

### DIFF
--- a/modules/system/resource-group/resource-group-sdk/Cargo.toml
+++ b/modules/system/resource-group/resource-group-sdk/Cargo.toml
@@ -2,11 +2,14 @@
 [package]
 name = "cf-resource-group-sdk"
 version = "0.1.0"
-publish = false
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "SDK for resource-group module: API trait, types, and error definitions"
+repository.workspace = true
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-system", "resource-group"]
+categories = ["api-bindings"]
 
 [lints]
 workspace = true

--- a/modules/system/resource-group/resource-group-sdk/README.md
+++ b/modules/system/resource-group/resource-group-sdk/README.md
@@ -1,0 +1,94 @@
+# Resource Group SDK
+
+SDK crate for the Resource Group module, providing public API contracts for hierarchical resource group management with the GTS type system in CyberFabric.
+
+## Overview
+
+This crate defines the transport-agnostic interface for the Resource Group module:
+
+- **`ResourceGroupClient`** — Async trait for full type/group/membership lifecycle
+- **`ResourceGroupReadHierarchy`** — Narrow read-only trait for in-process plugin consumers (e.g. AuthZ resolver, tenant-resolver RG plugin) that need ancestor/descendant walks plus flat OData listing
+- Models: `ResourceGroupType`, `ResourceGroup`, `ResourceGroupMembership`, `ResourceGroupWithDepth`, `GroupHierarchy`, etc.
+- **`ResourceGroupError`** — Error type for all operations
+- OData filter field definitions (behind the `odata` feature)
+
+## Usage
+
+### Getting the Client
+
+Consumers obtain the client from `ClientHub`:
+
+```rust
+use resource_group_sdk::ResourceGroupClient;
+
+let rg = hub.get::<dyn ResourceGroupClient>()?;
+```
+
+### Type Lifecycle
+
+```rust
+use resource_group_sdk::CreateTypeRequest;
+
+let rg_type = rg.create_type(&ctx, CreateTypeRequest { /* ... */ }).await?;
+let fetched = rg.get_type(&ctx, &rg_type.code).await?;
+```
+
+### Group Lifecycle
+
+```rust
+use resource_group_sdk::CreateGroupRequest;
+
+let group = rg.create_group(&ctx, CreateGroupRequest { /* ... */ }).await?;
+let same = rg.get_group(&ctx, group.id).await?;
+```
+
+### Hierarchy Traversal
+
+```rust
+use modkit_odata::ODataQuery;
+
+let descendants = rg.get_group_descendants(&ctx, group.id, &ODataQuery::default()).await?;
+let ancestors   = rg.get_group_ancestors(&ctx, group.id, &ODataQuery::default()).await?;
+```
+
+### Memberships
+
+```rust
+rg.add_membership(&ctx, group.id, "tenant", &tenant_id.to_string()).await?;
+rg.remove_membership(&ctx, group.id, "tenant", &tenant_id.to_string()).await?;
+```
+
+## Read-Only Hierarchy Trait
+
+Plugin consumers that need only read access can depend on the narrower
+`ResourceGroupReadHierarchy` trait. It exposes ancestor/descendant walks and
+OData-filtered listing — enough to support batch lookups like
+`id in (id1, id2, …)` without pulling in the full client surface.
+
+```rust
+use resource_group_sdk::ResourceGroupReadHierarchy;
+
+let read = hub.get::<dyn ResourceGroupReadHierarchy>()?;
+let page = read.list_groups(&ctx, &query).await?;
+```
+
+## Error Handling
+
+```rust
+use resource_group_sdk::ResourceGroupError;
+
+match rg.get_group(&ctx, id).await {
+    Ok(group) => { /* ... */ }
+    Err(ResourceGroupError::GroupNotFound { .. }) => { /* ... */ }
+    Err(e) => return Err(e.into()),
+}
+```
+
+## Features
+
+- `odata` (default) — enables OData filter field definitions and typed query
+  helpers (depends on `modkit-odata-macros` and `modkit-sdk`).
+
+## License
+
+Apache-2.0

--- a/modules/system/resource-group/resource-group/Cargo.toml
+++ b/modules/system/resource-group/resource-group/Cargo.toml
@@ -2,11 +2,14 @@
 [package]
 name = "cf-resource-group"
 version = "0.1.0"
-publish = false
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "Resource Group module: hierarchical resource group management with GTS type system"
+repository.workspace = true
+readme = "README.md"
+keywords = ["cyberfabric", "cyberfabric-system", "resource-group"]
+categories = ["web-programming"]
 
 [lints]
 workspace = true
@@ -17,7 +20,7 @@ odata = []
 
 [dependencies]
 # SDK - public API, models, and errors
-resource-group-sdk = { package = "cf-resource-group-sdk", path = "../resource-group-sdk", features = ["odata"] }
+resource-group-sdk = { package = "cf-resource-group-sdk", version = "0.1.0", path = "../resource-group-sdk", features = ["odata"] }
 
 # Core dependencies
 anyhow = { workspace = true }

--- a/modules/system/resource-group/resource-group/README.md
+++ b/modules/system/resource-group/resource-group/README.md
@@ -1,0 +1,72 @@
+# Resource Group
+
+Main module for hierarchical resource group management in CyberFabric. Backed by `cf-resource-group-sdk`, persisted via SeaORM, exposed over REST, and integrated with the AuthZ resolver and types registry.
+
+## Overview
+
+The `cf-resource-group` module provides:
+
+- **GTS-typed groups** — every group is bound to a GTS type (validated against the types registry)
+- **Hierarchy** — parent/child relationships with ancestor/descendant traversal and depth tracking
+- **Memberships** — `(resource_type, resource_id)` links to groups
+- **OData listing** — filterable, cursor-paginated reads for types, groups, and memberships
+- **AuthZ enforcement** — every mutation and read goes through `PolicyEnforcer` from `cf-authz-resolver-sdk`
+- **ClientHub integration** — registers `ResourceGroupClient` (full surface) and `ResourceGroupReadHierarchy` (narrow read-only) for in-process consumers
+
+The module owns its database schema via `DatabaseCapability` and exposes a REST surface via `RestApiCapability`.
+
+## Architecture
+
+```
+Consumer Module
+    │
+    ▼
+ResourceGroupClient / ResourceGroupReadHierarchy  (SDK traits, ClientHub)
+    │
+    ▼
+cf-resource-group  (this crate — services, repos, REST handlers)
+    │
+    ├──▶ AuthZ resolver  (PolicyEnforcer)
+    ├──▶ Types registry  (GTS schema validation)
+    └──▶ Database         (SeaORM, sqlite + pg)
+```
+
+## Capabilities
+
+- `db` — SeaORM-backed storage with module-owned migrations
+- `rest` — REST API for types, groups, and memberships (OpenAPI-described)
+- Module dependencies: `authz-resolver`, `types-registry`
+
+## Usage (in-process)
+
+Consumers use the SDK trait from `cf-resource-group-sdk`:
+
+```rust
+use resource_group_sdk::ResourceGroupClient;
+
+let rg = hub.get::<dyn ResourceGroupClient>()?;
+let group = rg.get_group(&ctx, group_id).await?;
+```
+
+For read-only consumers (e.g. AuthZ plugin, tenant-resolver RG plugin):
+
+```rust
+use resource_group_sdk::ResourceGroupReadHierarchy;
+
+let read = hub.get::<dyn ResourceGroupReadHierarchy>()?;
+let descendants = read.get_group_descendants(&ctx, group_id, &query).await?;
+```
+
+## REST API
+
+The module registers REST routes for types, groups, hierarchy traversal, and memberships. See the generated OpenAPI document for the full surface, including cascade-delete endpoints that are intentionally not exposed via the SDK.
+
+## Testing
+
+```bash
+cargo test -p cf-resource-group
+```
+
+## License
+
+Apache-2.0

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -210,6 +210,11 @@ changelog_update = false
 git_release_enable = false
 
 [[package]]
+name = "cf-resource-group"
+changelog_update = false
+git_release_enable = false
+
+[[package]]
 name = "cf-tenant-resolver-sdk"
 changelog_update = false
 git_release_enable = false

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -205,6 +205,11 @@ changelog_update = false
 git_release_enable = false
 
 [[package]]
+name = "cf-resource-group-sdk"
+changelog_update = false
+git_release_enable = false
+
+[[package]]
 name = "cf-tenant-resolver-sdk"
 changelog_update = false
 git_release_enable = false


### PR DESCRIPTION
## Summary

- Make `cf-resource-group-sdk` and `cf-resource-group` publishable to crates.io: drop `publish = false`, add `repository`/`readme`/`keywords`/`categories`, and pin the path dependency between them to a concrete `version` so cargo can resolve path/version pairs at publish time.
- Add READMEs for both crates, modeled after `cf-tenant-resolver{-sdk}` and reflecting the actual API.
- Register both crates in `release-plz.toml` with `changelog_update = false` / `git_release_enable = false`, matching the convention used for other system modules — they publish to crates.io but the release notes stay unified under `cf-modkit`.
- Knock-on effect: `cf-rg-tr-plugin` (under `modules/system/tenant-resolver/plugins/rg-tr-plugin`) becomes publishable in the same release. It was previously blocked because its path dependency `cf-resource-group-sdk` was marked `publish = false` and not on crates.io.

## Why

`cf-rg-tr-plugin` is a new tenant-resolver plugin that should ship to crates.io alongside the other plugins (`cf-static-tr-plugin`, `cf-single-tenant-tr-plugin`, …). release-plz already picks up unflagged workspace crates by default, so the only blocker was the unpublished SDK it depends on. Publishing the SDK requires the main `cf-resource-group` module to either also be publishable or stay isolated — the latter is awkward because both crates share the same module surface, so we publish both, mirroring how `cf-tenant-resolver` and `cf-credstore` do it.

## Publication order (release-plz handles this automatically)

1. `cf-resource-group-sdk` 0.1.0
2. `cf-resource-group` 0.1.0
3. `cf-rg-tr-plugin` 0.1.0

## Test plan

- [x] `cargo check -p cf-resource-group-sdk -p cf-resource-group -p cf-rg-tr-plugin` — green
- [x] `cargo package --no-verify -p cf-resource-group-sdk` — succeeds
- [x] `cargo package -p cf-resource-group` / `-p cf-rg-tr-plugin` — fails locally only because the SDK is not yet on crates.io; release-plz publishes workspace crates in topological order inside a single release, so this resolves at publish time
- [ ] After merge: verify release-plz opens a release PR that bumps `cf-resource-group-sdk`, `cf-resource-group`, and `cf-rg-tr-plugin`
- [ ] After release PR merge: verify all three crates appear on crates.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive README for the Resource Group SDK with API overview and usage examples.
  * Added module README for the Resource Group system covering integration, schema/migrations, APIs, and testing.
* **Chores**
  * Updated package metadata to improve crate documentation and discoverability.
  * Added workspace release configuration entries to opt these crates out of automated changelog/release generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->