### PR TITLE
chore: regenerate api.json after #1746

### DIFF
--- a/docs/api/api.json
+++ b/docs/api/api.json
@@ -8275,7 +8275,7 @@
             }
           },
           {
-            "description": "OData v4 filter expression\n- type: eq|ne|contains|startswith|endswith|in\n- hierarchy/parent_id: eq|ne|in\n- id: eq|ne|in\n- name: eq|ne|contains|startswith|endswith|in",
+            "description": "OData v4 filter expression\n- type: eq|ne|contains|startswith|endswith|in\n- hierarchy/parent_id: eq|ne|in\n- tenant_id: eq|ne|in\n- id: eq|ne|in\n- name: eq|ne|contains|startswith|endswith|in",
             "in": "query",
             "name": "$filter",
             "required": false,
@@ -8343,6 +8343,11 @@
               "contains",
               "startswith",
               "endswith",
+              "in"
+            ],
+            "tenant_id": [
+              "eq",
+              "ne",
               "in"
             ],
             "type": [


### PR DESCRIPTION
## Summary

PR #1746 (`feat(resource-group): add tenant_id to GroupFilterField
whitelist`) added `tenant_id` to the resource-group OData filter
field whitelist and updated the module-level
`modules/system/resource-group/docs/openapi.yaml`, but the
workspace-aggregate `docs/api/api.json` was not regenerated.

CI's `API Contract Checks` job flags the resulting freshness drift
on every downstream PR — every new branch CI'd against `main` fails
with:

```
##[error]docs/api/api.json does not match the spec generated from code.
  To fix: run 'make openapi' locally and commit the updated docs/api/api.json.
```

This commit is purely the output of `make openapi` against the
current `main`. The diff is the OData filter description block plus
the `tenant_id` whitelist entry on the affected endpoint —
exactly the changes #1746 introduced at the code level.

## Test plan

- [x] `make openapi` regenerates `docs/api/api.json` deterministically
      (sorted via `tools/scripts/sort_openapi_json.py`)
- [x] No source files touched; only the generated artifact updates
- [ ] CI `API Contract Checks` turns green